### PR TITLE
[codex] Recommend removal for dead plant fields

### DIFF
--- a/packages/game/src/hud/raisedBed/featuredOperations.ts
+++ b/packages/game/src/hud/raisedBed/featuredOperations.ts
@@ -136,7 +136,7 @@ export const PLANT_STATUS_STAGE_SEQUENCE: Record<
     notSprouted: ['sowing', 'maintenance'],
     ready: ['harvest', 'storage'],
     harvested: ['storage'],
-    died: ['maintenance', 'soilPreparation'],
+    died: ['storage'],
     removed: ['maintenance', 'maintenance'],
 } as const;
 

--- a/packages/game/src/hud/raisedBed/featuredOperations.unit.ts
+++ b/packages/game/src/hud/raisedBed/featuredOperations.unit.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    FEATURED_OPERATIONS_BY_STAGE,
+    PLANT_STATUS_STAGE_SEQUENCE,
+} from './featuredOperations';
+
+describe('featured operations', () => {
+    it('recommends dead plant fields like harvested plant fields', () => {
+        assert.deepStrictEqual(
+            PLANT_STATUS_STAGE_SEQUENCE.died,
+            PLANT_STATUS_STAGE_SEQUENCE.harvested,
+        );
+
+        assert.deepStrictEqual(
+            FEATURED_OPERATIONS_BY_STAGE[PLANT_STATUS_STAGE_SEQUENCE.died[0]],
+            ['plantRemoval'],
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Map dead raised-bed plant fields to the same recommendation stage as harvested fields.
- Add a regression test so the dead status continues to feature the configured plant removal operation.

## Root cause

Dead fields were mapped to maintenance and soil preparation stages, so the plant details modal could surface alive-plant care operations instead of the removal flow used for harvested fields.

## Validation

- `pnpm --filter @gredice/game exec tsx --test src/hud/raisedBed/featuredOperations.unit.ts`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter @gredice/game test`
- `git diff --check`