### PR TITLE
[codex] Polish raised bed watering visuals

### DIFF
--- a/packages/game/src/entities/RaisedBed.tsx
+++ b/packages/game/src/entities/RaisedBed.tsx
@@ -7,7 +7,6 @@ import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useDeliveryRequests } from '../hooks/useDeliveryRequests';
 import { useAllSorts } from '../hooks/usePlantSorts';
 import { useRaisedBedOperationVisualRewards } from '../hooks/useRaisedBedOperationVisualRewards';
-import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
@@ -26,7 +25,6 @@ import {
     resolveRaisedBedHarvestBasketPlacement,
     resolveRaisedBedHarvestBasketState,
 } from './raisedBed/raisedBedHarvestRewards';
-import { isWateringRewardVisible } from './raisedBed/raisedBedWateringRewards';
 
 const combinedOverlap = 0.1;
 const halfOverlap = combinedOverlap / 2;
@@ -212,7 +210,6 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
     const { data: garden } = useCurrentGarden();
     const raisedBed = findRaisedBedByBlockId(garden, block.id);
     const visualRewards = useRaisedBedOperationVisualRewards(raisedBed);
-    const currentTime = useSnapshotTime();
     const isMock = useGameState((state) => state.isMock);
     const isLocalSandbox = useGameState(
         (state) => state.localSandboxStorageKey !== null,
@@ -317,13 +314,6 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
         shape1 = 'Raised_Bed_O_1';
         shape2 = 'Raised_Bed_O_2';
     }
