### PR TITLE
[codex] Fix impersonation account handoff

### DIFF
--- a/apps/app/app/api/logout/route.ts
+++ b/apps/app/app/api/logout/route.ts
@@ -22,7 +22,7 @@ export async function POST() {
 
     await clearCookie();
     await clearRefreshCookie();
-    clearImpersonationCookies(await cookies());
+    await clearImpersonationCookies(await cookies());
 
     return new Response(null, { status: 200 });
 }

--- a/apps/app/app/api/users/[userId]/impersonate/route.ts
+++ b/apps/app/app/api/users/[userId]/impersonate/route.ts
@@ -1,8 +1,10 @@
 import { createRefreshToken } from '@gredice/storage';
 import { cookies } from 'next/headers';
 import { createJwt, setCookie, withAuth } from '../../../../../lib/auth/auth';
+import { authCookieSettings } from '../../../../../lib/auth/cookieSecurity';
 import { setRefreshCookie } from '../../../../../lib/auth/refreshCookies';
 import {
+    accountCookieName,
     cookieDomain,
     impersonationFlagCookieName,
     impersonationRefreshCookieName,
@@ -21,6 +23,7 @@ export async function POST(
 
     return await withAuth(['admin'], async () => {
         const cookieStore = await cookies();
+        const cookieSettings = await authCookieSettings();
 
         // Save the admin's current refresh token so we can restore the session later
         const adminRefreshToken = cookieStore.get(
@@ -36,7 +39,7 @@ export async function POST(
         // Store admin's refresh token in a backup cookie (httpOnly for security)
         cookieStore.set(impersonationRefreshCookieName, adminRefreshToken, {
             httpOnly: true,
-            secure: true,
+            secure: cookieSettings.secure,
             sameSite: 'lax',
             domain: cookieDomain,
             expires: new Date(Date.now() + refreshTokenExpiryMs),
@@ -45,10 +48,19 @@ export async function POST(
         // Set a non-httpOnly flag cookie so client-side code can detect impersonation
         cookieStore.set(impersonationFlagCookieName, '1', {
             httpOnly: false,
-            secure: true,
+            secure: cookieSettings.secure,
             sameSite: 'lax',
             domain: cookieDomain,
             expires: new Date(Date.now() + refreshTokenExpiryMs),
+        });
+
+        // Reset the active account so the impersonated session chooses from the user's accounts.
+        cookieStore.set(accountCookieName, '', {
+            httpOnly: true,
+            secure: cookieSettings.secure,
+            sameSite: 'lax',
+            domain: cookieSettings.domain,
+            maxAge: 0,
         });
 
         // Create tokens for the impersonated user
@@ -56,8 +68,10 @@ export async function POST(
             createJwt(userId),
             createRefreshToken(userId),
         ]);
-        await setCookie(accessToken);
-        setRefreshCookie(refreshToken);
+        await Promise.all([
+            setCookie(accessToken),
+            setRefreshCookie(refreshToken),
+        ]);
         return new Response(null, { status: 201 });
     });
 }

--- a/apps/app/app/api/users/[userId]/impersonate/route.ts
+++ b/apps/app/app/api/users/[userId]/impersonate/route.ts
@@ -50,7 +50,7 @@ export async function POST(
             httpOnly: false,
             secure: cookieSettings.secure,
             sameSite: 'lax',
-            domain: cookieDomain,
+            domain: cookieSettings.domain,
             expires: new Date(Date.now() + refreshTokenExpiryMs),
         });
 

--- a/apps/app/app/api/users/stop-impersonate/route.ts
+++ b/apps/app/app/api/users/stop-impersonate/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: Request) {
     const refreshResult = await doUseRefreshToken(adminRefreshToken);
     if (!refreshResult) {
         // Backup token is invalid/expired — clear impersonation cookies and redirect
-        clearImpersonationCookies(cookieStore);
+        await clearImpersonationCookies(cookieStore);
         return Response.redirect(getAdminUrl(request));
     }
 
@@ -84,7 +84,7 @@ export async function POST(request: Request) {
     await setRefreshCookie(newRefreshToken);
 
     // Clear impersonation cookies
-    clearImpersonationCookies(cookieStore);
+    await clearImpersonationCookies(cookieStore);
 
     return Response.redirect(getAdminUrl(request));
 }

--- a/apps/app/lib/auth/cookieSecurity.ts
+++ b/apps/app/lib/auth/cookieSecurity.ts
@@ -15,6 +15,11 @@ type RequestCookieContext = {
     origin?: string;
 };
 
+type AuthCookieSettings = {
+    domain: string | undefined;
+    secure: boolean;
+};
+
 function hostnameFromHostHeader(hostHeader: string) {
     try {
         return new URL(`http://${hostHeader}`).hostname;
@@ -88,18 +93,43 @@ function shouldUseSecureCookiesForContext(context: RequestCookieContext) {
     );
 }
 
+function configuredCookieDomain() {
+    const domain = process.env.COOKIE_DOMAIN?.trim();
+    return domain || undefined;
+}
+
+function inferredGrediceCookieDomain(hostname: string) {
+    if (hostname === 'gredice.com' || hostname.endsWith('.gredice.com')) {
+        return 'gredice.com';
+    }
+
+    if (hostname === 'gredice.test' || hostname.endsWith('.gredice.test')) {
+        return 'gredice.test';
+    }
+
+    return undefined;
+}
+
 function cookieDomainForContext(context: RequestCookieContext) {
     if (isLoopbackHost(context.host)) {
         return undefined;
     }
 
-    return process.env.COOKIE_DOMAIN || undefined;
+    return (
+        configuredCookieDomain() ?? inferredGrediceCookieDomain(context.host)
+    );
 }
 
-export async function authCookieSettings() {
-    const context = await requestCookieContext();
+export function resolveAuthCookieSettingsForContext(
+    context: RequestCookieContext,
+): AuthCookieSettings {
     return {
         domain: cookieDomainForContext(context),
         secure: shouldUseSecureCookiesForContext(context),
     };
+}
+
+export async function authCookieSettings() {
+    const context = await requestCookieContext();
+    return resolveAuthCookieSettingsForContext(context);
 }

--- a/apps/app/lib/auth/cookieSecurity.unit.ts
+++ b/apps/app/lib/auth/cookieSecurity.unit.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { resolveAuthCookieSettingsForContext } from './cookieSecurity';
+
+const originalCookieDomain = process.env.COOKIE_DOMAIN;
+
+afterEach(() => {
+    if (originalCookieDomain === undefined) {
+        delete process.env.COOKIE_DOMAIN;
+    } else {
+        process.env.COOKIE_DOMAIN = originalCookieDomain;
+    }
+});
+
+test('infers shared production cookie domain for Gredice apps', () => {
+    delete process.env.COOKIE_DOMAIN;
+
+    assert.deepEqual(
+        resolveAuthCookieSettingsForContext({
+            forwardedProto: 'https',
+            host: 'app.gredice.com',
+        }),
+        {
+            domain: 'gredice.com',
+            secure: true,
+        },
+    );
+});
+
+test('infers shared local proxy cookie domain for Gredice apps', () => {
+    delete process.env.COOKIE_DOMAIN;
+
+    assert.deepEqual(
+        resolveAuthCookieSettingsForContext({
+            forwardedProto: 'https',
+            host: 'app.gredice.test',
+        }),
+        {
+            domain: 'gredice.test',
+            secure: true,
+        },
+    );
+});
+
+test('keeps loopback auth cookies host scoped', () => {
+    process.env.COOKIE_DOMAIN = 'gredice.test';
+
+    assert.equal(
+        resolveAuthCookieSettingsForContext({
+            forwardedProto: 'http',
+            host: 'localhost',
+        }).domain,
+        undefined,
+    );
+});

--- a/apps/app/lib/auth/impersonationCookies.ts
+++ b/apps/app/lib/auth/impersonationCookies.ts
@@ -1,25 +1,55 @@
 import type { cookies } from 'next/headers';
+import { authCookieSettings } from './cookieSecurity';
 import {
     cookieDomain,
     impersonationFlagCookieName,
     impersonationRefreshCookieName,
 } from './sessionConfig';
 
-export function clearImpersonationCookies(
+function clearImpersonationCookie(
+    cookieStore: Awaited<ReturnType<typeof cookies>>,
+    name: string,
+    {
+        domain,
+        httpOnly,
+        secure,
+    }: {
+        domain: string | undefined;
+        httpOnly: boolean;
+        secure: boolean;
+    },
+) {
+    cookieStore.set(name, '', {
+        httpOnly,
+        secure,
+        sameSite: 'lax',
+        domain,
+        maxAge: 0,
+    });
+}
+
+export async function clearImpersonationCookies(
     cookieStore: Awaited<ReturnType<typeof cookies>>,
 ) {
-    cookieStore.set(impersonationRefreshCookieName, '', {
+    const cookieSettings = await authCookieSettings();
+
+    clearImpersonationCookie(cookieStore, impersonationRefreshCookieName, {
+        domain: cookieDomain,
         httpOnly: true,
-        secure: true,
-        sameSite: 'lax',
-        domain: cookieDomain,
-        maxAge: 0,
+        secure: cookieSettings.secure,
     });
-    cookieStore.set(impersonationFlagCookieName, '', {
+
+    clearImpersonationCookie(cookieStore, impersonationFlagCookieName, {
+        domain: cookieSettings.domain,
         httpOnly: false,
-        secure: true,
-        sameSite: 'lax',
-        domain: cookieDomain,
-        maxAge: 0,
+        secure: cookieSettings.secure,
     });
+
+    if (cookieSettings.domain !== cookieDomain) {
+        clearImpersonationCookie(cookieStore, impersonationFlagCookieName, {
+            domain: cookieDomain,
+            httpOnly: false,
+            secure: cookieSettings.secure,
+        });
+    }
 }

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -12,7 +12,7 @@
         "start": "node ../../scripts/run-app-command.mjs start",
         "test": "pnpm run test:run",
         "test:prepare": "turbo build --filter=app",
-        "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test src/ai/aiAnalyticsCost.unit.ts src/social/providers/reddit/redditAdapter.unit.ts src/social/providers/directAdapters.unit.ts app/admin/schedule/scheduleDayFilters.unit.ts app/admin/greenhouse/operationMatching.unit.ts 'app/admin/inventory/[inventoryId]/inventoryStatus.unit.ts' 'app/(actions)/socialPublishActions.unit.ts' 'app/(actions)/socialAccountActions.unit.ts'",
+        "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test src/ai/aiAnalyticsCost.unit.ts src/social/providers/reddit/redditAdapter.unit.ts src/social/providers/directAdapters.unit.ts lib/auth/cookieSecurity.unit.ts app/admin/schedule/scheduleDayFilters.unit.ts app/admin/greenhouse/operationMatching.unit.ts 'app/admin/inventory/[inventoryId]/inventoryStatus.unit.ts' 'app/(actions)/socialPublishActions.unit.ts' 'app/(actions)/socialAccountActions.unit.ts'",
         "test:run": "pnpm run test:unit && playwright test",
         "test-ui": "pnpm run test:prepare && playwright test --ui",
         "test:local": "pnpm run test:prepare && pnpm run test:run"


### PR DESCRIPTION
## Summary

- infer the shared Gredice cookie domain for app auth cookies when `COOKIE_DOMAIN` is not configured
- reset the active account cookie when starting impersonation so the garden/account picker resolves from the impersonated user's accounts
- await both impersonated session cookie writes and cover the domain inference with app unit tests

## Root cause

Multi-account support made the garden picker depend on the authenticated user's account set and active-account cookie. The app impersonation route could leave stale admin account state behind, and in environments without an explicit `COOKIE_DOMAIN`, the new impersonated session could be scoped to `app` instead of the shared Gredice domain consumed by the garden/API app.

## Validation

- `pnpm --filter app lint`
- `pnpm --filter app test:unit`
- `pnpm --filter app build`
- `pnpm typecheck --filter app`
- `git diff --check`

Note: `pnpm exec tsc --noEmit --pretty false --project apps/app/tsconfig.json` still reports pre-existing app/generated type errors outside this change, so it is not a clean repo-wide signal today.