### PR TITLE
Cover visit summary QA flows

### DIFF
--- a/apps/garden/tests/GardenVisitSummaryModalStory.tsx
+++ b/apps/garden/tests/GardenVisitSummaryModalStory.tsx
@@ -1,13 +1,32 @@
-import { useState } from 'react';
+import * as ReactQuery from '@tanstack/react-query';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { type PropsWithChildren, useMemo, useState } from 'react';
+import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
 import {
     formatGardenVisitSummaryFacts,
     type GardenVisitSummaryFact,
+    gardenVisitSummaryQueryKey,
 } from '../../../packages/game/src/hooks/gardenVisitSummary';
-import { GardenVisitSummaryModalContent } from '../../../packages/game/src/hud/GardenVisitSummaryModal';
+import { currentGardenKeys } from '../../../packages/game/src/hooks/useCurrentGarden';
+import { queryKey as currentUserQueryKey } from '../../../packages/game/src/hooks/useCurrentUser';
+import { dailyRewardKeys } from '../../../packages/game/src/hooks/useDailyReward';
+import { useGardensKeys } from '../../../packages/game/src/hooks/useGardens';
+import { whatsNewEntriesQueryKey } from '../../../packages/game/src/hooks/useWhatsNewEntries';
+import {
+    GardenVisitSummaryModal,
+    GardenVisitSummaryModalContent,
+} from '../../../packages/game/src/hud/GardenVisitSummaryModal';
+import { WelcomeMessage } from '../../../packages/game/src/hud/WelcomeMessage';
+import { WhatsNewWidget } from '../../../packages/game/src/hud/WhatsNewWidget';
+import {
+    createGameState,
+    GameStateContext,
+} from '../../../packages/game/src/useGameState';
 
 const now = '2026-06-10T10:00:00.000Z';
+const TEST_GARDEN_ID = 3336;
 
