### PR TITLE
[codex] Remove avatar notification badge

### DIFF
--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -266,11 +266,6 @@ export function AccountHud() {
                             onClick={() => track('game_profile_menu_opened')}
                         >
                             <ProfileAvatar variant="transparentOnMobile" />
-                            {hasUnreadNotifications && (
-                                <div className="md:hidden absolute right-0 -top-1">
-                                    <DotIndicator size={14} color={'success'} />
-                                </div>
-                            )}
                         </IconButton>
                     </DropdownMenuTrigger>
                     <ProfileCard />


### PR DESCRIPTION
## Summary
- remove the unread notification dot from the account avatar trigger in the game HUD
- keep the dedicated notifications HUD button and its unread indicator unchanged

## Why
Notifications are now always reachable from the HUD, including mobile, so the old avatar badge duplicates the notification signal.

## Validation
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`