### PR TITLE
[codex] Inset raised bed weed scatter

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -42,7 +42,8 @@ const fieldAgrotextileCoverSize = 0.25;
 const wholeBedAgrotextileCoverPadding = 0.02;
 const wholeBedAgrotextileHemThickness = 0.018;
 const raisedBedFieldCount = 9;
-const weedFieldScatterRadius = 0.108;
+// Keep weed bases inside the visible dirt inset, not out on the raised-bed rim.
+const weedFieldScatterRadius = 0.082;
 const weedBladeIds = [
     'sprout-a',
     'sprout-b',


### PR DESCRIPTION
## Summary
- Tighten raised-bed weed scatter radius so weed blades stay inside the visible dirt inset instead of reaching onto the wooden rim.

## Validation
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game exec biome check src/entities/raisedBed/RaisedBedFields.tsx`
- `git diff --check`
- `pnpm --filter @gredice/game test`
- `pnpm --filter garden profile:game -- --scenario-set rewards --screenshots` rendered the reward matrix screenshot; local profiler still reports the known long-task budget failure (`longTaskCount 24 > 12`).
