### PR TITLE
[codex] Hide block hover outlines while dragging

### DIFF
--- a/packages/game/src/controls/GardenBoxSelectableGroup.tsx
+++ b/packages/game/src/controls/GardenBoxSelectableGroup.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import type { Block } from '../types/Block';
+import { useGameState } from '../useGameState';
 import {
     gardenBoxesInventoryTab,
     useBackpackInventoryParams,
@@ -14,10 +15,17 @@ export function GardenBoxSelectableGroup({
 }: PropsWithChildren<{ block: Block }>) {
     const { track } = useGameAnalytics();
     const hovered = useHoveredBlockStore();
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
     const [, setBackpackInventoryParams] = useBackpackInventoryParams();
     const handleClick = useDeferredSingleClick(handleSelected);
 
     function handleSelected() {
+        if (hasActiveDragPreview) {
+            return;
+        }
+
         track('game_garden_box_inventory_opened', {
             block_id: block.id,
         });
@@ -32,6 +40,10 @@ export function GardenBoxSelectableGroup({
         // biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive
         <group
             onPointerEnter={(event) => {
+                if (hasActiveDragPreview) {
+                    return;
+                }
+
                 event.stopPropagation();
                 hovered.setHoveredBlock(block);
             }}

--- a/packages/game/src/controls/GiftBoxSelectableGroup.tsx
+++ b/packages/game/src/controls/GiftBoxSelectableGroup.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import type { Block } from '../types/Block';
+import { useGameState } from '../useGameState';
 import { useGiftBoxParam } from '../useUrlState';
 import { useDeferredSingleClick } from './useDeferredSingleClick';
 import { useHoveredBlockStore } from './useHoveredBlockStore';
@@ -9,10 +10,17 @@ export function GiftBoxSelectableGroup({
     block,
 }: PropsWithChildren<{ block: Block }>) {
     const hovered = useHoveredBlockStore();
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
     const [, setGiftBoxParam] = useGiftBoxParam();
     const handleClick = useDeferredSingleClick(handleSelected);
 
     function handleSelected() {
+        if (hasActiveDragPreview) {
+            return;
+        }
+
         setGiftBoxParam(block.id);
     }
 
@@ -20,6 +28,10 @@ export function GiftBoxSelectableGroup({
         // biome-ignore lint/a11y/noStaticElementInteractions: Three.js element is interactive
         <group
             onPointerEnter={(event) => {
+                if (hasActiveDragPreview) {
+                    return;
+                }
+
                 event.stopPropagation();
                 hovered.setHoveredBlock(block);
             }}

--- a/packages/game/src/controls/RaisedBedSelectableGroup.tsx
+++ b/packages/game/src/controls/RaisedBedSelectableGroup.tsx
@@ -1,6 +1,7 @@
 import { type PropsWithChildren, useRef } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import type { Block } from '../types/Block';
+import { useGameState } from '../useGameState';
 import {
     useRemoveRaisedBedCloseupParam,
     useSetRaisedBedCloseupParam,
@@ -16,6 +17,9 @@ export function RaisedBedSelectableGroup({
     const groupRef = useRef(null);
     const { track } = useGameAnalytics();
     const hovered = useHoveredBlockStore();
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
     const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
     const { mutate: removeRaisedBedCloseupParam } =
         useRemoveRaisedBedCloseupParam();
@@ -26,6 +30,10 @@ export function RaisedBedSelectableGroup({
     }
 
     function handleOpenChange(open: boolean) {
+        if (open && hasActiveDragPreview) {
+            return;
+        }
+
         if (open) {
             track('game_raised_bed_opened', {
                 block_id: block.id,
@@ -43,6 +51,10 @@ export function RaisedBedSelectableGroup({
         <group
             ref={groupRef}
             onPointerEnter={(event) => {
+                if (hasActiveDragPreview) {
+                    return;
+                }
+
                 event.stopPropagation();
                 hovered.setHoveredBlock(block);
             }}

--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -746,8 +746,15 @@ function RaisedBedHoverOutlines({
     stacks: Stack[] | undefined;
 }) {
     const hoveredBlock = useHoveredBlockStore((state) => state.hoveredBlock);
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
 
-    if (hoveredBlock?.name !== 'Raised_Bed' || !stacks) {
+    if (
+        hasActiveDragPreview ||
+        hoveredBlock?.name !== 'Raised_Bed' ||
+        !stacks
+    ) {
         return null;
     }
 
@@ -1154,6 +1161,9 @@ function GardenBoxHoverOutlines({
     openGardenBoxBlockId: string | null;
 }) {
     const hoveredBlock = useHoveredBlockStore((state) => state.hoveredBlock);
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
     const isLocalSandbox = useGameState(
         (state) => state.localSandboxStorageKey !== null,
     );
@@ -1167,7 +1177,9 @@ function GardenBoxHoverOutlines({
         const lidOpen =
             hoveredGardenBoxBlockId === instance.block.id ||
             openGardenBoxBlockId === instance.block.id;
-        const hovered = hoveredBlock === instance.block || lidOpen;
+        const hovered =
+            (!hasActiveDragPreview && hoveredBlock === instance.block) ||
+            lidOpen;
 
         if (!hovered) {
             return null;
@@ -1669,6 +1681,9 @@ function GiftBoxHoverOutlines({
     stacks: Stack[] | undefined;
 }) {
     const hoveredBlock = useHoveredBlockStore((state) => state.hoveredBlock);
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
     const instances = useEntityBlockInstances({
         name,
         stacks,
@@ -1676,7 +1691,7 @@ function GiftBoxHoverOutlines({
     });
 
     return instances?.map((instance) => {
-        if (hoveredBlock !== instance.block) {
+        if (hasActiveDragPreview || hoveredBlock !== instance.block) {
             return null;
         }
 

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -1,6 +1,6 @@
 import { Edges } from '@react-three/drei';
 import type { ThreeEvent } from '@react-three/fiber';
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren, useEffect } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import {
     createBlockInteractionTargetKey,
@@ -112,7 +112,10 @@ function InstancedEntitySelectionRegistration({
 }) {
     const { data: garden } = useCurrentGarden();
     const { track } = useGameAnalytics();
-    const hovered = useHoveredBlockStore();
+    const hoveredBlock = useHoveredBlockStore((state) => state.hoveredBlock);
+    const setHoveredBlock = useHoveredBlockStore(
+        (state) => state.setHoveredBlock,
+    );
     const isSandbox = useIsSandboxGarden();
     const hasActiveDragPreview = useGameState((state) =>
         Boolean(state.activeDragPreview),
@@ -130,9 +133,21 @@ function InstancedEntitySelectionRegistration({
         block.name === 'GardenBox' ||
         block.name.startsWith('GiftBox_') ||
         Boolean(raisedBed);
+    const selectionHoverEnabled = selectable && !hasActiveDragPreview;
+
+    useEffect(() => {
+        if (hasActiveDragPreview && hoveredBlock === block) {
+            setHoveredBlock(null);
+        }
+    }, [block, hasActiveDragPreview, hoveredBlock, setHoveredBlock]);
+
     const handleSelected = useDeferredSingleClick(() => {
+        if (hasActiveDragPreview) {
+            return;
+        }
+
         if (block.name === 'GardenBox') {
-            if (!isSandbox && !hasActiveDragPreview) {
+            if (!isSandbox) {
                 setOpenGardenBoxBlockId(block.id);
             }
             return;
@@ -144,7 +159,7 @@ function InstancedEntitySelectionRegistration({
                 raised_bed_name: raisedBed.name,
             });
             setRaisedBedCloseupParam(raisedBed.name);
-            hovered.setHoveredBlock(null);
+            setHoveredBlock(null);
             return;
         }
 
@@ -168,14 +183,20 @@ function InstancedEntitySelectionRegistration({
             },
             ...(selectable
                 ? {
-                      onPointerEnter: (event: ThreeEvent<PointerEvent>) => {
-                          event.stopPropagation();
-                          hovered.setHoveredBlock(block);
-                      },
+                      ...(selectionHoverEnabled
+                          ? {
+                                onPointerEnter: (
+                                    event: ThreeEvent<PointerEvent>,
+                                ) => {
+                                    event.stopPropagation();
+                                    setHoveredBlock(block);
+                                },
+                            }
+                          : {}),
                       onPointerLeave: (event: ThreeEvent<PointerEvent>) => {
-                          if (hovered.hoveredBlock === block) {
+                          if (hoveredBlock === block) {
                               event.stopPropagation();
-                              hovered.setHoveredBlock(null);
+                              setHoveredBlock(null);
                           }
                       },
                   }

--- a/packages/game/src/entities/RaisedBed.tsx
+++ b/packages/game/src/entities/RaisedBed.tsx
@@ -29,11 +29,15 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
     const visitSummaryHighlight = useGameState(
         (state) => state.gardenVisitSummaryHighlight,
     );
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
     const hoveredRaisedBed = hoveredBlock
         ? findRaisedBedByBlockId(garden, hoveredBlock.id)
         : null;
     const hovered = Boolean(
-        garden &&
+        !hasActiveDragPreview &&
+            garden &&
             hoveredRaisedBed &&
             getRaisedBedBlockIds(garden, hoveredRaisedBed.id).includes(
                 block.id,

--- a/packages/game/src/entities/helpers/GardenBox.tsx
+++ b/packages/game/src/entities/helpers/GardenBox.tsx
@@ -39,6 +39,8 @@ export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
         !isLocalSandbox &&
         (hoveredGardenBoxBlockId === block.id ||
             openGardenBoxBlockId === block.id);
+    const showHoverOutline =
+        !isLocalSandbox && ((!hasActiveDragPreview && hovered) || isLidOpen);
     const { rotation: lidRotation } = useSpring({
         config: {
             mass: 0.18,
@@ -55,11 +57,7 @@ export function GardenBox({ stack, block, rotation }: EntityInstanceProps) {
     });
 
     return (
-        <HoverOutline
-            hovered={!isLocalSandbox && (hovered || isLidOpen)}
-            thickness={7}
-            color="#f8fafc"
-        >
+        <HoverOutline hovered={showHoverOutline} thickness={7} color="#f8fafc">
             <animated.group
                 onClick={handleClick}
                 position={stack.position.clone().setY(currentStackHeight)}

--- a/packages/game/src/entities/helpers/GiftBox.tsx
+++ b/packages/game/src/entities/helpers/GiftBox.tsx
@@ -3,6 +3,7 @@ import { useHoveredBlockStore } from '../../controls/useHoveredBlockStore';
 import { SnowOverlay } from '../../snow/SnowOverlay';
 import { snowPresets } from '../../snow/snowPresets';
 import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProps';
+import { useGameState } from '../../useGameState';
 import { useStackHeight } from '../../utils/getStackHeight';
 import { useGameGLTF } from '../../utils/useGameGLTF';
 import { HoverOutline } from './HoverOutline';
@@ -29,9 +30,12 @@ export function GiftBox({
     const currentStackHeight = useStackHeight(stack, block);
     const hovered =
         useHoveredBlockStore((state) => state.hoveredBlock) === block;
+    const hasActiveDragPreview = useGameState((state) =>
+        Boolean(state.activeDragPreview),
+    );
 
     return (
-        <HoverOutline hovered={hovered}>
+        <HoverOutline hovered={!hasActiveDragPreview && hovered}>
             <animated.group
                 position={stack.position
                     .clone()


### PR DESCRIPTION
## Summary

- Suppress selectable block hover handlers while a block drag preview is active.
- Gate raised-bed, gift-box, and garden-box selection outlines so stale hover state cannot render outlines during pickup dragging.
- Preserve garden-box drop-target/open-lid feedback while dragging blocks.

## Root Cause

Selectable hover state was still being set and rendered while `activeDragPreview` was active, even though selecting another block is not possible during a pickup drag.

## Validation

- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter @gredice/game test`
- `git diff --check`

Browser smoke check: `/debug/sandbox` loaded with a WebGL canvas and no console errors. The browser screenshot call timed out on the WebGL view, so there is no visual proof screenshot.