### PR TITLE
[codex] Improve automations queue UI

### DIFF
--- a/apps/app/app/admin/automations/AutomationDefinitionsList.tsx
+++ b/apps/app/app/admin/automations/AutomationDefinitionsList.tsx
@@ -4,60 +4,19 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
-import { useMemo } from 'react';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../src/KnownPages';
 import {
     AutomationDefinitionStatusIndicator,
     AutomationRunStatusIndicator,
 } from './AutomationStatusIndicator';
-import type {
-    AutomationDefinitionListItem,
-    AutomationRunListItem,
-} from './types';
-
-function latestRunsByDefinition(runs: AutomationRunListItem[]) {
-    const latestRuns = new Map<number, AutomationRunListItem>();
-
-    for (const run of runs) {
-        if (!latestRuns.has(run.automationDefinitionId)) {
-            latestRuns.set(run.automationDefinitionId, run);
-        }
-    }
-
-    return latestRuns;
-}
-
-function loadedFailedRunsByDefinition(runs: AutomationRunListItem[]) {
-    const failedRuns = new Map<number, number>();
-
-    for (const run of runs) {
-        if (run.status !== 'failed') {
-            continue;
-        }
-
-        failedRuns.set(
-            run.automationDefinitionId,
-            (failedRuns.get(run.automationDefinitionId) ?? 0) + 1,
-        );
-    }
-
-    return failedRuns;
-}
+import type { AutomationDefinitionListItem } from './types';
 
 export function AutomationDefinitionsList({
     definitions,
-    runs,
 }: {
     definitions: AutomationDefinitionListItem[];
-    runs: AutomationRunListItem[];
 }) {
-    const latestRuns = useMemo(() => latestRunsByDefinition(runs), [runs]);
-    const failedRuns = useMemo(
-        () => loadedFailedRunsByDefinition(runs),
-        [runs],
-    );
-
     return (
         <Card className="h-full">
             <CardHeader>
@@ -76,9 +35,8 @@ export function AutomationDefinitionsList({
                 ) : (
                     <ul className="divide-y">
                         {definitions.map((definition) => {
-                            const latestRun = latestRuns.get(definition.id);
-                            const failedCount =
-                                failedRuns.get(definition.id) ?? 0;
+                            const latestRun = definition.latestRun;
+                            const failedCount = definition.failedRunsCount;
 
                             return (
                                 <li key={definition.id} className="p-4">

--- a/apps/app/app/admin/automations/AutomationDefinitionsList.tsx
+++ b/apps/app/app/admin/automations/AutomationDefinitionsList.tsx
@@ -1,0 +1,180 @@
+import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
+import { KnownPages } from '../../../src/KnownPages';
+import {
+    AutomationDefinitionStatusIndicator,
+    AutomationRunStatusIndicator,
+} from './AutomationStatusIndicator';
+import type {
+    AutomationDefinitionListItem,
+    AutomationRunListItem,
+} from './types';
+
+function latestRunsByDefinition(runs: AutomationRunListItem[]) {
+    const latestRuns = new Map<number, AutomationRunListItem>();
+
+    for (const run of runs) {
+        if (!latestRuns.has(run.automationDefinitionId)) {
+            latestRuns.set(run.automationDefinitionId, run);
+        }
+    }
+
+    return latestRuns;
+}
+
+function loadedFailedRunsByDefinition(runs: AutomationRunListItem[]) {
+    const failedRuns = new Map<number, number>();
+
+    for (const run of runs) {
+        if (run.status !== 'failed') {
+            continue;
+        }
+
+        failedRuns.set(
+            run.automationDefinitionId,
+            (failedRuns.get(run.automationDefinitionId) ?? 0) + 1,
+        );
+    }
+
+    return failedRuns;
+}
+
+export function AutomationDefinitionsList({
+    definitions,
+    runs,
+}: {
+    definitions: AutomationDefinitionListItem[];
+    runs: AutomationRunListItem[];
+}) {
+    const latestRuns = useMemo(() => latestRunsByDefinition(runs), [runs]);
+    const failedRuns = useMemo(
+        () => loadedFailedRunsByDefinition(runs),
+        [runs],
+    );
+
+    return (
+        <Card className="h-full">
+            <CardHeader>
+                <CardTitle>Definicije</CardTitle>
+                <Typography level="body3" className="text-muted-foreground">
+                    Aktivne automatizacije i njihova zadnja učitana izvođenja.
+                </Typography>
+            </CardHeader>
+            <CardOverflow>
+                {definitions.length === 0 ? (
+                    <div className="p-4">
+                        <NoDataPlaceholder>
+                            Nema automatizacija za odabrane filtre.
+                        </NoDataPlaceholder>
+                    </div>
+                ) : (
+                    <ul className="divide-y">
+                        {definitions.map((definition) => {
+                            const latestRun = latestRuns.get(definition.id);
+                            const failedCount =
+                                failedRuns.get(definition.id) ?? 0;
+
+                            return (
+                                <li key={definition.id} className="p-4">
+                                    <Stack spacing={3}>
+                                        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                            <Stack
+                                                spacing={1}
+                                                className="min-w-0"
+                                            >
+                                                <Link
+                                                    href={KnownPages.Automation(
+                                                        definition.id,
+                                                    )}
+                                                    className="truncate font-medium text-primary hover:underline"
+                                                >
+                                                    {definition.name}
+                                                </Link>
+                                                <Typography
+                                                    level="body3"
+                                                    className="break-all text-muted-foreground"
+                                                >
+                                                    {definition.key}
+                                                </Typography>
+                                            </Stack>
+                                            <AutomationDefinitionStatusIndicator
+                                                status={definition.status}
+                                            />
+                                        </div>
+
+                                        <dl className="grid gap-2 text-sm">
+                                            <div className="grid gap-1">
+                                                <dt className="text-muted-foreground">
+                                                    Okidač
+                                                </dt>
+                                                <dd>
+                                                    {definition.triggerSummary}
+                                                </dd>
+                                            </div>
+                                            <div className="grid gap-1">
+                                                <dt className="text-muted-foreground">
+                                                    Akcije
+                                                </dt>
+                                                <dd>
+                                                    {definition.actionSummary}
+                                                </dd>
+                                            </div>
+                                        </dl>
+
+                                        <Row
+                                            spacing={3}
+                                            className="flex-wrap items-center text-sm"
+                                        >
+                                            {latestRun ? (
+                                                <>
+                                                    <AutomationRunStatusIndicator
+                                                        status={
+                                                            latestRun.status
+                                                        }
+                                                    />
+                                                    <LocalDateTime>
+                                                        {latestRun.createdAt}
+                                                    </LocalDateTime>
+                                                </>
+                                            ) : (
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-muted-foreground"
+                                                >
+                                                    Nema izvođenja
+                                                </Typography>
+                                            )}
+                                            {failedCount > 0 ? (
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-red-700 dark:text-red-300"
+                                                >
+                                                    Greške: {failedCount}
+                                                </Typography>
+                                            ) : null}
+                                            <Typography
+                                                level="body3"
+                                                className="text-muted-foreground"
+                                            >
+                                                Ažurirano{' '}
+                                                <LocalDateTime>
+                                                    {definition.updatedAt}
+                                                </LocalDateTime>
+                                            </Typography>
+                                        </Row>
+                                    </Stack>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </CardOverflow>
+        </Card>
+    );
+}

--- a/apps/app/app/admin/automations/AutomationJobsQueueTable.tsx
+++ b/apps/app/app/admin/automations/AutomationJobsQueueTable.tsx
@@ -1,54 +1,19 @@
-import type {
-    AutomationRunSource,
-    AutomationRunStatus,
-    SelectAutomationRun,
-} from '@gredice/storage';
+import { Button } from '@gredice/ui/Button';
 import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
+import { LoaderSpinner } from '@gredice/ui/icons';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
-import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../src/KnownPages';
-import { automationRunStatusMeta } from './presentation';
+import { AutomationRunStatusIndicator } from './AutomationStatusIndicator';
+import type { AutomationRunListItem } from './types';
 
-type AutomationJobQueueRun = Pick<
-    SelectAutomationRun,
-    | 'id'
-    | 'automationDefinitionId'
-    | 'automationDefinitionKey'
-    | 'automationDefinitionName'
-    | 'source'
-    | 'sourceEventType'
-    | 'sourceAggregateId'
-    | 'parentRunId'
-    | 'status'
-    | 'dryRun'
-    | 'attempt'
-    | 'maxAttempts'
-    | 'nextRunAt'
-    | 'lockedAt'
-    | 'lockedBy'
-    | 'errorMessage'
-    | 'startedAt'
-    | 'completedAt'
-    | 'createdAt'
-    | 'updatedAt'
->;
-
-function renderRunStatusChip(status: AutomationRunStatus) {
-    const meta = automationRunStatusMeta(status);
-    return (
-        <Chip color={meta.color} size="sm" variant="soft">
-            {meta.label}
-        </Chip>
-    );
-}
-
-function sourceLabel(source: AutomationRunSource) {
+function sourceLabel(source: AutomationRunListItem['source']) {
     switch (source) {
         case 'event':
             return 'Event';
@@ -63,7 +28,7 @@ function sourceLabel(source: AutomationRunSource) {
     }
 }
 
-function renderDateTimeValue(value: Date | null) {
+function DateTimeValue({ value }: { value: string | null }) {
     if (!value) {
         return <span>-</span>;
     }
@@ -71,25 +36,19 @@ function renderDateTimeValue(value: Date | null) {
     return <LocalDateTime>{value}</LocalDateTime>;
 }
 
-function renderQueueTiming(run: AutomationJobQueueRun) {
+function QueueTiming({ run }: { run: AutomationRunListItem }) {
     if (run.status === 'queued' || run.status === 'retrying') {
         return (
-            <Stack spacing={1}>
-                <Typography level="body3" className="text-muted-foreground">
-                    Sljedeće
-                </Typography>
+            <DetailItem label="Sljedeće">
                 <LocalDateTime>{run.nextRunAt}</LocalDateTime>
-            </Stack>
+            </DetailItem>
         );
     }
 
     if (run.status === 'running') {
         return (
-            <Stack spacing={1}>
-                <Typography level="body3" className="text-muted-foreground">
-                    Zaključano
-                </Typography>
-                {renderDateTimeValue(run.lockedAt)}
+            <DetailItem label="Zaključano">
+                <DateTimeValue value={run.lockedAt} />
                 {run.lockedBy ? (
                     <Typography
                         level="body3"
@@ -98,69 +57,90 @@ function renderQueueTiming(run: AutomationJobQueueRun) {
                         {run.lockedBy}
                     </Typography>
                 ) : null}
-            </Stack>
+            </DetailItem>
         );
     }
 
     if (run.completedAt) {
         return (
-            <Stack spacing={1}>
-                <Typography level="body3" className="text-muted-foreground">
-                    Završeno
-                </Typography>
+            <DetailItem label="Završeno">
                 <LocalDateTime>{run.completedAt}</LocalDateTime>
-            </Stack>
+            </DetailItem>
         );
     }
 
+    return <DetailItem label="Obrada">-</DetailItem>;
+}
+
+function DetailItem({
+    children,
+    label,
+}: {
+    children: ReactNode;
+    label: string;
+}) {
     return (
-        <Typography level="body3" className="text-muted-foreground">
-            -
-        </Typography>
+        <div className="min-w-0">
+            <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {label}
+            </dt>
+            <dd className="mt-1 min-w-0 break-words text-sm">{children}</dd>
+        </div>
     );
 }
 
-export function AutomationJobsQueueTable({
+export function AutomationJobsQueueList({
+    hasMore,
+    isFetching,
+    isFetchingNextPage,
+    loadMore,
     runs,
 }: {
-    runs: AutomationJobQueueRun[];
+    hasMore: boolean;
+    isFetching: boolean;
+    isFetchingNextPage: boolean;
+    loadMore: () => void;
+    runs: AutomationRunListItem[];
 }) {
     return (
-        <Card>
+        <Card className="h-full">
             <CardHeader>
-                <CardTitle>Red poslova</CardTitle>
-                <Typography level="body3" className="text-muted-foreground">
-                    Automatizacijski poslovi s trenutnim statusom, pokušajima i
-                    podacima za obradu.
-                </Typography>
+                <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <Stack spacing={1} className="min-w-0">
+                        <CardTitle>Red poslova</CardTitle>
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Automatizacijski poslovi s trenutnim statusom,
+                            pokušajima i podacima za obradu.
+                        </Typography>
+                    </Stack>
+                    {isFetching && !isFetchingNextPage ? (
+                        <Row
+                            spacing={1}
+                            className="shrink-0 items-center text-muted-foreground"
+                        >
+                            <LoaderSpinner className="size-4 animate-spin" />
+                            <Typography level="body3">Osvježavanje</Typography>
+                        </Row>
+                    ) : null}
+                </div>
             </CardHeader>
             <CardOverflow>
-                <div className="overflow-auto">
-                    <Table>
-                        <Table.Header>
-                            <Table.Row>
-                                <Table.Head>Posao</Table.Head>
-                                <Table.Head>Status</Table.Head>
-                                <Table.Head>Izvor</Table.Head>
-                                <Table.Head>Pokušaji</Table.Head>
-                                <Table.Head>Obrada</Table.Head>
-                                <Table.Head>Vrijeme</Table.Head>
-                            </Table.Row>
-                        </Table.Header>
-                        <Table.Body>
-                            {runs.length === 0 ? (
-                                <Table.Row>
-                                    <Table.Cell colSpan={6}>
-                                        <NoDataPlaceholder>
-                                            Nema poslova za odabrane filtere.
-                                        </NoDataPlaceholder>
-                                    </Table.Cell>
-                                </Table.Row>
-                            ) : null}
-                            {runs.map((run) => (
-                                <Table.Row key={run.id}>
-                                    <Table.Cell>
-                                        <Stack spacing={1}>
+                {runs.length === 0 ? (
+                    <div className="p-4">
+                        <NoDataPlaceholder>
+                            Nema poslova za odabrane filtere.
+                        </NoDataPlaceholder>
+                    </div>
+                ) : (
+                    <ul className="divide-y">
+                        {runs.map((run) => (
+                            <li key={run.id} className="p-4">
+                                <Stack spacing={3}>
+                                    <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                        <Stack spacing={1} className="min-w-0">
                                             <Link
                                                 href={KnownPages.Automation(
                                                     run.automationDefinitionId,
@@ -185,100 +165,92 @@ export function AutomationJobsQueueTable({
                                                 </Typography>
                                             ) : null}
                                         </Stack>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        <Stack spacing={1}>
-                                            <Row
-                                                spacing={1}
-                                                className="flex-wrap"
-                                            >
-                                                {renderRunStatusChip(
-                                                    run.status,
-                                                )}
-                                                {run.dryRun ? (
-                                                    <Chip
-                                                        size="sm"
-                                                        color="info"
-                                                        variant="soft"
-                                                    >
-                                                        Probno
-                                                    </Chip>
-                                                ) : null}
-                                            </Row>
-                                            {run.errorMessage ? (
-                                                <Typography
-                                                    level="body3"
-                                                    className="max-w-80 break-words text-red-700 dark:text-red-300"
+                                        <Stack
+                                            spacing={1}
+                                            className="items-start sm:items-end"
+                                        >
+                                            <AutomationRunStatusIndicator
+                                                status={run.status}
+                                            />
+                                            {run.dryRun ? (
+                                                <Chip
+                                                    size="sm"
+                                                    color="info"
+                                                    variant="soft"
                                                 >
-                                                    {run.errorMessage}
-                                                </Typography>
+                                                    Probno
+                                                </Chip>
                                             ) : null}
                                         </Stack>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        <Stack spacing={1}>
-                                            <Chip size="sm" variant="soft">
-                                                {sourceLabel(run.source)}
-                                            </Chip>
-                                            <Typography level="body3">
-                                                {run.sourceEventType ?? '-'}
-                                            </Typography>
-                                            <Typography
-                                                level="body3"
-                                                className="break-all text-muted-foreground"
-                                            >
-                                                {run.sourceAggregateId ?? '-'}
-                                            </Typography>
-                                        </Stack>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        <Typography level="body3">
-                                            {run.attempt} / {run.maxAttempts}
+                                    </div>
+
+                                    {run.errorMessage ? (
+                                        <Typography
+                                            level="body3"
+                                            className="break-words rounded-md bg-red-50 p-2 text-red-700 dark:bg-red-950 dark:text-red-300"
+                                        >
+                                            {run.errorMessage}
                                         </Typography>
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        {renderQueueTiming(run)}
-                                    </Table.Cell>
-                                    <Table.Cell>
-                                        <Stack spacing={1}>
-                                            <Typography
-                                                level="body3"
-                                                className="text-muted-foreground"
-                                            >
-                                                Kreirano
-                                            </Typography>
+                                    ) : null}
+
+                                    <dl className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                                        <DetailItem label="Izvor">
+                                            <Stack spacing={1}>
+                                                <Chip size="sm" variant="soft">
+                                                    {sourceLabel(run.source)}
+                                                </Chip>
+                                                <span>
+                                                    {run.sourceEventType ?? '-'}
+                                                </span>
+                                                <Typography
+                                                    level="body3"
+                                                    className="break-all text-muted-foreground"
+                                                >
+                                                    {run.sourceAggregateId ??
+                                                        '-'}
+                                                </Typography>
+                                            </Stack>
+                                        </DetailItem>
+                                        <DetailItem label="Pokušaji">
+                                            {run.attempt} / {run.maxAttempts}
+                                        </DetailItem>
+                                        <QueueTiming run={run} />
+                                        <DetailItem label="Kreirano">
                                             <LocalDateTime>
                                                 {run.createdAt}
                                             </LocalDateTime>
-                                            <Typography
-                                                level="body3"
-                                                className="text-muted-foreground"
-                                            >
-                                                Ažurirano
-                                            </Typography>
+                                        </DetailItem>
+                                        <DetailItem label="Ažurirano">
                                             <LocalDateTime>
                                                 {run.updatedAt}
                                             </LocalDateTime>
-                                            {run.startedAt ? (
-                                                <>
-                                                    <Typography
-                                                        level="body3"
-                                                        className="text-muted-foreground"
-                                                    >
-                                                        Početak
-                                                    </Typography>
-                                                    <LocalDateTime>
-                                                        {run.startedAt}
-                                                    </LocalDateTime>
-                                                </>
-                                            ) : null}
-                                        </Stack>
-                                    </Table.Cell>
-                                </Table.Row>
-                            ))}
-                        </Table.Body>
-                    </Table>
-                </div>
+                                        </DetailItem>
+                                        <DetailItem label="Početak">
+                                            <DateTimeValue
+                                                value={run.startedAt}
+                                            />
+                                        </DetailItem>
+                                    </dl>
+                                </Stack>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+
+                {hasMore ? (
+                    <div className="border-t p-4">
+                        <Button
+                            type="button"
+                            variant="outlined"
+                            color="neutral"
+                            fullWidth
+                            loading={isFetchingNextPage}
+                            onClick={loadMore}
+                        >
+                            Učitaj još
+                        </Button>
+                    </div>
+                ) : null}
             </CardOverflow>
         </Card>
     );

--- a/apps/app/app/admin/automations/AutomationOverviewPanels.tsx
+++ b/apps/app/app/admin/automations/AutomationOverviewPanels.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import type { AutomationRunStatus } from '@gredice/storage';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { AutomationDefinitionsList } from './AutomationDefinitionsList';
+import { AutomationJobsQueueList } from './AutomationJobsQueueTable';
+import { isAutomationRunLive } from './AutomationStatusIndicator';
+import type { AutomationDefinitionListItem, AutomationRunsPage } from './types';
+
+function activeRunsInPages(pages: AutomationRunsPage[] | undefined) {
+    return pages?.some((page) =>
+        page.runs.some((run) => isAutomationRunLive(run.status)),
+    );
+}
+
+async function fetchAutomationRunsPage({
+    failedOnly,
+    limit,
+    offset,
+    runStatus,
+}: {
+    failedOnly: boolean;
+    limit: number;
+    offset: number;
+    runStatus?: AutomationRunStatus;
+}) {
+    const searchParams = new URLSearchParams({
+        limit: String(limit),
+        offset: String(offset),
+    });
+
+    if (runStatus) {
+        searchParams.set('runStatus', runStatus);
+    }
+
+    if (failedOnly) {
+        searchParams.set('failedOnly', '1');
+    }
+
+    const response = await fetch(
+        `/api/admin/automations/runs?${searchParams.toString()}`,
+        { cache: 'no-store' },
+    );
+
+    if (!response.ok) {
+        throw new Error('Failed to load automation runs.');
+    }
+
+    return (await response.json()) as AutomationRunsPage;
+}
+
+export function AutomationOverviewPanels({
+    definitions,
+    failedOnly,
+    initialRunsPage,
+    runStatus,
+}: {
+    definitions: AutomationDefinitionListItem[];
+    failedOnly: boolean;
+    initialRunsPage: AutomationRunsPage;
+    runStatus?: AutomationRunStatus;
+}) {
+    const runsQuery = useInfiniteQuery({
+        queryKey: ['automation-runs', { failedOnly, runStatus }],
+        queryFn: ({ pageParam }) =>
+            fetchAutomationRunsPage({
+                failedOnly,
+                limit: initialRunsPage.pageSize,
+                offset: pageParam,
+                runStatus,
+            }),
+        initialData: {
+            pages: [initialRunsPage],
+            pageParams: [0],
+        },
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+        refetchInterval: (query) =>
+            activeRunsInPages(query.state.data?.pages) ? 7000 : false,
+        refetchIntervalInBackground: false,
+        staleTime: 5000,
+    });
+    const runs = useMemo(
+        () => runsQuery.data.pages.flatMap((page) => page.runs),
+        [runsQuery.data.pages],
+    );
+    const definitionsPanel = (
+        <AutomationDefinitionsList definitions={definitions} runs={runs} />
+    );
+    const queuePanel = (
+        <AutomationJobsQueueList
+            hasMore={runsQuery.hasNextPage}
+            isFetching={runsQuery.isFetching}
+            isFetchingNextPage={runsQuery.isFetchingNextPage}
+            loadMore={() => {
+                void runsQuery.fetchNextPage();
+            }}
+            runs={runs}
+        />
+    );
+
+    return (
+        <>
+            <div className="md:hidden">
+                <Tabs defaultValue="definitions">
+                    <TabsList className="grid w-full grid-cols-2">
+                        <TabsTrigger value="definitions">
+                            Definicije
+                        </TabsTrigger>
+                        <TabsTrigger value="queue">Red poslova</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="definitions">
+                        {definitionsPanel}
+                    </TabsContent>
+                    <TabsContent value="queue">{queuePanel}</TabsContent>
+                </Tabs>
+            </div>
+
+            <div className="hidden gap-4 md:grid md:grid-cols-[minmax(0,0.92fr)_minmax(360px,1.08fr)] xl:grid-cols-[minmax(0,0.85fr)_minmax(440px,1.15fr)]">
+                {definitionsPanel}
+                {queuePanel}
+            </div>
+        </>
+    );
+}

--- a/apps/app/app/admin/automations/AutomationOverviewPanels.tsx
+++ b/apps/app/app/admin/automations/AutomationOverviewPanels.tsx
@@ -87,7 +87,7 @@ export function AutomationOverviewPanels({
         [runsQuery.data.pages],
     );
     const definitionsPanel = (
-        <AutomationDefinitionsList definitions={definitions} runs={runs} />
+        <AutomationDefinitionsList definitions={definitions} />
     );
     const queuePanel = (
         <AutomationJobsQueueList

--- a/apps/app/app/admin/automations/AutomationRunsTable.tsx
+++ b/apps/app/app/admin/automations/AutomationRunsTable.tsx
@@ -11,20 +11,23 @@ import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
-import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import type { Route } from 'next';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import type { ReactNode } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { AutomationSlidePanel } from './AutomationSlidePanel';
+import {
+    AutomationRunStatusIndicator,
+    AutomationStepStatusIndicator,
+    isAutomationRunLive,
+} from './AutomationStatusIndicator';
 import { AutomationRunRetryControls } from './AutomationTestPanel';
 import {
     automationModuleKindLabel,
     automationRunStatusMeta,
-    automationStepStatusMeta,
 } from './presentation';
 
 export type AutomationRunStatusFilter =
@@ -62,24 +65,6 @@ export type AutomationRunsTableRun = {
         createdAt: string;
     }>;
 };
-
-function RunStatusChip({ status }: { status: AutomationRunStatus }) {
-    const meta = automationRunStatusMeta(status);
-    return (
-        <Chip color={meta.color} size="sm" variant="soft">
-            {meta.label}
-        </Chip>
-    );
-}
-
-function StepStatusChip({ status }: { status: AutomationStepStatus }) {
-    const meta = automationStepStatusMeta(status);
-    return (
-        <Chip color={meta.color} size="sm" variant="soft">
-            {meta.label}
-        </Chip>
-    );
-}
 
 function formatDuration(startedAt: string | null, completedAt: string | null) {
     if (!startedAt || !completedAt) {
@@ -127,6 +112,23 @@ function DetailItem({
     );
 }
 
+function ListDetailItem({
+    children,
+    label,
+}: {
+    children: ReactNode;
+    label: string;
+}) {
+    return (
+        <div className="min-w-0">
+            <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {label}
+            </dt>
+            <dd className="mt-1 min-w-0 break-words">{children}</dd>
+        </div>
+    );
+}
+
 export function AutomationRunsTable({
     currentStatusFilter,
     runs,
@@ -143,6 +145,10 @@ export function AutomationRunsTable({
     const selectedRun = useMemo(
         () => runs.find(({ run }) => run.id === selectedRunId) ?? null,
         [runs, selectedRunId],
+    );
+    const hasLiveRuns = useMemo(
+        () => runs.some(({ run }) => isAutomationRunLive(run.status)),
+        [runs],
     );
     const filterItems = useMemo<
         Array<{ value: AutomationRunStatusFilter; label: string }>
@@ -173,6 +179,18 @@ export function AutomationRunsTable({
         );
     }
 
+    useEffect(() => {
+        if (!hasLiveRuns) {
+            return;
+        }
+
+        const intervalId = window.setInterval(() => {
+            router.refresh();
+        }, 7000);
+
+        return () => window.clearInterval(intervalId);
+    }, [hasLiveRuns, router]);
+
     return (
         <>
             <div className="min-w-0 overflow-hidden rounded-md border bg-background">
@@ -198,110 +216,93 @@ export function AutomationRunsTable({
                         onValueChange={updateStatusFilter}
                     />
                 </div>
-                <Table>
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.Head>Status</Table.Head>
-                            <Table.Head>Događaj</Table.Head>
-                            <Table.Head>Trajanje</Table.Head>
-                            <Table.Head>Greška</Table.Head>
-                            <Table.Head>Vrijeme</Table.Head>
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        {runs.length === 0 ? (
-                            <Table.Row>
-                                <Table.Cell colSpan={5}>
-                                    <NoDataPlaceholder>
-                                        Automatizacija nema izvođenja za
-                                        odabrani filter.
-                                    </NoDataPlaceholder>
-                                </Table.Cell>
-                            </Table.Row>
-                        ) : null}
+                {runs.length === 0 ? (
+                    <div className="p-4">
+                        <NoDataPlaceholder>
+                            Automatizacija nema izvođenja za odabrani filter.
+                        </NoDataPlaceholder>
+                    </div>
+                ) : (
+                    <ul className="divide-y">
                         {runs.map(({ run, steps }) => (
-                            <Table.Row
-                                key={run.id}
-                                aria-selected={selectedRunId === run.id}
-                                className={cx(
-                                    'cursor-pointer focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
-                                    selectedRunId === run.id && 'bg-muted/70',
-                                )}
-                                onClick={() => setSelectedRunId(run.id)}
-                                onKeyDown={(event) => {
-                                    if (
-                                        event.key === 'Enter' ||
-                                        event.key === ' '
-                                    ) {
-                                        event.preventDefault();
-                                        setSelectedRunId(run.id);
-                                    }
-                                }}
-                                role="button"
-                                tabIndex={0}
-                            >
-                                <Table.Cell>
-                                    <Stack spacing={1}>
-                                        <RunStatusChip status={run.status} />
-                                        {run.dryRun ? (
-                                            <Chip
-                                                size="sm"
-                                                color="info"
-                                                variant="soft"
-                                            >
-                                                Probno
-                                            </Chip>
-                                        ) : null}
-                                    </Stack>
-                                </Table.Cell>
-                                <Table.Cell>
-                                    <Stack spacing={1}>
-                                        <Typography level="body3">
-                                            {run.sourceEventType ?? '-'}
-                                        </Typography>
-                                        <Typography
-                                            level="body3"
-                                            className="text-muted-foreground"
-                                        >
-                                            {run.sourceAggregateId ?? '-'}
-                                        </Typography>
-                                    </Stack>
-                                </Table.Cell>
-                                <Table.Cell>
-                                    {formatDuration(
-                                        run.startedAt,
-                                        run.completedAt,
+                            <li key={run.id}>
+                                <button
+                                    type="button"
+                                    aria-pressed={selectedRunId === run.id}
+                                    className={cx(
+                                        'grid w-full gap-3 p-4 text-left transition-colors hover:bg-muted/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+                                        selectedRunId === run.id &&
+                                            'bg-muted/70',
                                     )}
-                                </Table.Cell>
-                                <Table.Cell>
+                                    onClick={() => setSelectedRunId(run.id)}
+                                >
+                                    <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                        <Stack spacing={1} className="min-w-0">
+                                            <Row
+                                                spacing={2}
+                                                className="flex-wrap items-center"
+                                            >
+                                                <AutomationRunStatusIndicator
+                                                    status={run.status}
+                                                />
+                                                {run.dryRun ? (
+                                                    <Chip
+                                                        size="sm"
+                                                        color="info"
+                                                        variant="soft"
+                                                    >
+                                                        Probno
+                                                    </Chip>
+                                                ) : null}
+                                            </Row>
+                                            <Typography
+                                                level="body3"
+                                                className="text-muted-foreground"
+                                            >
+                                                {steps.length} koraka
+                                            </Typography>
+                                        </Stack>
+                                        <Stack
+                                            spacing={1}
+                                            className="text-muted-foreground sm:items-end"
+                                        >
+                                            <LocalDateTime>
+                                                {run.createdAt}
+                                            </LocalDateTime>
+                                            <Typography level="body3">
+                                                {formatDuration(
+                                                    run.startedAt,
+                                                    run.completedAt,
+                                                )}
+                                            </Typography>
+                                        </Stack>
+                                    </div>
+
+                                    <dl className="grid gap-3 text-sm sm:grid-cols-3">
+                                        <ListDetailItem label="Tip eventa">
+                                            {run.sourceEventType ?? '-'}
+                                        </ListDetailItem>
+                                        <ListDetailItem label="Agregat">
+                                            {run.sourceAggregateId ?? '-'}
+                                        </ListDetailItem>
+                                        <ListDetailItem label="Pokušaj">
+                                            {run.attempt} / {run.maxAttempts}
+                                        </ListDetailItem>
+                                    </dl>
+
                                     {run.errorMessage ? (
                                         <Typography
                                             level="body3"
-                                            className="text-red-700 dark:text-red-300"
+                                            className="break-words rounded-md bg-red-50 p-2 text-red-700 dark:bg-red-950 dark:text-red-300"
                                         >
                                             {run.errorMessage}
                                         </Typography>
-                                    ) : (
-                                        '-'
-                                    )}
-                                </Table.Cell>
-                                <Table.Cell>
-                                    <Stack spacing={1}>
-                                        <LocalDateTime>
-                                            {run.createdAt}
-                                        </LocalDateTime>
-                                        <Typography
-                                            level="body3"
-                                            className="text-muted-foreground"
-                                        >
-                                            {steps.length} koraka
-                                        </Typography>
-                                    </Stack>
-                                </Table.Cell>
-                            </Table.Row>
+                                    ) : null}
+                                </button>
+                            </li>
                         ))}
-                    </Table.Body>
-                </Table>
+                    </ul>
+                )}
             </div>
 
             <AutomationSlidePanel
@@ -326,7 +327,7 @@ export function AutomationRunsTable({
                     <Stack spacing={5}>
                         <Stack spacing={3}>
                             <Row spacing={1} className="flex-wrap">
-                                <RunStatusChip
+                                <AutomationRunStatusIndicator
                                     status={selectedRun.run.status}
                                 />
                                 {selectedRun.run.dryRun ? (
@@ -423,7 +424,7 @@ export function AutomationRunsTable({
                                             <Typography level="body2" semiBold>
                                                 {step.nodeId}
                                             </Typography>
-                                            <StepStatusChip
+                                            <AutomationStepStatusIndicator
                                                 status={step.status}
                                             />
                                             <Chip size="sm" variant="soft">

--- a/apps/app/app/admin/automations/AutomationStatusIndicator.tsx
+++ b/apps/app/app/admin/automations/AutomationStatusIndicator.tsx
@@ -1,0 +1,135 @@
+import type {
+    AutomationDefinitionStatus,
+    AutomationRunStatus,
+    AutomationStepStatus,
+} from '@gredice/storage';
+import { cx } from '@gredice/ui/utils';
+import {
+    automationRunStatusMeta,
+    automationStatusMeta,
+    automationStepStatusMeta,
+} from './presentation';
+
+type StatusTone =
+    | 'primary'
+    | 'secondary'
+    | 'error'
+    | 'warning'
+    | 'info'
+    | 'success'
+    | 'neutral';
+
+const dotClassNames: Record<StatusTone, string> = {
+    primary: 'bg-primary',
+    secondary: 'bg-secondary',
+    error: 'bg-red-500',
+    warning: 'bg-amber-500',
+    info: 'bg-blue-500',
+    success: 'bg-green-500',
+    neutral: 'bg-muted-foreground',
+};
+
+export function isAutomationRunLive(status: AutomationRunStatus) {
+    return status === 'queued' || status === 'running' || status === 'retrying';
+}
+
+function isAutomationStepLive(status: AutomationStepStatus) {
+    return status === 'pending' || status === 'running';
+}
+
+function AutomationStatusIndicator({
+    className,
+    label,
+    pulse,
+    tone,
+}: {
+    className?: string;
+    label: string;
+    pulse?: boolean;
+    tone: StatusTone;
+}) {
+    return (
+        <span
+            className={cx(
+                'inline-flex min-w-0 items-center gap-2 text-sm font-medium',
+                className,
+            )}
+        >
+            <span className="relative inline-flex size-2.5 shrink-0">
+                {pulse ? (
+                    <span
+                        aria-hidden="true"
+                        className={cx(
+                            'absolute inline-flex h-full w-full animate-ping rounded-full opacity-60',
+                            dotClassNames[tone],
+                        )}
+                    />
+                ) : null}
+                <span
+                    aria-hidden="true"
+                    className={cx(
+                        'relative inline-flex size-2.5 rounded-full',
+                        dotClassNames[tone],
+                    )}
+                />
+            </span>
+            <span className="truncate">{label}</span>
+        </span>
+    );
+}
+
+export function AutomationDefinitionStatusIndicator({
+    className,
+    status,
+}: {
+    className?: string;
+    status: AutomationDefinitionStatus;
+}) {
+    const meta = automationStatusMeta(status);
+
+    return (
+        <AutomationStatusIndicator
+            className={className}
+            label={meta.label}
+            tone={meta.color}
+        />
+    );
+}
+
+export function AutomationRunStatusIndicator({
+    className,
+    status,
+}: {
+    className?: string;
+    status: AutomationRunStatus;
+}) {
+    const meta = automationRunStatusMeta(status);
+
+    return (
+        <AutomationStatusIndicator
+            className={className}
+            label={meta.label}
+            pulse={isAutomationRunLive(status)}
+            tone={meta.color}
+        />
+    );
+}
+
+export function AutomationStepStatusIndicator({
+    className,
+    status,
+}: {
+    className?: string;
+    status: AutomationStepStatus;
+}) {
+    const meta = automationStepStatusMeta(status);
+
+    return (
+        <AutomationStatusIndicator
+            className={className}
+            label={meta.label}
+            pulse={isAutomationStepLive(status)}
+            tone={meta.color}
+        />
+    );
+}

--- a/apps/app/app/admin/automations/automationRunsData.ts
+++ b/apps/app/app/admin/automations/automationRunsData.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import {
+    type AutomationDefinitionRunSummary,
     type AutomationRunStatus,
     listAutomationRuns,
     type SelectAutomationDefinition,
@@ -49,10 +50,12 @@ export function serializeAutomationRun(
 export function serializeAutomationDefinition({
     actionSummary,
     definition,
+    runSummary,
     triggerSummary,
 }: {
     actionSummary: string;
     definition: SelectAutomationDefinition;
+    runSummary?: AutomationDefinitionRunSummary;
     triggerSummary: string;
 }): AutomationDefinitionListItem {
     return {
@@ -62,6 +65,10 @@ export function serializeAutomationDefinition({
         status: definition.status,
         triggerSummary,
         actionSummary,
+        latestRun: runSummary?.latestRun
+            ? serializeAutomationRun(runSummary.latestRun)
+            : null,
+        failedRunsCount: runSummary?.failedRunsCount ?? 0,
         updatedAt: definition.updatedAt.toISOString(),
     };
 }

--- a/apps/app/app/admin/automations/automationRunsData.ts
+++ b/apps/app/app/admin/automations/automationRunsData.ts
@@ -1,0 +1,104 @@
+import 'server-only';
+
+import {
+    type AutomationRunStatus,
+    listAutomationRuns,
+    type SelectAutomationDefinition,
+    type SelectAutomationRun,
+} from '@gredice/storage';
+import type {
+    AutomationDefinitionListItem,
+    AutomationRunListItem,
+    AutomationRunsPage,
+} from './types';
+
+export const automationQueuePageSize = 50;
+const maxAutomationQueuePageSize = 100;
+
+function dateToIso(value: Date | null) {
+    return value ? value.toISOString() : null;
+}
+
+export function serializeAutomationRun(
+    run: SelectAutomationRun,
+): AutomationRunListItem {
+    return {
+        id: run.id,
+        automationDefinitionId: run.automationDefinitionId,
+        automationDefinitionKey: run.automationDefinitionKey,
+        automationDefinitionName: run.automationDefinitionName,
+        source: run.source,
+        sourceEventType: run.sourceEventType,
+        sourceAggregateId: run.sourceAggregateId,
+        parentRunId: run.parentRunId,
+        status: run.status,
+        dryRun: run.dryRun,
+        attempt: run.attempt,
+        maxAttempts: run.maxAttempts,
+        nextRunAt: run.nextRunAt.toISOString(),
+        lockedAt: dateToIso(run.lockedAt),
+        lockedBy: run.lockedBy,
+        errorMessage: run.errorMessage,
+        startedAt: dateToIso(run.startedAt),
+        completedAt: dateToIso(run.completedAt),
+        createdAt: run.createdAt.toISOString(),
+        updatedAt: run.updatedAt.toISOString(),
+    };
+}
+
+export function serializeAutomationDefinition({
+    actionSummary,
+    definition,
+    triggerSummary,
+}: {
+    actionSummary: string;
+    definition: SelectAutomationDefinition;
+    triggerSummary: string;
+}): AutomationDefinitionListItem {
+    return {
+        id: definition.id,
+        key: definition.key,
+        name: definition.name,
+        status: definition.status,
+        triggerSummary,
+        actionSummary,
+        updatedAt: definition.updatedAt.toISOString(),
+    };
+}
+
+function normalizeLimit(limit: number | undefined) {
+    if (!limit || !Number.isFinite(limit)) {
+        return automationQueuePageSize;
+    }
+
+    return Math.min(Math.max(Math.trunc(limit), 1), maxAutomationQueuePageSize);
+}
+
+export async function listAutomationRunsPage({
+    failedOnly,
+    limit,
+    offset = 0,
+    status,
+}: {
+    failedOnly?: boolean;
+    limit?: number;
+    offset?: number;
+    status?: AutomationRunStatus;
+}): Promise<AutomationRunsPage> {
+    const pageSize = normalizeLimit(limit);
+    const rows = await listAutomationRuns({
+        failedOnly,
+        status,
+        limit: pageSize + 1,
+        offset,
+    });
+    const hasMore = rows.length > pageSize;
+    const runs = rows.slice(0, pageSize).map(serializeAutomationRun);
+
+    return {
+        runs,
+        hasMore,
+        nextOffset: hasMore ? offset + pageSize : null,
+        pageSize,
+    };
+}

--- a/apps/app/app/admin/automations/page.tsx
+++ b/apps/app/app/admin/automations/page.tsx
@@ -6,29 +6,22 @@ import {
     ensureDefaultAutomationDefinitions,
     getAutomationModuleMetadata,
     listAutomationDefinitions,
-    listAutomationRuns,
 } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
-import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardOverflow,
-    CardTitle,
-} from '@gredice/ui/Card';
-import { Chip } from '@gredice/ui/Chip';
+import { Card, CardContent } from '@gredice/ui/Card';
 import { Add, Search } from '@gredice/ui/icons';
-import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
-import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
-import Link from 'next/link';
 import { AdminPageHeader } from '../../../components/admin/navigation';
-import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { auth } from '../../../lib/auth/auth';
 import { KnownPages } from '../../../src/KnownPages';
-import { AutomationJobsQueueTable } from './AutomationJobsQueueTable';
+import { AutomationOverviewPanels } from './AutomationOverviewPanels';
+import {
+    automationQueuePageSize,
+    listAutomationRunsPage,
+    serializeAutomationDefinition,
+} from './automationRunsData';
 import {
     automationActionSummary,
     automationRunStatusMeta,
@@ -64,24 +57,6 @@ function parseRunStatus(
     return automationRunStatusValues.find((item) => item === status);
 }
 
-function StatusChip({ status }: { status: AutomationDefinitionStatus }) {
-    const meta = automationStatusMeta(status);
-    return (
-        <Chip color={meta.color} size="sm" variant="soft">
-            {meta.label}
-        </Chip>
-    );
-}
-
-function RunStatusChip({ status }: { status: AutomationRunStatus }) {
-    const meta = automationRunStatusMeta(status);
-    return (
-        <Chip color={meta.color} size="sm" variant="soft">
-            {meta.label}
-        </Chip>
-    );
-}
-
 export default async function AutomationsPage({
     searchParams,
 }: {
@@ -104,29 +79,31 @@ export default async function AutomationsPage({
             triggerEventType,
             limit: 200,
         }),
-        listAutomationRuns({
+        listAutomationRunsPage({
+            failedOnly,
             status: failedOnly ? 'failed' : runStatus,
-            limit: 300,
+            limit: automationQueuePageSize,
         }),
     ]);
-    const queuedRunsCount = runs.filter(
+    const queuedRunsCount = runs.runs.filter(
         (run) => run.status === 'queued' || run.status === 'retrying',
     ).length;
-    const runningRunsCount = runs.filter(
+    const runningRunsCount = runs.runs.filter(
         (run) => run.status === 'running',
     ).length;
-    const runsByDefinitionId = new Map<number, typeof runs>();
-
-    for (const run of runs) {
-        const definitionRuns = runsByDefinitionId.get(
-            run.automationDefinitionId,
-        );
-        if (definitionRuns) {
-            definitionRuns.push(run);
-        } else {
-            runsByDefinitionId.set(run.automationDefinitionId, [run]);
-        }
-    }
+    const definitionItems = definitions.map((definition) =>
+        serializeAutomationDefinition({
+            actionSummary: automationActionSummary(
+                definition.graph,
+                modulesByKey,
+            ),
+            definition,
+            triggerSummary: automationTriggerSummary(
+                definition.graph,
+                modulesByKey,
+            ),
+        }),
+    );
 
     return (
         <Stack spacing={5}>
@@ -262,9 +239,13 @@ export default async function AutomationsPage({
                 <Card>
                     <CardContent>
                         <Typography level="body3" secondary>
-                            Poslovi
+                            Učitani poslovi
                         </Typography>
-                        <Typography level="h4">{runs.length}</Typography>
+                        <Typography level="h4">
+                            {runs.hasMore
+                                ? `${runs.runs.length}+`
+                                : runs.runs.length}
+                        </Typography>
                     </CardContent>
                 </Card>
                 <Card>
@@ -290,134 +271,21 @@ export default async function AutomationsPage({
                         </Typography>
                         <Typography level="h4">
                             {
-                                runs.filter((run) => run.status === 'failed')
-                                    .length
+                                runs.runs.filter(
+                                    (run) => run.status === 'failed',
+                                ).length
                             }
                         </Typography>
                     </CardContent>
                 </Card>
             </div>
 
-            <AutomationJobsQueueTable runs={runs} />
-
-            <Card>
-                <CardHeader>
-                    <CardTitle>Definicije</CardTitle>
-                </CardHeader>
-                <CardOverflow>
-                    <div className="overflow-auto">
-                        <Table>
-                            <Table.Header>
-                                <Table.Row>
-                                    <Table.Head>Naziv</Table.Head>
-                                    <Table.Head>Status</Table.Head>
-                                    <Table.Head>Okidač</Table.Head>
-                                    <Table.Head>Akcije</Table.Head>
-                                    <Table.Head>Zadnje izvođenje</Table.Head>
-                                    <Table.Head>Greške</Table.Head>
-                                    <Table.Head>Ažurirano</Table.Head>
-                                </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                                {definitions.length === 0 ? (
-                                    <Table.Row>
-                                        <Table.Cell colSpan={7}>
-                                            <NoDataPlaceholder>
-                                                Nema automatizacija za odabrane
-                                                filtre.
-                                            </NoDataPlaceholder>
-                                        </Table.Cell>
-                                    </Table.Row>
-                                ) : null}
-                                {definitions.map((definition) => {
-                                    const definitionRuns =
-                                        runsByDefinitionId.get(definition.id) ??
-                                        [];
-                                    const latestRun = definitionRuns[0];
-                                    const failedCount = definitionRuns.filter(
-                                        (run) => run.status === 'failed',
-                                    ).length;
-
-                                    return (
-                                        <Table.Row key={definition.id}>
-                                            <Table.Cell>
-                                                <Stack spacing={1}>
-                                                    <Link
-                                                        href={KnownPages.Automation(
-                                                            definition.id,
-                                                        )}
-                                                        className="font-medium text-primary hover:underline"
-                                                    >
-                                                        {definition.name}
-                                                    </Link>
-                                                    <Typography
-                                                        level="body3"
-                                                        className="text-muted-foreground"
-                                                    >
-                                                        {definition.key}
-                                                    </Typography>
-                                                </Stack>
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <StatusChip
-                                                    status={definition.status}
-                                                />
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <Typography level="body3">
-                                                    {automationTriggerSummary(
-                                                        definition.graph,
-                                                        modulesByKey,
-                                                    )}
-                                                </Typography>
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <Typography level="body3">
-                                                    {automationActionSummary(
-                                                        definition.graph,
-                                                        modulesByKey,
-                                                    )}
-                                                </Typography>
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                {latestRun ? (
-                                                    <Stack spacing={1}>
-                                                        <RunStatusChip
-                                                            status={
-                                                                latestRun.status
-                                                            }
-                                                        />
-                                                        <LocalDateTime>
-                                                            {
-                                                                latestRun.createdAt
-                                                            }
-                                                        </LocalDateTime>
-                                                    </Stack>
-                                                ) : (
-                                                    <Typography
-                                                        level="body3"
-                                                        className="text-muted-foreground"
-                                                    >
-                                                        Nema izvođenja
-                                                    </Typography>
-                                                )}
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                {failedCount}
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                <LocalDateTime>
-                                                    {definition.updatedAt}
-                                                </LocalDateTime>
-                                            </Table.Cell>
-                                        </Table.Row>
-                                    );
-                                })}
-                            </Table.Body>
-                        </Table>
-                    </div>
-                </CardOverflow>
-            </Card>
+            <AutomationOverviewPanels
+                definitions={definitionItems}
+                failedOnly={failedOnly}
+                initialRunsPage={runs}
+                runStatus={failedOnly ? 'failed' : runStatus}
+            />
         </Stack>
     );
 }

--- a/apps/app/app/admin/automations/page.tsx
+++ b/apps/app/app/admin/automations/page.tsx
@@ -5,6 +5,7 @@ import {
     automationRunStatusValues,
     ensureDefaultAutomationDefinitions,
     getAutomationModuleMetadata,
+    listAutomationDefinitionRunSummaries,
     listAutomationDefinitions,
 } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
@@ -85,6 +86,15 @@ export default async function AutomationsPage({
             limit: automationQueuePageSize,
         }),
     ]);
+    const runSummaries = await listAutomationDefinitionRunSummaries(
+        definitions.map((definition) => definition.id),
+    );
+    const runSummariesByDefinitionId = new Map(
+        runSummaries.map((summary) => [
+            summary.automationDefinitionId,
+            summary,
+        ]),
+    );
     const queuedRunsCount = runs.runs.filter(
         (run) => run.status === 'queued' || run.status === 'retrying',
     ).length;
@@ -98,6 +108,7 @@ export default async function AutomationsPage({
                 modulesByKey,
             ),
             definition,
+            runSummary: runSummariesByDefinitionId.get(definition.id),
             triggerSummary: automationTriggerSummary(
                 definition.graph,
                 modulesByKey,

--- a/apps/app/app/admin/automations/types.ts
+++ b/apps/app/app/admin/automations/types.ts
@@ -1,0 +1,45 @@
+import type {
+    AutomationDefinitionStatus,
+    AutomationRunSource,
+    AutomationRunStatus,
+} from '@gredice/storage';
+
+export type AutomationRunListItem = {
+    id: number;
+    automationDefinitionId: number;
+    automationDefinitionKey: string;
+    automationDefinitionName: string;
+    source: AutomationRunSource;
+    sourceEventType: string | null;
+    sourceAggregateId: string | null;
+    parentRunId: number | null;
+    status: AutomationRunStatus;
+    dryRun: boolean;
+    attempt: number;
+    maxAttempts: number;
+    nextRunAt: string;
+    lockedAt: string | null;
+    lockedBy: string | null;
+    errorMessage: string | null;
+    startedAt: string | null;
+    completedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+};
+
+export type AutomationRunsPage = {
+    runs: AutomationRunListItem[];
+    hasMore: boolean;
+    nextOffset: number | null;
+    pageSize: number;
+};
+
+export type AutomationDefinitionListItem = {
+    id: number;
+    key: string;
+    name: string;
+    status: AutomationDefinitionStatus;
+    triggerSummary: string;
+    actionSummary: string;
+    updatedAt: string;
+};

--- a/apps/app/app/admin/automations/types.ts
+++ b/apps/app/app/admin/automations/types.ts
@@ -41,5 +41,7 @@ export type AutomationDefinitionListItem = {
     status: AutomationDefinitionStatus;
     triggerSummary: string;
     actionSummary: string;
+    latestRun: AutomationRunListItem | null;
+    failedRunsCount: number;
     updatedAt: string;
 };

--- a/apps/app/app/api/admin/automations/runs/route.ts
+++ b/apps/app/app/api/admin/automations/runs/route.ts
@@ -1,0 +1,48 @@
+import {
+    type AutomationRunStatus,
+    automationRunStatusValues,
+} from '@gredice/storage';
+import { withAuth } from '../../../../../lib/auth/auth';
+import {
+    automationQueuePageSize,
+    listAutomationRunsPage,
+} from '../../../../admin/automations/automationRunsData';
+
+export const dynamic = 'force-dynamic';
+
+function parseAutomationRunStatus(
+    value: string | null,
+): AutomationRunStatus | undefined {
+    return automationRunStatusValues.find((status) => status === value);
+}
+
+function parseInteger(value: string | null, fallback: number) {
+    if (!value) {
+        return fallback;
+    }
+
+    const parsed = Number(value);
+
+    return Number.isInteger(parsed) ? parsed : fallback;
+}
+
+export async function GET(request: Request) {
+    return await withAuth(['admin'], async () => {
+        const searchParams = new URL(request.url).searchParams;
+        const page = await listAutomationRunsPage({
+            failedOnly: searchParams.get('failedOnly') === '1',
+            limit: parseInteger(
+                searchParams.get('limit'),
+                automationQueuePageSize,
+            ),
+            offset: Math.max(0, parseInteger(searchParams.get('offset'), 0)),
+            status: parseAutomationRunStatus(searchParams.get('runStatus')),
+        });
+
+        return Response.json(page, {
+            headers: {
+                'Cache-Control': 'no-store',
+            },
+        });
+    });
+}

--- a/packages/storage/src/repositories/automationsRepo.ts
+++ b/packages/storage/src/repositories/automationsRepo.ts
@@ -452,6 +452,70 @@ export async function listAutomationRuns(filters?: {
         .limit(filters?.limit ?? defaultRunLimit);
 }
 
+export type AutomationDefinitionRunSummary = {
+    automationDefinitionId: number;
+    latestRun: SelectAutomationRun | null;
+    failedRunsCount: number;
+};
+
+export async function listAutomationDefinitionRunSummaries(
+    automationDefinitionIds: number[],
+): Promise<AutomationDefinitionRunSummary[]> {
+    const definitionIds = [...new Set(automationDefinitionIds)].filter((id) =>
+        Number.isInteger(id),
+    );
+
+    if (definitionIds.length === 0) {
+        return [];
+    }
+
+    const [latestRuns, failedCountRows] = await Promise.all([
+        storage()
+            .selectDistinctOn([automationRuns.automationDefinitionId])
+            .from(automationRuns)
+            .where(
+                inArray(automationRuns.automationDefinitionId, definitionIds),
+            )
+            .orderBy(
+                automationRuns.automationDefinitionId,
+                desc(automationRuns.createdAt),
+                desc(automationRuns.id),
+            ),
+        storage()
+            .select({
+                automationDefinitionId: automationRuns.automationDefinitionId,
+                failedRunsCount: sql<number>`count(*)::int`,
+            })
+            .from(automationRuns)
+            .where(
+                and(
+                    inArray(
+                        automationRuns.automationDefinitionId,
+                        definitionIds,
+                    ),
+                    eq(automationRuns.status, 'failed'),
+                ),
+            )
+            .groupBy(automationRuns.automationDefinitionId),
+    ]);
+    const latestRunsByDefinitionId = new Map(
+        latestRuns.map((run) => [run.automationDefinitionId, run]),
+    );
+    const failedRunsByDefinitionId = new Map(
+        failedCountRows.map((row) => [
+            row.automationDefinitionId,
+            Number(row.failedRunsCount),
+        ]),
+    );
+
+    return definitionIds.map((automationDefinitionId) => ({
+        automationDefinitionId,
+        latestRun: latestRunsByDefinitionId.get(automationDefinitionId) ?? null,
+        failedRunsCount:
+            failedRunsByDefinitionId.get(automationDefinitionId) ?? 0,
+    }));
+}
+
 export async function getAutomationRunById(
     id: number,
 ): Promise<SelectAutomationRun | null> {

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -27,6 +27,7 @@ import {
     getRaisedBed,
     knownEvents,
     knownEventTypes,
+    listAutomationDefinitionRunSummaries,
     listAutomationDefinitions,
     listAutomationRuns,
     listEnabledAutomationDefinitionsForEventType,
@@ -322,6 +323,88 @@ test('automation graph validation waits for all incoming dependencies', () => {
             'queue-seasonal-waterings',
         ],
     );
+});
+
+test('automation definition run summaries are independent per definition', async () => {
+    createTestDb();
+    const firstDefinition = await createAutomationDefinition({
+        key: 'test.summary-first-automation',
+        name: 'Summary first automation',
+        status: 'enabled',
+        graph: seasonalSowedWateringAutomationGraph(),
+    });
+    const secondDefinition = await createAutomationDefinition({
+        key: 'test.summary-second-automation',
+        name: 'Summary second automation',
+        status: 'enabled',
+        graph: seasonalSowedWateringAutomationGraph(),
+    });
+    const firstFailedRun = await createAutomationRun({
+        automationDefinition: firstDefinition,
+        source: 'test',
+        input: { order: 'first-failed' },
+    });
+    assert.ok(firstFailedRun);
+    await completeAutomationRun({
+        id: firstFailedRun.id,
+        status: 'failed',
+        errorMessage: 'Expected test failure.',
+    });
+
+    const firstLatestRun = await createAutomationRun({
+        automationDefinition: firstDefinition,
+        source: 'test',
+        input: { order: 'first-latest' },
+    });
+    assert.ok(firstLatestRun);
+    await completeAutomationRun({
+        id: firstLatestRun.id,
+        status: 'succeeded',
+        output: { ok: true },
+    });
+
+    const secondFailedRun = await createAutomationRun({
+        automationDefinition: secondDefinition,
+        source: 'test',
+        input: { order: 'second-failed' },
+    });
+    assert.ok(secondFailedRun);
+    await completeAutomationRun({
+        id: secondFailedRun.id,
+        status: 'failed',
+        errorMessage: 'Expected second test failure.',
+    });
+
+    const summaries = await listAutomationDefinitionRunSummaries([
+        firstDefinition.id,
+        secondDefinition.id,
+        -1,
+    ]);
+    const summariesByDefinitionId = new Map(
+        summaries.map((summary) => [summary.automationDefinitionId, summary]),
+    );
+
+    assert.strictEqual(
+        summariesByDefinitionId.get(firstDefinition.id)?.latestRun?.id,
+        firstLatestRun.id,
+    );
+    assert.strictEqual(
+        summariesByDefinitionId.get(firstDefinition.id)?.failedRunsCount,
+        1,
+    );
+    assert.strictEqual(
+        summariesByDefinitionId.get(secondDefinition.id)?.latestRun?.id,
+        secondFailedRun.id,
+    );
+    assert.strictEqual(
+        summariesByDefinitionId.get(secondDefinition.id)?.failedRunsCount,
+        1,
+    );
+    assert.deepStrictEqual(summariesByDefinitionId.get(-1), {
+        automationDefinitionId: -1,
+        latestRun: null,
+        failedRunsCount: 0,
+    });
 });
 
 test('automation run claiming respects definition concurrency', async () => {


### PR DESCRIPTION
## Summary

- Split the automations overview into definitions and queue panels on desktop, with mobile tabs for switching between them.
- Reworked automation jobs/runs from table rows into responsive list items, using colored status dots with pulse animation for queued/running/retrying work.
- Added an authenticated paginated runs endpoint and React Query infinite loading so the queue starts with the latest 50 jobs, supports Load more, and refreshes active jobs every 7 seconds.

## Validation

- `pnpm --filter app exec biome check app/admin/automations/page.tsx app/admin/automations/AutomationJobsQueueTable.tsx app/admin/automations/AutomationRunsTable.tsx app/admin/automations/AutomationDefinitionsList.tsx app/admin/automations/AutomationOverviewPanels.tsx app/admin/automations/AutomationStatusIndicator.tsx app/admin/automations/automationRunsData.ts app/admin/automations/types.ts app/api/admin/automations/runs/route.ts`
- `pnpm --filter app exec tsc --ignoreConfig --noEmit --pretty false --jsx react-jsx --moduleResolution bundler --module esnext --target ESNext --strict --skipLibCheck --esModuleInterop --allowSyntheticDefaultImports --allowJs --resolveJsonModule --allowImportingTsExtensions --isolatedModules --lib dom,dom.iterable,esnext app/admin/automations/page.tsx app/admin/automations/AutomationJobsQueueTable.tsx app/admin/automations/AutomationRunsTable.tsx app/admin/automations/AutomationDefinitionsList.tsx app/admin/automations/AutomationOverviewPanels.tsx app/admin/automations/AutomationStatusIndicator.tsx app/admin/automations/automationRunsData.ts app/admin/automations/types.ts app/api/admin/automations/runs/route.ts`
- `pnpm build --filter app`
- Browser smoke against `http://localhost:3003/admin/automations`: unauthenticated session rendered the login dialog with no Next.js error overlay and no browser console errors; authenticated dashboard visual verification was not reachable in this session.

Note: direct full-app `pnpm --filter app exec tsc --noEmit --pretty false` still reports unrelated baseline errors outside this change; the touched-file TypeScript pass above is clean.