### PR TITLE
Render harvest baskets for instanced raised beds

### DIFF
--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -35,6 +35,7 @@ import { HoverOutline } from './helpers/HoverOutline';
 import { resolveEntityNeighbors } from './helpers/useEntityNeighbors';
 import { RaisedBedFields } from './raisedBed/RaisedBedFields';
 import { RaisedBedGeneratedPlantFieldBatches } from './raisedBed/RaisedBedGeneratedPlantFieldBatches';
+import { RaisedBedHarvestBasketForBlock } from './raisedBed/RaisedBedHarvestBasket';
 import {
     resolveWaterFoamCorners,
     resolveWaterFoamEdges,
@@ -702,6 +703,12 @@ function RaisedBedInstances({
                         generatedPlantsHandledExternally
                     />
                 </group>
+            ))}
+            {instances.map((instance) => (
+                <RaisedBedHarvestBasketForBlock
+                    key={`Raised_Bed-harvest-basket-${instance.id}`}
+                    blockId={instance.block.id}
+                />
             ))}
             <RaisedBedHoverOutlines
                 instances={instances}

--- a/packages/game/src/entities/RaisedBed.tsx
+++ b/packages/game/src/entities/RaisedBed.tsx
@@ -1,12 +1,7 @@
 import { animated } from '@react-spring/three';
-import { useMemo } from 'react';
 import { Vector3 } from 'three';
 import { useHoveredBlockStore } from '../controls/useHoveredBlockStore';
-import { useBlockData } from '../hooks/useBlockData';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
-import { useDeliveryRequests } from '../hooks/useDeliveryRequests';
-import { useAllSorts } from '../hooks/usePlantSorts';
-import { useRaisedBedOperationVisualRewards } from '../hooks/useRaisedBedOperationVisualRewards';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
@@ -20,214 +15,20 @@ import { useGameGLTF } from '../utils/useGameGLTF';
 import { HoverOutline } from './helpers/HoverOutline';
 import { useEntityNeighbors } from './helpers/useEntityNeighbors';
 import { RaisedBedFields } from './raisedBed/RaisedBedFields';
-import {
-    type RaisedBedHarvestBasketFillLevel,
-    resolveRaisedBedHarvestBasketPlacement,
-    resolveRaisedBedHarvestBasketState,
-} from './raisedBed/raisedBedHarvestRewards';
+import { RaisedBedHarvestBasketForBlock } from './raisedBed/RaisedBedHarvestBasket';
 
 const combinedOverlap = 0.1;
 const halfOverlap = combinedOverlap / 2;
 
