### PR TITLE
[api] Surface failed delivery request creation

### DIFF
--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -67,6 +67,7 @@ async function processNonStripeCartItems(
     accountId: string,
     deliveryInfo?: unknown,
     scheduledDeliveryEmailKeys?: Set<string>,
+    checkoutSessionId?: string | null,
 ): Promise<ShoppingCartItemWithShopData[]> {
     const inventoryNormalizedCart =
         await normalizeShoppingCartInventoryUsage(cartId);
@@ -151,6 +152,7 @@ async function processNonStripeCartItems(
                     amount_total: sunflowerAmount,
                     additionalData,
                     scheduledDeliveryEmailKeys,
+                    checkoutSessionId,
                 }),
             ]);
         }
@@ -233,6 +235,7 @@ async function processNonStripeCartItems(
                     amount_total: 0,
                     additionalData,
                     scheduledDeliveryEmailKeys,
+                    checkoutSessionId,
                 }),
             ]);
 
@@ -471,6 +474,7 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
                 accountId: resolvedAccountId,
                 amount_total: item.amount_total,
                 scheduledDeliveryEmailKeys,
+                checkoutSessionId: session.id,
             });
         } catch (error) {
             console.error(
@@ -528,6 +532,7 @@ export async function processCheckoutSession(checkoutSessionId?: string) {
                 accountId,
                 deliveryInfo,
                 scheduledDeliveryEmailKeys,
+                session.id,
             );
         }
     }
@@ -688,6 +693,7 @@ export async function processItem(itemData: {
     currency: string | null;
     amount_total: number; // Amount in cents or sunflowers
     scheduledDeliveryEmailKeys?: Set<string>;
+    checkoutSessionId?: string | null;
 }) {
     console.debug(
         `Processing item with entityId ${itemData.entityId} and entityTypeName ${itemData.entityTypeName} for account ${itemData.accountId} in total amount ${itemData.amount_total}`,
@@ -869,7 +875,20 @@ export async function processItem(itemData: {
                             `Failed to create delivery request for operation ${operationId}:`,
                             error,
                         );
-                        // Don't fail the whole payment, just log the error
+                        // Payment already captured -- do not re-throw. Surface the failure so ops
+                        // can reconcile the paid-but-undelivered order.
+                        (await getPostHogClient()).capture({
+                            distinctId: itemData.accountId,
+                            event: 'delivery_request_creation_failed',
+                            properties: {
+                                operation_id: operationId,
+                                account_id: itemData.accountId,
+                                slot_id: deliveryInfo.slotId,
+                                mode: deliveryInfo.mode,
+                                checkout_session_id:
+                                    itemData.checkoutSessionId ?? null,
+                            },
+                        });
                     }
                 } else {
                     console.warn(


### PR DESCRIPTION
## Summary
- emit a PostHog `delivery_request_creation_failed` event when checkout delivery-request creation or follow-up notifications fail
- keep the payment-safe catch behavior intact so Stripe webhook processing is not re-thrown

Closes #3367

## Validation
- `pnpm install`
- `pnpm typecheck --filter api`
- `pnpm lint --filter api`
- `grep -n "delivery_request_creation_failed" apps/api/lib/stripe/processCheckoutSession.ts`
- `git diff --check`

## Notes
- Drift check `git diff --stat 17aca58ba..HEAD -- apps/api/lib/stripe/processCheckoutSession.ts` returned no file changes before editing, and the catch block matched the plan excerpt.
- `plans/README.md` is not present in this checkout, so there was no plan status row to update.
- PR #3376 is still open and touches the same file for checkout idempotency, but its changes are in earlier checkout-processing logic; this PR changes only the delivery-request failure catch and targets `main` so it can close #3367 directly.