### PR TITLE
Verify shopping-cart ownership on item writes (IDOR fix)

### DIFF
--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -9,6 +9,7 @@ import {
     getOrCreateShoppingCart,
     getOutletOffer,
     getRaisedBed,
+    getShoppingCart,
     getSunflowers,
     normalizeShoppingCartInventoryUsage,
     normalizeShoppingCartScheduledDates,
@@ -152,6 +153,17 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 forceCreate,
             } = context.req.valid('json');
             const { accountId } = context.get('authContext');
+            const cart = await getShoppingCart(cartId);
+            if (!cart || cart.accountId !== accountId) {
+                return context.json({ error: 'Cart not found' }, 404);
+            }
+            // If updating an existing item, it must belong to this cart.
+            if (
+                typeof id === 'number' &&
+                !cart.items.some((item) => item.id === id)
+            ) {
+                return context.json({ error: 'Cart item not found' }, 404);
+            }
             if (outletOfferId && entityTypeName !== 'plantSort') {
                 return context.json(
                     { error: 'Outlet offers can only be used for plant sorts' },


### PR DESCRIPTION
## Summary

Closes #3361.

The authenticated `POST /shopping-cart` endpoint accepted a client-supplied `cartId` (and optional item `id`) and mutated the cart **without verifying it belongs to the caller's account**. Since carts and items use sequential integer PKs, any logged-in user could add, modify, or delete items in another account's cart by enumerating ids — a classic IDOR.

This adds an ownership guard in the `POST /` handler, mirroring the proven pattern already used in `checkoutRoutes.ts`:

- Reject if the cart doesn't exist or `cart.accountId !== accountId` → `404`.
- If an existing item `id` is supplied, require it to belong to the caller's cart → `404`. (`upsertOrRemoveCartItem` locates items by `id` alone, so the `cartId` check alone is insufficient.)

`404` is used rather than `403` to avoid confirming the cart's existence. The guard runs before every mutation branch (`upsertOrRemoveCartItem` / `upsertOrRemoveCartItemWithOutletReservation`).

Scope is limited to the route layer — the shared storage signature is untouched. The `DELETE /` handler is already safe (derives the cart from the server-side `accountId`).

## Verification

- `pnpm typecheck --filter api` → pass
- `pnpm lint --filter api` → pass

## Follow-up (deferred, separate ticket)

- Defense-in-depth `accountId` param on `upsertOrRemoveCartItem` in the storage layer.
- Playwright integration test asserting a foreign `cartId`/`id` yields 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)