### PR TITLE
[codex] Fix harvest trace status contrast and delivery links

### DIFF
--- a/apps/storybook/stories/apps/www/HarvestTraceStatus.stories.tsx
+++ b/apps/storybook/stories/apps/www/HarvestTraceStatus.stories.tsx
@@ -1,0 +1,88 @@
+import { HarvestTraceStatusEvent } from '@apps/www/app/trag/[token]/HarvestTraceStatusEvent';
+import { plantFieldStatusLabel } from '@gredice/js/plants';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const statusOrder = [
+    'pendingVerification',
+    'sowed',
+    'sprouted',
+    'firstFlowers',
+    'firstFruitSet',
+    'ready',
+    'harvested',
+    'removed',
+    'notSprouted',
+    'died',
+];
+
+function buildStatusItem(status: string, index: number) {
+    const label = plantFieldStatusLabel(status);
+
+    return {
+        description: label.description,
+        location: {
+            fieldLabel: `${index + 1}`,
+            raisedBedName: 'Gredica rajcice',
+            raisedBedPhysicalId: '12B',
+        },
+        plantStatus: status,
+        title: label.shortLabel,
+    };
+}
+
+const meta = {
+    title: 'apps/www/Trace/HarvestTraceStatus',
+    component: HarvestTraceStatusEvent,
+    tags: ['autodocs'],
+    args: {
+        item: buildStatusItem('sprouted', 2),
+    },
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Plant lifecycle rows used by the public harvest trace timeline.',
+            },
+        },
+        layout: 'fullscreen',
+    },
+} satisfies Meta<typeof HarvestTraceStatusEvent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const statusItems = statusOrder.map(buildStatusItem);
+
+export const Default: Story = {};
+
+export const DarkModeAllStatuses: Story = {
+    render: () => (
+        <div className="dark">
+            <div className="min-h-screen bg-background p-4 text-foreground sm:p-8">
+                <div className="mx-auto max-w-2xl rounded-lg bg-card p-4 shadow-sm ring-1 ring-border/80 sm:p-5">
+                    <Stack spacing={4}>
+                        <Stack spacing={1}>
+                            <Typography level="h2" className="text-2xl">
+                                Status biljke
+                            </Typography>
+                            <Typography className="text-muted-foreground">
+                                Javni trag berbe
+                            </Typography>
+                        </Stack>
+                        <div className="space-y-2">
+                            {statusItems.map((item) => (
+                                <HarvestTraceStatusEvent
+                                    key={item.plantStatus}
+                                    item={item}
+                                />
+                            ))}
+                        </div>
+                    </Stack>
+                </div>
+            </div>
+        </div>
+    ),
+};

--- a/apps/storybook/styles.css
+++ b/apps/storybook/styles.css
@@ -4,6 +4,7 @@
 @source "../farm/components";
 @source "../garden/components";
 @source "../www/components";
+@source "../www/app/trag";
 @source "../../packages/game/src";
 @source "../../packages/ui/src";
 

--- a/apps/www/app/trag/[token]/HarvestTraceStatusEvent.tsx
+++ b/apps/www/app/trag/[token]/HarvestTraceStatusEvent.tsx
@@ -1,0 +1,140 @@
+import { plantFieldStatusEmoji } from '@gredice/js/plants';
+import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+
+export type HarvestTraceStatusEventItem = {
+    description?: string;
+    location?: {
+        fieldLabel?: string;
+        raisedBedName: string;
+        raisedBedPhysicalId: string | null;
+    };
+    plantStatus: string;
+    title: string;
+};
+
+function statusTimelineIconClassName(status: string) {
+    if (status === 'sowed' || status === 'pendingVerification') {
+        return 'bg-amber-100 text-amber-950 dark:bg-amber-900/70 dark:text-amber-100 dark:ring-1 dark:ring-amber-400/30';
+    }
+
+    if (status === 'sprouted') {
+        return 'bg-emerald-100 text-emerald-950 dark:bg-emerald-900/70 dark:text-emerald-100 dark:ring-1 dark:ring-emerald-400/30';
+    }
+
+    if (status === 'firstFlowers') {
+        return 'bg-pink-100 text-pink-950 dark:bg-pink-900/70 dark:text-pink-100 dark:ring-1 dark:ring-pink-400/30';
+    }
+
+    if (status === 'firstFruitSet') {
+        return 'bg-red-100 text-red-950 dark:bg-red-900/70 dark:text-red-100 dark:ring-1 dark:ring-red-400/30';
+    }
+
+    if (status === 'ready') {
+        return 'bg-orange-100 text-orange-950 dark:bg-orange-900/70 dark:text-orange-100 dark:ring-1 dark:ring-orange-400/30';
+    }
+
+    if (status === 'harvested') {
+        return 'bg-lime-100 text-lime-950 dark:bg-lime-900/70 dark:text-lime-100 dark:ring-1 dark:ring-lime-400/30';
+    }
+
+    if (status === 'removed') {
+        return 'bg-stone-100 text-stone-950 dark:bg-stone-800 dark:text-stone-100 dark:ring-1 dark:ring-stone-400/30';
+    }
+
+    if (status === 'notSprouted' || status === 'died') {
+        return 'bg-red-100 text-red-950 dark:bg-red-900/70 dark:text-red-100 dark:ring-1 dark:ring-red-400/30';
+    }
+
+    return 'bg-muted text-foreground';
+}
+
+function statusTimelineItemClassName(status: string) {
+    if (status === 'sowed' || status === 'pendingVerification') {
+        return 'border-amber-200 bg-amber-50/80 text-amber-950 dark:border-amber-400/45 dark:bg-amber-950/45 dark:text-amber-50';
+    }
+
+    if (status === 'sprouted') {
+        return 'border-emerald-200 bg-emerald-50/80 text-emerald-950 dark:border-emerald-400/45 dark:bg-emerald-950/45 dark:text-emerald-50';
+    }
+
+    if (status === 'firstFlowers') {
+        return 'border-pink-200 bg-pink-50/80 text-pink-950 dark:border-pink-400/45 dark:bg-pink-950/45 dark:text-pink-50';
+    }
+
+    if (status === 'firstFruitSet') {
+        return 'border-red-200 bg-red-50/80 text-red-950 dark:border-red-400/45 dark:bg-red-950/50 dark:text-red-50';
+    }
+
+    if (status === 'ready') {
+        return 'border-orange-200 bg-orange-50/80 text-orange-950 dark:border-orange-400/45 dark:bg-orange-950/45 dark:text-orange-50';
+    }
+
+    if (status === 'harvested') {
+        return 'border-lime-200 bg-lime-50/80 text-lime-950 dark:border-lime-400/45 dark:bg-lime-950/45 dark:text-lime-50';
+    }
+
+    if (status === 'removed') {
+        return 'border-stone-200 bg-stone-50/80 text-stone-950 dark:border-stone-500/60 dark:bg-stone-900/60 dark:text-stone-100';
+    }
+
+    if (status === 'notSprouted' || status === 'died') {
+        return 'border-red-200 bg-red-50/80 text-red-950 dark:border-red-400/45 dark:bg-red-950/50 dark:text-red-50';
+    }
+
+    return 'border-border bg-muted/40 text-foreground dark:bg-muted/60';
+}
+
+export function HarvestTraceStatusEvent({
+    item,
+}: {
+    item: HarvestTraceStatusEventItem;
+}) {
+    return (
+        <article
+            className={cx(
+                '-mx-2 flex min-w-0 gap-3 rounded-lg border px-2 py-2 shadow-xs',
+                statusTimelineItemClassName(item.plantStatus),
+            )}
+        >
+            <span
+                className={cx(
+                    'flex size-10 shrink-0 items-center justify-center rounded-lg text-xl leading-none',
+                    statusTimelineIconClassName(item.plantStatus),
+                )}
+                aria-hidden="true"
+            >
+                {plantFieldStatusEmoji(item.plantStatus)}
+            </span>
+            <Stack spacing={1} className="min-w-0">
+                <Typography semiBold className="break-words leading-snug">
+                    {item.title}
+                </Typography>
+                {item.description ? (
+                    <Typography level="body2" className="text-current/75">
+                        {item.description}
+                    </Typography>
+                ) : null}
+                {item.location ? (
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-1">
+                        <RaisedBedLabel
+                            physicalId={item.location.raisedBedPhysicalId}
+                            name={item.location.raisedBedName}
+                            size="compact"
+                        />
+                        {item.location.fieldLabel ? (
+                            <Typography
+                                level="body2"
+                                className="text-current/70"
+                            >
+                                Polje {item.location.fieldLabel}
+                            </Typography>
+                        ) : null}
+                    </div>
+                ) : null}
+            </Stack>
+        </article>
+    );
+}

