### PR TITLE
Map visit facts to concise Croatian summary copy

### DIFF
--- a/packages/client/src/hono.ts
+++ b/packages/client/src/hono.ts
@@ -54,3 +54,10 @@ export type GardenResponse = InferResponseType<
     ReturnType<typeof client>['api']['gardens'][':gardenId']['$get'],
     200
 >;
+
+export type GardenVisitSummaryResponse = InferResponseType<
+    ReturnType<
+        typeof client
+    >['api']['gardens'][':gardenId']['visit-summary']['$get'],
+    200
+>;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,7 +1,12 @@
 export * from './directories-api';
 export * from './favorites';
 export * from './harvest-traces';
-export type { ClientMode, ClientOptions, GardenResponse } from './hono';
+export type {
+    ClientMode,
+    ClientOptions,
+    GardenResponse,
+    GardenVisitSummaryResponse,
+} from './hono';
 export { client, clientAuthenticated, clientPublic } from './hono';
 export {
     type GrediceAppOrigin,

--- a/packages/game/src/hooks/gardenVisitSummary.ts
+++ b/packages/game/src/hooks/gardenVisitSummary.ts
@@ -1,0 +1,528 @@
+import type { GardenVisitSummaryResponse } from '@gredice/client';
+
+export type GardenVisitSummaryFact =
+    GardenVisitSummaryResponse['facts'][number];
+export type GardenVisitSummaryTarget = NonNullable<
+    GardenVisitSummaryFact['target']
+>;
+export type GardenVisitSummarySource = GardenVisitSummaryFact['source'];
+
+export type GardenVisitSummaryDisplayItem = {
+    id: string;
+    type: GardenVisitSummaryFact['type'];
+    message: string;
+    priority: number;
+    occurredAt: string;
+    facts: GardenVisitSummaryFact[];
+    sources: GardenVisitSummarySource[];
+    targets: GardenVisitSummaryTarget[];
+    visualHints: GardenVisitSummaryFact['visualHint'][];
+};
+
+type FormatGardenVisitSummaryFactsOptions = {
+    maxItems?: number;
+};
+
+type CroatianCountForms = {
+    one: string;
+    few: string;
+    many: string;
+};
+
+type PlantCopy = {
+    label: string;
+    growthPredicate: string;
+    supportPredicate: string;
+    readyPredicate: string;
+};
+
+export const DEFAULT_GARDEN_VISIT_SUMMARY_DISPLAY_ITEMS = 5;
+
+const gardenBedLocativeForms: CroatianCountForms = {
+    one: 'gredici',
+    few: 'gredice',
+    many: 'gredica',
+};
+const fieldLocativeForms: CroatianCountForms = {
+    one: 'polju',
+    few: 'polja',
+    many: 'polja',
+};
+const dayForms: CroatianCountForms = {
+    one: 'dan',
+    few: 'dana',
+    many: 'dana',
+};
+const operationForms: CroatianCountForms = {
+    one: 'radnja',
+    few: 'radnje',
+    many: 'radnji',
+};
+
+const knownPlantCopy = new Map<string, PlantCopy>([
+    [
+        'rajčica',
+        {
+            label: 'Rajčice',
+            growthPredicate: 'su vidljivo narasle',
+            supportPredicate: 'trebaju',
+            readyPredicate: 'su spremne',
+        },
+    ],
+    [
+        'krastavac',
+        {
+            label: 'Krastavci',
+            growthPredicate: 'su vidljivo narasli',
+            supportPredicate: 'trebaju',
+            readyPredicate: 'su spremni',
+        },
+    ],
+    [
+        'paprika',
+        {
+            label: 'Paprike',
+            growthPredicate: 'su vidljivo narasle',
+            supportPredicate: 'trebaju',
+            readyPredicate: 'su spremne',
+        },
+    ],
+    [
+        'mrkva',
+        {
+            label: 'Mrkve',
+            growthPredicate: 'su vidljivo narasle',
+            supportPredicate: 'trebaju',
+            readyPredicate: 'su spremne',
+        },
+    ],
+    [
+        'salata',
+        {
+            label: 'Salate',
+            growthPredicate: 'su vidljivo narasle',
+            supportPredicate: 'trebaju',
+            readyPredicate: 'su spremne',
+        },
+    ],
+    [
+        'brokula',
+        {
+            label: 'Brokule',
+            growthPredicate: 'su vidljivo narasle',
+            supportPredicate: 'trebaju',
+            readyPredicate: 'su spremne',
+        },
+    ],
+    [
+        'luk',
+        {
+            label: 'Luk',
+            growthPredicate: 'je vidljivo narastao',
+            supportPredicate: 'treba',
+            readyPredicate: 'je spreman',
+        },
+    ],
+    [
+        'špinat',
+        {
+            label: 'Špinat',
+            growthPredicate: 'je vidljivo narastao',
+            supportPredicate: 'treba',
+            readyPredicate: 'je spreman',
+        },
+    ],
+]);
+
+const fallbackPlantCopy: PlantCopy = {
+    label: 'Biljke',
+    growthPredicate: 'su vidljivo narasle',
+    supportPredicate: 'trebaju',
+    readyPredicate: 'su spremne',
+};
+
+export function gardenVisitSummaryQueryKey(
+    gardenId: number | null | undefined,
+) {
+    return ['garden-visit-summary', gardenId ?? null];
+}
+
+function sentenceCaseCroatian(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return trimmed;
+    }
+
+    return `${trimmed.charAt(0).toLocaleUpperCase('hr-HR')}${trimmed.slice(1)}`;
+}
+
+function normalizePlantName(value: string) {
+    return value.trim().toLocaleLowerCase('hr-HR');
+}
+
+function plantNameForFact(fact: GardenVisitSummaryFact) {
+    return fact.plant?.plantName ?? fact.plant?.sortName ?? null;
+}
+
+function genericPlantCopy(name: string): PlantCopy {
+    const label = sentenceCaseCroatian(name);
+    const normalized = normalizePlantName(name);
+    if (normalized.endsWith('a')) {
+        return {
+            label: `${label.slice(0, -1)}e`,
+            growthPredicate: 'su vidljivo narasle',
+            supportPredicate: 'trebaju',
+            readyPredicate: 'su spremne',
+        };
+    }
+
+    if (normalized.endsWith('ac')) {
+        return {
+            label: `${label.slice(0, -2)}ci`,
+            growthPredicate: 'su vidljivo narasli',
+            supportPredicate: 'trebaju',
+            readyPredicate: 'su spremni',
+        };
+    }
+
+    return {
+        label,
+        growthPredicate: 'je vidljivo narastao',
+        supportPredicate: 'treba',
+        readyPredicate: 'je spreman',
+    };
+}
+
+function plantCopyForFacts(facts: GardenVisitSummaryFact[]): PlantCopy {
+    const plantName = facts.map(plantNameForFact).find(Boolean);
+    if (!plantName) {
+        return fallbackPlantCopy;
+    }
+
+    return (
+        knownPlantCopy.get(normalizePlantName(plantName)) ??
+        genericPlantCopy(plantName)
+    );
+}
+
+function isCroatianFewCount(count: number) {
+    const absoluteCount = Math.abs(count);
+    const lastDigit = absoluteCount % 10;
+    const lastTwoDigits = absoluteCount % 100;
+
+    return (
+        lastDigit >= 2 &&
+        lastDigit <= 4 &&
+        !(lastTwoDigits >= 12 && lastTwoDigits <= 14)
+    );
+}
+
+function croatianCountForm(count: number, forms: CroatianCountForms) {
+    const absoluteCount = Math.abs(count);
+    const lastDigit = absoluteCount % 10;
+    const lastTwoDigits = absoluteCount % 100;
+
+    if (lastDigit === 1 && lastTwoDigits !== 11) {
+        return forms.one;
+    }
+
+    if (isCroatianFewCount(count)) {
+        return forms.few;
+    }
+
+    return forms.many;
+}
+
+function formatCroatianCount(count: number, forms: CroatianCountForms) {
+    return `${count.toString()} ${croatianCountForm(count, forms)}`;
+}
+
+function countFacts(facts: GardenVisitSummaryFact[]) {
+    const explicitTotal = facts.reduce(
+        (total, fact) => total + Math.max(0, fact.count ?? 1),
+        0,
+    );
+
+    return explicitTotal > 0 ? explicitTotal : facts.length;
+}
+
+function priorityForFacts(facts: GardenVisitSummaryFact[]) {
+    return facts.reduce(
+        (highestPriority, fact) => Math.max(highestPriority, fact.priority),
+        0,
+    );
+}
+
+function occurredAtForFacts(facts: GardenVisitSummaryFact[]) {
+    return facts.reduce(
+        (latestOccurredAt, fact) =>
+            fact.occurredAt > latestOccurredAt
+                ? fact.occurredAt
+                : latestOccurredAt,
+        '',
+    );
+}
+
+function targetsForFacts(facts: GardenVisitSummaryFact[]) {
+    const targets: GardenVisitSummaryTarget[] = [];
+    const seenTargetKeys = new Set<string>();
+
+    for (const fact of facts) {
+        if (!fact.target) {
+            continue;
+        }
+
+        const key = [
+            fact.target.raisedBedId?.toString() ?? '',
+            fact.target.fieldId?.toString() ?? '',
+            fact.target.positionIndex?.toString() ?? '',
+        ].join(':');
+        if (seenTargetKeys.has(key)) {
+            continue;
+        }
+
+        seenTargetKeys.add(key);
+        targets.push(fact.target);
+    }
+
+    return targets;
+}
+
+function visualHintsForFacts(facts: GardenVisitSummaryFact[]) {
+    return [...new Set(facts.flatMap((fact) => fact.visualHint ?? []))];
+}
+
+function displayItemFromFacts({
+    id,
+    message,
+    type,
+    facts,
+}: {
+    id: string;
+    message: string;
+    type: GardenVisitSummaryFact['type'];
+    facts: GardenVisitSummaryFact[];
+}): GardenVisitSummaryDisplayItem {
+    return {
+        id,
+        type,
+        message,
+        priority: priorityForFacts(facts),
+        occurredAt: occurredAtForFacts(facts),
+        facts,
+        sources: facts.map((fact) => fact.source),
+        targets: targetsForFacts(facts),
+        visualHints: visualHintsForFacts(facts),
+    };
+}
+
+function sortFacts(facts: GardenVisitSummaryFact[]) {
+    return [...facts].sort((left, right) => {
+        if (left.priority !== right.priority) {
+            return right.priority - left.priority;
+        }
+
+        if (left.occurredAt !== right.occurredAt) {
+            return right.occurredAt.localeCompare(left.occurredAt);
+        }
+
+        return left.id.localeCompare(right.id);
+    });
+}
+
+function sortDisplayItems(items: GardenVisitSummaryDisplayItem[]) {
+    return [...items].sort((left, right) => {
+        if (left.priority !== right.priority) {
+            return right.priority - left.priority;
+        }
+
+        if (left.occurredAt !== right.occurredAt) {
+            return right.occurredAt.localeCompare(left.occurredAt);
+        }
+
+        return left.id.localeCompare(right.id);
+    });
+}
+
+function groupFactsByKey(
+    facts: GardenVisitSummaryFact[],
+    keyForFact: (fact: GardenVisitSummaryFact) => string,
+) {
+    const groupsByKey = new Map<string, GardenVisitSummaryFact[]>();
+
+    for (const fact of facts) {
+        const key = keyForFact(fact);
+        groupsByKey.set(key, [...(groupsByKey.get(key) ?? []), fact]);
+    }
+
+    return [...groupsByKey.entries()].map(([key, groupFacts]) => ({
+        key,
+        facts: groupFacts,
+    }));
+}
+
+function plantGroupKey(fact: GardenVisitSummaryFact) {
+    if (fact.plant?.sortId != null) {
+        return `sort:${fact.plant.sortId.toString()}`;
+    }
+
+    return `name:${normalizePlantName(plantNameForFact(fact) ?? 'biljke')}`;
+}
+
+function drySoilDisplayItem(facts: GardenVisitSummaryFact[]) {
+    return displayItemFromFacts({
+        id: 'drySoil',
+        type: 'drySoil',
+        facts,
+        message: `Tlo je suho na ${formatCroatianCount(countFacts(facts), gardenBedLocativeForms)}.`,
+    });
+}
+
+function weedDisplayItems(facts: GardenVisitSummaryFact[]) {
+    return groupFactsByKey(facts, (fact) =>
+        fact.visualHint === 'field' || fact.target?.fieldId != null
+            ? 'fields'
+            : 'raisedBeds',
+    ).map(({ key, facts: groupedFacts }) =>
+        displayItemFromFacts({
+            id: `weed:${key}`,
+            type: 'weed',
+            facts: groupedFacts,
+            message: `Pojavio se korov na ${formatCroatianCount(
+                countFacts(groupedFacts),
+                key === 'fields' ? fieldLocativeForms : gardenBedLocativeForms,
+            )}.`,
+        }),
+    );
+}
+
+function supportNeededDisplayItems(facts: GardenVisitSummaryFact[]) {
+    return groupFactsByKey(facts, plantGroupKey).map(
+        ({ key, facts: groupedFacts }) => {
+            const plantCopy = plantCopyForFacts(groupedFacts);
+
+            return displayItemFromFacts({
+                id: `supportNeeded:${key}`,
+                type: 'supportNeeded',
+                facts: groupedFacts,
+                message: `${plantCopy.label} ${plantCopy.supportPredicate} potporu.`,
+            });
+        },
+    );
+}
+
+function plantGrowthDisplayItems(facts: GardenVisitSummaryFact[]) {
+    return groupFactsByKey(facts, plantGroupKey).map(
+        ({ key, facts: groupedFacts }) => {
+            const plantCopy = plantCopyForFacts(groupedFacts);
+
+            return displayItemFromFacts({
+                id: `plantGrowth:${key}`,
+                type: 'plantGrowth',
+                facts: groupedFacts,
+                message: `${plantCopy.label} ${plantCopy.growthPredicate}.`,
+            });
+        },
+    );
+}
+
+function rangeForFacts(facts: GardenVisitSummaryFact[]) {
+    const ranges = facts.flatMap((fact) => (fact.range ? [fact.range] : []));
+    if (ranges.length === 0) {
+        return null;
+    }
+
+    return {
+        min: Math.min(...ranges.map((range) => range.min)),
+        max: Math.max(...ranges.map((range) => range.max)),
+    };
+}
+
+function formatHarvestRange(range: { min: number; max: number }) {
+    if (range.min <= 0 && range.max <= 0) {
+        return 'danas';
+    }
+
+    if (range.min <= 0) {
+        return `u sljedeća ${formatCroatianCount(range.max, dayForms)}`;
+    }
+
+    if (range.min === range.max) {
+        return `za ${formatCroatianCount(range.min, dayForms)}`;
+    }
+
+    return `za ${range.min.toString()}-${range.max.toString()} dana`;
+}
+
+function harvestWindowDisplayItems(facts: GardenVisitSummaryFact[]) {
+    return groupFactsByKey(facts, plantGroupKey).map(
+        ({ key, facts: groupedFacts }) => {
+            const range = rangeForFacts(groupedFacts);
+            const plantCopy = plantCopyForFacts(groupedFacts);
+            const message =
+                range && (range.min > 0 || range.max > 0)
+                    ? `Berba bi mogla biti ${formatHarvestRange(range)}.`
+                    : `${plantCopy.label} ${plantCopy.readyPredicate} za berbu.`;
+
+            return displayItemFromFacts({
+                id: `harvestWindow:${key}`,
+                type: 'harvestWindow',
+                facts: groupedFacts,
+                message,
+            });
+        },
+    );
+}
+
+function operationCompletedDisplayItem(facts: GardenVisitSummaryFact[]) {
+    const count = countFacts(facts);
+    const message =
+        count === 1
+            ? 'Dovršena je radnja u vrtu.'
+            : isCroatianFewCount(count)
+              ? `Dovršene su ${formatCroatianCount(count, operationForms)} u vrtu.`
+              : `Dovršeno je ${formatCroatianCount(count, operationForms)} u vrtu.`;
+
+    return displayItemFromFacts({
+        id: 'operationCompleted',
+        type: 'operationCompleted',
+        facts,
+        message,
+    });
+}
+
+export function formatGardenVisitSummaryFacts(
+    facts: GardenVisitSummaryFact[],
+    options: FormatGardenVisitSummaryFactsOptions = {},
+) {
+    const sortedFacts = sortFacts(facts);
+    const plantGrowthFacts = sortedFacts.filter(
+        (fact) => fact.type === 'plantGrowth',
+    );
+    const operationCompletedFacts = sortedFacts.filter(
+        (fact) => fact.type === 'operationCompleted',
+    );
+    const drySoilFacts = sortedFacts.filter((fact) => fact.type === 'drySoil');
+    const weedFacts = sortedFacts.filter((fact) => fact.type === 'weed');
+    const supportNeededFacts = sortedFacts.filter(
+        (fact) => fact.type === 'supportNeeded',
+    );
+    const harvestWindowFacts = sortedFacts.filter(
+        (fact) => fact.type === 'harvestWindow',
+    );
+    const items = [
+        ...weedDisplayItems(weedFacts),
+        ...(drySoilFacts.length > 0 ? [drySoilDisplayItem(drySoilFacts)] : []),
+        ...supportNeededDisplayItems(supportNeededFacts),
+        ...harvestWindowDisplayItems(harvestWindowFacts),
+        ...plantGrowthDisplayItems(plantGrowthFacts),
+        ...(operationCompletedFacts.length > 0
+            ? [operationCompletedDisplayItem(operationCompletedFacts)]
+            : []),
+    ];
+
+    return sortDisplayItems(items).slice(
+        0,
+        options.maxItems ?? DEFAULT_GARDEN_VISIT_SUMMARY_DISPLAY_ITEMS,
+    );
+}

