### PR TITLE
[codex] Add scheduled date editing to game cart

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -6,6 +6,7 @@ import {
     getUser,
     markCartPaidIfAllItemsPaid,
     normalizeShoppingCartInventoryUsage,
+    normalizeShoppingCartScheduledDates,
     OUTLET_RESERVATION_HOLD_MINUTES,
     OutletOfferUnavailableError,
     OutletReservationUnavailableError,
@@ -84,9 +85,16 @@ const app = new Hono<{ Variables: AuthVariables }>()
             if (!initialCart) {
                 return context.json({ error: 'Cart not found' }, 404);
             }
-            const cart =
+            const inventoryNormalizedCart =
                 (await normalizeShoppingCartInventoryUsage(cartId)) ??
                 initialCart;
+            const cart =
+                (await normalizeShoppingCartScheduledDates(
+                    inventoryNormalizedCart.id,
+                    {
+                        defaultMissingScheduledDates: true,
+                    },
+                )) ?? inventoryNormalizedCart;
             if (cart.accountId !== accountId) {
                 console.warn('Account ID mismatch', {
                     accountId,

--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -247,6 +247,16 @@ const app = new Hono<{ Variables: AuthVariables }>()
                         409,
                     );
                 }
+                if (
+                    error instanceof Error &&
+                    error.message ===
+                        'Cannot update paid shopping cart item via API'
+                ) {
+                    return context.json(
+                        { error: 'Cannot update paid shopping cart item' },
+                        400,
+                    );
+                }
 
                 throw error;
             }

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -17,6 +17,7 @@ import {
     createTransaction,
     earnSunflowersForPayment,
     getAllTransactions,
+    getDefaultShoppingCartScheduledDate,
     getInventory,
     getOutletOfferReservationForCartItem,
     getRaisedBed,
@@ -26,6 +27,7 @@ import {
     knownEvents,
     markCartPaidIfAllItemsPaid,
     normalizeShoppingCartInventoryUsage,
+    normalizeShoppingCartScheduledDates,
     setCartItemPaid,
     spendSunflowers,
     updateRaisedBed,
@@ -66,13 +68,18 @@ async function processNonStripeCartItems(
     deliveryInfo?: unknown,
     scheduledDeliveryEmailKeys?: Set<string>,
 ): Promise<ShoppingCartItemWithShopData[]> {
-    const cart = await normalizeShoppingCartInventoryUsage(cartId);
-    if (!cart) {
+    const inventoryNormalizedCart =
+        await normalizeShoppingCartInventoryUsage(cartId);
+    if (!inventoryNormalizedCart) {
         console.warn(
             `No cart found for ID ${cartId} when processing non-stripe items.`,
         );
         return [];
     }
+    const cart =
+        (await normalizeShoppingCartScheduledDates(inventoryNormalizedCart.id, {
+            defaultMissingScheduledDates: true,
+        })) ?? inventoryNormalizedCart;
 
     const cartInfo = await getCartInfo(cart.items, accountId);
     if (!cartInfo.allowPurchase) {
@@ -626,13 +633,41 @@ async function outletReservationForCheckout(itemData: {
     return reservation;
 }
 
+function parseAdditionalDataValue(additionalData: unknown) {
+    if (typeof additionalData !== 'string') {
+        return additionalData;
+    }
+
+    try {
+        return JSON.parse(additionalData);
+    } catch {
+        return null;
+    }
+}
+
 function scheduledDateFromAdditionalData(additionalData: unknown) {
-    return typeof additionalData === 'object' &&
-        additionalData != null &&
-        'scheduledDate' in additionalData &&
-        typeof additionalData.scheduledDate === 'string'
-        ? additionalData.scheduledDate
-        : null;
+    const parsedAdditionalData = parseAdditionalDataValue(additionalData);
+    const scheduledDate =
+        typeof parsedAdditionalData === 'object' &&
+        parsedAdditionalData != null &&
+        'scheduledDate' in parsedAdditionalData &&
+        typeof parsedAdditionalData.scheduledDate === 'string'
+            ? parsedAdditionalData.scheduledDate
+            : null;
+    if (!scheduledDate) {
+        return null;
+    }
+
+    return Number.isNaN(new Date(scheduledDate).getTime())
+        ? null
+        : scheduledDate;
+}
+
+function checkoutScheduledDateFromAdditionalData(additionalData: unknown) {
+    return (
+        scheduledDateFromAdditionalData(additionalData) ??
+        getDefaultShoppingCartScheduledDate()
+    );
 }
 
 export async function processItem(itemData: {
@@ -711,8 +746,6 @@ export async function processItem(itemData: {
             )?.id;
         }
 
-        // Try to extract scheduled date from additional data
-        let scheduledDate: string | null = null;
         let additionalData = itemData.additionalData;
         if (typeof additionalData === 'string') {
             try {
@@ -729,14 +762,8 @@ export async function processItem(itemData: {
                 additionalData = null;
             }
         }
-        if (
-            typeof additionalData === 'object' &&
-            additionalData != null &&
-            'scheduledDate' in additionalData &&
-            typeof additionalData.scheduledDate === 'string'
-        ) {
-            scheduledDate = additionalData.scheduledDate;
-        }
+        const scheduledDate =
+            checkoutScheduledDateFromAdditionalData(additionalData);
 
         const operationId = await createOperation({
             accountId: itemData.accountId,
@@ -759,34 +786,25 @@ export async function processItem(itemData: {
             `Created operation ${itemData.entityId} of type ${itemData.entityTypeName} for account ${itemData.accountId} in garden ${itemData.gardenId ?? 'N/A'} with raised bed ${itemData.raisedBedId ?? 'N/A'} and field ${fieldId ?? 'N/A'}.`,
         );
 
-        // Make operation scheduled event if there is schedule date in the request
-        if (scheduledDate) {
-            try {
-                await createEvent(
-                    knownEvents.operations.scheduledV1(operationId.toString(), {
-                        scheduledDate,
-                    }),
-                );
-                console.debug(
-                    `Scheduled operation ${operationId} for date ${scheduledDate}.`,
-                );
-            } catch (error) {
-                console.error(
-                    `Failed to create scheduled event for operation ${operationId}:`,
-                    error,
-                );
-            }
-            const scheduledDateValue = new Date(scheduledDate);
-            if (!Number.isNaN(scheduledDateValue.getTime())) {
-                await notifyOperationUpdate(operationId, 'scheduled', {
-                    scheduledDate: scheduledDateValue.toISOString(),
-                });
-            } else {
-                console.warn(
-                    `Skipping scheduled notification update for operation ${operationId} due to invalid scheduledDate metadata: ${scheduledDate}`,
-                );
-            }
+        // Every purchased operation is scheduled; missing dates default to tomorrow.
+        try {
+            await createEvent(
+                knownEvents.operations.scheduledV1(operationId.toString(), {
+                    scheduledDate,
+                }),
+            );
+            console.debug(
+                `Scheduled operation ${operationId} for date ${scheduledDate}.`,
+            );
+        } catch (error) {
+            console.error(
+                `Failed to create scheduled event for operation ${operationId}:`,
+                error,
+            );
         }
+        await notifyOperationUpdate(operationId, 'scheduled', {
+            scheduledDate: new Date(scheduledDate).toISOString(),
+        });
 
         // Check if this operation/entity is deliverable and create delivery request if needed
         if (itemData.cartId) {
@@ -882,7 +900,9 @@ export async function processItem(itemData: {
                 plantSortId: itemData.entityId,
                 scheduledDate: outletReservation
                     ? null
-                    : scheduledDateFromAdditionalData(itemData.additionalData),
+                    : checkoutScheduledDateFromAdditionalData(
+                          itemData.additionalData,
+                      ),
                 sowingLocation: outletReservation ? 'greenhouse' : undefined,
             }),
         );

--- a/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
+++ b/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
@@ -68,6 +68,16 @@ function createOutletCartItem() {
     } as unknown as ShoppingCartItemData;
 }
 
+function createPaidCartItem() {
+    return {
+        ...cartItem,
+        additionalData: JSON.stringify({
+            scheduledDate: '2040-01-05T00:00:00.000Z',
+        }),
+        status: 'paid',
+    } as unknown as ShoppingCartItemData;
+}
+
 function createOptimisticToggleQueryClient(item = cartItem) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
@@ -169,6 +179,16 @@ export function ShoppingCartOptimisticToggleStory() {
 
 export function ShoppingCartOutletCountdownStory() {
     const item = useMemo(() => createOutletCartItem(), []);
+
+    return (
+        <ShoppingCartOptimisticToggleProviders item={item}>
+            <ShoppingCartOptimisticTogglePanel />
+        </ShoppingCartOptimisticToggleProviders>
+    );
+}
+
+export function ShoppingCartPaidItemStory() {
+    const item = useMemo(() => createPaidCartItem(), []);
 
     return (
         <ShoppingCartOptimisticToggleProviders item={item}>

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -2,7 +2,32 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import {
     ShoppingCartOptimisticToggleStory,
     ShoppingCartOutletCountdownStory,
+    ShoppingCartPaidItemStory,
 } from './ShoppingCartOptimisticToggleStory';
+
+function addDays(date: Date, days: number) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
+}
+
+function formatDateInput(date: Date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function formatCartDate(date: Date) {
+    return date.toLocaleDateString('hr-HR', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    });
+}
+
+function scheduledDateIsoFromDateInput(date: string) {
+    const [year, month, day] = date.split('-').map(Number);
+    return new Date(Date.UTC(year, month - 1, day)).toISOString();
+}
 
 test('shopping cart payment toggle updates before the server responds', async ({
     mount,
@@ -52,6 +77,76 @@ test('shopping cart payment toggle updates before the server responds', async ({
     );
 
     releasePost?.();
+});
+
+test('shopping cart item shows tomorrow date when unscheduled', async ({
+    mount,
+    page,
+}) => {
+    await mount(<ShoppingCartOptimisticToggleStory />);
+
+    const tomorrowLabel = formatCartDate(addDays(new Date(), 1));
+
+    await expect(
+        page.getByTitle(`Promijeni datum: ${tomorrowLabel}`),
+    ).toBeVisible();
+});
+
+test('shopping cart date chip updates scheduled date metadata', async ({
+    mount,
+    page,
+}) => {
+    let resolvePayload:
+        | ((payload: Record<string, unknown>) => void)
+        | undefined;
+    const postedPayload = new Promise<Record<string, unknown>>((resolve) => {
+        resolvePayload = resolve;
+    });
+
+    await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+        if (route.request().method() !== 'POST') {
+            await route.fallback();
+            return;
+        }
+
+        const payload = route.request().postDataJSON();
+        if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+            resolvePayload?.(payload);
+        }
+        await route.fulfill({
+            body: JSON.stringify({ success: true }),
+            contentType: 'application/json',
+            status: 200,
+        });
+    });
+
+    await mount(<ShoppingCartOptimisticToggleStory />);
+
+    const tomorrowLabel = formatCartDate(addDays(new Date(), 1));
+    await page.getByTitle(`Promijeni datum: ${tomorrowLabel}`).click();
+
+    const selectedDate = formatDateInput(addDays(new Date(), 7));
+    await page.getByLabel('Datum').fill(selectedDate);
+
+    const payload = await postedPayload;
+    const additionalData =
+        typeof payload.additionalData === 'string'
+            ? JSON.parse(payload.additionalData)
+            : null;
+
+    expect(additionalData?.scheduledDate).toBe(
+        scheduledDateIsoFromDateInput(selectedDate),
+    );
+});
+
+test('paid shopping cart item date is not editable', async ({
+    mount,
+    page,
+}) => {
+    await mount(<ShoppingCartPaidItemStory />);
+
+    await expect(page.getByText('05. 01. 2040.')).toBeVisible();
+    await expect(page.getByTitle(/Promijeni datum/u)).toHaveCount(0);
 });
 
 test('shopping cart outlet item shows a live reservation countdown', async ({

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -1,6 +1,7 @@
 import { BackpackIcon } from '@gredice/ui/BackpackIcon';
 import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
+import { Input } from '@gredice/ui/Input';
 import {
     Close,
     Delete,
@@ -10,6 +11,7 @@ import {
     Timer,
 } from '@gredice/ui/icons';
 import { ModalConfirm } from '@gredice/ui/ModalConfirm';
+import { Popper } from '@gredice/ui/Popper';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Row } from '@gredice/ui/Row';
@@ -39,6 +41,93 @@ function formatCountdown(remainingMs: number) {
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseAdditionalData(additionalData?: string | null) {
+    if (!additionalData) {
+        return {};
+    }
+
+    try {
+        const parsed = JSON.parse(additionalData);
+        return isRecord(parsed) ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
+function dateFromUnknown(value: unknown) {
+    if (typeof value !== 'string' && !(value instanceof Date)) {
+        return null;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getTomorrowDate() {
+    const today = new Date();
+    return new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1);
+}
+
+function formatDateInput(date: Date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function parseDateInput(date: string) {
+    const [year, month, day] = date.split('-').map(Number);
+    if (!year || !month || !day) {
+        return null;
+    }
+
+    const parsedDate = new Date(Date.UTC(year, month - 1, day));
+    return Number.isNaN(parsedDate.getTime()) ? null : parsedDate;
+}
+
+function formatCartDate(date: Date) {
+    return date.toLocaleDateString('hr-HR', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    });
+}
+
+type CartItemScheduledDateInfo = {
+    date: Date;
+    source: 'scheduled' | 'outlet' | 'default';
+};
+
+function getCartItemScheduledDateInfo(
+    item: ShoppingCartItemData,
+): CartItemScheduledDateInfo {
+    const outletSowingDate = dateFromUnknown(item.outlet?.sowingDate);
+    if (outletSowingDate) {
+        return {
+            date: outletSowingDate,
+            source: 'outlet',
+        };
+    }
+
+    const additionalData = parseAdditionalData(item.additionalData);
+    const scheduledDate = dateFromUnknown(additionalData.scheduledDate);
+    if (scheduledDate) {
+        return {
+            date: scheduledDate,
+            source: 'scheduled',
+        };
+    }
+
+    return {
+        date: getTomorrowDate(),
+        source: 'default',
+    };
+}
+
 export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     const { data: garden } = useCurrentGarden();
     const { data: account } = useCurrentAccount();
@@ -46,20 +135,20 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     const { track } = useGameAnalytics();
     const queryClient = useQueryClient();
     const [countdownNowMs, setCountdownNowMs] = useState(() => Date.now());
+    const [datePickerOpen, setDatePickerOpen] = useState(false);
+    const [datePickerError, setDatePickerError] = useState<string | null>(null);
 
     const hasDiscount = typeof item.shopData.discountPrice === 'number';
     const hasRaisedBed = Boolean(item.raisedBedId);
     const hasPosition = typeof item.positionIndex === 'number';
+    const isProcessed = item.status === 'paid';
 
     const raisedBed = hasRaisedBed
         ? garden?.raisedBeds.find((rb) => rb.id === item.raisedBedId)
         : null;
-    const scheduledDateString = item.additionalData
-        ? JSON.parse(item.additionalData).scheduledDate
-        : null;
-    const scheduledDate = scheduledDateString
-        ? new Date(scheduledDateString)
-        : null;
+    const scheduledDateInfo = getCartItemScheduledDateInfo(item);
+    const scheduledDate = scheduledDateInfo.date;
+    const scheduledDateLabel = formatCartDate(scheduledDate);
     const outletHoldExpiresAt = item.outlet?.holdExpiresAt
         ? new Date(item.outlet.holdExpiresAt)
         : null;
@@ -98,6 +187,8 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
           : 'bg-muted';
     const changeCurrencyShoppingCartItem = useSetShoppingCartItem();
     const removeShoppingCartItem = useSetShoppingCartItem();
+    const changeScheduledDateShoppingCartItem = useSetShoppingCartItem();
+    const canChangeScheduledDate = !isProcessed && !hasOutletReservation;
 
     useEffect(() => {
         if (
@@ -205,8 +296,44 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
         });
     }
 
-    // Hide delete button for paid items
-    const isProcessed = item.status === 'paid';
+    async function handleScheduledDateChange(date: string) {
+        const parsedDate = parseDateInput(date);
+        if (!parsedDate) {
+            setDatePickerError('Odaberi datum.');
+            return;
+        }
+
+        const nextScheduledDate = parsedDate.toISOString();
+        const additionalData = {
+            ...parseAdditionalData(item.additionalData),
+            scheduledDate: nextScheduledDate,
+        };
+
+        setDatePickerError(null);
+        track('game_cart_scheduled_date_changed', {
+            entity_id: item.entityId,
+            entity_type: item.entityTypeName,
+            item_id: item.id,
+            scheduled_date: nextScheduledDate,
+        });
+
+        try {
+            await changeScheduledDateShoppingCartItem.mutateAsync({
+                id: item.id,
+                amount: item.amount,
+                entityId: item.entityId,
+                entityTypeName: item.entityTypeName,
+                currency: item.currency,
+                additionalData: JSON.stringify(additionalData),
+                positionIndex: item.positionIndex ?? undefined,
+                gardenId: item.gardenId ?? undefined,
+                raisedBedId: item.raisedBedId ?? undefined,
+            });
+            setDatePickerOpen(false);
+        } catch {
+            setDatePickerError('Promjena datuma nije uspjela.');
+        }
+    }
 
     const plantSort =
         item.entityTypeName === 'plantSort' ? item.entityData : null;
@@ -374,27 +501,90 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                                 )}
                             </Row>
                         </Row>
-                        {scheduledDate && (
-                            <Row>
+                        <Row>
+                            {canChangeScheduledDate ? (
+                                <Popper
+                                    open={datePickerOpen}
+                                    onOpenChange={(open) => {
+                                        setDatePickerOpen(open);
+                                        if (open) {
+                                            setDatePickerError(null);
+                                        }
+                                    }}
+                                    side="bottom"
+                                    align="start"
+                                    sideOffset={8}
+                                    className="w-72 p-3"
+                                    trigger={
+                                        <Chip
+                                            startDecorator={
+                                                <Timer className="size-4" />
+                                            }
+                                            className="bg-muted"
+                                            disabled={
+                                                changeScheduledDateShoppingCartItem.isPending
+                                            }
+                                            onClick={() =>
+                                                setDatePickerError(null)
+                                            }
+                                            title={`Promijeni datum: ${scheduledDateLabel}`}
+                                        >
+                                            <Typography level="body3" secondary>
+                                                {scheduledDateLabel}
+                                            </Typography>
+                                        </Chip>
+                                    }
+                                >
+                                    <Stack spacing={2}>
+                                        <Input
+                                            type="date"
+                                            label="Datum"
+                                            name={`cartItemScheduledDate-${item.id}`}
+                                            className="w-full bg-card"
+                                            value={formatDateInput(
+                                                scheduledDate,
+                                            )}
+                                            min={formatDateInput(
+                                                getTomorrowDate(),
+                                            )}
+                                            disabled={
+                                                changeScheduledDateShoppingCartItem.isPending
+                                            }
+                                            onChange={(event) => {
+                                                void handleScheduledDateChange(
+                                                    event.target.value,
+                                                );
+                                            }}
+                                            required
+                                        />
+                                        {datePickerError ? (
+                                            <Typography
+                                                level="body3"
+                                                className="text-red-600"
+                                            >
+                                                {datePickerError}
+                                            </Typography>
+                                        ) : null}
+                                    </Stack>
+                                </Popper>
+                            ) : (
                                 <Chip
                                     startDecorator={
                                         <Timer className="size-4" />
                                     }
                                     className="bg-muted"
+                                    title={
+                                        scheduledDateInfo.source === 'outlet'
+                                            ? 'Datum sjetve outlet sadnice'
+                                            : 'Datum'
+                                    }
                                 >
                                     <Typography level="body3" secondary>
-                                        {scheduledDate.toLocaleDateString(
-                                            'hr-HR',
-                                            {
-                                                year: 'numeric',
-                                                month: '2-digit',
-                                                day: '2-digit',
-                                            },
-                                        )}
+                                        {scheduledDateLabel}
                                     </Typography>
                                 </Chip>
-                            </Row>
-                        )}
+                            )}
+                        </Row>
                     </Stack>
                     {!isProcessed && (
                         <ModalConfirm

--- a/packages/storage/src/repositories/shoppingCartRepo.ts
+++ b/packages/storage/src/repositories/shoppingCartRepo.ts
@@ -26,23 +26,48 @@ function getMinimumScheduledDate(baseDate = new Date()) {
     return tomorrow;
 }
 
-function normalizeScheduledDateAdditionalData(additionalData?: string | null) {
+export function getDefaultShoppingCartScheduledDate(baseDate = new Date()) {
+    return getMinimumScheduledDate(baseDate).toISOString();
+}
+
+function normalizeScheduledDateAdditionalData(
+    additionalData?: string | null,
+    {
+        defaultMissingScheduledDate = false,
+    }: { defaultMissingScheduledDate?: boolean } = {},
+) {
     if (!additionalData) {
-        return additionalData ?? null;
+        return defaultMissingScheduledDate
+            ? JSON.stringify({
+                  scheduledDate: getDefaultShoppingCartScheduledDate(),
+              })
+            : (additionalData ?? null);
     }
 
     try {
         const parsed = JSON.parse(additionalData);
-        if (
-            !parsed ||
-            typeof parsed !== 'object' ||
-            !('scheduledDate' in parsed)
-        ) {
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return additionalData;
+        }
+
+        if (!('scheduledDate' in parsed)) {
+            if (defaultMissingScheduledDate) {
+                return JSON.stringify({
+                    ...parsed,
+                    scheduledDate: getDefaultShoppingCartScheduledDate(),
+                });
+            }
             return additionalData;
         }
 
         const scheduledDate = parsed.scheduledDate;
         if (typeof scheduledDate !== 'string') {
+            if (defaultMissingScheduledDate) {
+                return JSON.stringify({
+                    ...parsed,
+                    scheduledDate: getDefaultShoppingCartScheduledDate(),
+                });
+            }
             return additionalData;
         }
 
@@ -74,7 +99,12 @@ function normalizeScheduledDateAdditionalData(additionalData?: string | null) {
     }
 }
 
-export async function normalizeShoppingCartScheduledDates(cartId: number) {
+export async function normalizeShoppingCartScheduledDates(
+    cartId: number,
+    {
+        defaultMissingScheduledDates = false,
+    }: { defaultMissingScheduledDates?: boolean } = {},
+) {
     const cart = await getShoppingCart(cartId);
     if (!cart) {
         return cart;
@@ -92,6 +122,9 @@ export async function normalizeShoppingCartScheduledDates(cartId: number) {
             originalAdditionalData: item.additionalData,
             additionalData: normalizeScheduledDateAdditionalData(
                 item.additionalData,
+                {
+                    defaultMissingScheduledDate: defaultMissingScheduledDates,
+                },
             ),
         }))
         .filter((item) => item.additionalData !== item.originalAdditionalData);
@@ -234,9 +267,9 @@ export async function upsertOrRemoveCartItem(
             })
           : null;
 
-    // Prevent deletion of paid items
-    if (!forceDelete && amount <= 0 && existingItem?.status === 'paid') {
-        throw new Error('Cannot delete paid shopping cart item via API');
+    // Prevent API changes to paid items. Historical cart rows are immutable.
+    if (!forceDelete && existingItem?.status === 'paid') {
+        throw new Error('Cannot update paid shopping cart item via API');
     }
 
     if (amount <= 0) {

--- a/packages/storage/tests/shoppingCartRepo.node.spec.ts
+++ b/packages/storage/tests/shoppingCartRepo.node.spec.ts
@@ -240,6 +240,32 @@ test('paid items are not included in new cart queries', async () => {
     assert.ok(!carts.some((c) => c.id === cart.id));
 });
 
+test('paid cart items cannot be updated through cart upsert', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    if (!cart) throw new Error('Cart not created');
+    const itemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'entity-1',
+        'plant',
+        1,
+    );
+    assert.ok(itemId, 'Item ID should be defined');
+
+    await setCartItemPaid(itemId);
+
+    await assert.rejects(
+        () => upsertOrRemoveCartItem(itemId, cart.id, 'entity-1', 'plant', 2),
+        /Cannot update paid shopping cart item via API/,
+    );
+    await assert.rejects(
+        () => upsertOrRemoveCartItem(itemId, cart.id, 'entity-1', 'plant', 0),
+        /Cannot update paid shopping cart item via API/,
+    );
+});
+
 test('normalizeShoppingCartInventoryUsage moves duplicate inventory usage back to eur', async () => {
     createTestDb();
     const accountId = await createTestAccount();
@@ -501,4 +527,63 @@ test('normalizeShoppingCartScheduledDates updates past scheduled dates in cart',
         futureDate.toISOString(),
         expectedTomorrow.toISOString(),
     ]);
+});
+
+test('normalizeShoppingCartScheduledDates can default missing scheduled dates to tomorrow', async () => {
+    createTestDb();
+    const fixedNow = new Date('2024-01-15T12:00:00Z');
+    test.mock.timers.enable({ now: fixedNow });
+    try {
+        const accountId = await createTestAccount();
+        const cart = await getOrCreateShoppingCart(accountId);
+        if (!cart) throw new Error('Cart not created');
+
+        await upsertOrRemoveCartItem(null, cart.id, 'entity-1', 'operation', 1);
+        await upsertOrRemoveCartItem(
+            null,
+            cart.id,
+            'entity-2',
+            'plantSort',
+            1,
+            undefined,
+            undefined,
+            undefined,
+            JSON.stringify({
+                delivery: {
+                    mode: 'pickup',
+                },
+            }),
+            undefined,
+            true,
+        );
+
+        const normalizedCart = await normalizeShoppingCartScheduledDates(
+            cart.id,
+            {
+                defaultMissingScheduledDates: true,
+            },
+        );
+        assert.ok(normalizedCart);
+
+        const expectedTomorrow = new Date(
+            Date.UTC(
+                fixedNow.getUTCFullYear(),
+                fixedNow.getUTCMonth(),
+                fixedNow.getUTCDate() + 1,
+            ),
+        ).toISOString();
+        const additionalData = normalizedCart.items.map((item) =>
+            item.additionalData ? JSON.parse(item.additionalData) : null,
+        );
+
+        assert.deepStrictEqual(
+            additionalData.map((data) => data?.scheduledDate),
+            [expectedTomorrow, expectedTomorrow],
+        );
+        assert.deepStrictEqual(additionalData[1]?.delivery, {
+            mode: 'pickup',
+        });
+    } finally {
+        test.mock.timers.reset();
+    }
 });


### PR DESCRIPTION
## Summary
- always show an effective date chip on game shopping cart rows, using tomorrow when no scheduled date exists
- let users edit unpaid cart-row scheduled dates from the chip popover while keeping paid and outlet reservation dates immutable
- default missing checkout scheduled dates before processing so operations and direct sowing tasks receive a scheduled date

## Validation
- pnpm --filter @gredice/storage test:node shoppingCartRepo.node.spec.ts
- pnpm --filter @gredice/game typecheck
- pnpm --filter garden typecheck
- pnpm --filter api build
- pnpm --filter garden build
- pnpm --filter garden exec playwright test tests/shopping-cart-optimistic-toggle.spec.tsx
- pnpm --filter @gredice/storage lint
- pnpm --filter @gredice/game lint
- pnpm --filter garden lint
- pnpm --filter api lint
- git diff --check