### PR TITLE
[codex] Use material shader for raised bed soil

### DIFF
--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -11,11 +11,16 @@ import { useHoveredBlockStore } from '../controls/useHoveredBlockStore';
 import type { GameAssetName } from '../data/models';
 import { useBlockData } from '../hooks/useBlockData';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useOperations } from '../hooks/useOperations';
+import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import type { GLTFResult } from '../models/GameAssets';
 import { snowPresets } from '../snow/snowPresets';
 import type { Stack } from '../types/Stack';
 import { useGameState } from '../useGameState';
-import { getConnectedRaisedBedBlockIds } from '../utils/raisedBedBlocks';
+import {
+    getConnectedRaisedBedBlockIds,
+    getRaisedBedBlockIds,
+} from '../utils/raisedBedBlocks';
 import { useGameGLTF } from '../utils/useGameGLTF';
 import { useWaterBlockMaterial } from './BlockWater';
 import { getCactusVariantConfig } from './Cactus';
@@ -36,6 +41,10 @@ import { resolveEntityNeighbors } from './helpers/useEntityNeighbors';
 import { RaisedBedFields } from './raisedBed/RaisedBedFields';
 import { RaisedBedGeneratedPlantFieldBatches } from './raisedBed/RaisedBedGeneratedPlantFieldBatches';
 import { RaisedBedHarvestBasketForBlock } from './raisedBed/RaisedBedHarvestBasket';
