### PR TITLE
Add garden visit summary opening modal

### DIFF
--- a/apps/garden/tests/GardenVisitSummaryModalStory.tsx
+++ b/apps/garden/tests/GardenVisitSummaryModalStory.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import {
+    formatGardenVisitSummaryFacts,
+    type GardenVisitSummaryFact,
+} from '../../../packages/game/src/hooks/gardenVisitSummary';
+import { GardenVisitSummaryModalContent } from '../../../packages/game/src/hud/GardenVisitSummaryModal';
+
+const now = '2026-06-10T10:00:00.000Z';
+
+const displayItems = formatGardenVisitSummaryFacts([
+    {
+        id: 'weed-1',
+        type: 'weed',
+        priority: 100,
+        occurredAt: now,
+        confidence: 'high',
+        source: {
+            type: 'weedState',
+            id: 'weed-1',
+            observedAt: now,
+        },
+        target: {
+            raisedBedId: 7,
+            raisedBedName: 'Sjeverna gredica',
+            fieldId: 70,
+            positionIndex: 3,
+        },
+        count: 4,
+        visualHint: 'field',
+    },
+    {
+        id: 'growth-1',
+        type: 'plantGrowth',
+        priority: 70,
+        occurredAt: '2026-06-10T08:00:00.000Z',
+        confidence: 'high',
+        source: {
+            type: 'plantLifecycle',
+            id: 'field:70:growth',
+            observedAt: '2026-06-10T08:00:00.000Z',
+        },
+        plant: {
+            plantName: 'Rajčica',
+            sortName: 'Rajčica',
+        },
+        target: {
+            raisedBedId: 7,
+            raisedBedName: 'Sjeverna gredica',
+            fieldId: 70,
+            positionIndex: 3,
+        },
+        visualHint: 'field',
+    },
+] satisfies GardenVisitSummaryFact[]);
+
+export function VisitSummaryModalFixture() {
+    const [open, setOpen] = useState(true);
+
+    return (
+        <div className="relative h-[560px] w-[720px] bg-background">
+            <GardenVisitSummaryModalContent
+                displayItems={displayItems}
+                onClose={() => setOpen(false)}
+                open={open}
+            />
+        </div>
+    );
+}

--- a/apps/garden/tests/garden-visit-summary-modal.spec.tsx
+++ b/apps/garden/tests/garden-visit-summary-modal.spec.tsx
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { VisitSummaryModalFixture } from './GardenVisitSummaryModalStory';
+
+test('garden visit summary modal renders facts and closes cleanly', async ({
+    mount,
+    page,
+}) => {
+    await mount(<VisitSummaryModalFixture />);
+
+    await expect(
+        page.getByRole('dialog', { name: 'Od zadnjeg posjeta' }),
+    ).toBeVisible();
+    await expect(page.getByText('Pojavio se korov na 4 polja.')).toBeVisible();
+    await expect(page.getByText('Rajčice su vidljivo narasle.')).toBeVisible();
+    await expect(page.getByText('Polje 4')).toHaveCount(2);
+
+    await page.getByRole('button', { name: 'Kreni u obilazak' }).click();
+
+    await expect(
+        page.getByRole('dialog', { name: 'Od zadnjeg posjeta' }),
+    ).toHaveCount(0);
+});