--- a/packages/game/src/hooks/useGardenVisitSummary.ts
+++ b/packages/game/src/hooks/useGardenVisitSummary.ts
@@ -1,0 +1,99 @@
+import {
+    clientAuthenticated,
+    type GardenVisitSummaryResponse,
+} from '@gredice/client';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useGameState } from '../useGameState';
+import {
+    DEFAULT_GARDEN_VISIT_SUMMARY_DISPLAY_ITEMS,
+    formatGardenVisitSummaryFacts,
+    gardenVisitSummaryQueryKey,
+} from './gardenVisitSummary';
+import { useCurrentGarden } from './useCurrentGarden';
+
+export type {
+    GardenVisitSummaryDisplayItem,
+    GardenVisitSummaryFact,
+    GardenVisitSummarySource,
+    GardenVisitSummaryTarget,
+} from './gardenVisitSummary';
+export {
+    formatGardenVisitSummaryFacts,
+    gardenVisitSummaryQueryKey,
+} from './gardenVisitSummary';
+
+async function getGardenVisitSummary(
+    gardenId: number,
+): Promise<GardenVisitSummaryResponse> {
+    const response = await clientAuthenticated().api.gardens[':gardenId'][
+        'visit-summary'
+    ].$get({
+        param: {
+            gardenId: gardenId.toString(),
+        },
+    });
+
+    if (response.status === 401) {
+        throw new Error('Login required to load garden visit summary');
+    }
+
+    if (response.status === 404) {
+        throw new Error('Garden visit summary not found');
+    }
+
+    if (!response.ok) {
+        throw new Error(
+            `Failed to load garden visit summary: ${response.status.toString()} ${response.statusText}`,
+        );
+    }
+
+    return response.json();
+}
+
+export function useGardenVisitSummary({
+    enabled = true,
+    maxItems = DEFAULT_GARDEN_VISIT_SUMMARY_DISPLAY_ITEMS,
+}: {
+    enabled?: boolean;
+    maxItems?: number;
+} = {}) {
+    const { data: currentGarden } = useCurrentGarden();
+    const isMock = useGameState((state) => state.isMock);
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
+    const canLoadSummary =
+        enabled &&
+        currentGarden?.id != null &&
+        !isMock &&
+        localSandboxStorageKey === null;
+    const query = useQuery({
+        queryKey: gardenVisitSummaryQueryKey(currentGarden?.id),
+        queryFn: async () => {
+            if (currentGarden?.id == null) {
+                throw new Error('Garden ID is required to load visit summary');
+            }
+
+            return getGardenVisitSummary(currentGarden.id);
+        },
+        enabled: canLoadSummary,
+        staleTime: 60 * 1000,
+        refetchOnWindowFocus: false,
+    });
+    const displayItems = useMemo(
+        () =>
+            formatGardenVisitSummaryFacts(query.data?.facts ?? [], {
+                maxItems,
+            }),
+        [query.data?.facts, maxItems],
+    );
+
+    return {
+        ...query,
+        displayItems,
+        facts: query.data?.facts ?? [],
+        factsHash: query.data?.factsHash ?? null,
+        hasDisplayItems: displayItems.length > 0,
+    };
+}