-const displayItems = formatGardenVisitSummaryFacts([
+const summaryFacts = [
     {
         id: 'weed-1',
         type: 'weed',
@@ -51,7 +70,229 @@ const displayItems = formatGardenVisitSummaryFacts([
         },
         visualHint: 'field',
     },
+] satisfies GardenVisitSummaryFact[];
+
+const displayItems = formatGardenVisitSummaryFacts(summaryFacts);
+
+const longNameDisplayItems = formatGardenVisitSummaryFacts([
+    {
+        id: 'long-harvest-1',
+        type: 'harvestWindow',
+        priority: 90,
+        occurredAt: now,
+        confidence: 'high',
+        source: {
+            type: 'harvestWindow',
+            id: 'harvest-window-long-name',
+            observedAt: now,
+        },
+        plant: {
+            plantName:
+                'Rajčica volovsko srce ekstra rana crvena selekcija obitelji Horvat',
+            sortName:
+                'Rajčica volovsko srce ekstra rana crvena selekcija obitelji Horvat',
+        },
+        target: {
+            raisedBedId: 7,
+            raisedBedName: 'Sjeverna gredica s jako dugim nazivom lokacije',
+            fieldId: 70,
+            positionIndex: 3,
+        },
+        range: { min: 3, max: 5, unit: 'days' },
+        visualHint: 'field',
+    },
+    {
+        id: 'long-support-1',
+        type: 'supportNeeded',
+        priority: 80,
+        occurredAt: now,
+        confidence: 'high',
+        source: {
+            type: 'operation',
+            id: 'support-long-name',
+            observedAt: now,
+        },
+        plant: {
+            plantName: 'Krastavac salatni vrlo dugi naziv sorte za uske ekrane',
+            sortName: 'Krastavac salatni vrlo dugi naziv sorte za uske ekrane',
+        },
+        target: {
+            raisedBedId: 8,
+            raisedBedName: 'Južna gredica',
+            fieldId: 80,
+            positionIndex: 1,
+        },
+        visualHint: 'field',
+    },
 ] satisfies GardenVisitSummaryFact[]);
+
+const currentUser = {
+    avatarUrl: null,
+    birthday: null,
+    birthdayLastRewardAt: null,
+    birthdayLastUpdatedAt: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    displayName: 'Test User',
+    email: 'test@example.com',
+    id: 'test-user',
+    userName: 'test-user',
+    whatsNewLastSeenAt: null,
+    whatsNewPopupDisabled: false,
+};
+
+const whatsNewEntry = {
+    canonicalPath: '/novosti/sto-je-novo/vrt-je-zivlji',
+    category: null,
+    cmsSlug: 'novosti/sto-je-novo/vrt-je-zivlji',
+    contentKind: 'changelog',
+    excerpt: 'Vrt sada jasnije pokazuje što se promijenilo.',
+    id: 3336,
+    metaDescription: 'Vrt sada jasnije pokazuje što se promijenilo.',
+    metaImageUrl: null,
+    metaTitle: 'Vrt je življi',
+    noIndex: false,
+    path: '/novosti/sto-je-novo/vrt-je-zivlji',
+    publishedAt: new Date('2026-06-10T08:00:00.000Z'),
+    seoImageUrl: null,
+    slug: 'vrt-je-zivlji',
+    tags: ['Vrt'],
+    title: 'Vrt je življi',
+    updatedAt: new Date('2026-06-10T08:00:00.000Z'),
+};
+
+function dailyReward(canClaim: boolean) {
+    return {
+        canClaim,
+        current: { amount: canClaim ? 5 : 0, day: 1 },
+        next: { amount: 10, day: 2 },
+        streak: [],
+        expiresAt: '2026-06-11T22:00:00.000Z',
+    };
+}
+
+function openingFlowGarden() {
+    return {
+        id: TEST_GARDEN_ID,
+        name: 'QA garden',
+        backgroundPalette: 'default',
+        farmId: null,
+        isSandbox: false,
+        location: { lat: 45.739, lon: 16.572 },
+        raisedBeds: [],
+        stacks: [],
+    };
+}
+
+function createOpeningFlowQueryClient({
+    dailyRewardCanClaim,
+    facts,
+    factsHash,
+}: {
+    dailyRewardCanClaim: boolean;
+    facts: GardenVisitSummaryFact[];
+    factsHash: string | null;
+}) {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            mutations: { retry: false },
+            queries: { retry: false, staleTime: Infinity },
+        },
+    });
+    const garden = openingFlowGarden();
+
+    queryClient.setQueryData(useGardensKeys, [
+        { id: TEST_GARDEN_ID, name: garden.name },
+    ]);
+    queryClient.setQueryData(
+        currentGardenKeys('summer', TEST_GARDEN_ID),
+        garden,
+    );
+    queryClient.setQueryData(dailyRewardKeys, dailyReward(dailyRewardCanClaim));
+    queryClient.setQueryData(currentUserQueryKey.currentUser, currentUser);
+    queryClient.setQueryData(gardenVisitSummaryQueryKey(TEST_GARDEN_ID), {
+        window: {
+            firstVisit: facts.length === 0,
+            since: facts.length > 0 ? '2026-06-09T10:00:00.000Z' : null,
+            until: now,
+        },
+        facts,
+        factsHash,
+        state: null,
+    });
+    queryClient.setQueryData(
+        [...whatsNewEntriesQueryKey, { limit: 8, since: null }],
+        [whatsNewEntry],
+    );
+
+    return queryClient;
+}
+
+function OpeningFlowProviders({
+    children,
+    dailyRewardCanClaim,
+    facts,
+    factsHash,
+}: PropsWithChildren<{
+    dailyRewardCanClaim: boolean;
+    facts: GardenVisitSummaryFact[];
+    factsHash: string | null;
+}>) {
+    const queryClient = useMemo(
+        () =>
+            createOpeningFlowQueryClient({
+                dailyRewardCanClaim,
+                facts,
+                factsHash,
+            }),
+        [dailyRewardCanClaim, facts, factsHash],
+    );
+    const gameState = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: '',
+                freezeTime: new Date('2026-06-10T10:00:00.000Z'),
+                isMock: false,
+            }),
+        [],
+    );
+
+    return (
+        <NuqsTestingAdapter>
+            <ReactQuery.QueryClientProvider client={queryClient}>
+                <GameStateContext.Provider value={gameState}>
+                    <GameAnalyticsProvider capture={() => undefined}>
+                        {children}
+                    </GameAnalyticsProvider>
+                </GameStateContext.Provider>
+            </ReactQuery.QueryClientProvider>
+        </NuqsTestingAdapter>
+    );
+}
+
+function OpeningFlowHarness() {
+    const [welcomeConfirmed, setWelcomeConfirmed] = useState(false);
+    const [visitSummaryConfirmed, setVisitSummaryConfirmed] = useState(false);
+    const summaryEnabled = welcomeConfirmed && !visitSummaryConfirmed;
+    const openingFlowComplete = welcomeConfirmed && visitSummaryConfirmed;
+
+    return (
+        <div className="relative h-[640px] w-[720px] bg-background">
+            <WelcomeMessage onClosed={() => setWelcomeConfirmed(true)} />
+            <GardenVisitSummaryModal
+                enabled={summaryEnabled}
+                onClosed={() => setVisitSummaryConfirmed(true)}
+            />
+            <WhatsNewWidget enabled={openingFlowComplete} />
+            <output data-testid="opening-flow-state" className="sr-only">
+                {[
+                    welcomeConfirmed ? 'welcome:closed' : 'welcome:open',
+                    visitSummaryConfirmed ? 'summary:closed' : 'summary:open',
+                    openingFlowComplete ? 'whats-new:enabled' : 'whats-new:off',
+                ].join('|')}
+            </output>
+        </div>
+    );
+}
 
 export function VisitSummaryModalFixture() {
     const [open, setOpen] = useState(true);
@@ -71,5 +312,39 @@ export function VisitSummaryModalFixture() {
                 </output>
             ) : null}
         </div>