-type HarvestProduceKind = 'green' | 'leafy' | 'orange' | 'pale' | 'red';
-
-const harvestBasketProduceSlots = [
-    { id: 'front-left', position: [-0.12, 0.175, -0.055] },
-    { id: 'center-left', position: [-0.045, 0.19, 0.02] },
-    { id: 'center-right', position: [0.04, 0.18, -0.04] },
-    { id: 'front-right', position: [0.12, 0.19, 0.04] },
-    { id: 'back-left', position: [-0.085, 0.22, 0.075] },
-    { id: 'back-right', position: [0.075, 0.225, 0.085] },
-    { id: 'front-center', position: [0, 0.235, -0.095] },
-    { id: 'outer-right', position: [0.145, 0.225, -0.08] },
-] as const;
-
-function normalizeProduceLabel(value: string) {
-    return value
-        .normalize('NFD')
-        .replace(/\p{Diacritic}/gu, '')
-        .toLowerCase();
-}
-
-function resolveHarvestProduceKind(
-    labels: Array<string | null | undefined>,
-): HarvestProduceKind {
-    const text = normalizeProduceLabel(labels.filter(Boolean).join(' '));
-
-    if (
-        /rajc|paradajz|tomato|jagod|strawberry|paprika|pepper|rotkv|radish/.test(
-            text,
-        )
-    ) {
-        return 'red';
-    }
-
-    if (/mrkv|carrot|tikv|pumpkin|dinj|melon|cikla|beet/.test(text)) {
-        return 'orange';
-    }
-
-    if (
-        /salat|lettuce|spinat|spinach|blitv|chard|rukol|arugula|kelj|kale|kupus|cabbage|brokul|broccoli/.test(
-            text,
-        )
-    ) {
-        return 'leafy';
-    }
-
-    if (/luk|onion|cesnjak|garlic|poriluk|leek/.test(text)) {
-        return 'pale';
-    }
-
-    return 'green';
-}
-
-function HarvestBasketProduce({
-    index,
-    kind,
-}: {
-    index: number;
-    kind: HarvestProduceKind;
-}) {
-    const position =
-        harvestBasketProduceSlots[index % harvestBasketProduceSlots.length]
-            ?.position ?? harvestBasketProduceSlots[0].position;
-
-    if (kind === 'leafy') {
-        return (
-            <group position={position} rotation={[0, index * 0.9, 0]}>
-                <mesh scale={[1.6, 0.45, 0.9]}>
-                    <sphereGeometry args={[0.04, 8, 6]} />
-                    <meshStandardMaterial color="#4f8d45" roughness={0.85} />
-                </mesh>
-                <mesh
-                    position={[0.018, 0.012, -0.012]}
-                    scale={[1.1, 0.35, 0.7]}
-                >
-                    <sphereGeometry args={[0.032, 8, 6]} />
-                    <meshStandardMaterial color="#6aa84f" roughness={0.85} />
-                </mesh>
-            </group>
-        );
-    }
-
-    if (kind === 'pale') {
-        return (
-            <group position={position}>
-                <mesh>
-                    <sphereGeometry args={[0.034, 8, 6]} />
-                    <meshStandardMaterial color="#efe0b8" roughness={0.82} />
-                </mesh>
-                <mesh position={[0, 0.04, 0]} rotation={[0.35, 0, 0]}>
-                    <coneGeometry args={[0.012, 0.075, 5]} />
-                    <meshStandardMaterial color="#6c8f42" roughness={0.9} />
-                </mesh>
-            </group>
-        );
-    }
-
-    const color =
-        kind === 'red' ? '#c74335' : kind === 'orange' ? '#d9822b' : '#5f8c44';
-    const scale =
-        kind === 'green' ? ([1.65, 0.72, 0.86] as const) : ([1, 1, 1] as const);
-
-    return (
-        <mesh position={position} rotation={[0, index * 0.7, 0]} scale={scale}>
-            <sphereGeometry args={[0.038, 8, 6]} />
-            <meshStandardMaterial color={color} roughness={0.82} />
-        </mesh>
-    );
-}
-
-function RaisedBedHarvestBasketVisual({
-    fillLevel,
-    position,
-    produceKinds,
-    rotation,
-}: {
-    fillLevel: RaisedBedHarvestBasketFillLevel;
-    position: [number, number, number];
-    produceKinds: HarvestProduceKind[];
-    rotation: number;
-}) {
-    const produceCount =
-        fillLevel === 'full' ? 8 : fillLevel === 'partial' ? 5 : 0;
-    const visibleProduceKinds =
-        produceKinds.length > 0 ? produceKinds : (['green'] as const);
-
-    return (
-        <group position={position} rotation={[0, rotation, 0]}>
-            <mesh castShadow receiveShadow position={[0, 0.055, 0]}>
-                <boxGeometry args={[0.52, 0.08, 0.36]} />
-                <meshStandardMaterial color="#7a4f2b" roughness={0.95} />
-            </mesh>
-            <mesh castShadow position={[0, 0.125, -0.19]}>
-                <boxGeometry args={[0.56, 0.13, 0.035]} />
-                <meshStandardMaterial color="#b47a43" roughness={0.95} />
-            </mesh>
-            <mesh castShadow position={[0, 0.125, 0.19]}>
-                <boxGeometry args={[0.56, 0.13, 0.035]} />
-                <meshStandardMaterial color="#b47a43" roughness={0.95} />
-            </mesh>
-            <mesh castShadow position={[-0.28, 0.125, 0]}>
-                <boxGeometry args={[0.035, 0.13, 0.36]} />
-                <meshStandardMaterial color="#a16939" roughness={0.95} />
-            </mesh>
-            <mesh castShadow position={[0.28, 0.125, 0]}>
-                <boxGeometry args={[0.035, 0.13, 0.36]} />
-                <meshStandardMaterial color="#a16939" roughness={0.95} />
-            </mesh>
-            <mesh castShadow position={[0, 0.205, -0.205]}>
-                <boxGeometry args={[0.48, 0.028, 0.035]} />
-                <meshStandardMaterial color="#d09a5b" roughness={0.9} />
-            </mesh>
-            <mesh castShadow position={[0, 0.205, 0.205]}>
-                <boxGeometry args={[0.48, 0.028, 0.035]} />
-                <meshStandardMaterial color="#d09a5b" roughness={0.9} />
-            </mesh>
-            {harvestBasketProduceSlots
-                .slice(0, produceCount)
-                .map((slot, index) => (
-                    <HarvestBasketProduce
-                        key={`harvest-basket-produce-${slot.id}`}
-                        index={index}
-                        kind={
-                            visibleProduceKinds[
-                                index % visibleProduceKinds.length
-                            ]
-                        }
-                    />
-                ))}
-        </group>
-    );
-}
-
 export function RaisedBed({ stack, block }: EntityInstanceProps) {
     const { nodes, materials } = useGameGLTF('RaisedBed');
-    const { data: blockData } = useBlockData();
-    const { data: sortData } = useAllSorts();
     const currentStackHeight = useStackHeight(stack, block);
     const hoveredBlock = useHoveredBlockStore((state) => state.hoveredBlock);
     const { data: garden } = useCurrentGarden();
     const raisedBed = findRaisedBedByBlockId(garden, block.id);
-    const visualRewards = useRaisedBedOperationVisualRewards(raisedBed);
-    const isMock = useGameState((state) => state.isMock);
-    const isLocalSandbox = useGameState(
-        (state) => state.localSandboxStorageKey !== null,
-    );
     const visitSummaryHighlight = useGameState(
         (state) => state.gardenVisitSummaryHighlight,
     );
-    const hasHarvestRewards = visualRewards.some(
-        (reward) =>
-            reward.family === 'harvest' && reward.raisedBedId === raisedBed?.id,
-    );
-    const deliveryRequests = useDeliveryRequests({
-        enabled:
-            Boolean(raisedBed) &&
-            hasHarvestRewards &&
-            !isMock &&
-            !isLocalSandbox,
-    });
     const hoveredRaisedBed = hoveredBlock
         ? findRaisedBedByBlockId(garden, hoveredBlock.id)
         : null;
@@ -314,53 +115,6 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
         shape1 = 'Raised_Bed_O_1';
         shape2 = 'Raised_Bed_O_2';
     }
