### PR TITLE
[codex] Move time of day into weather hud

### DIFF
--- a/apps/garden/tests/WeatherHudStory.tsx
+++ b/apps/garden/tests/WeatherHudStory.tsx
@@ -141,6 +141,16 @@ const groupedWeatherAlerts = [
     }),
 ];
 
+const forecastDays = Array.from({ length: 7 }, (_, index) => ({
+    date: new Date(Date.UTC(2026, 5, index + 1)).toISOString(),
+    maxTemp: 24 + index,
+    minTemp: 13 + index,
+    rain: index % 2 === 0 ? index + 1 : 0,
+    symbol: index % 3 === 0 ? 3 : 1,
+    windDirection: index % 2 === 0 ? 'NE' : 'SW',
+    windStrength: (index % 3) + 1,
+}));
+
 function createWeatherHudQueryClient({
     alerts = [],
 }: {
@@ -178,7 +188,7 @@ function createWeatherHudQueryClient({
     };
     queryClient.setQueryData(['weather', 'now', 1], weatherNow);
     queryClient.setQueryData(['weather', 'now', null], weatherNow);
-    queryClient.setQueryData(['weather', 'forecast'], []);
+    queryClient.setQueryData(['weather', 'forecast'], forecastDays);
 
     return queryClient;
 }

--- a/apps/garden/tests/WeatherHudStory.tsx
+++ b/apps/garden/tests/WeatherHudStory.tsx
@@ -213,7 +213,7 @@ function WeatherHudTestProviders({
     );
 }
 
-export function WeatherHudTimePopoverStory({
+export function WeatherHudStory({
     withAlerts = false,
 }: {
     withAlerts?: boolean;

--- a/apps/garden/tests/weather-hud.spec.tsx
+++ b/apps/garden/tests/weather-hud.spec.tsx
@@ -1,18 +1,22 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Page } from '@playwright/test';
-import { WeatherHudTimePopoverStory } from './WeatherHudStory';
+import { WeatherHudStory } from './WeatherHudStory';
 
 const DESKTOP_VIEWPORT = { width: 770, height: 610 };
 const MOBILE_VIEWPORT = { width: 320, height: 568 };
 
-async function expectTimePopoverWithinViewport(
+async function expectWeatherTimeVisualizationWithinViewport(
     page: Page,
     viewport: { width: number; height: number },
 ) {
-    await page.getByTitle('Doba dana').click();
+    await expect(page.getByTitle('Doba dana')).toHaveCount(0);
+    await page.getByTitle('Trenutno vrijeme').click();
 
-    const popover = page.locator('[data-time-display="true"]');
+    const popover = page.locator('[data-weather-now-details="true"]');
     await expect(popover).toBeVisible();
+    await expect(
+        page.locator('[data-time-of-day-details="true"]'),
+    ).toBeVisible();
 
     const popoverBox = await popover.boundingBox();
     expect(popoverBox).not.toBeNull();
@@ -38,29 +42,32 @@ async function expectTimePopoverWithinViewport(
     );
 }
 
-test('time popover has enough room on desktop', async ({ mount, page }) => {
+test('weather popover includes time of day on desktop', async ({
+    mount,
+    page,
+}) => {
     await page.setViewportSize(DESKTOP_VIEWPORT);
-    await mount(<WeatherHudTimePopoverStory />);
+    await mount(<WeatherHudStory />);
 
-    await expectTimePopoverWithinViewport(page, DESKTOP_VIEWPORT);
+    await expectWeatherTimeVisualizationWithinViewport(page, DESKTOP_VIEWPORT);
 
     const popoverBox = await page
-        .locator('[data-time-display="true"]')
+        .locator('[data-weather-now-details="true"]')
         .boundingBox();
     expect(popoverBox?.width ?? 0).toBeGreaterThan(360);
 });
 
-test('time popover fits on narrow mobile viewports', async ({
+test('weather popover time of day fits on narrow mobile viewports', async ({
     mount,
     page,
 }) => {
     await page.setViewportSize(MOBILE_VIEWPORT);
-    await mount(<WeatherHudTimePopoverStory />);
+    await mount(<WeatherHudStory />);
 
-    await expectTimePopoverWithinViewport(page, MOBILE_VIEWPORT);
+    await expectWeatherTimeVisualizationWithinViewport(page, MOBILE_VIEWPORT);
 
     const popoverBox = await page
-        .locator('[data-time-display="true"]')
+        .locator('[data-weather-now-details="true"]')
         .boundingBox();
     expect(popoverBox?.width ?? 0).toBeLessThanOrEqual(
         MOBILE_VIEWPORT.width - 16 + 1,
@@ -72,7 +79,7 @@ test('weather warnings are grouped and scroll within the mobile popover', async 
     page,
 }) => {
     await page.setViewportSize(MOBILE_VIEWPORT);
-    await mount(<WeatherHudTimePopoverStory withAlerts />);
+    await mount(<WeatherHudStory withAlerts />);
 
     await page.getByTitle('Trenutno vrijeme').click();
 

--- a/apps/garden/tests/weather-hud.spec.tsx
+++ b/apps/garden/tests/weather-hud.spec.tsx
@@ -74,6 +74,37 @@ test('weather popover time of day fits on narrow mobile viewports', async ({
     );
 });
 
+test('forecast popover scrolls within desktop viewport with time of day', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(DESKTOP_VIEWPORT);
+    await mount(<WeatherHudStory />);
+
+    await page.getByTitle('Prognoza vremena').click();
+    await page.getByRole('button', { name: 'Sve' }).click();
+
+    const details = page.locator('[data-weather-forecast-details="true"]');
+    await expect(details).toBeVisible();
+    await expect(
+        details.locator('[data-time-of-day-details="true"]'),
+    ).toBeVisible();
+
+    const detailsBox = await details.boundingBox();
+    expect(detailsBox).not.toBeNull();
+    expect(detailsBox?.height ?? 0).toBeLessThanOrEqual(
+        DESKTOP_VIEWPORT.height - 48,
+    );
+
+    const scrollStats = await page
+        .locator('[data-weather-forecast-scroll="true"]')
+        .evaluate((element) => ({
+            clientHeight: element.clientHeight,
+            scrollHeight: element.scrollHeight,
+        }));
+    expect(scrollStats.scrollHeight).toBeGreaterThan(scrollStats.clientHeight);
+});
+
 test('weather warnings are grouped and scroll within the mobile popover', async ({
     mount,
     page,

--- a/apps/storybook/stories/packages/game/hud/TimeOfDayVisualization.stories.tsx
+++ b/apps/storybook/stories/packages/game/hud/TimeOfDayVisualization.stories.tsx
@@ -85,6 +85,14 @@ export const Night: Story = {
     },
 };
 
+export const Compact: Story = {
+    name: 'Compact',
+    args: {
+        compact: true,
+        timeOfDay: 0.35,
+    },
+};
+
 export const DebugInteractive: Story = {
     name: 'Debug interactive',
     render: () => <InteractiveTimeOfDayVisualization />,

--- a/packages/game/src/hud/WeatherHud.tsx
+++ b/packages/game/src/hud/WeatherHud.tsx
@@ -6,22 +6,17 @@ import { Popper } from '@gredice/ui/Popper';
 import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
-import { useLiveTime } from '../hooks/useLiveTime';
 import { useWeatherForecast } from '../hooks/useWeatherForecast';
 import { useWeatherNow } from '../hooks/useWeatherNow';
 import { HudCard } from './components/HudCard';
-import { TimeDisplay } from './components/TimeDisplay';
 import { WeatherForecastDetails } from './components/weather/WeatherForecastDetails';
 import { weatherIcons } from './components/weather/WeatherIcons';
 import { WeatherNowDetails } from './components/weather/WeatherNowDetails';
 
 const weatherPopperClassName =
     'w-fit max-w-[calc(100vw-1rem)] overflow-hidden border-tertiary border-b-4';
-const timePopperClassName =
-    'w-[min(calc(100vw-1rem),26rem)] overflow-hidden border-tertiary border-b-4';
 
 export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
-    const currentTime = useLiveTime();
     const weatherEnabled = !noWeather;
     const { data: currentGarden } = useCurrentGarden();
     const farmId = currentGarden?.farmId;
@@ -35,10 +30,6 @@ export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
     const WeatherIcon =
         weatherData?.symbol != null ? weatherIcons[weatherData.symbol] : null;
     const hasAlerts = (weatherData?.alerts?.length ?? 0) > 0;
-    const formattedTime = currentTime?.toLocaleTimeString('hr-HR', {
-        hour: '2-digit',
-        minute: '2-digit',
-    });
 
     return (
         <HudCard open position="floating" className="static md:px-1">
@@ -79,7 +70,7 @@ export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
                         <WeatherNowDetails farmId={farmId} />
                     </Popper>
                 )}
-                {weatherData && (forecastData || formattedTime) && (
+                {weatherData && forecastData && (
                     <div className="w-[1px] h-4 border-r" />
                 )}
                 {forecastData && (
@@ -110,29 +101,6 @@ export function WeatherHud({ noWeather }: { noWeather?: boolean }) {
                         }
                     >
                         <WeatherForecastDetails />
-                    </Popper>
-                )}
-                {forecastData && formattedTime && (
-                    <div className="w-[1px] h-4 border-r hidden md:inline" />
-                )}
-                {formattedTime && (
-                    <Popper
-                        side="bottom"
-                        sideOffset={12}
-                        className={timePopperClassName}
-                        trigger={
-                            <Button
-                                title="Doba dana"
-                                variant="plain"
-                                className="rounded-full px-2 md:pr-2 pr-3"
-                            >
-                                <Typography level="body2" className="text-base">
-                                    {formattedTime}
-                                </Typography>
-                            </Button>
-                        }
-                    >
-                        <TimeDisplay />
                     </Popper>
                 )}
             </Row>

--- a/packages/game/src/hud/components/TimeDisplay.tsx
+++ b/packages/game/src/hud/components/TimeDisplay.tsx
@@ -4,35 +4,9 @@ import { Divider } from '@gredice/ui/Divider';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { useCallback } from 'react';
-import { useGameFlags } from '../../GameFlagsContext';
-import { useLiveTime } from '../../hooks/useLiveTime';
-import { useGameState } from '../../useGameState';
-import { createDateForGameTimeOfDay } from '../../utils/timeOfDay';
-import { TimeOfDayVisualization } from './TimeOfDayVisualization';
+import { TimeOfDayDetails } from './TimeOfDayDetails';
 
 export function TimeDisplay() {
-    const { enableDebugHudFlag = false } = useGameFlags();
-    const currentTime = useLiveTime();
-    const timeOfDay = useGameState((state) => state.timeOfDay);
-    const sunrise = useGameState((state) => state.sunriseTime);
-    const sunset = useGameState((state) => state.sunsetTime);
-    const setFreezeTime = useGameState((state) => state.setFreezeTime);
-    const setDayNightCycleDisabled = useGameState(
-        (state) => state.setDayNightCycleDisabled,
-    );
-
-    const isDaytime = timeOfDay >= 0.2 && timeOfDay <= 0.8;
-    const updateTimeOfDay = useCallback(
-        (nextTimeOfDay: number) => {
-            setDayNightCycleDisabled(false);
-            setFreezeTime(
-                createDateForGameTimeOfDay(currentTime, nextTimeOfDay),
-            );
-        },
-        [currentTime, setDayNightCycleDisabled, setFreezeTime],
-    );
-
     return (
         <Stack data-time-display="true" className="min-w-0">
             <Row
@@ -44,44 +18,7 @@ export function TimeDisplay() {
                 </Typography>
             </Row>
             <Divider />
-            <Stack className="px-4 py-3">
-                <TimeOfDayVisualization
-                    className="mb-2"
-                    interactive={enableDebugHudFlag}
-                    onChange={updateTimeOfDay}
-                    timeOfDay={timeOfDay}
-                />
-                <Row className="gap-3" justifyContent="space-between">
-                    <Typography level="body3" className="whitespace-nowrap">
-                        {(isDaytime ? sunrise : sunset)?.toLocaleTimeString(
-                            'hr-HR',
-                            { hour: '2-digit', minute: '2-digit' },
-                        )}
-                    </Typography>
-                    <Typography
-                        center
-                        className="min-w-0 whitespace-nowrap font-[Arial,sans-serif]"
-                    >
-                        {currentTime?.toLocaleTimeString('hr-HR', {
-                            hour: '2-digit',
-                            minute: '2-digit',
-                        })}
-                    </Typography>
-                    <Typography level="body3" className="whitespace-nowrap">
-                        {(isDaytime ? sunset : sunrise)?.toLocaleTimeString(
-                            'hr-HR',
-                            { hour: '2-digit', minute: '2-digit' },
-                        )}
-                    </Typography>
-                </Row>
-                <Typography level="body2" center>
-                    {currentTime.toLocaleDateString('hr-HR', {
-                        day: 'numeric',
-                        month: 'long',
-                        year: 'numeric',
-                    })}
-                </Typography>
-            </Stack>
+            <TimeOfDayDetails />
         </Stack>
     );
 }

--- a/packages/game/src/hud/components/TimeOfDayDetails.tsx
+++ b/packages/game/src/hud/components/TimeOfDayDetails.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import { useCallback } from 'react';
+import { useGameFlags } from '../../GameFlagsContext';
+import { useLiveTime } from '../../hooks/useLiveTime';
+import { useGameState } from '../../useGameState';
+import { createDateForGameTimeOfDay } from '../../utils/timeOfDay';
+import { TimeOfDayVisualization } from './TimeOfDayVisualization';
+
+export function TimeOfDayDetails({
+    className,
+    compact = false,
+}: {
+    className?: string;
+    compact?: boolean;
+}) {
+    const { enableDebugHudFlag = false } = useGameFlags();
+    const currentTime = useLiveTime();
+    const timeOfDay = useGameState((state) => state.timeOfDay);
+    const sunrise = useGameState((state) => state.sunriseTime);
+    const sunset = useGameState((state) => state.sunsetTime);
+    const setFreezeTime = useGameState((state) => state.setFreezeTime);
+    const setDayNightCycleDisabled = useGameState(
+        (state) => state.setDayNightCycleDisabled,
+    );
+
+    const isDaytime = timeOfDay >= 0.2 && timeOfDay <= 0.8;
+    const updateTimeOfDay = useCallback(
+        (nextTimeOfDay: number) => {
+            setDayNightCycleDisabled(false);
+            setFreezeTime(
+                createDateForGameTimeOfDay(currentTime, nextTimeOfDay),
+            );
+        },
+        [currentTime, setDayNightCycleDisabled, setFreezeTime],
+    );
+
+    return (
+        <Stack
+            className={cx('min-w-0 px-4 py-3', className)}
+            data-time-of-day-details="true"
+        >
+            <TimeOfDayVisualization
+                className={compact ? 'mb-1' : 'mb-2'}
+                compact={compact}
+                interactive={enableDebugHudFlag}
+                onChange={updateTimeOfDay}
+                timeOfDay={timeOfDay}
+            />
+            <Row className="gap-3" justifyContent="space-between">
+                <Typography level="body3" className="whitespace-nowrap">
+                    {(isDaytime ? sunrise : sunset)?.toLocaleTimeString(
+                        'hr-HR',
+                        { hour: '2-digit', minute: '2-digit' },
+                    )}
+                </Typography>
+                <Typography
+                    center
+                    className="min-w-0 whitespace-nowrap font-[Arial,sans-serif]"
+                >
+                    {currentTime?.toLocaleTimeString('hr-HR', {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                    })}
+                </Typography>
+                <Typography level="body3" className="whitespace-nowrap">
+                    {(isDaytime ? sunset : sunrise)?.toLocaleTimeString(
+                        'hr-HR',
+                        { hour: '2-digit', minute: '2-digit' },
+                    )}
+                </Typography>
+            </Row>
+            <Typography level={compact ? 'body3' : 'body2'} center>
+                {currentTime.toLocaleDateString('hr-HR', {
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
+                })}
+            </Typography>
+        </Stack>
+    );
+}

--- a/packages/game/src/hud/components/TimeOfDayVisualization.tsx
+++ b/packages/game/src/hud/components/TimeOfDayVisualization.tsx
@@ -63,6 +63,7 @@ export type TimeOfDayVisualizationProps = Omit<
     HTMLAttributes<HTMLDivElement>,
     'onChange'
 > & {
+    compact?: boolean;
     interactive?: boolean;
     onChange?: (timeOfDay: number) => void;
     timeOfDay: number;
@@ -70,6 +71,7 @@ export type TimeOfDayVisualizationProps = Omit<
 
 export function TimeOfDayVisualization({
     className,
+    compact = false,
     interactive = false,
     onChange,
     timeOfDay,
@@ -152,7 +154,8 @@ export function TimeOfDayVisualization({
 
     const isInteractive = interactive && typeof onChange === 'function';
     const containerClassName = cx(
-        'h-28 w-full select-none overflow-visible rounded-md bg-gradient-to-b from-sky-100 via-sky-50 to-slate-200 outline-hidden ring-offset-background dark:from-slate-800 dark:via-slate-900 dark:to-slate-950',
+        compact ? 'h-20' : 'h-28',
+        'w-full select-none overflow-visible rounded-md bg-gradient-to-b from-sky-100 via-sky-50 to-slate-200 outline-hidden ring-offset-background dark:from-slate-800 dark:via-slate-900 dark:to-slate-950',
         isInteractive &&
             'touch-none cursor-ew-resize focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         className,

--- a/packages/game/src/hud/components/weather/WeatherForecastDetails.tsx
+++ b/packages/game/src/hud/components/weather/WeatherForecastDetails.tsx
@@ -19,6 +19,7 @@ import { Link } from '@gredice/ui/Link';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
 import Image from 'next/image';
 import { type FC, useState } from 'react';
 import { useWeatherForecast } from '../../../hooks/useWeatherForecast';
@@ -130,14 +131,16 @@ export function WeatherForecastDetails() {
 
     return (
         <Stack
-            className={
+            className={cx(
+                'max-h-[min(calc(100vh-6rem),44rem)] min-h-0 overflow-hidden',
                 view === 'graph'
                     ? 'w-[min(calc(100vw-1rem),44rem)]'
-                    : 'w-[min(calc(100vw-1rem),28rem)]'
-            }
+                    : 'w-[min(calc(100vw-1rem),28rem)]',
+            )}
+            data-weather-forecast-details="true"
         >
             <Row
-                className="bg-background px-4 py-2"
+                className="shrink-0 bg-background px-4 py-2"
                 justifyContent="space-between"
             >
                 <Typography level="body2" bold>
@@ -178,14 +181,22 @@ export function WeatherForecastDetails() {
                 </Row>
             </Row>
             <Divider />
-            <TimeOfDayDetails compact className="border-b bg-muted/20" />
-            {view === 'graph' ? (
-                <WeatherHistoryPanel className="p-3" />
-            ) : (
-                <WeatherForecastDays limit={forecastLimit} />
-            )}
+            <TimeOfDayDetails
+                compact
+                className="shrink-0 border-b bg-muted/20"
+            />
+            <div
+                className="min-h-0 overflow-y-auto overscroll-contain"
+                data-weather-forecast-scroll="true"
+            >
+                {view === 'graph' ? (
+                    <WeatherHistoryPanel className="p-3" />
+                ) : (
+                    <WeatherForecastDays limit={forecastLimit} />
+                )}
+            </div>
             <Divider />
-            <Row className="px-4 py-2" justifyContent="space-between">
+            <Row className="shrink-0 px-4 py-2" justifyContent="space-between">
                 <Link
                     href={
                         'https://meteo.hr/proizvodi.php?section=podaci&param=xml_korisnici'

--- a/packages/game/src/hud/components/weather/WeatherForecastDetails.tsx
+++ b/packages/game/src/hud/components/weather/WeatherForecastDetails.tsx
@@ -22,6 +22,7 @@ import { Typography } from '@gredice/ui/Typography';
 import Image from 'next/image';
 import { type FC, useState } from 'react';
 import { useWeatherForecast } from '../../../hooks/useWeatherForecast';
+import { TimeOfDayDetails } from '../TimeOfDayDetails';
 import { RainIcon } from './icons/RainIcon';
 import { WeatherHistoryPanel } from './WeatherHistoryModal';
 import { weatherIcons } from './WeatherIcons';
@@ -177,6 +178,7 @@ export function WeatherForecastDetails() {
                 </Row>
             </Row>
             <Divider />
+            <TimeOfDayDetails compact className="border-b bg-muted/20" />
             {view === 'graph' ? (
                 <WeatherHistoryPanel className="p-3" />
             ) : (

--- a/packages/game/src/hud/components/weather/WeatherNowDetails.tsx
+++ b/packages/game/src/hud/components/weather/WeatherNowDetails.tsx
@@ -32,6 +32,7 @@ import {
 import { usePushPermissionOnboarding } from '../../../hooks/usePushPermissionOnboarding';
 import { useWeatherNow } from '../../../hooks/useWeatherNow';
 import { notificationsViewSearchParam } from '../../../notificationFilters';
+import { TimeOfDayDetails } from '../TimeOfDayDetails';
 import { RainIcon } from './icons/RainIcon';
 import { WeatherForecastDays } from './WeatherForecastDetails';
 import { WeatherHistoryPanel } from './WeatherHistoryModal';
@@ -498,6 +499,10 @@ export function WeatherNowDetails({ farmId }: { farmId?: number | null } = {}) {
                 <WeatherViewToggle value={view} onValueChange={setView} />
             </Row>
             <Divider />
+            <TimeOfDayDetails
+                compact
+                className="shrink-0 border-b bg-muted/20"
+            />
             <div
                 className="min-h-0 overflow-y-auto overscroll-contain"
                 data-weather-now-scroll="true"


### PR DESCRIPTION
## Summary
- remove the standalone current-time trigger from the normal game weather HUD
- add a compact time-of-day visualization panel to the top of current weather and forecast popovers
- keep the existing full `TimeDisplay` behavior reusable for sandbox/debug flows and cover the compact visualization in Storybook

## Why
The current time control sat beside the weather controls and added HUD clutter. Moving the day/night visualization into the weather details keeps the information available without another top-level HUD item.

## Validation
- `corepack pnpm exec biome check --write src/hud/WeatherHud.tsx src/hud/components/TimeDisplay.tsx src/hud/components/TimeOfDayDetails.tsx src/hud/components/TimeOfDayVisualization.tsx src/hud/components/weather/WeatherNowDetails.tsx src/hud/components/weather/WeatherForecastDetails.tsx` from `packages/game`
- `corepack pnpm exec biome check --write tests/WeatherHudStory.tsx tests/weather-hud.spec.tsx` from `apps/garden`
- `corepack pnpm exec biome check --write stories/packages/game/hud/TimeOfDayVisualization.stories.tsx` from `apps/storybook`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter storybook`
- `corepack pnpm build --filter garden`
- `GREDICE_PLAYWRIGHT_REUSE_SERVER=true corepack pnpm exec playwright test tests/weather-hud.spec.tsx tests/time-display.spec.tsx` from `apps/garden`

Note: the in-app browser could not reach the local `127.0.0.1:3001` server, so browser-level smoke verification was not available; the component tests and garden build passed locally.