+    );
+}
+
+export function LongVisitSummaryModalFixture() {
+    const [open, setOpen] = useState(true);
+
+    return (
+        <div className="relative min-h-[640px] w-full bg-background">
+            <GardenVisitSummaryModalContent
+                displayItems={longNameDisplayItems}
+                onClose={() => setOpen(false)}
+                open={open}
+            />
+        </div>
+    );
+}
+
+export function VisitSummaryOpeningFlowFixture({
+    dailyRewardCanClaim = false,
+    facts = summaryFacts,
+    factsHash = 'summary-fixture-hash',
+}: {
+    dailyRewardCanClaim?: boolean;
+    facts?: GardenVisitSummaryFact[];
+    factsHash?: string | null;
+}) {
+    return (
+        <OpeningFlowProviders
+            dailyRewardCanClaim={dailyRewardCanClaim}
+            facts={facts}
+            factsHash={factsHash}
+        >
+            <OpeningFlowHarness />
+        </OpeningFlowProviders>
     );
 }

--- a/apps/garden/tests/garden-visit-summary-modal.spec.tsx
+++ b/apps/garden/tests/garden-visit-summary-modal.spec.tsx
@@ -1,5 +1,124 @@
 import { expect, test } from '@playwright/experimental-ct-react';
-import { VisitSummaryModalFixture } from './GardenVisitSummaryModalStory';
+import type { Page, Route } from '@playwright/test';
+import {
+    LongVisitSummaryModalFixture,
+    VisitSummaryModalFixture,
+    VisitSummaryOpeningFlowFixture,
+} from './GardenVisitSummaryModalStory';
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+    await route.fulfill({
+        body: JSON.stringify(body),
+        contentType: 'application/json',
+        status,
+    });
+}
+
+async function mockOpeningFlowMutations(page: Page) {
+    const seenRequests: unknown[] = [];
+    const claimRequests: string[] = [];
+
+    await page.route('**/api/**', async (route) => {
+        const request = route.request();
+        const method = request.method();
+        const { pathname } = new URL(request.url());
+
+        if (
+            pathname.endsWith('/api/accounts/current/sunflowers/daily') &&
+            method === 'POST'
+        ) {
+            claimRequests.push(pathname);
+            await fulfillJson(route, {});
+            return;
+        }
+
+        if (
+            pathname.endsWith('/api/accounts/current/sunflowers/daily') &&
+            method === 'GET'
+        ) {
+            await fulfillJson(route, {
+                canClaim: false,
+                current: { amount: 5, day: 1 },
+                expiresAt: '2026-06-11T22:00:00.000Z',
+                next: { amount: 10, day: 2 },
+                streak: [],
+            });
+            return;
+        }
+
+        if (
+            pathname.endsWith('/api/gardens/3336/visit-summary/seen') &&
+            method === 'POST'
+        ) {
+            const body = request.postDataJSON();
+            seenRequests.push(body);
+            await fulfillJson(route, {
+                state: {
+                    id: 1,
+                    userId: 'test-user',
+                    accountId: 'test-account',
+                    gardenId: 3336,
+                    lastOpenedAt: '2026-06-10T10:00:00.000Z',
+                    lastSummarySeenAt: '2026-06-10T10:00:00.000Z',
+                    lastSummaryFactsHash: body.factsHash ?? null,
+                },
+            });
+            return;
+        }
+
+        if (
+            pathname.endsWith('/api/gardens/3336/visit-summary') &&
+            method === 'GET'
+        ) {
+            await fulfillJson(route, {
+                window: {
+                    firstVisit: false,
+                    since: '2026-06-09T10:00:00.000Z',
+                    until: '2026-06-10T10:00:00.000Z',
+                },
+                facts: [],
+                factsHash: null,
+                state: null,
+            });
+            return;
+        }
+
+        if (pathname.endsWith('/api/news/changelog') && method === 'GET') {
+            await fulfillJson(route, {
+                items: [
+                    {
+                        canonicalPath: '/novosti/sto-je-novo/vrt-je-zivlji',
+                        category: null,
+                        cmsSlug: 'novosti/sto-je-novo/vrt-je-zivlji',
+                        contentKind: 'changelog',
+                        excerpt:
+                            'Vrt sada jasnije pokazuje što se promijenilo.',
+                        id: 3336,
+                        metaDescription:
+                            'Vrt sada jasnije pokazuje što se promijenilo.',
+                        metaImageUrl: null,
+                        metaTitle: 'Vrt je življi',
+                        noIndex: false,
+                        path: '/novosti/sto-je-novo/vrt-je-zivlji',
+                        publishedAt: '2026-06-10T08:00:00.000Z',
+                        seoImageUrl: null,
+                        slug: 'vrt-je-zivlji',
+                        tags: ['Vrt'],
+                        title: 'Vrt je življi',
+                        updatedAt: '2026-06-10T08:00:00.000Z',
+                    },
+                ],
+            });
+            return;
+        }
+
+        throw new Error(
+            `Unexpected opening-flow request: ${method} ${pathname}`,
+        );
+    });
+
+    return { claimRequests, seenRequests };
+}
 
 test('garden visit summary modal renders facts and closes cleanly', async ({
     mount,
@@ -26,4 +145,119 @@ test('garden visit summary modal renders facts and closes cleanly', async ({
     await expect(
         page.getByRole('dialog', { name: 'Od zadnjeg posjeta' }),
     ).toHaveCount(0);
+});
+
+test('opening flow shows daily reward, visit summary, then what is new', async ({
+    mount,
+    page,
+}) => {
+    const recorded = await mockOpeningFlowMutations(page);
+
+    await mount(<VisitSummaryOpeningFlowFixture dailyRewardCanClaim />);
+
+    await expect(
+        page.getByRole('button', { name: /Kreni u avanturu/u }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('dialog', { name: 'Od zadnjeg posjeta' }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('button', { name: /Vrt je življi/u }),
+    ).toHaveCount(0);
+
+    await page.getByRole('button', { name: /Kreni u avanturu/u }).click();
+
+    await expect(
+        page.getByRole('dialog', { name: 'Od zadnjeg posjeta' }),
+    ).toBeVisible();
+    await expect.poll(() => recorded.claimRequests.length).toBe(1);
+    await expect(
+        page.getByRole('button', { name: /Vrt je življi/u }),
+    ).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Kreni u obilazak' }).click();
+
+    await expect(
+        page.getByRole('dialog', { name: 'Od zadnjeg posjeta' }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('button', { name: /Vrt je življi/u }),
+    ).toBeVisible();
+    await expect
+        .poll(() => recorded.seenRequests)
+        .toEqual([{ factsHash: 'summary-fixture-hash' }]);
+});
+
+test('opening flow shows the visit summary when there is no daily reward', async ({
+    mount,
+    page,
+}) => {
+    const recorded = await mockOpeningFlowMutations(page);
+
+    await mount(<VisitSummaryOpeningFlowFixture />);
+
+    await expect(
+        page.getByRole('button', { name: /Kreni u avanturu/u }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('dialog', { name: 'Od zadnjeg posjeta' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: /Vrt je življi/u }),
+    ).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Kreni u obilazak' }).click();
+
+    await expect(
+        page.getByRole('button', { name: /Vrt je življi/u }),
+    ).toBeVisible();
+    await expect
+        .poll(() => recorded.seenRequests)
+        .toEqual([{ factsHash: 'summary-fixture-hash' }]);
+});
+
+test('opening flow skips no-fact summaries after advancing the visit marker', async ({
+    mount,
+    page,
+}) => {
+    const recorded = await mockOpeningFlowMutations(page);
+
+    await mount(<VisitSummaryOpeningFlowFixture facts={[]} factsHash={null} />);
+
+    await expect(
+        page.getByRole('dialog', { name: 'Od zadnjeg posjeta' }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('button', { name: /Vrt je življi/u }),
+    ).toBeVisible();
+    await expect
+        .poll(() => recorded.seenRequests)
+        .toEqual([{ factsHash: null }]);
+});
+
+test('garden visit summary modal keeps long copy readable on mobile', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 390, height: 740 });
+
+    await mount(<LongVisitSummaryModalFixture />);
+
+    await expect(
+        page.getByRole('dialog', { name: 'Od zadnjeg posjeta' }),
+    ).toBeVisible();
+    await expect(
+        page.getByText('Berba bi mogla biti za 3-5 dana.'),
+    ).toBeVisible();
+    await expect(page.getByText(/potporu/u)).toBeVisible();
+
+    const overflow = await page.evaluate(() => ({
+        bodyScrollWidth: document.body.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+        documentScrollWidth: document.documentElement.scrollWidth,
+    }));
+
+    expect(
+        Math.max(overflow.bodyScrollWidth, overflow.documentScrollWidth),
+    ).toBeLessThanOrEqual(overflow.clientWidth + 1);
 });

--- a/packages/storage/tests/gardenVisitStatesRepo.node.spec.ts
+++ b/packages/storage/tests/gardenVisitStatesRepo.node.spec.ts
@@ -79,6 +79,24 @@ test('markGardenVisitSummarySeen advances opened and summary markers together', 
     assert.strictEqual(seen.lastSummaryFactsHash, 'growth:12');
 });
 
+test('markGardenVisitSummarySeen creates an empty-summary baseline marker', async () => {
+    const fixture = await createVisitFixture();
+    const seenAt = new Date('2026-06-02T10:00:00.000Z');
+
+    const seen = await markGardenVisitSummarySeen({
+        ...fixture,
+        seenAt,
+        factsHash: null,
+    });
+
+    assert.strictEqual(seen.userId, fixture.userId);
+    assert.strictEqual(seen.accountId, fixture.accountId);
+    assert.strictEqual(seen.gardenId, fixture.gardenId);
+    assert.deepStrictEqual(seen.lastOpenedAt, seenAt);
+    assert.deepStrictEqual(seen.lastSummarySeenAt, seenAt);
+    assert.strictEqual(seen.lastSummaryFactsHash, null);
+});
+
 test('garden visit markers are isolated by user within a shared account garden', async () => {
     const fixture = await createVisitFixture();
     const secondUserId = await createUserWithPassword(


### PR DESCRIPTION
Closes #3336

Depends on #3394, which depends on #3393. This is stacked so the diff contains only QA coverage changes.

## Summary
- adds opening-flow CT coverage for daily reward -> visit summary -> What's New sequencing
- covers no-daily-reward summary, no-facts skip with marker advancement, and mobile long-copy layout
- adds storage regression coverage for creating an empty-summary baseline marker

## Validation
- `pnpm --filter garden exec playwright test tests/garden-visit-summary-modal.spec.tsx`
- `pnpm --filter @gredice/storage run test:node gardenVisitStatesRepo.node.spec.ts`
- `pnpm --filter api exec node --import tsx --test --conditions=react-server lib/garden/gardenVisitSummaryService.node.spec.ts`
- `pnpm --filter @gredice/game exec tsx --test src/hooks/useGardenVisitSummary.unit.ts`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden exec biome check tests/GardenVisitSummaryModalStory.tsx tests/garden-visit-summary-modal.spec.tsx`
- `pnpm --filter @gredice/storage exec biome check tests/gardenVisitStatesRepo.node.spec.ts`
- `git diff --check`