### PR TITLE
Refine HUD entry animations and item picker placement

### DIFF
--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -54,6 +54,54 @@ test('item picker stays centered on tablet layouts', async ({
     );
 });
 
+test('item picker floats above the bottom edge without a border', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(SHORT_MOBILE_VIEWPORT);
+    await mount(<ItemsHudAlignmentStory />);
+
+    const picker = page.locator('[data-items-hud]');
+    await expect(picker).toBeVisible();
+    await page.waitForTimeout(350);
+
+    const pickerBox = await picker.boundingBox();
+    expect(pickerBox).not.toBeNull();
+
+    const bottomGap =
+        SHORT_MOBILE_VIEWPORT.height -
+        ((pickerBox?.y ?? 0) + (pickerBox?.height ?? 0));
+    expect(Math.round(bottomGap)).toBeGreaterThanOrEqual(4);
+
+    const surfaceStyle = await picker.evaluate((node) => {
+        const style = window.getComputedStyle(node);
+        return {
+            borderWidths: [
+                style.borderTopWidth,
+                style.borderRightWidth,
+                style.borderBottomWidth,
+                style.borderLeftWidth,
+            ],
+            boxShadow: style.boxShadow,
+        };
+    });
+
+    expect(surfaceStyle.borderWidths).toEqual(['0px', '0px', '0px', '0px']);
+    expect(surfaceStyle.boxShadow).not.toBe('none');
+});
+
+test('bottom helper controls are left aligned', async ({ mount, page }) => {
+    await page.setViewportSize(SHORT_MOBILE_VIEWPORT);
+    await mount(<ItemsHudAlignmentStory />);
+
+    const controls = page.getByTestId('bottom-controls');
+    await expect(controls).toBeVisible();
+
+    const controlsBox = await controls.boundingBox();
+    expect(controlsBox).not.toBeNull();
+    expect(Math.round(controlsBox?.x ?? 0)).toBe(0);
+});
+
 test('controls instructions clear the item picker on tablet layouts', async ({
     mount,
     page,

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -33,7 +33,10 @@ export const gameHudBottomBarClassName =
     'pointer-events-none absolute bottom-0 left-0 right-0 flex flex-col items-center md:block';
 
 export const gameHudBottomControlsClassName =
-    'flex flex-row items-end p-2 md:absolute md:bottom-0 md:left-0';
+    'self-start flex flex-row items-end justify-start p-2 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-300 motion-safe:ease-out md:absolute md:bottom-0 md:left-0';
+
+const gameHudEntranceClassName =
+    'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-300 motion-safe:ease-out';
 
 export function GameHud({
     debugHud,
@@ -71,7 +74,13 @@ export function GameHud({
 
     return (
         <>
-            <div className="absolute top-2 left-2 flex flex-col items-start gap-2">
+            <div
+                className={cx(
+                    'absolute top-2 left-2 flex flex-col items-start gap-2',
+                    gameHudEntranceClassName,
+                    'motion-safe:slide-in-from-left-4',
+                )}
+            >
                 {!isLocalSandbox && <AccountHud />}
                 {!isSandbox && <ShoppingCartHud />}
                 {!isSandbox && (
@@ -90,7 +99,13 @@ export function GameHud({
                     </div>
                 )}
             </div>
-            <div className="absolute top-2 right-2 flex items-end flex-col-reverse md:flex-row gap-1 md:gap-2">
+            <div
+                className={cx(
+                    'absolute top-2 right-2 flex items-end flex-col-reverse gap-1 md:flex-row md:gap-2',
+                    gameHudEntranceClassName,
+                    'motion-safe:slide-in-from-right-4',
+                )}
+            >
                 <div className={closeupHiddenHudClassName}>
                     {isSandbox ? (
                         <SandboxEnvironmentHud />

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -558,7 +558,7 @@ export function ItemsHud() {
             data-items-hud
             open
             position="bottom"
-            className="static mx-auto w-fit max-w-[calc(100vw-1rem)] overflow-x-auto md:px-1 pointer-events-auto"
+            className="pointer-events-auto static mx-auto mb-1 w-fit max-w-[calc(100vw-1rem)] overflow-x-auto rounded-xl border-0 bg-background/95 shadow-xl shadow-foreground/10 backdrop-blur-sm motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-300 motion-safe:ease-out md:px-1"
             animateHeight
         >
             <Row


### PR DESCRIPTION
## Summary
- Add side-aware entrance motion for the top HUD groups and bottom helper controls
- Restyle the item picker as a borderless floating bottom surface with shadow and a 4px bottom gap
- Keep rotate, mute, and controls helper buttons left-aligned on mobile
- Add component coverage for the floating item picker and helper-control alignment

## Testing
- pnpm lint --filter @gredice/game
- pnpm lint --filter garden
- pnpm typecheck --filter @gredice/game
- pnpm typecheck --filter garden
- pnpm typecheck --filter www
- pnpm test --filter @gredice/game
- pnpm build --filter garden
- pnpm --filter garden exec playwright test tests/items-hud.spec.tsx
- Browser check: http://localhost:3001/debug/sandbox at 500x1000 confirmed item HUD bottom gap 4px, zero border width, shadow, and helper controls left=0