### PR TITLE
[storage] Group raised bed field events by aggregate id

### DIFF
--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -2542,12 +2542,22 @@ export async function getRaisedBedFieldsWithEvents(raisedBedId: number) {
         }
     }
 
+    const fieldsEventsByAggregateId = new Map<string, typeof fieldsEvents>();
+    for (const event of fieldsEvents) {
+        const aggregateEvents = fieldsEventsByAggregateId.get(
+            event.aggregateId,
+        );
+        if (aggregateEvents) {
+            aggregateEvents.push(event);
+        } else {
+            fieldsEventsByAggregateId.set(event.aggregateId, [event]);
+        }
+    }
+
     // For each field, fetch and apply events
     return fields.map((field) => {
         const aggregateId = `${field.raisedBedId}|${field.positionIndex}`;
-        const events = fieldsEvents.filter(
-            (event) => event.aggregateId === aggregateId,
-        );
+        const events = fieldsEventsByAggregateId.get(aggregateId) ?? [];
 
         // Reduce events to get latest status, plant info, etc.
         let plantStatus: string | undefined;


### PR DESCRIPTION
## Summary

- Group all fetched raised-bed-field events by aggregate id once in `getRaisedBedFieldsWithEvents`.
- Replace the per-field `fieldsEvents.filter(...)` scan with a map lookup while leaving the plant-cycle-only map and reducer behavior unchanged.

Closes #3365

## Validation

- `pnpm install`
- `pnpm typecheck --filter @gredice/storage` (exit 0; Turbo reports no typecheck task for `@gredice/storage`)
- `pnpm test --filter @gredice/storage` (308 pass, 0 fail)
- `pnpm lint --filter @gredice/storage`
- `git diff --check`
- `grep -n "fieldsEvents.filter" packages/storage/src/repositories/gardensRepo.ts` (no matches)

## Notes

- Drift check passed: `git diff --stat 17aca58ba..origin/main -- packages/storage/src/repositories/gardensRepo.ts` returned no changes.
- `plans/README.md` is not present in this checkout, so there was no status row to update.
- Existing raised-bed-field coverage is present in `packages/storage/tests/gardensRepo.raisedBedFields.node.spec.ts`; no new test was needed per the plan.
