### PR TITLE
[codex] Fix image gallery viewport overflow

### DIFF
--- a/apps/garden/tests/image-gallery.spec.tsx
+++ b/apps/garden/tests/image-gallery.spec.tsx
@@ -1,0 +1,91 @@
+import { ImageGallery } from '@gredice/ui/ImageGallery';
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
+
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
+const MOBILE_VIEWPORT = { width: 390, height: 640 };
+
+const wideImageSvg = encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="2400" height="900" viewBox="0 0 2400 900"><rect width="2400" height="900" fill="#86b6d6"/><rect y="520" width="2400" height="380" fill="#4f7d45"/><path d="M0 610 C360 470 680 700 1040 560 S1750 520 2400 610" fill="#8db15d"/><text x="1200" y="450" text-anchor="middle" font-size="120" font-family="Arial" fill="#1f2937">2400 x 900 panorama</text></svg>',
+);
+const wideImageSrc = `data:image/svg+xml,${wideImageSvg}`;
+
+const images = [
+    {
+        src: wideImageSrc,
+        alt: 'Wide garden panorama',
+    },
+];
+
+async function expectViewportBounded(
+    page: Page,
+    viewport: { width: number; height: number },
+) {
+    const dialog = page.getByRole('dialog', { name: 'Pregled galerije' });
+    await expect(dialog).toBeVisible();
+
+    const dialogBox = await dialog.boundingBox();
+    expect(dialogBox).not.toBeNull();
+    expect(dialogBox?.x ?? 0).toBeGreaterThanOrEqual(-1);
+    expect(dialogBox?.y ?? 0).toBeGreaterThanOrEqual(-1);
+    expect((dialogBox?.width ?? 0) + (dialogBox?.x ?? 0)).toBeLessThanOrEqual(
+        viewport.width + 1,
+    );
+    expect((dialogBox?.height ?? 0) + (dialogBox?.y ?? 0)).toBeLessThanOrEqual(
+        viewport.height + 1,
+    );
+
+    const viewportOverflow = await page.evaluate(() => ({
+        bodyScrollWidth: document.body.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+        documentScrollWidth: document.documentElement.scrollWidth,
+    }));
+
+    expect(viewportOverflow.documentScrollWidth).toBeLessThanOrEqual(
+        viewportOverflow.clientWidth + 1,
+    );
+    expect(viewportOverflow.bodyScrollWidth).toBeLessThanOrEqual(
+        viewportOverflow.clientWidth + 1,
+    );
+
+    for (const buttonName of [
+        'Prethodna slika',
+        'Sljedeća slika',
+        'Smanji sliku',
+        'Uvećaj sliku',
+        'Preuzmi sliku',
+        'Zatvori pregled galerije',
+    ]) {
+        await expect(
+            page.getByRole('button', { name: buttonName }),
+        ).toBeInViewport();
+    }
+}
+
+test('wide gallery image stays within the desktop viewport while zooming out', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(DESKTOP_VIEWPORT);
+    await mount(<ImageGallery images={images} />);
+
+    await page.getByRole('button', { name: /Otvori sliku 1/u }).click();
+
+    const zoomOut = page.getByRole('button', { name: 'Smanji sliku' });
+    await expect(zoomOut).toBeEnabled();
+    await zoomOut.click();
+
+    await expectViewportBounded(page, DESKTOP_VIEWPORT);
+});
+
+test('wide gallery image stays within the mobile viewport', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await mount(<ImageGallery images={images} />);
+
+    await page.getByRole('button', { name: /Otvori sliku 1/u }).click();
+
+    await expectViewportBounded(page, MOBILE_VIEWPORT);
+});

--- a/apps/storybook/stories/packages/ui/ImageGallery.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ImageGallery.stories.tsx
@@ -6,6 +6,11 @@ const largeImageSvg = encodeURIComponent(
 );
 const largeImageSrc = `data:image/svg+xml,${largeImageSvg}`;
 
