### PR TITLE
[codex] Optimize game rendering and debug profiles

### DIFF
--- a/apps/garden/app/debug/GameSceneLauncher.tsx
+++ b/apps/garden/app/debug/GameSceneLauncher.tsx
@@ -128,9 +128,10 @@ function ToggleButton({
 export function GameSceneLauncher() {
     const [mode, setMode] = useState<Mode>('baseline');
     const [quality, setQuality] = useState<Quality>('auto');
-    const [details, setDetails] = useState(false);
-    const [hud, setHud] = useState(true);
-    const [controls, setControls] = useState(true);
+    const [details, setDetails] = useState(true);
+    const [hud, setHud] = useState(false);
+    const [debugHud, setDebugHud] = useState(false);
+    const [controls, setControls] = useState(false);
 
     const href = useMemo(() => {
         const params = new URLSearchParams();
@@ -140,18 +141,21 @@ export function GameSceneLauncher() {
         if (quality !== 'auto') {
             params.set('quality', quality);
         }
-        if (details) {
-            params.set('details', '1');
+        if (!details) {
+            params.set('details', '0');
         }
         if (hud) {
             params.set('hud', '1');
         }
-        if (!controls) {
-            params.set('controls', '0');
+        if (debugHud) {
+            params.set('debugHud', '1');
+        }
+        if (controls) {
+            params.set('controls', '1');
         }
         const queryString = params.toString();
         return `/debug/profile/game${queryString ? `?${queryString}` : ''}`;
-    }, [mode, quality, details, hud, controls]);
+    }, [mode, quality, details, hud, debugHud, controls]);
 
     return (
         <div className="flex flex-col gap-5 rounded-lg border border-neutral-800 bg-neutral-900 p-5">
@@ -193,15 +197,21 @@ export function GameSceneLauncher() {
                 <div className="flex flex-wrap gap-2">
                     <ToggleButton
                         label="Details"
-                        description="Render deferred scene details: mulch, ground decoration (details)."
+                        description="Render scene details: mulch, ground decoration, animals (details)."
                         enabled={details}
                         onToggle={() => setDetails((current) => !current)}
                     />
                     <ToggleButton
                         label="HUD"
-                        description="Show the in-game HUD overlay, including the debug HUD (hud)."
+                        description="Show the in-game HUD overlay (hud)."
                         enabled={hud}
                         onToggle={() => setHud((current) => !current)}
+                    />
+                    <ToggleButton
+                        label="Debug HUD"
+                        description="Show the debug metrics and scene controls (debugHud)."
+                        enabled={debugHud}
+                        onToggle={() => setDebugHud((current) => !current)}
                     />
                     <ToggleButton
                         label="Controls"

--- a/apps/garden/app/debug/page.tsx
+++ b/apps/garden/app/debug/page.tsx
@@ -47,9 +47,9 @@ const debugGroups = [
         pages: [
             {
                 href: '/debug/plants',
-                title: 'Plant performance',
+                title: 'Plant-heavy game scene',
                 description:
-                    'Generated plant presets rendered in dense batches.',
+                    'Normal mock game scene prepopulated with planted raised beds.',
             },
         ],
     },

--- a/apps/garden/app/debug/plants/page.tsx
+++ b/apps/garden/app/debug/plants/page.tsx
@@ -5,11 +5,11 @@ export default function DebugPlantsPage() {
         <div className="flex h-screen w-screen flex-col bg-neutral-900">
             <div className="border-b border-neutral-700 p-4">
                 <h1 className="text-xl font-bold text-white">
-                    Plant Performance Debug View
+                    Plant Garden Debug View
                 </h1>
                 <p className="text-sm text-neutral-400">
-                    Generated presets rendered in dense batches for rollout
-                    validation.
+                    Normal game scene with a plant-heavy mock garden of raised
+                    beds.
                 </p>
             </div>
             <div className="flex-1">

--- a/apps/garden/app/debug/profile/game/page.tsx
+++ b/apps/garden/app/debug/profile/game/page.tsx
@@ -183,10 +183,10 @@ export default async function GameProfilePage({
 }) {
     const params = await searchParams;
     const mode = resolveMode(firstValue(params.mode));
-    const renderDetails =
-        mode === 'details' || firstValue(params.details) === '1';
+    const renderDetails = firstValue(params.details) !== '0';
     const showHud = firstValue(params.hud) === '1';
-    const enableControls = firstValue(params.controls) !== '0';
+    const showDebugHud = firstValue(params.debugHud) === '1';
+    const enableControls = firstValue(params.controls) === '1';
     const mockGardenProfile = resolveMockGardenProfile(
         firstValue(params.profile),
     );
@@ -199,21 +199,25 @@ export default async function GameProfilePage({
             className="h-screen w-screen overflow-hidden bg-[#e7e2cc]"
             data-game-profile-mode={mode}
             data-game-profile-controls={enableControls ? '1' : '0'}
+            data-game-profile-details={renderDetails ? '1' : '0'}
+            data-game-profile-debug-hud={showDebugHud ? '1' : '0'}
+            data-game-profile-hud={showHud ? '1' : '0'}
             data-game-profile-garden-profile={mockGardenProfile}
             data-game-profile-quality={quality ?? 'auto'}
         >
             <GameScene
                 className="h-full w-full"
                 dayNightCycleDisabled={false}
-                deferDetails={!renderDetails}
                 flags={debugGameFlags}
                 freezeTime={freezeTime}
+                debugHud={showDebugHud}
                 hideHud={!showHud}
                 initialQualitySetting={quality}
                 mockGarden
                 mockGardenProfile={mockGardenProfile}
                 noControls={!enableControls}
                 noSound
+                renderDetails={renderDetails}
                 weather={weather}
                 winterMode={mode === 'snow' ? 'winter' : 'summer'}
             />

--- a/apps/garden/scripts/profile-game-scene.mjs
+++ b/apps/garden/scripts/profile-game-scene.mjs
@@ -12,7 +12,7 @@ const defaultOutDir = resolve(appRoot, 'test-results/game-profile');
 const coreScenarios = [
     {
         name: 'game-baseline-desktop',
-        path: '/debug/profile/game?mode=baseline&controls=0&quality=medium',
+        path: '/debug/profile/game?mode=baseline&quality=medium',
         viewport: { width: 1280, height: 720 },
         dpr: 1,
         isMobile: false,
@@ -20,7 +20,7 @@ const coreScenarios = [
     },
     {
         name: 'game-baseline-mobile',
-        path: '/debug/profile/game?mode=baseline&controls=0&quality=low',
+        path: '/debug/profile/game?mode=baseline&quality=medium',
         viewport: { width: 390, height: 844 },
         dpr: 3,
         isMobile: true,
@@ -28,7 +28,7 @@ const coreScenarios = [
     },
     {
         name: 'game-details-desktop',
-        path: '/debug/profile/game?mode=details&controls=0&quality=medium',
+        path: '/debug/profile/game?mode=details&quality=medium',
         viewport: { width: 1280, height: 720 },
         dpr: 1,
         isMobile: false,
@@ -36,7 +36,7 @@ const coreScenarios = [
     },
     {
         name: 'game-rain-mobile',
-        path: '/debug/profile/game?mode=rain&controls=0&quality=low',
+        path: '/debug/profile/game?mode=rain&quality=medium',
         viewport: { width: 390, height: 844 },
         dpr: 3,
         isMobile: true,
@@ -44,7 +44,7 @@ const coreScenarios = [
     },
     {
         name: 'game-snow-mobile',
-        path: '/debug/profile/game?mode=snow&controls=0&quality=low',
+        path: '/debug/profile/game?mode=snow&quality=medium',
         viewport: { width: 390, height: 844 },
         dpr: 3,
         isMobile: true,
@@ -63,7 +63,7 @@ const coreScenarios = [
 const denseScenarios = [
     {
         name: 'game-dense-25x25-desktop',
-        path: '/debug/profile/game?mode=details&profile=dense&controls=0&quality=medium',
+        path: '/debug/profile/game?mode=details&profile=dense&quality=medium',
         viewport: { width: 1280, height: 720 },
         dpr: 1,
         isMobile: false,
@@ -71,7 +71,7 @@ const denseScenarios = [
     },
     {
         name: 'game-dense-25x25-high-desktop',
-        path: '/debug/profile/game?mode=details&profile=dense&controls=0&quality=high',
+        path: '/debug/profile/game?mode=details&profile=dense&quality=high',
         viewport: { width: 1280, height: 720 },
         dpr: 1,
         isMobile: false,
@@ -96,7 +96,7 @@ const denseScenarios = [
     },
     {
         name: 'game-dense-25x25-rain-desktop',
-        path: '/debug/profile/game?mode=rain&profile=dense&details=1&controls=0&quality=medium',
+        path: '/debug/profile/game?mode=rain&profile=dense&quality=medium',
         viewport: { width: 1280, height: 720 },
         dpr: 1,
         isMobile: false,
@@ -104,7 +104,7 @@ const denseScenarios = [
     },
     {
         name: 'game-dense-25x25-snow-desktop',
-        path: '/debug/profile/game?mode=snow&profile=dense&details=1&controls=0&quality=medium',
+        path: '/debug/profile/game?mode=snow&profile=dense&quality=medium',
         viewport: { width: 1280, height: 720 },
         dpr: 1,
         isMobile: false,
@@ -112,7 +112,7 @@ const denseScenarios = [
     },
     {
         name: 'game-dense-25x25-cloudy-desktop',
-        path: '/debug/profile/game?mode=cloudy&profile=dense&details=1&controls=0&quality=medium',
+        path: '/debug/profile/game?mode=cloudy&profile=dense&quality=medium',
         viewport: { width: 1280, height: 720 },
         dpr: 1,
         isMobile: false,
@@ -120,7 +120,7 @@ const denseScenarios = [
     },
     {
         name: 'game-dense-25x25-windy-desktop',
-        path: '/debug/profile/game?mode=windy&profile=dense&details=1&controls=0&quality=medium',
+        path: '/debug/profile/game?mode=windy&profile=dense&quality=medium',
         viewport: { width: 1280, height: 720 },
         dpr: 1,
         isMobile: false,
@@ -128,7 +128,7 @@ const denseScenarios = [
     },
     {
         name: 'game-plant-heavy-25x25-desktop',
-        path: '/debug/profile/game?mode=details&profile=plant-heavy&controls=0&quality=medium',
+        path: '/debug/profile/game?mode=details&profile=plant-heavy&quality=medium',
         viewport: { width: 1280, height: 720 },
         dpr: 1,
         isMobile: false,
@@ -365,8 +365,11 @@ function resolveScenarios(scenarioSet) {
 function getScenarioRequest(path) {
     const url = new URL(path, 'http://profile.local');
     return {
-        controls: url.searchParams.get('controls') ?? '1',
+        controls: url.searchParams.get('controls') ?? '0',
+        details: url.searchParams.get('details') ?? '1',
+        debugHud: url.searchParams.get('debugHud') ?? '0',
         gardenProfile: url.searchParams.get('profile') ?? 'default',
+        hud: url.searchParams.get('hud') ?? '0',
         mode: url.searchParams.get('mode') ?? 'baseline',
         quality: url.searchParams.get('quality') ?? 'auto',
     };
@@ -669,7 +672,10 @@ async function measureScenario(browser, baseUrl, scenario, options) {
 
         return {
             controls: element.dataset.gameProfileControls ?? null,
+            details: element.dataset.gameProfileDetails ?? null,
+            debugHud: element.dataset.gameProfileDebugHud ?? null,
             gardenProfile: element.dataset.gameProfileGardenProfile ?? null,
+            hud: element.dataset.gameProfileHud ?? null,
             mode: element.dataset.gameProfileMode ?? null,
             quality: element.dataset.gameProfileQuality ?? null,
         };
@@ -879,9 +885,12 @@ async function measureScenario(browser, baseUrl, scenario, options) {
         path: scenario.path,
         requested: {
             controls: profileMetadata?.controls ?? request.controls,
+            details: profileMetadata?.details ?? request.details,
+            debugHud: profileMetadata?.debugHud ?? request.debugHud,
             dpr: scenario.dpr,
             gardenProfile:
                 profileMetadata?.gardenProfile ?? request.gardenProfile,
+            hud: profileMetadata?.hud ?? request.hud,
             isMobile: scenario.isMobile,
             mode: profileMetadata?.mode ?? request.mode,
             motion: scenario.motion ?? 'none',
@@ -966,8 +975,8 @@ function buildMarkdown(report) {
         '',
         `Budget status: ${report.summary.failedScenarios === 0 ? 'pass' : 'fail'}`,
         '',
-        '| Scenario | Mode | Profile | Controls | Motion | Quality | Canvas | Shadow | Rain/Snow | Overlays/Decor | FPS | p95 | Max | Draw/frame | Triangles/frame | Long tasks | Heap | Budget |',
-        '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+        '| Scenario | Mode | Profile | Details | Controls | HUD | Debug HUD | Motion | Quality | Canvas | Shadow | Rain/Snow | Overlays/Decor | FPS | p95 | Max | Draw/frame | Triangles/frame | Long tasks | Heap | Budget |',
+        '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
     ];
 
     for (const scenario of report.scenarios) {
@@ -987,7 +996,7 @@ function buildMarkdown(report) {
             ? `${scenario.runtime.instancedSnowOverlayCount ?? 0}+${scenario.runtime.raisedBedMulchOverlayCount ?? 0}/${scenario.runtime.groundDecorationCount ?? 0} decor, visible ${scenario.runtime.groundDecorationVisibleCount ?? 'n/a'}, pages ${scenario.runtime.groundDecorationAtlasPageCount ?? 'n/a'}, chunks ${scenario.runtime.groundDecorationChunkCount ?? 'n/a'}`
             : 'n/a';
         lines.push(
-            `| ${scenario.name} | ${scenario.requested.mode} | ${scenario.requested.gardenProfile} | ${scenario.requested.controls} | ${scenario.requested.motion} | ${quality} | ${canvas} | ${shadow} | ${weather} | ${detailCounts} | ${scenario.sample.fps} | ${scenario.sample.p95FrameMs} ms | ${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerFrame} | ${scenario.sample.trianglesPerFrame} | ${scenario.sample.longTaskCount} | ${scenario.sample.jsHeapMb ?? 'n/a'} MB | ${scenario.budget.pass ? 'pass' : 'fail'} |`,
+            `| ${scenario.name} | ${scenario.requested.mode} | ${scenario.requested.gardenProfile} | ${scenario.requested.details} | ${scenario.requested.controls} | ${scenario.requested.hud} | ${scenario.requested.debugHud} | ${scenario.requested.motion} | ${quality} | ${canvas} | ${shadow} | ${weather} | ${detailCounts} | ${scenario.sample.fps} | ${scenario.sample.p95FrameMs} ms | ${scenario.sample.maxFrameMs} ms | ${scenario.sample.drawCallsPerFrame} | ${scenario.sample.trianglesPerFrame} | ${scenario.sample.longTaskCount} | ${scenario.sample.jsHeapMb ?? 'n/a'} MB | ${scenario.budget.pass ? 'pass' : 'fail'} |`,
         );
     }
 

--- a/docs/game-rendering-architecture-optimization-plan.md
+++ b/docs/game-rendering-architecture-optimization-plan.md
@@ -541,6 +541,10 @@ Progress:
   rendered `1353` decorations with `1235` submitted after culling, `2` atlas
   pages, and `113` chunks. Controls-enabled medium kept the same `839/914`
   visible decoration count, `2` pages, and `106` chunks.
+- 2026-06-09 local dev smoke against
+  `/debug/profile/game?mode=details&profile=dense&quality=medium&debugHud=1`
+  rendered `914` decorations with `845` submitted after culling, `2` atlas
+  pages, `57` chunks, `126` renderer calls, and no shader/WebGLProgram errors.
 - The longer profile recorded render-size budgets within target despite local
   headless frame-time budget failures from Chromium `ReadPixels`/GPU stalls:
   medium `88.9` draw calls/frame, `76862` triangles/frame, `35.6 MB` heap;
@@ -811,10 +815,12 @@ Progress:
   `88144` triangles/frame, `28 MB`; snow dense `126.6` draw calls/frame,
   `141251` triangles/frame, `37.8 MB`; plant-heavy `60.8` draw calls/frame,
   `84707` triangles/frame, `61 MB`.
+- Hover outline rendering moved off `useFrame`; it now subscribes to the
+  after-render pass only while outline targets are active.
 - Remaining callbacks are camera rig/render invalidation, active weather/cloud
-  transitions, hover outline render control, particle/animal simulations, and
-  plant LOD/culling. Those are still tied to visible simulation, input, or
-  render invalidation work rather than simple duplicated time-uniform writes.
+  transitions, particle/animal simulations, and plant LOD/culling. Those are
+  still tied to visible simulation, input, or render invalidation work rather
+  than simple duplicated time-uniform writes.
 
 ## Milestone 8: Profiling and QA harness
 
@@ -918,10 +924,10 @@ Run the narrowest relevant checks per task:
 
 For visual/rendering tasks, also run a production browser smoke against:
 
-- `/debug/profile/game?mode=baseline&controls=0&quality=medium`
-- `/debug/profile/game?mode=details&controls=0&quality=medium`
-- `/debug/profile/game?mode=rain&controls=0&quality=medium`
-- `/debug/profile/game?mode=snow&controls=0&quality=medium`
+- `/debug/profile/game?mode=baseline&quality=medium`
+- `/debug/profile/game?mode=details&quality=medium`
+- `/debug/profile/game?mode=rain&quality=medium`
+- `/debug/profile/game?mode=snow&quality=medium`
 - `/debug/profile/game?mode=details&controls=1&quality=medium`
 - `/debug/sandbox` with a dense 25x25 local garden
 

--- a/docs/game-scene-performance.md
+++ b/docs/game-scene-performance.md
@@ -98,25 +98,32 @@ warnings that will not exactly match production.
 
 The garden app now has a profiling route and report generator for future checks.
 The route `apps/garden/app/debug/profile/game/page.tsx` renders the mock game
-scene without signed-in game data requirements, login UI, HUD, or sound. In dev
-it still inherits app-level providers, so reports can include unrelated
-auth/analytics console noise; isolating that is now part of the profiling cleanup
-step. It supports these stable modes:
+scene without signed-in game data requirements, login UI, HUD, controls, or
+sound, while keeping the normal in-game scene details enabled. In dev it still
+inherits app-level providers, so reports can include unrelated auth/analytics
+console noise; isolating that is now part of the profiling cleanup step. It
+supports these stable modes:
 
-- `/debug/profile/game?mode=baseline&controls=0&quality=medium`
-- `/debug/profile/game?mode=baseline&controls=0&quality=low`
-- `/debug/profile/game?mode=details&controls=0&quality=medium`
-- `/debug/profile/game?mode=rain&controls=0&quality=medium`
-- `/debug/profile/game?mode=snow&controls=0&quality=medium`
-- `/debug/profile/game?mode=cloudy&controls=0&quality=medium`
-- `/debug/profile/game?mode=windy&controls=0&quality=medium`
-- `/debug/profile/game?mode=details&profile=dense&controls=0&quality=medium`
-- `/debug/profile/game?mode=details&profile=plant-heavy&controls=0&quality=medium`
+- `/debug/profile/game?mode=baseline&quality=medium`
+- `/debug/profile/game?mode=details&quality=medium`
+- `/debug/profile/game?mode=rain&quality=medium`
+- `/debug/profile/game?mode=snow&quality=medium`
+- `/debug/profile/game?mode=cloudy&quality=medium`
+- `/debug/profile/game?mode=windy&quality=medium`
+- `/debug/profile/game?mode=details&profile=dense&quality=medium`
+- `/debug/profile/game?mode=details&profile=plant-heavy&quality=medium`
 
 The `quality` query accepts `low`, `medium`, or `high`. When omitted, the game
 uses the automatic quality resolver. The `profile` query accepts `default`,
 `dense`, or `plant-heavy`. Dense profile scenes use deterministic 25x25 mock
-gardens so larger-scene measurements do not depend on signed-in garden data.
+gardens so larger-scene measurements do not depend on signed-in garden data. The
+`details` query defaults to `1`; use `details=0` only when intentionally
+profiling the reduced scene without detail layers such as mulch, ground
+decorations, and animals. Controls, the regular HUD, and the debug HUD are
+hidden by default; add `controls=1`, `hud=1`, or `debugHud=1` only when needed.
+Mobile profile scenarios use `quality=medium`, matching the automatic resolver
+policy that no longer selects the low tier by default. Use `quality=low` only
+for explicit manual low-tier comparisons.
 
 Generate the default production report. This builds the garden app, starts it
 with `pnpm start` on `http://localhost:3101`, profiles the scenarios, and then
@@ -258,9 +265,9 @@ are still dev/headless measurements; use them for relative deltas only.
 | Plants desktop p95 | shadow 8192 -> medium 2048 | 642.6 ms | 434.3 ms | -32.4% |
 
 Canvas backing sizes and active quality metadata are now visible in the Markdown
-report. The important mobile confirmation: the baseline/rain/snow mobile scenes
-now render at `390 x 844` instead of `780 x 1688`, and report low quality with
-shadows off.
+report. Mobile scenarios should be profiled at medium quality by default,
+matching the automatic resolver and using the medium DPR cap instead of the
+manual low-tier cap.
 
 Frame-time budgets still fail in dev because every scenario reports many long
 tasks and low rAF cadence in headless Chromium. The draw-call and triangle deltas
@@ -285,9 +292,9 @@ that the quality gates are active in production output.
 
 The short profile still fails frame-time budgets. The reported p95 values are
 dominated by long headless-browser stalls, so use draw calls, triangles, active
-detail counts, and repeated longer samples for optimization deltas. The useful
-confirmation is that low mobile now eliminates optional ground decorations, and
-clear scenes no longer mount snow overlays.
+detail counts, and repeated longer samples for optimization deltas. These
+historical mobile rows used the manual low tier; current mobile profiling uses
+medium because automatic quality no longer resolves to low.
 
 ### 2026-06-01 dense 25x25 production smoke
 
@@ -315,6 +322,10 @@ The VS Code browser sample stayed at DPR 2 even when different profiles were
 requested, so treat this as a steady-state draw-call sample rather than a true
 desktop-vs-mobile comparison. It ran a 5 second `requestAnimationFrame` sample
 after the scene was already loaded.
+
+Note: the `/debug/plants` row is historical from the older standalone generated
+plant grid. The current `/debug/plants` route uses the normal game scene with
+the `plant-heavy` mock garden profile.
 
 | Route | FPS | p95 frame | Draw calls / 5s | Approx draw calls / frame | Triangles / 5s | Approx triangles / frame |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -391,7 +402,8 @@ Recommended work:
 
 - Continue refining the automatic game quality resolver using viewport, pointer
   type, DPR, memory, CPU cores, and eventually a persisted user override.
-- Keep explicit DPR caps by tier: `1` low/mobile, `1.5` default, `2` high.
+- Keep explicit DPR caps by tier: `1` manual low, `1.5` medium/default, `2`
+  high.
 - The debug HUD now exposes FPS/p95, active tier, DPR cap, canvas backing size,
   shadow size, and weather particle counts.
 - Add adaptive degradation after sustained slow frames: lower DPR, reduce
@@ -507,13 +519,15 @@ time.
   suppress or isolate unrelated auth/analytics requests on debug routes, and
   keep dev-headless frame timing separate from render-work deltas.
 2. Continue batching detail layers: snow overlays and ground decorations are now
-  gated by coverage, zoom, and quality; the next win is batching/instancing
-  active overlays and atlas sprites.
+  gated by coverage, zoom, and quality; ground decorations are batched by atlas
+  page with per-instance sprite UVs, so the next win is active overlay and
+  plant/detail LOD batching.
 3. Replace CPU weather particle loops with shader-driven animation or a mobile
    overlay fallback.
 4. Tighten plant/detail LOD. `deferDetails` is now enabled on the main garden
   route, but dense plant/detail work still needs quality-aware LOD.
-5. Batch atlas sprites; static and animated sprite billboards are already split.
+5. Batch remaining plant/detail billboards; ground atlas sprites now share
+   atlas-page instanced batches.
 6. Evaluate `frameloop="demand"` or adaptive frame-loop modes after optional
    continuous effects are controlled.
 7. Add adaptive quality fallback after sustained slow frames.

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -34,9 +34,11 @@ export const gameHudBottomControlsClassName =
     'flex flex-row items-end p-2 md:absolute md:bottom-0 md:left-0';
 
 export function GameHud({
+    debugHud,
     flags,
     noWeather,
 }: {
+    debugHud?: boolean;
     flags: GameSceneProps['flags'];
     noWeather?: boolean;
 }) {
@@ -106,7 +108,7 @@ export function GameHud({
                 </>
             )}
             {!isLocalSandbox && <PaymentSuccessfulMessage />}
-            {Boolean(flags?.enableDebugHudFlag) && <DebugHud />}
+            {debugHud && <DebugHud />}
         </>
     );
 }

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -2,6 +2,7 @@
 
 import { cx } from '@gredice/ui/utils';
 import {
+    Fragment,
     type HTMLAttributes,
     Suspense,
     useEffect,
@@ -74,6 +75,7 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
     noBackground?: boolean;
     noControls?: boolean;
     hideHud?: boolean;
+    debugHud?: boolean;
     noWeather?: boolean;
     noSound?: boolean;
     mockGarden?: boolean;
@@ -83,6 +85,7 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
     winterMode?: WinterMode;
     weather?: Partial<GameState['weather']>;
     deferDetails?: boolean;
+    renderDetails?: boolean;
     quality?: GameQualityTier;
     initialQualitySetting?: GameQualitySetting;
 
@@ -174,9 +177,11 @@ export function GameScene({
     hideHud,
     className,
     flags,
+    debugHud,
     quality,
     weather,
     deferDetails,
+    renderDetails: renderDetailsOverride,
     ...rest
 }: GameSceneInnerProps) {
     useFocusPlacedBlock();
@@ -194,7 +199,8 @@ export function GameScene({
         (state) => state.gameQualityCustomProfile,
     );
     const weatherDisabled = noWeather || weatherVisualizationDisabled;
-    const renderDetails = useDeferredSceneDetails(deferDetails);
+    const deferredRenderDetails = useDeferredSceneDetails(deferDetails);
+    const renderDetails = renderDetailsOverride ?? deferredRenderDetails;
     const [sunflowerDropFlyOrigin, setSunflowerDropFlyOrigin] =
         useState<SunflowerDropFlyOrigin | null>(null);
     const autoQualityProfileMetrics = useAutoQualityProfileMetrics(
@@ -244,6 +250,8 @@ export function GameScene({
         return loadingContext ? null : <GardenLoadingIndicator />;
     }
 
+    const showDebugHud = debugHud ?? Boolean(flags?.enableDebugHudFlag);
+
     return (
         <div
             className={cx('animate-in duration-1000 fade-in', className)}
@@ -251,6 +259,7 @@ export function GameScene({
         >
             <GameSceneDetailContext.Provider value={{ renderDetails }}>
                 <Scene
+                    debugStats={showDebugHud}
                     position={cameraPosition}
                     quality={qualityProfile}
                     zoom={
@@ -270,7 +279,7 @@ export function GameScene({
                                 quality={qualityProfile}
                                 weather={weather}
                             />
-                            <group>
+                            <group name="GameScene:Entities">
                                 {garden?.stacks.map((stack) =>
                                     stack.blocks?.map((block, i) => {
                                         if (
@@ -307,9 +316,9 @@ export function GameScene({
                                             )
                                         ) {
                                             return (
-                                                <group key={key}>
+                                                <Fragment key={key}>
                                                     {entityFactory}
-                                                </group>
+                                                </Fragment>
                                             );
                                         }
 
@@ -384,8 +393,14 @@ export function GameScene({
                     </ParticleSystemProvider>
                 </Scene>
             </GameSceneDetailContext.Provider>
-            {!hideHud && <GameHud flags={flags} noWeather={noWeather} />}
-            {hideHud && Boolean(flags?.enableDebugHudFlag) && <DebugHud />}
+            {!hideHud && (
+                <GameHud
+                    debugHud={showDebugHud}
+                    flags={flags}
+                    noWeather={noWeather}
+                />
+            )}
+            {hideHud && showDebugHud && <DebugHud />}
             {sunflowerDropFlyOrigin && (
                 <SunflowerDropFlyAnimation
                     origin={sunflowerDropFlyOrigin}

--- a/packages/game/src/controls/BlockInteractionLayer.tsx
+++ b/packages/game/src/controls/BlockInteractionLayer.tsx
@@ -246,6 +246,7 @@ export function BlockInteractionLayer({
         // biome-ignore lint/a11y/noStaticElementInteractions: Three.js mesh is the single block interaction plane.
         <mesh
             ref={layerRef}
+            name={`Interaction:BlockLayer:targets:${targets.length}`}
             frustumCulled={false}
             onClick={handleClick}
             onPointerDown={handlePointerDown}

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -701,7 +701,7 @@ export function PickableGroup({
         spawn(
             resolveBlockParticleType(block.name),
             stack.position.clone().setY(currentStackHeight),
-            6,
+            4,
         );
         applyActivePreview(preview);
     }
@@ -789,11 +789,7 @@ export function PickableGroup({
             });
             dropSound.play();
             triggerPlaceHaptic();
-            spawn(
-                resolveBlockParticleType(block.name),
-                previewDropPosition,
-                12,
-            );
+            spawn(resolveBlockParticleType(block.name), previewDropPosition, 8);
             const blockDataForInventory = getBlockDataByName(
                 blocksData,
                 block.name,
@@ -881,7 +877,7 @@ export function PickableGroup({
         });
         dropSound.play();
         triggerPlaceHaptic();
-        spawn(resolveBlockParticleType(block.name), previewDropPosition, 12);
+        spawn(resolveBlockParticleType(block.name), previewDropPosition, 8);
 
         await moveBlock
             .mutateAsync({
@@ -1122,39 +1118,54 @@ export function PickableGroup({
     ) : (
         children
     );
+    const dragPosition = dragSprings.internalPosition as unknown as [
+        number,
+        number,
+        number,
+    ];
+    const blockedIndicator = showBlockedIndicator ? (
+        <animated.group
+            scale={blockedScaleSprings.scale}
+            position={indicatorPosition}
+        >
+            <Shadow color={0xff0000} opacity={1} colorStop={0.5} scale={2} />
+        </animated.group>
+    ) : null;
+    const recycleIndicator = isOverRecycler ? (
+        <Suspense>
+            <animated.group position={recyclePosition}>
+                <RecycleIndicator />
+            </animated.group>
+        </Suspense>
+    ) : null;
+
+    if (interactionTargetKey) {
+        return (
+            <>
+                {pickupOutlineContent}
+                {(blockedIndicator || recycleIndicator) && (
+                    <animated.group
+                        position={dragPosition}
+                        scale={dragSprings.scale}
+                    >
+                        {blockedIndicator}
+                        {recycleIndicator}
+                    </animated.group>
+                )}
+            </>
+        );
+    }
 
     return (
         <animated.group
-            position={
-                dragSprings.internalPosition as unknown as [
-                    number,
-                    number,
-                    number,
-                ]
-            }
+            position={dragPosition}
             scale={dragSprings.scale}
-            onPointerDown={interactionTargetKey ? undefined : handlePointerDown}
-            onClick={interactionTargetKey ? undefined : handleClick}
+            onPointerDown={handlePointerDown}
+            onClick={handleClick}
         >
-            <animated.group
-                scale={blockedScaleSprings.scale}
-                position={indicatorPosition}
-            >
-                <Shadow
-                    color={0xff0000}
-                    opacity={1}
-                    colorStop={0.5}
-                    scale={2}
-                />
-            </animated.group>
+            {blockedIndicator}
             {pickupOutlineContent}
-            {isOverRecycler && (
-                <Suspense>
-                    <animated.group position={recyclePosition}>
-                        <RecycleIndicator />
-                    </animated.group>
-                </Suspense>
-            )}
+            {recycleIndicator}
         </animated.group>
     );
 }

--- a/packages/game/src/controls/RotatableGroup.tsx
+++ b/packages/game/src/controls/RotatableGroup.tsx
@@ -117,13 +117,15 @@ export function RotatableGroup({
         },
     );
 
+    if (interactionTargetKey) {
+        return <>{children}</>;
+    }
+
     return (
         <group
-            onPointerDown={interactionTargetKey ? undefined : handlePointerDown}
-            onPointerLeave={
-                interactionTargetKey ? undefined : handleRotateCancel
-            }
-            onPointerUp={interactionTargetKey ? undefined : handlePointerUp}
+            onPointerDown={handlePointerDown}
+            onPointerLeave={handleRotateCancel}
+            onPointerUp={handlePointerUp}
         >
             {children}
         </group>

--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -34,6 +34,7 @@ import {
 import { HoverOutline } from './helpers/HoverOutline';
 import { resolveEntityNeighbors } from './helpers/useEntityNeighbors';
 import { RaisedBedFields } from './raisedBed/RaisedBedFields';
+import { RaisedBedGeneratedPlantFieldBatches } from './raisedBed/RaisedBedGeneratedPlantFieldBatches';
 import {
     resolveWaterFoamCorners,
     resolveWaterFoamEdges,
@@ -685,12 +686,21 @@ function RaisedBedInstances({
                     </Suspense>
                 );
             })}
+            <RaisedBedGeneratedPlantFieldBatches
+                blocks={instances.map((instance) => ({
+                    blockId: instance.block.id,
+                    position: instance.position,
+                }))}
+            />
             {instances.map((instance) => (
                 <group
                     key={`Raised_Bed-fields-${instance.id}`}
                     position={instance.position}
                 >
-                    <RaisedBedFields blockId={instance.block.id} />
+                    <RaisedBedFields
+                        blockId={instance.block.id}
+                        generatedPlantsHandledExternally
+                    />
                 </group>
             ))}
             <RaisedBedHoverOutlines

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -55,6 +55,7 @@ function EntityRenderModeDebugOverlay({
 
     return (
         <mesh
+            name={`Debug:EntityRenderMode:${instanced ? 'instanced' : 'component'}:${block.name}:${block.id}`}
             position={[
                 stack.position.x,
                 currentStackHeight + overlayHeight / 2,
@@ -225,7 +226,7 @@ export function EntityFactory({
         }
 
         return (
-            <SelectableGroup block={block}>
+            <>
                 <InstancedEntitySelectionRegistration
                     block={block}
                     blockIndex={blockIndex}
@@ -252,7 +253,7 @@ export function EntityFactory({
                         />
                     </RotatableGroup>
                 </PickableGroup>
-            </SelectableGroup>
+            </>
         );
     }
 

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -522,6 +522,7 @@ export function EntityInstancesGeometry(
                     key={`${instanceKey}:${chunk.key}`}
                     castShadow={castShadow}
                     chunk={chunk}
+                    debugName={`BlockInstances:${instanceKey}:chunk:${chunk.key}:count:${chunk.instances.length}`}
                     geometry={geometry}
                     localTransform={localTransform}
                     material={material}
@@ -584,6 +585,7 @@ export function EntityInstancesGeometry(
 function ChunkedInstancedMesh({
     castShadow,
     chunk,
+    debugName,
     geometry,
     localTransform,
     material,
@@ -594,6 +596,7 @@ function ChunkedInstancedMesh({
 }: {
     castShadow: boolean;
     chunk: InstanceChunk;
+    debugName: string;
     geometry: BufferGeometry;
     localTransform: {
         position: [number, number, number];
@@ -628,6 +631,7 @@ function ChunkedInstancedMesh({
     return (
         <instancedMesh
             ref={meshRef}
+            name={debugName}
             args={[geometry, material, chunk.instances.length]}
             castShadow={castShadow}
             receiveShadow={receiveShadow}
@@ -705,6 +709,7 @@ function InstancedSnowOverlays({
             key={`snow:${chunk.key}`}
             castShadow={false}
             chunk={chunk}
+            debugName={`SnowOverlay:${chunk.key}:count:${chunk.instances.length}`}
             geometry={overlayGeometry}
             localTransform={liftedTransform}
             material={material}
@@ -741,6 +746,7 @@ function InstancedRainWetOverlays({
             key={`rain:${chunk.key}`}
             castShadow={false}
             chunk={chunk}
+            debugName={`RainWetOverlay:${chunk.key}:count:${chunk.instances.length}`}
             geometry={geometry}
             localTransform={localTransform}
             material={material}

--- a/packages/game/src/entities/SunflowerDropReward.tsx
+++ b/packages/game/src/entities/SunflowerDropReward.tsx
@@ -188,7 +188,7 @@ function SunflowerDropAtPlacement({
         claimSunflowerDrop.mutate(spawn.spawnId, {
             onSuccess: () => {
                 setHovered(false);
-                spawnParticles(ParticleType.Leaf, drop.particlePosition, 12);
+                spawnParticles(ParticleType.Leaf, drop.particlePosition, 8);
                 onClaimed(origin);
             },
             onError: onRejected,

--- a/packages/game/src/entities/groundDecorations/GroundDecorationInstances.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundDecorationInstances.tsx
@@ -41,12 +41,16 @@ type GroundDecorationBatch = {
     atlasPageIndex: number;
     instances: GroundDecorationBatchInstance[];
     key: string;
-    sprite: SpriteAtlasSprite;
-    spriteName: string;
 };
 
 type GroundDecorationBatchInstance = GroundDecorationInstance & {
     aspect: number;
+    uvTransform: [
+        offsetU: number,
+        offsetV: number,
+        scaleU: number,
+        scaleV: number,
+    ];
     wobble: [
         waveScale: number,
         driftScale: number,
@@ -119,25 +123,9 @@ function resolveAtlasPage(
         : null;
 }
 
-function createSpriteGeometry(
-    maxInstanceCount: number,
-    atlasPage: SpriteAtlasPage,
-    sprite: SpriteAtlasSprite,
-) {
+function createSpriteGeometry(maxInstanceCount: number) {
     const geometry = new PlaneGeometry(1, 1);
     geometry.translate(0, 0.5, 0);
-    const atlas = atlasPage.atlas;
-    const u0 = sprite.frame.x / atlas.width;
-    const u1 = (sprite.frame.x + sprite.frame.width) / atlas.width;
-    const v0 = 1 - (sprite.frame.y + sprite.frame.height) / atlas.height;
-    const v1 = 1 - sprite.frame.y / atlas.height;
-    const uv = geometry.getAttribute('uv');
-
-    uv.setXY(0, u0, v1);
-    uv.setXY(1, u1, v1);
-    uv.setXY(2, u0, v0);
-    uv.setXY(3, u1, v0);
-    uv.needsUpdate = true;
 
     geometry.setAttribute(
         'instanceWobble',
@@ -151,6 +139,13 @@ function createSpriteGeometry(
         new InstancedBufferAttribute(
             new Float32Array(maxInstanceCount * 2),
             2,
+        ).setUsage(DynamicDrawUsage),
+    );
+    geometry.setAttribute(
+        'instanceUvTransform',
+        new InstancedBufferAttribute(
+            new Float32Array(maxInstanceCount * 4),
+            4,
         ).setUsage(DynamicDrawUsage),
     );
 
@@ -172,10 +167,16 @@ function createBatchInstance({
     const rng = new SeededRNG(
         `${groundDecorationAtlasBasePath}:${atlasPage.index}:${instance.spriteName}:${positionKey}`,
     );
+    const atlas = atlasPage.atlas;
+    const u0 = sprite.frame.x / atlas.width;
+    const u1 = (sprite.frame.x + sprite.frame.width) / atlas.width;
+    const v0 = 1 - (sprite.frame.y + sprite.frame.height) / atlas.height;
+    const v1 = 1 - sprite.frame.y / atlas.height;
 
     return {
         ...instance,
         aspect: sprite.aspect,
+        uvTransform: [u0, v0, u1 - u0, v1 - v0],
         wobble: [
             rng.nextRange(1.15, 1.75),
             rng.nextRange(0.7, 1.25),
@@ -245,11 +246,21 @@ function applyGroundDecorationWobbleShader(
 #include <common>
 attribute vec4 instanceWobble;
 attribute vec2 instanceAlphaOpacity;
+attribute vec4 instanceUvTransform;
 varying float vGroundDecorationAlphaTest;
 varying float vGroundDecorationOpacity;
 uniform float uTime;
 uniform vec3 uWindDirection;
 uniform float uWindStrength;
+`,
+        );
+        shader.vertexShader = shader.vertexShader.replace(
+            '#include <uv_vertex>',
+            `
+#include <uv_vertex>
+#ifdef USE_MAP
+vMapUv = instanceUvTransform.xy + uv * instanceUvTransform.zw;
+#endif
 `,
         );
         shader.vertexShader = shader.vertexShader.replace(
@@ -297,7 +308,7 @@ if ( diffuseColor.a < vGroundDecorationAlphaTest ) discard;
         );
         material.userData.groundDecorationShader = shader;
     };
-    material.customProgramCacheKey = () => 'ground-decoration-sprite-batch-v2';
+    material.customProgramCacheKey = () => 'ground-decoration-sprite-batch-v3';
 }
 
 export function GroundDecorationInstances({
@@ -442,8 +453,8 @@ function GroundDecorationPageInstances({
     );
     const { error: textureError, texture } =
         useSpriteAtlasTexture(pageAssetPaths);
-    const batches = useMemo(() => {
-        const batchBySpriteName = new Map<string, GroundDecorationBatch>();
+    const batch = useMemo<GroundDecorationBatch>(() => {
+        const batchInstances: GroundDecorationBatchInstance[] = [];
 
         for (const instance of instances) {
             const sprite = manifestSprites[instance.spriteName];
@@ -451,30 +462,20 @@ function GroundDecorationPageInstances({
                 continue;
             }
 
-            const batchInstance = createBatchInstance({
-                atlasPage,
-                instance,
-                sprite,
-            });
-            const batch = batchBySpriteName.get(instance.spriteName);
-
-            if (batch) {
-                batch.instances.push(batchInstance);
-                continue;
-            }
-
-            batchBySpriteName.set(instance.spriteName, {
-                atlasPageIndex: atlasPage.index,
-                instances: [batchInstance],
-                key: `page:${atlasPage.index}:sprite:${instance.spriteName}`,
-                sprite,
-                spriteName: instance.spriteName,
-            });
+            batchInstances.push(
+                createBatchInstance({
+                    atlasPage,
+                    instance,
+                    sprite,
+                }),
+            );
         }
 
-        return [...batchBySpriteName.values()].sort((left, right) =>
-            left.key.localeCompare(right.key),
-        );
+        return {
+            atlasPageIndex: atlasPage.index,
+            instances: batchInstances,
+            key: `page:${atlasPage.index}`,
+        };
     }, [atlasPage, instances, manifestSprites]);
 
     if (textureError) {
@@ -489,28 +490,24 @@ function GroundDecorationPageInstances({
         return null;
     }
 
+    if (batch.instances.length === 0) {
+        return null;
+    }
+
     return (
-        <>
-            {batches.map((batch) => (
-                <GroundDecorationInstancedBatch
-                    key={batch.key}
-                    atlasPage={atlasPage}
-                    batch={batch}
-                    recordProfileBatch={recordProfileBatch}
-                    texture={texture}
-                />
-            ))}
-        </>
+        <GroundDecorationInstancedBatch
+            batch={batch}
+            recordProfileBatch={recordProfileBatch}
+            texture={texture}
+        />
     );
 }
 
 function GroundDecorationInstancedBatch({
-    atlasPage,
     batch,
     recordProfileBatch,
     texture,
 }: {
-    atlasPage: SpriteAtlasPage;
     batch: GroundDecorationBatch;
     recordProfileBatch: RecordGroundDecorationProfileBatch;
     texture: NonNullable<ReturnType<typeof useSpriteAtlasTexture>['texture']>;
@@ -525,12 +522,8 @@ function GroundDecorationInstancedBatch({
     const rotationZ = useMemo(() => new Quaternion(), []);
     const scale = useMemo(() => new Vector3(), []);
     const geometry = useMemo(() => {
-        return createSpriteGeometry(
-            batch.instances.length,
-            atlasPage,
-            batch.sprite,
-        );
-    }, [atlasPage, batch.instances.length, batch.sprite]);
+        return createSpriteGeometry(batch.instances.length);
+    }, [batch.instances.length]);
     const chunks = useMemo(
         () => createGroundDecorationChunks(batch.instances),
         [batch.instances],
@@ -603,6 +596,9 @@ function GroundDecorationInstancedBatch({
             const alphaOpacityAttribute = geometry.getAttribute(
                 'instanceAlphaOpacity',
             ) as InstancedBufferAttribute;
+            const uvTransformAttribute = geometry.getAttribute(
+                'instanceUvTransform',
+            ) as InstancedBufferAttribute;
             let visibleIndex = 0;
 
             for (const chunk of chunks) {
@@ -627,14 +623,20 @@ function GroundDecorationInstancedBatch({
                         instance.alphaTest,
                         instance.opacity,
                     );
+                    uvTransformAttribute.setXYZW(
+                        visibleIndex,
+                        ...instance.uvTransform,
+                    );
                     visibleIndex += 1;
                 }
             }
 
             mesh.count = visibleIndex;
+            mesh.visible = visibleIndex > 0;
             mesh.instanceMatrix.needsUpdate = true;
             wobbleAttribute.needsUpdate = true;
             alphaOpacityAttribute.needsUpdate = true;
+            uvTransformAttribute.needsUpdate = true;
             mesh.computeBoundingBox();
             mesh.computeBoundingSphere();
             recordProfileBatch(batch.key, {
@@ -681,6 +683,7 @@ function GroundDecorationInstancedBatch({
     return (
         <instancedMesh
             ref={meshRef}
+            name={`GroundDecorations:page:${batch.atlasPageIndex}:instances:${batch.instances.length}`}
             args={[geometry, material, batch.instances.length]}
             receiveShadow
             renderOrder={20}

--- a/packages/game/src/entities/helpers/HoverOutline.tsx
+++ b/packages/game/src/entities/helpers/HoverOutline.tsx
@@ -1,4 +1,4 @@
-import { type RootState, useFrame } from '@react-three/fiber';
+import { addAfterEffect, type RootState, useThree } from '@react-three/fiber';
 import {
     createContext,
     type PropsWithChildren,
@@ -7,6 +7,7 @@ import {
     useLayoutEffect,
     useMemo,
     useRef,
+    useSyncExternalStore,
 } from 'react';
 import {
     Box3,
@@ -34,7 +35,6 @@ import {
 
 const hoverOutlineLayer = 29;
 const maxOutlineThickness = 12;
-const outlineRenderPriority = 1;
 
 type HoverOutlineTarget = {
     active: boolean;
@@ -48,10 +48,14 @@ type HoverOutlineTarget = {
 type HoverOutlineRegistry = {
     deleteTarget: (id: symbol) => void;
     getActiveTargets: () => HoverOutlineTarget[];
+    getSnapshot: () => number;
     setTarget: (id: symbol, target: HoverOutlineTarget) => void;
+    subscribe: (listener: () => void) => () => void;
 };
 
 const HoverOutlineContext = createContext<HoverOutlineRegistry | null>(null);
+const noopSubscribe = () => () => {};
+const zeroSnapshot = () => 0;
 
 function createMaskMaterial() {
     const material = new MeshBasicMaterial({
@@ -248,23 +252,40 @@ function getOutlineScreenBounds({
 }
 
 function useHoverOutlineRegistry() {
+    const listeners = useRef(new Set<() => void>());
     const targets = useRef(new Map<symbol, HoverOutlineTarget>());
+    const version = useRef(0);
 
-    return useMemo<HoverOutlineRegistry>(
-        () => ({
+    return useMemo<HoverOutlineRegistry>(() => {
+        const notify = () => {
+            version.current += 1;
+            for (const listener of listeners.current) {
+                listener();
+            }
+        };
+
+        return {
             deleteTarget: (id) => {
-                targets.current.delete(id);
+                if (!targets.current.delete(id)) {
+                    return;
+                }
+                notify();
             },
             getActiveTargets: () =>
                 Array.from(targets.current.values()).filter(
                     (target) => target.active && target.object.parent,
                 ),
+            getSnapshot: () => version.current,
             setTarget: (id, target) => {
                 targets.current.set(id, target);
+                notify();
             },
-        }),
-        [],
-    );
+            subscribe: (listener) => {
+                listeners.current.add(listener);
+                return () => listeners.current.delete(listener);
+            },
+        };
+    }, []);
 }
 
 function useTargetId() {
@@ -463,110 +484,156 @@ export function HoverOutline({
         return () => registry.deleteTarget(id);
     }, [clampedThickness, color, hovered, id, opacity, priority, registry]);
 
-    return <group ref={ref}>{children}</group>;
+    return (
+        <group ref={ref} name="Interaction:HoverOutlineTarget">
+            {children}
+        </group>
+    );
 }
 
 export function HoverOutlineEffect() {
     const registry = useContext(HoverOutlineContext);
+    const camera = useThree((state) => state.camera);
     const drawingBufferSize = useMemo(() => new Vector2(), []);
+    const gl = useThree((state) => state.gl);
+    const invalidate = useThree((state) => state.invalidate);
     const maskMaterial = useMemo(createMaskMaterial, []);
     const maskRenderTarget = useMaskRenderTarget();
-    const outlineOverlay = useOutlineOverlay();
+    const {
+        camera: outlineCamera,
+        material: outlineMaterial,
+        scene: outlineScene,
+    } = useOutlineOverlay();
+    const scene = useThree((state) => state.scene);
     const screenBoundsScratch = useMemo<ScreenBoundsScratch>(
         () => ({ box: new Box3(), point: new Vector3() }),
         [],
     );
+    const registryVersion = useSyncExternalStore(
+        registry?.subscribe ?? noopSubscribe,
+        registry?.getSnapshot ?? zeroSnapshot,
+        zeroSnapshot,
+    );
+    const hasActiveTargets = (registry?.getActiveTargets().length ?? 0) > 0;
+    const wasActiveRef = useRef(false);
 
     useEffect(() => () => maskMaterial.dispose(), [maskMaterial]);
 
-    useFrame(({ camera, gl, scene }) => {
-        gl.render(scene, camera);
-
-        const targets = registry?.getActiveTargets() ?? [];
-        if (targets.length === 0) {
+    useEffect(() => {
+        if (!registry || !hasActiveTargets) {
             return;
         }
 
-        const targetsByStyle = new Map<string, HoverOutlineTarget[]>();
-        for (const target of targets) {
-            const key = [
-                target.priority,
-                target.color,
-                target.opacity,
-                target.thickness,
-            ].join('|');
-            targetsByStyle.set(key, [
-                ...(targetsByStyle.get(key) ?? []),
-                target,
-            ]);
-        }
+        const renderOutline = () => {
+            const targets = registry.getActiveTargets();
+            if (targets.length === 0) {
+                return;
+            }
 
-        const targetGroups = Array.from(targetsByStyle.values()).sort(
-            (left, right) => {
-                const leftTarget = left[0];
-                const rightTarget = right[0];
-                return (
-                    (leftTarget?.priority ?? 0) - (rightTarget?.priority ?? 0)
+            const targetsByStyle = new Map<string, HoverOutlineTarget[]>();
+            for (const target of targets) {
+                const key = [
+                    target.priority,
+                    target.color,
+                    target.opacity,
+                    target.thickness,
+                ].join('|');
+                targetsByStyle.set(key, [
+                    ...(targetsByStyle.get(key) ?? []),
+                    target,
+                ]);
+            }
+
+            const targetGroups = Array.from(targetsByStyle.values()).sort(
+                (left, right) => {
+                    const leftTarget = left[0];
+                    const rightTarget = right[0];
+                    return (
+                        (leftTarget?.priority ?? 0) -
+                        (rightTarget?.priority ?? 0)
+                    );
+                },
+            );
+
+            for (const targetGroup of targetGroups) {
+                const [firstTarget] = targetGroup;
+                if (!firstTarget) {
+                    continue;
+                }
+
+                renderMask({
+                    camera,
+                    drawingBufferSize,
+                    gl,
+                    maskMaterial,
+                    renderTarget: maskRenderTarget,
+                    scene,
+                    targets: targetGroup,
+                });
+
+                outlineMaterial.uniforms.maskTexture.value =
+                    maskRenderTarget.texture;
+                outlineMaterial.uniforms.outlineColor.value.set(
+                    firstTarget.color,
                 );
-            },
-        );
+                outlineMaterial.uniforms.opacity.value = firstTarget.opacity;
+                const screenBounds = getOutlineScreenBounds({
+                    camera,
+                    drawingBufferSize,
+                    scratch: screenBoundsScratch,
+                    targets: targetGroup,
+                    thickness: firstTarget.thickness,
+                });
 
-        for (const targetGroup of targetGroups) {
-            const [firstTarget] = targetGroup;
-            if (!firstTarget) {
-                continue;
+                if (!screenBounds) {
+                    continue;
+                }
+
+                outlineMaterial.uniforms.screenMin.value.set(
+                    screenBounds.minX,
+                    screenBounds.minY,
+                );
+                outlineMaterial.uniforms.screenMax.value.set(
+                    screenBounds.maxX,
+                    screenBounds.maxY,
+                );
+                outlineMaterial.uniforms.texelSize.value.set(
+                    1 / maskRenderTarget.width,
+                    1 / maskRenderTarget.height,
+                );
+                outlineMaterial.uniforms.thickness.value =
+                    firstTarget.thickness;
+
+                const previousAutoClear = gl.autoClear;
+                gl.autoClear = false;
+                gl.render(outlineScene, outlineCamera);
+                gl.autoClear = previousAutoClear;
             }
+        };
 
-            renderMask({
-                camera,
-                drawingBufferSize,
-                gl,
-                maskMaterial,
-                renderTarget: maskRenderTarget,
-                scene,
-                targets: targetGroup,
-            });
+        return addAfterEffect(renderOutline);
+    }, [
+        camera,
+        drawingBufferSize,
+        gl,
+        hasActiveTargets,
+        maskMaterial,
+        maskRenderTarget,
+        outlineCamera,
+        outlineMaterial,
+        outlineScene,
+        registry,
+        scene,
+        screenBoundsScratch,
+    ]);
 
-            outlineOverlay.material.uniforms.maskTexture.value =
-                maskRenderTarget.texture;
-            outlineOverlay.material.uniforms.outlineColor.value.set(
-                firstTarget.color,
-            );
-            outlineOverlay.material.uniforms.opacity.value =
-                firstTarget.opacity;
-            const screenBounds = getOutlineScreenBounds({
-                camera,
-                drawingBufferSize,
-                scratch: screenBoundsScratch,
-                targets: targetGroup,
-                thickness: firstTarget.thickness,
-            });
-
-            if (!screenBounds) {
-                continue;
-            }
-
-            outlineOverlay.material.uniforms.screenMin.value.set(
-                screenBounds.minX,
-                screenBounds.minY,
-            );
-            outlineOverlay.material.uniforms.screenMax.value.set(
-                screenBounds.maxX,
-                screenBounds.maxY,
-            );
-            outlineOverlay.material.uniforms.texelSize.value.set(
-                1 / maskRenderTarget.width,
-                1 / maskRenderTarget.height,
-            );
-            outlineOverlay.material.uniforms.thickness.value =
-                firstTarget.thickness;
-
-            const previousAutoClear = gl.autoClear;
-            gl.autoClear = false;
-            gl.render(outlineOverlay.scene, outlineOverlay.camera);
-            gl.autoClear = previousAutoClear;
+    useEffect(() => {
+        void registryVersion;
+        if (wasActiveRef.current || hasActiveTargets) {
+            invalidate();
         }
-    }, outlineRenderPriority);
+        wasActiveRef.current = hasActiveTargets;
+    }, [hasActiveTargets, invalidate, registryVersion]);
 
     return null;
 }

--- a/packages/game/src/entities/helpers/PlacementDropAnimation.tsx
+++ b/packages/game/src/entities/helpers/PlacementDropAnimation.tsx
@@ -72,7 +72,7 @@ export function PlacementDropAnimation({
             spawn(
                 resolveBlockParticleType(block.name),
                 toVector3(particlePosition),
-                12,
+                8,
             );
         };
         const finish = () => {
@@ -103,8 +103,16 @@ export function PlacementDropAnimation({
     ]);
 
     return (
-        <group position={position}>
-            <animated.group position-y={dropOffsetY}>{children}</animated.group>
+        <group
+            name={`Animation:PlacementDrop:${block.name}:${block.id}`}
+            position={position}
+        >
+            <animated.group
+                name={`Animation:PlacementDropOffset:${block.name}:${block.id}`}
+                position-y={dropOffsetY}
+            >
+                {children}
+            </animated.group>
         </group>
     );
 }

--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -1,5 +1,11 @@
+import { useGameFlags } from '../../GameFlagsContext';
 import { useGameSceneDetails } from '../../GameSceneDetailContext';
-import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { resolveInGamePlantPreset } from '../../generators/plant/lib/inGamePlantPresets';
+import {
+    useCurrentGarden,
+    useIsSandboxGarden,
+} from '../../hooks/useCurrentGarden';
+import { useAllSorts } from '../../hooks/usePlantSorts';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
 import { useGameState } from '../../useGameState';
 import {
@@ -7,11 +13,37 @@ import {
     getRaisedBedBlockIds,
 } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
-import { RaisedBedPlantField } from './RaisedBedPlantField';
+import {
+    mockPlantPresetLabelsBySortId,
+    RaisedBedPlantField,
+} from './RaisedBedPlantField';
 
-export function RaisedBedFields({ blockId }: { blockId: string }) {
+function shouldRenderGeneratedPlantField(field: {
+    positionIndex: number;
+    plantStatus?: string | null;
+    plantSowDate?: string | null;
+}) {
+    return (
+        Boolean(field.plantSowDate) &&
+        (field.plantStatus === 'sprouted' ||
+            field.plantStatus === 'ready' ||
+            field.plantStatus === 'harvested')
+    );
+}
+
+export function RaisedBedFields({
+    blockId,
+    generatedPlantsHandledExternally = false,
+}: {
+    blockId: string;
+    generatedPlantsHandledExternally?: boolean;
+}) {
     const { renderDetails } = useGameSceneDetails();
+    const flags = useGameFlags();
     const { data: currentGarden } = useCurrentGarden();
+    const { data: sortData } = useAllSorts();
+    const isMock = useGameState((state) => state.isMock);
+    const isSandbox = useIsSandboxGarden();
     const isLocalSandbox = useGameState(
         (state) => state.localSandboxStorageKey !== null,
     );
@@ -56,6 +88,8 @@ export function RaisedBedFields({ blockId }: { blockId: string }) {
             return field;
         }) || []),
     ];
+    const generatedPlantsEnabled =
+        Boolean(flags.enablePlantGeneratorFlag) || isMock || isSandbox;
 
     if (!renderDetails) {
         return null;
@@ -65,6 +99,29 @@ export function RaisedBedFields({ blockId }: { blockId: string }) {
         <>
             {displayedFields.map((field) => {
                 if (!field) return null;
+                if (
+                    generatedPlantsHandledExternally &&
+                    generatedPlantsEnabled &&
+                    field.plantSortId &&
+                    shouldRenderGeneratedPlantField(field)
+                ) {
+                    const sort = sortData?.find(
+                        (item) => item.id === field.plantSortId,
+                    );
+                    const resolvedPlantPreset = resolveInGamePlantPreset([
+                        sort?.information.name,
+                        sort?.information.plant.information?.name,
+                        sort?.information.plant.information?.latinName,
+                        isMock || isSandbox
+                            ? mockPlantPresetLabelsBySortId[field.plantSortId]
+                            : undefined,
+                    ]);
+
+                    if (resolvedPlantPreset) {
+                        return null;
+                    }
+                }
+
                 return (
                     <RaisedBedPlantField
                         key={field.id}

--- a/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantBatch.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantBatch.tsx
@@ -1,30 +1,25 @@
 'use client';
 
-import { useLayoutEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import * as THREE from 'three';
-import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
-import CSM from 'three-custom-shader-material';
 import { useGeneratedLSystemSymbolsBatch } from '../../generators/plant/hooks/useGeneratedLSystem';
-import type { PlantLodLevel } from '../../generators/plant/hooks/usePlantLod';
-import { usePlantSway } from '../../generators/plant/hooks/usePlantSway';
-import { buildPlantRenderData } from '../../generators/plant/lib/buildPlantRenderData';
+import {
+    buildPlantRenderData,
+    type PlantStemSegment,
+} from '../../generators/plant/lib/buildPlantRenderData';
 import {
     MAX_PLANT_GENERATION,
     type PlantDefinition,
 } from '../../generators/plant/lib/plant-definitions';
-import {
-    createStemSurfaceUniforms,
-    stemSurfaceFragmentShader,
-    stemSurfaceVertexShader,
-} from '../../generators/plant/lib/plant-stem-material';
-import { PlantGenerator } from '../../generators/plant/PlantGenerator';
+import type { PlantLodLevel } from '../../generators/plant/lib/plantLod';
 import { Flowers } from '../../generators/plant/parts/flowers';
 import { Leaves } from '../../generators/plant/parts/leaves';
-import { PlantBillboard } from '../../generators/plant/parts/PlantBillboard';
+import { PlantBillboardBatch } from '../../generators/plant/parts/PlantBillboard';
+import { Stems } from '../../generators/plant/parts/stems';
 import { Thorns } from '../../generators/plant/parts/thorns';
 import { Vegetables } from '../../generators/plant/parts/vegetables';
 
-interface RaisedBedGeneratedPlantBatchInstance {
+export interface RaisedBedGeneratedPlantBatchInstance {
     generation: number;
     position: readonly [number, number, number];
     scale: number;
@@ -49,7 +44,7 @@ type BatchedPlantRenderData = {
     flowers: THREE.Matrix4[];
     leafColors: THREE.Color[];
     leaves: THREE.Matrix4[];
-    stemGeometry: THREE.BufferGeometry;
+    stemSegments: PlantStemSegment[];
     thorns: THREE.Matrix4[];
     vegetables: ReturnType<typeof buildPlantRenderData>['vegetables'];
 };
@@ -63,36 +58,20 @@ function RaisedBedDetailedPlantBatch({
     batchedData: BatchedPlantRenderData;
     definition: PlantDefinition;
 }) {
-    const stemSwayUniforms = usePlantSway(batchSeed, {
-        amplitude: 0.055,
-        speed: 1.1,
-    });
-    const stemSurfaceUniforms = useMemo(
-        () => createStemSurfaceUniforms(definition.stem),
-        [definition.stem],
-    );
-
     return (
-        <group>
-            <mesh geometry={batchedData.stemGeometry} castShadow>
-                <CSM
-                    baseMaterial={THREE.MeshStandardMaterial}
-                    vertexShader={stemSurfaceVertexShader}
-                    fragmentShader={stemSurfaceFragmentShader}
-                    uniforms={{
-                        ...stemSwayUniforms,
-                        ...stemSurfaceUniforms,
-                    }}
-                    color={definition.stem.color}
-                    roughness={0.8}
-                    metalness={0.2}
-                />
-            </mesh>
+        <group name={`RaisedBedPlantBatch:${definition.name}:near`}>
+            <Stems
+                seed={batchSeed}
+                segments={batchedData.stemSegments}
+                stem={definition.stem}
+                debugName={`RaisedBedPlantStems:${definition.name}:segments:${batchedData.stemSegments.length}`}
+            />
             <Leaves
                 seed={`${batchSeed}-leaves`}
                 matrices={batchedData.leaves}
                 colors={batchedData.leafColors}
                 type={definition.leaf.type}
+                debugName={`RaisedBedPlantLeaves:${definition.name}:count:${batchedData.leaves.length}`}
             />
             {definition.flower.enabled && (
                 <Flowers
@@ -154,7 +133,7 @@ export function RaisedBedGeneratedPlantBatch({
         const rootPosition = new THREE.Vector3();
         const rootScale = new THREE.Vector3();
         const rootMatrix = new THREE.Matrix4();
-        const stemGeometries: THREE.BufferGeometry[] = [];
+        const stemSegments: PlantStemSegment[] = [];
         const leaves: THREE.Matrix4[] = [];
         const leafColors: THREE.Color[] = [];
         const flowers: THREE.Matrix4[] = [];
@@ -196,17 +175,15 @@ export function RaisedBedGeneratedPlantBatch({
             rootMatrix.compose(rootPosition, ROOT_QUATERNION, rootScale);
 
             if (!renderDetailedGeometry) {
-                plantData.stemGeometry.dispose();
                 return;
             }
 
-            if (plantData.stemGeometry.getAttribute('position')) {
-                plantData.stemGeometry.applyMatrix4(rootMatrix);
-                stemGeometries.push(plantData.stemGeometry);
-            } else {
-                plantData.stemGeometry.dispose();
-            }
-
+            plantData.stemSegments.forEach((segment) => {
+                stemSegments.push({
+                    ...segment,
+                    matrix: segment.matrix.clone().premultiply(rootMatrix),
+                });
+            });
             plantData.leaves.forEach((matrix) => {
                 leaves.push(matrix.clone().premultiply(rootMatrix));
             });
@@ -226,29 +203,16 @@ export function RaisedBedGeneratedPlantBatch({
                 thorns.push(matrix.clone().premultiply(rootMatrix));
             });
         });
-        const stemGeometry = stemGeometries.length
-            ? mergeGeometries(stemGeometries)
-            : new THREE.BufferGeometry();
-        stemGeometries.forEach((geometry) => {
-            geometry.dispose();
-        });
-
         return {
             billboards,
             flowers,
             leafColors,
             leaves,
-            stemGeometry,
+            stemSegments,
             thorns,
             vegetables,
         } satisfies BatchedPlantRenderData;
     }, [definition, instances, renderDetailedGeometry, symbols]);
-
-    useLayoutEffect(() => {
-        return () => {
-            batchedData?.stemGeometry.dispose();
-        };
-    }, [batchedData]);
 
     if (!batchedData) {
         return null;
@@ -256,44 +220,11 @@ export function RaisedBedGeneratedPlantBatch({
 
     if (lodLevel !== 'near') {
         return (
-            <group>
-                {batchedData.billboards.map((billboard) => (
-                    <group
-                        key={billboard.seed}
-                        position={billboard.position}
-                        scale={[
-                            billboard.scale,
-                            billboard.scale,
-                            billboard.scale,
-                        ]}
-                    >
-                        <PlantBillboard
-                            level={lodLevel}
-                            summary={billboard.summary}
-                        />
-                    </group>
-                ))}
-            </group>
-        );
-    }
-
-    if (instances.length <= 1 && symbols[0]) {
-        const [instance] = instances;
-
-        return (
-            <group
-                position={instance.position}
-                scale={[instance.scale, instance.scale, instance.scale]}
-            >
-                <PlantGenerator
-                    plantDefinition={definition}
-                    lSystemSymbols={symbols[0]}
-                    generation={instance.generation}
-                    seed={instance.seed}
-                    flowerGrowth={1}
-                    fruitGrowth={1}
-                />
-            </group>
+            <PlantBillboardBatch
+                billboards={batchedData.billboards}
+                debugName={`RaisedBedPlantBillboards:${definition.name}`}
+                level={lodLevel}
+            />
         );
     }
 

--- a/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedGeneratedPlantFieldBatches.tsx
@@ -1,0 +1,483 @@
+'use client';
+
+import { calculatePlantsPerField } from '@gredice/js/plants';
+import { useFrame, useThree } from '@react-three/fiber';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { useGameFlags } from '../../GameFlagsContext';
+import { useGameSceneDetails } from '../../GameSceneDetailContext';
+import { getApproximatePlantHeight } from '../../generators/plant/lib/buildPlantRenderData';
+import {
+    calculateInGamePlantGeneration,
+    getPlantLifecycleWindowDays,
+    type ResolvedInGamePlantPreset,
+    resolveInGamePlantPreset,
+} from '../../generators/plant/lib/inGamePlantPresets';
+import {
+    type PlantLodLevel,
+    resolvePlantLodLevelWithHysteresis,
+} from '../../generators/plant/lib/plantLod';
+import {
+    useCurrentGarden,
+    useIsSandboxGarden,
+} from '../../hooks/useCurrentGarden';
+import { useAllSorts } from '../../hooks/usePlantSorts';
+import { useShoppingCart } from '../../hooks/useShoppingCart';
+import { useSnapshotTime } from '../../hooks/useSnapshotTime';
+import { useGameState } from '../../useGameState';
+import {
+    findRaisedBedByBlockId,
+    getRaisedBedBlockIds,
+} from '../../utils/raisedBedBlocks';
+import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
+import {
+    getGridPositionFromIndex,
+    type RaisedBedOrientation,
+} from '../../utils/raisedBedOrientation';
+import {
+    RaisedBedGeneratedPlantBatch,
+    type RaisedBedGeneratedPlantBatchInstance,
+} from './RaisedBedGeneratedPlantBatch';
+import { mockPlantPresetLabelsBySortId } from './RaisedBedPlantField';
+
+export interface RaisedBedGeneratedPlantFieldBatchBlock {
+    blockId: string;
+    position: readonly [number, number, number];
+}
+
+type DisplayedRaisedBedField = {
+    id?: number | string;
+    positionIndex: number;
+    plantSortId: number | null | undefined;
+    plantStatus?: string | null;
+    plantSowDate?: string | null;
+};
+
+type GeneratedPlantField = {
+    approximatePlantHeight: number;
+    definition: ResolvedInGamePlantPreset['definition'];
+    fieldKey: string;
+    instances: RaisedBedGeneratedPlantBatchInstance[];
+    plantType: ResolvedInGamePlantPreset['plantType'];
+    position: readonly [number, number, number];
+};
+
+type GeneratedPlantBatch = {
+    definition: ResolvedInGamePlantPreset['definition'];
+    instances: RaisedBedGeneratedPlantBatchInstance[];
+    lodLevel: PlantLodLevel;
+    plantType: ResolvedInGamePlantPreset['plantType'];
+};
+
+const seedLayoutByPlantsPerRow = [
+    { multiplier: 0, offset: 0 },
+    { multiplier: 0, offset: 0 },
+    { multiplier: 0.13, offset: 0.03 },
+    { multiplier: 0.09, offset: 0.025 },
+    { multiplier: 0.07, offset: 0.0225 },
+];
+
+const FIELD_VISIBILITY_MARGIN = 0.24;
+
+function getFieldRenderKey(blockId: string, field: DisplayedRaisedBedField) {
+    return `${blockId}:${field.id ?? 'field'}:${field.positionIndex}:${field.plantSortId ?? 'sort'}`;
+}
+
+function shouldRenderGeneratedPlantField(field: DisplayedRaisedBedField) {
+    return (
+        Boolean(field.plantSowDate) &&
+        (field.plantStatus === 'sprouted' ||
+            field.plantStatus === 'ready' ||
+            field.plantStatus === 'harvested')
+    );
+}
+
+function getFieldPosition({
+    blockIndex,
+    blockPosition,
+    orientation,
+    positionIndex,
+}: {
+    blockIndex: number;
+    blockPosition: readonly [number, number, number];
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+}) {
+    const offsetX =
+        orientation === 'vertical' ? 0.31 - blockIndex * 0.05 : 0.27;
+    const offsetY =
+        orientation === 'vertical' ? 0.27 : 0.27 + blockIndex * 0.05;
+    const multiplierX = orientation === 'vertical' ? 0.285 : 0.27;
+    const multiplierY = orientation === 'vertical' ? 0.27 : 0.285;
+    const { row, col } = getGridPositionFromIndex(positionIndex, orientation);
+
+    return [
+        blockPosition[0] + col * multiplierX - offsetX,
+        blockPosition[1] - 0.75,
+        blockPosition[2] + (2 - row) * multiplierY - offsetY,
+    ] as const;
+}
+
+function getOrthographicCameraZoom(camera: THREE.Camera) {
+    return camera instanceof THREE.OrthographicCamera ? camera.zoom : 0;
+}
+
+function resolveGeneratedFieldVisibility({
+    approximatePlantHeight,
+    camera,
+    viewportHeight,
+    worldPosition,
+}: {
+    approximatePlantHeight: number;
+    camera: THREE.Camera;
+    viewportHeight: number;
+    worldPosition: THREE.Vector3;
+}) {
+    const projected = worldPosition.clone().project(camera);
+    if (
+        !Number.isFinite(projected.x) ||
+        !Number.isFinite(projected.y) ||
+        !Number.isFinite(projected.z)
+    ) {
+        return true;
+    }
+
+    const plantMargin = Math.max(approximatePlantHeight, 0.25) / viewportHeight;
+    const ndcMargin = FIELD_VISIBILITY_MARGIN + plantMargin * 2;
+
+    return (
+        Math.abs(projected.x) <= 1 + ndcMargin &&
+        Math.abs(projected.y) <= 1 + ndcMargin
+    );
+}
+
+function useGeneratedPlantFieldLods(generatedFields: GeneratedPlantField[]) {
+    const camera = useThree((state) => state.camera);
+    const viewport = useThree((state) => state.viewport);
+    const gameCamera = useGameState((state) => state.gameCamera);
+    const worldPosition = useMemo(() => new THREE.Vector3(), []);
+    const [lodByFieldKey, setLodByFieldKey] = useState(
+        () => new Map<string, { level: PlantLodLevel; visible: boolean }>(),
+    );
+    const lodByFieldKeyRef = useRef(lodByFieldKey);
+
+    useLayoutEffect(() => {
+        lodByFieldKeyRef.current = lodByFieldKey;
+    }, [lodByFieldKey]);
+
+    const updateLods = useCallback(() => {
+        if (generatedFields.length === 0) {
+            setLodByFieldKey((current) =>
+                current.size === 0 ? current : new Map(),
+            );
+            return;
+        }
+
+        const next = new Map<
+            string,
+            { level: PlantLodLevel; visible: boolean }
+        >();
+
+        for (const field of generatedFields) {
+            worldPosition.set(...field.position);
+            const currentViewport = viewport.getCurrentViewport(
+                camera,
+                worldPosition,
+            );
+            const viewportHeight = Math.max(currentViewport.height, 0.001);
+            const screenOccupancy =
+                Math.max(field.approximatePlantHeight, 0.25) / viewportHeight;
+            const visible = resolveGeneratedFieldVisibility({
+                approximatePlantHeight: field.approximatePlantHeight,
+                camera,
+                viewportHeight,
+                worldPosition,
+            });
+            const previousLevel =
+                lodByFieldKeyRef.current.get(field.fieldKey)?.level ?? 'far';
+            const level = resolvePlantLodLevelWithHysteresis({
+                cameraZoom: getOrthographicCameraZoom(camera),
+                currentLevel: previousLevel,
+                screenOccupancy,
+            });
+
+            next.set(field.fieldKey, {
+                level: visible ? level : 'far',
+                visible,
+            });
+        }
+
+        setLodByFieldKey((current) => {
+            if (current.size !== next.size) {
+                return next;
+            }
+
+            for (const [key, nextState] of next) {
+                const currentState = current.get(key);
+                if (
+                    !currentState ||
+                    currentState.level !== nextState.level ||
+                    currentState.visible !== nextState.visible
+                ) {
+                    return next;
+                }
+            }
+
+            return current;
+        });
+    }, [camera, generatedFields, viewport, worldPosition]);
+
+    useLayoutEffect(() => {
+        updateLods();
+
+        if (!gameCamera) {
+            return;
+        }
+
+        return gameCamera.subscribe(() => updateLods());
+    }, [gameCamera, updateLods]);
+
+    useFrame(() => {
+        if (gameCamera) {
+            return;
+        }
+
+        updateLods();
+    });
+
+    return lodByFieldKey;
+}
+
+export function RaisedBedGeneratedPlantFieldBatches({
+    blocks,
+}: {
+    blocks: RaisedBedGeneratedPlantFieldBatchBlock[];
+}) {
+    const { renderDetails } = useGameSceneDetails();
+    const flags = useGameFlags();
+    const { data: currentGarden } = useCurrentGarden();
+    const { data: sortData } = useAllSorts();
+    const isMock = useGameState((state) => state.isMock);
+    const isSandbox = useIsSandboxGarden();
+    const isLocalSandbox = useGameState(
+        (state) => state.localSandboxStorageKey !== null,
+    );
+    const currentTime = useSnapshotTime();
+    const { data: cart } = useShoppingCart(renderDetails && !isLocalSandbox);
+    const generatedPlantsEnabled =
+        Boolean(flags.enablePlantGeneratorFlag) || isMock || isSandbox;
+    const generatedFields = useMemo(() => {
+        const fields: GeneratedPlantField[] = [];
+
+        if (!renderDetails || !generatedPlantsEnabled || !currentGarden) {
+            return fields;
+        }
+
+        for (const block of blocks) {
+            const raisedBed = findRaisedBedByBlockId(
+                currentGarden,
+                block.blockId,
+            );
+            if (!raisedBed) {
+                continue;
+            }
+
+            const orientation = raisedBed.orientation ?? 'vertical';
+            const blockIds = getRaisedBedBlockIds(currentGarden, raisedBed.id);
+            const blockIndex = blockIds.indexOf(block.blockId);
+            const blockOffset =
+                Math.max(blockIds.length - 1 - blockIndex, 0) * 9;
+            const cartItems = cart?.items.filter(
+                (item) =>
+                    item.gardenId === currentGarden.id &&
+                    item.raisedBedId === raisedBed.id &&
+                    item.entityTypeName === 'plantSort' &&
+                    typeof item.positionIndex === 'number' &&
+                    item.positionIndex >= blockOffset &&
+                    item.positionIndex < blockOffset + 9,
+            );
+            const displayedFields: DisplayedRaisedBedField[] = [
+                ...(raisedBed.fields
+                    ?.filter(
+                        (field) =>
+                            isRaisedBedFieldOccupied(field) &&
+                            field.positionIndex >= blockOffset &&
+                            field.positionIndex < blockOffset + 9,
+                    )
+                    .map((field) => ({
+                        id: field.id,
+                        plantSortId: field.plantSortId,
+                        plantStatus: field.plantStatus,
+                        plantSowDate: field.plantSowDate,
+                        positionIndex: field.positionIndex,
+                    })) ?? []),
+                ...(cartItems?.flatMap((item) => {
+                    if (item.positionIndex === null) {
+                        return [];
+                    }
+
+                    return [
+                        {
+                            id: `cart-item-${item.id}`,
+                            plantSortId: Number(item.entityId),
+                            positionIndex: item.positionIndex,
+                        },
+                    ];
+                }) ?? []),
+            ];
+
+            for (const field of displayedFields) {
+                const plantSortId = field.plantSortId;
+                const sort = sortData?.find((item) => item.id === plantSortId);
+                const resolvedPlantPreset = resolveInGamePlantPreset([
+                    sort?.information.name,
+                    sort?.information.plant.information?.name,
+                    sort?.information.plant.information?.latinName,
+                    isMock || isSandbox
+                        ? mockPlantPresetLabelsBySortId[plantSortId ?? 0]
+                        : undefined,
+                ]);
+
+                if (
+                    !plantSortId ||
+                    !resolvedPlantPreset ||
+                    !shouldRenderGeneratedPlantField(field)
+                ) {
+                    continue;
+                }
+
+                const { plantsPerRow, totalPlants } = calculatePlantsPerField(
+                    sort?.information.plant.attributes?.seedingDistance,
+                );
+                const safePlantsPerRow = Math.max(plantsPerRow, 1);
+                const seedLayout =
+                    seedLayoutByPlantsPerRow[safePlantsPerRow] ??
+                    seedLayoutByPlantsPerRow[
+                        seedLayoutByPlantsPerRow.length - 1
+                    ];
+                const plantGeneration = calculateInGamePlantGeneration({
+                    currentTime,
+                    sowDate: field.plantSowDate ?? '',
+                    lifecycleWindowDays: getPlantLifecycleWindowDays({
+                        germinationWindowMax:
+                            sort?.information.plant.attributes
+                                ?.germinationWindowMax,
+                        growthWindowMax:
+                            sort?.information.plant.attributes?.growthWindowMax,
+                        harvestWindowMax:
+                            sort?.information.plant.attributes
+                                ?.harvestWindowMax,
+                    }),
+                    growthMultiplier: resolvedPlantPreset.growthMultiplier,
+                });
+                const plantInstanceScale =
+                    resolvedPlantPreset.instanceScale *
+                    Math.max(
+                        0.72,
+                        1 - Math.max(0, safePlantsPerRow - 2) * 0.12,
+                    );
+                const fieldPosition = getFieldPosition({
+                    blockIndex,
+                    blockPosition: block.position,
+                    orientation,
+                    positionIndex: field.positionIndex - blockOffset,
+                });
+                const approximatePlantHeight =
+                    getApproximatePlantHeight(
+                        resolvedPlantPreset.definition,
+                        plantGeneration,
+                    ) * plantInstanceScale;
+                const instances: RaisedBedGeneratedPlantBatchInstance[] = [];
+
+                for (let index = 0; index < totalPlants; index += 1) {
+                    const slotX =
+                        Math.floor(index / safePlantsPerRow) *
+                            seedLayout.multiplier -
+                        safePlantsPerRow * seedLayout.offset;
+                    const slotZ =
+                        (index % safePlantsPerRow) * seedLayout.multiplier -
+                        safePlantsPerRow * seedLayout.offset;
+
+                    instances.push({
+                        generation: plantGeneration,
+                        position: [
+                            fieldPosition[0] + slotX,
+                            fieldPosition[1] + 0.02,
+                            fieldPosition[2] + slotZ,
+                        ],
+                        scale: plantInstanceScale,
+                        seed: `${block.blockId}:${plantSortId}:${field.positionIndex}:${index}`,
+                    });
+                }
+
+                fields.push({
+                    approximatePlantHeight,
+                    definition: resolvedPlantPreset.definition,
+                    fieldKey: getFieldRenderKey(block.blockId, field),
+                    instances,
+                    plantType: resolvedPlantPreset.plantType,
+                    position: fieldPosition,
+                });
+            }
+        }
+
+        return fields;
+    }, [
+        blocks,
+        cart?.items,
+        currentGarden,
+        currentTime,
+        generatedPlantsEnabled,
+        isMock,
+        isSandbox,
+        renderDetails,
+        sortData,
+    ]);
+    const lods = useGeneratedPlantFieldLods(generatedFields);
+    const batches = useMemo(() => {
+        const batchMap = new Map<string, GeneratedPlantBatch>();
+
+        for (const field of generatedFields) {
+            const lod = lods.get(field.fieldKey);
+            if (!lod?.visible) {
+                continue;
+            }
+
+            const batchKey = `${field.plantType}:${lod.level}`;
+            let batch = batchMap.get(batchKey);
+
+            if (!batch) {
+                batch = {
+                    definition: field.definition,
+                    instances: [],
+                    lodLevel: lod.level,
+                    plantType: field.plantType,
+                };
+                batchMap.set(batchKey, batch);
+            }
+
+            batch.instances.push(...field.instances);
+        }
+
+        return Array.from(batchMap.values());
+    }, [generatedFields, lods]);
+
+    if (!renderDetails || batches.length === 0) {
+        return null;
+    }
+
+    return (
+        <group
+            name={`RaisedBedGeneratedPlantFieldBatches:batches:${batches.length}`}
+        >
+            {batches.map((batch) => (
+                <RaisedBedGeneratedPlantBatch
+                    key={`${batch.plantType}:${batch.lodLevel}`}
+                    definition={batch.definition}
+                    instances={batch.instances}
+                    lodLevel={batch.lodLevel}
+                />
+            ))}
+        </group>
+    );
+}

--- a/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
@@ -21,7 +21,7 @@ import {
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { RaisedBedGeneratedPlantBatch } from './RaisedBedGeneratedPlantBatch';
 
-const mockPlantPresetLabelsBySortId: Record<number, string> = {
+export const mockPlantPresetLabelsBySortId: Record<number, string> = {
     219: 'pepper',
     226: 'cucumber',
     230: 'carrot',

--- a/packages/game/src/generators/plant/PlantGenerator.tsx
+++ b/packages/game/src/generators/plant/PlantGenerator.tsx
@@ -1,24 +1,18 @@
 'use client';
 
 import { useMemo, useRef } from 'react';
-import * as THREE from 'three';
-import CSM from 'three-custom-shader-material';
+import type * as THREE from 'three';
 import { usePlantLod } from './hooks/usePlantLod';
-import { usePlantSway } from './hooks/usePlantSway';
 import {
     buildPlantRenderData,
     getApproximatePlantHeight,
 } from './lib/buildPlantRenderData';
 import type { LSystemSymbol } from './lib/l-system';
 import type { PlantDefinition } from './lib/plant-definitions';
-import {
-    createStemSurfaceUniforms,
-    stemSurfaceFragmentShader,
-    stemSurfaceVertexShader,
-} from './lib/plant-stem-material';
 import { Flowers } from './parts/flowers';
 import { Leaves } from './parts/leaves';
 import { PlantBillboard } from './parts/PlantBillboard';
+import { Stems } from './parts/stems';
 import { Thorns } from './parts/thorns';
 import { Vegetables } from './parts/vegetables';
 
@@ -47,15 +41,6 @@ export function PlantGenerator({
     showFlowers = true,
     showProduce = true,
 }: PlantGeneratorProps) {
-    const stemSwayUniforms = usePlantSway(seed, {
-        amplitude: 0.055,
-        enabled: animate,
-        speed: 1.1,
-    });
-    const stemSurfaceUniforms = useMemo(
-        () => createStemSurfaceUniforms(plantDefinition.stem),
-        [plantDefinition.stem],
-    );
     const groupRef = useRef<THREE.Group | null>(null);
     const lodLevel = usePlantLod(
         groupRef,
@@ -90,21 +75,14 @@ export function PlantGenerator({
     return (
         <group ref={groupRef}>
             {lodLevel === 'near' ? (
-                <group>
-                    <mesh geometry={renderData.stemGeometry} castShadow>
-                        <CSM
-                            baseMaterial={THREE.MeshStandardMaterial}
-                            vertexShader={stemSurfaceVertexShader}
-                            fragmentShader={stemSurfaceFragmentShader}
-                            uniforms={{
-                                ...stemSwayUniforms,
-                                ...stemSurfaceUniforms,
-                            }}
-                            color={plantDefinition.stem.color}
-                            roughness={0.8}
-                            metalness={0.2}
-                        />
-                    </mesh>
+                <group name={`PlantGenerator:${plantDefinition.name}:near`}>
+                    <Stems
+                        seed={seed}
+                        segments={renderData.stemSegments}
+                        stem={plantDefinition.stem}
+                        animate={animate}
+                        debugName={`PlantStems:${plantDefinition.name}:${seed}:segments:${renderData.stemSegments.length}`}
+                    />
                     {showLeaves && (
                         <Leaves
                             seed={seed}
@@ -112,6 +90,7 @@ export function PlantGenerator({
                             colors={renderData.leafColors}
                             type={plantDefinition.leaf.type}
                             animate={animate}
+                            debugName={`PlantLeaves:${plantDefinition.name}:${seed}:count:${renderData.leaves.length}`}
                         />
                     )}
                     {showFlowers && plantDefinition.flower.enabled && (

--- a/packages/game/src/generators/plant/hooks/usePlantLod.ts
+++ b/packages/game/src/generators/plant/hooks/usePlantLod.ts
@@ -11,12 +11,12 @@ import {
 } from 'react';
 import * as THREE from 'three';
 import { useGameState } from '../../../useGameState';
+import {
+    type PlantLodLevel,
+    resolvePlantLodLevel,
+    resolvePlantLodLevelWithHysteresis,
+} from '../lib/plantLod';
 
-export type PlantLodLevel = 'near' | 'mid' | 'far';
-
-const NEAR_THRESHOLD = 0.12;
-const FAR_THRESHOLD = 0.045;
-const HYSTERESIS = 0.012;
 const DEFAULT_VISIBILITY_MARGIN = 0.14;
 
 export type PlantLodState = {
@@ -31,44 +31,8 @@ type PlantLodOptions = {
     visibilityMargin?: number;
 };
 
-function resolveLodLevel(screenOccupancy: number): PlantLodLevel {
-    if (screenOccupancy >= NEAR_THRESHOLD) {
-        return 'near';
-    }
-
-    if (screenOccupancy >= FAR_THRESHOLD) {
-        return 'mid';
-    }
-
-    return 'far';
-}
-
-function resolveLodLevelWithHysteresis(
-    currentLevel: PlantLodLevel,
-    screenOccupancy: number,
-) {
-    if (currentLevel === 'near') {
-        if (screenOccupancy >= NEAR_THRESHOLD - HYSTERESIS) {
-            return 'near';
-        }
-        return screenOccupancy >= FAR_THRESHOLD - HYSTERESIS ? 'mid' : 'far';
-    }
-
-    if (currentLevel === 'mid') {
-        if (screenOccupancy >= NEAR_THRESHOLD + HYSTERESIS) {
-            return 'near';
-        }
-        if (screenOccupancy < FAR_THRESHOLD - HYSTERESIS) {
-            return 'far';
-        }
-        return 'mid';
-    }
-
-    if (screenOccupancy >= NEAR_THRESHOLD + HYSTERESIS) {
-        return 'near';
-    }
-
-    return screenOccupancy >= FAR_THRESHOLD + HYSTERESIS ? 'mid' : 'far';
+function getOrthographicCameraZoom(camera: THREE.Camera) {
+    return camera instanceof THREE.OrthographicCamera ? camera.zoom : 0;
 }
 
 function resolvePlantVisibility({
@@ -121,7 +85,7 @@ export function usePlantLodState(
     const gameCamera = useGameState((state) => state.gameCamera);
     const worldPosition = useMemo(() => new THREE.Vector3(), []);
     const [lodState, setLodState] = useState<PlantLodState>(() => ({
-        level: cullOffscreen ? 'far' : resolveLodLevel(1),
+        level: cullOffscreen ? 'far' : resolvePlantLodLevel(1),
         measured: false,
         screenOccupancy: cullOffscreen ? 0 : 1,
         visible: !cullOffscreen,
@@ -155,10 +119,11 @@ export function usePlantLodState(
             viewportHeight,
             worldPosition,
         });
-        const nextLevel = resolveLodLevelWithHysteresis(
-            lodStateRef.current.level,
+        const nextLevel = resolvePlantLodLevelWithHysteresis({
+            cameraZoom: getOrthographicCameraZoom(camera),
+            currentLevel: lodStateRef.current.level,
             screenOccupancy,
-        );
+        });
 
         const resolvedLevel = visible ? nextLevel : 'far';
         setLodState((current) => {

--- a/packages/game/src/generators/plant/lib/buildPlantRenderData.ts
+++ b/packages/game/src/generators/plant/lib/buildPlantRenderData.ts
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import type { VegetableData } from '../parts/vegetables';
 import { vegetableMaterialProps } from '../parts/vegetables';
 import type { LSystemSymbol } from './l-system';
@@ -28,6 +27,12 @@ interface StemPathPoint {
     radius: number;
 }
 
+export interface PlantStemSegment {
+    endRadius: number;
+    matrix: THREE.Matrix4;
+    startRadius: number;
+}
+
 export interface PlantLodSummary {
     accentCenterY: number;
     accentColor?: string;
@@ -42,7 +47,7 @@ export interface PlantLodSummary {
 }
 
 export interface PlantRenderData {
-    stemGeometry: THREE.BufferGeometry;
+    stemSegments: PlantStemSegment[];
     leaves: THREE.Matrix4[];
     leafColors: THREE.Color[];
     flowers: THREE.Matrix4[];
@@ -64,9 +69,9 @@ interface BuildPlantRenderDataOptions {
     showProduce?: boolean;
 }
 
-function createStemTubeGeometry(path: StemPathPoint[]): THREE.BufferGeometry {
+function createStemSegments(path: StemPathPoint[]): PlantStemSegment[] {
     if (path.length < 2) {
-        return new THREE.BufferGeometry();
+        return [];
     }
 
     const curve = new THREE.CatmullRomCurve3(
@@ -99,73 +104,36 @@ function createStemTubeGeometry(path: StemPathPoint[]): THREE.BufferGeometry {
         };
     });
 
-    const vertices: number[] = [];
-    const normals: number[] = [];
-    const indices: number[] = [];
+    const segments: PlantStemSegment[] = [];
+    const segmentQuaternion = new THREE.Quaternion();
+    const segmentScale = new THREE.Vector3(1, 1, 1);
 
-    for (let pathIndex = 0; pathIndex < sampledPath.length; pathIndex++) {
-        const { position, quaternion, radius } = sampledPath[pathIndex];
+    for (let index = 0; index < sampledPath.length - 1; index += 1) {
+        const start = sampledPath[index];
+        const end = sampledPath[index + 1];
+        const direction = end.position.clone().sub(start.position);
+        const length = direction.length();
 
-        for (
-            let radialIndex = 0;
-            radialIndex <= RADIAL_SEGMENTS;
-            radialIndex++
-        ) {
-            const angle = (radialIndex / RADIAL_SEGMENTS) * Math.PI * 2;
-            const localOffset = new THREE.Vector3(
-                Math.cos(angle) * radius,
-                0,
-                Math.sin(angle) * radius,
-            );
-            localOffset.applyQuaternion(quaternion);
-
-            vertices.push(
-                position.x + localOffset.x,
-                position.y + localOffset.y,
-                position.z + localOffset.z,
-            );
-
-            if (radius > 0) {
-                const normal = localOffset.normalize();
-                normals.push(normal.x, normal.y, normal.z);
-            } else {
-                const forward = new THREE.Vector3(0, 1, 0).applyQuaternion(
-                    quaternion,
-                );
-                normals.push(forward.x, forward.y, forward.z);
-            }
+        if (length <= MIN_SEGMENT_LENGTH) {
+            continue;
         }
+
+        direction.normalize();
+        segmentQuaternion.setFromUnitVectors(STEM_UP, direction);
+        segmentScale.set(1, length, 1);
+
+        segments.push({
+            endRadius: end.radius,
+            matrix: new THREE.Matrix4().compose(
+                start.position,
+                segmentQuaternion.clone(),
+                segmentScale.clone(),
+            ),
+            startRadius: start.radius,
+        });
     }
 
-    const ringSize = RADIAL_SEGMENTS + 1;
-    for (let pathIndex = 0; pathIndex < sampledPath.length - 1; pathIndex++) {
-        for (
-            let radialIndex = 0;
-            radialIndex < RADIAL_SEGMENTS;
-            radialIndex++
-        ) {
-            const a = pathIndex * ringSize + radialIndex;
-            const b = (pathIndex + 1) * ringSize + radialIndex;
-            const c = pathIndex * ringSize + radialIndex + 1;
-            const d = (pathIndex + 1) * ringSize + radialIndex + 1;
-
-            indices.push(a, b, c);
-            indices.push(c, b, d);
-        }
-    }
-
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute(
-        'position',
-        new THREE.Float32BufferAttribute(vertices, 3),
-    );
-    geometry.setAttribute(
-        'normal',
-        new THREE.Float32BufferAttribute(normals, 3),
-    );
-    geometry.setIndex(indices);
-
-    return geometry;
+    return segments;
 }
 
 function getLifecycleGrowth(
@@ -762,18 +730,9 @@ export function buildPlantRenderData({
         });
     }
 
-    const stemGeometry = renderDetailedGeometry
-        ? (() => {
-              const stemTubeGeometries = stemPaths.map(createStemTubeGeometry);
-              const mergedStemGeometry = stemTubeGeometries.length
-                  ? mergeGeometries(stemTubeGeometries)
-                  : new THREE.BufferGeometry();
-              stemTubeGeometries.forEach((geometry) => {
-                  geometry.dispose();
-              });
-              return mergedStemGeometry;
-          })()
-        : new THREE.BufferGeometry();
+    const stemSegments = renderDetailedGeometry
+        ? stemPaths.flatMap(createStemSegments)
+        : [];
 
     if (showLeaves) {
         dominantColor.lerp(baseLeafColor, 0.68);
@@ -821,7 +780,7 @@ export function buildPlantRenderData({
             stemColor: plantDefinition.stem.color,
             stemWidth: Math.max(maxStemRadius * 4.5, 0.05),
         },
-        stemGeometry,
+        stemSegments,
         thorns: thornsData,
         vegetables: vegetablesData,
     };

--- a/packages/game/src/generators/plant/lib/plant-stem-material.ts
+++ b/packages/game/src/generators/plant/lib/plant-stem-material.ts
@@ -14,6 +14,27 @@ export const stemSurfaceVertexShader = /* glsl */ `
     )}
 `;
 
+export const instancedStemSurfaceVertexShader = /* glsl */ `
+    attribute vec2 stemRadius;
+    varying vec3 vStemSurfacePosition;
+
+    ${plantSwayVertexShader
+        .replace(
+            'void main() {',
+            `
+        void main() {
+            float stemT = clamp(position.y, 0.0, 1.0);
+            float radius = mix(stemRadius.x, stemRadius.y, stemT);
+            vec3 taperedPosition = vec3(position.x * radius, position.y, position.z * radius);
+            vStemSurfacePosition = (instanceMatrix * vec4(taperedPosition, 1.0)).xyz;
+        `,
+        )
+        .replace(
+            'vec4 localPosition = vec4(position, 1.0);',
+            'vec4 localPosition = vec4(taperedPosition, 1.0);',
+        )}
+`;
+
 export const stemSurfaceFragmentShader = /* glsl */ `
     uniform vec3 uStemDetailColor;
     uniform float uStemDetailScale;

--- a/packages/game/src/generators/plant/lib/plantLod.ts
+++ b/packages/game/src/generators/plant/lib/plantLod.ts
@@ -1,0 +1,60 @@
+export type PlantLodLevel = 'near' | 'mid' | 'far';
+
+const NEAR_THRESHOLD = 0.12;
+const FAR_THRESHOLD = 0.045;
+const HYSTERESIS = 0.012;
+const CLOSE_NEAR_ZOOM = 180;
+const CLOSE_NEAR_ZOOM_HYSTERESIS = 20;
+
+export function resolvePlantLodLevel(screenOccupancy: number): PlantLodLevel {
+    if (screenOccupancy >= NEAR_THRESHOLD) {
+        return 'near';
+    }
+
+    if (screenOccupancy >= FAR_THRESHOLD) {
+        return 'mid';
+    }
+
+    return 'far';
+}
+
+export function resolvePlantLodLevelWithHysteresis({
+    cameraZoom,
+    currentLevel,
+    screenOccupancy,
+}: {
+    cameraZoom: number;
+    currentLevel: PlantLodLevel;
+    screenOccupancy: number;
+}): PlantLodLevel {
+    if (
+        cameraZoom >=
+        CLOSE_NEAR_ZOOM -
+            (currentLevel === 'near' ? CLOSE_NEAR_ZOOM_HYSTERESIS : 0)
+    ) {
+        return 'near';
+    }
+
+    if (currentLevel === 'near') {
+        if (screenOccupancy >= NEAR_THRESHOLD - HYSTERESIS) {
+            return 'near';
+        }
+        return screenOccupancy >= FAR_THRESHOLD - HYSTERESIS ? 'mid' : 'far';
+    }
+
+    if (currentLevel === 'mid') {
+        if (screenOccupancy >= NEAR_THRESHOLD + HYSTERESIS) {
+            return 'near';
+        }
+        if (screenOccupancy < FAR_THRESHOLD - HYSTERESIS) {
+            return 'far';
+        }
+        return 'mid';
+    }
+
+    if (screenOccupancy >= NEAR_THRESHOLD + HYSTERESIS) {
+        return 'near';
+    }
+
+    return screenOccupancy >= FAR_THRESHOLD + HYSTERESIS ? 'mid' : 'far';
+}

--- a/packages/game/src/generators/plant/lib/plantLod.unit.ts
+++ b/packages/game/src/generators/plant/lib/plantLod.unit.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    resolvePlantLodLevel,
+    resolvePlantLodLevelWithHysteresis,
+} from './plantLod';
+
+test('plant LOD uses projected plant size at normal zoom', () => {
+    assert.equal(resolvePlantLodLevel(0.13), 'near');
+    assert.equal(resolvePlantLodLevel(0.05), 'mid');
+    assert.equal(resolvePlantLodLevel(0.03), 'far');
+});
+
+test('plant LOD forces geometry when orthographic camera is close', () => {
+    assert.equal(
+        resolvePlantLodLevelWithHysteresis({
+            cameraZoom: 180,
+            currentLevel: 'far',
+            screenOccupancy: 0.01,
+        }),
+        'near',
+    );
+});
+
+test('plant LOD keeps close geometry through zoom hysteresis', () => {
+    assert.equal(
+        resolvePlantLodLevelWithHysteresis({
+            cameraZoom: 161,
+            currentLevel: 'near',
+            screenOccupancy: 0.01,
+        }),
+        'near',
+    );
+    assert.equal(
+        resolvePlantLodLevelWithHysteresis({
+            cameraZoom: 159,
+            currentLevel: 'near',
+            screenOccupancy: 0.01,
+        }),
+        'far',
+    );
+});

--- a/packages/game/src/generators/plant/parts/PlantBillboard.tsx
+++ b/packages/game/src/generators/plant/parts/PlantBillboard.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 import * as THREE from 'three';
 import { useGameState } from '../../../useGameState';
-import type { PlantLodLevel } from '../hooks/usePlantLod';
+import type { PlantLodLevel } from '../lib/plantLod';
 
 export interface PlantBillboardSummary {
     accentCenterY: number;
@@ -29,6 +29,64 @@ interface PlantBillboardProps {
     level: Exclude<PlantLodLevel, 'near'>;
     summary: PlantBillboardSummary;
 }
+
+export interface PlantBillboardBatchItem {
+    position: readonly [number, number, number];
+    scale: number;
+    summary: PlantBillboardSummary;
+}
+
+interface PlantBillboardBatchProps {
+    debugName?: string;
+    level: Exclude<PlantLodLevel, 'near'>;
+    billboards: PlantBillboardBatchItem[];
+}
+
+interface BillboardInstanceItem {
+    color: THREE.Color;
+    matrix: THREE.Matrix4;
+}
+
+interface BillboardInstanceMeshProps {
+    debugName: string;
+    geometry: THREE.BufferGeometry;
+    items: BillboardInstanceItem[];
+    opacity: number;
+}
+
+const BILLBOARD_IDENTITY_QUATERNION = new THREE.Quaternion();
+const billboardPlaneGeometry = new THREE.PlaneGeometry(1, 1);
+const billboardCircleGeometry = new THREE.CircleGeometry(1, 18);
+
+const billboardVertexShader = /* glsl */ `
+    attribute vec3 instanceTint;
+
+    varying vec3 vInstanceTint;
+
+    void main() {
+        vInstanceTint = instanceTint;
+
+        vec4 instanceCenter = instanceMatrix * vec4(0.0, 0.0, 0.0, 1.0);
+        vec3 instanceOffset = (instanceMatrix * vec4(position, 0.0)).xyz;
+        vec4 mvPosition = modelViewMatrix * instanceCenter;
+        mvPosition.xy += instanceOffset.xy;
+        mvPosition.z += instanceOffset.z;
+
+        gl_Position = projectionMatrix * mvPosition;
+    }
+`;
+
+const billboardFragmentShader = /* glsl */ `
+    uniform float uOpacity;
+
+    varying vec3 vInstanceTint;
+
+    void main() {
+        gl_FragColor = vec4(vInstanceTint, uOpacity);
+        #include <tonemapping_fragment>
+        #include <colorspace_fragment>
+    }
+`;
 
 function CameraFacingBillboard({ children }: PropsWithChildren) {
     const groupRef = useRef<THREE.Group>(null);
@@ -50,6 +108,259 @@ function CameraFacingBillboard({ children }: PropsWithChildren) {
     }, [gameCamera, updateCameraFacing]);
 
     return <group ref={groupRef}>{children}</group>;
+}
+
+function createBillboardItem({
+    color,
+    height,
+    position,
+    radius,
+    width,
+}: {
+    color: string;
+    height: number;
+    position: readonly [number, number, number];
+    radius?: number;
+    width?: number;
+}) {
+    const scaleX = radius ?? width ?? 1;
+    const scaleY = radius ?? height;
+
+    return {
+        color: new THREE.Color(color),
+        matrix: new THREE.Matrix4().compose(
+            new THREE.Vector3(...position),
+            BILLBOARD_IDENTITY_QUATERNION,
+            new THREE.Vector3(scaleX, scaleY, 1),
+        ),
+    } satisfies BillboardInstanceItem;
+}
+
+function BillboardInstanceMesh({
+    debugName,
+    geometry: sourceGeometry,
+    items,
+    opacity,
+}: BillboardInstanceMeshProps) {
+    const meshRef = useRef<THREE.InstancedMesh | null>(null);
+    const instanceCapacity = Math.max(items.length, 1);
+    const geometry = useMemo(() => sourceGeometry.clone(), [sourceGeometry]);
+    const tintAttribute = useMemo(() => {
+        const attribute = new THREE.InstancedBufferAttribute(
+            new Float32Array(instanceCapacity * 3),
+            3,
+        );
+        attribute.setUsage(THREE.DynamicDrawUsage);
+        return attribute;
+    }, [instanceCapacity]);
+    const uniforms = useMemo(
+        () => ({
+            uOpacity: { value: opacity },
+        }),
+        [opacity],
+    );
+
+    useLayoutEffect(() => {
+        const mesh = meshRef.current;
+        if (!mesh) {
+            return;
+        }
+
+        mesh.geometry.setAttribute('instanceTint', tintAttribute);
+        items.forEach((item, index) => {
+            mesh.setMatrixAt(index, item.matrix);
+            tintAttribute.setXYZ(
+                index,
+                item.color.r,
+                item.color.g,
+                item.color.b,
+            );
+        });
+        mesh.count = items.length;
+        mesh.visible = items.length > 0;
+        mesh.instanceMatrix.needsUpdate = true;
+        tintAttribute.needsUpdate = true;
+        mesh.computeBoundingBox();
+        mesh.computeBoundingSphere();
+    }, [items, tintAttribute]);
+
+    useLayoutEffect(() => () => geometry.dispose(), [geometry]);
+
+    if (items.length === 0) {
+        return null;
+    }
+
+    return (
+        <instancedMesh
+            ref={meshRef}
+            name={debugName}
+            args={[geometry, undefined, instanceCapacity]}
+            frustumCulled={false}
+        >
+            <shaderMaterial
+                depthWrite={false}
+                fragmentShader={billboardFragmentShader}
+                transparent
+                uniforms={uniforms}
+                vertexShader={billboardVertexShader}
+            />
+        </instancedMesh>
+    );
+}
+
+export function PlantBillboardBatch({
+    debugName = 'PlantBillboardBatch',
+    level,
+    billboards,
+}: PlantBillboardBatchProps) {
+    const farItems = useMemo(() => {
+        if (level !== 'far') {
+            return [];
+        }
+
+        return billboards.map(({ position, scale, summary }) =>
+            createBillboardItem({
+                color: summary.dominantColor,
+                height: Math.max(summary.height * 0.72, 0.18) * scale,
+                position: [
+                    position[0],
+                    position[1] + summary.height * 0.5 * scale,
+                    position[2],
+                ],
+                width: Math.max(summary.canopyWidth * 0.42, 0.12) * scale,
+            }),
+        );
+    }, [billboards, level]);
+    const midStemItems = useMemo(() => {
+        if (level !== 'mid') {
+            return [];
+        }
+
+        return billboards.map(({ position, scale, summary }) =>
+            createBillboardItem({
+                color: summary.stemColor,
+                height: Math.max(summary.height * 0.9, 0.2) * scale,
+                position: [
+                    position[0],
+                    position[1] + summary.height * 0.42 * scale,
+                    position[2] - 0.02 * scale,
+                ],
+                width: Math.max(summary.stemWidth, 0.06) * scale,
+            }),
+        );
+    }, [billboards, level]);
+    const midCanopyPrimaryItems = useMemo(() => {
+        if (level !== 'mid') {
+            return [];
+        }
+
+        return billboards
+            .filter((billboard) => billboard.summary.hasFoliage)
+            .map(({ position, scale, summary }) =>
+                createBillboardItem({
+                    color: summary.foliageColor,
+                    height: 1,
+                    position: [
+                        position[0] - summary.canopyWidth * 0.08 * scale,
+                        position[1] + summary.canopyCenterY * scale,
+                        position[2],
+                    ],
+                    radius: Math.max(summary.canopyWidth * 0.28, 0.16) * scale,
+                }),
+            );
+    }, [billboards, level]);
+    const midCanopySecondaryItems = useMemo(() => {
+        if (level !== 'mid') {
+            return [];
+        }
+
+        return billboards
+            .filter((billboard) => billboard.summary.hasFoliage)
+            .map(({ position, scale, summary }) =>
+                createBillboardItem({
+                    color: summary.foliageColor,
+                    height: 1,
+                    position: [
+                        position[0] + summary.canopyWidth * 0.1 * scale,
+                        position[1] +
+                            (summary.canopyCenterY + summary.height * 0.06) *
+                                scale,
+                        position[2] + 0.01 * scale,
+                    ],
+                    radius: Math.max(summary.canopyWidth * 0.24, 0.14) * scale,
+                }),
+            );
+    }, [billboards, level]);
+    const midAccentItems = useMemo(() => {
+        if (level !== 'mid') {
+            return [];
+        }
+
+        return billboards
+            .filter(
+                (
+                    billboard,
+                ): billboard is PlantBillboardBatchItem & {
+                    summary: PlantBillboardSummary & { accentColor: string };
+                } => Boolean(billboard.summary.accentColor),
+            )
+            .map(({ position, scale, summary }) =>
+                createBillboardItem({
+                    color: summary.accentColor,
+                    height: 1,
+                    position: [
+                        position[0],
+                        position[1] + summary.accentCenterY * scale,
+                        position[2] + 0.02 * scale,
+                    ],
+                    radius: Math.max(summary.canopyWidth * 0.1, 0.07) * scale,
+                }),
+            );
+    }, [billboards, level]);
+
+    if (billboards.length === 0) {
+        return null;
+    }
+
+    if (level === 'far') {
+        return (
+            <BillboardInstanceMesh
+                debugName={`${debugName}:far:count:${farItems.length}`}
+                geometry={billboardPlaneGeometry}
+                items={farItems}
+                opacity={0.84}
+            />
+        );
+    }
+
+    return (
+        <group name={`${debugName}:mid:count:${billboards.length}`}>
+            <BillboardInstanceMesh
+                debugName={`${debugName}:mid:stems:${midStemItems.length}`}
+                geometry={billboardPlaneGeometry}
+                items={midStemItems}
+                opacity={0.9}
+            />
+            <BillboardInstanceMesh
+                debugName={`${debugName}:mid:canopyA:${midCanopyPrimaryItems.length}`}
+                geometry={billboardCircleGeometry}
+                items={midCanopyPrimaryItems}
+                opacity={0.88}
+            />
+            <BillboardInstanceMesh
+                debugName={`${debugName}:mid:canopyB:${midCanopySecondaryItems.length}`}
+                geometry={billboardCircleGeometry}
+                items={midCanopySecondaryItems}
+                opacity={0.78}
+            />
+            <BillboardInstanceMesh
+                debugName={`${debugName}:mid:accents:${midAccentItems.length}`}
+                geometry={billboardCircleGeometry}
+                items={midAccentItems}
+                opacity={0.95}
+            />
+        </group>
+    );
 }
 
 export function PlantBillboard({ level, summary }: PlantBillboardProps) {

--- a/packages/game/src/generators/plant/parts/leaves.tsx
+++ b/packages/game/src/generators/plant/parts/leaves.tsx
@@ -12,9 +12,8 @@ interface LeavesProps {
     colors: THREE.Color[];
     type: PlantDefinition['leaf']['type'];
     animate?: boolean;
+    debugName?: string;
 }
-
-const MAX_LEAF_INSTANCES = 10000;
 
 const leafGeometries = {
     round: new THREE.CircleGeometry(1, 6),
@@ -106,8 +105,10 @@ export function Leaves({
     colors,
     type,
     animate = true,
+    debugName,
 }: LeavesProps) {
     const leafRef = useRef<THREE.InstancedMesh | null>(null);
+    const instanceCapacity = Math.max(matrices.length, 1);
     const swayUniforms = usePlantSway(`${seed}-leaves`, {
         amplitude: 0.11,
         enabled: animate,
@@ -120,12 +121,12 @@ export function Leaves({
     );
     const leafInstanceColor = useMemo(() => {
         const attribute = new THREE.InstancedBufferAttribute(
-            new Float32Array(MAX_LEAF_INSTANCES * 3),
+            new Float32Array(instanceCapacity * 3),
             3,
         );
         attribute.setUsage(THREE.DynamicDrawUsage);
         return attribute;
-    }, []);
+    }, [instanceCapacity]);
 
     useLayoutEffect(() => {
         const updateInstances = (
@@ -149,6 +150,9 @@ export function Leaves({
                 mesh.material.needsUpdate = true;
             }
             mesh.count = matrices.length;
+            mesh.visible = matrices.length > 0;
+            mesh.computeBoundingBox();
+            mesh.computeBoundingSphere();
         };
 
         updateInstances(leafRef.current, colors, leafInstanceColor);
@@ -160,10 +164,15 @@ export function Leaves({
         };
     }, [geometry]);
 
+    if (matrices.length === 0) {
+        return null;
+    }
+
     return (
         <instancedMesh
             ref={leafRef}
-            args={[geometry, undefined, MAX_LEAF_INSTANCES]}
+            name={debugName ?? `PlantLeaves:${type}:count:${matrices.length}`}
+            args={[geometry, undefined, instanceCapacity]}
             castShadow
         >
             <CSM

--- a/packages/game/src/generators/plant/parts/stems.tsx
+++ b/packages/game/src/generators/plant/parts/stems.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import * as THREE from 'three';
+import CSM from 'three-custom-shader-material';
+import { usePlantSway } from '../hooks/usePlantSway';
+import type { PlantStemSegment } from '../lib/buildPlantRenderData';
+import type { PlantDefinition } from '../lib/plant-definitions';
+import {
+    createStemSurfaceUniforms,
+    instancedStemSurfaceVertexShader,
+    stemSurfaceFragmentShader,
+} from '../lib/plant-stem-material';
+
+interface StemsProps {
+    seed: string;
+    segments: PlantStemSegment[];
+    stem: PlantDefinition['stem'];
+    animate?: boolean;
+    debugName?: string;
+}
+
+const STEM_RADIAL_SEGMENTS = 5;
+
+function createStemSegmentGeometry() {
+    const vertices: number[] = [];
+    const normals: number[] = [];
+    const indices: number[] = [];
+
+    for (let ringIndex = 0; ringIndex <= 1; ringIndex += 1) {
+        const y = ringIndex;
+
+        for (
+            let radialIndex = 0;
+            radialIndex <= STEM_RADIAL_SEGMENTS;
+            radialIndex += 1
+        ) {
+            const angle = (radialIndex / STEM_RADIAL_SEGMENTS) * Math.PI * 2;
+            const x = Math.cos(angle);
+            const z = Math.sin(angle);
+
+            vertices.push(x, y, z);
+            normals.push(x, 0, z);
+        }
+    }
+
+    const ringSize = STEM_RADIAL_SEGMENTS + 1;
+    for (
+        let radialIndex = 0;
+        radialIndex < STEM_RADIAL_SEGMENTS;
+        radialIndex += 1
+    ) {
+        const a = radialIndex;
+        const b = ringSize + radialIndex;
+        const c = radialIndex + 1;
+        const d = ringSize + radialIndex + 1;
+
+        indices.push(a, b, c);
+        indices.push(c, b, d);
+    }
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute(vertices, 3),
+    );
+    geometry.setAttribute(
+        'normal',
+        new THREE.Float32BufferAttribute(normals, 3),
+    );
+    geometry.setIndex(indices);
+    return geometry;
+}
+
+export function Stems({
+    seed,
+    segments,
+    stem,
+    animate = true,
+    debugName,
+}: StemsProps) {
+    const stemRef = useRef<THREE.InstancedMesh | null>(null);
+    const instanceCapacity = Math.max(segments.length, 1);
+    const swayUniforms = usePlantSway(`${seed}-stems`, {
+        amplitude: 0.055,
+        enabled: animate,
+        speed: 1.1,
+    });
+    const stemSurfaceUniforms = useMemo(
+        () => createStemSurfaceUniforms(stem),
+        [stem],
+    );
+    const geometry = useMemo(() => createStemSegmentGeometry(), []);
+    const stemRadius = useMemo(() => {
+        const attribute = new THREE.InstancedBufferAttribute(
+            new Float32Array(instanceCapacity * 2),
+            2,
+        );
+        attribute.setUsage(THREE.DynamicDrawUsage);
+        return attribute;
+    }, [instanceCapacity]);
+
+    useLayoutEffect(() => {
+        const mesh = stemRef.current;
+        if (!mesh) {
+            return;
+        }
+
+        mesh.geometry.setAttribute('stemRadius', stemRadius);
+        segments.forEach((segment, index) => {
+            mesh.setMatrixAt(index, segment.matrix);
+            stemRadius.setXY(index, segment.startRadius, segment.endRadius);
+        });
+        mesh.count = segments.length;
+        mesh.visible = segments.length > 0;
+        mesh.instanceMatrix.needsUpdate = true;
+        stemRadius.needsUpdate = true;
+        mesh.computeBoundingBox();
+        mesh.computeBoundingSphere();
+
+        if (!Array.isArray(mesh.material)) {
+            mesh.material.needsUpdate = true;
+        }
+    }, [segments, stemRadius]);
+
+    useLayoutEffect(() => () => geometry.dispose(), [geometry]);
+
+    if (segments.length === 0) {
+        return null;
+    }
+
+    return (
+        <instancedMesh
+            ref={stemRef}
+            name={debugName ?? `PlantStems:segments:${segments.length}`}
+            args={[geometry, undefined, instanceCapacity]}
+            castShadow
+        >
+            <CSM
+                baseMaterial={THREE.MeshStandardMaterial}
+                vertexShader={instancedStemSurfaceVertexShader}
+                fragmentShader={stemSurfaceFragmentShader}
+                uniforms={{
+                    ...swayUniforms,
+                    ...stemSurfaceUniforms,
+                }}
+                color={stem.color}
+                roughness={0.8}
+                metalness={0.2}
+            />
+        </instancedMesh>
+    );
+}

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -110,6 +110,12 @@ function formatMetric(value: number | null | undefined, suffix = '') {
         : 'n/a';
 }
 
+function formatCount(value: number | null | undefined) {
+    return typeof value === 'number' && Number.isFinite(value)
+        ? Math.round(value).toLocaleString('hr-HR')
+        : 'n/a';
+}
+
 function formatTemperature(value: number | null | undefined) {
     return typeof value === 'number' && Number.isFinite(value)
         ? `${Math.round(value)}°C`
@@ -775,6 +781,62 @@ export function DebugHud() {
                                     icon={FullWidth}
                                     label="Canvas"
                                     value={canvasSize}
+                                />
+                                <InfoRow
+                                    icon={Graph}
+                                    label="Render calls"
+                                    value={formatCount(
+                                        profileSnapshot?.rendererRenderCalls,
+                                    )}
+                                />
+                                <InfoRow
+                                    icon={Layers}
+                                    label="Triangles"
+                                    value={formatCount(
+                                        profileSnapshot?.rendererTriangles,
+                                    )}
+                                />
+                                <InfoRow
+                                    icon={Custom}
+                                    label="Shaders"
+                                    value={formatCount(
+                                        profileSnapshot?.rendererShaders,
+                                    )}
+                                />
+                                <InfoRow
+                                    icon={Layers}
+                                    label="Geometries"
+                                    value={formatCount(
+                                        profileSnapshot?.rendererGeometries,
+                                    )}
+                                />
+                                <InfoRow
+                                    icon={Desktop}
+                                    label="Textures"
+                                    value={formatCount(
+                                        profileSnapshot?.rendererTextures,
+                                    )}
+                                />
+                                <InfoRow
+                                    icon={FullWidth}
+                                    label="Lines"
+                                    value={formatCount(
+                                        profileSnapshot?.rendererLines,
+                                    )}
+                                />
+                                <InfoRow
+                                    icon={MapPin}
+                                    label="Points"
+                                    value={formatCount(
+                                        profileSnapshot?.rendererPoints,
+                                    )}
+                                />
+                                <InfoRow
+                                    icon={Settings}
+                                    label="Matrices"
+                                    value={formatCount(
+                                        profileSnapshot?.rendererMatrices,
+                                    )}
                                 />
                                 <InfoRow
                                     icon={Sun}

--- a/packages/game/src/indicators/PlacementGrid.tsx
+++ b/packages/game/src/indicators/PlacementGrid.tsx
@@ -16,6 +16,7 @@ export function PlacementGrid() {
 
     return (
         <gridHelper
+            name="Interaction:PlacementGrid"
             args={[
                 100,
                 100,

--- a/packages/game/src/particles/ParticleSystem.tsx
+++ b/packages/game/src/particles/ParticleSystem.tsx
@@ -7,7 +7,7 @@ import {
     useMemo,
     useRef,
 } from 'react';
-import { Euler, type InstancedMesh, Matrix4, Object3D, Vector3 } from 'three';
+import { Euler, type InstancedMesh, Object3D, Vector3 } from 'three';
 
 export enum ParticleType {
     Default = 'default',
@@ -17,6 +17,17 @@ export enum ParticleType {
     Stone = 'stone',
     Water = 'water',
 }
+
+const particlePoolSize = 96;
+const defaultParticleBurstCount = 6;
+const particleTypes = [
+    ParticleType.Default,
+    ParticleType.Hay,
+    ParticleType.Leaf,
+    ParticleType.TreeLeaf,
+    ParticleType.Stone,
+    ParticleType.Water,
+] as const;
 
 interface ParticleContextValue {
     spawn: (
@@ -71,10 +82,9 @@ export function ParticleSystemProvider({ children }: PropsWithChildren) {
     const meshTreeLeaf = useRef<InstancedMesh>(null);
     const meshStone = useRef<InstancedMesh>(null);
     const meshWater = useRef<InstancedMesh>(null);
-    const count = 500;
     const particles = useMemo(() => {
         const temp = [];
-        for (let i = 0; i < count; i++) {
+        for (let i = 0; i < particlePoolSize; i++) {
             temp.push({
                 rotation: {
                     x: 0,
@@ -182,7 +192,7 @@ export function ParticleSystemProvider({ children }: PropsWithChildren) {
     const spawn = (
         type: ParticleType | null | undefined,
         position: Vector3,
-        count = 8,
+        count = defaultParticleBurstCount,
     ) => {
         // Use default particle type if none provided
         const particleType = type ?? ParticleType.Default;
@@ -217,11 +227,27 @@ export function ParticleSystemProvider({ children }: PropsWithChildren) {
     };
 
     const dummy = useMemo(() => new Object3D(), []);
-    const hiddenMatrix = useMemo(() => new Matrix4().makeScale(0, 0, 0), []);
+
+    const getParticleMesh = (type: ParticleType) => {
+        switch (type) {
+            case ParticleType.Default:
+                return meshDefault.current;
+            case ParticleType.Hay:
+                return meshHay.current;
+            case ParticleType.Leaf:
+                return meshLeaf.current;
+            case ParticleType.TreeLeaf:
+                return meshTreeLeaf.current;
+            case ParticleType.Stone:
+                return meshStone.current;
+            case ParticleType.Water:
+                return meshWater.current;
+        }
+    };
 
     useLayoutEffect(() => {
-        // InstancedMesh starts every instance at identity; hide pooled particles
-        // until spawn assigns real transforms.
+        // Keep idle particle pools out of the draw list. Active particles are
+        // compacted to the first N instances per mesh type during useFrame.
         const meshes = [
             meshDefault.current,
             meshHay.current,
@@ -236,23 +262,23 @@ export function ParticleSystemProvider({ children }: PropsWithChildren) {
                 continue;
             }
 
-            for (let i = 0; i < count; i++) {
-                mesh.setMatrixAt(i, hiddenMatrix);
-            }
-            mesh.instanceMatrix.needsUpdate = true;
+            mesh.count = 0;
+            mesh.visible = false;
         }
-    }, [hiddenMatrix]);
+    }, []);
 
     useFrame((_, delta) => {
-        let i = -1;
-        let updateDefaultMesh = false;
-        let updateHayMesh = false;
-        let updateLeafMesh = false;
-        let updateTreeLeafMesh = false;
-        let updateStoneMesh = false;
-        let updateWaterMesh = false;
+        const activeCounts: Record<ParticleType, number> = {
+            [ParticleType.Default]: 0,
+            [ParticleType.Hay]: 0,
+            [ParticleType.Leaf]: 0,
+            [ParticleType.TreeLeaf]: 0,
+            [ParticleType.Stone]: 0,
+            [ParticleType.Water]: 0,
+        };
+        const touchedMeshes = new Set<InstancedMesh>();
+
         for (const p of particles) {
-            i++;
             if (p.life >= p.maxLife) {
                 continue;
             }
@@ -358,56 +384,38 @@ export function ParticleSystemProvider({ children }: PropsWithChildren) {
             dummy.updateMatrix();
 
             p.life = p.life + delta;
-            let targetMesh: InstancedMesh | null = null;
-            switch (p.type) {
-                case ParticleType.Default:
-                    targetMesh = meshDefault.current;
-                    updateDefaultMesh = true;
-                    break;
-                case ParticleType.Hay:
-                    targetMesh = meshHay.current;
-                    updateHayMesh = true;
-                    break;
-                case ParticleType.Leaf:
-                    targetMesh = meshLeaf.current;
-                    updateLeafMesh = true;
-                    break;
-                case ParticleType.TreeLeaf:
-                    targetMesh = meshTreeLeaf.current;
-                    updateTreeLeafMesh = true;
-                    break;
-                case ParticleType.Stone:
-                    targetMesh = meshStone.current;
-                    updateStoneMesh = true;
-                    break;
-                case ParticleType.Water:
-                    targetMesh = meshWater.current;
-                    updateWaterMesh = true;
-                    break;
+            if (p.life >= p.maxLife) {
+                continue;
             }
-            targetMesh?.setMatrixAt(
-                i,
-                p.life < p.maxLife ? dummy.matrix : hiddenMatrix,
-            );
+
+            const targetMesh = getParticleMesh(p.type);
+            if (!targetMesh) {
+                continue;
+            }
+
+            const matrixIndex = activeCounts[p.type];
+            activeCounts[p.type] += 1;
+            targetMesh.setMatrixAt(matrixIndex, dummy.matrix);
+            touchedMeshes.add(targetMesh);
         }
 
-        if (updateDefaultMesh && meshDefault.current) {
-            meshDefault.current.instanceMatrix.needsUpdate = true;
-        }
-        if (updateHayMesh && meshHay.current) {
-            meshHay.current.instanceMatrix.needsUpdate = true;
-        }
-        if (updateLeafMesh && meshLeaf.current) {
-            meshLeaf.current.instanceMatrix.needsUpdate = true;
-        }
-        if (updateTreeLeafMesh && meshTreeLeaf.current) {
-            meshTreeLeaf.current.instanceMatrix.needsUpdate = true;
-        }
-        if (updateStoneMesh && meshStone.current) {
-            meshStone.current.instanceMatrix.needsUpdate = true;
-        }
-        if (updateWaterMesh && meshWater.current) {
-            meshWater.current.instanceMatrix.needsUpdate = true;
+        for (const type of particleTypes) {
+            const mesh = getParticleMesh(type);
+            if (!mesh) {
+                continue;
+            }
+
+            const nextCount = activeCounts[type];
+            mesh.visible = nextCount > 0;
+            if (mesh.count !== nextCount) {
+                mesh.count = nextCount;
+                mesh.instanceMatrix.needsUpdate = true;
+                continue;
+            }
+
+            if (nextCount > 0 && touchedMeshes.has(mesh)) {
+                mesh.instanceMatrix.needsUpdate = true;
+            }
         }
     });
 
@@ -417,20 +425,29 @@ export function ParticleSystemProvider({ children }: PropsWithChildren) {
             {/* Default mesh */}
             <instancedMesh
                 ref={meshDefault}
-                args={[undefined, undefined, count]}
+                name="Particles:default"
+                args={[undefined, undefined, particlePoolSize]}
             >
                 <boxGeometry args={[0.03, 0.03, 0.03]} />
                 <meshStandardMaterial color="#4a270d" />
             </instancedMesh>
 
             {/* Hay mesh */}
-            <instancedMesh ref={meshHay} args={[undefined, undefined, count]}>
+            <instancedMesh
+                ref={meshHay}
+                name="Particles:hay"
+                args={[undefined, undefined, particlePoolSize]}
+            >
                 <boxGeometry args={[0.05, 0.01, 0.01]} />
                 <meshStandardMaterial color="yellow" />
             </instancedMesh>
 
             {/* Leaf mesh */}
-            <instancedMesh ref={meshLeaf} args={[undefined, undefined, count]}>
+            <instancedMesh
+                ref={meshLeaf}
+                name="Particles:leaf"
+                args={[undefined, undefined, particlePoolSize]}
+            >
                 <planeGeometry args={[0.08, 0.05]} />
                 <meshStandardMaterial color="#558b22" side={2} />
             </instancedMesh>
@@ -438,20 +455,29 @@ export function ParticleSystemProvider({ children }: PropsWithChildren) {
             {/* Tree Leaf mesh */}
             <instancedMesh
                 ref={meshTreeLeaf}
-                args={[undefined, undefined, count]}
+                name="Particles:treeLeaf"
+                args={[undefined, undefined, particlePoolSize]}
             >
                 <planeGeometry args={[0.08, 0.05]} />
                 <meshStandardMaterial color="#558b22" side={2} />
             </instancedMesh>
 
             {/* Stone mesh */}
-            <instancedMesh ref={meshStone} args={[undefined, undefined, count]}>
+            <instancedMesh
+                ref={meshStone}
+                name="Particles:stone"
+                args={[undefined, undefined, particlePoolSize]}
+            >
                 <sphereGeometry args={[0.04, 4, 4]} />
                 <meshStandardMaterial color="#555566" />
             </instancedMesh>
 
             {/* Water mesh */}
-            <instancedMesh ref={meshWater} args={[undefined, undefined, count]}>
+            <instancedMesh
+                ref={meshWater}
+                name="Particles:water"
+                args={[undefined, undefined, particlePoolSize]}
+            >
                 <sphereGeometry args={[0.035, 6, 6]} />
                 <meshStandardMaterial
                     color="#8fcfc4"

--- a/packages/game/src/rain/RainWetOverlay.tsx
+++ b/packages/game/src/rain/RainWetOverlay.tsx
@@ -13,6 +13,7 @@ import { useGameState } from '../useGameState';
 
 type RainWetOverlayProps = {
     geometry: BufferGeometry;
+    debugName?: string;
     minRain?: number;
     intensityMultiplier?: number;
     drySpeed?: number;
@@ -213,6 +214,7 @@ export function useRainWetOverlayMaterial({
 }
 
 function RainWetOverlayEffect({
+    debugName = 'RainWetOverlay',
     geometry,
     minRain = 0.08,
     intensityMultiplier = 1,
@@ -242,5 +244,5 @@ function RainWetOverlayEffect({
         return null;
     }
 
-    return <mesh geometry={geometry} material={material} />;
+    return <mesh name={debugName} geometry={geometry} material={material} />;
 }

--- a/packages/game/src/scene/CloudLayer.tsx
+++ b/packages/game/src/scene/CloudLayer.tsx
@@ -605,10 +605,11 @@ export function CloudLayer({
     return (
         <>
             {cloudDefinitions.map((cloud, index) => (
-                <group key={cloud.id}>
+                <group key={cloud.id} name={`Environment:CloudSlot:${index}`}>
                     <mesh
                         castShadow
                         frustumCulled={false}
+                        name={`Environment:CloudShadowCaster:${index}`}
                         receiveShadow={false}
                         ref={(mesh) => {
                             cloudShadowRefs.current[index] = mesh;
@@ -632,6 +633,7 @@ export function CloudLayer({
                     <mesh
                         castShadow={false}
                         frustumCulled={false}
+                        name={`Environment:CloudBillboard:${index}`}
                         renderOrder={CLOUD_RENDER_ORDER}
                         ref={(mesh) => {
                             cloudRefs.current[index] = mesh;

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -1152,14 +1152,19 @@ export function Environment({
             {!noBackground && (
                 <SceneBackgroundColor animate color={background} />
             )}
-            <ambientLight intensity={ambient.intensity} />
+            <ambientLight
+                name="Environment:AmbientLight"
+                intensity={ambient.intensity}
+            />
             {lightningFlash > 0 && (
                 <ambientLight
+                    name="Environment:LightningAmbientLight"
                     color={0xf8fbff}
                     intensity={lightningFlash * 1.2}
                 />
             )}
             <hemisphereLight
+                name="Environment:HemisphereLight"
                 position={[0, 1, 0]}
                 color={hemisphere.color}
                 groundColor={hemisphere.groundColor}
@@ -1168,6 +1173,7 @@ export function Environment({
             {/* TODO: Update shadow camera position based on camera position */}
             <directionalLight
                 key={directionalLightKey}
+                name="Environment:SunDirectionalLight"
                 intensity={directionalLight.intensity}
                 color={directionalLight.color}
                 position={directionalLight.position}
@@ -1181,6 +1187,7 @@ export function Environment({
                 castShadow={qualityProfile.shadows}
             >
                 <orthographicCamera
+                    name="Environment:SunShadowCamera"
                     attach="shadow-camera"
                     args={[
                         -shadowCameraSize,

--- a/packages/game/src/scene/Rain/Drops.tsx
+++ b/packages/game/src/scene/Rain/Drops.tsx
@@ -204,8 +204,9 @@ export const Drops = ({ count = 2000 }: DropsProps) => {
     );
 
     return (
-        <group ref={fref}>
+        <group ref={fref} name="Weather:Rain">
             <instancedMesh
+                name={`Weather:RainDrops:count:${count}`}
                 args={[geometry, undefined, count]}
                 frustumCulled={false}
                 renderOrder={35}

--- a/packages/game/src/scene/Scene.tsx
+++ b/packages/game/src/scene/Scene.tsx
@@ -1,7 +1,17 @@
 'use client';
 
-import { Canvas, type Vector3 as FiberVector3 } from '@react-three/fiber';
-import { type HTMLAttributes, type PropsWithChildren, useEffect } from 'react';
+import {
+    Canvas,
+    type Vector3 as FiberVector3,
+    useFrame,
+    useThree,
+} from '@react-three/fiber';
+import {
+    type HTMLAttributes,
+    type PropsWithChildren,
+    useEffect,
+    useRef,
+} from 'react';
 import { PCFShadowMap } from 'three';
 import {
     HoverOutlineEffect,
@@ -16,13 +26,51 @@ import { SceneTimeProvider } from './SceneTime';
 
 export type SceneProps = HTMLAttributes<HTMLDivElement> &
     PropsWithChildren<{
+        debugStats?: boolean;
         position: FiberVector3;
         quality?: GameQualityProfile;
         zoom: number;
     }>;
 
+const rendererStatsUpdateMs = 500;
+
+function RendererStatsReporter() {
+    const lastUpdateRef = useRef(0);
+
+    useFrame(({ gl }) => {
+        const now = performance.now();
+        if (now - lastUpdateRef.current < rendererStatsUpdateMs) {
+            return;
+        }
+
+        lastUpdateRef.current = now;
+        updateGameProfileMetadata({
+            rendererGeometries: gl.info.memory.geometries,
+            rendererLines: gl.info.render.lines,
+            rendererPoints: gl.info.render.points,
+            rendererRenderCalls: gl.info.render.calls,
+            rendererShaders: gl.info.programs?.length,
+            rendererTextures: gl.info.memory.textures,
+            rendererTriangles: gl.info.render.triangles,
+        });
+    });
+
+    return null;
+}
+
+function SceneDebugName() {
+    const scene = useThree((state) => state.scene);
+
+    useEffect(() => {
+        scene.name = 'GrediceGameScene';
+    }, [scene]);
+
+    return null;
+}
+
 export function Scene({
     children,
+    debugStats,
     position,
     quality,
     zoom,
@@ -63,6 +111,8 @@ export function Scene({
         >
             <SceneTimeProvider>
                 <HoverOutlineProvider>
+                    <SceneDebugName />
+                    {debugStats && <RendererStatsReporter />}
                     {children}
                     <HoverOutlineEffect />
                 </HoverOutlineProvider>

--- a/packages/game/src/scene/Snow/Snow.tsx
+++ b/packages/game/src/scene/Snow/Snow.tsx
@@ -239,8 +239,9 @@ const Snow = ({
     );
 
     return (
-        <group ref={fref}>
+        <group ref={fref} name="Weather:Snow">
             <instancedMesh
+                name={`Weather:SnowFlakes:count:${count}`}
                 args={[geometry, undefined, count]}
                 frustumCulled={false}
                 renderOrder={36}

--- a/packages/game/src/scene/Stars.tsx
+++ b/packages/game/src/scene/Stars.tsx
@@ -286,6 +286,7 @@ export function Stars({ visibility = 1 }: StarsProps) {
     return (
         <points
             ref={pointsRef}
+            name={`Environment:Stars:count:${visibleCount}`}
             frustumCulled={false}
             renderOrder={STAR_RENDERING.renderOrder}
             visible={visibleCount > 0}

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -399,6 +399,7 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
         <>
             <mesh
                 ref={sunMesh}
+                name="Environment:SunBillboard"
                 frustumCulled={false}
                 renderOrder={-1}
                 material={sunMaterial}
@@ -407,6 +408,7 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
             </mesh>
             <mesh
                 ref={moonMesh}
+                name="Environment:MoonBillboard"
                 frustumCulled={false}
                 renderOrder={-1}
                 material={moonMaterial}

--- a/packages/game/src/scene/gameProfileMetadata.ts
+++ b/packages/game/src/scene/gameProfileMetadata.ts
@@ -16,6 +16,14 @@ export type GameProfileMetadata = {
     qualityTier?: GameQualityProfileTier;
     rainParticleCount?: number;
     raisedBedMulchOverlayCount?: number;
+    rendererGeometries?: number;
+    rendererLines?: number;
+    rendererMatrices?: number;
+    rendererPoints?: number;
+    rendererRenderCalls?: number;
+    rendererShaders?: number;
+    rendererTextures?: number;
+    rendererTriangles?: number;
     shadowMapAutoUpdate?: boolean;
     shadowMapDynamicRefreshMs?: number;
     shadowMapInvalidationCount?: number;

--- a/packages/game/src/snow/SnowOverlay.tsx
+++ b/packages/game/src/snow/SnowOverlay.tsx
@@ -39,6 +39,7 @@ export type SnowMaterialOptions = {
 
 export type SnowOverlayProps = SnowMaterialOptions & {
     geometry: BufferGeometry;
+    debugName?: string;
     minCoverage?: number;
     renderOrder?: number;
     overrideSnow?: number;
@@ -235,6 +236,7 @@ function SnowOverlayMesh({
     });
     return (
         <mesh
+            name={options.debugName ?? 'SnowOverlay'}
             geometry={overlayGeometry}
             material={material}
             renderOrder={renderOrder}

--- a/packages/game/src/sprites/SpriteAtlasBillboard.tsx
+++ b/packages/game/src/sprites/SpriteAtlasBillboard.tsx
@@ -17,6 +17,7 @@ type SpriteAtlasBillboardProps = {
     alphaTest?: number;
     atlasBasePath: string;
     depthWrite?: boolean;
+    debugName?: string;
     follow?: boolean;
     height?: number;
     opacity?: number;
@@ -45,6 +46,7 @@ type WobbleAnimation = {
 type BillboardMeshProps = {
     alphaTest: number;
     color: Color;
+    debugName: string;
     depthWrite: boolean;
     geometry: PlaneGeometry;
     opacity: number;
@@ -187,6 +189,7 @@ transformed =
 export function SpriteAtlasBillboard({
     alphaTest = 0.05,
     atlasBasePath,
+    debugName,
     depthWrite = false,
     follow = true,
     height = 1,
@@ -204,6 +207,8 @@ export function SpriteAtlasBillboard({
         () => resolveSpriteAtlasAssetPaths(atlasBasePath),
         [atlasBasePath],
     );
+    const resolvedDebugName =
+        debugName ?? `SpriteAtlasBillboard:${atlasBasePath}:${spriteName}`;
     const brightness = getSpriteBrightness(timeOfDay, weather);
     const color = useMemo(() => {
         return new Color().setScalar(brightness);
@@ -349,10 +354,15 @@ export function SpriteAtlasBillboard({
     }
 
     return (
-        <Billboard follow={follow} position={position}>
+        <Billboard
+            follow={follow}
+            name={`${resolvedDebugName}:billboard`}
+            position={position}
+        >
             <SpriteAtlasBillboardMesh
                 alphaTest={alphaTest}
                 color={color}
+                debugName={resolvedDebugName}
                 depthWrite={depthWrite}
                 geometry={geometry}
                 opacity={opacity}
@@ -384,6 +394,7 @@ function SpriteAtlasBillboardMesh({
 function StaticSpriteAtlasBillboardMesh({
     alphaTest,
     color,
+    debugName,
     depthWrite,
     geometry,
     opacity,
@@ -393,6 +404,7 @@ function StaticSpriteAtlasBillboardMesh({
 }: BillboardMeshProps) {
     return (
         <mesh
+            name={`${debugName}:mesh`}
             renderOrder={renderOrder}
             receiveShadow
             rotation={[0, 0, rotationZ]}
@@ -413,6 +425,7 @@ function StaticSpriteAtlasBillboardMesh({
 function AnimatedSpriteAtlasBillboardMesh({
     alphaTest,
     color,
+    debugName,
     depthWrite,
     geometry,
     opacity,
@@ -438,6 +451,7 @@ function AnimatedSpriteAtlasBillboardMesh({
 
     return (
         <mesh
+            name={`${debugName}:animatedMesh`}
             renderOrder={renderOrder}
             receiveShadow
             rotation={[0, 0, rotationZ]}

--- a/packages/game/src/viewers/EntityViewer.tsx
+++ b/packages/game/src/viewers/EntityViewer.tsx
@@ -139,6 +139,7 @@ export function EntityViewer({
                 >
                     <GameSceneDetailContext.Provider value={{ renderDetails }}>
                         <Scene
+                            debugStats={debugHud}
                             position={100}
                             zoom={zoom ?? 90}
                             quality={quality}

--- a/packages/game/src/viewers/PlantPerformanceViewer.tsx
+++ b/packages/game/src/viewers/PlantPerformanceViewer.tsx
@@ -1,141 +1,54 @@
 'use client';
 
-import { Html } from '@react-three/drei';
-import { useMemo, useRef } from 'react';
-import { RaisedBedGeneratedPlantBatch } from '../entities/raisedBed/RaisedBedGeneratedPlantBatch';
-import { plantTypes } from '../generators/plant/lib/plant-presets';
-import { DebugHud } from '../hud/DebugHud';
-import { Environment } from '../scene/Environment';
-import { Scene } from '../scene/Scene';
-import {
-    createGameState,
-    GameStateContext,
-    type GameStateStore,
-    useDisposeGameStateStore,
-} from '../useGameState';
+import { GameSceneDynamic } from '../GameSceneDynamic';
 
 export interface PlantPerformanceViewerProps {
     className?: string;
     debugHud?: boolean;
 }
 
-const PRESET_COLUMNS = 5;
-const PRESET_SPACING = 3.4;
-const INSTANCE_GRID = 3;
-const INSTANCE_SPACING = 0.42;
+const plantDebugFlags = {
+    enableDebugHudFlag: true,
+    enablePlantGeneratorFlag: true,
+    enableRainWetOverlayFlag: true,
+};
+
+const plantDebugFreezeTime = new Date('2026-06-02T12:00:00+02:00');
+
+const plantDebugWeather = {
+    cloudy: 0,
+    rainy: 0,
+    snowy: 0,
+    foggy: 0,
+    thundery: 0,
+    windSpeed: 0,
+};
 
 export function PlantPerformanceViewer({
     className,
     debugHud,
 }: PlantPerformanceViewerProps) {
-    const storeRef = useRef<GameStateStore>(null);
-    if (!storeRef.current) {
-        storeRef.current = createGameState({
-            appBaseUrl: '',
-            dayNightCycleDisabled: false,
-            freezeTime: new Date(2024, 5, 21, 12, 0, 0),
-            isMock: true,
-            winterMode: 'summer',
-        });
-    }
-    useDisposeGameStateStore(storeRef.current);
-
-    const presets = useMemo(() => {
-        return Object.entries(plantTypes).map(([key, definition], index) => {
-            const column = index % PRESET_COLUMNS;
-            const row = Math.floor(index / PRESET_COLUMNS);
-            const position: [number, number, number] = [
-                column * PRESET_SPACING,
-                0,
-                row * PRESET_SPACING,
-            ];
-            const instances = Array.from(
-                { length: INSTANCE_GRID * INSTANCE_GRID },
-                (_, instanceIndex) => {
-                    const instanceColumn = instanceIndex % INSTANCE_GRID;
-                    const instanceRow = Math.floor(
-                        instanceIndex / INSTANCE_GRID,
-                    );
-
-                    return {
-                        generation: 8.8,
-                        position: [
-                            (instanceColumn - (INSTANCE_GRID - 1) / 2) *
-                                INSTANCE_SPACING,
-                            0.02,
-                            (instanceRow - (INSTANCE_GRID - 1) / 2) *
-                                INSTANCE_SPACING,
-                        ] as const,
-                        scale: 0.28,
-                        seed: `${key}:${instanceIndex}`,
-                    };
-                },
-            );
-
-            return {
-                definition,
-                key,
-                label: definition.name,
-                position,
-                instances,
-            };
-        });
-    }, []);
-
-    const rowCount = Math.ceil(presets.length / PRESET_COLUMNS);
-    const centerX = ((PRESET_COLUMNS - 1) * PRESET_SPACING) / 2;
-    const centerZ = ((rowCount - 1) * PRESET_SPACING) / 2;
+    const flags = debugHud
+        ? plantDebugFlags
+        : {
+              enablePlantGeneratorFlag: true,
+              enableRainWetOverlayFlag: true,
+          };
 
     return (
-        <GameStateContext.Provider value={storeRef.current}>
-            <Scene position={150} zoom={28} className={className}>
-                <ambientLight intensity={0.8} />
-                <directionalLight
-                    position={[8, 14, 10]}
-                    intensity={1.5}
-                    castShadow
-                />
-                <Environment noBackground noSound noWeather />
-                <mesh
-                    rotation={[-Math.PI / 2, 0, 0]}
-                    position={[0, -0.02, 0]}
-                    receiveShadow
-                >
-                    <planeGeometry args={[80, 80]} />
-                    <meshStandardMaterial color="#536b3a" roughness={0.94} />
-                </mesh>
-                <group position={[-centerX, 0, -centerZ]}>
-                    {presets.map((preset) => (
-                        <group key={preset.key} position={preset.position}>
-                            <mesh
-                                rotation={[-Math.PI / 2, 0, 0]}
-                                position={[0, 0, 0]}
-                                receiveShadow
-                            >
-                                <planeGeometry args={[2.2, 2.2]} />
-                                <meshStandardMaterial
-                                    color="#654a35"
-                                    roughness={0.95}
-                                />
-                            </mesh>
-                            <RaisedBedGeneratedPlantBatch
-                                definition={preset.definition}
-                                instances={preset.instances}
-                            />
-                            <Html
-                                position={[0, 0.12, 1.32]}
-                                center
-                                distanceFactor={18}
-                            >
-                                <div className="rounded bg-black/70 px-2 py-1 text-[10px] text-white whitespace-nowrap">
-                                    {preset.label}
-                                </div>
-                            </Html>
-                        </group>
-                    ))}
-                </group>
-            </Scene>
-            {debugHud && <DebugHud />}
-        </GameStateContext.Provider>
+        <GameSceneDynamic
+            className={className}
+            dayNightCycleDisabled={false}
+            debugHud={debugHud}
+            deferDetails={false}
+            flags={flags}
+            freezeTime={plantDebugFreezeTime}
+            initialQualitySetting="medium"
+            mockGarden
+            mockGardenProfile="plant-heavy"
+            noSound
+            weather={plantDebugWeather}
+            zoom="far"
+        />
     );
 }


### PR DESCRIPTION
## Summary

- Adds debug profile toggles for details, controls, and HUD, with details enabled by default and controls/HUD disabled by default.
- Expands the debug HUD and profiling docs with render stats, current mobile medium-tier profiling guidance, and cleaner `/debug/plants` coverage.
- Reduces scene draw overhead by naming render objects for debugger inspection, cutting idle particle work, removing unnecessary interaction wrappers, and batching raised-bed generated plant rendering.
- Reworks generated plant rendering with instanced stems, instanced billboards, shared LOD logic, and a close-zoom near-geometry override so close views do not keep billboard plants.

## Why

The basic garden and plant debug scenes were still paying for too many draw calls, invisible particle pools, per-object wrappers, and unbatched generated plant pieces. The plant LOD also only considered projected plant height, so tiny plants could remain billboards even when the orthographic camera was zoomed in.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game test`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `git diff --check --cached`

Also verified `/debug/plants` manually in the browser at close zoom after the LOD adjustment.