--- a/packages/game/src/hooks/useGardenVisitSummary.unit.ts
+++ b/packages/game/src/hooks/useGardenVisitSummary.unit.ts
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    formatGardenVisitSummaryFacts,
+    type GardenVisitSummaryFact,
+} from './gardenVisitSummary';
+
+function fact({
+    count,
+    id,
+    occurredAt = '2026-06-10T10:00:00.000Z',
+    plantName,
+    priority = 50,
+    range,
+    target,
+    type,
+    visualHint,
+}: {
+    count?: number;
+    id: string;
+    occurredAt?: string;
+    plantName?: string;
+    priority?: number;
+    range?: GardenVisitSummaryFact['range'];
+    target?: GardenVisitSummaryFact['target'];
+    type: GardenVisitSummaryFact['type'];
+    visualHint?: GardenVisitSummaryFact['visualHint'];
+}): GardenVisitSummaryFact {
+    return {
+        id,
+        type,
+        priority,
+        occurredAt,
+        confidence: 'high',
+        source: {
+            type: 'plantLifecycle',
+            id,
+            observedAt: occurredAt,
+        },
+        plant: plantName
+            ? {
+                  plantName,
+              }
+            : undefined,
+        count,
+        range,
+        target,
+        visualHint,
+    };
+}
+
+test('formatGardenVisitSummaryFacts formats plant growth in concise Croatian copy', () => {
+    const [item] = formatGardenVisitSummaryFacts([
+        fact({
+            id: 'growth-1',
+            type: 'plantGrowth',
+            plantName: 'Rajčica',
+            priority: 70,
+        }),
+    ]);
+
+    assert.equal(item?.message, 'Rajčice su vidljivo narasle.');
+});
+
+test('formatGardenVisitSummaryFacts pluralizes dry soil raised bed counts', () => {
+    assert.equal(
+        formatGardenVisitSummaryFacts([
+            fact({ id: 'dry-1', type: 'drySoil', visualHint: 'raisedBed' }),
+        ])[0]?.message,
+        'Tlo je suho na 1 gredici.',
+    );
+    assert.equal(
+        formatGardenVisitSummaryFacts([
+            fact({ id: 'dry-1', type: 'drySoil', visualHint: 'raisedBed' }),
+            fact({ id: 'dry-2', type: 'drySoil', visualHint: 'raisedBed' }),
+        ])[0]?.message,
+        'Tlo je suho na 2 gredice.',
+    );
+    assert.equal(
+        formatGardenVisitSummaryFacts([
+            fact({
+                id: 'dry-5',
+                type: 'drySoil',
+                count: 5,
+                visualHint: 'raisedBed',
+            }),
+        ])[0]?.message,
+        'Tlo je suho na 5 gredica.',
+    );
+});
+
+test('formatGardenVisitSummaryFacts pluralizes weed field counts and keeps targets', () => {
+    const [item] = formatGardenVisitSummaryFacts([
+        fact({
+            id: 'weed-1',
+            type: 'weed',
+            count: 4,
+            target: { raisedBedId: 10, fieldId: 20, positionIndex: 3 },
+            visualHint: 'field',
+            priority: 90,
+        }),
+    ]);
+
+    assert.equal(item?.message, 'Pojavio se korov na 4 polja.');
+    assert.equal(item?.targets.length, 1);
+    assert.equal(item?.targets[0]?.fieldId, 20);
+});
+
+test('formatGardenVisitSummaryFacts formats support needs with plant names', () => {
+    const [item] = formatGardenVisitSummaryFacts([
+        fact({
+            id: 'support-1',
+            type: 'supportNeeded',
+            plantName: 'Krastavac',
+            priority: 90,
+        }),
+    ]);
+
+    assert.equal(item?.message, 'Krastavci trebaju potporu.');
+});
+
+test('formatGardenVisitSummaryFacts formats harvest estimates and ready plants', () => {
+    const estimate = formatGardenVisitSummaryFacts([
+        fact({
+            id: 'harvest-1',
+            type: 'harvestWindow',
+            plantName: 'Rajčica',
+            range: { min: 3, max: 5, unit: 'days' },
+            priority: 60,
+        }),
+    ]);
+    const ready = formatGardenVisitSummaryFacts([
+        fact({
+            id: 'harvest-2',
+            type: 'harvestWindow',
+            plantName: 'Rajčica',
+            range: { min: 0, max: 0, unit: 'days' },
+            priority: 80,
+        }),
+    ]);
+
+    assert.equal(estimate[0]?.message, 'Berba bi mogla biti za 3-5 dana.');
+    assert.equal(ready[0]?.message, 'Rajčice su spremne za berbu.');
+});
+
+test('formatGardenVisitSummaryFacts formats completed operations', () => {
+    const single = formatGardenVisitSummaryFacts([
+        fact({ id: 'operation-1', type: 'operationCompleted' }),
+    ]);
+    const several = formatGardenVisitSummaryFacts([
+        fact({ id: 'operation-1', type: 'operationCompleted' }),
+        fact({ id: 'operation-2', type: 'operationCompleted' }),
+        fact({ id: 'operation-3', type: 'operationCompleted' }),
+    ]);
+    const many = formatGardenVisitSummaryFacts([
+        fact({ id: 'operation-5', type: 'operationCompleted', count: 5 }),
+    ]);
+
+    assert.equal(single[0]?.message, 'Dovršena je radnja u vrtu.');
+    assert.equal(several[0]?.message, 'Dovršene su 3 radnje u vrtu.');
+    assert.equal(many[0]?.message, 'Dovršeno je 5 radnji u vrtu.');
+});
+
+test('formatGardenVisitSummaryFacts returns ordered mobile-sized display items', () => {
+    const items = formatGardenVisitSummaryFacts(
+        [
+            fact({
+                id: 'operation-1',
+                type: 'operationCompleted',
+                priority: 50,
+            }),
+            fact({ id: 'growth-1', type: 'plantGrowth', priority: 70 }),
+            fact({ id: 'harvest-1', type: 'harvestWindow', priority: 80 }),
+            fact({ id: 'support-1', type: 'supportNeeded', priority: 90 }),
+            fact({ id: 'dry-1', type: 'drySoil', priority: 95 }),
+            fact({ id: 'weed-1', type: 'weed', priority: 100 }),
+        ],
+        { maxItems: 5 },
+    );
+
+    assert.equal(items.length, 5);
+    assert.deepEqual(
+        items.map((item) => item.type),
+        ['weed', 'drySoil', 'supportNeeded', 'harvestWindow', 'plantGrowth'],
+    );
+});

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -5,6 +5,17 @@ export {
 export type { GameSceneProps } from './GameScene';
 export { GameSceneDynamic as GameScene } from './GameSceneDynamic';
 export { PlantEditor } from './generators/plant/editor/PlantEditor';
+export type {
+    GardenVisitSummaryDisplayItem,
+    GardenVisitSummaryFact,
+    GardenVisitSummarySource,
+    GardenVisitSummaryTarget,
+} from './hooks/useGardenVisitSummary';
+export {
+    formatGardenVisitSummaryFacts,
+    gardenVisitSummaryQueryKey,
+    useGardenVisitSummary,
+} from './hooks/useGardenVisitSummary';
 export { useThemeManager } from './hooks/useThemeManager';
 export type { PlantStageName } from './hud/raisedBed/featuredOperations';
 export {


### PR DESCRIPTION
## Summary
- export a typed garden visit summary response from `@gredice/client`
- add a pure `@gredice/game` formatter that maps visit facts into concise Croatian display items
- add a React-query hook for loading visit summaries and exposing display items while preserving source/target metadata
- cover plant growth, dry soil, weed, support, harvest, operation, ordering, and count copy in unit tests

## Validation
- `pnpm --filter @gredice/game exec tsx --test src/hooks/useGardenVisitSummary.unit.ts`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game exec biome check src/hooks/gardenVisitSummary.ts src/hooks/useGardenVisitSummary.ts src/hooks/useGardenVisitSummary.unit.ts src/index.ts`
- `pnpm --filter @gredice/client exec biome check src/hono.ts src/index.ts`
- `git diff --check origin/main...HEAD`

Closes #3333