-    const hiddenHarvestOperationIds = useMemo(
-        () =>
-            new Set(
-                (deliveryRequests.data ?? [])
-                    .filter(
-                        (request) =>
-                            request.state === 'ready' ||
-                            request.state === 'fulfilled',
-                    )
-                    .map((request) => request.operationId),
-            ),
-        [deliveryRequests.data],
-    );
-    const harvestBasketState =
-        raisedBed && raisedBed.blockId === block.id
-            ? resolveRaisedBedHarvestBasketState({
-                  fields: raisedBed.fields,
-                  hiddenOperationIds: hiddenHarvestOperationIds,
-                  raisedBedId: raisedBed.id,
-                  visualRewards,
-              })
-            : null;
-    const harvestBasketPlacement =
-        garden && raisedBed && harvestBasketState
-            ? resolveRaisedBedHarvestBasketPlacement({
-                  blockData,
-                  blockIds: getRaisedBedBlockIds(garden, raisedBed.id),
-                  stacks: garden.stacks,
-              })
-            : null;
-    const sortDataById = useMemo(
-        () => new Map((sortData ?? []).map((sort) => [sort.id, sort])),
-        [sortData],
-    );
-    const harvestProduceKinds = useMemo(
-        () =>
-            harvestBasketState?.producePlantSortIds.map((plantSortId) => {
-                const sort = sortDataById.get(plantSortId);
-
-                return resolveHarvestProduceKind([
-                    sort?.information.name,
-                    sort?.information.plant.information?.name,
-                    sort?.information.plant.information?.latinName,
-                ]);
-            }) ?? [],
-        [harvestBasketState?.producePlantSortIds, sortDataById],
-    );
     const isVisitSummaryHighlighted =
         raisedBed?.id != null &&
         visitSummaryHighlight?.raisedBedId === raisedBed.id;
