### PR TITLE
[storage] Add checkout transaction characterization tests

### DIFF
--- a/packages/storage/tests/shoppingCartRepo.payment.node.spec.ts
+++ b/packages/storage/tests/shoppingCartRepo.payment.node.spec.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getOrCreateShoppingCart,
+    getShoppingCart,
+    markCartPaidIfAllItemsPaid,
+    setCartItemPaid,
+    upsertOrRemoveCartItem,
+} from '@gredice/storage';
+import { createTestAccount } from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+async function createCartWithItems() {
+    const accountId = await createTestAccount();
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart, 'Cart should be created');
+
+    const firstItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'payment-entity-1',
+        'plant',
+        1,
+    );
+    const secondItemId = await upsertOrRemoveCartItem(
+        null,
+        cart.id,
+        'payment-entity-2',
+        'plant',
+        1,
+    );
+    assert.ok(firstItemId, 'First item ID should be defined');
+    assert.ok(secondItemId, 'Second item ID should be defined');
+
+    return { cartId: cart.id, firstItemId, secondItemId };
+}
+
+test('setCartItemPaid marks one cart item paid', async () => {
+    createTestDb();
+    const { cartId, firstItemId, secondItemId } = await createCartWithItems();
+
+    await setCartItemPaid(firstItemId);
+
+    const cart = await getShoppingCart(cartId);
+    assert.ok(cart, 'Cart should be found');
+    const firstItem = cart.items.find((item) => item.id === firstItemId);
+    const secondItem = cart.items.find((item) => item.id === secondItemId);
+    assert.strictEqual(firstItem?.status, 'paid');
+    assert.strictEqual(secondItem?.status, 'new');
+});
+
+test('markCartPaidIfAllItemsPaid marks cart paid only after every item is paid', async () => {
+    createTestDb();
+    const { cartId, firstItemId, secondItemId } = await createCartWithItems();
+
+    await setCartItemPaid(firstItemId);
+    await markCartPaidIfAllItemsPaid(cartId);
+
+    let cart = await getShoppingCart(cartId);
+    assert.ok(cart, 'Cart should be found after marking one item paid');
+    assert.strictEqual(cart.status, 'new');
+
+    await setCartItemPaid(secondItemId);
+    await markCartPaidIfAllItemsPaid(cartId);
+
+    cart = await getShoppingCart(cartId);
+    assert.ok(cart, 'Cart should be found after marking all items paid');
+    assert.strictEqual(cart.status, 'paid');
+    assert.ok(cart.items.every((item) => item.status === 'paid'));
+});
+
+test('setCartItemPaid is a safe no-op for already-paid cart items', async () => {
+    createTestDb();
+    const { cartId, firstItemId } = await createCartWithItems();
+
+    await setCartItemPaid(firstItemId);
+    await setCartItemPaid(firstItemId);
+
+    const cart = await getShoppingCart(cartId);
+    assert.ok(cart, 'Cart should be found');
+    const item = cart.items.find((cartItem) => cartItem.id === firstItemId);
+    assert.strictEqual(item?.status, 'paid');
+});

--- a/packages/storage/tests/transactionsRepo.node.spec.ts
+++ b/packages/storage/tests/transactionsRepo.node.spec.ts
@@ -25,22 +25,55 @@ async function baseTransaction(): Promise<InsertTransaction> {
 
 test('createTransaction and getTransaction', async () => {
     createTestDb();
-    const txId = await createTransaction(await baseTransaction());
+    const transaction = await baseTransaction();
+    const txId = await createTransaction(transaction);
     const tx = await getTransaction(txId);
     assert.ok(tx);
     assert.strictEqual(tx.id, txId);
+    assert.strictEqual(tx.accountId, transaction.accountId);
+    assert.strictEqual(tx.amount, transaction.amount);
+    assert.strictEqual(tx.currency, transaction.currency);
+    assert.strictEqual(tx.status, transaction.status);
+});
+
+test('createTransaction throws when accountId is missing', async () => {
+    createTestDb();
+    await assert.rejects(
+        () =>
+            createTransaction({
+                amount: 100,
+                currency: 'eur',
+                status: 'pending',
+                stripePaymentId: 'stripe-without-account',
+            }),
+        /Transaction must have an accountId/,
+    );
 });
 
 test('getAllTransactions with account filter returns transactions for account', async () => {
     createTestDb();
-    const transaction = await baseTransaction();
-    const txId = await createTransaction(transaction);
-    assert.ok(transaction.accountId != null);
+    const accountId = await createTestAccount();
+    const otherAccountId = await createTestAccount();
+    const txId = await createTransaction({
+        accountId,
+        amount: 100,
+        currency: 'eur',
+        status: 'pending',
+        stripePaymentId: randomUUID(),
+    });
+    const otherTxId = await createTransaction({
+        accountId: otherAccountId,
+        amount: 200,
+        currency: 'eur',
+        status: 'pending',
+        stripePaymentId: randomUUID(),
+    });
     const txs = await getAllTransactions({
-        filter: { accountId: transaction.accountId },
+        filter: { accountId },
     });
     assert.ok(Array.isArray(txs));
     assert.ok(txs.some((t) => t.id === txId));
+    assert.ok(!txs.some((t) => t.id === otherTxId));
 });
 
 test('getAllTransactions returns all transactions', async () => {
@@ -78,4 +111,25 @@ test('getTransactionByStripeId returns correct transaction', async () => {
     const tx = await getTransactionByStripeId(stripePaymentId);
     assert.ok(tx);
     assert.strictEqual(tx?.id, txId);
+});
+
+test('createTransaction currently creates duplicate rows for the same completed stripePaymentId', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const stripePaymentId = randomUUID();
+    const transaction = {
+        accountId,
+        amount: 100,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId,
+    };
+
+    await createTransaction(transaction);
+    await createTransaction(transaction);
+
+    const txs = await getAllTransactions({ filter: { accountId } });
+    // Documents pre-003 behavior; plan 003 makes this idempotent.
+    assert.strictEqual(txs.length, 2);
+    assert.ok(txs.every((tx) => tx.stripePaymentId === stripePaymentId));
 });


### PR DESCRIPTION
## Summary
- Extend transaction repository tests to assert persisted transaction fields, missing-account rejection, account-scoped filtering, and current duplicate `stripePaymentId` insert behavior.
- Add a focused shopping-cart payment spec for item paid transitions, all-items-paid cart status, and already-paid item no-op behavior.
- Kept scope test-only under `packages/storage/tests/**`; no production `src/` files changed.

Closes #3362

## Validation
- `git diff --stat 17aca58ba..origin/main -- packages/storage/src/repositories/transactionsRepo.ts packages/storage/src/repositories/shoppingCartRepo.ts packages/storage/tests` (clean drift check)
- `pnpm --filter @gredice/storage test:node tests/transactionsRepo.node.spec.ts`
- `pnpm --filter @gredice/storage test:node tests/shoppingCartRepo.payment.node.spec.ts`
- `pnpm test --filter @gredice/storage` (308 passed, 0 failed)
- `pnpm --filter @gredice/storage exec biome check tests/transactionsRepo.node.spec.ts tests/shoppingCartRepo.payment.node.spec.ts`
- `git diff --check`

## Notes
- `plans/README.md` is not present in this checkout, so there was no plan status row to update.