-    const dirtShape = shape1 === 'Raised_Bed_O_1' ? shape2 : shape1;
-    const hasRaisedBedWateringReward = visualRewards.some(
-        (reward) =>
-            reward.scope === 'raisedBed' &&
-            reward.raisedBedId === raisedBed?.id &&
-            isWateringRewardVisible(reward, currentTime),
-    );
     const hiddenHarvestOperationIds = useMemo(
         () =>
             new Set(
@@ -428,22 +418,6 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
                         coverageMultiplier={0.9}
                     />
                     <RainWetOverlay geometry={nodes[shape2].geometry} />
-                    {hasRaisedBedWateringReward && (
-                        <mesh
-                            geometry={nodes[dirtShape].geometry}
-                            renderOrder={1}
-                        >
-                            <meshStandardMaterial
-                                color="#18201d"
-                                depthWrite={false}
-                                opacity={0.46}
-                                polygonOffset
-                                polygonOffsetFactor={-5}
-                                roughness={0.6}
-                                transparent
-                            />
-                        </mesh>
-                    )}
                 </animated.group>
             </HoverOutline>
             <group position={raisedBedPosition}>

--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -41,6 +41,9 @@ const raisedBedHalfOverlap = 0.05;
 const fieldAgrotextileCoverSize = 0.25;
 const wholeBedAgrotextileCoverPadding = 0.02;
 const wholeBedAgrotextileHemThickness = 0.018;
+const soilOverlayFieldSize = 0.255;
+const soilOverlayPadding = 0.012;
+const soilOverlayY = -0.748;
 const raisedBedFieldCount = 9;
 const weedFieldScatterRadius = 0.108;
 const weedBladeIds = [
@@ -70,6 +73,28 @@ type RaisedBedWholeAgrotextileCoverLayout = {
     position: [number, number, number];
     width: number;
 };
+
+type RaisedBedSoilOverlayLayout = RaisedBedWholeAgrotextileCoverLayout;
+
+const drySoilCrackSegments = [
+    { id: 'a', start: [-0.43, -0.34], end: [-0.31, -0.28] },
+    { id: 'b', start: [-0.34, -0.28], end: [-0.27, -0.18] },
+    { id: 'c', start: [-0.18, -0.39], end: [-0.08, -0.31] },
+    { id: 'd', start: [-0.1, -0.3], end: [0.02, -0.24] },
+    { id: 'e', start: [0.15, -0.38], end: [0.28, -0.3] },
+    { id: 'f', start: [0.24, -0.29], end: [0.36, -0.2] },
+    { id: 'g', start: [-0.46, -0.03], end: [-0.34, 0.04] },
+    { id: 'h', start: [-0.25, 0.12], end: [-0.12, 0.05] },
+    { id: 'i', start: [-0.04, 0.01], end: [0.1, 0.1] },
+    { id: 'j', start: [0.19, 0.05], end: [0.32, 0.13] },
+    { id: 'k', start: [-0.38, 0.31], end: [-0.24, 0.24] },
+    { id: 'l', start: [0.06, 0.31], end: [0.2, 0.23] },
+    { id: 'm', start: [-0.31, -0.28], end: [-0.27, -0.36] },
+    { id: 'n', start: [0.02, -0.24], end: [0.07, -0.33] },
+    { id: 'o', start: [-0.12, 0.05], end: [-0.16, -0.03] },
+    { id: 'p', start: [0.32, 0.13], end: [0.37, 0.03] },
+    { id: 'q', start: [0.2, 0.23], end: [0.28, 0.3] },
+] as const;
 
 function findRaisedBedBlockPlacement(
     garden: CurrentGardenData,
@@ -210,6 +235,165 @@ function getRaisedBedWholeAgrotextileCoverLayout({
     };
 }
 
+function getRaisedBedSoilOverlayLayout({
+    blockId,
+    blockIds,
+    garden,
+    orientation,
+}: {
+    blockId: string;
+    blockIds: string[];
+    garden: CurrentGardenData;
+    orientation: RaisedBedOrientation;
+}): RaisedBedSoilOverlayLayout | null {
+    const ownerOrigin = getRaisedBedBlockSurfaceOrigin(garden, blockId);
+    if (!ownerOrigin) {
+        return null;
+    }
+
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let minZ = Number.POSITIVE_INFINITY;
+    let maxZ = Number.NEGATIVE_INFINITY;
+    const fieldHalfSize = soilOverlayFieldSize / 2;
+
+    for (const [blockIndex, raisedBedBlockId] of blockIds.entries()) {
+        const origin = getRaisedBedBlockSurfaceOrigin(garden, raisedBedBlockId);
+        if (!origin) {
+            continue;
+        }
+
+        for (
+            let positionIndex = 0;
+            positionIndex < raisedBedFieldCount;
+            positionIndex += 1
+        ) {
+            const [fieldX, , fieldZ] = getRaisedBedFieldSurfacePosition({
+                blockIndex,
+                orientation,
+                positionIndex,
+                y: 0,
+            });
+            const centerX = origin.x - ownerOrigin.x + fieldX;
+            const centerZ = origin.z - ownerOrigin.z + fieldZ;
+
+            minX = Math.min(minX, centerX - fieldHalfSize);
+            maxX = Math.max(maxX, centerX + fieldHalfSize);
+            minZ = Math.min(minZ, centerZ - fieldHalfSize);
+            maxZ = Math.max(maxZ, centerZ + fieldHalfSize);
+        }
+    }
+
+    if (
+        !Number.isFinite(minX) ||
+        !Number.isFinite(maxX) ||
+        !Number.isFinite(minZ) ||
+        !Number.isFinite(maxZ)
+    ) {
+        return null;
+    }
+
+    minX -= soilOverlayPadding;
+    maxX += soilOverlayPadding;
+    minZ -= soilOverlayPadding;
+    maxZ += soilOverlayPadding;
+
+    return {
+        depth: maxZ - minZ,
+        position: [(minX + maxX) / 2, soilOverlayY, (minZ + maxZ) / 2],
+        width: maxX - minX,
+    };
+}
+
+function RaisedBedDrySoilOverlay({
+    layout,
+}: {
+    layout: RaisedBedSoilOverlayLayout;
+}) {
+    const crackThickness = Math.max(
+        0.01,
+        Math.min(layout.width, layout.depth) * 0.014,
+    );
+
+    return (
+        <group position={layout.position}>
+            <mesh rotation={[-Math.PI / 2, 0, 0]} renderOrder={1}>
+                <planeGeometry args={[layout.width, layout.depth]} />
+                <meshStandardMaterial
+                    color="#a1744f"
+                    depthWrite={false}
+                    opacity={0.56}
+                    polygonOffset
+                    polygonOffsetFactor={-2}
+                    roughness={1}
+                    transparent
+                />
+            </mesh>
+            {drySoilCrackSegments.map((segment) => {
+                const startX = segment.start[0] * layout.width;
+                const startZ = segment.start[1] * layout.depth;
+                const endX = segment.end[0] * layout.width;
+                const endZ = segment.end[1] * layout.depth;
+                const deltaX = endX - startX;
+                const deltaZ = endZ - startZ;
+                const length = Math.hypot(deltaX, deltaZ);
+                const angle = Math.atan2(deltaZ, deltaX);
+
+                return (
+                    <mesh
+                        key={`raised-bed-dry-soil-crack-${segment.id}`}
+                        position={[
+                            (startX + endX) / 2,
+                            0.003,
+                            (startZ + endZ) / 2,
+                        ]}
+                        renderOrder={2}
+                        rotation={[0, -angle, 0]}
+                    >
+                        <boxGeometry args={[length, 0.002, crackThickness]} />
+                        <meshStandardMaterial
+                            color="#2f1f18"
+                            depthWrite={false}
+                            opacity={0.74}
+                            polygonOffset
+                            polygonOffsetFactor={-3}
+                            roughness={1}
+                            transparent
+                        />
+                    </mesh>
+                );
+            })}
+        </group>
+    );
+}
+
+function RaisedBedMoistSoilOverlay({
+    layout,
+}: {
+    layout: RaisedBedSoilOverlayLayout;
+}) {
+    return (
+        <group position={layout.position}>
+            <mesh
+                position={[0, 0.006, 0]}
+                rotation={[-Math.PI / 2, 0, 0]}
+                renderOrder={3}
+            >
+                <planeGeometry args={[layout.width, layout.depth]} />
+                <meshStandardMaterial
+                    color="#28170f"
+                    depthWrite={false}
+                    opacity={0.74}
+                    polygonOffset
+                    polygonOffsetFactor={-6}
+                    roughness={1}
+                    transparent
+                />
+            </mesh>
+        </group>
+    );
+}
+
 function RaisedBedFieldMoistSoilOverlay({
     blockIndex,
     orientation,
@@ -223,37 +407,20 @@ function RaisedBedFieldMoistSoilOverlay({
         blockIndex,
         orientation,
         positionIndex,
-        y: -0.748,
+        y: soilOverlayY + 0.004,
     });
 
     return (
         <group position={position}>
-            <mesh rotation={[-Math.PI / 2, 0, 0]} renderOrder={1}>
+            <mesh rotation={[-Math.PI / 2, 0, 0]} renderOrder={3}>
                 <planeGeometry args={[0.255, 0.255]} />
                 <meshStandardMaterial
-                    color="#1d201d"
+                    color="#28170f"
                     depthWrite={false}
-                    opacity={0.52}
+                    opacity={0.7}
                     polygonOffset
-                    polygonOffsetFactor={-3}
-                    roughness={0.72}
-                    transparent
-                />
-            </mesh>
-            <mesh
-                position={[0.042, 0.004, -0.036]}
-                rotation={[-Math.PI / 2, 0, 0.32]}
-                scale={[1.7, 0.8, 1]}
-                renderOrder={2}
-            >
-                <circleGeometry args={[0.036, 14]} />
-                <meshStandardMaterial
-                    color="#6f8f88"
-                    depthWrite={false}
-                    opacity={0.2}
-                    polygonOffset
-                    polygonOffsetFactor={-4}
-                    roughness={0.32}
+                    polygonOffsetFactor={-6}
+                    roughness={1}
                     transparent
                 />
             </mesh>
@@ -675,15 +842,10 @@ export function RaisedBedFields({
             reward.raisedBedId === raisedBed?.id &&
             isWateringRewardVisible(reward, currentTime),
     );
-    const moistFieldPositionSet = hasRaisedBedWateringReward
-        ? new Set(
-              Array.from(
-                  { length: raisedBedFieldCount },
-                  (_, localPositionIndex) => localPositionIndex,
-              ),
-          )
-        : new Set(
-              visualRewards.flatMap((reward) => {
+    const moistFieldPositionSet = new Set(
+        hasRaisedBedWateringReward
+            ? []
+            : visualRewards.flatMap((reward) => {
                   if (
                       reward.scope !== 'field' ||
                       reward.raisedBedFieldId == null ||
@@ -707,7 +869,7 @@ export function RaisedBedFields({
 
                   return [field.positionIndex - blockOffset];
               }),
-          );
+    );
     const weedFieldVisuals = raisedBed
         ? Array.from({ length: 9 }, (_, localPositionIndex) => {
               const positionIndex = blockOffset + localPositionIndex;
@@ -767,6 +929,15 @@ export function RaisedBedFields({
                   orientation,
               })
             : null;
+    const soilOverlayLayout =
+        currentGarden && blockIds.length > 0 && blockIndex === 0
+            ? getRaisedBedSoilOverlayLayout({
+                  blockId,
+                  blockIds,
+                  garden: currentGarden,
+                  orientation,
+              })
+            : null;
     const fieldAgrotextileCoverPositions = hasRaisedBedAgrotextileCover
         ? []
         : agrotextileCoverPositions;
@@ -812,6 +983,12 @@ export function RaisedBedFields({
 
     return (
         <>
+            {soilOverlayLayout && !hasRaisedBedWateringReward ? (
+                <RaisedBedDrySoilOverlay layout={soilOverlayLayout} />
+            ) : null}
+            {soilOverlayLayout && hasRaisedBedWateringReward ? (
+                <RaisedBedMoistSoilOverlay layout={soilOverlayLayout} />
+            ) : null}
             {highlightedLocalPositionIndex != null ? (
                 <RaisedBedFieldVisitSummaryHighlight
                     blockIndex={blockIndex}


### PR DESCRIPTION
## Summary
- render dry raised-bed soil as a lighter full-bed surface with irregular cracks
- render raised-bed watering as one smooth dark soil layer instead of per-field gray patches
- remove the older raised-bed mesh darkening pass so watering is handled on the dirt surface only

## Validation
- pnpm --filter @gredice/game typecheck
- pnpm --filter @gredice/game exec biome check src/entities/raisedBed/RaisedBedFields.tsx src/entities/RaisedBed.tsx
- pnpm --filter garden typecheck
- pnpm --filter @gredice/game test
- pnpm --filter garden profile:game -- --scenario-set rewards --screenshots (build and screenshot completed; existing profile budget still fails with longTaskCount 21 > 12)
- git diff --check