### PR TITLE
[codex] Disable unaffordable item picker purchases

### DIFF
--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -6,6 +6,7 @@ import {
     gameHudBottomBarClassName,
     gameHudBottomControlsClassName,
 } from '../../../packages/game/src/GameHud';
+import { currentAccountKeys } from '../../../packages/game/src/hooks/useCurrentAccount';
 import { ControlsTooltipHud } from '../../../packages/game/src/hud/ControlsTooltipHud';
 import { ItemsHud } from '../../../packages/game/src/hud/ItemsHud';
 import { SandboxBlockTrashDropTarget } from '../../../packages/game/src/hud/SandboxBlockTrashDropTarget';
@@ -118,12 +119,14 @@ const blockNames = [
 ];
 
 type ItemsHudStoryOptions = {
+    accountSunflowers?: number;
     isSandbox?: boolean;
     pickupBlock?: boolean;
     trashTargetActive?: boolean;
 };
 
 function createItemsHudQueryClient({
+    accountSunflowers = 50,
     isSandbox = false,
 }: ItemsHudStoryOptions) {
     const queryClient = new ReactQuery.QueryClient({
@@ -134,6 +137,13 @@ function createItemsHudQueryClient({
 
     queryClient.setQueryData(['blocks'], blockNames.map(createBlockData));
     queryClient.setQueryData(['currentUser'], { id: 'test-user' });
+    queryClient.setQueryData(currentAccountKeys, {
+        id: 'test-account',
+        sunflowers: {
+            amount: accountSunflowers,
+            history: [],
+        },
+    });
     queryClient.setQueryData(['gardens'], [{ id: 1, isSandbox }]);
     queryClient.setQueryData(['gardens', 'current', 'summer', 1], {
         id: 1,
@@ -150,13 +160,14 @@ function createItemsHudQueryClient({
 
 function ItemsHudTestProviders({
     children,
+    accountSunflowers,
     isSandbox = false,
     pickupBlock = false,
     trashTargetActive = false,
 }: PropsWithChildren<ItemsHudStoryOptions>) {
     const queryClient = useMemo(
-        () => createItemsHudQueryClient({ isSandbox }),
-        [isSandbox],
+        () => createItemsHudQueryClient({ accountSunflowers, isSandbox }),
+        [accountSunflowers, isSandbox],
     );
     const gameStore = useMemo(() => {
         const store = createGameState({
@@ -192,6 +203,27 @@ function ItemsHudTestProviders({
 export function ItemsHudAlignmentStory() {
     return (
         <ItemsHudTestProviders>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <div
+                        data-testid="bottom-controls"
+                        className={gameHudBottomControlsClassName}
+                    >
+                        <div className="h-10 w-40 rounded-lg border bg-muted" />
+                    </div>
+                    <ItemsHud />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}
+
+export function LowSunflowerBalanceItemsHudStory() {
+    return (
+        <ItemsHudTestProviders accountSunflowers={20}>
             <div className="relative h-screen w-screen overflow-hidden">
                 <div
                     data-testid="bottom-hud"

--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import {
     ItemsHudAlignmentStory,
     ItemsHudControlsTooltipStory,
+    LowSunflowerBalanceItemsHudStory,
     SandboxBlockTrashDropTargetStory,
     SandboxItemsHudStory,
 } from './ItemsHudStory';
@@ -216,6 +217,32 @@ test('item picker price buttons use the soft surface', async ({
     await expect(priceButton).toHaveClass(/bg-primary\/10/u);
 });
 
+test('item picker disables purchase buttons above the sunflower balance', async ({
+    mount,
+    page,
+}) => {
+    await mount(<ItemsHudAlignmentStory />);
+
+    await page.getByRole('button', { name: 'Alat' }).click();
+
+    const affordablePriceButton = page
+        .getByRole('button', { name: /10/u })
+        .first();
+    await expect(affordablePriceButton).toBeEnabled();
+
+    const expensivePriceButton = page.getByRole('button', { name: /100/u });
+    await expect(expensivePriceButton).toBeVisible();
+    await expect(expensivePriceButton).toBeDisabled();
+
+    await page.getByRole('button', { name: 'PaintRoller' }).click();
+
+    const detailsPlaceButton = page.getByRole('button', {
+        name: /Postavi.*100/u,
+    });
+    await expect(detailsPlaceButton).toBeDisabled();
+    await expect(page.getByText('Nedovoljno suncokreta.')).toBeVisible();
+});
+
 test('item details place button keeps the soft color treatment', async ({
     mount,
     page,
@@ -280,6 +307,58 @@ test('item placement reserves local positions while requests are pending', async
     await expect.poll(() => placeRequestPositions.length).toBe(2);
     await expect(placeButton).toBeEnabled();
     expect(placeRequestPositions[0]).not.toEqual(placeRequestPositions[1]);
+
+    for (const releaseResponse of releaseResponses) {
+        releaseResponse();
+    }
+});
+
+test('item placement subtracts pending sunflower spends before enabling more purchases', async ({
+    mount,
+    page,
+}) => {
+    const placeRequestPositions: Array<{ x: number; y: number }> = [];
+    const releaseResponses: Array<() => void> = [];
+
+    await page.route(
+        /\/api(?:\/gredice)?\/gardens\/1\/blocks$/u,
+        async (route) => {
+            const position = getPlacementRequestPosition(
+                route.request().postDataJSON(),
+            );
+            if (position) {
+                placeRequestPositions.push(position);
+            }
+            const blockId = `placed-block-${placeRequestPositions.length.toString()}`;
+
+            await new Promise<void>((resolve) => {
+                releaseResponses.push(resolve);
+            });
+
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    id: blockId,
+                    position: { x: 0, y: 0 },
+                }),
+            });
+        },
+    );
+
+    await mount(<LowSunflowerBalanceItemsHudStory />);
+
+    await page.getByRole('button', { name: 'Blokovi' }).click();
+    await page
+        .getByRole('button', { name: 'Block Grass', exact: true })
+        .click();
+
+    const placeButton = page.getByRole('button', { name: /Postavi.*10/u });
+    await expect(placeButton).toBeEnabled();
+
+    await placeButton.dblclick();
+    await expect.poll(() => placeRequestPositions.length).toBe(2);
+    await expect(placeButton).toBeDisabled();
 
     for (const releaseResponse of releaseResponses) {
         releaseResponse();

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -11,11 +11,18 @@ import {
     replaceOptimisticBlockId,
 } from './optimisticBlockPlacement';
 import { useBlockData } from './useBlockData';
-import { currentAccountKeys } from './useCurrentAccount';
+import {
+    currentAccountKeys,
+    type useCurrentAccount,
+} from './useCurrentAccount';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
 
 const mutationKey = ['gardens', 'current', 'blockPlace'];
 const optimisticBlockIdPrefix = 'optimistic-block';
+
+type CurrentAccountData = NonNullable<
+    ReturnType<typeof useCurrentAccount>['data']
+>;
 
 type CurrentGardenData = NonNullable<
     ReturnType<typeof useCurrentGarden>['data']
@@ -55,6 +62,31 @@ function createOptimisticBlockId(blockName: string) {
     const timestamp = Date.now().toString(36);
     const randomSuffix = Math.random().toString(36).slice(2);
     return `${optimisticBlockIdPrefix}:${blockName}:${timestamp}:${randomSuffix}`;
+}
+
+function updateCurrentAccountSunflowers(
+    currentAccount: CurrentAccountData | null | undefined,
+    amountDelta: number,
+) {
+    if (!currentAccount) {
+        return currentAccount;
+    }
+
+    const nextAmount = Math.max(
+        0,
+        currentAccount.sunflowers.amount + amountDelta,
+    );
+    if (nextAmount === currentAccount.sunflowers.amount) {
+        return currentAccount;
+    }
+
+    return {
+        ...currentAccount,
+        sunflowers: {
+            ...currentAccount.sunflowers,
+            amount: nextAmount,
+        },
+    };
 }
 
 async function runQueuedPlacement<T>(
@@ -150,6 +182,9 @@ export function useBlockPlace() {
                     await queryClient.cancelQueries({
                         queryKey: gardenQueryKey,
                     });
+                    await queryClient.cancelQueries({
+                        queryKey: currentAccountKeys,
+                    });
                     const currentGarden =
                         queryClient.getQueryData<CurrentGardenData>(
                             gardenQueryKey,
@@ -205,10 +240,19 @@ export function useBlockPlace() {
                             kind: 'sunflowers',
                             amount,
                         });
+                        queryClient.setQueryData<CurrentAccountData | null>(
+                            currentAccountKeys,
+                            (currentAccount) =>
+                                updateCurrentAccountSunflowers(
+                                    currentAccount,
+                                    -amount,
+                                ),
+                        );
                     }
 
                     return {
                         optimisticBlockId,
+                        sunflowerAmount: amount,
                     };
                 },
             );
@@ -244,16 +288,26 @@ export function useBlockPlace() {
                             : currentGarden,
                 );
             }
+            if (context?.sunflowerAmount) {
+                queryClient.setQueryData<CurrentAccountData | null>(
+                    currentAccountKeys,
+                    (currentAccount) =>
+                        updateCurrentAccountSunflowers(
+                            currentAccount,
+                            context.sunflowerAmount,
+                        ),
+                );
+            }
         },
         onSettled: async () => {
             if (localSandboxStorageKey) {
                 return;
             }
 
-            await queryClient.invalidateQueries({
-                queryKey: currentAccountKeys,
-            });
             if (queryClient.isMutating({ mutationKey }) === 1) {
+                await queryClient.invalidateQueries({
+                    queryKey: currentAccountKeys,
+                });
                 await queryClient.invalidateQueries({
                     queryKey: gardenQueryKey,
                 });

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -15,6 +15,7 @@ import Image from 'next/image';
 import { useMemo, useState } from 'react';
 import { useBlockData } from '../hooks/useBlockData';
 import { useBlockPlace } from '../hooks/useBlockPlace';
+import { useCurrentAccount } from '../hooks/useCurrentAccount';
 import { useIsSandboxGarden } from '../hooks/useCurrentGarden';
 import { KnownPages } from '../knownPages';
 import { useGameState } from '../useGameState';
@@ -286,17 +287,25 @@ function PlaceEntityButton({
     const { data: blockData } = useBlockData();
     const placeBlock = useBlockPlace();
     const timeOfDay = useGameState((state) => state.timeOfDay);
+    const { data: account, isLoading: isAccountLoading } = useCurrentAccount();
     // Sandbox ("play") gardens build for free — every block is placeable
     // regardless of price or night-only availability.
     const isSandbox = useIsSandboxGarden();
 
     const block = blockData?.find((block) => block.information.name === name);
     if (!block) return null;
-    const hasSunflowerPrice = Boolean(block.prices.sunflowers);
+    const sunflowerPrice = block.prices.sunflowers ?? 0;
+    const hasSunflowerPrice = sunflowerPrice > 0;
     const isAvailableNow =
         isSandbox ||
         !isNightOnlyBlockPurchase(block) ||
         isNightTimeOfDay(timeOfDay);
+    const accountSunflowers = account?.sunflowers.amount;
+    const hasEnoughSunflowers =
+        isSandbox ||
+        !hasSunflowerPrice ||
+        (typeof accountSunflowers === 'number' &&
+            accountSunflowers >= sunflowerPrice);
     const isPlaceable = isSandbox || hasSunflowerPrice;
 
     function placeEntity() {
@@ -316,6 +325,12 @@ function PlaceEntityButton({
         placeBlock.error instanceof Error ? placeBlock.error.message : null;
     const availabilityMessage =
         !isAvailableNow && hasSunflowerPrice ? 'Dostupno samo noću.' : null;
+    const insufficientSunflowersMessage =
+        !hasEnoughSunflowers &&
+        !isAccountLoading &&
+        typeof accountSunflowers === 'number'
+            ? 'Nedovoljno suncokreta.'
+            : null;
 
     return (
         <Stack spacing={1}>
@@ -327,19 +342,21 @@ function PlaceEntityButton({
                 onClick={placeEntity}
                 size={simple ? 'sm' : 'md'}
                 variant="soft"
-                disabled={!isPlaceable || !isAvailableNow}
+                disabled={
+                    !isPlaceable || !isAvailableNow || !hasEnoughSunflowers
+                }
                 endDecorator={
                     <Row
                         className={cx(
                             !simple &&
                                 'rounded-full p-1 gap border border-primary/15 bg-primary/15 text-primary w-fit pr-2',
-                            !isSandbox && !block.prices.sunflowers && 'pl-2',
+                            !isSandbox && !sunflowerPrice && 'pl-2',
                         )}
                     >
                         {isSandbox
                             ? '🌻 0'
                             : hasSunflowerPrice && isAvailableNow
-                              ? `🌻 ${block.prices.sunflowers}`
+                              ? `🌻 ${sunflowerPrice}`
                               : availabilityMessage
                                 ? 'Noću'
                                 : 'Nedostupno'}
@@ -351,6 +368,11 @@ function PlaceEntityButton({
             {availabilityMessage && !simple && (
                 <Typography level="body3" className="text-muted-foreground">
                     {availabilityMessage}
+                </Typography>
+            )}
+            {insufficientSunflowersMessage && !simple && (
+                <Typography level="body3" className="text-muted-foreground">
+                    {insufficientSunflowersMessage}
                 </Typography>
             )}
             {errorMessage && (


### PR DESCRIPTION
## Summary

- Disable game item picker purchase buttons when the current account does not have enough sunflowers for the block price.
- Optimistically subtract pending block-placement sunflower spends so rapid clicks cannot keep enabling already-unaffordable purchases while placement requests are in flight.
- Keep sandbox/free placement behavior available and keep night-only availability handling intact.
- Add component regressions covering compact picker price buttons, the item details `Postavi` button, and pending placement spends.

## Root Cause

The item picker only checked whether a block had a sunflower price and whether it was available at the current time of day. It did not compare that price against the current account sunflower balance, and pending placement spends did not update `currentAccountKeys` until mutations settled.

## Validation

- `pnpm --filter garden exec biome check --write ../../packages/game/src/hooks/useBlockPlace.ts ../../packages/game/src/hud/ItemsHud.tsx tests/ItemsHudStory.tsx tests/items-hud.spec.tsx`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `pnpm build --filter garden`
- `pnpm --filter garden exec playwright test tests/items-hud.spec.tsx`