### PR TITLE
[transactional] Add email render tests

### DIFF
--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -7,6 +7,8 @@
     ],
     "scripts": {
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
+        "test": "pnpm run test:node",
+        "test:node": "node --import tsx --test ./tests/**/*.node.spec.tsx",
         "lint": "biome check --write",
         "lint:migrate": "biome migrate --write",
         "dev": "email dev -p 4001"
@@ -19,6 +21,7 @@
         "@types/node": "24.12.4",
         "@types/react": "19.2.15",
         "tailwindcss": "4.3.0",
+        "tsx": "4.22.3",
         "typescript": "6.0.3"
     },
     "dependencies": {

--- a/packages/transactional/tests/accountEmails.node.spec.tsx
+++ b/packages/transactional/tests/accountEmails.node.spec.tsx
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import { createElement } from 'react';
+import AccountDeleteConfirmationEmailTemplate from '../emails/Account/delete-confirmation';
+import EmailVerifyEmailTemplate from '../emails/Account/email-verify';
+import AccountInvitationEmailTemplate from '../emails/Account/invitation';
+import ResetPasswordEmailTemplate from '../emails/Account/reset-password';
+import WelcomeEmailTemplate from '../emails/Account/welcome';
+import { assertHtmlIncludes, renderNonEmpty } from './renderEmail';
+
+test('delete-confirmation renders with the confirmation link', async () => {
+    const confirmLink = 'https://example.test/delete-confirmation';
+    const html = await renderNonEmpty(
+        createElement(AccountDeleteConfirmationEmailTemplate, {
+            confirmLink,
+            email: 'delete@example.test',
+        }),
+    );
+
+    assertHtmlIncludes(html, confirmLink);
+    assertHtmlIncludes(html, 'delete@example.test');
+});
+
+test('email-verify renders with the confirmation link', async () => {
+    const confirmLink = 'https://example.test/email-verify';
+    const html = await renderNonEmpty(
+        createElement(EmailVerifyEmailTemplate, {
+            confirmLink,
+            email: 'verify@example.test',
+        }),
+    );
+
+    assertHtmlIncludes(html, confirmLink);
+    assertHtmlIncludes(html, 'verify@example.test');
+});
+
+test('invitation renders with the accept URL and inviter name', async () => {
+    const acceptUrl = 'https://example.test/invitation';
+    const invitedByName = 'Marta Test';
+    const html = await renderNonEmpty(
+        createElement(AccountInvitationEmailTemplate, {
+            acceptUrl,
+            email: 'invite@example.test',
+            invitedByName,
+        }),
+    );
+
+    assertHtmlIncludes(html, acceptUrl);
+    assertHtmlIncludes(html, invitedByName);
+});
+
+test('reset-password renders with the confirmation link', async () => {
+    const confirmLink = 'https://example.test/reset-password';
+    const html = await renderNonEmpty(
+        createElement(ResetPasswordEmailTemplate, {
+            confirmLink,
+            email: 'reset@example.test',
+        }),
+    );
+
+    assertHtmlIncludes(html, confirmLink);
+    assertHtmlIncludes(html, 'reset@example.test');
+});
+
+test('welcome renders with the call-to-action URL', async () => {
+    const ctaUrl = 'https://example.test/welcome';
+    const html = await renderNonEmpty(
+        createElement(WelcomeEmailTemplate, {
+            ctaUrl,
+            email: 'welcome@example.test',
+        }),
+    );
+
+    assertHtmlIncludes(html, ctaUrl);
+    assertHtmlIncludes(html, 'welcome@example.test');
+});

--- a/packages/transactional/tests/deliveryEmails.node.spec.tsx
+++ b/packages/transactional/tests/deliveryEmails.node.spec.tsx
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import { createElement } from 'react';
+import DeliveryCancelledEmailTemplate from '../emails/Notifications/delivery-cancelled';
+import DeliveryReadyEmailTemplate from '../emails/Notifications/delivery-ready';
+import DeliveryScheduledEmailTemplate from '../emails/Notifications/delivery-scheduled';
+import DeliverySurveyEmailTemplate from '../emails/Notifications/delivery-survey';
+import { assertHtmlIncludes, renderNonEmpty } from './renderEmail';
+
+test('delivery-scheduled renders with delivery details', async () => {
+    const deliveryWindow = '15. lipnja 2026. od 10:00 do 12:00';
+    const manageUrl = 'https://example.test/delivery-scheduled';
+    const html = await renderNonEmpty(
+        createElement(DeliveryScheduledEmailTemplate, {
+            addressLine: 'Testna ulica 12',
+            contactName: 'Luka',
+            deliveryWindow,
+            email: 'scheduled@example.test',
+            manageUrl,
+        }),
+    );
+
+    assertHtmlIncludes(html, deliveryWindow);
+    assertHtmlIncludes(html, manageUrl);
+});
+
+test('delivery-ready renders with ready items and delivery details', async () => {
+    const deliveryWindow = '16. lipnja 2026. od 14:00 do 16:00';
+    const manageUrl = 'https://example.test/delivery-ready';
+    const readyItem = 'Testna rajcica';
+    const html = await renderNonEmpty(
+        createElement(DeliveryReadyEmailTemplate, {
+            addressLine: 'Probna avenija 3',
+            contactName: 'Ana',
+            deliveryWindow,
+            email: 'ready@example.test',
+            manageUrl,
+            readyItems: [readyItem, 'Testna salata'],
+        }),
+    );
+
+    assertHtmlIncludes(html, deliveryWindow);
+    assertHtmlIncludes(html, manageUrl);
+    assertHtmlIncludes(html, readyItem);
+});
+
+test('delivery-cancelled renders with the cancelled delivery details', async () => {
+    const deliveryWindow = '17. lipnja 2026. od 09:00 do 11:00';
+    const manageUrl = 'https://example.test/delivery-cancelled';
+    const html = await renderNonEmpty(
+        createElement(DeliveryCancelledEmailTemplate, {
+            addressLine: 'Primjer cesta 4',
+            contactName: 'Iva',
+            deliveryWindow,
+            email: 'cancelled@example.test',
+            manageUrl,
+        }),
+    );
+
+    assertHtmlIncludes(html, deliveryWindow);
+    assertHtmlIncludes(html, manageUrl);
+});
+
+test('delivery-survey renders with the survey URL and period', async () => {
+    const deliveryPeriod = 'probnog lipnja';
+    const surveyUrl = 'https://example.test/delivery-survey';
+    const html = await renderNonEmpty(
+        createElement(DeliverySurveyEmailTemplate, {
+            deliveryCount: 3,
+            deliveryPeriod,
+            email: 'survey@example.test',
+            surveyUrl,
+        }),
+    );
+
+    assertHtmlIncludes(html, deliveryPeriod);
+    assertHtmlIncludes(html, surveyUrl);
+});

--- a/packages/transactional/tests/newsletterEmails.node.spec.tsx
+++ b/packages/transactional/tests/newsletterEmails.node.spec.tsx
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import { createElement } from 'react';
+import MarkdownEmailTemplate from '../emails/Newsletter/newsletter';
+import { assertHtmlIncludes, renderNonEmpty } from './renderEmail';
+
+test('newsletter renders with markdown content and links', async () => {
+    const newsletterUrl = 'https://example.test/newsletter';
+    const html = await renderNonEmpty(
+        createElement(MarkdownEmailTemplate, {
+            content: `Procitaj [testnu objavu](${newsletterUrl}) o sezoni.`,
+            header: 'Testni newsletter',
+            previewText: 'Testni pregled newslettera',
+        }),
+    );
+
+    assertHtmlIncludes(html, 'Testni newsletter');
+    assertHtmlIncludes(html, newsletterUrl);
+});

--- a/packages/transactional/tests/notificationEmails.node.spec.tsx
+++ b/packages/transactional/tests/notificationEmails.node.spec.tsx
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import { createElement } from 'react';
+import BirthdayEmailTemplate from '../emails/Notifications/birthday';
+import EmailNotificationsBulkTemplate from '../emails/Notifications/notifications-bulk';
+import { assertHtmlIncludes, renderNonEmpty } from './renderEmail';
+
+test('birthday renders with the recipient name and sunflower amount', async () => {
+    const html = await renderNonEmpty(
+        createElement(BirthdayEmailTemplate, {
+            appDomain: 'example.test',
+            email: 'birthday@example.test',
+            name: 'Mila Test',
+            sunflowerAmount: 1234,
+        }),
+    );
+
+    assertHtmlIncludes(html, 'Mila Test');
+    assertHtmlIncludes(html, '1234');
+    assertHtmlIncludes(html, 'vrt.example.test');
+});
+
+test('notifications-bulk renders with the notification image URL', async () => {
+    const notificationImageUrl = 'https://example.test/notification.jpg';
+    const html = await renderNonEmpty(
+        createElement(EmailNotificationsBulkTemplate, {
+            email: 'bulk@example.test',
+            notificationImageUrls: [notificationImageUrl],
+            notificationsCount: 3,
+        }),
+    );
+
+    assertHtmlIncludes(html, notificationImageUrl);
+    assertHtmlIncludes(html, 'bulk@example.test');
+});

--- a/packages/transactional/tests/renderEmail.ts
+++ b/packages/transactional/tests/renderEmail.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import type { ReactElement } from 'react';
+import { render } from 'react-email';
+
+export async function renderNonEmpty(element: ReactElement) {
+    const html = await render(element);
+
+    assert.ok(html.trim().length > 0);
+
+    return html;
+}
+
+export function assertHtmlIncludes(html: string, expected: string) {
+    assert.ok(
+        html.includes(expected),
+        `Expected rendered HTML to include "${expected}".`,
+    );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1443,6 +1443,9 @@ importers:
       tailwindcss:
         specifier: 4.3.0
         version: 4.3.0
+      tsx:
+        specifier: 4.22.3
+        version: 4.22.3
       typescript:
         specifier: 6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary
- add node-test scripts for @gredice/transactional using react-email render through tsx
- add render coverage for all 12 templates listed in Plan 012
- assert each render returns non-empty HTML and includes a required dynamic value

Closes #3372

## Issue notes
- Drift check: `git diff --stat 17aca58ba..HEAD -- packages/transactional packages/email` returned no package/email drift before edits and again after rebasing onto current `origin/main`.
- `render` from `react-email` is still the entry point used by `@gredice/email`; tests await it to match the transport.
- No transactional email templates were modified.
- `plans/README.md` does not exist in this checkout, so there was no status row to update.

## Validation
- `pnpm install`
- `pnpm --filter @gredice/transactional test:node`
- `pnpm test --filter @gredice/transactional`
- `pnpm typecheck --filter @gredice/transactional`
- `pnpm lint --filter @gredice/transactional`