--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -99,6 +99,8 @@ async function mockGardenApi(page: Page, signedIn: boolean) {
             body = [];
         } else if (pathname.endsWith('/api/data/weather')) {
             body = [];
+        } else if (pathname.endsWith('/api/news/changelog')) {
+            body = { items: [] };
         } else if (
             pathname.endsWith('/api/accounts/current/sunflowers/daily')
         ) {
@@ -106,6 +108,10 @@ async function mockGardenApi(page: Page, signedIn: boolean) {
                 current: { amount: 0, day: 1 },
                 next: { amount: 1, day: 2 },
             };
+        } else if (
+            pathname.includes('/api/accounts/current/sunflowers/drops/gardens/')
+        ) {
+            body = null;
         } else if (pathname.endsWith('/api/occasions/advent/calendar-2025')) {
             body = adventCalendar;
         } else if (pathname.endsWith('/api/accounts/current/sunflowers')) {

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -10,6 +10,7 @@ import { AudioHud } from './hud/AudioHud';
 import { CameraHud } from './hud/CameraHud';
 import { ControlsTooltipHud } from './hud/ControlsTooltipHud';
 import { DebugHud } from './hud/DebugHud';
+import { GardenVisitSummaryModal } from './hud/GardenVisitSummaryModal';
 import { InventoryHud } from './hud/InventoryHud';
 import { ItemsHud } from './hud/ItemsHud';
 import { OutletHud } from './hud/OutletHud';
@@ -43,6 +44,10 @@ export function GameHud({
     noWeather?: boolean;
 }) {
     const [welcomeConfirmed, setWelcomeConfirmed] = useState(false);
+    const [visitSummaryConfirmation, setVisitSummaryConfirmation] = useState<{
+        confirmed: boolean;
+        gardenId: number | null;
+    }>({ confirmed: false, gardenId: null });
     const isCloseup = useGameState((state) => state.view) === 'closeup';
     const { data: currentGarden } = useCurrentGarden();
     // Sandbox ("play") gardens are decoration only: no economy or inventory.
@@ -54,6 +59,14 @@ export function GameHud({
         'empty:hidden',
         isCloseup && 'hidden md:block',
     );
+    const currentGardenId = currentGarden?.id ?? null;
+    const visitSummaryConfirmed =
+        visitSummaryConfirmation.confirmed &&
+        visitSummaryConfirmation.gardenId === currentGardenId;
+    const visitSummaryEnabled =
+        welcomeConfirmed && !visitSummaryConfirmed && !isSandbox;
+    const openingFlowComplete =
+        welcomeConfirmed && (isSandbox || visitSummaryConfirmed);
 
     return (
         <>
@@ -104,7 +117,16 @@ export function GameHud({
                     <WelcomeMessage
                         onClosed={() => setWelcomeConfirmed(true)}
                     />
-                    <WhatsNewWidget enabled={welcomeConfirmed} />
+                    <GardenVisitSummaryModal
+                        enabled={visitSummaryEnabled}
+                        onClosed={() =>
+                            setVisitSummaryConfirmation({
+                                confirmed: true,
+                                gardenId: currentGardenId,
+                            })
+                        }
+                    />
+                    <WhatsNewWidget enabled={openingFlowComplete} />
                 </>
             )}
             {!isLocalSandbox && <PaymentSuccessfulMessage />}

--- a/packages/game/src/hooks/useGardenVisitSummary.ts
+++ b/packages/game/src/hooks/useGardenVisitSummary.ts
@@ -2,7 +2,7 @@ import {
     clientAuthenticated,
     type GardenVisitSummaryResponse,
 } from '@gredice/client';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { useGameState } from '../useGameState';
 import {
@@ -22,6 +22,10 @@ export {
     formatGardenVisitSummaryFacts,
     gardenVisitSummaryQueryKey,
 } from './gardenVisitSummary';
+
+type MarkGardenVisitSummarySeenVariables = {
+    factsHash?: string | null;
+};
 
 async function getGardenVisitSummary(
     gardenId: number,
@@ -58,7 +62,8 @@ export function useGardenVisitSummary({
     enabled?: boolean;
     maxItems?: number;
 } = {}) {
-    const { data: currentGarden } = useCurrentGarden();
+    const currentGardenQuery = useCurrentGarden();
+    const currentGarden = currentGardenQuery.data;
     const isMock = useGameState((state) => state.isMock);
     const localSandboxStorageKey = useGameState(
         (state) => state.localSandboxStorageKey,
@@ -94,6 +99,50 @@ export function useGardenVisitSummary({
         displayItems,
         facts: query.data?.facts ?? [],
         factsHash: query.data?.factsHash ?? null,
+        canLoadSummary,
+        gardenReady: currentGardenQuery.isFetched || currentGardenQuery.isError,
         hasDisplayItems: displayItems.length > 0,
     };
+}
+
+export function useMarkGardenVisitSummarySeen() {
+    const queryClient = useQueryClient();
+    const { data: currentGarden } = useCurrentGarden();
+    const gardenId = currentGarden?.id;
+
+    return useMutation({
+        mutationFn: async ({
+            factsHash,
+        }: MarkGardenVisitSummarySeenVariables = {}) => {
+            if (gardenId == null) {
+                throw new Error(
+                    'Garden ID is required to mark visit summary seen',
+                );
+            }
+
+            const response = await clientAuthenticated().api.gardens[
+                ':gardenId'
+            ]['visit-summary'].seen.$post({
+                param: {
+                    gardenId: gardenId.toString(),
+                },
+                json: {
+                    factsHash: factsHash ?? null,
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(
+                    `Failed to mark garden visit summary seen: ${response.status.toString()} ${response.statusText}`,
+                );
+            }
+
+            return response.json();
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: gardenVisitSummaryQueryKey(gardenId),
+            });
+        },
+    });
 }

--- a/packages/game/src/hud/GardenVisitSummaryModal.tsx
+++ b/packages/game/src/hud/GardenVisitSummaryModal.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
+import {
+    Approved,
+    Droplet,
+    Fence,
+    Leaf,
+    Sprout,
+    Timer,
+} from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import { type ComponentType, useCallback, useEffect, useState } from 'react';
+import type {
+    GardenVisitSummaryDisplayItem,
+    GardenVisitSummaryFact,
+} from '../hooks/gardenVisitSummary';
+import {
+    useGardenVisitSummary,
+    useMarkGardenVisitSummarySeen,
+} from '../hooks/useGardenVisitSummary';
+
+type GardenVisitSummaryModalProps = {
+    enabled: boolean;
+    onClosed?: () => void;
+};
+
+type GardenVisitSummaryModalContentProps = {
+    displayItems: GardenVisitSummaryDisplayItem[];
+    isClosing?: boolean;
+    onClose: () => void;
+    open: boolean;
+};
+
+type SummaryIcon = ComponentType<{
+    'aria-hidden'?: boolean;
+    className?: string;
+}>;
+
+const summaryTypeMeta = {
+    plantGrowth: {
+        chip: 'Rast',
+        color: 'success',
+        icon: Sprout,
+    },
+    operationCompleted: {
+        chip: 'Radnja',
+        color: 'info',
+        icon: Approved,
+    },
+    drySoil: {
+        chip: 'Tlo',
+        color: 'warning',
+        icon: Droplet,
+    },
+    weed: {
+        chip: 'Korov',
+        color: 'neutral',
+        icon: Leaf,
+    },
+    supportNeeded: {
+        chip: 'Potpora',
+        color: 'info',
+        icon: Fence,
+    },
+    harvestWindow: {
+        chip: 'Berba',
+        color: 'success',
+        icon: Timer,
+    },
+} satisfies Record<
+    GardenVisitSummaryFact['type'],
+    {
+        chip: string;
+        color: 'info' | 'neutral' | 'success' | 'warning';
+        icon: SummaryIcon;
+    }
+>;
+
+function targetLabel(targets: NonNullable<GardenVisitSummaryFact['target']>[]) {
+    if (targets.length === 0) {
+        return null;
+    }
+
+    if (targets.length > 1) {
+        return targets.some((target) => target.fieldId != null)
+            ? `${targets.length.toString()} polja`
+            : `${targets.length.toString()} gredice`;
+    }
+
+    const target = targets[0];
+    if (target.positionIndex != null) {
+        return `Polje ${(target.positionIndex + 1).toString()}`;
+    }
+
+    return target.raisedBedName || 'Gredica';
+}
+
+export function GardenVisitSummaryModal({
+    enabled,
+    onClosed,
+}: GardenVisitSummaryModalProps) {
+    const summary = useGardenVisitSummary({ enabled });
+    const markSeen = useMarkGardenVisitSummarySeen();
+    const [dismissedFactsHash, setDismissedFactsHash] = useState<string | null>(
+        null,
+    );
+    const currentFactsHash = summary.factsHash ?? null;
+    const hasCurrentDismissal =
+        currentFactsHash !== null && dismissedFactsHash === currentFactsHash;
+    const open =
+        enabled &&
+        summary.hasDisplayItems &&
+        summary.isSuccess &&
+        !hasCurrentDismissal;
+
+    const completeFlow = useCallback(() => {
+        onClosed?.();
+    }, [onClosed]);
+
+    useEffect(() => {
+        if (!enabled) {
+            setDismissedFactsHash(null);
+            return;
+        }
+
+        if (!summary.gardenReady) {
+            return;
+        }
+
+        if (!summary.canLoadSummary) {
+            completeFlow();
+            return;
+        }
+
+        if (summary.isPending || summary.isFetching) {
+            return;
+        }
+
+        if (summary.isError || !summary.hasDisplayItems) {
+            completeFlow();
+        }
+    }, [
+        completeFlow,
+        enabled,
+        summary.canLoadSummary,
+        summary.gardenReady,
+        summary.hasDisplayItems,
+        summary.isError,
+        summary.isFetching,
+        summary.isPending,
+    ]);
+
+    const handleClose = () => {
+        setDismissedFactsHash(currentFactsHash);
+        markSeen.mutate(
+            { factsHash: currentFactsHash },
+            {
+                onError: (error) => {
+                    console.error(
+                        'Failed to mark garden visit summary seen',
+                        error,
+                    );
+                },
+                onSettled: () => {
+                    completeFlow();
+                },
+            },
+        );
+    };
+
+    return (
+        <GardenVisitSummaryModalContent
+            displayItems={summary.displayItems}
+            isClosing={markSeen.isPending}
+            onClose={handleClose}
+            open={open}
+        />
+    );
+}
+
+export function GardenVisitSummaryModalContent({
+    displayItems,
+    isClosing = false,
+    onClose,
+    open,
+}: GardenVisitSummaryModalContentProps) {
+    return (
+        <Modal
+            title="Od zadnjeg posjeta"
+            open={open}
+            className="max-w-xl overflow-hidden border-tertiary border-b-4 p-0"
+            dismissible={false}
+        >
+            <div className="flex max-h-[calc(100dvh-2rem)] min-h-0 flex-col">
+                <Row
+                    className="shrink-0 border-b px-4 py-3 pr-4"
+                    justifyContent="space-between"
+                    spacing={3}
+                >
+                    <Stack spacing={0.5}>
+                        <Typography level="body3" secondary>
+                            Pregled vrta
+                        </Typography>
+                        <Typography level="h4" component="h2">
+                            Od zadnjeg posjeta
+                        </Typography>
+                    </Stack>
+                    <div className="flex size-11 shrink-0 items-center justify-center rounded-lg border border-tertiary/60 bg-card text-tertiary-foreground">
+                        <Sprout aria-hidden className="size-5" />
+                    </div>
+                </Row>
+                <div className="min-h-0 overflow-y-auto p-3 md:p-4">
+                    <Stack spacing={2}>
+                        {displayItems.map((item) => {
+                            const meta = summaryTypeMeta[item.type];
+                            const Icon = meta.icon;
+                            const label = targetLabel(item.targets);
+
+                            return (
+                                <Row
+                                    alignItems="start"
+                                    className="min-w-0 rounded-lg border border-border/70 bg-card/70 p-3"
+                                    key={item.id}
+                                    spacing={3}
+                                >
+                                    <span
+                                        className={cx(
+                                            'mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md border',
+                                            item.type === 'drySoil'
+                                                ? 'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-200'
+                                                : 'bg-muted text-foreground',
+                                        )}
+                                    >
+                                        <Icon aria-hidden className="size-4" />
+                                    </span>
+                                    <Stack
+                                        className="min-w-0 flex-1"
+                                        spacing={1}
+                                    >
+                                        <Typography
+                                            className="min-w-0"
+                                            level="body2"
+                                            semiBold
+                                        >
+                                            {item.message}
+                                        </Typography>
+                                        <Row className="flex-wrap" spacing={1}>
+                                            <Chip
+                                                color={meta.color}
+                                                size="sm"
+                                                variant="soft"
+                                            >
+                                                {meta.chip}
+                                            </Chip>
+                                            {label ? (
+                                                <Chip
+                                                    color="neutral"
+                                                    size="sm"
+                                                    variant="outlined"
+                                                >
+                                                    {label}
+                                                </Chip>
+                                            ) : null}
+                                        </Row>
+                                    </Stack>
+                                </Row>
+                            );
+                        })}
+                    </Stack>
+                </div>
+                <Row
+                    className="shrink-0 border-t p-3 md:p-4"
+                    justifyContent="end"
+                >
+                    <Button
+                        disabled={isClosing}
+                        loading={isClosing}
+                        onClick={onClose}
+                    >
+                        Kreni u obilazak
+                    </Button>
+                </Row>
+            </div>
+        </Modal>
+    );
+}

--- a/packages/game/src/hud/GardenVisitSummaryModal.tsx
+++ b/packages/game/src/hud/GardenVisitSummaryModal.tsx
@@ -15,7 +15,13 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { type ComponentType, useCallback, useEffect, useState } from 'react';
+import {
+    type ComponentType,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
 import type {
     GardenVisitSummaryDisplayItem,
     GardenVisitSummaryFact,
@@ -110,6 +116,7 @@ export function GardenVisitSummaryModal({
     const [dismissedFactsHash, setDismissedFactsHash] = useState<string | null>(
         null,
     );
+    const emptySummarySeenRequestKeyRef = useRef<string | null>(null);
     const currentFactsHash = summary.factsHash ?? null;
     const hasCurrentDismissal =
         currentFactsHash !== null && dismissedFactsHash === currentFactsHash;
@@ -126,6 +133,7 @@ export function GardenVisitSummaryModal({
     useEffect(() => {
         if (!enabled) {
             setDismissedFactsHash(null);
+            emptySummarySeenRequestKeyRef.current = null;
             return;
         }
 
@@ -142,12 +150,42 @@ export function GardenVisitSummaryModal({
             return;
         }
 
-        if (summary.isError || !summary.hasDisplayItems) {
+        if (summary.isError) {
             completeFlow();
+            return;
+        }
+
+        if (!summary.hasDisplayItems) {
+            const requestKey = currentFactsHash ?? 'empty-summary';
+            if (
+                markSeen.isPending ||
+                emptySummarySeenRequestKeyRef.current === requestKey
+            ) {
+                return;
+            }
+
+            emptySummarySeenRequestKeyRef.current = requestKey;
+            markSeen.mutate(
+                { factsHash: currentFactsHash },
+                {
+                    onError: (error) => {
+                        console.error(
+                            'Failed to mark empty garden visit summary seen',
+                            error,
+                        );
+                        completeFlow();
+                    },
+                    onSuccess: () => {
+                        completeFlow();
+                    },
+                },
+            );
         }
     }, [
         completeFlow,
+        currentFactsHash,
         enabled,
+        markSeen,
         summary.canLoadSummary,
         summary.gardenReady,
         summary.hasDisplayItems,
@@ -157,7 +195,10 @@ export function GardenVisitSummaryModal({
     ]);
 
     const handleClose = () => {
-        setDismissedFactsHash(currentFactsHash);
+        if (markSeen.isPending) {
+            return;
+        }
+
         markSeen.mutate(
             { factsHash: currentFactsHash },
             {
@@ -167,7 +208,8 @@ export function GardenVisitSummaryModal({
                         error,
                     );
                 },
-                onSettled: () => {
+                onSuccess: () => {
+                    setDismissedFactsHash(currentFactsHash);
                     completeFlow();
                 },
             },

--- a/packages/game/src/hud/WelcomeMessage.tsx
+++ b/packages/game/src/hud/WelcomeMessage.tsx
@@ -47,12 +47,14 @@ const messageTypes = {
 };
 
 export function WelcomeMessage({ onClosed }: { onClosed?: () => void }) {
-    const { data: dailyReward } = useDailyReward();
+    const dailyRewardQuery = useDailyReward();
     const claimDailyReward = useClaimDailyReward();
+    const dailyReward = dailyRewardQuery.data;
     const shouldShow = Boolean(dailyReward?.canClaim);
     const [open, setOpen] = useState(shouldShow);
     const [isClosing, setIsClosing] = useState(false);
     const previousShouldShow = useRef(shouldShow);
+    const openingCompleteNotifiedRef = useRef(false);
     const closeTimeoutRef = useRef<number | null>(null);
     useEffect(() => {
         if (shouldShow && !previousShouldShow.current) {
@@ -102,9 +104,34 @@ export function WelcomeMessage({ onClosed }: { onClosed?: () => void }) {
             if (dailyReward?.canClaim) {
                 claimDailyReward.mutate();
             }
+            openingCompleteNotifiedRef.current = true;
             onClosed?.();
         }, animationDuration + 50);
     };
+
+    useEffect(() => {
+        if (shouldShow) {
+            openingCompleteNotifiedRef.current = false;
+            return;
+        }
+
+        if (
+            openingCompleteNotifiedRef.current ||
+            open ||
+            (!dailyRewardQuery.isFetched && !dailyRewardQuery.isError)
+        ) {
+            return;
+        }
+
+        openingCompleteNotifiedRef.current = true;
+        onClosed?.();
+    }, [
+        dailyRewardQuery.isError,
+        dailyRewardQuery.isFetched,
+        onClosed,
+        open,
+        shouldShow,
+    ]);
 
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const isDay = timeOfDay > 0.2 && timeOfDay < 0.8;


### PR DESCRIPTION
## Summary
- insert a compact garden visit summary modal between the daily welcome and Whats New opening flow
- add a mark-seen mutation so dismissal records the displayed facts hash before unblocking the next step
- advance the welcome flow when there is no daily reward, and skip the summary on no facts, loading errors, mock, or sandbox gardens
- add focused Playwright component coverage for the summary modal content

Closes #3334

## Validation
- pnpm --filter @gredice/game typecheck
- pnpm --filter @gredice/game exec tsx --test src/hooks/useGardenVisitSummary.unit.ts
- pnpm --filter garden exec playwright test tests/garden-visit-summary-modal.spec.tsx
- pnpm --filter @gredice/game exec biome check src/GameHud.tsx src/hud/WelcomeMessage.tsx src/hud/GardenVisitSummaryModal.tsx src/hooks/useGardenVisitSummary.ts
- pnpm --filter garden exec biome check tests/GardenVisitSummaryModalStory.tsx tests/garden-visit-summary-modal.spec.tsx
- git diff --check origin/main...HEAD