### PR TITLE
Generalize raised-bed plant automation actions

### DIFF
--- a/apps/app/app/admin/automations/AutomationFlowEditor.tsx
+++ b/apps/app/app/admin/automations/AutomationFlowEditor.tsx
@@ -185,7 +185,9 @@ const automationModuleIcons = new Map<string, IconComponent>([
     [automationModuleKeys.actionQueueSeasonalSowingOfferOperations, Droplets],
     [automationModuleKeys.actionCreateOperation, Hammer],
     [automationModuleKeys.actionCreateFarmInventoryOperations, Store],
+    [automationModuleKeys.actionUpdateRaisedBedFieldPlantAttributes, Sprout],
     [automationModuleKeys.actionUpdateRaisedBedFieldPlantStatus, Sprout],
+    [automationModuleKeys.actionUpdateRaisedBedFieldSowingLocation, Sprout],
     [automationModuleKeys.actionCreatePlantStatusRequestsFromImageAnalysis, AI],
     [automationModuleKeys.actionLog, Text],
 ]);
@@ -347,7 +349,12 @@ function updateNodeSelection(nodes: FlowNode[], selectedNodeId: string | null) {
 function defaultConfig(module: AutomationModuleMetadata): AutomationJsonObject {
     return Object.fromEntries(
         module.configFields
-            .filter((field) => field.type === 'select' && field.options?.[0])
+            .filter(
+                (field) =>
+                    field.type === 'select' &&
+                    field.required &&
+                    field.options?.[0],
+            )
             .map((field) => [field.key, field.options?.[0]?.value]),
     );
 }

--- a/apps/app/app/admin/automations/actions.ts
+++ b/apps/app/app/admin/automations/actions.ts
@@ -185,6 +185,7 @@ const requiredFieldLabels: Record<string, string> = {
     operations: 'Radnje',
     path: 'Putanja podataka',
     status: 'Status',
+    targetSowingLocation: 'Ciljana lokacija sijanja',
     targetStatus: 'Ciljani status',
     timeZone: 'Vremenska zona',
 };
@@ -219,6 +220,15 @@ function localizeAutomationValidationError(error: string) {
     }
     if (error === 'minConfidence must be a number from 0 to 1.') {
         return 'Minimalna pouzdanost mora biti broj od 0 do 1.';
+    }
+    if (
+        error ===
+        'At least one of targetStatus or targetSowingLocation is required.'
+    ) {
+        return 'Unesite ciljani status ili ciljanu lokaciju sijanja.';
+    }
+    if (error === 'targetSowingLocation must be direct or greenhouse.') {
+        return 'Ciljana lokacija sijanja mora biti direct ili greenhouse.';
     }
 
     const requiredMatch = /^(.+) is required\.$/.exec(error);

--- a/apps/app/app/admin/automations/presentation.ts
+++ b/apps/app/app/admin/automations/presentation.ts
@@ -26,6 +26,8 @@ export const automationModuleKeys = {
         'action.queuePostTransplantWateringOperations',
     actionQueueSeasonalSowingOfferOperations:
         'action.queueSeasonalSowingOfferOperations',
+    actionUpdateRaisedBedFieldPlantAttributes:
+        'action.updateRaisedBedFieldPlantAttributes',
     actionUpdateRaisedBedFieldPlantStatus:
         'action.updateRaisedBedFieldPlantStatus',
     actionUpdateRaisedBedFieldSowingLocation:
@@ -155,6 +157,29 @@ const automationModulePresentations: Record<
                 label: 'Radnje',
                 description:
                     'JSON niz: [{"entityId": 123, "entityTypeName": "operation", "scheduledInDays": 0}]',
+            },
+        },
+    },
+    [automationModuleKeys.actionUpdateRaisedBedFieldPlantAttributes]: {
+        title: 'Ažuriraj biljku u gredici',
+        description:
+            'Upisuje status biljke i/ili lokaciju sijanja za ciljano polje gredice.',
+        inputDescription: 'Event radnje s ciljanom gredicom i poljem gredice.',
+        outputDescription: 'Ažurirani atributi biljke ili razlog preskakanja.',
+        fields: {
+            targetStatus: {
+                label: 'Ciljani status',
+                placeholder: 'sprouted',
+            },
+            targetSowingLocation: {
+                label: 'Ciljana lokacija sijanja',
+                description: 'Neobavezno. Vrijednosti: direct, greenhouse.',
+                options: {
+                    '': 'Bez promjene',
+                    direct: 'Direktno',
+                    greenhouse: 'Staklenik',
+                },
+                placeholder: 'direct',
             },
         },
     },

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -12,7 +12,9 @@ greenhouse sowing to direct sowing and queues 50L watering operations for the
 next two days when that raised bed does not already have at least 50L of
 watering scheduled on those days. Verifying the `Uklanjanje biljke` operation
 marks the targeted raised-bed field plant status as `removed`, which closes the
