### PR TITLE
[codex] Fix sunflower drop spawns

### DIFF
--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -52,6 +52,7 @@ import {
 } from '../../../lib/auth/sessionConfig';
 import { authSecurity } from '../../../lib/docs/security';
 import { sendAccountInvitation } from '../../../lib/email/transactional';
+import { isSunflowerDropWeatherEligible } from '../../../lib/garden/sunflowerDropWeather';
 import {
     type AuthVariables,
     authValidator,
@@ -238,13 +239,10 @@ async function getSunflowerDropWeather(now: Date) {
 
     const weather = populateWeatherFromSymbol(closestEntry.symbol);
     return {
-        sunny:
-            closestEntry.rain <= 0.05 &&
-            weather.cloudy <= 0.2 &&
-            weather.rainy <= 0 &&
-            weather.snowy <= 0 &&
-            weather.foggy <= 0 &&
-            weather.thundery <= 0,
+        sunny: isSunflowerDropWeatherEligible({
+            ...weather,
+            rain: closestEntry.rain,
+        }),
         symbol: closestEntry.symbol,
     };
 }

--- a/apps/api/lib/garden/sunflowerDropWeather.node.spec.ts
+++ b/apps/api/lib/garden/sunflowerDropWeather.node.spec.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { populateWeatherFromSymbol } from '../weather/populateWeatherFromSymbol';
+import { isSunflowerDropWeatherEligible } from './sunflowerDropWeather';
+
+function eligibilityForSymbol(symbol: number, rain = 0) {
+    return isSunflowerDropWeatherEligible({
+        ...populateWeatherFromSymbol(symbol),
+        rain,
+    });
+}
+
+describe('sunflower drop weather eligibility', () => {
+    it('allows sunny and light-cloud garden visits', () => {
+        assert.equal(eligibilityForSymbol(1), true);
+        assert.equal(eligibilityForSymbol(2), true);
+        assert.equal(eligibilityForSymbol(5), true);
+    });
+
+    it('rejects wetter, foggier, stormier, and too-cloudy visits', () => {
+        assert.equal(eligibilityForSymbol(3), false);
+        assert.equal(eligibilityForSymbol(8), false);
+        assert.equal(eligibilityForSymbol(12), false);
+        assert.equal(eligibilityForSymbol(16), false);
+        assert.equal(eligibilityForSymbol(1, 0.06), false);
+    });
+});

--- a/apps/api/lib/garden/sunflowerDropWeather.ts
+++ b/apps/api/lib/garden/sunflowerDropWeather.ts
@@ -1,0 +1,29 @@
+export const SUNFLOWER_DROP_MAX_RAIN_MM = 0.05;
+export const SUNFLOWER_DROP_MAX_CLOUD_COVER = 0.33;
+
+export type SunflowerDropWeatherConditions = {
+    cloudy: number;
+    foggy: number;
+    rain: number;
+    rainy: number;
+    snowy: number;
+    thundery: number;
+};
+
+export function isSunflowerDropWeatherEligible({
+    cloudy,
+    foggy,
+    rain,
+    rainy,
+    snowy,
+    thundery,
+}: SunflowerDropWeatherConditions) {
+    return (
+        rain <= SUNFLOWER_DROP_MAX_RAIN_MM &&
+        cloudy <= SUNFLOWER_DROP_MAX_CLOUD_COVER &&
+        rainy <= 0 &&
+        snowy <= 0 &&
+        foggy <= 0 &&
+        thundery <= 0
+    );
+}

--- a/packages/game/src/entities/SunflowerDropReward.tsx
+++ b/packages/game/src/entities/SunflowerDropReward.tsx
@@ -19,7 +19,6 @@ import { SunflowerHeadModel } from './Sunflower';
 import {
     findSunflowerDropPlacement,
     getSunflowerDropPosition,
-    getSunflowerDropSpawnDelayMs,
     type SunflowerDropPlacement,
 } from './sunflowerDropRewardCore';
 
@@ -229,32 +228,6 @@ function SunflowerDropAtPlacement({
     );
 }
 
-function useSunflowerDropSpawnReady({
-    enabled,
-    gardenId,
-}: {
-    enabled: boolean;
-    gardenId: number | null | undefined;
-}) {
-    const [ready, setReady] = useState(false);
-
-    useEffect(() => {
-        setReady(false);
-
-        if (!enabled || gardenId == null || typeof window === 'undefined') {
-            return;
-        }
-
-        const timeoutId = window.setTimeout(() => {
-            setReady(true);
-        }, getSunflowerDropSpawnDelayMs());
-
-        return () => window.clearTimeout(timeoutId);
-    }, [enabled, gardenId]);
-
-    return ready;
-}
-
 export function SunflowerDropReward({
     enabled,
     garden,
@@ -265,12 +238,10 @@ export function SunflowerDropReward({
     onClaimed?: (origin: SunflowerDropFlyOrigin) => void;
 }) {
     const [claimedSpawnId, setClaimedSpawnId] = useState<string | null>(null);
-    const spawnReady = useSunflowerDropSpawnReady({
-        enabled: enabled && Boolean(garden) && !garden?.isSandbox,
-        gardenId: garden?.id,
-    });
-    const sunflowerDrop = useSunflowerDrop(garden?.id, spawnReady);
-    const spawn = spawnReady ? (sunflowerDrop.data?.spawn ?? null) : null;
+    const sunflowerDropEnabled =
+        enabled && Boolean(garden) && !garden?.isSandbox;
+    const sunflowerDrop = useSunflowerDrop(garden?.id, sunflowerDropEnabled);
+    const spawn = sunflowerDrop.data?.spawn ?? null;
 
     useEffect(() => {
         if (claimedSpawnId && spawn?.spawnId !== claimedSpawnId) {

--- a/packages/game/src/entities/sunflowerDropRewardCore.ts
+++ b/packages/game/src/entities/sunflowerDropRewardCore.ts
@@ -2,8 +2,6 @@ import { Vector3 } from 'three';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
 
-export const SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS = 60 * 1000;
-export const SUNFLOWER_DROP_MAX_SPAWN_DELAY_MS = 5 * 60 * 1000;
 export const SUNFLOWER_DROP_MIN_GROUND_DISTANCE = 0.55;
 export const SUNFLOWER_DROP_MAX_GROUND_DISTANCE = 0.77;
 export const SUNFLOWER_DROP_GROUND_Y_OFFSET = 0.085;
@@ -27,23 +25,6 @@ function hashString(value: string) {
         hash = (hash * 31 + value.charCodeAt(index)) % 100_000;
     }
     return hash / 100_000;
-}
-
-function clampUnit(value: number) {
-    if (!Number.isFinite(value)) {
-        return 0;
-    }
-    return Math.min(Math.max(value, 0), 1);
-}
-
-export function getSunflowerDropSpawnDelayMs(random = Math.random) {
-    const unitValue = clampUnit(random());
-    return Math.round(
-        SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS +
-            unitValue *
-                (SUNFLOWER_DROP_MAX_SPAWN_DELAY_MS -
-                    SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS),
-    );
 }
 
 export function findSunflowerDropPlacement(

--- a/packages/game/src/entities/sunflowerDropRewardCore.unit.ts
+++ b/packages/game/src/entities/sunflowerDropRewardCore.unit.ts
@@ -6,12 +6,9 @@ import type { Stack } from '../types/Stack';
 import {
     findSunflowerDropPlacement,
     getSunflowerDropPosition,
-    getSunflowerDropSpawnDelayMs,
     SUNFLOWER_DROP_GROUND_Y_OFFSET,
     SUNFLOWER_DROP_MAX_GROUND_DISTANCE,
-    SUNFLOWER_DROP_MAX_SPAWN_DELAY_MS,
     SUNFLOWER_DROP_MIN_GROUND_DISTANCE,
-    SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS,
     SUNFLOWER_DROP_PARTICLE_Y_OFFSET,
 } from './sunflowerDropRewardCore';
 
@@ -25,25 +22,6 @@ const sunflowerStack: Stack = {
     blocks: [sunflowerBlock],
     position: new Vector3(3, 0, -2),
 };
-
-test('sunflower drop spawn delay is between one and five minutes', () => {
-    assert.equal(
-        getSunflowerDropSpawnDelayMs(() => 0),
-        SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS,
-    );
-    assert.equal(
-        getSunflowerDropSpawnDelayMs(() => 1),
-        SUNFLOWER_DROP_MAX_SPAWN_DELAY_MS,
-    );
-
-    const midpoint = getSunflowerDropSpawnDelayMs(() => 0.5);
-    assert.equal(
-        midpoint,
-        (SUNFLOWER_DROP_MIN_SPAWN_DELAY_MS +
-            SUNFLOWER_DROP_MAX_SPAWN_DELAY_MS) /
-            2,
-    );
-});
 
 test('sunflower drop placement resolves the source sunflower block', () => {
     assert.deepEqual(

--- a/packages/game/src/hooks/useSunflowerDrop.ts
+++ b/packages/game/src/hooks/useSunflowerDrop.ts
@@ -43,7 +43,7 @@ export function useSunflowerDrop(
         enabled: enabled && gardenId != null,
         refetchOnWindowFocus: false,
         retry: false,
-        staleTime: Infinity,
+        staleTime: 0,
     });
 }
 
@@ -69,6 +69,9 @@ export function useClaimSunflowerDrop() {
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: currentAccountKeys });
+            queryClient.invalidateQueries({
+                queryKey: ['accounts', 'current', 'sunflowers', 'drops'],
+            });
         },
     });
 }


### PR DESCRIPTION
## Summary
- roll sunflower drops as soon as a real garden opens instead of waiting up to five minutes before asking the API
- allow drops during sunny, sunny-light-cloud, and light-cloud weather while still rejecting rain, fog, snow, thunder, and heavier cloud cover
- add focused API tests for sunflower drop weather eligibility

## Root Cause
The client delayed the initial drop request by one to five minutes, so many garden opens never rolled a server spawn before the user left. The API weather gate also only allowed nearly clear weather (`cloudy <= 0.2`), excluding the light-cloud overcast condition that should still be eligible.

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `pnpm --filter api test:node`
- `pnpm --filter @gredice/game exec biome check --write src/entities/SunflowerDropReward.tsx src/entities/sunflowerDropRewardCore.ts src/entities/sunflowerDropRewardCore.unit.ts src/hooks/useSunflowerDrop.ts`
- `pnpm --filter api exec biome check --write 'app/api/[...route]/accountsRoutes.ts' lib/garden/sunflowerDropWeather.ts lib/garden/sunflowerDropWeather.node.spec.ts`
- `git diff --check`