### PR TITLE
Restore support reward debug visuals

### DIFF
--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -760,8 +760,8 @@ function RaisedBedFieldSupportVisual({
 
     return (
         <group position={position}>
-            <mesh castShadow position={[0, 0.24, 0]} renderOrder={3}>
-                <cylinderGeometry args={[0.012, 0.014, 0.48, 5]} />
+            <mesh castShadow position={[0, 0.39, 0]} renderOrder={8}>
+                <cylinderGeometry args={[0.018, 0.022, 0.78, 6]} />
                 <meshStandardMaterial color="#7a4f2b" roughness={0.9} />
             </mesh>
         </group>

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -238,8 +238,8 @@ const DEMO_RAISED_BED_FIELD_LAYOUT: MockRaisedBedFieldConfig[] = [
     },
 ];
 
-function mockDaysAgoIso(daysAgo: number) {
-    const date = new Date();
+function mockDaysAgoIso(daysAgo: number, referenceDate: string) {
+    const date = new Date(referenceDate);
     date.setDate(date.getDate() - daysAgo);
     return date.toISOString();
 }
@@ -254,12 +254,13 @@ function mockRaisedBedField(
     raisedBedId: number,
     id: number,
     field: MockRaisedBedFieldConfig,
+    referenceDate: string,
 ): MockRaisedBedField {
-    const plantSowDate = mockDaysAgoIso(field.sowDaysAgo);
-    const plantGrowthDate = mockDaysAgoIso(field.growthDaysAgo);
+    const plantSowDate = mockDaysAgoIso(field.sowDaysAgo, referenceDate);
+    const plantGrowthDate = mockDaysAgoIso(field.growthDaysAgo, referenceDate);
     const plantReadyDate =
         field.readyDaysAgo != null
-            ? mockDaysAgoIso(field.readyDaysAgo)
+            ? mockDaysAgoIso(field.readyDaysAgo, referenceDate)
             : undefined;
 
     return {
@@ -322,9 +323,15 @@ function mockRaisedBedField(
 function mockRaisedBedFields(
     raisedBedId: number,
     idOffset: number,
+    referenceDate: string,
 ): MockRaisedBed['fields'] {
     return DEMO_RAISED_BED_FIELD_LAYOUT.map((field, index) =>
-        mockRaisedBedField(raisedBedId, idOffset + index + 1, field),
+        mockRaisedBedField(
+            raisedBedId,
+            idOffset + index + 1,
+            field,
+            referenceDate,
+        ),
     );
 }
 
@@ -484,7 +491,7 @@ function createProfileRaisedBed(
         name: `Profile raised bed ${id}`,
         blockId,
         physicalId: `profile-raised-bed:${id}`,
-        fields: mockRaisedBedFields(id, fieldOffset),
+        fields: mockRaisedBedFields(id, fieldOffset, now),
         appliedOperations: [],
         weedState: null,
         status: 'new',
@@ -834,7 +841,7 @@ function denseMockGarden(
 function operationRewardDebugMockGarden(
     winterMode: WinterMode,
 ): useCurrentGardenResponse {
-    const now = new Date().toISOString();
+    const now = operationVisualRewardDebugTimestamp;
     const { stackByPosition, stacks } =
         createOperationRewardDebugStacks(winterMode);
     const raisedBeds: useCurrentGardenResponse['raisedBeds'] = [];
@@ -905,7 +912,7 @@ function mockGarden(
             name: 'Raised Bed 1',
             blockId: '3',
             physicalId: '42',
-            fields: mockRaisedBedFields(1, 0),
+            fields: mockRaisedBedFields(1, 0, now),
             appliedOperations: [],
             weedState: null,
             status: 'new',
@@ -920,7 +927,7 @@ function mockGarden(
             name: 'Raised Bed 2',
             physicalId: '42',
             blockId: '8',
-            fields: mockRaisedBedFields(2, 100),
+            fields: mockRaisedBedFields(2, 100, now),
             appliedOperations: [],
             weedState: null,
             status: 'new',


### PR DESCRIPTION
Summary:
- align operation-reward mock plant dates with the frozen debug reward timestamp
- restore support rewards in the debug/profile matrix after plant-cycle filtering
- make the single center support stake more readable at profile zoom

Validation:
- pnpm --filter @gredice/game exec biome check src/hooks/useCurrentGarden.ts src/entities/raisedBed/RaisedBedFields.tsx
- pnpm --filter @gredice/game typecheck
- pnpm --filter @gredice/game test
- pnpm --filter garden profile:game -- --scenario-set rewards --screenshots (screenshot verified; known long-task budget failure remains)