+const wideImageSvg = encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="2400" height="900" viewBox="0 0 2400 900"><defs><linearGradient id="sky" x1="0" x2="1"><stop stop-color="#86b6d6"/><stop offset="1" stop-color="#f4c56a"/></linearGradient></defs><rect width="2400" height="900" fill="url(#sky)"/><rect y="520" width="2400" height="380" fill="#4f7d45"/><path d="M0 610 C360 470 680 700 1040 560 S1750 520 2400 610" fill="#8db15d"/><text x="1200" y="450" text-anchor="middle" font-size="120" font-family="Arial" fill="#1f2937">2400 x 900 panorama</text></svg>',
+);
+const wideImageSrc = `data:image/svg+xml,${wideImageSvg}`;
+
 const sampleImages = [
     {
         src: 'https://cdn.gredice.com/sunflower-sad-500x500.png',
@@ -66,6 +71,17 @@ export const LargeImage: Story = {
             {
                 src: largeImageSrc,
                 alt: 'Large garden image',
+            },
+        ],
+    },
+};
+
+export const WideImage: Story = {
+    args: {
+        images: [
+            {
+                src: wideImageSrc,
+                alt: 'Wide garden panorama',
             },
         ],
     },

--- a/packages/ui/src/ImageGallery/ImageGallery.tsx
+++ b/packages/ui/src/ImageGallery/ImageGallery.tsx
@@ -634,22 +634,26 @@ export function ImageGallery({
                 onOpenChange={handleModalOpenChange}
                 title="Pregled galerije"
                 dismissible={false}
+                disableMobile
                 className={cx(
-                    'm-0 h-[100dvh] w-[100dvw] max-h-none max-w-none rounded-none border-0 p-0',
-                    'bg-black/60 backdrop-blur',
-                    '[&>div:last-child]:h-full [&>div:last-child]:p-0 [&>div:not(:last-child)]:hidden',
+                    '!inset-0 !m-0 h-auto max-h-none w-auto max-w-none !translate-x-0 !translate-y-0 overflow-hidden rounded-none border-0 p-0',
+                    'bg-black/60 backdrop-blur overscroll-none',
+                    '[&>div:last-child]:h-full [&>div:last-child]:overflow-hidden [&>div:last-child]:p-0 [&>div:not(:last-child)]:hidden',
                 )}
             >
-                <div className="relative flex h-full w-full overflow-clip">
+                <div className="relative flex h-full max-h-full w-full max-w-full min-w-0 overflow-hidden">
                     <p id={imageInstructionsId} className="sr-only">
                         Pritisni Escape za zatvaranje, lijevu ili desnu strelicu
                         za promjenu slike, plus ili minus za zumiranje i nulu za
                         prilagodbu zaslonu.
                     </p>
                     <div
-                        className="absolute right-4 top-4 z-10 flex gap-1"
+                        className="absolute z-10 flex max-w-[calc(100%-1.5rem)] justify-end gap-1 overflow-x-auto"
                         style={{
-                            top: 'calc(env(safe-area-inset-top) + 1rem)',
+                            right: 'calc(env(safe-area-inset-right) + 0.75rem)',
+                            top: 'calc(env(safe-area-inset-top) + 0.75rem)',
+                            WebkitOverflowScrolling: 'touch',
+                            touchAction: 'pan-x',
                         }}
                     >
                         <IconButton
@@ -710,7 +714,19 @@ export function ImageGallery({
                         </IconButton>
                     </div>
 
-                    <div className="flex h-full min-h-0 w-full min-w-0 items-center justify-center pb-32 sm:pb-36">
+                    <div
+                        className="flex h-full min-h-0 w-full min-w-0 items-center justify-center"
+                        style={{
+                            paddingBottom:
+                                'calc(env(safe-area-inset-bottom) + 6.5rem)',
+                            paddingLeft:
+                                'calc(env(safe-area-inset-left) + 0.5rem)',
+                            paddingRight:
+                                'calc(env(safe-area-inset-right) + 0.5rem)',
+                            paddingTop:
+                                'calc(env(safe-area-inset-top) + 4.5rem)',
+                        }}
+                    >
                         <button
                             type="button"
                             ref={imageRef}
@@ -730,7 +746,7 @@ export function ImageGallery({
                             style={{ touchAction: 'none' }}
                         >
                             <span
-                                className="relative flex h-full w-full select-none items-center justify-center transition-transform duration-200 ease-out will-change-transform"
+                                className="relative block h-full w-full select-none transition-transform duration-200 ease-out will-change-transform"
                                 style={{
                                     transform: `scale(${zoomLevel}) translate(${position.x / zoomLevel}px, ${position.y / zoomLevel}px)`,
                                     transformOrigin: 'center center',
@@ -744,7 +760,7 @@ export function ImageGallery({
                                         activeImage?.alt,
                                         safeIndex,
                                     )}
-                                    className="h-auto w-auto max-h-none max-w-none select-none object-contain"
+                                    className="absolute left-1/2 top-1/2 h-auto w-auto max-h-none max-w-none -translate-x-1/2 -translate-y-1/2 select-none object-contain"
                                     draggable={false}
                                     onLoad={handleImageLoad}
                                 />
@@ -755,16 +771,16 @@ export function ImageGallery({
                     <Chip
                         aria-label={`Slika ${safeIndex + 1} od ${images.length}, zumiranje ${Math.round(zoomLevel * 100)} posto`}
                         aria-live="polite"
-                        className="absolute left-4 [top:calc(env(safe-area-inset-top)+1rem)] z-10 select-none border-0 bg-black/60 text-white/80 backdrop-blur"
+                        className="absolute [left:calc(env(safe-area-inset-left)+1rem)] [top:calc(env(safe-area-inset-top)+0.75rem)] z-10 select-none border-0 bg-black/60 text-white/80 backdrop-blur"
                         variant="solid"
                     >
                         {safeIndex + 1}/{images.length} •{' '}
                         {Math.round(zoomLevel * 100)}%
                     </Chip>
 
-                    <div className="absolute bottom-0 left-0 z-10 w-full border-t border-white/10 bg-black/55 px-4 py-3 backdrop-blur [padding-bottom:calc(env(safe-area-inset-bottom)+0.75rem)]">
+                    <div className="absolute bottom-0 left-0 z-10 w-full max-w-full overflow-hidden border-t border-white/10 bg-black/55 py-3 backdrop-blur [padding-bottom:calc(env(safe-area-inset-bottom)+0.75rem)] [padding-left:calc(env(safe-area-inset-left)+1rem)] [padding-right:calc(env(safe-area-inset-right)+1rem)]">
                         <div
-                            className="mx-auto flex max-w-5xl gap-2 overflow-x-auto"
+                            className="mx-auto flex max-w-full gap-2 overflow-x-auto"
                             style={{
                                 WebkitOverflowScrolling: 'touch',
                                 touchAction: 'pan-x',


### PR DESCRIPTION
## Summary
- keep the expanded ImageGallery viewport-bound instead of allowing natural image width to stretch the dialog
- opt the gallery viewer out of the mobile drawer path so pan/zoom media uses the same full-screen dialog on all viewports
- add a wide panorama Storybook state and Playwright regression coverage for desktop zoom-out and mobile viewport bounds

## Validation
- pnpm --filter @gredice/ui lint
- pnpm --filter storybook lint
- pnpm --filter garden lint
- pnpm --filter @gredice/ui typecheck
- pnpm --filter storybook typecheck
- pnpm --filter garden typecheck
- pnpm --filter garden test:prepare
- pnpm --filter garden exec playwright test tests/image-gallery.spec.tsx
- git diff --check