@@ -423,14 +177,7 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
             <group position={raisedBedPosition}>
                 <RaisedBedFields blockId={block.id} />
             </group>
-            {harvestBasketState && harvestBasketPlacement && (
-                <RaisedBedHarvestBasketVisual
-                    fillLevel={harvestBasketState.fillLevel}
-                    position={harvestBasketPlacement.position}
-                    produceKinds={harvestProduceKinds}
-                    rotation={harvestBasketPlacement.rotation}
-                />
-            )}
+            <RaisedBedHarvestBasketForBlock blockId={block.id} />
         </>
     );
 }

--- a/packages/game/src/entities/raisedBed/RaisedBedHarvestBasket.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedHarvestBasket.tsx
@@ -1,0 +1,279 @@
+import { useMemo } from 'react';
+import { useBlockData } from '../../hooks/useBlockData';
+import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { useDeliveryRequests } from '../../hooks/useDeliveryRequests';
+import { useAllSorts } from '../../hooks/usePlantSorts';
+import { useRaisedBedOperationVisualRewards } from '../../hooks/useRaisedBedOperationVisualRewards';
+import { useGameState } from '../../useGameState';
+import {
+    findRaisedBedByBlockId,
+    getRaisedBedBlockIds,
+} from '../../utils/raisedBedBlocks';
+import {
+    type RaisedBedHarvestBasketFillLevel,
+    resolveRaisedBedHarvestBasketPlacement,
+    resolveRaisedBedHarvestBasketState,
+} from './raisedBedHarvestRewards';
+
+type HarvestProduceKind = 'green' | 'leafy' | 'orange' | 'pale' | 'red';
+
+const harvestBasketProduceSlots = [
+    { id: 'front-left', position: [-0.12, 0.175, -0.055] },
+    { id: 'center-left', position: [-0.045, 0.19, 0.02] },
+    { id: 'center-right', position: [0.04, 0.18, -0.04] },
+    { id: 'front-right', position: [0.12, 0.19, 0.04] },
+    { id: 'back-left', position: [-0.085, 0.22, 0.075] },
+    { id: 'back-right', position: [0.075, 0.225, 0.085] },
+    { id: 'front-center', position: [0, 0.235, -0.095] },
+    { id: 'outer-right', position: [0.145, 0.225, -0.08] },
+] as const;
+
+function normalizeProduceLabel(value: string) {
+    return value
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .toLowerCase();
+}
+
+function resolveHarvestProduceKind(
+    labels: Array<string | null | undefined>,
+): HarvestProduceKind {
+    const text = normalizeProduceLabel(labels.filter(Boolean).join(' '));
+
+    if (
+        /rajc|paradajz|tomato|jagod|strawberry|paprika|pepper|rotkv|radish/.test(
+            text,
+        )
+    ) {
+        return 'red';
+    }
+
+    if (/mrkv|carrot|tikv|pumpkin|dinj|melon|cikla|beet/.test(text)) {
+        return 'orange';
+    }
+
+    if (
+        /salat|lettuce|spinat|spinach|blitv|chard|rukol|arugula|kelj|kale|kupus|cabbage|brokul|broccoli/.test(
+            text,
+        )
+    ) {
+        return 'leafy';
+    }
+
+    if (/luk|onion|cesnjak|garlic|poriluk|leek/.test(text)) {
+        return 'pale';
+    }
+
+    return 'green';
+}
+
+function HarvestBasketProduce({
+    index,
+    kind,
+}: {
+    index: number;
+    kind: HarvestProduceKind;
+}) {
+    const position =
+        harvestBasketProduceSlots[index % harvestBasketProduceSlots.length]
+            ?.position ?? harvestBasketProduceSlots[0].position;
+
+    if (kind === 'leafy') {
+        return (
+            <group position={position} rotation={[0, index * 0.9, 0]}>
+                <mesh scale={[1.6, 0.45, 0.9]}>
+                    <sphereGeometry args={[0.04, 8, 6]} />
+                    <meshStandardMaterial color="#4f8d45" roughness={0.85} />
+                </mesh>
+                <mesh
+                    position={[0.018, 0.012, -0.012]}
+                    scale={[1.1, 0.35, 0.7]}
+                >
+                    <sphereGeometry args={[0.032, 8, 6]} />
+                    <meshStandardMaterial color="#6aa84f" roughness={0.85} />
+                </mesh>
+            </group>
+        );
+    }
+
+    if (kind === 'pale') {
+        return (
+            <group position={position}>
+                <mesh>
+                    <sphereGeometry args={[0.034, 8, 6]} />
+                    <meshStandardMaterial color="#efe0b8" roughness={0.82} />
+                </mesh>
+                <mesh position={[0, 0.04, 0]} rotation={[0.35, 0, 0]}>
+                    <coneGeometry args={[0.012, 0.075, 5]} />
+                    <meshStandardMaterial color="#6c8f42" roughness={0.9} />
+                </mesh>
+            </group>
+        );
+    }
+
+    const color =
+        kind === 'red' ? '#c74335' : kind === 'orange' ? '#d9822b' : '#5f8c44';
+    const scale =
+        kind === 'green' ? ([1.65, 0.72, 0.86] as const) : ([1, 1, 1] as const);
+
+    return (
+        <mesh position={position} rotation={[0, index * 0.7, 0]} scale={scale}>
+            <sphereGeometry args={[0.038, 8, 6]} />
+            <meshStandardMaterial color={color} roughness={0.82} />
+        </mesh>
+    );
+}
+
+function RaisedBedHarvestBasketVisual({
+    fillLevel,
+    position,
+    produceKinds,
+    rotation,
+}: {
+    fillLevel: RaisedBedHarvestBasketFillLevel;
+    position: [number, number, number];
+    produceKinds: HarvestProduceKind[];
+    rotation: number;
+}) {
+    const produceCount =
+        fillLevel === 'full' ? 8 : fillLevel === 'partial' ? 5 : 0;
+    const visibleProduceKinds =
+        produceKinds.length > 0 ? produceKinds : (['green'] as const);
+
+    return (
+        <group
+            position={position}
+            rotation={[0, rotation, 0]}
+            scale={[1.25, 1.12, 1.25]}
+        >
+            <mesh castShadow receiveShadow position={[0, 0.055, 0]}>
+                <boxGeometry args={[0.52, 0.08, 0.36]} />
+                <meshStandardMaterial color="#7a4f2b" roughness={0.95} />
+            </mesh>
+            <mesh castShadow position={[0, 0.125, -0.19]}>
+                <boxGeometry args={[0.56, 0.13, 0.035]} />
+                <meshStandardMaterial color="#b47a43" roughness={0.95} />
+            </mesh>
+            <mesh castShadow position={[0, 0.125, 0.19]}>
+                <boxGeometry args={[0.56, 0.13, 0.035]} />
+                <meshStandardMaterial color="#b47a43" roughness={0.95} />
+            </mesh>
+            <mesh castShadow position={[-0.28, 0.125, 0]}>
+                <boxGeometry args={[0.035, 0.13, 0.36]} />
+                <meshStandardMaterial color="#a16939" roughness={0.95} />
+            </mesh>
+            <mesh castShadow position={[0.28, 0.125, 0]}>
+                <boxGeometry args={[0.035, 0.13, 0.36]} />
+                <meshStandardMaterial color="#a16939" roughness={0.95} />
+            </mesh>
+            <mesh castShadow position={[0, 0.205, -0.205]}>
+                <boxGeometry args={[0.48, 0.028, 0.035]} />
+                <meshStandardMaterial color="#d09a5b" roughness={0.9} />
+            </mesh>
+            <mesh castShadow position={[0, 0.205, 0.205]}>
+                <boxGeometry args={[0.48, 0.028, 0.035]} />
+                <meshStandardMaterial color="#d09a5b" roughness={0.9} />
+            </mesh>
+            {harvestBasketProduceSlots
+                .slice(0, produceCount)
+                .map((slot, index) => (
+                    <HarvestBasketProduce
+                        key={`harvest-basket-produce-${slot.id}`}
+                        index={index}
+                        kind={
+                            visibleProduceKinds[
+                                index % visibleProduceKinds.length
+                            ]
+                        }
+                    />
+                ))}
+        </group>
+    );
+}
+
+export function RaisedBedHarvestBasketForBlock({
+    blockId,
+}: {
+    blockId: string;
+}) {
+    const { data: blockData } = useBlockData();
+    const { data: sortData } = useAllSorts();
+    const { data: garden } = useCurrentGarden();
+    const raisedBed = findRaisedBedByBlockId(garden, blockId);
+    const visualRewards = useRaisedBedOperationVisualRewards(raisedBed);
+    const isMock = useGameState((state) => state.isMock);
+    const isLocalSandbox = useGameState(
+        (state) => state.localSandboxStorageKey !== null,
+    );
+    const hasHarvestRewards = visualRewards.some(
+        (reward) =>
+            reward.family === 'harvest' && reward.raisedBedId === raisedBed?.id,
+    );
+    const deliveryRequests = useDeliveryRequests({
+        enabled:
+            Boolean(raisedBed) &&
+            hasHarvestRewards &&
+            !isMock &&
+            !isLocalSandbox,
+    });
+    const hiddenHarvestOperationIds = useMemo(
+        () =>
+            new Set(
+                (deliveryRequests.data ?? [])
+                    .filter(
+                        (request) =>
+                            request.state === 'ready' ||
+                            request.state === 'fulfilled',
+                    )
+                    .map((request) => request.operationId),
+            ),
+        [deliveryRequests.data],
+    );
+    const harvestBasketState =
+        raisedBed && raisedBed.blockId === blockId
+            ? resolveRaisedBedHarvestBasketState({
+                  fields: raisedBed.fields,
+                  hiddenOperationIds: hiddenHarvestOperationIds,
+                  raisedBedId: raisedBed.id,
+                  visualRewards,
+              })
+            : null;
+    const harvestBasketPlacement =
+        garden && raisedBed && harvestBasketState
+            ? resolveRaisedBedHarvestBasketPlacement({
+                  blockData,
+                  blockIds: getRaisedBedBlockIds(garden, raisedBed.id),
+                  stacks: garden.stacks,
+              })
+            : null;
+    const sortDataById = useMemo(
+        () => new Map((sortData ?? []).map((sort) => [sort.id, sort])),
+        [sortData],
+    );
+    const harvestProduceKinds = useMemo(
+        () =>
+            harvestBasketState?.producePlantSortIds.map((plantSortId) => {
+                const sort = sortDataById.get(plantSortId);
+
+                return resolveHarvestProduceKind([
+                    sort?.information.name,
+                    sort?.information.plant.information?.name,
+                    sort?.information.plant.information?.latinName,
+                ]);
+            }) ?? [],
+        [harvestBasketState?.producePlantSortIds, sortDataById],
+    );
+
+    if (!harvestBasketState || !harvestBasketPlacement) {
+        return null;
+    }
+
+    return (
+        <RaisedBedHarvestBasketVisual
+            fillLevel={harvestBasketState.fillLevel}
+            position={harvestBasketPlacement.position}
+            produceKinds={harvestProduceKinds}
+            rotation={harvestBasketPlacement.rotation}
+        />
+    );
+}

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -567,6 +567,29 @@ function completedDebugAppliedOperation({
     };
 }
 
