### PR TITLE
Highlight visit summary targets in the garden

### DIFF
--- a/apps/garden/tests/GardenVisitSummaryModalStory.tsx
+++ b/apps/garden/tests/GardenVisitSummaryModalStory.tsx
@@ -55,14 +55,21 @@ const displayItems = formatGardenVisitSummaryFacts([
 
 export function VisitSummaryModalFixture() {
     const [open, setOpen] = useState(true);
+    const [inspectedItemId, setInspectedItemId] = useState<string | null>(null);
 
     return (
         <div className="relative h-[560px] w-[720px] bg-background">
             <GardenVisitSummaryModalContent
                 displayItems={displayItems}
                 onClose={() => setOpen(false)}
+                onInspect={(item) => setInspectedItemId(item.id)}
                 open={open}
             />
+            {inspectedItemId ? (
+                <output aria-live="polite" className="sr-only">
+                    {inspectedItemId}
+                </output>
+            ) : null}
         </div>
     );
 }

--- a/apps/garden/tests/garden-visit-summary-modal.spec.tsx
+++ b/apps/garden/tests/garden-visit-summary-modal.spec.tsx
@@ -14,6 +14,13 @@ test('garden visit summary modal renders facts and closes cleanly', async ({
     await expect(page.getByText('Rajčice su vidljivo narasle.')).toBeVisible();
     await expect(page.getByText('Polje 4')).toHaveCount(2);
 
+    await page
+        .getByRole('button', {
+            name: 'Prikaži u vrtu: Pojavio se korov na 4 polja.',
+        })
+        .click();
+    await expect(page.locator('output')).toHaveText('weed:fields');
+
     await page.getByRole('button', { name: 'Kreni u obilazak' }).click();
 
     await expect(

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -10,6 +10,7 @@ import { AudioHud } from './hud/AudioHud';
 import { CameraHud } from './hud/CameraHud';
 import { ControlsTooltipHud } from './hud/ControlsTooltipHud';
 import { DebugHud } from './hud/DebugHud';
+import { GardenVisitSummaryHighlightHud } from './hud/GardenVisitSummaryHighlightHud';
 import { GardenVisitSummaryModal } from './hud/GardenVisitSummaryModal';
 import { InventoryHud } from './hud/InventoryHud';
 import { ItemsHud } from './hud/ItemsHud';
@@ -126,6 +127,7 @@ export function GameHud({
                             })
                         }
                     />
+                    <GardenVisitSummaryHighlightHud />
                     <WhatsNewWidget enabled={openingFlowComplete} />
                 </>
             )}

--- a/packages/game/src/entities/RaisedBed.tsx
+++ b/packages/game/src/entities/RaisedBed.tsx
@@ -217,6 +217,9 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
     const isLocalSandbox = useGameState(
         (state) => state.localSandboxStorageKey !== null,
     );
+    const visitSummaryHighlight = useGameState(
+        (state) => state.gardenVisitSummaryHighlight,
+    );
     const hasHarvestRewards = visualRewards.some(
         (reward) =>
             reward.family === 'harvest' && reward.raisedBedId === raisedBed?.id,
@@ -368,10 +371,19 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
             }) ?? [],
         [harvestBasketState?.producePlantSortIds, sortDataById],
     );
+    const isVisitSummaryHighlighted =
+        raisedBed?.id != null &&
+        visitSummaryHighlight?.raisedBedId === raisedBed.id;
 
     return (
         <>
-            <HoverOutline hovered={hovered}>
+            <HoverOutline
+                color={isVisitSummaryHighlighted ? '#f6c445' : 'white'}
+                hovered={hovered || isVisitSummaryHighlighted}
+                opacity={isVisitSummaryHighlighted ? 0.95 : 1}
+                priority={isVisitSummaryHighlighted ? 10 : 0}
+                thickness={isVisitSummaryHighlighted ? 8 : 5}
+            >
                 <animated.group
                     position={raisedBedPosition}
                     rotation={[0, shapeRotation * (Math.PI / 2), 0]}

--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -1,3 +1,4 @@
+import { animated, useSpring } from '@react-spring/three';
 import { useGameFlags } from '../../GameFlagsContext';
 import { useGameSceneDetails } from '../../GameSceneDetailContext';
 import { resolveInGamePlantPreset } from '../../generators/plant/lib/inGamePlantPresets';
@@ -257,6 +258,63 @@ function RaisedBedFieldMoistSoilOverlay({
                 />
             </mesh>
         </group>
+    );
+}
+
+function RaisedBedFieldVisitSummaryHighlight({
+    blockIndex,
+    orientation,
+    positionIndex,
+}: {
+    blockIndex: number;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+}) {
+    const pulse = useSpring({
+        from: { opacity: 0.85, scale: 0.82 },
+        to: [
+            { opacity: 0.3, scale: 1.18 },
+            { opacity: 0.85, scale: 0.82 },
+        ],
+        loop: true,
+        duration: 1200,
+    });
+    const position = getRaisedBedFieldSurfacePosition({
+        blockIndex,
+        orientation,
+        positionIndex,
+        y: -0.682,
+    });
+
+    return (
+        <animated.group position={position} scale={pulse.scale}>
+            <mesh rotation={[-Math.PI / 2, 0, 0]} renderOrder={24}>
+                <ringGeometry args={[0.155, 0.205, 48]} />
+                <animated.meshBasicMaterial
+                    color="#f6c445"
+                    depthWrite={false}
+                    opacity={pulse.opacity}
+                    polygonOffset
+                    polygonOffsetFactor={-8}
+                    transparent
+                />
+            </mesh>
+            <mesh
+                position={[0, 0.006, 0]}
+                rotation={[-Math.PI / 2, 0, 0]}
+                renderOrder={23}
+            >
+                <circleGeometry args={[0.18, 48]} />
+                <meshBasicMaterial
+                    color="#f6c445"
+                    depthWrite={false}
+                    opacity={0.12}
+                    polygonOffset
+                    polygonOffsetFactor={-7}
+                    transparent
+                />
+            </mesh>
+        </animated.group>
     );
 }
 
@@ -563,6 +621,9 @@ export function RaisedBedFields({
     const visualRewards = useRaisedBedOperationVisualRewards(raisedBed);
     const currentTime = useSnapshotTime();
     const orientation = raisedBed?.orientation ?? 'vertical';
+    const visitSummaryHighlight = useGameState(
+        (state) => state.gardenVisitSummaryHighlight,
+    );
 
     const blockIds =
         raisedBed && currentGarden
@@ -732,8 +793,32 @@ export function RaisedBedFields({
         (positionIndex) => !agrotextileCoverPositionSet.has(positionIndex),
     );
     const harvestPositionSet = new Set(visibleHarvestPositions);
+    const highlightedPositionIndex =
+        raisedBed && visitSummaryHighlight?.raisedBedId === raisedBed.id
+            ? (raisedBed.fields.find(
+                  (field) =>
+                      typeof field.id === 'number' &&
+                      field.id === visitSummaryHighlight.fieldId,
+              )?.positionIndex ??
+              visitSummaryHighlight.positionIndex ??
+              null)
+            : null;
+    const highlightedLocalPositionIndex =
+        highlightedPositionIndex != null &&
+        highlightedPositionIndex >= blockOffset &&
+        highlightedPositionIndex < blockOffset + 9
+            ? highlightedPositionIndex - blockOffset
+            : null;
+
     return (
         <>
+            {highlightedLocalPositionIndex != null ? (
+                <RaisedBedFieldVisitSummaryHighlight
+                    blockIndex={blockIndex}
+                    orientation={orientation}
+                    positionIndex={highlightedLocalPositionIndex}
+                />
+            ) : null}
             {Array.from(moistFieldPositionSet).map((positionIndex) => (
                 <RaisedBedFieldMoistSoilOverlay
                     key={`raised-bed-field-moist-soil-${blockId}-${positionIndex}`}

--- a/packages/game/src/hud/GardenVisitSummaryHighlightHud.tsx
+++ b/packages/game/src/hud/GardenVisitSummaryHighlightHud.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Close, Sprout } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useEffect } from 'react';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useGameState } from '../useGameState';
+
+const highlightDurationMs = 9000;
+
+export function GardenVisitSummaryHighlightHud() {
+    const highlight = useGameState(
+        (state) => state.gardenVisitSummaryHighlight,
+    );
+    const clearHighlight = useGameState(
+        (state) => state.clearGardenVisitSummaryHighlight,
+    );
+    const { data: currentGarden } = useCurrentGarden();
+    const currentGardenId = currentGarden?.id ?? null;
+
+    useEffect(() => {
+        if (!highlight) {
+            return;
+        }
+
+        const timeout = window.setTimeout(clearHighlight, highlightDurationMs);
+
+        return () => window.clearTimeout(timeout);
+    }, [clearHighlight, highlight]);
+
+    useEffect(() => {
+        if (
+            highlight?.gardenId != null &&
+            currentGardenId != null &&
+            highlight.gardenId !== currentGardenId
+        ) {
+            clearHighlight();
+        }
+    }, [clearHighlight, currentGardenId, highlight]);
+
+    if (!highlight) {
+        return null;
+    }
+
+    const locationLabel =
+        highlight.raisedBedName && highlight.raisedBedName !== highlight.label
+            ? `${highlight.raisedBedName} · ${highlight.label}`
+            : highlight.label;
+
+    return (
+        <div className="pointer-events-none absolute top-16 left-1/2 z-20 w-[min(calc(100vw-1rem),26rem)] -translate-x-1/2 px-2">
+            <Row
+                alignItems="center"
+                className="pointer-events-auto rounded-lg border border-tertiary/50 bg-background/95 p-2 pr-1 shadow-lg backdrop-blur"
+                spacing={2}
+            >
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-tertiary-foreground">
+                    <Sprout aria-hidden className="size-4" />
+                </span>
+                <Stack className="min-w-0 flex-1" spacing={0}>
+                    <Typography level="body3" secondary>
+                        Prikaz u vrtu
+                    </Typography>
+                    <Typography className="truncate" level="body2" semiBold>
+                        {locationLabel}
+                    </Typography>
+                    <Typography className="truncate" level="body3" secondary>
+                        {highlight.message}
+                    </Typography>
+                </Stack>
+                <Button
+                    aria-label="Sakrij oznaku"
+                    className="size-8 shrink-0 px-0"
+                    onClick={clearHighlight}
+                    size="sm"
+                    variant="plain"
+                >
+                    <Close aria-hidden className="size-4" />
+                </Button>
+            </Row>
+        </div>
+    );
+}

--- a/packages/game/src/hud/GardenVisitSummaryModal.tsx
+++ b/packages/game/src/hud/GardenVisitSummaryModal.tsx
@@ -7,6 +7,7 @@ import {
     Droplet,
     Fence,
     Leaf,
+    Navigate,
     Sprout,
     Timer,
 } from '@gredice/ui/icons';
@@ -25,11 +26,15 @@ import {
 import type {
     GardenVisitSummaryDisplayItem,
     GardenVisitSummaryFact,
+    GardenVisitSummaryTarget,
 } from '../hooks/gardenVisitSummary';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import {
     useGardenVisitSummary,
     useMarkGardenVisitSummarySeen,
 } from '../hooks/useGardenVisitSummary';
+import { useGameState } from '../useGameState';
+import { getRaisedBedBlockIds } from '../utils/raisedBedBlocks';
 
 type GardenVisitSummaryModalProps = {
     enabled: boolean;
@@ -40,6 +45,7 @@ type GardenVisitSummaryModalContentProps = {
     displayItems: GardenVisitSummaryDisplayItem[];
     isClosing?: boolean;
     onClose: () => void;
+    onInspect?: (item: GardenVisitSummaryDisplayItem) => void;
     open: boolean;
 };
 
@@ -47,6 +53,14 @@ type SummaryIcon = ComponentType<{
     'aria-hidden'?: boolean;
     className?: string;
 }>;
+
+type InspectableSummaryTarget = {
+    fieldId?: number | null;
+    label: string;
+    positionIndex?: number | null;
+    raisedBedId: number;
+    raisedBedName?: string | null;
+};
 
 const summaryTypeMeta = {
     plantGrowth: {
@@ -107,12 +121,54 @@ function targetLabel(targets: NonNullable<GardenVisitSummaryFact['target']>[]) {
     return target.raisedBedName || 'Gredica';
 }
 
+function hasRaisedBedId(
+    target: GardenVisitSummaryTarget,
+): target is GardenVisitSummaryTarget & { raisedBedId: number } {
+    return target.raisedBedId != null;
+}
+
+function inspectTargetForItem(
+    item: GardenVisitSummaryDisplayItem,
+): InspectableSummaryTarget | null {
+    const targets = item.targets.filter(hasRaisedBedId);
+    const firstTarget = targets[0];
+    if (!firstTarget) {
+        return null;
+    }
+
+    const sameRaisedBed = targets.every(
+        (target) => target.raisedBedId === firstTarget.raisedBedId,
+    );
+    const preciseTarget = targets.length === 1 ? firstTarget : null;
+    const positionIndex = preciseTarget?.positionIndex ?? null;
+    const fieldId = preciseTarget?.fieldId ?? null;
+    const label =
+        positionIndex != null
+            ? `Polje ${(positionIndex + 1).toString()}`
+            : sameRaisedBed
+              ? (firstTarget.raisedBedName ?? 'Gredica')
+              : `${targets.length.toString()} gredice`;
+
+    return {
+        fieldId,
+        label,
+        positionIndex,
+        raisedBedId: firstTarget.raisedBedId,
+        raisedBedName: firstTarget.raisedBedName ?? null,
+    };
+}
+
 export function GardenVisitSummaryModal({
     enabled,
     onClosed,
 }: GardenVisitSummaryModalProps) {
     const summary = useGardenVisitSummary({ enabled });
     const markSeen = useMarkGardenVisitSummarySeen();
+    const { data: currentGarden } = useCurrentGarden();
+    const setView = useGameState((state) => state.setView);
+    const setGardenVisitSummaryHighlight = useGameState(
+        (state) => state.setGardenVisitSummaryHighlight,
+    );
     const [dismissedFactsHash, setDismissedFactsHash] = useState<string | null>(
         null,
     );
@@ -194,26 +250,66 @@ export function GardenVisitSummaryModal({
         summary.isPending,
     ]);
 
-    const handleClose = () => {
-        if (markSeen.isPending) {
+    const closeSummary = useCallback(
+        (afterClose?: () => void) => {
+            if (markSeen.isPending) {
+                return;
+            }
+
+            markSeen.mutate(
+                { factsHash: currentFactsHash },
+                {
+                    onError: (error) => {
+                        console.error(
+                            'Failed to mark garden visit summary seen',
+                            error,
+                        );
+                    },
+                    onSuccess: () => {
+                        setDismissedFactsHash(currentFactsHash);
+                        afterClose?.();
+                        completeFlow();
+                    },
+                },
+            );
+        },
+        [completeFlow, currentFactsHash, markSeen],
+    );
+
+    const handleInspect = (item: GardenVisitSummaryDisplayItem) => {
+        const target = inspectTargetForItem(item);
+        if (!target || !currentGarden) {
             return;
         }
 
-        markSeen.mutate(
-            { factsHash: currentFactsHash },
-            {
-                onError: (error) => {
-                    console.error(
-                        'Failed to mark garden visit summary seen',
-                        error,
-                    );
-                },
-                onSuccess: () => {
-                    setDismissedFactsHash(currentFactsHash);
-                    completeFlow();
-                },
-            },
+        const blockIds = getRaisedBedBlockIds(
+            currentGarden,
+            target.raisedBedId,
         );
+        const block = currentGarden.stacks
+            .flatMap((stack) => stack.blocks)
+            .find((candidate) => candidate.id === blockIds[0]);
+
+        if (!block) {
+            return;
+        }
+
+        closeSummary(() => {
+            setGardenVisitSummaryHighlight({
+                fieldId: target.fieldId,
+                gardenId: currentGarden.id,
+                label: target.label,
+                message: item.message,
+                positionIndex: target.positionIndex,
+                raisedBedId: target.raisedBedId,
+                raisedBedName: target.raisedBedName,
+            });
+            setView({ view: 'closeup', block });
+        });
+    };
+
+    const handleClose = () => {
+        closeSummary();
     };
 
     return (
@@ -221,6 +317,7 @@ export function GardenVisitSummaryModal({
             displayItems={summary.displayItems}
             isClosing={markSeen.isPending}
             onClose={handleClose}
+            onInspect={handleInspect}
             open={open}
         />
     );
@@ -230,6 +327,7 @@ export function GardenVisitSummaryModalContent({
     displayItems,
     isClosing = false,
     onClose,
+    onInspect,
     open,
 }: GardenVisitSummaryModalContentProps) {
     return (
@@ -263,6 +361,8 @@ export function GardenVisitSummaryModalContent({
                             const meta = summaryTypeMeta[item.type];
                             const Icon = meta.icon;
                             const label = targetLabel(item.targets);
+                            const inspectTarget =
+                                onInspect && inspectTargetForItem(item);
 
                             return (
                                 <Row
@@ -292,7 +392,11 @@ export function GardenVisitSummaryModalContent({
                                         >
                                             {item.message}
                                         </Typography>
-                                        <Row className="flex-wrap" spacing={1}>
+                                        <Row
+                                            alignItems="center"
+                                            className="flex-wrap"
+                                            spacing={1}
+                                        >
                                             <Chip
                                                 color={meta.color}
                                                 size="sm"
@@ -308,6 +412,26 @@ export function GardenVisitSummaryModalContent({
                                                 >
                                                     {label}
                                                 </Chip>
+                                            ) : null}
+                                            {inspectTarget ? (
+                                                <Button
+                                                    aria-label={`Prikaži u vrtu: ${item.message}`}
+                                                    color="primary"
+                                                    disabled={isClosing}
+                                                    onClick={() =>
+                                                        onInspect(item)
+                                                    }
+                                                    size="xs"
+                                                    startDecorator={
+                                                        <Navigate
+                                                            aria-hidden
+                                                            className="size-3"
+                                                        />
+                                                    }
+                                                    variant="plain"
+                                                >
+                                                    Prikaži u vrtu
+                                                </Button>
                                             ) : null}
                                         </Row>
                                     </Stack>

--- a/packages/game/src/hud/GardenVisitSummaryModal.tsx
+++ b/packages/game/src/hud/GardenVisitSummaryModal.tsx
@@ -34,7 +34,7 @@ import {
     useMarkGardenVisitSummarySeen,
 } from '../hooks/useGardenVisitSummary';
 import { useGameState } from '../useGameState';
-import { getRaisedBedBlockIds } from '../utils/raisedBedBlocks';
+import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
 
 type GardenVisitSummaryModalProps = {
     enabled: boolean;
@@ -139,15 +139,17 @@ function inspectTargetForItem(
     const sameRaisedBed = targets.every(
         (target) => target.raisedBedId === firstTarget.raisedBedId,
     );
+    if (!sameRaisedBed) {
+        return null;
+    }
+
     const preciseTarget = targets.length === 1 ? firstTarget : null;
     const positionIndex = preciseTarget?.positionIndex ?? null;
     const fieldId = preciseTarget?.fieldId ?? null;
     const label =
         positionIndex != null
             ? `Polje ${(positionIndex + 1).toString()}`
-            : sameRaisedBed
-              ? (firstTarget.raisedBedName ?? 'Gredica')
-              : `${targets.length.toString()} gredice`;
+            : (firstTarget.raisedBedName ?? 'Gredica');
 
     return {
         fieldId,
@@ -165,10 +167,10 @@ export function GardenVisitSummaryModal({
     const summary = useGardenVisitSummary({ enabled });
     const markSeen = useMarkGardenVisitSummarySeen();
     const { data: currentGarden } = useCurrentGarden();
-    const setView = useGameState((state) => state.setView);
     const setGardenVisitSummaryHighlight = useGameState(
         (state) => state.setGardenVisitSummaryHighlight,
     );
+    const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
     const [dismissedFactsHash, setDismissedFactsHash] = useState<string | null>(
         null,
     );
@@ -282,15 +284,13 @@ export function GardenVisitSummaryModal({
             return;
         }
 
-        const blockIds = getRaisedBedBlockIds(
-            currentGarden,
-            target.raisedBedId,
-        );
-        const block = currentGarden.stacks
-            .flatMap((stack) => stack.blocks)
-            .find((candidate) => candidate.id === blockIds[0]);
-
-        if (!block) {
+        const raisedBedName =
+            target.raisedBedName ??
+            currentGarden.raisedBeds.find(
+                (raisedBed) => raisedBed.id === target.raisedBedId,
+            )?.name ??
+            null;
+        if (!raisedBedName) {
             return;
         }
 
@@ -304,7 +304,7 @@ export function GardenVisitSummaryModal({
                 raisedBedId: target.raisedBedId,
                 raisedBedName: target.raisedBedName,
             });
-            setView({ view: 'closeup', block });
+            setRaisedBedCloseupParam(raisedBedName, target.positionIndex);
         });
     };
 

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -78,6 +78,18 @@ export type BlockPlacementDropAnimation = {
     sequence: number;
 };
 
+export type GardenVisitSummaryHighlight = {
+    createdAt: number;
+    fieldId?: number | null;
+    gardenId?: number | null;
+    label: string;
+    message: string;
+    positionIndex?: number | null;
+    raisedBedId: number;
+    raisedBedName?: string | null;
+    sequence: number;
+};
+
 export type AnimalDebugEntry = {
     debugBehaviors?: string[];
     id: string;
@@ -203,6 +215,11 @@ export type GameState = {
     queueBlockPlacementDropAnimation: (blockId: string) => void;
     markBlockPlacementDropParticlesSpawned: (blockId: string) => boolean;
     completeBlockPlacementDropAnimation: (blockId: string) => void;
+    gardenVisitSummaryHighlight: GardenVisitSummaryHighlight | null;
+    setGardenVisitSummaryHighlight: (
+        highlight: Omit<GardenVisitSummaryHighlight, 'createdAt' | 'sequence'>,
+    ) => void;
+    clearGardenVisitSummaryHighlight: () => void;
     animalDebugEntries: AnimalDebugEntry[];
     setAnimalDebugEntry: (entry: AnimalDebugEntry) => void;
     removeAnimalDebugEntry: (id: string) => void;
@@ -485,6 +502,18 @@ export function createGameState({
 
                 return { blockPlacementDropAnimations };
             }),
+        gardenVisitSummaryHighlight: null,
+        setGardenVisitSummaryHighlight: (highlight) =>
+            set((state) => ({
+                gardenVisitSummaryHighlight: {
+                    ...highlight,
+                    createdAt: Date.now(),
+                    sequence:
+                        (state.gardenVisitSummaryHighlight?.sequence ?? 0) + 1,
+                },
+            })),
+        clearGardenVisitSummaryHighlight: () =>
+            set({ gardenVisitSummaryHighlight: null }),
         animalDebugEntries: [],
         setAnimalDebugEntry: (entry) =>
             set((state) => {


### PR DESCRIPTION
Closes #3335

Depends on #3393. This is stacked on the visit-summary modal branch so the diff stays limited to the highlight layer until #3393 lands.

## Summary
- adds temporary visit-summary highlight state and a dismissible HUD cue
- adds per-summary-item `Prikaži u vrtu` actions that focus the relevant raised bed/field
- renders subtle raised-bed/field highlight visuals without adding heavy scene assets

## Validation
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden exec playwright test tests/garden-visit-summary-modal.spec.tsx`
- `pnpm --filter @gredice/game exec tsx --test src/hooks/useGardenVisitSummary.unit.ts`
- `pnpm --filter @gredice/game exec biome check src/GameHud.tsx src/hud/GardenVisitSummaryModal.tsx src/hud/GardenVisitSummaryHighlightHud.tsx src/entities/RaisedBed.tsx src/entities/raisedBed/RaisedBedFields.tsx src/useGameState.ts`
- `pnpm --filter garden exec biome check tests/GardenVisitSummaryModalStory.tsx tests/garden-visit-summary-modal.spec.tsx`
- `git diff --check`