### PR TITLE
[api] Bound garden-detail operations fetch

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -28,12 +28,12 @@ import {
     GardenDiaryRescheduleError,
     getAccount,
     getAccountGardens,
+    getAppliedRaisedBedOperationsForGarden,
     getEvents,
     getGarden,
     getGardenBlocks,
     getGardenStack,
     getGardenStackForUpdate,
-    getOperations,
     getOperationsPage,
     getRaisedBed,
     getRaisedBedAiHistoryEntries,
@@ -305,7 +305,9 @@ function isAppliedRaisedBedOperationStatus(status: string) {
 }
 
 function serializeAppliedRaisedBedOperation(
-    operation: Awaited<ReturnType<typeof getOperations>>[number],
+    operation: Awaited<
+        ReturnType<typeof getAppliedRaisedBedOperationsForGarden>
+    >[number],
 ) {
     return {
         id: operation.id,
@@ -319,7 +321,7 @@ function serializeAppliedRaisedBedOperation(
 }
 
 function serializeGardenOperation(
-    operation: Awaited<ReturnType<typeof getOperations>>[number],
+    operation: Awaited<ReturnType<typeof getOperationsPage>>['items'][number],
     targetsByRaisedBedFieldId: Map<number, string>,
     targetsByRaisedBedId: Map<number, string>,
 ) {
@@ -735,7 +737,10 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     getGarden(gardenIdNumber),
                     // getEvents(knownEventTypes.gardens.blockPlace, gardenId, 0, 10000),
                     getGardenBlocks(gardenIdNumber),
-                    getOperations(accountId, gardenIdNumber),
+                    getAppliedRaisedBedOperationsForGarden(
+                        accountId,
+                        gardenIdNumber,
+                    ),
                 ]);
             if (!garden || garden.accountId !== accountId) {
                 return context.json({ error: 'Garden not found' }, 404);

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -6,6 +6,7 @@ import {
     eq,
     gte,
     inArray,
+    isNotNull,
     isNull,
     lte,
     or,
@@ -419,6 +420,12 @@ function getOperationStatusWhere(
     )})`;
 }
 
+const appliedRaisedBedOperationStatuses: OperationStatus[] = [
+    // Keep in sync with isAppliedRaisedBedOperationStatus in the garden route.
+    'completed',
+    'pendingVerification',
+];
+
 function getOperationTimelineSortExpression() {
     const scheduledDateExpression = getOperationScheduledDateExpression();
 
@@ -505,6 +512,36 @@ export async function getOperationsPage(
         nextCursor: pageRows.length > pageSize ? offset + pageSize : null,
         total: totalResult[0]?.count ?? 0,
     };
+}
+
+export async function getAppliedRaisedBedOperationsForGarden(
+    accountId: string,
+    gardenId: number,
+) {
+    const rows = await storage()
+        .select({
+            id: operations.id,
+        })
+        .from(operations)
+        .where(
+            and(
+                getOperationsWhere({ accountId, gardenId }),
+                getOperationStatusWhere(appliedRaisedBedOperationStatuses),
+                isNotNull(operations.raisedBedId),
+            ),
+        )
+        .orderBy(desc(operations.timestamp));
+
+    const operationIds = rows.map((row) => row.id);
+    const hydratedOperations = await getOperationsByIds(operationIds);
+    const hydratedOperationsById = new Map(
+        hydratedOperations.map((operation) => [operation.id, operation]),
+    );
+
+    return operationIds.flatMap((operationId) => {
+        const operation = hydratedOperationsById.get(operationId);
+        return operation ? [operation] : [];
+    });
 }
 
 export async function getAllOperations(filter?: {

--- a/packages/storage/tests/operationsRepo.node.spec.ts
+++ b/packages/storage/tests/operationsRepo.node.spec.ts
@@ -10,9 +10,11 @@ import {
     createOperation,
     events,
     getAllOperations,
+    getAppliedRaisedBedOperationsForGarden,
     getAssignableFarmUsersByOperationIds,
     getFarmUserAcceptedOperations,
     getOperationById,
+    getOperations,
     getOperationsPage,
     knownEvents,
     knownEventTypes,
@@ -289,4 +291,154 @@ test('all operations can be filtered by event-derived status', async () => {
         new Set([newOperationId, plannedOperationId]),
     );
     assert.ok(!operationIds.includes(pendingOperationId));
+});
+
+test('getAppliedRaisedBedOperationsForGarden matches the previous in-memory applied raised-bed filter', async () => {
+    createTestDb();
+
+    const accountId = await createAccount();
+    const otherAccountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const otherGardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(
+        gardenId,
+        'garden-applied-operations-block',
+    );
+    const otherBlockId = await createTestBlock(
+        otherGardenId,
+        'other-garden-applied-operations-block',
+    );
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+    const otherRaisedBedId = await createTestRaisedBed(
+        otherGardenId,
+        accountId,
+        otherBlockId,
+    );
+
+    const pendingRaisedBedOperationId = await createOperation({
+        entityId: 1,
+        entityTypeName: 'operation',
+        accountId,
+        gardenId,
+        raisedBedId,
+        timestamp: new Date('2040-02-01T00:00:00.000Z'),
+    });
+    const completedRaisedBedOperationId = await createOperation({
+        entityId: 2,
+        entityTypeName: 'operation',
+        accountId,
+        gardenId,
+        raisedBedId,
+        timestamp: new Date('2040-02-02T00:00:00.000Z'),
+    });
+    const plannedRaisedBedOperationId = await createOperation({
+        entityId: 3,
+        entityTypeName: 'operation',
+        accountId,
+        gardenId,
+        raisedBedId,
+        timestamp: new Date('2040-02-03T00:00:00.000Z'),
+    });
+    const pendingGardenOperationId = await createOperation({
+        entityId: 4,
+        entityTypeName: 'operation',
+        accountId,
+        gardenId,
+        timestamp: new Date('2040-02-04T00:00:00.000Z'),
+    });
+    const pendingOtherGardenOperationId = await createOperation({
+        entityId: 5,
+        entityTypeName: 'operation',
+        accountId,
+        gardenId: otherGardenId,
+        raisedBedId: otherRaisedBedId,
+        timestamp: new Date('2040-02-05T00:00:00.000Z'),
+    });
+    const pendingOtherAccountOperationId = await createOperation({
+        entityId: 6,
+        entityTypeName: 'operation',
+        accountId: otherAccountId,
+        gardenId,
+        raisedBedId,
+        timestamp: new Date('2040-02-06T00:00:00.000Z'),
+    });
+
+    await createEvent(
+        knownEvents.operations.completedV1(
+            pendingRaisedBedOperationId.toString(),
+            {
+                completedBy: randomUUID(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.operations.completedV1(
+            completedRaisedBedOperationId.toString(),
+            {
+                completedBy: randomUUID(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.operations.verifiedV1(
+            completedRaisedBedOperationId.toString(),
+            {
+                verifiedBy: randomUUID(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.operations.scheduledV1(
+            plannedRaisedBedOperationId.toString(),
+            {
+                scheduledDate: '2040-02-10T00:00:00.000Z',
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.operations.completedV1(
+            pendingGardenOperationId.toString(),
+            {
+                completedBy: randomUUID(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.operations.completedV1(
+            pendingOtherGardenOperationId.toString(),
+            {
+                completedBy: randomUUID(),
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.operations.completedV1(
+            pendingOtherAccountOperationId.toString(),
+            {
+                completedBy: randomUUID(),
+            },
+        ),
+    );
+
+    const oldFilteredOperationIds = (await getOperations(accountId, gardenId))
+        .filter(
+            (operation) =>
+                operation.raisedBedId &&
+                (operation.status === 'completed' ||
+                    operation.status === 'pendingVerification'),
+        )
+        .map((operation) => operation.id);
+    const boundedOperationIds = (
+        await getAppliedRaisedBedOperationsForGarden(accountId, gardenId)
+    ).map((operation) => operation.id);
+
+    assert.deepStrictEqual(
+        new Set(boundedOperationIds),
+        new Set(oldFilteredOperationIds),
+    );
+    assert.deepStrictEqual(
+        new Set(boundedOperationIds),
+        new Set([completedRaisedBedOperationId, pendingRaisedBedOperationId]),
+    );
 });


### PR DESCRIPTION
## Summary
- Add a targeted storage helper that selects applied, raised-bed-scoped garden operations at the SQL layer before aggregate hydration.
- Use the targeted helper in the garden-detail endpoint while leaving the downstream reducer and response shape unchanged.
- Add a storage equivalence test against the previous `getOperations(accountId, gardenId)` in-memory filter behavior.

## Investigation
- Drift check passed: no target-file drift from `17aca58ba` for `gardensRoutes.ts` or `operationsRepo.ts`.
- Step 1 go/no-go cleared: applied statuses are `completed` and `pendingVerification`; `getOperationStatusExpression()` supports SQL `IN`; raised-bed scoping is expressible with `raisedBedId IS NOT NULL`.
- Checked open PR overlap before publish: #3379 also touches `gardensRoutes.ts`, but in a different change set; this branch is based on current `origin/main`.
- `plans/README.md` is not present in this checkout, so there was no plan status row to update.

## Validation
- `pnpm install` - pass
- `pnpm typecheck --filter api --filter @gredice/storage` - pass (Turbo completed available typecheck tasks; no direct api/storage typecheck task executed)
- `pnpm lint --filter api --filter @gredice/storage` - pass
- `pnpm test --filter @gredice/storage` - pass, 309 tests

Closes #3368
