### PR TITLE
[codex] Fix delivery harvest plant snapshots

### DIFF
--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -51,6 +51,15 @@ import { getPickupLocation } from './pickupLocationsRepo';
 import { closeTimeSlot, getTimeSlot } from './timeSlotsRepo';
 
 type DbEvent = Awaited<ReturnType<typeof getEvents>>[number];
+type DeliveryTraceLink = Awaited<
+    ReturnType<typeof getHarvestTraceLinksForOperationIds>
+>[number];
+type RaisedBedFieldWithEvents = Awaited<
+    ReturnType<typeof getRaisedBedFieldsWithEvents>
+>[number];
+type DeliveryRaisedBedField = Partial<
+    Pick<RaisedBedFieldWithEvents, 'plantCycles' | 'plantSortId'>
+>;
 
 // TODO: Should use types from union of payloads for delivery events
 interface DeliveryEventData {
@@ -134,6 +143,60 @@ export interface PendingDeliveryReadyEmailRequest {
     requestId: string;
     readyEventId: number;
     processedRecipients: string[];
+}
+
+function getDeliveryPlantSortId({
+    traceLink,
+    raisedBedField,
+}: {
+    traceLink?: DeliveryTraceLink;
+    raisedBedField?: DeliveryRaisedBedField | null;
+}): number | undefined {
+    if (typeof traceLink?.plantSortId === 'number') {
+        return traceLink.plantSortId;
+    }
+
+    if (typeof traceLink?.plantPlaceEventId === 'number') {
+        const tracedCycle = raisedBedField?.plantCycles?.find(
+            (cycle) => cycle.plantPlaceEventId === traceLink.plantPlaceEventId,
+        );
+        if (typeof tracedCycle?.plantSortId === 'number') {
+            return tracedCycle.plantSortId;
+        }
+    }
+
+    return typeof raisedBedField?.plantSortId === 'number'
+        ? raisedBedField.plantSortId
+        : undefined;
+}
+
+function getDeliveryTraceLink({
+    operationId,
+    raisedBedFieldId,
+    traceLinksByOperationId,
+    traceLinkCountsByOperationId,
+    traceLinksByOperationAndFieldId,
+}: {
+    operationId: number;
+    raisedBedFieldId?: number | null;
+    traceLinksByOperationId: Map<number, DeliveryTraceLink>;
+    traceLinkCountsByOperationId: Map<number, number>;
+    traceLinksByOperationAndFieldId: Map<string, DeliveryTraceLink>;
+}): DeliveryTraceLink | undefined {
+    if (typeof raisedBedFieldId === 'number') {
+        return (
+            traceLinksByOperationAndFieldId.get(
+                `${operationId}:${raisedBedFieldId}`,
+            ) ??
+            (traceLinkCountsByOperationId.get(operationId) === 1
+                ? traceLinksByOperationId.get(operationId)
+                : undefined)
+        );
+    }
+
+    return traceLinkCountsByOperationId.get(operationId) === 1
+        ? traceLinksByOperationId.get(operationId)
+        : undefined;
 }
 
 function reconstructDeliveryRequestState(
@@ -451,8 +514,7 @@ async function reconstructDeliveryRequestFromEvents(
         getOperationById(request.operationId),
     ]);
 
-    // Fetch operation entity, raised bed, and plantSort fields in parallel
-    const [operationEntity, raisedBed, fields] = await Promise.all([
+    const [operationEntity, raisedBed, fields, traceLinks] = await Promise.all([
         operation?.entityId
             ? getEntityFormatted<OperationData>(operation.entityId).catch(
                   (error) => {
@@ -478,31 +540,58 @@ async function reconstructDeliveryRequestFromEvents(
                   },
               )
             : [],
+        getHarvestTraceLinksForOperationIds([request.operationId]).catch(
+            (error) => {
+                console.error('Failed to fetch harvest trace links:', error);
+                return [];
+            },
+        ),
     ]);
 
-    // Get plantSort info if we have fields
-    let plantSort: PlantSortData | null = null;
-    if (fields.length > 0 && operation?.raisedBedFieldId) {
-        const field = fields.find((f) => f.id === operation.raisedBedFieldId);
-        if (field?.plantSortId) {
-            try {
-                const plantSortEntity = await getEntityFormatted<PlantSortData>(
-                    field.plantSortId,
-                );
-                if (plantSortEntity) {
-                    plantSort = plantSortEntity;
-                }
-            } catch (error) {
-                console.error('Failed to fetch plantSort info:', error);
-            }
-        }
-    }
-
-    // Get the field for position index info
     const raisedBedField =
         fields.length > 0 && operation?.raisedBedFieldId
             ? fields.find((f) => f.id === operation.raisedBedFieldId)
             : null;
+    const traceLinksByOperationId = new Map(
+        traceLinks.map((link) => [link.harvestOperationId, link]),
+    );
+    const traceLinkCountsByOperationId = new Map<number, number>();
+    for (const link of traceLinks) {
+        traceLinkCountsByOperationId.set(
+            link.harvestOperationId,
+            (traceLinkCountsByOperationId.get(link.harvestOperationId) ?? 0) +
+                1,
+        );
+    }
+    const traceLinksByOperationAndFieldId = new Map(
+        traceLinks.map((link) => [
+            `${link.harvestOperationId}:${link.raisedBedFieldId}`,
+            link,
+        ]),
+    );
+    const traceLink = getDeliveryTraceLink({
+        operationId: request.operationId,
+        raisedBedFieldId: operation?.raisedBedFieldId,
+        traceLinksByOperationId,
+        traceLinkCountsByOperationId,
+        traceLinksByOperationAndFieldId,
+    });
+    const plantSortId = getDeliveryPlantSortId({
+        traceLink,
+        raisedBedField,
+    });
+    let plantSort: PlantSortData | null = null;
+    if (typeof plantSortId === 'number') {
+        try {
+            const plantSortEntity =
+                await getEntityFormatted<PlantSortData>(plantSortId);
+            if (plantSortEntity) {
+                plantSort = plantSortEntity;
+            }
+        } catch (error) {
+            console.error('Failed to fetch plantSort info:', error);
+        }
+    }
 
     return {
         id: request.id,
@@ -521,6 +610,13 @@ async function reconstructDeliveryRequestFromEvents(
         requestNotes,
         deliveryNotes,
         surveySent,
+        trace: traceLink
+            ? {
+                  id: traceLink.id,
+                  publicToken: traceLink.publicToken,
+                  publicPath: traceLink.publicPath,
+              }
+            : null,
         createdAt: request.createdAt,
         updatedAt: request.updatedAt,
         accountId,
@@ -723,9 +819,26 @@ export async function getDeliveryRequestsWithEvents(
     const plantSortIds = Array.from(
         new Set(
             filteredRows
-                .map((row) => row.request.operation?.raisedBedFieldId)
-                .filter((id): id is number => id !== null && id !== undefined)
-                .map((id) => fieldsById.get(id)?.plantSortId)
+                .map((row) => {
+                    const rawOperation = row.request.operation;
+                    const raisedBedFieldId = rawOperation?.raisedBedFieldId;
+                    const raisedBedField =
+                        typeof raisedBedFieldId === 'number'
+                            ? fieldsById.get(raisedBedFieldId)
+                            : undefined;
+                    const traceLink = getDeliveryTraceLink({
+                        operationId: row.request.operationId,
+                        raisedBedFieldId,
+                        traceLinksByOperationId,
+                        traceLinkCountsByOperationId,
+                        traceLinksByOperationAndFieldId,
+                    });
+
+                    return getDeliveryPlantSortId({
+                        traceLink,
+                        raisedBedField,
+                    });
+                })
                 .filter(
                     (plantSortId): plantSortId is number =>
                         plantSortId !== undefined,
@@ -760,25 +873,21 @@ export async function getDeliveryRequestsWithEvents(
                 typeof raisedBedFieldId === 'number'
                     ? (raisedBedFieldWithEvents ?? rawOperation?.raisedBedField)
                     : rawOperation?.raisedBedField;
+            const traceLink = getDeliveryTraceLink({
+                operationId: request.operationId,
+                raisedBedFieldId,
+                traceLinksByOperationId,
+                traceLinkCountsByOperationId,
+                traceLinksByOperationAndFieldId,
+            });
+            const plantSortId = getDeliveryPlantSortId({
+                traceLink,
+                raisedBedField: raisedBedFieldWithEvents,
+            });
             const plantSort =
-                typeof raisedBedFieldWithEvents?.plantSortId === 'number'
-                    ? (plantSortsById.get(
-                          raisedBedFieldWithEvents.plantSortId,
-                      ) ?? null)
+                typeof plantSortId === 'number'
+                    ? (plantSortsById.get(plantSortId) ?? null)
                     : null;
-            const traceLink =
-                typeof raisedBedFieldId === 'number'
-                    ? (traceLinksByOperationAndFieldId.get(
-                          `${request.operationId}:${raisedBedFieldId}`,
-                      ) ??
-                      (traceLinkCountsByOperationId.get(request.operationId) ===
-                      1
-                          ? traceLinksByOperationId.get(request.operationId)
-                          : undefined))
-                    : traceLinkCountsByOperationId.get(request.operationId) ===
-                        1
-                      ? traceLinksByOperationId.get(request.operationId)
-                      : undefined;
 
             return {
                 id: request.id,

--- a/packages/storage/src/repositories/harvestTraceLinksRepo.ts
+++ b/packages/storage/src/repositories/harvestTraceLinksRepo.ts
@@ -150,6 +150,7 @@ export type HarvestTraceLinkDeliverySummary = {
     harvestOperationId: number;
     raisedBedFieldId: number;
     plantPlaceEventId: number;
+    plantSortId: number | null;
 };
 
 export type HarvestTraceBackfillResult = {
@@ -1293,6 +1294,7 @@ export async function getHarvestTraceLinksForOperationIds(
                       harvestOperationId: link.harvestOperationId,
                       raisedBedFieldId: link.raisedBedFieldId,
                       plantPlaceEventId: link.plantPlaceEventId,
+                      plantSortId: link.plantSortId,
                   },
               ]
             : [],

--- a/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
@@ -3,7 +3,9 @@ import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
     acceptOperation,
+    createAttributeDefinition,
     createDeliveryRequest,
+    createEntity,
     createEvent,
     createFarm,
     createOperation,
@@ -20,6 +22,9 @@ import {
     raisedBeds,
     storage,
     TimeSlotStatuses,
+    updateEntity,
+    upsertAttributeValue,
+    upsertEntityType,
     upsertRaisedBedField,
 } from '@gredice/storage';
 import { eq } from 'drizzle-orm';
@@ -81,9 +86,65 @@ async function insertDeliveryReadyEmailProcessedEvent({
         });
 }
 
+type DeliveryFixtureEntityTypeName = 'operation' | 'plantSort';
+
+async function createPublishedDeliveryEntity(
+    entityTypeName: DeliveryFixtureEntityTypeName,
+    label: string,
+) {
+    await upsertEntityType({
+        name: entityTypeName,
+        label: entityTypeName === 'operation' ? 'Operations' : 'Plant sorts',
+    });
+
+    const nameDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'name',
+        label: 'Name',
+        entityTypeName,
+        dataType: 'text',
+    });
+    const labelDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'label',
+        label: 'Label',
+        entityTypeName,
+        dataType: 'text',
+    });
+    const entityId = await createEntity(entityTypeName);
+
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityTypeName,
+        entityId,
+        value: label,
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: labelDefinitionId,
+        entityTypeName,
+        entityId,
+        value: label,
+    });
+    await updateEntity({ id: entityId, state: 'published' });
+
+    return entityId;
+}
+
 async function createDeliveryRequestWithTraceFixture() {
     createTestDb();
 
+    const harvestOperationEntityId = await createPublishedDeliveryEntity(
+        'operation',
+        'Harvest fruit',
+    );
+    const originalPlantSortId = await createPublishedDeliveryEntity(
+        'plantSort',
+        'Original tomato',
+    );
+    const latestPlantSortId = await createPublishedDeliveryEntity(
+        'plantSort',
+        'Latest cucumber',
+    );
     const accountId = await createTestAccount();
     const farmId = await createFarm({
         name: `Delivery trace farm ${randomUUID()}`,
@@ -111,7 +172,7 @@ async function createDeliveryRequestWithTraceFixture() {
     assert.ok(field);
 
     const operationId = await createOperation({
-        entityId: 1,
+        entityId: harvestOperationEntityId,
         entityTypeName: 'operation',
         accountId,
         farmId,
@@ -134,7 +195,7 @@ async function createDeliveryRequestWithTraceFixture() {
             ...knownEvents.raisedBedFields.plantPlaceV1(
                 `${raisedBedId}|${field.positionIndex}`,
                 {
-                    plantSortId: '1',
+                    plantSortId: originalPlantSortId.toString(),
                     scheduledDate: null,
                     sowingLocation: 'direct',
                 },
@@ -152,9 +213,23 @@ async function createDeliveryRequestWithTraceFixture() {
         fieldPositionIndex: field.positionIndex,
         fieldLabel: '1',
         plantPlaceEventId: plantPlaceEvent.id,
-        plantSortId: null,
+        plantSortId: originalPlantSortId,
         harvestOperationId: operationId,
     });
+
+    await storage()
+        .insert(events)
+        .values({
+            ...knownEvents.raisedBedFields.plantPlaceV1(
+                `${raisedBedId}|${field.positionIndex}`,
+                {
+                    plantSortId: latestPlantSortId.toString(),
+                    scheduledDate: null,
+                    sowingLocation: 'direct',
+                },
+            ),
+            createdAt: new Date('2026-06-15T08:00:00.000Z'),
+        });
 
     const locationId = await createPickupLocation({
         name: 'Gredice HQ',
@@ -179,7 +254,13 @@ async function createDeliveryRequestWithTraceFixture() {
         accountId,
     });
 
-    return { accountId, operationId, traceLink };
+    return {
+        accountId,
+        latestPlantSortId,
+        operationId,
+        originalPlantSortId,
+        traceLink,
+    };
 }
 
 test('getPendingDeliveryReadyEmailRequestIds returns ordered retryable ready events', async () => {
@@ -269,7 +350,7 @@ test('getPendingDeliveryReadyEmailRequestIds returns ordered retryable ready eve
     );
 });
 
-test('getDeliveryRequestsWithEvents includes harvest trace links for plant rows', async () => {
+test('getDeliveryRequestsWithEvents uses the traced harvest plant sort for plant rows', async () => {
     const fixture = await createDeliveryRequestWithTraceFixture();
 
     const requests = await getDeliveryRequestsWithEvents(fixture.accountId);
@@ -283,4 +364,7 @@ test('getDeliveryRequestsWithEvents includes harvest trace links for plant rows'
         publicToken: fixture.traceLink.publicToken,
         publicPath: fixture.traceLink.tracePath,
     });
+    assert.equal(request.plantSort?.id, fixture.originalPlantSortId);
+    assert.notEqual(request.plantSort?.id, fixture.latestPlantSortId);
+    assert.equal(request.plantSort?.information.name, 'Original tomato');
 });

--- a/packages/storage/tests/harvestTraceLinksRepo.node.spec.ts
+++ b/packages/storage/tests/harvestTraceLinksRepo.node.spec.ts
@@ -558,6 +558,7 @@ test('getHarvestTraceLinksForOperationIds returns active trace summaries', async
         harvestOperationId: fixture.harvestOperationId,
         raisedBedFieldId: fixture.raisedBedFieldId,
         plantPlaceEventId: fixture.plantPlaceEventId,
+        plantSortId: fixture.plantSortId,
     });
 
     await updateHarvestTraceLinkStatus(fixture.link.id, 'revoked');
@@ -601,6 +602,7 @@ test('backfillHarvestTraceLinksForCompletedHarvests creates missing completed ha
     assert.equal(links[0]?.harvestOperationId, operationId);
     assert.equal(links[0]?.raisedBedFieldId, fixture.raisedBedFieldId);
     assert.equal(links[0]?.plantPlaceEventId, fixture.plantPlaceEventId);
+    assert.equal(links[0]?.plantSortId, fixture.plantSortId);
 });
 
 test('getPublicHarvestTraceByToken includes raised-bed operations and excludes other-field operations', async () => {


### PR DESCRIPTION
## Summary

- Resolve delivery request plant details from the harvest trace plant sort before falling back to the field's current plant.
- Include the trace link plant sort in delivery summaries so historical harvest rows keep the plant that was actually delivered.
- Add a regression test where the same field is replanted after a traced harvest and the delivery row still shows the original plant.

## Root cause

Delivery requests were hydrating `plantSort` from the current event-sourced raised-bed field state. Once a field was replanted, older delivery rows showed the latest plant instead of the plant captured by the delivered harvest trace.

## Validation

- `pnpm --filter @gredice/storage test:node deliveryRequestsRepo.node.spec.ts`
- `pnpm lint --filter @gredice/storage`
- `git diff --check`

## Notes

- `pnpm typecheck --filter @gredice/storage` executes no tasks because the storage package has no Turbo typecheck script.
- Direct `pnpm --filter @gredice/storage exec tsc --noEmit --project tsconfig.json` still fails on unrelated existing diagnostics in storage scripts/tests, with no diagnostics in the touched files.