### PR TITLE
Fix trace watering visibility and same-day grouping

### DIFF
--- a/apps/www/app/trag/[token]/page.tsx
+++ b/apps/www/app/trag/[token]/page.tsx
@@ -895,6 +895,8 @@ function statusTimelineItemClassName(status: string | undefined) {
 
 function TimelineEvent({ item }: { item: PublicHarvestTraceTimelineItem }) {
     const isStatusItem = isPlantStatusTimelineItem(item);
+    const operationCount =
+        item.kind === 'operation' ? item.operationCount : undefined;
 
     return (
         <article
@@ -907,19 +909,35 @@ function TimelineEvent({ item }: { item: PublicHarvestTraceTimelineItem }) {
             )}
         >
             <TimelineVisual item={item} />
-            <Stack spacing={1} className="min-w-0">
-                <Typography semiBold className="break-words leading-snug">
-                    {item.title}
-                </Typography>
-                {item.description ? (
-                    <Typography level="body2" className="text-muted-foreground">
-                        {item.description}
+            <div className="flex min-w-0 flex-1 items-start justify-between gap-3">
+                <Stack spacing={1} className="min-w-0">
+                    <Typography semiBold className="break-words leading-snug">
+                        {item.title}
+                    </Typography>
+                    {item.description ? (
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            {item.description}
+                        </Typography>
+                    ) : null}
+                    {item.location ? (
+                        <TraceTimelineLocation location={item.location} />
+                    ) : null}
+                </Stack>
+                {operationCount && operationCount > 1 ? (
+                    <Typography
+                        component="span"
+                        level="body2"
+                        semiBold
+                        className="mt-0.5 inline-flex min-w-8 shrink-0 justify-center rounded-md bg-muted px-2 py-0.5 text-muted-foreground"
+                        aria-label={`${operationCount} radnji`}
+                    >
+                        x{operationCount}
                     </Typography>
                 ) : null}
-                {item.location ? (
-                    <TraceTimelineLocation location={item.location} />
-                ) : null}
-            </Stack>
+            </div>
         </article>
     );
 }
@@ -994,7 +1012,15 @@ function WeekImageGallery({
 }
 
 function timelineItemCount(week: TimelineWeekGroup) {
-    return week.days.reduce((total, day) => total + day.items.length, 0);
+    return week.days.reduce(
+        (total, day) =>
+            total +
+            day.items.reduce(
+                (dayTotal, item) => dayTotal + (item.operationCount ?? 1),
+                0,
+            ),
+        0,
+    );
 }
 
 function eventCountLabel(count: number) {

--- a/packages/storage/src/repositories/harvestTraceLinksRepo.ts
+++ b/packages/storage/src/repositories/harvestTraceLinksRepo.ts
@@ -69,6 +69,7 @@ export type PublicHarvestTraceTimelineItem = {
     images?: PublicHarvestTraceTimelineImage[];
     location?: PublicHarvestTraceLocation;
     operationCategoryName?: string;
+    operationCount?: number;
     plantStatus?: string;
     tone?: 'seed' | 'growth' | 'ready' | 'harvest' | 'care';
 };
@@ -552,6 +553,71 @@ function compareTimelineItems(
     return left.title.localeCompare(right.title, 'hr');
 }
 
+function timelineDayKey(item: PublicHarvestTraceTimelineItem) {
+    return item.occurredAt.slice(0, 10);
+}
+
+function operationGroupKey(item: PublicHarvestTraceTimelineItem) {
+    if (item.kind !== 'operation') {
+        return null;
+    }
+
+    return [
+        timelineDayKey(item),
+        item.title,
+        item.description ?? '',
+        item.operationCategoryName ?? '',
+        item.imageUrl ?? '',
+        item.imageAlt ?? '',
+    ].join('\u0000');
+}
+
+function mergeTimelineImages(
+    left: PublicHarvestTraceTimelineImage[] | undefined,
+    right: PublicHarvestTraceTimelineImage[] | undefined,
+) {
+    if (!left?.length && !right?.length) {
+        return undefined;
+    }
+
+    const merged: PublicHarvestTraceTimelineImage[] = [];
+    const existingUrls = new Set<string>();
+    addImages(merged, existingUrls, left ?? []);
+    addImages(merged, existingUrls, right ?? []);
+
+    return merged;
+}
+
+function groupSameDayOperations(items: PublicHarvestTraceTimelineItem[]) {
+    const groupedItems: PublicHarvestTraceTimelineItem[] = [];
+    const operationIndexesByKey = new Map<string, number>();
+
+    for (const item of items) {
+        const groupKey = operationGroupKey(item);
+        if (!groupKey) {
+            groupedItems.push(item);
+            continue;
+        }
+
+        const existingIndex = operationIndexesByKey.get(groupKey);
+        if (existingIndex === undefined) {
+            operationIndexesByKey.set(groupKey, groupedItems.length);
+            groupedItems.push(item);
+            continue;
+        }
+
+        const existingItem = groupedItems[existingIndex];
+        groupedItems[existingIndex] = {
+            ...existingItem,
+            operationCount:
+                (existingItem.operationCount ?? 1) + (item.operationCount ?? 1),
+            images: mergeTimelineImages(existingItem.images, item.images),
+        };
+    }
+
+    return groupedItems;
+}
+
 function pushTimelineItem(
     items: PublicHarvestTraceTimelineItem[],
     item: PublicHarvestTraceTimelineItem | null,
@@ -755,7 +821,6 @@ async function getRelevantOperationsForTrace(
                 eq(operations.gardenId, link.gardenId),
                 eq(operations.raisedBedId, link.raisedBedId),
                 eq(operations.isDeleted, false),
-                eq(operations.isAccepted, true),
                 or(
                     eq(operations.raisedBedFieldId, link.raisedBedFieldId),
                     isNull(operations.raisedBedFieldId),
@@ -1033,14 +1098,9 @@ async function buildPublicTrace(
           ].filter(
               (item): item is PublicHarvestTraceStatusDate => item !== null,
           );
-    const sortedTimeline = timeline
-        .toSorted(compareTimelineItems)
-        .filter(
-            (item, index, items) =>
-                index === 0 ||
-                item.title !== items[index - 1]?.title ||
-                item.occurredAt !== items[index - 1]?.occurredAt,
-        );
+    const sortedTimeline = groupSameDayOperations(
+        timeline.toSorted(compareTimelineItems),
+    );
     const imageUrl = entityImageUrl(plantSort);
 
     return {

--- a/packages/storage/tests/harvestTraceLinksRepo.node.spec.ts
+++ b/packages/storage/tests/harvestTraceLinksRepo.node.spec.ts
@@ -233,6 +233,7 @@ async function createAcceptedOperation(input: {
     timestamp: Date;
     completedAt: Date;
     imageUrls?: string[];
+    accepted?: boolean;
     verified?: boolean;
 }) {
     const operationId = await createOperation({
@@ -245,7 +246,9 @@ async function createAcceptedOperation(input: {
         raisedBedFieldId: input.raisedBedFieldId,
         timestamp: input.timestamp,
     });
-    await acceptOperation(operationId);
+    if (input.accepted ?? true) {
+        await acceptOperation(operationId);
+    }
     await createEvent({
         ...knownEvents.operations.completedV1(operationId.toString(), {
             completedBy: randomUUID(),
@@ -441,9 +444,11 @@ async function createHarvestTraceFixture() {
         accountId,
         farmId,
         gardenId,
+        bedCareEntityId,
         harvestEntityId,
         harvestOperationId,
         link,
+        photoEntityId,
         plantPlaceEventId,
         plantSortId,
         raisedBedPhysicalId,
@@ -625,6 +630,62 @@ test('getPublicHarvestTraceByToken includes raised-bed operations and excludes o
     assert.equal(serialized.includes('"harvestOperationId"'), false);
     assert.equal(serialized.includes('"raisedBedFieldId"'), false);
     assert.equal(serialized.includes('Radnja #'), false);
+});
+
+test('getPublicHarvestTraceByToken includes completed operations before acceptance and groups same-day operations', async () => {
+    const fixture = await createHarvestTraceFixture();
+
+    await createAcceptedOperation({
+        accountId: fixture.accountId,
+        farmId: fixture.farmId,
+        gardenId: fixture.gardenId,
+        raisedBedId: fixture.raisedBedId,
+        entityId: fixture.bedCareEntityId,
+        timestamp: new Date('2026-05-12T09:30:00.000Z'),
+        completedAt: new Date('2026-05-12T10:00:00.000Z'),
+        accepted: false,
+    });
+    await createAcceptedOperation({
+        accountId: fixture.accountId,
+        farmId: fixture.farmId,
+        gardenId: fixture.gardenId,
+        raisedBedId: fixture.raisedBedId,
+        entityId: fixture.photoEntityId,
+        timestamp: new Date('2026-05-14T09:30:00.000Z'),
+        completedAt: new Date('2026-05-14T10:00:00.000Z'),
+        imageUrls: ['https://cdn.gredice.com/trace/photo-3.jpg'],
+    });
+    await createAcceptedOperation({
+        accountId: fixture.accountId,
+        farmId: fixture.farmId,
+        gardenId: fixture.gardenId,
+        raisedBedId: fixture.raisedBedId,
+        entityId: fixture.photoEntityId,
+        timestamp: new Date('2026-05-14T10:30:00.000Z'),
+        completedAt: new Date('2026-05-14T11:00:00.000Z'),
+        imageUrls: ['https://cdn.gredice.com/trace/photo-4.jpg'],
+    });
+
+    const trace = await getPublicHarvestTraceByToken(fixture.link.publicToken);
+    assert.ok(trace);
+
+    assert.equal(trace.statistics.wateringCount, 2);
+    assert.equal(trace.statistics.totalWaterLiters, 108);
+    assert.equal(trace.statistics.plantWaterLiters, 6);
+    assert.equal(trace.statistics.imageCount, 4);
+
+    const wateringItems = trace.timeline.filter(
+        (item) => item.title === 'Navodnjavanje (54L)',
+    );
+    assert.equal(wateringItems.length, 1);
+    assert.equal(wateringItems[0]?.operationCount, 2);
+
+    const photoItems = trace.timeline.filter(
+        (item) => item.title === 'Fotografiranje gredice',
+    );
+    assert.equal(photoItems.length, 1);
+    assert.equal(photoItems[0]?.operationCount, 3);
+    assert.equal(photoItems[0]?.images?.length, 4);
 });
 
 test('revoked harvest trace links do not resolve publicly', async () => {


### PR DESCRIPTION
## Summary
- Include completed trace operations even when the base row was not marked accepted, so watering entries now appear on the public trace.
- Group same-day duplicate operations into a single timeline item and render the merged count as a right-aligned `xN` badge.
- Keep timeline statistics and image aggregation consistent with the grouped rows.

## Testing
- Added a storage regression test covering unaccepted completed watering rows and same-day operation grouping.
- Ran the focused storage node test suite and the `www` typecheck.
- Verified the trace page locally in the browser, including the visible watering rows and `x8` badge.