### PR TITLE
Add default automation for plant removal verification

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -10,7 +10,9 @@ status changes that create pending admin approval requests. Verifying the
 seedling transplanting operation also switches the targeted plant from
 greenhouse sowing to direct sowing and queues 50L watering operations for the
 next two days when that raised bed does not already have at least 50L of
-watering scheduled on those days.
+watering scheduled on those days. Verifying the `Uklanjanje biljke` operation
+marks the targeted raised-bed field plant status as `removed`, which closes the
+plant cycle and frees the field for future planting.
 
 ## Ownership
 
@@ -97,7 +99,8 @@ MVP modules:
   operations for every active farm from a JSON list in the automation
   definition.
 - `action.updateRaisedBedFieldPlantStatus`: writes a
-  `raisedBedField.plantUpdate` event for an operation target.
+  `raisedBedField.plantUpdate` event for an operation target, including the
+  default plant-removal workflow that sets `targetStatus = "removed"`.
 - `action.updateRaisedBedFieldSowingLocation`: writes a
   `raisedBedField.plantSchedule` event for an operation target, preserving the
   scheduled date while changing `sowingLocation`.

--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -15,8 +15,11 @@ export const seedlingTransplantDirectSowingLocationAutomationKey =
     'default.seedling-transplant-direct-sowing-location';
 export const seedlingTransplantWateringAutomationKey =
     'default.seedling-transplant-watering';
+export const plantRemovalOperationStatusAutomationKey =
+    'default.plant-removal-operation-status';
 
 const seedlingTransplantingOperationId = 593;
+const plantRemovalOperationId = 346;
 
 export function seasonalSowedWateringAutomationGraph(): AutomationGraph {
     return {
@@ -207,6 +210,54 @@ export function seedlingTransplantWateringAutomationGraph(): AutomationGraph {
     };
 }
 
+export function plantRemovalOperationStatusAutomationGraph(): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerDomainEvent,
+                position: { x: 0, y: 160 },
+                config: {
+                    eventType: knownEventTypes.operations.verify,
+                },
+            },
+            {
+                id: 'operation-is-plant-removal',
+                kind: 'condition',
+                moduleKey: automationModuleKeys.conditionOperationMatches,
+                position: { x: 280, y: 160 },
+                config: {
+                    status: 'completed',
+                    entityId: plantRemovalOperationId,
+                },
+            },
+            {
+                id: 'set-plant-status-removed',
+                kind: 'action',
+                moduleKey:
+                    automationModuleKeys.actionUpdateRaisedBedFieldPlantStatus,
+                position: { x: 620, y: 160 },
+                config: {
+                    targetStatus: 'removed',
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-operation-match',
+                source: 'trigger',
+                target: 'operation-is-plant-removal',
+            },
+            {
+                id: 'operation-match-to-set-removed',
+                source: 'operation-is-plant-removal',
+                target: 'set-plant-status-removed',
+            },
+        ],
+    };
+}
+
 export async function ensureDefaultAutomationDefinitions() {
     await initializeAutomationEventCursorToLatest();
 
@@ -267,10 +318,26 @@ export async function ensureDefaultAutomationDefinitions() {
         },
     });
 
