### PR TITLE
[codex] Include raised bed id in applied operation rewards

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -66,7 +66,10 @@ import { describeRoute, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { getBlockData } from '../../../lib/blocks/blockDataService';
 import { authSecurity, publicSecurity } from '../../../lib/docs/security';
-import { isAppliedOperationCurrentForRaisedBedFields } from '../../../lib/garden/appliedRaisedBedOperations';
+import {
+    isAppliedOperationCurrentForRaisedBedFields,
+    serializeAppliedRaisedBedOperation,
+} from '../../../lib/garden/appliedRaisedBedOperations';
 import { resolveGardenBlockPlacement } from '../../../lib/garden/blockPlacementService';
 import { deleteGardenBlock } from '../../../lib/garden/gardenBlocksService';
 import { synchronizeGardenStacksAndRaisedBeds } from '../../../lib/garden/gardenStacksSyncService';
@@ -315,22 +318,6 @@ async function trackGardenCreated(input: {
 
 function isAppliedRaisedBedOperationStatus(status: string) {
     return status === 'completed' || status === 'pendingVerification';
-}
-
-function serializeAppliedRaisedBedOperation(
-    operation: Awaited<
-        ReturnType<typeof getAppliedRaisedBedOperationsForGarden>
-    >[number],
-) {
-    return {
-        id: operation.id,
-        entityId: operation.entityId,
-        raisedBedFieldId: operation.raisedBedFieldId,
-        status: operation.status,
-        createdAt: operation.createdAt.toISOString(),
-        completedAt: operation.completedAt?.toISOString() ?? null,
-        scheduledDate: operation.scheduledDate?.toISOString() ?? null,
-    };
 }
 
 function serializeGardenOperation(

--- a/apps/api/lib/garden/appliedRaisedBedOperations.node.spec.ts
+++ b/apps/api/lib/garden/appliedRaisedBedOperations.node.spec.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { isAppliedOperationCurrentForRaisedBedFields } from './appliedRaisedBedOperations';
+import {
+    isAppliedOperationCurrentForRaisedBedFields,
+    serializeAppliedRaisedBedOperation,
+} from './appliedRaisedBedOperations';
 
 describe('isAppliedOperationCurrentForRaisedBedFields', () => {
     it('keeps full raised-bed operations active across plant cycles', () => {
@@ -93,6 +96,33 @@ describe('isAppliedOperationCurrentForRaisedBedFields', () => {
                 ],
             ),
             false,
+        );
+    });
+});
+
+describe('serializeAppliedRaisedBedOperation', () => {
+    it('includes raised-bed identity for whole-bed visual rewards', () => {
+        assert.deepStrictEqual(
+            serializeAppliedRaisedBedOperation({
+                id: 2057,
+                entityId: 9406,
+                raisedBedId: 459,
+                raisedBedFieldId: null,
+                status: 'completed',
+                createdAt: new Date('2026-05-13T23:17:16.911Z'),
+                completedAt: new Date('2026-05-14T16:39:28.536Z'),
+                scheduledDate: new Date('2026-05-14T09:00:00.000Z'),
+            }),
+            {
+                id: 2057,
+                entityId: 9406,
+                raisedBedId: 459,
+                raisedBedFieldId: null,
+                status: 'completed',
+                createdAt: '2026-05-13T23:17:16.911Z',
+                completedAt: '2026-05-14T16:39:28.536Z',
+                scheduledDate: '2026-05-14T09:00:00.000Z',
+            },
         );
     });
 });

--- a/apps/api/lib/garden/appliedRaisedBedOperations.ts
+++ b/apps/api/lib/garden/appliedRaisedBedOperations.ts
@@ -1,10 +1,19 @@
 type TimestampValue = Date | string | null | undefined;
 
 export type AppliedRaisedBedOperation = {
+    raisedBedId?: number | null;
     raisedBedFieldId?: number | null;
     createdAt: TimestampValue;
     completedAt?: TimestampValue;
 };
+
+export type SerializableAppliedRaisedBedOperation =
+    AppliedRaisedBedOperation & {
+        id: number;
+        entityId: number;
+        scheduledDate?: TimestampValue;
+        status: string;
+    };
 
 export type AppliedRaisedBedField = {
     id: number;
@@ -24,6 +33,26 @@ function timestampMs(value: TimestampValue) {
         value instanceof Date ? value.getTime() : Date.parse(value);
 
     return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function timestampIso(value: TimestampValue) {
+    if (!value) {
+        return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    const timestamp = date.getTime();
+
+    return Number.isFinite(timestamp) ? date.toISOString() : null;
+}
+
+function requiredTimestampIso(value: TimestampValue, fieldName: string) {
+    const isoValue = timestampIso(value);
+    if (!isoValue) {
+        throw new Error(`Applied operation is missing ${fieldName}.`);
+    }
+
+    return isoValue;
 }
 
 function activePlantCycleStartMs(field: AppliedRaisedBedField) {
@@ -63,4 +92,19 @@ export function isAppliedOperationCurrentForRaisedBedFields(
     }
 
     return appliedAtMs >= cycleStartMs;
+}
+
+export function serializeAppliedRaisedBedOperation(
+    operation: SerializableAppliedRaisedBedOperation,
+) {
+    return {
+        id: operation.id,
+        entityId: operation.entityId,
+        raisedBedId: operation.raisedBedId ?? null,
+        raisedBedFieldId: operation.raisedBedFieldId ?? null,
+        status: operation.status,
+        createdAt: requiredTimestampIso(operation.createdAt, 'createdAt'),
+        completedAt: timestampIso(operation.completedAt),
+        scheduledDate: timestampIso(operation.scheduledDate),
+    };
 }

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -546,16 +546,19 @@ function completedDebugAppliedOperation({
     completedAt,
     entityId,
     id,
+    raisedBedId,
     raisedBedFieldId,
 }: {
     completedAt: string;
     entityId: number;
     id: number;
+    raisedBedId: number;
     raisedBedFieldId?: number | null;
 }): MockRaisedBed['appliedOperations'][number] {
     return {
         id,
         entityId,
+        raisedBedId,
         raisedBedFieldId: raisedBedFieldId ?? null,
         status: 'completed',
         createdAt: completedAt,
@@ -598,6 +601,7 @@ function applyOperationRewardDebugState({
                         id: 9501,
                         entityId:
                             operationVisualRewardDebugOperationIds.watering,
+                        raisedBedId: raisedBed.id,
                         completedAt: operationVisualRewardDebugTimestamp,
                     }),
                 ];
@@ -614,6 +618,7 @@ function applyOperationRewardDebugState({
                         id: 9502,
                         entityId:
                             operationVisualRewardDebugOperationIds.weeding,
+                        raisedBedId: raisedBed.id,
                         completedAt: operationVisualRewardDebugNewerTimestamp,
                     }),
                 ];
@@ -625,6 +630,7 @@ function applyOperationRewardDebugState({
                     completedDebugAppliedOperation({
                         id: 9503,
                         entityId: operationVisualRewardDebugOperationIds.mulch,
+                        raisedBedId: raisedBed.id,
                         completedAt: operationVisualRewardDebugTimestamp,
                     }),
                 ];
@@ -635,6 +641,7 @@ function applyOperationRewardDebugState({
                 completedDebugAppliedOperation({
                     id: 9504,
                     entityId: operationVisualRewardDebugOperationIds.mulch,
+                    raisedBedId: raisedBed.id,
                     completedAt: operationVisualRewardDebugOlderTimestamp,
                 }),
                 ...(isAfter
@@ -643,6 +650,7 @@ function applyOperationRewardDebugState({
                               id: 9505,
                               entityId:
                                   operationVisualRewardDebugOperationIds.removeMulch,
+                              raisedBedId: raisedBed.id,
                               completedAt:
                                   operationVisualRewardDebugNewerTimestamp,
                           }),
@@ -657,6 +665,7 @@ function applyOperationRewardDebugState({
                         id: 9506,
                         entityId:
                             operationVisualRewardDebugOperationIds.agrotextile,
+                        raisedBedId: raisedBed.id,
                         completedAt: operationVisualRewardDebugTimestamp,
                     }),
                 ];
@@ -668,6 +677,7 @@ function applyOperationRewardDebugState({
                     id: 9507,
                     entityId:
                         operationVisualRewardDebugOperationIds.agrotextile,
+                    raisedBedId: raisedBed.id,
                     completedAt: operationVisualRewardDebugOlderTimestamp,
                 }),
                 ...(isAfter
@@ -676,6 +686,7 @@ function applyOperationRewardDebugState({
                               id: 9508,
                               entityId:
                                   operationVisualRewardDebugOperationIds.removeAgrotextile,
+                              raisedBedId: raisedBed.id,
                               completedAt:
                                   operationVisualRewardDebugNewerTimestamp,
                           }),
@@ -690,6 +701,7 @@ function applyOperationRewardDebugState({
                         id: 9509,
                         entityId:
                             operationVisualRewardDebugOperationIds.supports,
+                        raisedBedId: raisedBed.id,
                         completedAt: operationVisualRewardDebugTimestamp,
                     }),
                 ];
@@ -702,6 +714,7 @@ function applyOperationRewardDebugState({
                         id: 9510,
                         entityId:
                             operationVisualRewardDebugOperationIds.harvest,
+                        raisedBedId: raisedBed.id,
                         completedAt: operationVisualRewardDebugTimestamp,
                     }),
                 ];


### PR DESCRIPTION
## Summary
- Include `raisedBedId` in serialized applied raised-bed operations from the garden API.
- Move applied-operation serialization into the existing garden helper and cover the payload contract with a focused node test.
- Update operation reward debug mocks so their applied-operation payloads match the live API shape.

## Why
The pulled database already has May 14 completed remove-agrotextile operations for every May 12 agrotextile placement, so no data backfill was needed. The missing `raisedBedId` in the applied-operation payload prevented whole-bed visual rewards/removals from being targeted precisely by the game resolver.

## Data Check
- `pnpm bootstrap` completed and pulled development env files.
- Read-only storage query found 9 completed `setAgrotextileWhite` operations and 9 later completed `removeAgrotextileWhite` operations.
- Latest agrotextile state by raised bed: `active_agrotextile_count = 0`, `removed_agrotextile_count = 9`.

## Validation
- `pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/garden/appliedRaisedBedOperations.node.spec.ts`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter api exec biome check ./app/api/'[...route]'/gardensRoutes.ts ./lib/garden/appliedRaisedBedOperations.ts ./lib/garden/appliedRaisedBedOperations.node.spec.ts ../../packages/game/src/hooks/useCurrentGarden.ts`
- `git diff --check origin/main..HEAD`
- `pnpm --filter api build`