--- a/apps/www/app/trag/[token]/page.tsx
+++ b/apps/www/app/trag/[token]/page.tsx
@@ -35,6 +35,7 @@ import {
     PlantMonthCalendar,
     type PlantMonthCalendarRow,
 } from '../../biljke/PlantMonthCalendar';
+import { HarvestTraceStatusEvent } from './HarvestTraceStatusEvent';
 
 export const dynamic = 'force-dynamic';
 
@@ -466,35 +467,35 @@ function StatisticsImageGallery({
 
 function statusRangeClassName(status: string) {
     if (status === 'sowed' || status === 'pendingVerification') {
-        return 'bg-amber-900';
+        return 'bg-amber-900 dark:bg-amber-400';
     }
 
     if (status === 'sprouted') {
-        return 'bg-emerald-500';
+        return 'bg-emerald-500 dark:bg-emerald-400';
     }
 
     if (status === 'firstFlowers') {
-        return 'bg-pink-400';
+        return 'bg-pink-400 dark:bg-pink-300';
     }
 
     if (status === 'firstFruitSet') {
-        return 'bg-red-500';
+        return 'bg-red-500 dark:bg-red-400';
     }
 
     if (status === 'ready') {
-        return 'bg-orange-400';
+        return 'bg-orange-400 dark:bg-orange-300';
     }
 
     if (status === 'harvested') {
-        return 'bg-lime-600';
+        return 'bg-lime-600 dark:bg-lime-400';
     }
 
     if (status === 'removed') {
-        return 'bg-stone-500';
+        return 'bg-stone-500 dark:bg-stone-300';
     }
 
     if (status === 'notSprouted' || status === 'died') {
-        return 'bg-red-700';
+        return 'bg-red-700 dark:bg-red-400';
     }
 
     return 'bg-muted-foreground';
@@ -769,20 +770,6 @@ function TraceStatistics({ trace }: { trace: PublicHarvestTrace }) {
 function TimelineVisual({ item }: { item: PublicHarvestTraceTimelineItem }) {
     const iconClassName = 'size-4 text-primary';
 
-    if (item.plantStatus) {
-        return (
-            <span
-                className={cx(
-                    'flex size-10 shrink-0 items-center justify-center rounded-lg text-xl leading-none',
-                    statusTimelineIconClassName(item.plantStatus),
-                )}
-                aria-hidden="true"
-            >
-                {plantFieldStatusEmoji(item.plantStatus)}
-            </span>
-        );
-    }
-
     if (item.imageUrl) {
         return (
             <span className="relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg">
@@ -817,95 +804,24 @@ function TimelineVisual({ item }: { item: PublicHarvestTraceTimelineItem }) {
     );
 }
 
-function statusTimelineIconClassName(status: string) {
-    if (status === 'sowed' || status === 'pendingVerification') {
-        return 'bg-amber-100';
-    }
-
-    if (status === 'sprouted') {
-        return 'bg-emerald-100';
-    }
-
-    if (status === 'firstFlowers') {
-        return 'bg-pink-100';
-    }
-
-    if (status === 'firstFruitSet') {
-        return 'bg-red-100';
-    }
-
-    if (status === 'ready') {
-        return 'bg-orange-100';
-    }
-
-    if (status === 'harvested') {
-        return 'bg-lime-100';
-    }
-
-    if (status === 'removed') {
-        return 'bg-stone-100';
-    }
-
-    if (status === 'notSprouted' || status === 'died') {
-        return 'bg-red-100';
-    }
-
-    return 'bg-muted';
-}
-
-function statusTimelineItemClassName(status: string | undefined) {
-    if (!status) {
-        return '';
-    }
-
-    if (status === 'sowed' || status === 'pendingVerification') {
-        return 'border-amber-200 bg-amber-50/80';
-    }
-
-    if (status === 'sprouted') {
-        return 'border-emerald-200 bg-emerald-50/80';
-    }
-
-    if (status === 'firstFlowers') {
-        return 'border-pink-200 bg-pink-50/80';
-    }
-
-    if (status === 'firstFruitSet') {
-        return 'border-red-200 bg-red-50/80';
-    }
-
-    if (status === 'ready') {
-        return 'border-orange-200 bg-orange-50/80';
-    }
-
-    if (status === 'harvested') {
-        return 'border-lime-200 bg-lime-50/80';
-    }
-
-    if (status === 'removed') {
-        return 'border-stone-200 bg-stone-50/80';
-    }
-
-    if (status === 'notSprouted' || status === 'died') {
-        return 'border-red-200 bg-red-50/80';
-    }
-
-    return 'border-border bg-muted/40';
-}
-
 function TimelineEvent({ item }: { item: PublicHarvestTraceTimelineItem }) {
     const isStatusItem = isPlantStatusTimelineItem(item);
 
+    if (isStatusItem && item.plantStatus) {
+        return (
+            <HarvestTraceStatusEvent
+                item={{
+                    description: item.description,
+                    location: item.location,
+                    plantStatus: item.plantStatus,
+                    title: item.title,
+                }}
+            />
+        );
+    }
+
     return (
-        <article
-            className={cx(
-                'flex min-w-0 gap-3 py-1',
-                isStatusItem
-                    ? '-mx-2 rounded-lg border px-2 py-2 shadow-xs'
-                    : '',
-                statusTimelineItemClassName(item.plantStatus),
-            )}
-        >
+        <article className="flex min-w-0 gap-3 py-1">
             <TimelineVisual item={item} />
             <Stack spacing={1} className="min-w-0">
                 <Typography semiBold className="break-words leading-snug">

--- a/packages/game/src/knownPages.ts
+++ b/packages/game/src/knownPages.ts
@@ -17,6 +17,10 @@ export const KnownPages = {
     GrediceContact: 'https://www.gredice.com/kontakt',
     GrediceWhatsNew: 'https://www.gredice.com/novosti/sto-je-novo',
     GrediceDeliverySlots: 'https://www.gredice.com/dostava/termini',
+    GrediceHarvestTrace: (publicPath: string) =>
+        publicPath.startsWith('http')
+            ? publicPath
+            : `https://www.gredice.com/${publicPath.replace(/^\/+/, '')}`,
     AdventRules2025:
         'https://www.gredice.com/legalno/natjecaji/adventski-kalendar-2025',
 

--- a/packages/game/src/shared-ui/delivery/DeliveryRequestRow.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryRequestRow.tsx
@@ -1,5 +1,12 @@
 import { Button } from '@gredice/ui/Button';
-import { Close, MapPin, ShoppingCart, Timer, Truck } from '@gredice/ui/icons';
+import {
+    Close,
+    ExternalLink,
+    MapPin,
+    ShoppingCart,
+    Timer,
+    Truck,
+} from '@gredice/ui/icons';
 import { TimeRange } from '@gredice/ui/LocalDateTime';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { PlantOrSortImage } from '@gredice/ui/plants';
@@ -8,6 +15,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { DeliveryRequestData } from '../../hooks/useDeliveryRequests';
+import { KnownPages } from '../../knownPages';
 import {
     CANCEL_REASON_OPTIONS,
     DeliveryCancelRequestModal,
@@ -207,7 +215,22 @@ export function DeliveryRequestRow({
                 )}
             </Stack>
             <Stack className="items-end">
-                <Row spacing={2}>
+                <Row spacing={2} className="flex-wrap justify-end">
+                    {request.trace && (
+                        <Button
+                            variant="outlined"
+                            color="neutral"
+                            size="sm"
+                            href={KnownPages.GrediceHarvestTrace(
+                                request.trace.publicPath,
+                            )}
+                            target="_blank"
+                            rel="noreferrer"
+                            startDecorator={<ExternalLink className="size-4" />}
+                        >
+                            Trag
+                        </Button>
+                    )}
                     <DeliveryStatusChip state={request.state} />
                     {canCancel && (
                         <DeliveryCancelRequestModal

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -27,7 +27,8 @@
         "test:node": "bash ./tests/runNodeTests.sh",
         "notifications:backfill-rollout": "tsx --env-file=.env ./scripts/backfillNotificationRolloutDefaults.ts",
         "plant-relationships:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantRelationships.ts",
-        "plant-health:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantHealthDirectory.ts"
+        "plant-health:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantHealthDirectory.ts",
+        "harvest-traces:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillHarvestTraceLinks.ts"
     },
     "devDependencies": {
         "@biomejs/biome": "2.4.16",

--- a/packages/storage/scripts/backfillHarvestTraceLinks.ts
+++ b/packages/storage/scripts/backfillHarvestTraceLinks.ts
@@ -1,0 +1,91 @@
+import {
+    backfillHarvestTraceLinksForCompletedHarvests,
+    closeStorage,
+    type HarvestTraceBackfillResult,
+} from '../src/index';
+
+function parseLimit() {
+    const rawLimit = process.argv
+        .find((arg) => arg.startsWith('--limit='))
+        ?.slice('--limit='.length);
+    if (!rawLimit) {
+        return 1000;
+    }
+
+    const parsed = Number.parseInt(rawLimit, 10);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+        throw new Error('--limit must be a positive integer.');
+    }
+
+    return parsed;
+}
+
+function emptyResult(dryRun: boolean): HarvestTraceBackfillResult {
+    return {
+        dryRun,
+        scannedOperations: 0,
+        harvestOperations: 0,
+        targetLinks: 0,
+        existingLinks: 0,
+        createdLinks: 0,
+        wouldCreateLinks: 0,
+        skipped: {
+            missingAccount: 0,
+            missingGarden: 0,
+            missingRaisedBed: 0,
+            missingField: 0,
+            missingPlantCycle: 0,
+            unsupportedScope: 0,
+            notCompleted: 0,
+        },
+    };
+}
+
+function addResult(
+    total: HarvestTraceBackfillResult,
+    page: HarvestTraceBackfillResult,
+) {
+    total.scannedOperations += page.scannedOperations;
+    total.harvestOperations += page.harvestOperations;
+    total.targetLinks += page.targetLinks;
+    total.existingLinks += page.existingLinks;
+    total.createdLinks += page.createdLinks;
+    total.wouldCreateLinks += page.wouldCreateLinks;
+
+    for (const key of Object.keys(total.skipped) as Array<
+        keyof HarvestTraceBackfillResult['skipped']
+    >) {
+        total.skipped[key] += page.skipped[key];
+    }
+}
+
+async function main() {
+    const apply = process.argv.includes('--apply');
+    const dryRun = !apply;
+    const limit = parseLimit();
+    const total = emptyResult(dryRun);
+
+    for (let offset = 0; ; offset += limit) {
+        const page = await backfillHarvestTraceLinksForCompletedHarvests({
+            dryRun,
+            limit,
+            offset,
+        });
+        addResult(total, page);
+
+        if (page.scannedOperations < limit) {
+            break;
+        }
+    }
+
+    console.log(JSON.stringify(total, null, 2));
+}
+
+main()
+    .catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        await closeStorage();
+    });

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -45,6 +45,7 @@ import {
     knownEventTypes,
 } from './eventsRepo';
 import { getRaisedBed, getRaisedBedFieldsWithEvents } from './gardensRepo';
+import { getHarvestTraceLinksForOperationIds } from './harvestTraceLinksRepo';
 import { getOperationById, getOperationsByIds } from './operationsRepo';
 import { getPickupLocation } from './pickupLocationsRepo';
 import { closeTimeSlot, getTimeSlot } from './timeSlotsRepo';
@@ -653,30 +654,40 @@ export async function getDeliveryRequestsWithEvents(
         ),
     );
 
-    const [operationsWithState, operationEntities, fields] = await Promise.all([
-        getOperationsByIds(filteredOperationIds),
-        getEntitiesFormatted<OperationData>('operation').catch((error) => {
-            console.error('Failed to fetch operation entities:', error);
-            return null;
-        }),
-        uniqueRaisedBedIds.length > 0
-            ? Promise.all(
-                  uniqueRaisedBedIds.map(async (raisedBedId) => {
-                      try {
-                          return await getRaisedBedFieldsWithEvents(
-                              raisedBedId,
-                          );
-                      } catch (error) {
-                          console.error(
-                              'Failed to fetch raised bed fields:',
-                              error,
-                          );
-                          return [];
-                      }
-                  }),
-              ).then((fieldGroups) => fieldGroups.flat())
-            : Promise.resolve([]),
-    ]);
+    const [operationsWithState, operationEntities, fields, traceLinks] =
+        await Promise.all([
+            getOperationsByIds(filteredOperationIds),
+            getEntitiesFormatted<OperationData>('operation').catch((error) => {
+                console.error('Failed to fetch operation entities:', error);
+                return null;
+            }),
+            uniqueRaisedBedIds.length > 0
+                ? Promise.all(
+                      uniqueRaisedBedIds.map(async (raisedBedId) => {
+                          try {
+                              return await getRaisedBedFieldsWithEvents(
+                                  raisedBedId,
+                              );
+                          } catch (error) {
+                              console.error(
+                                  'Failed to fetch raised bed fields:',
+                                  error,
+                              );
+                              return [];
+                          }
+                      }),
+                  ).then((fieldGroups) => fieldGroups.flat())
+                : Promise.resolve([]),
+            getHarvestTraceLinksForOperationIds(filteredOperationIds).catch(
+                (error) => {
+                    console.error(
+                        'Failed to fetch harvest trace links:',
+                        error,
+                    );
+                    return [];
+                },
+            ),
+        ]);
 
     const operationsById = new Map(
         operationsWithState.map((operation) => [operation.id, operation]),
@@ -688,6 +699,27 @@ export async function getDeliveryRequestsWithEvents(
         ]),
     );
     const fieldsById = new Map(fields.map((field) => [field.id, field]));
+    const traceLinksByOperationId = new Map<
+        number,
+        (typeof traceLinks)[number]
+    >();
+    const traceLinkCountsByOperationId = new Map<number, number>();
+    for (const link of traceLinks) {
+        if (!traceLinksByOperationId.has(link.harvestOperationId)) {
+            traceLinksByOperationId.set(link.harvestOperationId, link);
+        }
+        traceLinkCountsByOperationId.set(
+            link.harvestOperationId,
+            (traceLinkCountsByOperationId.get(link.harvestOperationId) ?? 0) +
+                1,
+        );
+    }
+    const traceLinksByOperationAndFieldId = new Map(
+        traceLinks.map((link) => [
+            `${link.harvestOperationId}:${link.raisedBedFieldId}`,
+            link,
+        ]),
+    );
     const plantSortIds = Array.from(
         new Set(
             filteredRows
@@ -734,6 +766,19 @@ export async function getDeliveryRequestsWithEvents(
                           raisedBedFieldWithEvents.plantSortId,
                       ) ?? null)
                     : null;
+            const traceLink =
+                typeof raisedBedFieldId === 'number'
+                    ? (traceLinksByOperationAndFieldId.get(
+                          `${request.operationId}:${raisedBedFieldId}`,
+                      ) ??
+                      (traceLinkCountsByOperationId.get(request.operationId) ===
+                      1
+                          ? traceLinksByOperationId.get(request.operationId)
+                          : undefined))
+                    : traceLinkCountsByOperationId.get(request.operationId) ===
+                        1
+                      ? traceLinksByOperationId.get(request.operationId)
+                      : undefined;
 
             return {
                 id: request.id,
@@ -754,6 +799,13 @@ export async function getDeliveryRequestsWithEvents(
                 requestNotes: projection.requestNotes,
                 deliveryNotes: projection.deliveryNotes,
                 surveySent: projection.surveySent,
+                trace: traceLink
+                    ? {
+                          id: traceLink.id,
+                          publicToken: traceLink.publicToken,
+                          publicPath: traceLink.publicPath,
+                      }
+                    : null,
                 createdAt: request.createdAt,
                 updatedAt: request.updatedAt,
                 accountId: projection.accountId,

--- a/packages/storage/src/repositories/harvestTraceLinksRepo.ts
+++ b/packages/storage/src/repositories/harvestTraceLinksRepo.ts
@@ -9,6 +9,7 @@ import {
     eq,
     gte,
     inArray,
+    isNotNull,
     isNull,
     like,
     lte,
@@ -138,6 +139,35 @@ export type HarvestTraceLinkAdminDetail = HarvestTraceLinkAdminSummary & {
     plantSortId: number | null;
     fieldPositionIndex: number;
     timeline: PublicHarvestTrace | null;
+};
+
+export type HarvestTraceLinkDeliverySummary = {
+    id: number;
+    publicToken: string;
+    publicPath: string;
+    status: HarvestTraceLinkStatus;
+    harvestOperationId: number;
+    raisedBedFieldId: number;
+    plantPlaceEventId: number;
+};
+
+export type HarvestTraceBackfillResult = {
+    dryRun: boolean;
+    scannedOperations: number;
+    harvestOperations: number;
+    targetLinks: number;
+    existingLinks: number;
+    createdLinks: number;
+    wouldCreateLinks: number;
+    skipped: {
+        missingAccount: number;
+        missingGarden: number;
+        missingRaisedBed: number;
+        missingField: number;
+        missingPlantCycle: number;
+        unsupportedScope: number;
+        notCompleted: number;
+    };
 };
 
 type CreateOrGetHarvestTraceLinkInput = {
@@ -286,6 +316,32 @@ function operationCategoryName(entity: EntityStandardized | null | undefined) {
 
 function normalizedOperationClassifier(value: string | null | undefined) {
     return value?.toLocaleLowerCase('hr-HR').replace(/[\s_-]/g, '') ?? '';
+}
+
+const harvestOperationNames = new Set([
+    'harvestplant',
+    'harvestall',
+    'harvestmature',
+    'harvest50mature',
+    'harvest25mature',
+]);
+
+function isHarvestOperationEntity(
+    entity: EntityStandardized | null | undefined,
+) {
+    const stageName = expandedEntityInformationName(entity?.attributes?.stage);
+    if (normalizedOperationClassifier(stageName) === 'harvest') {
+        return true;
+    }
+
+    return harvestOperationNames.has(
+        normalizedOperationClassifier(entity?.information?.name),
+    );
+}
+
+function operationApplication(entity: EntityStandardized | null | undefined) {
+    const value = entity?.attributes?.application;
+    return typeof value === 'string' ? value : undefined;
 }
 
 function isWateringOperation(label: string, categoryName?: string) {
@@ -1148,6 +1204,41 @@ export async function createOrGetHarvestTraceLink(
     return racedExisting;
 }
 
+export async function getHarvestTraceLinksForOperationIds(
+    operationIds: number[],
+): Promise<HarvestTraceLinkDeliverySummary[]> {
+    const uniqueOperationIds = Array.from(
+        new Set(operationIds.filter((id) => positiveInteger(id))),
+    );
+    if (uniqueOperationIds.length === 0) {
+        return [];
+    }
+
+    const rows = await storage().query.harvestTraceLinks.findMany({
+        where: and(
+            inArray(harvestTraceLinks.harvestOperationId, uniqueOperationIds),
+            eq(harvestTraceLinks.status, 'active'),
+        ),
+        orderBy: [desc(harvestTraceLinks.createdAt)],
+    });
+
+    return rows.flatMap((link) =>
+        typeof link.harvestOperationId === 'number'
+            ? [
+                  {
+                      id: link.id,
+                      publicToken: link.publicToken,
+                      publicPath: link.tracePath,
+                      status: link.status,
+                      harvestOperationId: link.harvestOperationId,
+                      raisedBedFieldId: link.raisedBedFieldId,
+                      plantPlaceEventId: link.plantPlaceEventId,
+                  },
+              ]
+            : [],
+    );
+}
+
 export async function getPublicHarvestTraceByToken(tokenValue: string) {
     const token = normalizeHarvestTraceToken(tokenValue);
     if (!token) {
@@ -1494,4 +1585,267 @@ export async function getHarvestTraceLinksForTarget(input: {
         ),
         orderBy: [desc(harvestTraceLinks.createdAt)],
     });
+}
+
+function cycleMatchesOperationDate(
+    cycle: RaisedBedFieldPlantCycle,
+    operationDate: Date,
+) {
+    if (operationDate < cycle.startedAt) {
+        return false;
+    }
+
+    const cycleEnd = cycle.plantRemovedDate ?? cycle.plantHarvestedDate;
+    if (cycleEnd && operationDate > cycleEnd) {
+        return false;
+    }
+
+    return true;
+}
+
+function chooseTracePlantCycle(
+    cycles: RaisedBedFieldPlantCycle[],
+    positionIndex: number,
+    operationDate: Date,
+) {
+    const positionCycles = cycles
+        .filter((cycle) => cycle.positionIndex === positionIndex)
+        .toSorted((a, b) => a.startedAt.getTime() - b.startedAt.getTime());
+
+    return (
+        positionCycles.findLast((cycle) =>
+            cycleMatchesOperationDate(cycle, operationDate),
+        ) ??
+        positionCycles.findLast((cycle) =>
+            cycle.plantHarvestedDate
+                ? cycle.plantHarvestedDate <= operationDate
+                : false,
+        ) ??
+        positionCycles.at(-1)
+    );
+}
+
+export async function backfillHarvestTraceLinksForCompletedHarvests({
+    dryRun = true,
+    limit = 1000,
+    offset = 0,
+}: {
+    dryRun?: boolean;
+    limit?: number;
+    offset?: number;
+} = {}): Promise<HarvestTraceBackfillResult> {
+    const safeLimit = Math.min(Math.max(Math.trunc(limit), 1), 5000);
+    const safeOffset = Math.max(Math.trunc(offset), 0);
+    const operationRows = await storage()
+        .select({
+            operation: operations,
+            raisedBedAccountId: raisedBeds.accountId,
+            raisedBedGardenId: raisedBeds.gardenId,
+        })
+        .from(operations)
+        .innerJoin(raisedBeds, eq(operations.raisedBedId, raisedBeds.id))
+        .innerJoin(gardens, eq(raisedBeds.gardenId, gardens.id))
+        .where(
+            and(
+                eq(operations.entityTypeName, 'operation'),
+                eq(operations.isAccepted, true),
+                eq(operations.isDeleted, false),
+                eq(raisedBeds.isDeleted, false),
+                eq(gardens.isDeleted, false),
+                eq(gardens.isSandbox, false),
+                isNotNull(operations.raisedBedId),
+            ),
+        )
+        .orderBy(asc(operations.timestamp), asc(operations.id))
+        .offset(safeOffset)
+        .limit(safeLimit);
+
+    const result: HarvestTraceBackfillResult = {
+        dryRun,
+        scannedOperations: operationRows.length,
+        harvestOperations: 0,
+        targetLinks: 0,
+        existingLinks: 0,
+        createdLinks: 0,
+        wouldCreateLinks: 0,
+        skipped: {
+            missingAccount: 0,
+            missingGarden: 0,
+            missingRaisedBed: 0,
+            missingField: 0,
+            missingPlantCycle: 0,
+            unsupportedScope: 0,
+            notCompleted: 0,
+        },
+    };
+
+    if (operationRows.length === 0) {
+        return result;
+    }
+
+    const operationIds = operationRows.map((row) => row.operation.id);
+    const uniqueRaisedBedIds = Array.from(
+        new Set(operationRows.map((row) => row.operation.raisedBedId)),
+    ).filter((id): id is number => typeof id === 'number');
+    const [operationStates, operationEntities, fields, existingLinks] =
+        await Promise.all([
+            getOperationsByIds(operationIds),
+            getEntitiesFormatted<EntityStandardized>('operation'),
+            uniqueRaisedBedIds.length > 0
+                ? storage().query.raisedBedFields.findMany({
+                      where: and(
+                          inArray(
+                              raisedBedFields.raisedBedId,
+                              uniqueRaisedBedIds,
+                          ),
+                          eq(raisedBedFields.isDeleted, false),
+                      ),
+                      orderBy: [
+                          asc(raisedBedFields.raisedBedId),
+                          asc(raisedBedFields.positionIndex),
+                      ],
+                  })
+                : Promise.resolve([]),
+            storage().query.harvestTraceLinks.findMany({
+                where: inArray(
+                    harvestTraceLinks.harvestOperationId,
+                    operationIds,
+                ),
+            }),
+        ]);
+
+    const operationsById = new Map(
+        operationStates.map((operation) => [operation.id, operation]),
+    );
+    const operationEntitiesById = new Map(
+        operationEntities.map((entity) => [entity.id, entity]),
+    );
+    const fieldsByRaisedBedId = new Map<number, typeof fields>();
+    for (const field of fields) {
+        const raisedBedFieldsForBed =
+            fieldsByRaisedBedId.get(field.raisedBedId) ?? [];
+        raisedBedFieldsForBed.push(field);
+        fieldsByRaisedBedId.set(field.raisedBedId, raisedBedFieldsForBed);
+    }
+    const existingTargetKeys = new Set(
+        existingLinks.flatMap((link) =>
+            typeof link.harvestOperationId === 'number'
+                ? [
+                      `${link.harvestOperationId}:${link.raisedBedFieldId}:${link.plantPlaceEventId}`,
+                  ]
+                : [],
+        ),
+    );
+    result.existingLinks = existingTargetKeys.size;
+
+    const cyclesByRaisedBedId = new Map<
+        number,
+        Awaited<ReturnType<typeof getRaisedBedFieldPlantCycles>>
+    >();
+    async function getCycles(raisedBedId: number) {
+        const existing = cyclesByRaisedBedId.get(raisedBedId);
+        if (existing) {
+            return existing;
+        }
+
+        const cycles = await getRaisedBedFieldPlantCycles(raisedBedId);
+        cyclesByRaisedBedId.set(raisedBedId, cycles);
+        return cycles;
+    }
+
+    for (const row of operationRows) {
+        const hydratedOperation = operationsById.get(row.operation.id);
+        const operationEntity = operationEntitiesById.get(
+            row.operation.entityId,
+        );
+        if (!isHarvestOperationEntity(operationEntity)) {
+            continue;
+        }
+        result.harvestOperations += 1;
+
+        if (
+            hydratedOperation?.status !== 'completed' &&
+            hydratedOperation?.status !== 'pendingVerification'
+        ) {
+            result.skipped.notCompleted += 1;
+            continue;
+        }
+
+        const accountId = row.operation.accountId ?? row.raisedBedAccountId;
+        const gardenId = row.operation.gardenId ?? row.raisedBedGardenId;
+        const raisedBedId = row.operation.raisedBedId;
+        if (!accountId) {
+            result.skipped.missingAccount += 1;
+            continue;
+        }
+        if (!gardenId) {
+            result.skipped.missingGarden += 1;
+            continue;
+        }
+        if (!raisedBedId) {
+            result.skipped.missingRaisedBed += 1;
+            continue;
+        }
+
+        const operationDate = getOperationTimelineDate(hydratedOperation);
+        const fieldsForBed = fieldsByRaisedBedId.get(raisedBedId) ?? [];
+        const scopedFields =
+            typeof row.operation.raisedBedFieldId === 'number'
+                ? fieldsForBed.filter(
+                      (field) => field.id === row.operation.raisedBedFieldId,
+                  )
+                : operationApplication(operationEntity) === 'raisedBedFull'
+                  ? fieldsForBed
+                  : [];
+        if (scopedFields.length === 0) {
+            if (typeof row.operation.raisedBedFieldId === 'number') {
+                result.skipped.missingField += 1;
+            } else {
+                result.skipped.unsupportedScope += 1;
+            }
+            continue;
+        }
+
+        const cycles = await getCycles(raisedBedId);
+        for (const field of scopedFields) {
+            const cycle = chooseTracePlantCycle(
+                cycles,
+                field.positionIndex,
+                operationDate,
+            );
+            if (!cycle) {
+                result.skipped.missingPlantCycle += 1;
+                continue;
+            }
+
+            const targetKey = `${row.operation.id}:${field.id}:${cycle.plantPlaceEventId}`;
+            result.targetLinks += 1;
+            if (existingTargetKeys.has(targetKey)) {
+                continue;
+            }
+
+            if (dryRun) {
+                result.wouldCreateLinks += 1;
+                continue;
+            }
+
+            const link = await createOrGetHarvestTraceLink({
+                accountId,
+                gardenId,
+                raisedBedId,
+                raisedBedFieldId: field.id,
+                fieldPositionIndex: field.positionIndex,
+                fieldLabel: String(field.positionIndex + 1),
+                plantPlaceEventId: cycle.plantPlaceEventId,
+                plantSortId: cycle.plantSortId,
+                harvestOperationId: row.operation.id,
+            });
+            existingTargetKeys.add(
+                `${link.harvestOperationId}:${link.raisedBedFieldId}:${link.plantPlaceEventId}`,
+            );
+            result.createdLinks += 1;
+        }
+    }
+
+    return result;
 }

--- a/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
@@ -2,12 +2,33 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
+    acceptOperation,
+    createDeliveryRequest,
+    createEvent,
+    createFarm,
+    createOperation,
+    createOrGetHarvestTraceLink,
+    createPickupLocation,
+    createTimeSlot,
     DeliveryRequestStates,
     events,
+    getDeliveryRequestsWithEvents,
     getPendingDeliveryReadyEmailRequestIds,
+    knownEvents,
     knownEventTypes,
+    raisedBedFields,
+    raisedBeds,
     storage,
+    TimeSlotStatuses,
+    upsertRaisedBedField,
 } from '@gredice/storage';
+import { eq } from 'drizzle-orm';
+import {
+    createTestAccount,
+    createTestBlock,
+    createTestGarden,
+    createTestRaisedBed,
+} from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
 async function insertDeliveryReadyEvent(
@@ -58,6 +79,107 @@ async function insertDeliveryReadyEmailProcessedEvent({
                 skipped,
             },
         });
+}
+
+async function createDeliveryRequestWithTraceFixture() {
+    createTestDb();
+
+    const accountId = await createTestAccount();
+    const farmId = await createFarm({
+        name: `Delivery trace farm ${randomUUID()}`,
+        longitude: 0,
+        latitude: 0,
+    });
+    const gardenId = await createTestGarden({
+        name: `Delivery trace garden ${randomUUID()}`,
+        accountId,
+        farmId,
+    });
+    const blockId = await createTestBlock(
+        gardenId,
+        `Delivery trace block ${randomUUID()}`,
+    );
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+    await storage()
+        .update(raisedBeds)
+        .set({ name: 'Dostavna gredica', physicalId: 'DELIVERY-TRACE' })
+        .where(eq(raisedBeds.id, raisedBedId));
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+    const field = await storage().query.raisedBedFields.findFirst({
+        where: eq(raisedBedFields.raisedBedId, raisedBedId),
+    });
+    assert.ok(field);
+
+    const operationId = await createOperation({
+        entityId: 1,
+        entityTypeName: 'operation',
+        accountId,
+        farmId,
+        gardenId,
+        raisedBedId,
+        raisedBedFieldId: field.id,
+        timestamp: new Date('2026-05-30T07:00:00.000Z'),
+    });
+    await acceptOperation(operationId);
+    await createEvent({
+        ...knownEvents.operations.completedV1(operationId.toString(), {
+            completedBy: randomUUID(),
+        }),
+        createdAt: new Date('2026-05-30T08:00:00.000Z'),
+    });
+
+    const [plantPlaceEvent] = await storage()
+        .insert(events)
+        .values({
+            ...knownEvents.raisedBedFields.plantPlaceV1(
+                `${raisedBedId}|${field.positionIndex}`,
+                {
+                    plantSortId: '1',
+                    scheduledDate: null,
+                    sowingLocation: 'direct',
+                },
+            ),
+            createdAt: new Date('2026-05-01T08:00:00.000Z'),
+        })
+        .returning({ id: events.id });
+    assert.ok(plantPlaceEvent);
+
+    const traceLink = await createOrGetHarvestTraceLink({
+        accountId,
+        gardenId,
+        raisedBedId,
+        raisedBedFieldId: field.id,
+        fieldPositionIndex: field.positionIndex,
+        fieldLabel: '1',
+        plantPlaceEventId: plantPlaceEvent.id,
+        plantSortId: null,
+        harvestOperationId: operationId,
+    });
+
+    const locationId = await createPickupLocation({
+        name: 'Gredice HQ',
+        street1: 'Testna 1',
+        city: 'Zagreb',
+        postalCode: '10000',
+        countryCode: 'HR',
+    });
+    const slotStartAt = new Date('2099-01-01T08:00:00.000Z');
+    const slotId = await createTimeSlot({
+        locationId,
+        type: 'pickup',
+        startAt: slotStartAt,
+        endAt: new Date(slotStartAt.getTime() + 2 * 60 * 60 * 1000),
+        status: TimeSlotStatuses.SCHEDULED,
+    });
+    await createDeliveryRequest({
+        operationId,
+        slotId,
+        mode: 'pickup',
+        locationId,
+        accountId,
+    });
+
+    return { accountId, operationId, traceLink };
 }
 
 test('getPendingDeliveryReadyEmailRequestIds returns ordered retryable ready events', async () => {
@@ -145,4 +267,20 @@ test('getPendingDeliveryReadyEmailRequestIds returns ordered retryable ready eve
             },
         ],
     );
+});
+
+test('getDeliveryRequestsWithEvents includes harvest trace links for plant rows', async () => {
+    const fixture = await createDeliveryRequestWithTraceFixture();
+
+    const requests = await getDeliveryRequestsWithEvents(fixture.accountId);
+    const request = requests.find(
+        (item) => item.operationId === fixture.operationId,
+    );
+
+    assert.ok(request);
+    assert.deepEqual(request.trace, {
+        id: fixture.traceLink.id,
+        publicToken: fixture.traceLink.publicToken,
+        publicPath: fixture.traceLink.tracePath,
+    });
 });

--- a/packages/storage/tests/harvestTraceLinksRepo.node.spec.ts
+++ b/packages/storage/tests/harvestTraceLinksRepo.node.spec.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
     acceptOperation,
     assignUserToFarm,
+    backfillHarvestTraceLinksForCompletedHarvests,
     createAttributeDefinition,
     createEntity,
     createEvent,
@@ -14,6 +15,7 @@ import {
     getFarmUserPrintableHarvestTraceLinkIds,
     getHarvestTraceLinkAdminDetail,
     getHarvestTraceLinksAdmin,
+    getHarvestTraceLinksForOperationIds,
     getPublicHarvestTraceByToken,
     harvestTraceLinks,
     knownEvents,
@@ -531,6 +533,69 @@ test('createOrGetHarvestTraceLink reuses the same public token for the same harv
     assert.equal(secondLink.id, fixture.link.id);
     assert.equal(secondLink.publicToken, fixture.link.publicToken);
     assert.match(secondLink.tracePath, /^\/trag\/[A-Za-z0-9_-]+$/);
+});
+
+test('getHarvestTraceLinksForOperationIds returns active trace summaries', async () => {
+    const fixture = await createHarvestTraceFixture();
+
+    const links = await getHarvestTraceLinksForOperationIds([
+        fixture.harvestOperationId,
+        fixture.harvestOperationId,
+        -1,
+    ]);
+
+    assert.equal(links.length, 1);
+    assert.deepEqual(links[0], {
+        id: fixture.link.id,
+        publicToken: fixture.link.publicToken,
+        publicPath: fixture.link.tracePath,
+        status: 'active',
+        harvestOperationId: fixture.harvestOperationId,
+        raisedBedFieldId: fixture.raisedBedFieldId,
+        plantPlaceEventId: fixture.plantPlaceEventId,
+    });
+
+    await updateHarvestTraceLinkStatus(fixture.link.id, 'revoked');
+    assert.deepEqual(
+        await getHarvestTraceLinksForOperationIds([fixture.harvestOperationId]),
+        [],
+    );
+});
+
+test('backfillHarvestTraceLinksForCompletedHarvests creates missing completed harvest links', async () => {
+    const fixture = await createHarvestTraceFixture();
+    const harvestEntityId = await createPublishedEntity(
+        'operation',
+        'Berba za backfill',
+        { operationCategoryName: 'harvest' },
+    );
+    const operationId = await createAcceptedOperation({
+        accountId: fixture.accountId,
+        farmId: fixture.farmId,
+        gardenId: fixture.gardenId,
+        raisedBedId: fixture.raisedBedId,
+        raisedBedFieldId: fixture.raisedBedFieldId,
+        entityId: harvestEntityId,
+        timestamp: new Date('2026-05-31T07:00:00.000Z'),
+        completedAt: new Date('2026-05-31T08:00:00.000Z'),
+    });
+
+    const dryRun = await backfillHarvestTraceLinksForCompletedHarvests({
+        dryRun: true,
+    });
+    assert.equal(dryRun.createdLinks, 0);
+    assert.equal(dryRun.wouldCreateLinks, 1);
+
+    const applied = await backfillHarvestTraceLinksForCompletedHarvests({
+        dryRun: false,
+    });
+    assert.equal(applied.createdLinks, 1);
+
+    const links = await getHarvestTraceLinksForOperationIds([operationId]);
+    assert.equal(links.length, 1);
+    assert.equal(links[0]?.harvestOperationId, operationId);
+    assert.equal(links[0]?.raisedBedFieldId, fixture.raisedBedFieldId);
+    assert.equal(links[0]?.plantPlaceEventId, fixture.plantPlaceEventId);
 });
 
 test('getPublicHarvestTraceByToken includes raised-bed operations and excludes other-field operations', async () => {


### PR DESCRIPTION
## Summary

- Fix harvest trace status alert contrast in dark mode and add Storybook coverage for trace statuses.
- Add a `Trag` link to each delivery HUD plant row when an active harvest trace exists.
- Add storage support for looking up active trace links by harvest operation and an idempotent harvest trace backfill script.

## Backfill

- Ran `pnpm bootstrap` to pull DB env.
- Applied `pnpm --filter @gredice/storage harvest-traces:backfill -- --apply --limit=1000`.
- Created 166 missing trace links.
- Verified with a follow-up dry-run: 174 existing target links, 0 remaining creations, 29 harvest operations skipped because they are not completed.

## Validation

- `pnpm --filter @gredice/storage lint`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter api build`
- `pnpm --filter @gredice/storage test:node harvestTraceLinksRepo.node.spec.ts deliveryRequestsRepo.node.spec.ts`
- `git diff --check`