+    const plantRemovalOperationStatus = await upsertAutomationDefinitionByKey({
+        key: plantRemovalOperationStatusAutomationKey,
+        name: 'Označi biljku uklonjenom nakon potvrde uklanjanja',
+        description:
+            'Kada je radnja uklanjanja biljke potvrđena, postavi status ciljane biljke na uklonjeno.',
+        status: 'enabled',
+        graph: plantRemovalOperationStatusAutomationGraph(),
+        metadata: {
+            managedBy: 'gredice',
+            defaultAutomation: true,
+            operationEntityId: plantRemovalOperationId,
+            targetStatus: 'removed',
+        },
+    });
+
     return {
         seasonalSowedWatering,
         operationImagePlantStatusReview,
         seedlingTransplantDirectSowingLocation,
         seedlingTransplantWatering,
+        plantRemovalOperationStatus,
     };
 }

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -18,6 +18,7 @@ import {
     ensureDefaultAutomationDefinitions,
     executeAutomationRun,
     FREE_WATERING_OPERATION_ID,
+    getAutomationDefinitionByKey,
     getAutomationEventCursor,
     getAutomationRunWithSteps,
     getEvents,
@@ -31,6 +32,8 @@ import {
     listAutomationRuns,
     listEnabledAutomationDefinitionsForEventType,
     operationImagePlantStatusReviewAutomationGraph,
+    plantRemovalOperationStatusAutomationGraph,
+    plantRemovalOperationStatusAutomationKey,
     processDueAutomationRuns,
     RAISED_BED_WATERING_50L_OPERATION_ID,
     recordAutomationRunStep,
@@ -912,6 +915,99 @@ test('plant-status automation skips replay when target status already exists', a
     const replayResult = await executeAutomationRun(startedReplay);
 
     assert.strictEqual(replayResult.status, 'skipped');
+    assert.strictEqual(
+        (
+            await getEvents(knownEventTypes.raisedBedFields.plantUpdate, [
+                fieldAggregateId,
+            ])
+        ).length,
+        1,
+    );
+});
+
+test('default plant-removal automation marks the operation target removed after verification', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createAutomationRaisedBedContext();
+    const fieldAggregateId = `${raisedBedId}|0`;
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(fieldAggregateId, {
+            plantSortId: '101',
+            scheduledDate: '2026-04-01T08:00:00.000Z',
+        }),
+    );
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields[0];
+    assert.ok(field);
+
+    await ensureDefaultAutomationDefinitions();
+    const definition = await getAutomationDefinitionByKey(
+        plantRemovalOperationStatusAutomationKey,
+    );
+    assert.ok(definition);
+    assert.strictEqual(
+        definition.triggerEventType,
+        knownEventTypes.operations.verify,
+    );
+    assert.deepStrictEqual(
+        definition.graph,
+        plantRemovalOperationStatusAutomationGraph(),
+    );
+    assert.deepStrictEqual(definition.metadata, {
+        managedBy: 'gredice',
+        defaultAutomation: true,
+        operationEntityId: 346,
+        targetStatus: 'removed',
+    });
+
+    const operationId = await createOperation({
+        accountId,
+        entityId: 346,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+        raisedBedFieldId: field.id,
+    });
+    await createEvent(
+        knownEvents.operations.verifiedV1(operationId.toString(), {
+            verifiedBy: 'automations-test',
+        }),
+    );
+    const event = await getLatestEvent(
+        knownEventTypes.operations.verify,
+        operationId.toString(),
+    );
+    const run = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'event',
+        sourceEvent: event,
+        input: {
+            eventId: event.id,
+            eventType: event.type,
+            aggregateId: event.aggregateId,
+            data:
+                event.data && typeof event.data === 'object'
+                    ? (event.data as Record<string, unknown>)
+                    : {},
+        },
+    });
+    assert.ok(run);
+    const startedRun = await startAutomationRun(run.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedRun);
+
+    const result = await executeAutomationRun(startedRun);
+
+    assert.strictEqual(result.status, 'succeeded');
+    const updatedRaisedBed = await getRaisedBed(raisedBedId);
+    const updatedField = updatedRaisedBed?.fields.find(
+        (candidate) => candidate.id === field.id,
+    );
+    assert.strictEqual(updatedField?.plantStatus, 'removed');
+    assert.strictEqual(updatedField?.active, false);
+    assert.ok(updatedField?.plantRemovedDate);
     assert.strictEqual(
         (
             await getEvents(knownEventTypes.raisedBedFields.plantUpdate, [


### PR DESCRIPTION
## Summary
- Add a default automation that marks a raised-bed field plant as `removed` when the plant-removal operation is verified
- Document the plant-removal workflow in `docs/automations.md`
- Cover the new automation definition and execution path with a node test

## Testing
- Added/updated node tests for the default plant-removal automation
- Not run (not requested)