### PR TITLE
[api] Make Stripe checkout processing idempotent

### DIFF
--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -16,7 +16,7 @@ import {
     createOperation,
     createTransaction,
     earnSunflowersForPayment,
-    getAllTransactions,
+    getCompletedTransactionByStripePaymentId,
     getDefaultShoppingCartScheduledDate,
     getInventory,
     getOutletOfferReservationForCartItem,
@@ -268,6 +268,16 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
         return;
     }
 
+    const alreadyProcessed = await getCompletedTransactionByStripePaymentId(
+        session.id,
+    );
+    if (alreadyProcessed) {
+        console.info(
+            `Checkout session ${checkoutSessionId} already processed; skipping.`,
+        );
+        return;
+    }
+
     console.debug(
         `Processing checkout session ${checkoutSessionId} with amount ${session.amountTotal} cents`,
     );
@@ -280,7 +290,6 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
     }[] = [];
     const scheduledDeliveryEmailKeys = new Set<string>();
     let accountId: string | undefined;
-    let checkedExistingTransactions = false;
     for (const item of session.lineItems?.data ?? []) {
         console.debug(`Item: ${item.id} Quantity: ${item.quantity}`);
 
@@ -402,26 +411,6 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
             }
             accountId = resolvedAccountId;
 
-            // Check if transaction was already processed
-            if (!checkedExistingTransactions) {
-                // TODO: Use pagination and retrieve last N transactions or match via date
-                const transactions = await getAllTransactions({
-                    filter: { accountId },
-                });
-                checkedExistingTransactions = true;
-                const existingTransaction = transactions.find(
-                    (t) =>
-                        t.stripePaymentId === session.id &&
-                        t.status === 'completed',
-                );
-                if (existingTransaction) {
-                    console.info(
-                        `Transaction for session ${checkoutSessionId} already processed for account ${accountId}`,
-                    );
-                    return;
-                }
-            }
-
             // Find cart item by cartItemId for more reliable matching
             const cartItem = cart.items.find(
                 (i) => i.id === itemData.cartItemId,
@@ -539,7 +528,7 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
             ? createTransaction({
                   accountId,
                   amount: session.amountTotal,
-                  stripePaymentId: session.paymentId ?? session.id,
+                  stripePaymentId: session.id,
                   status: 'completed',
                   currency: 'eur',
               })

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -32,6 +32,7 @@ import {
     spendSunflowers,
     updateRaisedBed,
     upsertRaisedBedField,
+    withStripePaymentProcessingLock,
 } from '@gredice/storage';
 import { getStripeCheckoutSession } from '@gredice/stripe/server';
 import {
@@ -268,6 +269,15 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
         return;
     }
 
+    return withStripePaymentProcessingLock(session.id, () =>
+        processPaidCheckoutSession(checkoutSessionId, session),
+    );
+}
+
+async function processPaidCheckoutSession(
+    checkoutSessionId: string,
+    session: NonNullable<Awaited<ReturnType<typeof getStripeCheckoutSession>>>,
+) {
     const alreadyProcessed = await getCompletedTransactionByStripePaymentId(
         session.id,
     );

--- a/packages/storage/src/repositories/transactionsRepo.ts
+++ b/packages/storage/src/repositories/transactionsRepo.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import {
     type InsertTransaction,
     invoices,
@@ -51,6 +51,19 @@ export async function getCompletedTransactionByStripePaymentId(
             eq(transactions.status, 'completed'),
             eq(transactions.isDeleted, false),
         ),
+    });
+}
+
+export async function withStripePaymentProcessingLock<T>(
+    stripePaymentId: string,
+    callback: () => Promise<T>,
+) {
+    return storage().transaction(async (tx) => {
+        await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtext(${`stripe-payment:${stripePaymentId}`}));`,
+        );
+
+        return callback();
     });
 }
 

--- a/packages/storage/src/repositories/transactionsRepo.ts
+++ b/packages/storage/src/repositories/transactionsRepo.ts
@@ -14,6 +14,15 @@ export async function createTransaction(transaction: InsertTransaction) {
         throw new Error('Transaction must have an accountId');
     }
 
+    if (transaction.status === 'completed' && transaction.stripePaymentId) {
+        const existing = await getCompletedTransactionByStripePaymentId(
+            transaction.stripePaymentId,
+        );
+        if (existing) {
+            return existing.id;
+        }
+    }
+
     const transactionId = (
         await storage()
             .insert(transactions)
@@ -31,6 +40,18 @@ export async function createTransaction(transaction: InsertTransaction) {
     );
 
     return transactionId;
+}
+
+export async function getCompletedTransactionByStripePaymentId(
+    stripePaymentId: string,
+) {
+    return storage().query.transactions.findFirst({
+        where: and(
+            eq(transactions.stripePaymentId, stripePaymentId),
+            eq(transactions.status, 'completed'),
+            eq(transactions.isDeleted, false),
+        ),
+    });
 }
 
 export async function getTransaction(transactionId: number) {

--- a/packages/storage/tests/transactionsRepo.node.spec.ts
+++ b/packages/storage/tests/transactionsRepo.node.spec.ts
@@ -5,6 +5,7 @@ import {
     createTransaction,
     deleteTransaction,
     getAllTransactions,
+    getCompletedTransactionByStripePaymentId,
     getTransaction,
     getTransactionByStripeId,
     type InsertTransaction,
@@ -113,7 +114,34 @@ test('getTransactionByStripeId returns correct transaction', async () => {
     assert.strictEqual(tx?.id, txId);
 });
 
-test('createTransaction currently creates duplicate rows for the same completed stripePaymentId', async () => {
+test('getCompletedTransactionByStripePaymentId returns only completed transactions', async () => {
+    createTestDb();
+    const completedStripePaymentId = randomUUID();
+    const pendingStripePaymentId = randomUUID();
+    const completedTxId = await createTransaction({
+        ...(await baseTransaction()),
+        status: 'completed',
+        stripePaymentId: completedStripePaymentId,
+    });
+    await createTransaction({
+        ...(await baseTransaction()),
+        status: 'pending',
+        stripePaymentId: pendingStripePaymentId,
+    });
+
+    const completedTx = await getCompletedTransactionByStripePaymentId(
+        completedStripePaymentId,
+    );
+    const pendingTx = await getCompletedTransactionByStripePaymentId(
+        pendingStripePaymentId,
+    );
+
+    assert.ok(completedTx);
+    assert.strictEqual(completedTx.id, completedTxId);
+    assert.strictEqual(pendingTx, undefined);
+});
+
+test('createTransaction returns the existing row for the same completed stripePaymentId', async () => {
     createTestDb();
     const accountId = await createTestAccount();
     const stripePaymentId = randomUUID();
@@ -125,11 +153,16 @@ test('createTransaction currently creates duplicate rows for the same completed 
         stripePaymentId,
     };
 
-    await createTransaction(transaction);
-    await createTransaction(transaction);
+    const firstTxId = await createTransaction(transaction);
+    const secondTxId = await createTransaction(transaction);
 
     const txs = await getAllTransactions({ filter: { accountId } });
-    // Documents pre-003 behavior; plan 003 makes this idempotent.
-    assert.strictEqual(txs.length, 2);
+    // Documents post-003 idempotency for re-delivered Stripe checkout sessions.
+    assert.strictEqual(secondTxId, firstTxId);
+    assert.strictEqual(txs.length, 1);
     assert.ok(txs.every((tx) => tx.stripePaymentId === stripePaymentId));
+    const completedTx =
+        await getCompletedTransactionByStripePaymentId(stripePaymentId);
+    assert.ok(completedTx);
+    assert.strictEqual(completedTx.id, firstTxId);
 });


### PR DESCRIPTION
## Summary

- add a completed Stripe transaction lookup and make `createTransaction` return the existing completed row for duplicate `stripePaymentId` values
- short-circuit checkout session processing before item mutation when the session id was already recorded as completed
- store the checkout session id as the durable `stripePaymentId`, since the current `session.paymentId` maps to Stripe `payment_link` and can differ from the checkout session id
- update the Plan 002 transaction characterization test to assert the new idempotent behavior

## Dependency

Built on #3374 (`advisor/002-checkout-characterization-tests`). #3374 has merged, so this PR now targets `main` and keeps the diff scoped to Plan 003.

## Validation

- `pnpm typecheck --filter api --filter @gredice/storage` passed
- `pnpm lint --filter api --filter @gredice/storage` passed
- `pnpm test --filter @gredice/storage` passed: 309 passed, 0 failed

## Notes

- No schema or migration files were changed.
- Did not run `pnpm db-generate` or `pnpm db-push`.
- `plans/README.md` does not exist in this checkout, so no plan index row was updated.

Closes #3363