### PR TITLE
[codex] Tighten automation overview and queue responsiveness

### DIFF
--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -35,7 +35,7 @@
         },
         {
             "path": "/api/internal/cron/automations",
-            "schedule": "*/5 * * * *"
+            "schedule": "* * * * *"
         },
         {
             "path": "/api/internal/cron/outlet-lifecycle",

--- a/apps/app/app/admin/automations/AutomationDefinitionsList.tsx
+++ b/apps/app/app/admin/automations/AutomationDefinitionsList.tsx
@@ -1,7 +1,5 @@
 import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
-import { Row } from '@gredice/ui/Row';
-import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
@@ -39,59 +37,31 @@ export function AutomationDefinitionsList({
                             const failedCount = definition.failedRunsCount;
 
                             return (
-                                <li key={definition.id} className="p-4">
-                                    <Stack spacing={3}>
-                                        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                                            <Stack
-                                                spacing={1}
-                                                className="min-w-0"
+                                <li key={definition.id} className="px-4 py-3">
+                                    <div className="grid min-w-0 gap-1.5">
+                                        <div className="flex min-w-0 items-start justify-between gap-3">
+                                            <Link
+                                                href={KnownPages.Automation(
+                                                    definition.id,
+                                                )}
+                                                className="min-w-0 truncate font-medium text-primary hover:underline"
                                             >
-                                                <Link
-                                                    href={KnownPages.Automation(
-                                                        definition.id,
-                                                    )}
-                                                    className="truncate font-medium text-primary hover:underline"
-                                                >
-                                                    {definition.name}
-                                                </Link>
-                                                <Typography
-                                                    level="body3"
-                                                    className="break-all text-muted-foreground"
-                                                >
-                                                    {definition.key}
-                                                </Typography>
-                                            </Stack>
+                                                {definition.name}
+                                            </Link>
                                             <AutomationDefinitionStatusIndicator
+                                                className="shrink-0"
                                                 status={definition.status}
                                             />
                                         </div>
 
-                                        <dl className="grid gap-2 text-sm">
-                                            <div className="grid gap-1">
-                                                <dt className="text-muted-foreground">
-                                                    Okidač
-                                                </dt>
-                                                <dd>
-                                                    {definition.triggerSummary}
-                                                </dd>
-                                            </div>
-                                            <div className="grid gap-1">
-                                                <dt className="text-muted-foreground">
-                                                    Akcije
-                                                </dt>
-                                                <dd>
-                                                    {definition.actionSummary}
-                                                </dd>
-                                            </div>
-                                        </dl>
-
-                                        <Row
-                                            spacing={3}
-                                            className="flex-wrap items-center text-sm"
-                                        >
+                                        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                                            <span className="min-w-0 max-w-full truncate">
+                                                {definition.key}
+                                            </span>
                                             {latestRun ? (
-                                                <>
+                                                <span className="inline-flex items-center gap-1.5">
                                                     <AutomationRunStatusIndicator
+                                                        className="text-xs"
                                                         status={
                                                             latestRun.status
                                                         }
@@ -99,34 +69,17 @@ export function AutomationDefinitionsList({
                                                     <LocalDateTime>
                                                         {latestRun.createdAt}
                                                     </LocalDateTime>
-                                                </>
+                                                </span>
                                             ) : (
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-muted-foreground"
-                                                >
-                                                    Nema izvođenja
-                                                </Typography>
+                                                <span>Nema izvođenja</span>
                                             )}
                                             {failedCount > 0 ? (
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-red-700 dark:text-red-300"
-                                                >
+                                                <span className="font-medium text-red-700 dark:text-red-300">
                                                     Greške: {failedCount}
-                                                </Typography>
+                                                </span>
                                             ) : null}
-                                            <Typography
-                                                level="body3"
-                                                className="text-muted-foreground"
-                                            >
-                                                Ažurirano{' '}
-                                                <LocalDateTime>
-                                                    {definition.updatedAt}
-                                                </LocalDateTime>
-                                            </Typography>
-                                        </Row>
-                                    </Stack>
+                                        </div>
+                                    </div>
                                 </li>
                             );
                         })}

--- a/apps/app/app/admin/automations/AutomationJobsQueueTable.tsx
+++ b/apps/app/app/admin/automations/AutomationJobsQueueTable.tsx
@@ -7,7 +7,6 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
-import type { ReactNode } from 'react';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../src/KnownPages';
 import { AutomationRunStatusIndicator } from './AutomationStatusIndicator';
@@ -39,53 +38,32 @@ function DateTimeValue({ value }: { value: string | null }) {
 function QueueTiming({ run }: { run: AutomationRunListItem }) {
     if (run.status === 'queued' || run.status === 'retrying') {
         return (
-            <DetailItem label="Sljedeće">
-                <LocalDateTime>{run.nextRunAt}</LocalDateTime>
-            </DetailItem>
+            <>
+                Sljedeće <LocalDateTime>{run.nextRunAt}</LocalDateTime>
+            </>
         );
     }
 
     if (run.status === 'running') {
         return (
-            <DetailItem label="Zaključano">
-                <DateTimeValue value={run.lockedAt} />
-                {run.lockedBy ? (
-                    <Typography
-                        level="body3"
-                        className="break-all text-muted-foreground"
-                    >
-                        {run.lockedBy}
-                    </Typography>
-                ) : null}
-            </DetailItem>
+            <>
+                Zaključano <DateTimeValue value={run.lockedAt} />
+            </>
         );
     }
 
     if (run.completedAt) {
         return (
-            <DetailItem label="Završeno">
-                <LocalDateTime>{run.completedAt}</LocalDateTime>
-            </DetailItem>
+            <>
+                Završeno <LocalDateTime>{run.completedAt}</LocalDateTime>
+            </>
         );
     }
 
-    return <DetailItem label="Obrada">-</DetailItem>;
-}
-
-function DetailItem({
-    children,
-    label,
-}: {
-    children: ReactNode;
-    label: string;
-}) {
     return (
-        <div className="min-w-0">
-            <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {label}
-            </dt>
-            <dd className="mt-1 min-w-0 break-words text-sm">{children}</dd>
-        </div>
+        <>
+            Kreirano <LocalDateTime>{run.createdAt}</LocalDateTime>
+        </>
     );
 }
 
@@ -113,7 +91,7 @@ export function AutomationJobsQueueList({
                             className="text-muted-foreground"
                         >
                             Automatizacijski poslovi s trenutnim statusom,
-                            pokušajima i podacima za obradu.
+                            pokušajima i ključnim vremenom obrade.
                         </Typography>
                     </Stack>
                     {isFetching && !isFetchingNextPage ? (
@@ -137,39 +115,21 @@ export function AutomationJobsQueueList({
                 ) : (
                     <ul className="divide-y">
                         {runs.map((run) => (
-                            <li key={run.id} className="p-4">
-                                <Stack spacing={3}>
-                                    <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                                        <Stack spacing={1} className="min-w-0">
-                                            <Link
-                                                href={KnownPages.Automation(
-                                                    run.automationDefinitionId,
-                                                )}
-                                                className="font-medium text-primary hover:underline"
-                                            >
-                                                #{run.id}{' '}
-                                                {run.automationDefinitionName}
-                                            </Link>
-                                            <Typography
-                                                level="body3"
-                                                className="break-all text-muted-foreground"
-                                            >
-                                                {run.automationDefinitionKey}
-                                            </Typography>
-                                            {run.parentRunId ? (
-                                                <Typography
-                                                    level="body3"
-                                                    className="text-muted-foreground"
-                                                >
-                                                    Roditelj #{run.parentRunId}
-                                                </Typography>
-                                            ) : null}
-                                        </Stack>
-                                        <Stack
-                                            spacing={1}
-                                            className="items-start sm:items-end"
+                            <li key={run.id} className="px-4 py-3">
+                                <div className="grid min-w-0 gap-1.5">
+                                    <div className="flex min-w-0 items-start justify-between gap-3">
+                                        <Link
+                                            href={KnownPages.Automation(
+                                                run.automationDefinitionId,
+                                            )}
+                                            className="min-w-0 truncate font-medium text-primary hover:underline"
                                         >
+                                            #{run.id}{' '}
+                                            {run.automationDefinitionName}
+                                        </Link>
+                                        <div className="flex shrink-0 items-center gap-2">
                                             <AutomationRunStatusIndicator
+                                                className="text-xs sm:text-sm"
                                                 status={run.status}
                                             />
                                             {run.dryRun ? (
@@ -181,57 +141,37 @@ export function AutomationJobsQueueList({
                                                     Probno
                                                 </Chip>
                                             ) : null}
-                                        </Stack>
+                                        </div>
                                     </div>
 
                                     {run.errorMessage ? (
                                         <Typography
                                             level="body3"
-                                            className="break-words rounded-md bg-red-50 p-2 text-red-700 dark:bg-red-950 dark:text-red-300"
+                                            className="line-clamp-2 rounded-md bg-red-50 p-2 text-red-700 dark:bg-red-950 dark:text-red-300"
                                         >
                                             {run.errorMessage}
                                         </Typography>
                                     ) : null}
 
-                                    <dl className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                                        <DetailItem label="Izvor">
-                                            <Stack spacing={1}>
-                                                <Chip size="sm" variant="soft">
-                                                    {sourceLabel(run.source)}
-                                                </Chip>
-                                                <span>
-                                                    {run.sourceEventType ?? '-'}
-                                                </span>
-                                                <Typography
-                                                    level="body3"
-                                                    className="break-all text-muted-foreground"
-                                                >
-                                                    {run.sourceAggregateId ??
-                                                        '-'}
-                                                </Typography>
-                                            </Stack>
-                                        </DetailItem>
-                                        <DetailItem label="Pokušaji">
-                                            {run.attempt} / {run.maxAttempts}
-                                        </DetailItem>
-                                        <QueueTiming run={run} />
-                                        <DetailItem label="Kreirano">
-                                            <LocalDateTime>
-                                                {run.createdAt}
-                                            </LocalDateTime>
-                                        </DetailItem>
-                                        <DetailItem label="Ažurirano">
-                                            <LocalDateTime>
-                                                {run.updatedAt}
-                                            </LocalDateTime>
-                                        </DetailItem>
-                                        <DetailItem label="Početak">
-                                            <DateTimeValue
-                                                value={run.startedAt}
-                                            />
-                                        </DetailItem>
-                                    </dl>
-                                </Stack>
+                                    <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                                        <span className="min-w-0 max-w-full truncate">
+                                            {run.automationDefinitionKey}
+                                        </span>
+                                        <span>{sourceLabel(run.source)}</span>
+                                        <span>
+                                            Pokušaj {run.attempt} /{' '}
+                                            {run.maxAttempts}
+                                        </span>
+                                        <span>
+                                            <QueueTiming run={run} />
+                                        </span>
+                                        {run.parentRunId ? (
+                                            <span>
+                                                Roditelj #{run.parentRunId}
+                                            </span>
+                                        ) : null}
+                                    </div>
+                                </div>
                             </li>
                         ))}
                     </ul>

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -43,6 +43,12 @@ Event-triggered runs are idempotent through a partial unique index on
 test, and replay runs can be repeated while still keeping their source event
 context.
 
+Matching event-triggered runs are enqueued as part of `createEvent()`, so live
+domain events do not need to wait for the polling cron before they appear in the
+automation queue. The cursor-based polling runner remains as a safety net for
+event writes that bypass immediate enqueueing, missed duplicate-safe enqueue
+attempts, scheduled runs, and periodic queue execution.
+
 ## Runner Lifecycle
 
 `runAutomations()` in `packages/storage/src/automations/runner.ts` performs four
@@ -63,14 +69,14 @@ from backfilling historical sowing events and creating past-dated seasonal
 watering operations on first cron execution.
 
 The API cron route is protected with `CRON_SECRET` and is registered in
-`apps/api/vercel.json` on a five-minute schedule:
+`apps/api/vercel.json` on a one-minute schedule:
 
 ```json
-{ "path": "/api/internal/cron/automations", "schedule": "*/5 * * * *" }
+{ "path": "/api/internal/cron/automations", "schedule": "* * * * *" }
 ```
 
-Five minutes is the MVP tradeoff: follow-up work is asynchronous and visible in
-run logs without adding a high-frequency cron job.
+The cron remains bounded and idempotent: it enqueues missed schedule/event runs,
+recovers stale locks, and claims a limited batch of due queued/retrying runs.
 
 ## Module Registry
 

--- a/packages/storage/src/repositories/automationsRepo.ts
+++ b/packages/storage/src/repositories/automationsRepo.ts
@@ -265,6 +265,7 @@ export async function listAutomationDefinitions(filters?: {
     triggerEventType?: string;
     limit?: number;
     offset?: number;
+    db?: DatabaseClient;
 }): Promise<SelectAutomationDefinition[]> {
     const statuses = Array.isArray(filters?.status)
         ? filters.status
@@ -272,7 +273,9 @@ export async function listAutomationDefinitions(filters?: {
           ? [filters.status]
           : undefined;
 
-    return storage()
+    const db = filters?.db ?? storage();
+
+    return db
         .select()
         .from(automationDefinitions)
         .where(
@@ -295,11 +298,13 @@ export async function listAutomationDefinitions(filters?: {
 
 export function listEnabledAutomationDefinitionsForEventType(
     eventType: string,
+    db: DatabaseClient = storage(),
 ): Promise<SelectAutomationDefinition[]> {
     return listAutomationDefinitions({
         status: 'enabled',
         triggerEventType: eventType,
         limit: 500,
+        db,
     });
 }
 
@@ -321,6 +326,7 @@ export function listEnabledAutomationDefinitionsForTriggerModule(
 
 export async function createAutomationRun(
     input: CreateAutomationRunInput,
+    db: DatabaseClient = storage(),
 ): Promise<SelectAutomationRun | null> {
     const definition = input.automationDefinition;
     const sourceEvent = input.sourceEvent ?? null;
@@ -351,7 +357,7 @@ export async function createAutomationRun(
     }
 
     if (input.source === 'schedule') {
-        const [created] = await storage()
+        const [created] = await db
             .insert(automationRuns)
             .values(values)
             .onConflictDoNothing({
@@ -366,7 +372,7 @@ export async function createAutomationRun(
         return created ?? null;
     }
 
-    const [created] = await storage()
+    const [created] = await db
         .insert(automationRuns)
         .values(values)
         .onConflictDoNothing({
@@ -974,27 +980,36 @@ export async function getRunnableAutomationEventTypes() {
 
 export async function enqueueAutomationRunsForEvent(
     event: DomainEventRow,
+    {
+        db = storage(),
+    }: {
+        db?: DatabaseClient;
+    } = {},
 ): Promise<SelectAutomationRun[]> {
     const definitions = await listEnabledAutomationDefinitionsForEventType(
         event.type,
+        db,
     );
     const createdRuns: SelectAutomationRun[] = [];
 
     for (const definition of definitions) {
-        const run = await createAutomationRun({
-            automationDefinition: definition,
-            source: 'event',
-            sourceEvent: event,
-            input: {
-                eventId: event.id,
-                eventType: event.type,
-                aggregateId: event.aggregateId,
-                data:
-                    event.data && typeof event.data === 'object'
-                        ? (event.data as AutomationJsonObject)
-                        : {},
+        const run = await createAutomationRun(
+            {
+                automationDefinition: definition,
+                source: 'event',
+                sourceEvent: event,
+                input: {
+                    eventId: event.id,
+                    eventType: event.type,
+                    aggregateId: event.aggregateId,
+                    data:
+                        event.data && typeof event.data === 'object'
+                            ? (event.data as AutomationJsonObject)
+                            : {},
+                },
             },
-        });
+            db,
+        );
 
         if (run) {
             createdRuns.push(run);

--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -17,6 +17,7 @@ import {
 } from '../../cache/scheduleCache';
 import { automationRunSteps, automationRuns, events } from '../../schema';
 import { storage } from '../../storage';
+import { enqueueAutomationRunsForEvent } from '../automationsRepo';
 import { knownEventTypes } from './knownEventTypes';
 import type { AiRequestKind, Event, UserBirthdayRewardPayload } from './types';
 
@@ -411,14 +412,24 @@ export async function createEvent(
     { type, version, aggregateId, data, createdAt }: Event,
     db: DatabaseClient = storage(),
 ) {
-    await db.insert(events).values({
-        type,
-        version,
-        aggregateId,
-        data,
-        ...(createdAt && { createdAt }),
-    });
+    const [event] = await db
+        .insert(events)
+        .values({
+            type,
+            version,
+            aggregateId,
+            data,
+            ...(createdAt && { createdAt }),
+        })
+        .returning();
+    if (!event) {
+        throw new Error('Failed to create event.');
+    }
+
+    await enqueueAutomationRunsForEvent(event, { db });
     await bustReadModelCachesForEvent({ type, version, aggregateId, data });
+
+    return event;
 }
 
 async function getDomainAiAnalysisEvents(

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+import test, { afterEach } from 'node:test';
 import {
     type AutomationGraph,
     acceptOperation,
+    automationDefinitions,
     automationEventCursors,
     automationModuleKeys,
+    automationRunSteps,
+    automationRuns,
     claimDueAutomationRuns,
     completeAutomationRun,
     createAccount,
@@ -55,6 +58,13 @@ import {
 } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
+afterEach(async () => {
+    await storage().delete(automationRunSteps);
+    await storage().delete(automationRuns);
+    await storage().delete(automationDefinitions);
+    await storage().delete(automationEventCursors);
+});
+
 async function createAutomationRaisedBedContext() {
     const accountId = await createAccount();
     const farmId = await ensureFarmId();
@@ -81,6 +91,20 @@ async function getLatestEvent(type: string, aggregateId: string) {
     const event = events.at(-1);
     assert.ok(event, `Expected event ${type} for ${aggregateId}`);
     return event;
+}
+
+async function getAutomationRunForEvent(
+    automationDefinitionId: number,
+    sourceEventId: number,
+) {
+    const runs = await listAutomationRuns({
+        automationDefinitionId,
+        sourceEventId,
+    });
+    assert.strictEqual(runs.length, 1);
+    const run = runs[0];
+    assert.ok(run);
+    return run;
 }
 
 async function getScheduledFreeWateringDates(
@@ -187,20 +211,7 @@ test('automation definitions persist graph trigger metadata and event-run idempo
         aggregateId,
     );
 
-    const firstRun = await createAutomationRun({
-        automationDefinition: definition,
-        source: 'event',
-        sourceEvent: event,
-        input: {
-            eventId: event.id,
-            eventType: event.type,
-            aggregateId: event.aggregateId,
-            data:
-                event.data && typeof event.data === 'object'
-                    ? (event.data as Record<string, unknown>)
-                    : {},
-        },
-    });
+    const firstRun = await getAutomationRunForEvent(definition.id, event.id);
     const duplicateRun = await createAutomationRun({
         automationDefinition: definition,
         source: 'event',
@@ -811,21 +822,7 @@ test('default sowed automation queues seasonal watering operations through execu
     });
     assert.ok(definition);
 
-    const run = await createAutomationRun({
-        automationDefinition: definition,
-        source: 'event',
-        sourceEvent: event,
-        input: {
-            eventId: event.id,
-            eventType: event.type,
-            aggregateId: event.aggregateId,
-            data:
-                event.data && typeof event.data === 'object'
-                    ? (event.data as Record<string, unknown>)
-                    : {},
-        },
-    });
-    assert.ok(run);
+    const run = await getAutomationRunForEvent(definition.id, event.id);
     const [claimedRun] = await claimDueAutomationRuns({
         limit: 1,
         lockedBy: 'automations-test',
@@ -1061,21 +1058,7 @@ test('default plant-removal automation marks the operation target removed after 
         knownEventTypes.operations.verify,
         operationId.toString(),
     );
-    const run = await createAutomationRun({
-        automationDefinition: definition,
-        source: 'event',
-        sourceEvent: event,
-        input: {
-            eventId: event.id,
-            eventType: event.type,
-            aggregateId: event.aggregateId,
-            data:
-                event.data && typeof event.data === 'object'
-                    ? (event.data as Record<string, unknown>)
-                    : {},
-        },
-    });
-    assert.ok(run);
+    const run = await getAutomationRunForEvent(definition.id, event.id);
     const startedRun = await startAutomationRun(run.id, {
         lockedBy: 'automations-test',
     });
@@ -1195,13 +1178,10 @@ test('seedling transplant automation waits for verification before setting sowin
                 ? (verificationEvent.data as Record<string, unknown>)
                 : {},
     };
-    const run = await createAutomationRun({
-        automationDefinition: definition,
-        source: 'event',
-        sourceEvent: verificationEvent,
-        input: verificationInput,
-    });
-    assert.ok(run);
+    const run = await getAutomationRunForEvent(
+        definition.id,
+        verificationEvent.id,
+    );
     const startedRun = await startAutomationRun(run.id, {
         lockedBy: 'automations-test',
     });
@@ -1704,11 +1684,11 @@ test('automation runner seeds the initial event cursor without backfilling histo
     });
 
     assert.strictEqual(liveResult.scannedEvents, 1);
-    assert.ok(liveResult.enqueuedRuns >= 1);
+    assert.strictEqual(liveResult.enqueuedRuns, 0);
     assert.strictEqual(liveResult.lastEventId, liveEvent.id);
     assert.strictEqual(await getAutomationEventCursor(), liveEvent.id);
     const liveRuns = await listAutomationRuns({ sourceEventId: liveEvent.id });
-    assert.strictEqual(liveRuns.length, liveResult.enqueuedRuns);
+    assert.ok(liveRuns.length >= 1);
     assert.ok(liveRuns.every((run) => run.sourceEventId === liveEvent.id));
     for (const run of liveRuns) {
         await completeAutomationRun({
@@ -1740,20 +1720,7 @@ test('automation runner enqueues and processes due default automation runs', asy
         event.type,
     );
     assert.ok(definition);
-    await createAutomationRun({
-        automationDefinition: definition,
-        source: 'event',
-        sourceEvent: event,
-        input: {
-            eventId: event.id,
-            eventType: event.type,
-            aggregateId: event.aggregateId,
-            data:
-                event.data && typeof event.data === 'object'
-                    ? (event.data as Record<string, unknown>)
-                    : {},
-        },
-    });
+    await getAutomationRunForEvent(definition.id, event.id);
 
     const result = await processDueAutomationRuns({
         limit: 10,


### PR DESCRIPTION
## Summary

- compact the admin automations overview rows so definitions and queued jobs show only glancing-level data
- enqueue matching automation runs immediately when domain events are created
- reduce the automation cron fallback from five minutes to one minute
- document the new queue behavior and update focused automation tests

## Why

Automation work was only discovered on the five-minute polling cadence, which made event-triggered follow-up work feel slow. Event-created runs are now queued at the event boundary, while the cron remains a bounded idempotent fallback and executor.

## Validation

- `pnpm --filter @gredice/storage test:node tests/automationsRepo.node.spec.ts`
- `pnpm lint --filter @gredice/storage`
- `pnpm lint --filter api`
- `pnpm lint --filter app`
- `pnpm build --filter api`
- `git diff --check`