-plant cycle and frees the field for future planting.
+plant cycle and frees the field for future planting. Plant field changes are
+available as configurable action modules so new operation-driven plant-state
+automations can be created from the admin graph editor without adding code.
 
 ## Ownership
 
@@ -98,12 +100,16 @@ MVP modules:
 - `action.createFarmInventoryOperations`: creates accepted, scheduled farm-level
   operations for every active farm from a JSON list in the automation
   definition.
+- `action.updateRaisedBedFieldPlantAttributes`: writes plant status and/or
+  sowing location events for the operation target field. Use this for new
+  no-code plant-state automations.
 - `action.updateRaisedBedFieldPlantStatus`: writes a
-  `raisedBedField.plantUpdate` event for an operation target, including the
-  default plant-removal workflow that sets `targetStatus = "removed"`.
+  `raisedBedField.plantUpdate` event for an operation target. Existing
+  automations with this module key remain supported.
 - `action.updateRaisedBedFieldSowingLocation`: writes a
   `raisedBedField.plantSchedule` event for an operation target, preserving the
-  scheduled date while changing `sowingLocation`.
+  scheduled date while changing `sowingLocation`. Existing automations with
+  this module key remain supported.
 - `action.createPlantStatusRequestsFromImageAnalysis`: reviews hosted
   raised-bed images from operation completion or raised-bed AI analysis events,
   then creates pending plant-status approval requests when the visual evidence
@@ -114,6 +120,12 @@ When adding a module, define metadata, config validation, dry-run behavior, and
 the executor function in the registry. Prefer idempotent repository functions for
 actions that mutate operations, plant state, notifications, or customer-visible
 records.
+
+Graphs can branch after a shared condition. For example, an `operation.verify`
+trigger can flow into one `condition.operationMatches` node and then fan out to
+separate plant-attribute, watering, notification, or operation-creation actions.
+The executor records those sibling actions as separate steps; actions should
+remain idempotent because replays and retries can run the same graph again.
 
 ## Graph Validation
 

--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -142,7 +142,7 @@ export function seedlingTransplantDirectSowingLocationAutomationGraph(): Automat
                 id: 'set-location-direct',
                 kind: 'action',
                 moduleKey:
-                    automationModuleKeys.actionUpdateRaisedBedFieldSowingLocation,
+                    automationModuleKeys.actionUpdateRaisedBedFieldPlantAttributes,
                 position: { x: 620, y: 160 },
                 config: {
                     targetSowingLocation: 'direct',
@@ -236,7 +236,7 @@ export function plantRemovalOperationStatusAutomationGraph(): AutomationGraph {
                 id: 'set-plant-status-removed',
                 kind: 'action',
                 moduleKey:
-                    automationModuleKeys.actionUpdateRaisedBedFieldPlantStatus,
+                    automationModuleKeys.actionUpdateRaisedBedFieldPlantAttributes,
                 position: { x: 620, y: 160 },
                 config: {
                     targetStatus: 'removed',

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -32,6 +32,7 @@ import {
     AutomationModuleExecutionError,
     type AutomationModuleMetadata,
     type AutomationModuleResult,
+    type AutomationSourceEvent,
 } from './types';
 
 const domainEventTriggerKey = 'trigger.domainEvent';
@@ -46,6 +47,8 @@ const queuePostTransplantWateringOperationsActionKey =
 const createOperationActionKey = 'action.createOperation';
 const createFarmInventoryOperationsActionKey =
     'action.createFarmInventoryOperations';
+const updateRaisedBedFieldPlantAttributesActionKey =
+    'action.updateRaisedBedFieldPlantAttributes';
 const updateRaisedBedFieldPlantStatusActionKey =
     'action.updateRaisedBedFieldPlantStatus';
 const updateRaisedBedFieldSowingLocationActionKey =
@@ -69,6 +72,8 @@ export const automationModuleKeys = {
         queuePostTransplantWateringOperationsActionKey,
     actionCreateOperation: createOperationActionKey,
     actionCreateFarmInventoryOperations: createFarmInventoryOperationsActionKey,
+    actionUpdateRaisedBedFieldPlantAttributes:
+        updateRaisedBedFieldPlantAttributesActionKey,
     actionUpdateRaisedBedFieldPlantStatus:
         updateRaisedBedFieldPlantStatusActionKey,
     actionUpdateRaisedBedFieldSowingLocation:
@@ -400,6 +405,86 @@ function parseSowingLocation(
     value: unknown,
 ): RaisedBedFieldSowingLocation | null {
     return value === 'direct' || value === 'greenhouse' ? value : null;
+}
+
+function getTargetSowingLocation(config: AutomationJsonObject) {
+    const value = getString(config, 'targetSowingLocation');
+    return value ? parseSowingLocation(value) : null;
+}
+
+function hasTargetSowingLocation(config: AutomationJsonObject) {
+    return Boolean(getString(config, 'targetSowingLocation'));
+}
+
+function validateRaisedBedFieldPlantAttributesConfig(
+    config: AutomationJsonObject,
+) {
+    const errors: string[] = [];
+    const targetStatus = getString(config, 'targetStatus');
+    const targetSowingLocation = getTargetSowingLocation(config);
+
+    if (!targetStatus && !targetSowingLocation) {
+        errors.push(
+            'At least one of targetStatus or targetSowingLocation is required.',
+        );
+    }
+
+    if (hasTargetSowingLocation(config) && !targetSowingLocation) {
+        errors.push('targetSowingLocation must be direct or greenhouse.');
+    }
+
+    return errors;
+}
+
+async function resolveOperationRaisedBedFieldTarget(
+    event: AutomationSourceEvent | undefined,
+) {
+    if (!event) {
+        return {
+            ok: false as const,
+            result: skip('No source event is available.'),
+        };
+    }
+
+    const operationId = Number(event.aggregateId);
+    if (!Number.isInteger(operationId) || operationId <= 0) {
+        return {
+            ok: false as const,
+            result: skip('Source event aggregate is not an operation id.'),
+        };
+    }
+
+    const operation = await getOperationById(operationId);
+    if (!operation?.raisedBedId || !operation.raisedBedFieldId) {
+        return {
+            ok: false as const,
+            result: skip('Operation has no raised-bed field target.', {
+                operationId,
+            }),
+        };
+    }
+
+    const raisedBed = await getRaisedBed(operation.raisedBedId);
+    const field = raisedBed?.fields.find(
+        (candidate) => candidate.id === operation.raisedBedFieldId,
+    );
+    if (!raisedBed || !field) {
+        return {
+            ok: false as const,
+            result: skip('Operation target field was not found.', {
+                operationId,
+                raisedBedId: operation.raisedBedId,
+                raisedBedFieldId: operation.raisedBedFieldId,
+            }),
+        };
+    }
+
+    return {
+        ok: true as const,
+        operationId,
+        raisedBed,
+        field,
+    };
 }
 
 function configFieldsForEventType() {
@@ -1194,6 +1279,126 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
     },
 };
 
+async function updateRaisedBedFieldPlantAttributes({
+    context,
+    node,
+    noChangeReason = 'Plant already has the target attributes.',
+}: {
+    context: Parameters<AutomationModule['execute']>[0];
+    node: AutomationGraphNode;
+    noChangeReason?: string;
+}) {
+    const targetStatus = getString(node.config, 'targetStatus');
+    const targetSowingLocation = getTargetSowingLocation(node.config);
+
+    if (!targetStatus && !targetSowingLocation) {
+        throw new AutomationModuleExecutionError(
+            'Plant attribute action is missing targetStatus or targetSowingLocation.',
+            'invalid_config',
+        );
+    }
+
+    const target = await resolveOperationRaisedBedFieldTarget(context.event);
+    if (!target.ok) {
+        return target.result;
+    }
+
+    const statusChanged =
+        Boolean(targetStatus) && target.field.plantStatus !== targetStatus;
+    const sowingLocationChanged =
+        Boolean(targetSowingLocation) &&
+        target.field.sowingLocation !== targetSowingLocation;
+
+    if (!statusChanged && !sowingLocationChanged) {
+        return skip(noChangeReason, {
+            operationId: target.operationId,
+            targetStatus: targetStatus ?? null,
+            targetSowingLocation: targetSowingLocation ?? null,
+        });
+    }
+
+    const output = {
+        operationId: target.operationId,
+        raisedBedId: target.raisedBed.id,
+        positionIndex: target.field.positionIndex,
+        previousStatus: target.field.plantStatus ?? null,
+        targetStatus: targetStatus ?? null,
+        previousSowingLocation: target.field.sowingLocation,
+        targetSowingLocation: targetSowingLocation ?? null,
+        updatedAttributes: [
+            ...(statusChanged ? ['plantStatus'] : []),
+            ...(sowingLocationChanged ? ['sowingLocation'] : []),
+        ],
+    };
+
+    if (context.dryRun) {
+        return success({
+            dryRun: true,
+            ...output,
+        });
+    }
+
+    const aggregateId = `${target.raisedBed.id}|${target.field.positionIndex}`;
+    if (sowingLocationChanged && targetSowingLocation) {
+        await createEvent(
+            knownEvents.raisedBedFields.plantScheduleV1(aggregateId, {
+                scheduledDate:
+                    target.field.plantScheduledDate?.toISOString() ?? null,
+                sowingLocation: targetSowingLocation,
+            }),
+        );
+    }
+
+    if (statusChanged && targetStatus) {
+        await createEvent(
+            knownEvents.raisedBedFields.plantUpdateV1(
+                aggregateId,
+                buildRaisedBedFieldPlantUpdatePayload(
+                    targetStatus,
+                    target.field.assignedUserIds,
+                ),
+            ),
+        );
+    }
+
+    return success(output);
+}
+
+const updateRaisedBedFieldPlantAttributesActionModule: AutomationModule = {
+    key: updateRaisedBedFieldPlantAttributesActionKey,
+    kind: 'action',
+    title: 'Update plant attributes',
+    description:
+        'Updates plant status and/or sowing location for the operation target field.',
+    category: 'Raised-bed fields',
+    configFields: [
+        {
+            key: 'targetStatus',
+            label: 'Target status',
+            type: 'string',
+            placeholder: 'sprouted',
+        },
+        {
+            key: 'targetSowingLocation',
+            label: 'Target sowing location',
+            type: 'select',
+            placeholder: 'direct',
+            description: 'Optional. Accepted values: direct, greenhouse.',
+            options: [
+                { value: '', label: 'Do not change' },
+                { value: 'direct', label: 'Direct' },
+                { value: 'greenhouse', label: 'Greenhouse' },
+            ],
+        },
+    ],
+    dryRunSupported: true,
+    mutatesData: true,
+    retryable: true,
+    validateConfig: validateRaisedBedFieldPlantAttributesConfig,
+    execute: async (context, node) =>
+        updateRaisedBedFieldPlantAttributes({ context, node }),
+};
+
 const updateRaisedBedFieldPlantStatusActionModule: AutomationModule = {
     key: updateRaisedBedFieldPlantStatusActionKey,
     kind: 'action',
@@ -1214,76 +1419,12 @@ const updateRaisedBedFieldPlantStatusActionModule: AutomationModule = {
     mutatesData: true,
     retryable: true,
     validateConfig: (config) => requiredString(config, 'targetStatus'),
-    execute: async (context, node) => {
-        if (!context.event) {
-            return skip('No source event is available.');
-        }
-
-        const targetStatus = getString(node.config, 'targetStatus');
-        if (!targetStatus) {
-            throw new AutomationModuleExecutionError(
-                'Plant status action is missing targetStatus.',
-                'invalid_config',
-            );
-        }
-
-        const operationId = Number(context.event.aggregateId);
-        if (!Number.isInteger(operationId) || operationId <= 0) {
-            return skip('Source event aggregate is not an operation id.');
-        }
-
-        const operation = await getOperationById(operationId);
-        if (!operation?.raisedBedId || !operation.raisedBedFieldId) {
-            return skip('Operation has no raised-bed field target.', {
-                operationId,
-            });
-        }
-
-        const raisedBed = await getRaisedBed(operation.raisedBedId);
-        const field = raisedBed?.fields.find(
-            (candidate) => candidate.id === operation.raisedBedFieldId,
-        );
-        if (!raisedBed || !field) {
-            return skip('Operation target field was not found.', {
-                operationId,
-                raisedBedId: operation.raisedBedId,
-                raisedBedFieldId: operation.raisedBedFieldId,
-            });
-        }
-
-        if (field.plantStatus === targetStatus) {
-            return skip('Plant already has the target status.', {
-                targetStatus,
-            });
-        }
-
-        if (context.dryRun) {
-            return success({
-                dryRun: true,
-                raisedBedId: raisedBed.id,
-                positionIndex: field.positionIndex,
-                previousStatus: field.plantStatus ?? null,
-                targetStatus,
-            });
-        }
-
-        await createEvent(
-            knownEvents.raisedBedFields.plantUpdateV1(
-                `${raisedBed.id}|${field.positionIndex}`,
-                buildRaisedBedFieldPlantUpdatePayload(
-                    targetStatus,
-                    field.assignedUserIds,
-                ),
-            ),
-        );
-
-        return success({
-            raisedBedId: raisedBed.id,
-            positionIndex: field.positionIndex,
-            previousStatus: field.plantStatus ?? null,
-            targetStatus,
-        });
-    },
+    execute: async (context, node) =>
+        updateRaisedBedFieldPlantAttributes({
+            context,
+            node,
+            noChangeReason: 'Plant already has the target status.',
+        }),
 };
 
 const updateRaisedBedFieldSowingLocationActionModule: AutomationModule = {
@@ -1312,79 +1453,12 @@ const updateRaisedBedFieldSowingLocationActionModule: AutomationModule = {
         parseSowingLocation(config.targetSowingLocation)
             ? []
             : ['targetSowingLocation must be direct or greenhouse.'],
-    execute: async (context, node) => {
-        if (!context.event) {
-            return skip('No source event is available.');
-        }
-
-        const targetSowingLocation = parseSowingLocation(
-            node.config.targetSowingLocation,
-        );
-        if (!targetSowingLocation) {
-            throw new AutomationModuleExecutionError(
-                'Sowing location action is missing targetSowingLocation.',
-                'invalid_config',
-            );
-        }
-
-        const operationId = Number(context.event.aggregateId);
-        if (!Number.isInteger(operationId) || operationId <= 0) {
-            return skip('Source event aggregate is not an operation id.');
-        }
-
-        const operation = await getOperationById(operationId);
-        if (!operation?.raisedBedId || !operation.raisedBedFieldId) {
-            return skip('Operation has no raised-bed field target.', {
-                operationId,
-            });
-        }
-
-        const raisedBed = await getRaisedBed(operation.raisedBedId);
-        const field = raisedBed?.fields.find(
-            (candidate) => candidate.id === operation.raisedBedFieldId,
-        );
-        if (!raisedBed || !field) {
-            return skip('Operation target field was not found.', {
-                operationId,
-                raisedBedId: operation.raisedBedId,
-                raisedBedFieldId: operation.raisedBedFieldId,
-            });
-        }
-
-        if (field.sowingLocation === targetSowingLocation) {
-            return skip('Plant already has the target sowing location.', {
-                targetSowingLocation,
-            });
-        }
-
-        if (context.dryRun) {
-            return success({
-                dryRun: true,
-                raisedBedId: raisedBed.id,
-                positionIndex: field.positionIndex,
-                previousSowingLocation: field.sowingLocation,
-                targetSowingLocation,
-            });
-        }
-
-        await createEvent(
-            knownEvents.raisedBedFields.plantScheduleV1(
-                `${raisedBed.id}|${field.positionIndex}`,
-                {
-                    scheduledDate:
-                        field.plantScheduledDate?.toISOString() ?? null,
-                    sowingLocation: targetSowingLocation,
-                },
-            ),
-        );
-
-        return success({
-            raisedBedId: raisedBed.id,
-            positionIndex: field.positionIndex,
-            previousSowingLocation: field.sowingLocation,
-            targetSowingLocation,
-        });
-    },
+    execute: async (context, node) =>
+        updateRaisedBedFieldPlantAttributes({
+            context,
+            node,
+            noChangeReason: 'Plant already has the target sowing location.',
+        }),
 };
 
 const createPlantStatusRequestsFromImageAnalysisActionModule: AutomationModule =
@@ -1513,6 +1587,7 @@ export const automationModules = [
     queuePostTransplantWateringOperationsActionModule,
     createOperationActionModule,
     createFarmInventoryOperationsActionModule,
+    updateRaisedBedFieldPlantAttributesActionModule,
     updateRaisedBedFieldPlantStatusActionModule,
     updateRaisedBedFieldSowingLocationActionModule,
     createPlantStatusRequestsFromImageAnalysisActionModule,

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -1008,6 +1008,162 @@ test('plant-status automation skips replay when target status already exists', a
     );
 });
 
+test('generic plant-attributes automation updates status and sowing location together', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createAutomationRaisedBedContext();
+    const fieldAggregateId = `${raisedBedId}|0`;
+    const scheduledDate = '2026-04-01T08:00:00.000Z';
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(fieldAggregateId, {
+            plantSortId: '101',
+            scheduledDate,
+            sowingLocation: 'greenhouse',
+        }),
+    );
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const field = raisedBed?.fields[0];
+    assert.ok(field);
+
+    const operationId = await createOperation({
+        accountId,
+        entityId: 1,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+        raisedBedFieldId: field.id,
+    });
+    await createEvent(
+        knownEvents.operations.completedV1(operationId.toString(), {
+            completedBy: 'automations-test',
+        }),
+    );
+    const event = await getLatestEvent(
+        knownEventTypes.operations.complete,
+        operationId.toString(),
+    );
+    const graph = {
+        nodes: [
+            {
+                id: 'trigger',
+                moduleKey: automationModuleKeys.triggerDomainEvent,
+                kind: 'trigger' as const,
+                position: { x: 0, y: 0 },
+                config: {
+                    eventType: knownEventTypes.operations.complete,
+                },
+            },
+            {
+                id: 'update-plant-attributes',
+                moduleKey:
+                    automationModuleKeys.actionUpdateRaisedBedFieldPlantAttributes,
+                kind: 'action' as const,
+                position: { x: 280, y: 0 },
+                config: {
+                    targetStatus: 'sprouted',
+                    targetSowingLocation: 'direct',
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-update-plant-attributes',
+                source: 'trigger',
+                target: 'update-plant-attributes',
+            },
+        ],
+    };
+    const definition = await createAutomationDefinition({
+        key: 'test.operation-complete-plant-attributes',
+        name: 'Operation completion updates plant attributes',
+        status: 'enabled',
+        graph,
+    });
+    const input = {
+        eventId: event.id,
+        eventType: event.type,
+        aggregateId: event.aggregateId,
+        data:
+            event.data && typeof event.data === 'object'
+                ? (event.data as Record<string, unknown>)
+                : {},
+    };
+    const run = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'event',
+        sourceEvent: event,
+        input,
+    });
+    assert.ok(run);
+    const startedRun = await startAutomationRun(run.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedRun);
+
+    const result = await executeAutomationRun(startedRun);
+
+    assert.strictEqual(result.status, 'succeeded');
+    const updatedRaisedBed = await getRaisedBed(raisedBedId);
+    const updatedField = updatedRaisedBed?.fields.find(
+        (candidate) => candidate.id === field.id,
+    );
+    assert.strictEqual(updatedField?.plantStatus, 'sprouted');
+    assert.strictEqual(updatedField?.sowingLocation, 'direct');
+    assert.strictEqual(
+        updatedField?.plantScheduledDate?.toISOString(),
+        scheduledDate,
+    );
+    assert.strictEqual(
+        (
+            await getEvents(knownEventTypes.raisedBedFields.plantUpdate, [
+                fieldAggregateId,
+            ])
+        ).length,
+        1,
+    );
+    assert.strictEqual(
+        (
+            await getEvents(knownEventTypes.raisedBedFields.plantSchedule, [
+                fieldAggregateId,
+            ])
+        ).length,
+        1,
+    );
+
+    const replayRun = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'replay',
+        sourceEvent: event,
+        input,
+    });
+    assert.ok(replayRun);
+    const startedReplay = await startAutomationRun(replayRun.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedReplay);
+
+    const replayResult = await executeAutomationRun(startedReplay);
+
+    assert.strictEqual(replayResult.status, 'skipped');
+    assert.strictEqual(
+        (
+            await getEvents(knownEventTypes.raisedBedFields.plantUpdate, [
+                fieldAggregateId,
+            ])
+        ).length,
+        1,
+    );
+    assert.strictEqual(
+        (
+            await getEvents(knownEventTypes.raisedBedFields.plantSchedule, [
+                fieldAggregateId,
+            ])
+        ).length,
+        1,
+    );
+});
+
 test('default plant-removal automation marks the operation target removed after verification', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =


### PR DESCRIPTION
## Summary
- Add a shared `action.updateRaisedBedFieldPlantAttributes` module that can update plant status, sowing location, or both from one operation target
- Keep the existing specialized plant-status and sowing-location modules wired through the shared implementation
- Update admin editor defaults, labels, and docs to surface the new module and its validation rules
- Seed the default automations to use the generalized module and add repo coverage for combined updates and replay idempotency

## Testing
- Added node-level automation repo coverage for combined plant-attribute updates and replay skipping
- Not run (not requested)