+import {
+    getRaisedBedSoilWetPatches,
+    resolveRaisedBedWateringVisualRewards,
+} from './raisedBed/raisedBedSoilWetPatches';
 import {
     resolveWaterFoamCorners,
     resolveWaterFoamEdges,
@@ -627,11 +636,102 @@ function RaisedBedInstances({
     ...commonSnowProps
 }: { stacks: Stack[] | undefined } & CommonWeatherProps) {
     const { nodes, materials } = useGameGLTF('RaisedBed');
+    const { data: currentGarden } = useCurrentGarden();
+    const { data: operations } = useOperations();
+    const currentTime = useSnapshotTime();
     const instances = useEntityBlockInstances({
         name: 'Raised_Bed',
         stacks,
         yOffset: 1,
     })?.map((instance) => resolveRaisedBedInstance(instance, stacks));
+    const raisedBedContextByBlockId = useMemo(() => {
+        const context = new Map<
+            string,
+            {
+                blockIndex: number;
+                blockOffset: number;
+                raisedBed: NonNullable<
+                    typeof currentGarden
+                >['raisedBeds'][number];
+            }
+        >();
+
+        if (!currentGarden) {
+            return context;
+        }
+
+        for (const raisedBed of currentGarden.raisedBeds) {
+            const blockIds = getRaisedBedBlockIds(currentGarden, raisedBed.id);
+
+            blockIds.forEach((blockId, blockIndex) => {
+                context.set(blockId, {
+                    blockIndex,
+                    blockOffset:
+                        Math.max(blockIds.length - 1 - blockIndex, 0) * 9,
+                    raisedBed,
+                });
+            });
+        }
+
+        return context;
+    }, [currentGarden]);
+    const wateringRewardsByRaisedBedId = useMemo(() => {
+        const rewards = new Map<
+            number,
+            ReturnType<typeof resolveRaisedBedWateringVisualRewards>
+        >();
+
+        if (!currentGarden) {
+            return rewards;
+        }
+
+        for (const raisedBed of currentGarden.raisedBeds) {
+            rewards.set(
+                raisedBed.id,
+                resolveRaisedBedWateringVisualRewards({
+                    operations,
+                    raisedBed,
+                }),
+            );
+        }
+
+        return rewards;
+    }, [currentGarden, operations]);
+    const soilWetPatches = useMemo(
+        () =>
+            instances?.flatMap((instance) => {
+                const context = raisedBedContextByBlockId.get(
+                    instance.block.id,
+                );
+
+                if (!context) {
+                    return [];
+                }
+
+                return getRaisedBedSoilWetPatches({
+                    blockIndex: context.blockIndex,
+                    blockOffset: context.blockOffset,
+                    blockPosition: instance.position,
+                    currentTime,
+                    raisedBed: context.raisedBed,
+                    visualRewards:
+                        wateringRewardsByRaisedBedId.get(
+                            context.raisedBed.id,
+                        ) ?? [],
+                });
+            }) ?? [],
+        [
+            currentTime,
+            instances,
+            raisedBedContextByBlockId,
+            wateringRewardsByRaisedBedId,
+        ],
+    );
+    const raisedBedSoilMaterial = useGroundPatchMaterial(
+        materials[dirtMaterialName],
+        'raisedBedSoil',
+        { wetPatches: soilWetPatches },
+    );
 
     if (!instances?.length) {
         return null;
@@ -647,12 +747,12 @@ function RaisedBedInstances({
                 const shape2 = `${shape}_2` as keyof GLTFResult['nodes'];
                 const shape1Material =
                     shape1 === 'Raised_Bed_O_1'
-                        ? planksMaterialName
-                        : dirtMaterialName;
+                        ? materials[planksMaterialName]
+                        : raisedBedSoilMaterial;
                 const shape2Material =
                     shape2 === 'Raised_Bed_O_2'
-                        ? dirtMaterialName
-                        : planksMaterialName;
+                        ? raisedBedSoilMaterial
+                        : materials[planksMaterialName];
 
                 return (
                     <Suspense key={shape} fallback={null}>
@@ -660,7 +760,7 @@ function RaisedBedInstances({
                             instanceKey={shape1}
                             instances={shapeInstances}
                             geometry={nodes[shape1].geometry}
-                            material={materials[shape1Material]}
+                            material={shape1Material}
                             renderRainWetOverlay
                             snow={{
                                 maxThickness: 0.16,
@@ -674,7 +774,7 @@ function RaisedBedInstances({
                             instanceKey={shape2}
                             instances={shapeInstances}
                             geometry={nodes[shape2].geometry}
-                            material={materials[shape2Material]}
+                            material={shape2Material}
                             renderRainWetOverlay
                             snow={{
                                 maxThickness: 0.16,

--- a/packages/game/src/entities/RaisedBed.tsx
+++ b/packages/game/src/entities/RaisedBed.tsx
@@ -1,7 +1,10 @@
 import { animated } from '@react-spring/three';
+import { useMemo } from 'react';
 import { Vector3 } from 'three';
 import { useHoveredBlockStore } from '../controls/useHoveredBlockStore';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useRaisedBedOperationVisualRewards } from '../hooks/useRaisedBedOperationVisualRewards';
+import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
@@ -12,10 +15,12 @@ import {
     getRaisedBedBlockIds,
 } from '../utils/raisedBedBlocks';
 import { useGameGLTF } from '../utils/useGameGLTF';
+import { useGroundPatchMaterial } from './helpers/groundPatchMaterial';
 import { HoverOutline } from './helpers/HoverOutline';
 import { useEntityNeighbors } from './helpers/useEntityNeighbors';
 import { RaisedBedFields } from './raisedBed/RaisedBedFields';
 import { RaisedBedHarvestBasketForBlock } from './raisedBed/RaisedBedHarvestBasket';
+import { getRaisedBedSoilWetPatches } from './raisedBed/raisedBedSoilWetPatches';
 
 const combinedOverlap = 0.1;
 const halfOverlap = combinedOverlap / 2;
@@ -26,12 +31,16 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
     const hoveredBlock = useHoveredBlockStore((state) => state.hoveredBlock);
     const { data: garden } = useCurrentGarden();
     const raisedBed = findRaisedBedByBlockId(garden, block.id);
+    const visualRewards = useRaisedBedOperationVisualRewards(raisedBed);
+    const currentTime = useSnapshotTime();
     const visitSummaryHighlight = useGameState(
         (state) => state.gardenVisitSummaryHighlight,
     );
     const hoveredRaisedBed = hoveredBlock
         ? findRaisedBedByBlockId(garden, hoveredBlock.id)
         : null;
+    const raisedBedBlockIds =
+        garden && raisedBed ? getRaisedBedBlockIds(garden, raisedBed.id) : [];
     const hovered = Boolean(
         garden &&
             hoveredRaisedBed &&
@@ -118,6 +127,39 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
     const isVisitSummaryHighlighted =
         raisedBed?.id != null &&
         visitSummaryHighlight?.raisedBedId === raisedBed.id;
+    const blockIndex = Math.max(raisedBedBlockIds.indexOf(block.id), 0);
+    const blockOffset =
+        Math.max(raisedBedBlockIds.length - 1 - blockIndex, 0) * 9;
+    const soilWetPatches = useMemo(
+        () =>
+            getRaisedBedSoilWetPatches({
+                blockIndex,
+                blockOffset,
+                blockPosition: [
+                    raisedBedPosition.x,
+                    raisedBedPosition.y,
+                    raisedBedPosition.z,
+                ],
+                currentTime,
+                raisedBed,
+                visualRewards,
+            }),
+        [
+            blockIndex,
+            blockOffset,
+            currentTime,
+            raisedBed,
+            raisedBedPosition.x,
+            raisedBedPosition.y,
+            raisedBedPosition.z,
+            visualRewards,
+        ],
+    );
+    const raisedBedSoilMaterial = useGroundPatchMaterial(
+        materials['Material.Dirt'],
+        'raisedBedSoil',
+        { wetPatches: soilWetPatches },
+    );
 
     return (
         <>
@@ -137,11 +179,9 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
                         receiveShadow
                         geometry={nodes[shape1].geometry}
                         material={
-                            materials[
-                                shape1 === 'Raised_Bed_O_1'
-                                    ? 'Material.Planks'
-                                    : 'Material.Dirt'
-                            ]
+                            shape1 === 'Raised_Bed_O_1'
+                                ? materials['Material.Planks']
+                                : raisedBedSoilMaterial
                         }
                     />
                     <SnowOverlay
@@ -157,11 +197,9 @@ export function RaisedBed({ stack, block }: EntityInstanceProps) {
                         receiveShadow
                         geometry={nodes[shape2].geometry}
                         material={
-                            materials[
-                                shape2 === 'Raised_Bed_O_2'
-                                    ? 'Material.Dirt'
-                                    : 'Material.Planks'
-                            ]
+                            shape2 === 'Raised_Bed_O_2'
+                                ? raisedBedSoilMaterial
+                                : materials['Material.Planks']
                         }
                     />
                     <SnowOverlay

--- a/packages/game/src/entities/helpers/groundPatchMaterial.ts
+++ b/packages/game/src/entities/helpers/groundPatchMaterial.ts
@@ -1,7 +1,24 @@
 import { useMemo } from 'react';
-import { Color, type Material, MeshStandardMaterial } from 'three';
+import { Color, type Material, MeshStandardMaterial, Vector2 } from 'three';
 
-export type GroundPatchSurface = 'dirt' | 'grass' | 'sand' | 'snow';
+export type GroundPatchSurface =
+    | 'dirt'
+    | 'grass'
+    | 'raisedBedSoil'
+    | 'sand'
+    | 'snow';
+
+export type GroundPatchWetPatch = {
+    center: readonly [number, number];
+    halfSize: readonly [number, number];
+    strength?: number;
+};
+
+type GroundPatchOptions = {
+    wetColor?: string;
+    wetPatches?: readonly GroundPatchWetPatch[];
+    wetStrength?: number;
+};
 
 type GroundPatchPreset = {
     darkColor: string;
@@ -33,14 +50,24 @@ const groundPatchPresets = {
         lightStrength: 0.42,
         mode: 2,
     },
+    raisedBedSoil: {
+        darkColor: '#2c2018',
+        darkStrength: 0.32,
+        lightColor: '#75634f',
+        lightStrength: 0.34,
+        mode: 3,
+    },
     snow: {
         darkColor: '#bddcf0',
         darkStrength: 0.32,
         lightColor: '#f9fdff',
         lightStrength: 0.04,
-        mode: 3,
+        mode: 4,
     },
 } satisfies Record<GroundPatchSurface, GroundPatchPreset>;
+
+const maxWetPatchCount = 48;
+const emptyWetPatches: readonly GroundPatchWetPatch[] = [];
 
 const groundPatchVertexParameters = `
 varying vec3 vGroundPatchWorldPosition;
@@ -66,6 +93,12 @@ uniform vec3 uGroundPatchLightColor;
 uniform vec3 uGroundPatchDarkColor;
 uniform float uGroundPatchLightStrength;
 uniform float uGroundPatchDarkStrength;
+uniform float uGroundPatchWetPatchCount;
+uniform vec2 uGroundPatchWetPatchCenters[${maxWetPatchCount}];
+uniform vec2 uGroundPatchWetPatchHalfSizes[${maxWetPatchCount}];
+uniform float uGroundPatchWetPatchStrengths[${maxWetPatchCount}];
+uniform vec3 uGroundPatchWetColor;
+uniform float uGroundPatchWetStrength;
 
 float groundPatchHash(vec3 p) {
     return fract(sin(dot(p, vec3(127.1, 311.7, 74.7))) * 43758.5453123);
@@ -125,6 +158,29 @@ float groundPatchLayeredNoiseMask(vec3 p, float scale, float threshold, float ed
     return smoothstep(threshold, threshold + edge, field);
 }
 
+float groundPatchWetMask(vec3 worldPosition) {
+    float wetMask = 0.0;
+    vec2 point = worldPosition.xz;
+
+    for (int i = 0; i < ${maxWetPatchCount}; i++) {
+        if (float(i) >= uGroundPatchWetPatchCount) {
+            break;
+        }
+
+        vec2 halfSize = max(uGroundPatchWetPatchHalfSizes[i], vec2(0.001));
+        vec2 normalized = abs(point - uGroundPatchWetPatchCenters[i]) / halfSize;
+        float edge = max(normalized.x, normalized.y);
+        float wetPatch = 1.0 - smoothstep(0.58, 1.0, edge);
+        float mottled = 0.74 + groundPatchFbm(
+            vec3(point.x * 9.0, worldPosition.y * 1.7, point.y * 9.0) +
+            vec3(float(i) * 2.9, 4.2, 7.3)
+        ) * 0.26;
+        wetMask = max(wetMask, wetPatch * mottled * uGroundPatchWetPatchStrengths[i]);
+    }
+
+    return clamp(wetMask * uGroundPatchWetStrength, 0.0, 1.0);
+}
+
 vec2 groundPatchMasks(vec3 worldPosition) {
     vec3 p = worldPosition;
 
@@ -167,6 +223,35 @@ vec2 groundPatchMasks(vec3 worldPosition) {
         return vec2(lightMask, darkMask);
     }
 
+    if (uGroundPatchMode < 3.5) {
+        vec2 flow = vec2(
+            groundPatchFbm(p * vec3(1.1, 0.16, 1.3) + vec3(2.2, 0.0, 6.4)),
+            groundPatchFbm(p * vec3(1.24, 0.16, 1.04) + vec3(8.1, 3.0, 1.7))
+        ) - 0.5;
+        vec3 soilP = p + vec3(flow.x * 0.22, 0.0, flow.y * 0.22);
+        float warmGranules = groundPatchFbm(
+            soilP * vec3(8.0, 2.0, 8.0) + vec3(4.6, 1.3, 9.2)
+        );
+        float paleDust = groundPatchFbm(
+            soilP * vec3(16.0, 3.0, 16.0) + vec3(1.8, 5.6, 2.7)
+        );
+        float darkGrain = groundPatchFbm(
+            soilP * vec3(11.0, 2.5, 11.0) + vec3(7.8, 3.3, 5.1)
+        );
+        float dryClods = groundPatchFbm(
+            soilP * vec3(3.4, 0.9, 3.4) + vec3(6.0, 0.0, 12.0)
+        );
+        float lightMask =
+            smoothstep(0.58, 0.86, warmGranules) * 0.44 +
+            smoothstep(0.72, 0.96, paleDust) * 0.36;
+        float darkMask =
+            smoothstep(0.46, 0.76, dryClods) * 0.28 +
+            smoothstep(0.66, 0.9, darkGrain) * 0.3;
+        darkMask *= 1.0 - lightMask * 0.36;
+
+        return vec2(clamp(lightMask, 0.0, 1.0), clamp(darkMask, 0.0, 1.0));
+    }
+
     vec2 snowFlow = vec2(
         groundPatchFbm(p * vec3(0.54, 0.14, 0.62) + vec3(6.4, 2.0, 11.3)),
         groundPatchFbm(p * vec3(0.62, 0.14, 0.54) + vec3(2.8, 5.4, 1.8))
@@ -186,6 +271,8 @@ vec3 applyGroundPatches(vec3 baseColor, vec3 worldPosition) {
     vec2 masks = groundPatchMasks(worldPosition);
     vec3 patchedColor = mix(baseColor, uGroundPatchLightColor, masks.x * uGroundPatchLightStrength);
     patchedColor = mix(patchedColor, uGroundPatchDarkColor, masks.y * uGroundPatchDarkStrength);
+    float wetMask = groundPatchWetMask(worldPosition);
+    patchedColor = mix(patchedColor, uGroundPatchWetColor, wetMask);
 
     return patchedColor;
 }
@@ -195,11 +282,59 @@ const groundPatchColorFragment = `
 diffuseColor.rgb = applyGroundPatches(diffuseColor.rgb, vGroundPatchWorldPosition);
 `;
 
+function wetPatchKey(wetPatches: readonly GroundPatchWetPatch[]) {
+    return wetPatches
+        .slice(0, maxWetPatchCount)
+        .map(
+            (patch) =>
+                `${patch.center[0].toFixed(3)},${patch.center[1].toFixed(3)},${patch.halfSize[0].toFixed(3)},${patch.halfSize[1].toFixed(3)},${(patch.strength ?? 1).toFixed(3)}`,
+        )
+        .join('|');
+}
+
+function createWetPatchUniforms(
+    wetPatches: readonly GroundPatchWetPatch[],
+    options: GroundPatchOptions,
+) {
+    const centers = Array.from(
+        { length: maxWetPatchCount },
+        () => new Vector2(),
+    );
+    const halfSizes = Array.from(
+        { length: maxWetPatchCount },
+        () => new Vector2(0.001, 0.001),
+    );
+    const strengths = Array.from({ length: maxWetPatchCount }, () => 0);
+    const cappedPatches = wetPatches.slice(0, maxWetPatchCount);
+
+    cappedPatches.forEach((patch, index) => {
+        centers[index]?.set(patch.center[0], patch.center[1]);
+        halfSizes[index]?.set(
+            Math.max(patch.halfSize[0], 0.001),
+            Math.max(patch.halfSize[1], 0.001),
+        );
+        strengths[index] = patch.strength ?? 1;
+    });
+
+    return {
+        uGroundPatchWetPatchCount: { value: cappedPatches.length },
+        uGroundPatchWetPatchCenters: { value: centers },
+        uGroundPatchWetPatchHalfSizes: { value: halfSizes },
+        uGroundPatchWetPatchStrengths: { value: strengths },
+        uGroundPatchWetColor: {
+            value: new Color(options.wetColor ?? '#2f241d'),
+        },
+        uGroundPatchWetStrength: { value: options.wetStrength ?? 0.92 },
+    };
+}
+
 function applyGroundPatchMaterial(
     material: MeshStandardMaterial,
     surface: GroundPatchSurface,
+    options: GroundPatchOptions,
 ) {
     const preset = groundPatchPresets[surface];
+    const wetPatches = options.wetPatches ?? emptyWetPatches;
     const originalOnBeforeCompile = material.onBeforeCompile.bind(material);
     const originalCustomProgramCacheKey =
         material.customProgramCacheKey.bind(material);
@@ -220,6 +355,10 @@ function applyGroundPatchMaterial(
         shader.uniforms.uGroundPatchDarkStrength = {
             value: preset.darkStrength,
         };
+        Object.assign(
+            shader.uniforms,
+            createWetPatchUniforms(wetPatches, options),
+        );
         shader.vertexShader = shader.vertexShader
             .replace(
                 '#include <common>',
@@ -249,34 +388,44 @@ function applyGroundPatchMaterial(
 function createGroundPatchMaterial(
     material: Material,
     surface: GroundPatchSurface,
+    options: GroundPatchOptions,
 ) {
     if (!(material instanceof MeshStandardMaterial)) {
         return material;
     }
 
-    return applyGroundPatchMaterial(material.clone(), surface);
+    return applyGroundPatchMaterial(material.clone(), surface, options);
 }
 
 export function useGroundPatchMaterial(
     material: undefined,
     surface: GroundPatchSurface | undefined,
+    options?: GroundPatchOptions,
 ): undefined;
 export function useGroundPatchMaterial(
     material: Material,
     surface: GroundPatchSurface | undefined,
+    options?: GroundPatchOptions,
 ): Material;
 export function useGroundPatchMaterial(
     material: Material[],
     surface: GroundPatchSurface | undefined,
+    options?: GroundPatchOptions,
 ): Material[];
 export function useGroundPatchMaterial(
     material: Material | Material[],
     surface: GroundPatchSurface | undefined,
+    options?: GroundPatchOptions,
 ): Material | Material[];
 export function useGroundPatchMaterial(
     material: Material | Material[] | undefined,
     surface: GroundPatchSurface | undefined,
+    options: GroundPatchOptions = {},
 ) {
+    const wetPatches = options.wetPatches ?? emptyWetPatches;
+    const key = wetPatchKey(wetPatches);
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: wet patch values are tracked by key so equal patch arrays do not recompile materials.
     return useMemo(() => {
         if (!material || !surface) {
             return material;
@@ -284,12 +433,12 @@ export function useGroundPatchMaterial(
 
         if (Array.isArray(material)) {
             return material.map((item) =>
-                createGroundPatchMaterial(item, surface),
+                createGroundPatchMaterial(item, surface, options),
             );
         }
 
-        return createGroundPatchMaterial(material, surface);
-    }, [material, surface]);
+        return createGroundPatchMaterial(material, surface, options);
+    }, [key, material, options.wetColor, options.wetStrength, surface]);
 }
 
 export function useGroundPatchStandardMaterial({
@@ -312,6 +461,7 @@ export function useGroundPatchStandardMaterial({
                     roughness,
                 }),
                 surface,
+                {},
             ),
         [color, metalness, roughness, surface],
     );

--- a/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedFields.tsx
@@ -9,17 +9,13 @@ import {
 import { useAllSorts } from '../../hooks/usePlantSorts';
 import { useRaisedBedOperationVisualRewards } from '../../hooks/useRaisedBedOperationVisualRewards';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
-import { useSnapshotTime } from '../../hooks/useSnapshotTime';
 import { useGameState } from '../../useGameState';
 import {
     findRaisedBedByBlockId,
     getRaisedBedBlockIds,
 } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
-import {
-    getGridPositionFromIndex,
-    type RaisedBedOrientation,
-} from '../../utils/raisedBedOrientation';
+import type { RaisedBedOrientation } from '../../utils/raisedBedOrientation';
 import { resolveEntityNeighbors } from '../helpers/useEntityNeighbors';
 import {
     mockPlantPresetLabelsBySortId,
@@ -30,8 +26,8 @@ import {
     resolveRaisedBedAgrotextileCoverPositions,
 } from './raisedBedAgrotextileRewards';
 import { resolveRaisedBedHarvestPositions } from './raisedBedHarvestRewards';
+import { getRaisedBedFieldSurfacePosition } from './raisedBedSoilWetPatches';
 import { resolveRaisedBedSupportPositions } from './raisedBedSupportRewards';
-import { isWateringRewardVisible } from './raisedBedWateringRewards';
 import {
     resolveRaisedBedFieldWeedLevel,
     type VisibleRaisedBedWeedLevel,
@@ -41,10 +37,6 @@ const raisedBedHalfOverlap = 0.05;
 const fieldAgrotextileCoverSize = 0.25;
 const wholeBedAgrotextileCoverPadding = 0.02;
 const wholeBedAgrotextileHemThickness = 0.018;
-const soilOverlayFieldSize = 0.255;
-const soilOverlayPadding = 0.012;
-const soilOverlayY = -0.748;
-const raisedBedFieldCount = 9;
 // Keep weed bases inside the visible dirt inset, not out on the raised-bed rim.
 const weedFieldScatterRadius = 0.082;
 const weedBladeIds = [
@@ -74,28 +66,6 @@ type RaisedBedWholeAgrotextileCoverLayout = {
     position: [number, number, number];
     width: number;
 };
-
-type RaisedBedSoilOverlayLayout = RaisedBedWholeAgrotextileCoverLayout;
-
-const drySoilCrackSegments = [
-    { id: 'a', start: [-0.43, -0.34], end: [-0.31, -0.28] },
-    { id: 'b', start: [-0.34, -0.28], end: [-0.27, -0.18] },
-    { id: 'c', start: [-0.18, -0.39], end: [-0.08, -0.31] },
-    { id: 'd', start: [-0.1, -0.3], end: [0.02, -0.24] },
-    { id: 'e', start: [0.15, -0.38], end: [0.28, -0.3] },
-    { id: 'f', start: [0.24, -0.29], end: [0.36, -0.2] },
-    { id: 'g', start: [-0.46, -0.03], end: [-0.34, 0.04] },
-    { id: 'h', start: [-0.25, 0.12], end: [-0.12, 0.05] },
-    { id: 'i', start: [-0.04, 0.01], end: [0.1, 0.1] },
-    { id: 'j', start: [0.19, 0.05], end: [0.32, 0.13] },
-    { id: 'k', start: [-0.38, 0.31], end: [-0.24, 0.24] },
-    { id: 'l', start: [0.06, 0.31], end: [0.2, 0.23] },
-    { id: 'm', start: [-0.31, -0.28], end: [-0.27, -0.36] },
-    { id: 'n', start: [0.02, -0.24], end: [0.07, -0.33] },
-    { id: 'o', start: [-0.12, 0.05], end: [-0.16, -0.03] },
-    { id: 'p', start: [0.32, 0.13], end: [0.37, 0.03] },
-    { id: 'q', start: [0.2, 0.23], end: [0.28, 0.3] },
-] as const;
 
 function findRaisedBedBlockPlacement(
     garden: CurrentGardenData,
@@ -143,31 +113,6 @@ function getRaisedBedBlockSurfaceOrigin(
     }
 
     return { x, z };
-}
-
-function getRaisedBedFieldSurfacePosition({
-    blockIndex,
-    orientation,
-    positionIndex,
-    y,
-}: {
-    blockIndex: number;
-    orientation: RaisedBedOrientation;
-    positionIndex: number;
-    y: number;
-}) {
-    const offsetX =
-        orientation === 'vertical' ? 0.31 - blockIndex * 0.05 : 0.27;
-    const offsetZ =
-        orientation === 'vertical' ? 0.27 : 0.27 + blockIndex * 0.05;
-    const multiplierX = orientation === 'vertical' ? 0.285 : 0.27;
-    const multiplierZ = orientation === 'vertical' ? 0.27 : 0.285;
-    const { row, col } = getGridPositionFromIndex(positionIndex, orientation);
-    return [
-        col * multiplierX - offsetX,
-        y,
-        (2 - row) * multiplierZ - offsetZ,
-    ] satisfies [number, number, number];
 }
 
 function getRaisedBedWholeAgrotextileCoverLayout({
@@ -234,199 +179,6 @@ function getRaisedBedWholeAgrotextileCoverLayout({
         position: [(minX + maxX) / 2, -0.704, (minZ + maxZ) / 2],
         width: maxX - minX,
     };
-}
-
-function getRaisedBedSoilOverlayLayout({
-    blockId,
-    blockIds,
-    garden,
-    orientation,
-}: {
-    blockId: string;
-    blockIds: string[];
-    garden: CurrentGardenData;
-    orientation: RaisedBedOrientation;
-}): RaisedBedSoilOverlayLayout | null {
-    const ownerOrigin = getRaisedBedBlockSurfaceOrigin(garden, blockId);
-    if (!ownerOrigin) {
-        return null;
-    }
-
-    let minX = Number.POSITIVE_INFINITY;
-    let maxX = Number.NEGATIVE_INFINITY;
-    let minZ = Number.POSITIVE_INFINITY;
-    let maxZ = Number.NEGATIVE_INFINITY;
-    const fieldHalfSize = soilOverlayFieldSize / 2;
-
-    for (const [blockIndex, raisedBedBlockId] of blockIds.entries()) {
-        const origin = getRaisedBedBlockSurfaceOrigin(garden, raisedBedBlockId);
-        if (!origin) {
-            continue;
-        }
-
-        for (
-            let positionIndex = 0;
-            positionIndex < raisedBedFieldCount;
-            positionIndex += 1
-        ) {
-            const [fieldX, , fieldZ] = getRaisedBedFieldSurfacePosition({
-                blockIndex,
-                orientation,
-                positionIndex,
-                y: 0,
-            });
-            const centerX = origin.x - ownerOrigin.x + fieldX;
-            const centerZ = origin.z - ownerOrigin.z + fieldZ;
-
-            minX = Math.min(minX, centerX - fieldHalfSize);
-            maxX = Math.max(maxX, centerX + fieldHalfSize);
-            minZ = Math.min(minZ, centerZ - fieldHalfSize);
-            maxZ = Math.max(maxZ, centerZ + fieldHalfSize);
-        }
-    }
-
-    if (
-        !Number.isFinite(minX) ||
-        !Number.isFinite(maxX) ||
-        !Number.isFinite(minZ) ||
-        !Number.isFinite(maxZ)
-    ) {
-        return null;
-    }
-
-    minX -= soilOverlayPadding;
-    maxX += soilOverlayPadding;
-    minZ -= soilOverlayPadding;
-    maxZ += soilOverlayPadding;
-
-    return {
-        depth: maxZ - minZ,
-        position: [(minX + maxX) / 2, soilOverlayY, (minZ + maxZ) / 2],
-        width: maxX - minX,
-    };
-}
-
-function RaisedBedDrySoilOverlay({
-    layout,
-}: {
-    layout: RaisedBedSoilOverlayLayout;
-}) {
-    const crackThickness = Math.max(
-        0.01,
-        Math.min(layout.width, layout.depth) * 0.014,
-    );
-
-    return (
-        <group position={layout.position}>
-            <mesh rotation={[-Math.PI / 2, 0, 0]} renderOrder={1}>
-                <planeGeometry args={[layout.width, layout.depth]} />
-                <meshStandardMaterial
-                    color="#a1744f"
-                    depthWrite={false}
-                    opacity={0.56}
-                    polygonOffset
-                    polygonOffsetFactor={-2}
-                    roughness={1}
-                    transparent
-                />
-            </mesh>
-            {drySoilCrackSegments.map((segment) => {
-                const startX = segment.start[0] * layout.width;
-                const startZ = segment.start[1] * layout.depth;
-                const endX = segment.end[0] * layout.width;
-                const endZ = segment.end[1] * layout.depth;
-                const deltaX = endX - startX;
-                const deltaZ = endZ - startZ;
-                const length = Math.hypot(deltaX, deltaZ);
-                const angle = Math.atan2(deltaZ, deltaX);
-
-                return (
-                    <mesh
-                        key={`raised-bed-dry-soil-crack-${segment.id}`}
-                        position={[
-                            (startX + endX) / 2,
-                            0.003,
-                            (startZ + endZ) / 2,
-                        ]}
-                        renderOrder={2}
-                        rotation={[0, -angle, 0]}
-                    >
-                        <boxGeometry args={[length, 0.002, crackThickness]} />
-                        <meshStandardMaterial
-                            color="#2f1f18"
-                            depthWrite={false}
-                            opacity={0.74}
-                            polygonOffset
-                            polygonOffsetFactor={-3}
-                            roughness={1}
-                            transparent
-                        />
-                    </mesh>
-                );
-            })}
-        </group>
-    );
-}
-
-function RaisedBedMoistSoilOverlay({
-    layout,
-}: {
-    layout: RaisedBedSoilOverlayLayout;
-}) {
-    return (
-        <group position={layout.position}>
-            <mesh
-                position={[0, 0.006, 0]}
-                rotation={[-Math.PI / 2, 0, 0]}
-                renderOrder={3}
-            >
-                <planeGeometry args={[layout.width, layout.depth]} />
-                <meshStandardMaterial
-                    color="#28170f"
-                    depthWrite={false}
-                    opacity={0.74}
-                    polygonOffset
-                    polygonOffsetFactor={-6}
-                    roughness={1}
-                    transparent
-                />
-            </mesh>
-        </group>
-    );
-}
-
-function RaisedBedFieldMoistSoilOverlay({
-    blockIndex,
-    orientation,
-    positionIndex,
-}: {
-    blockIndex: number;
-    orientation: RaisedBedOrientation;
-    positionIndex: number;
-}) {
-    const position = getRaisedBedFieldSurfacePosition({
-        blockIndex,
-        orientation,
-        positionIndex,
-        y: soilOverlayY + 0.004,
-    });
-
-    return (
-        <group position={position}>
-            <mesh rotation={[-Math.PI / 2, 0, 0]} renderOrder={3}>
-                <planeGeometry args={[0.255, 0.255]} />
-                <meshStandardMaterial
-                    color="#28170f"
-                    depthWrite={false}
-                    opacity={0.7}
-                    polygonOffset
-                    polygonOffsetFactor={-6}
-                    roughness={1}
-                    transparent
-                />
-            </mesh>
-        </group>
-    );
 }
 
 function RaisedBedFieldVisitSummaryHighlight({
@@ -787,7 +539,6 @@ export function RaisedBedFields({
     const { data: cart } = useShoppingCart(renderDetails && !isLocalSandbox);
     const raisedBed = findRaisedBedByBlockId(currentGarden, blockId);
     const visualRewards = useRaisedBedOperationVisualRewards(raisedBed);
-    const currentTime = useSnapshotTime();
     const orientation = raisedBed?.orientation ?? 'vertical';
     const visitSummaryHighlight = useGameState(
         (state) => state.gardenVisitSummaryHighlight,
@@ -837,40 +588,6 @@ export function RaisedBedFields({
         return null;
     }
 
-    const hasRaisedBedWateringReward = visualRewards.some(
-        (reward) =>
-            reward.scope === 'raisedBed' &&
-            reward.raisedBedId === raisedBed?.id &&
-            isWateringRewardVisible(reward, currentTime),
-    );
-    const moistFieldPositionSet = new Set(
-        hasRaisedBedWateringReward
-            ? []
-            : visualRewards.flatMap((reward) => {
-                  if (
-                      reward.scope !== 'field' ||
-                      reward.raisedBedFieldId == null ||
-                      !isWateringRewardVisible(reward, currentTime)
-                  ) {
-                      return [];
-                  }
-
-                  const field = raisedBed?.fields.find(
-                      (candidate) =>
-                          candidate.active &&
-                          candidate.id === reward.raisedBedFieldId,
-                  );
-                  if (
-                      !field ||
-                      field.positionIndex < blockOffset ||
-                      field.positionIndex >= blockOffset + raisedBedFieldCount
-                  ) {
-                      return [];
-                  }
-
-                  return [field.positionIndex - blockOffset];
-              }),
-    );
     const weedFieldVisuals = raisedBed
         ? Array.from({ length: 9 }, (_, localPositionIndex) => {
               const positionIndex = blockOffset + localPositionIndex;
@@ -930,15 +647,6 @@ export function RaisedBedFields({
                   orientation,
               })
             : null;
-    const soilOverlayLayout =
-        currentGarden && blockIds.length > 0 && blockIndex === 0
-            ? getRaisedBedSoilOverlayLayout({
-                  blockId,
-                  blockIds,
-                  garden: currentGarden,
-                  orientation,
-              })
-            : null;
     const fieldAgrotextileCoverPositions = hasRaisedBedAgrotextileCover
         ? []
         : agrotextileCoverPositions;
@@ -984,12 +692,6 @@ export function RaisedBedFields({
 
     return (
         <>
-            {soilOverlayLayout && !hasRaisedBedWateringReward ? (
-                <RaisedBedDrySoilOverlay layout={soilOverlayLayout} />
-            ) : null}
-            {soilOverlayLayout && hasRaisedBedWateringReward ? (
-                <RaisedBedMoistSoilOverlay layout={soilOverlayLayout} />
-            ) : null}
             {highlightedLocalPositionIndex != null ? (
                 <RaisedBedFieldVisitSummaryHighlight
                     blockIndex={blockIndex}
@@ -997,14 +699,6 @@ export function RaisedBedFields({
                     positionIndex={highlightedLocalPositionIndex}
                 />
             ) : null}
-            {Array.from(moistFieldPositionSet).map((positionIndex) => (
-                <RaisedBedFieldMoistSoilOverlay
-                    key={`raised-bed-field-moist-soil-${blockId}-${positionIndex}`}
-                    blockIndex={blockIndex}
-                    orientation={orientation}
-                    positionIndex={positionIndex}
-                />
-            ))}
             {weedFieldVisuals.map((visual) =>
                 agrotextileCoverPositionSet.has(visual.positionIndex) ? null : (
                     <RaisedBedFieldWeeds

--- a/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedPlantField.tsx
@@ -173,7 +173,7 @@ export function RaisedBedPlantField({
         visualPlantGeneration,
     ]);
 
-    const seedColor = plantSowDate ? 'black' : '#6495ED';
+    const seedColor = plantSowDate ? '#4b3223' : '#6495ED';
     const seedOpacityToMax = useSpring({
         from: { opacity: 1 },
         to: [{ opacity: 0.5 }, { opacity: 1 }],
@@ -181,6 +181,7 @@ export function RaisedBedPlantField({
         loop: true,
         cancel: Boolean(plantSowDate),
     });
+    const seedOpacity = plantSowDate ? 0.72 : seedOpacityToMax.opacity;
 
     // TODO: Move to seed block/part
     const { nodes } = useGameGLTF('Seed');
@@ -223,8 +224,9 @@ export function RaisedBedPlantField({
                             >
                                 <animated.meshStandardMaterial
                                     color={seedColor}
+                                    opacity={seedOpacity}
+                                    roughness={0.95}
                                     transparent
-                                    {...seedOpacityToMax}
                                 />
                             </mesh>
                         );

--- a/packages/game/src/entities/raisedBed/raisedBedSoilWetPatches.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedSoilWetPatches.ts
@@ -1,0 +1,154 @@
+import type {
+    AppliedOperationVisualInput,
+    OperationVisualDefinitionInput,
+    OperationVisualReward,
+} from '../../operationVisualRewards';
+import { resolveOperationVisualRewards } from '../../operationVisualRewards';
+import type { RaisedBedOrientation } from '../../utils/raisedBedOrientation';
+import { getGridPositionFromIndex } from '../../utils/raisedBedOrientation';
+import type { GroundPatchWetPatch } from '../helpers/groundPatchMaterial';
+import { isWateringRewardVisible } from './raisedBedWateringRewards';
+
+type RaisedBedWetPatchField = {
+    active?: boolean | null;
+    id?: number | null;
+    plantSortId?: number | null;
+    positionIndex: number;
+};
+
+type RaisedBedWetPatchData = {
+    appliedOperations?: AppliedOperationVisualInput[] | null;
+    fields: RaisedBedWetPatchField[];
+    id: number;
+    orientation?: RaisedBedOrientation | null;
+};
+
+export function getRaisedBedFieldSurfacePosition({
+    blockIndex,
+    orientation,
+    positionIndex,
+    y,
+}: {
+    blockIndex: number;
+    orientation: RaisedBedOrientation;
+    positionIndex: number;
+    y: number;
+}) {
+    const offsetX =
+        orientation === 'vertical' ? 0.31 - blockIndex * 0.05 : 0.27;
+    const offsetZ =
+        orientation === 'vertical' ? 0.27 : 0.27 + blockIndex * 0.05;
+    const multiplierX = orientation === 'vertical' ? 0.285 : 0.27;
+    const multiplierZ = orientation === 'vertical' ? 0.27 : 0.285;
+    const { row, col } = getGridPositionFromIndex(positionIndex, orientation);
+    return [
+        col * multiplierX - offsetX,
+        y,
+        (2 - row) * multiplierZ - offsetZ,
+    ] satisfies [number, number, number];
+}
+
+export function resolveRaisedBedWateringVisualRewards({
+    operations,
+    raisedBed,
+}: {
+    operations: OperationVisualDefinitionInput[] | undefined;
+    raisedBed: RaisedBedWetPatchData | null | undefined;
+}) {
+    if (!operations || !raisedBed) {
+        return [] as OperationVisualReward[];
+    }
+
+    return resolveOperationVisualRewards({
+        appliedOperations: (raisedBed.appliedOperations ?? []).map(
+            (operation) => ({
+                ...operation,
+                raisedBedId: raisedBed.id,
+            }),
+        ),
+        operations,
+    }).filter((reward) => reward.kind === 'watering');
+}
+
+export function getRaisedBedSoilWetPatches({
+    blockIndex,
+    blockOffset,
+    blockPosition,
+    currentTime,
+    raisedBed,
+    visualRewards,
+}: {
+    blockIndex: number;
+    blockOffset: number;
+    blockPosition: readonly [number, number, number];
+    currentTime: Date;
+    raisedBed: RaisedBedWetPatchData | null | undefined;
+    visualRewards: readonly OperationVisualReward[];
+}): GroundPatchWetPatch[] {
+    if (!raisedBed) {
+        return [];
+    }
+
+    const orientation = raisedBed.orientation ?? 'vertical';
+    const patches: GroundPatchWetPatch[] = [];
+    const fullRaisedBedWet = visualRewards.some(
+        (reward) =>
+            reward.scope === 'raisedBed' &&
+            reward.raisedBedId === raisedBed.id &&
+            isWateringRewardVisible(reward, currentTime),
+    );
+
+    if (fullRaisedBedWet) {
+        patches.push({
+            center: [blockPosition[0], blockPosition[2]],
+            halfSize: [0.41, 0.41],
+            strength: 0.94,
+        });
+    }
+
+    const wetFieldIds = new Set(
+        visualRewards
+            .filter(
+                (reward) =>
+                    reward.scope === 'field' &&
+                    reward.raisedBedFieldId != null &&
+                    isWateringRewardVisible(reward, currentTime),
+            )
+            .map((reward) => reward.raisedBedFieldId),
+    );
+
+    if (wetFieldIds.size === 0) {
+        return patches;
+    }
+
+    for (const field of raisedBed.fields) {
+        if (
+            field.active === false ||
+            typeof field.id !== 'number' ||
+            typeof field.plantSortId !== 'number' ||
+            !wetFieldIds.has(field.id) ||
+            field.positionIndex < blockOffset ||
+            field.positionIndex >= blockOffset + 9
+        ) {
+            continue;
+        }
+
+        const localPosition = getRaisedBedFieldSurfacePosition({
+            blockIndex,
+            orientation,
+            positionIndex: field.positionIndex - blockOffset,
+            y: 0,
+        });
+
+        patches.push({
+            center: [
+                blockPosition[0] + localPosition[0],
+                blockPosition[2] + localPosition[2],
+            ],
+            halfSize: [0.13, 0.13],
+            strength: 1,
+        });
+    }
+
+    return patches;
+}


### PR DESCRIPTION
## Summary

- Replaces raised-bed dry/wet soil overlay panes with a procedural raised-bed soil material shader.
- Converts watering visual rewards into wet masks on the soil material for full-bed and field-level watering.
- Keeps non-soil raised-bed visuals such as harvest, agrotextile, support, weeds, and visit-summary highlights intact.

## Why

The old visual path drew low-quality panes and crack geometry over the raised-bed soil. That made dry soil look harsh and made wet soil feel detached from the actual bed surface. This moves the soil variation and wetness into the material itself so the mesh surface carries the visual state.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `git diff --cached --check`

Note: `pnpm --filter @gredice/game lint` formats an unrelated `RaisedBedDiary.tsx` import in this checkout; that formatter-only change was reverted and is not part of this PR.