+function plannedDebugAppliedOperation({
+    createdAt,
+    entityId,
+    id,
+    raisedBedId,
+}: {
+    createdAt: string;
+    entityId: number;
+    id: number;
+    raisedBedId: number;
+}): MockRaisedBed['appliedOperations'][number] {
+    return {
+        id,
+        entityId,
+        raisedBedId,
+        raisedBedFieldId: null,
+        status: 'planned',
+        createdAt,
+        completedAt: null,
+        scheduledDate: createdAt,
+    };
+}
+
 function heavyDebugWeedState(
     observedAt: string,
     eventId: number,
@@ -708,17 +731,23 @@ function applyOperationRewardDebugState({
             }
             break;
         case 'harvest':
-            if (isAfter) {
-                raisedBed.appliedOperations = [
-                    completedDebugAppliedOperation({
-                        id: 9510,
-                        entityId:
-                            operationVisualRewardDebugOperationIds.harvest,
-                        raisedBedId: raisedBed.id,
-                        completedAt: operationVisualRewardDebugTimestamp,
-                    }),
-                ];
-            }
+            raisedBed.appliedOperations = [
+                isAfter
+                    ? completedDebugAppliedOperation({
+                          id: 9510,
+                          entityId:
+                              operationVisualRewardDebugOperationIds.harvest,
+                          raisedBedId: raisedBed.id,
+                          completedAt: operationVisualRewardDebugTimestamp,
+                      })
+                    : plannedDebugAppliedOperation({
+                          id: 9510,
+                          entityId:
+                              operationVisualRewardDebugOperationIds.harvest,
+                          raisedBedId: raisedBed.id,
+                          createdAt: operationVisualRewardDebugTimestamp,
+                      }),
+            ];
             break;
     }
 }

--- a/packages/game/src/operationVisualRewardDebugProfile.ts
+++ b/packages/game/src/operationVisualRewardDebugProfile.ts
@@ -147,7 +147,7 @@ export const operationVisualRewardDebugScenarios = [
         before: {
             label: 'Before',
             raisedBedId: 115,
-            state: 'Ripe plants',
+            state: 'Requested harvest basket',
         },
         after: {
             label: 'After',


### PR DESCRIPTION
Summary:
- render harvest baskets from the instanced raised-bed renderer used by debug/profile views
- add planned harvest fixture data so the debug matrix shows the empty requested basket
- keep completed harvest baskets filled with matching produce and hidden for ready deliveries

Validation:
- pnpm --filter @gredice/game exec biome check src/entities/raisedBed/RaisedBedHarvestBasket.tsx src/entities/AdditionalEntityInstances.tsx src/entities/RaisedBed.tsx src/hooks/useCurrentGarden.ts src/operationVisualRewardDebugProfile.ts
- pnpm --filter @gredice/game typecheck
- pnpm --filter @gredice/game test