### PR TITLE
[codex] Speed up automation cron processing

### DIFF
--- a/apps/api/app/api/internal/cron/automations/route.ts
+++ b/apps/api/app/api/internal/cron/automations/route.ts
@@ -5,6 +5,9 @@ export const dynamic = 'force-dynamic';
 
 const EVENT_BATCH_LIMIT = 500;
 const RUN_BATCH_LIMIT = 25;
+const RUN_MAX_BATCHES = 10;
+const RUN_MAX_DURATION_MS = 45_000;
+const RUN_MIN_REMAINING_MS = 5_000;
 
 export async function GET(request: NextRequest) {
     const authHeader = request.headers.get('authorization');
@@ -20,6 +23,9 @@ export async function GET(request: NextRequest) {
         const result = await runAutomations({
             eventBatchLimit: EVENT_BATCH_LIMIT,
             runBatchLimit: RUN_BATCH_LIMIT,
+            runMaxBatches: RUN_MAX_BATCHES,
+            runMaxDurationMs: RUN_MAX_DURATION_MS,
+            runMinRemainingMs: RUN_MIN_REMAINING_MS,
             lockedBy: 'api-cron-automations',
         });
 

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -53,7 +53,7 @@ attempts, scheduled runs, and periodic queue execution.
 
 ## Runner Lifecycle
 
-`runAutomations()` in `packages/storage/src/automations/runner.ts` performs four
+`runAutomations()` in `packages/storage/src/automations/runner.ts` performs
 bounded phases:
 
 1. Ensure default automation definitions exist.
@@ -61,9 +61,13 @@ bounded phases:
    repeated cron ticks do not duplicate the same period.
 3. Read new domain events after the cursor and enqueue matching enabled
    automation runs.
-4. Recover stale running jobs, claim due queued/retryable runs up to each
-   automation definition's concurrency cap, and execute the claimed batch
-   through the graph executor.
+4. Recover stale running jobs.
+5. Claim due queued/retryable runs up to each automation definition's
+   concurrency cap and execute the claimed batch through the graph executor.
+6. When a batch finishes quickly, claim another due batch in the same cron
+   invocation. The runner measures batch duration and only starts another batch
+   when the estimated next batch plus the safety margin still fits inside the
+   processing budget.
 
 When defaults are first installed, the runner initializes the event cursor to
 the current latest domain event id if no cursor exists. This prevents the MVP
@@ -78,7 +82,11 @@ The API cron route is protected with `CRON_SECRET` and is registered in
 ```
 
 The cron remains bounded and idempotent: it enqueues missed schedule/event runs,
-recovers stale locks, and claims a limited batch of due queued/retrying runs.
+recovers stale locks, and claims limited batches of due queued/retrying runs.
+The API cron currently allows up to 10 processing batches, with a 45-second
+processing budget and a 5-second safety margin. This lets fast skipped/no-op
+jobs drain without waiting for another cron tick, while slower batches naturally
+pause for the next one.
 
 ## Module Registry
 

--- a/packages/storage/src/automations/runner.ts
+++ b/packages/storage/src/automations/runner.ts
@@ -15,7 +15,29 @@ import { automationModuleKeys, getMonthlyScheduleOccurrence } from './modules';
 
 const defaultEventBatchLimit = 500;
 const defaultRunBatchLimit = 25;
+const defaultRunMaxBatches = 10;
+const defaultRunMaxDurationMs = 45_000;
+const defaultRunMinRemainingMs = 5_000;
 const defaultStaleRunMinutes = 15;
+
+export type AutomationProcessingStopReason =
+    | 'queue_empty'
+    | 'time_budget'
+    | 'batch_limit';
+
+type AutomationProcessingResult = {
+    claimedRuns: number;
+    succeeded: number;
+    skipped: number;
+    failed: number;
+    retrying: number;
+    recoveredStaleRuns: number;
+    failedStaleRuns: number;
+    processedBatches: number;
+    processingDurationMs: number;
+    processingTimeBudgetMs: number;
+    processingStopReason: AutomationProcessingStopReason;
+};
 
 export type AutomationRunnerResult = {
     scannedEvents: number;
@@ -30,6 +52,10 @@ export type AutomationRunnerResult = {
     retrying: number;
     recoveredStaleRuns: number;
     failedStaleRuns: number;
+    processedBatches: number;
+    processingDurationMs: number;
+    processingTimeBudgetMs: number;
+    processingStopReason: AutomationProcessingStopReason;
 };
 
 export async function enqueueAutomationRunsFromSchedules({
@@ -124,40 +150,100 @@ export async function enqueueAutomationRunsFromDomainEvents({
 
 export async function processDueAutomationRuns({
     limit = defaultRunBatchLimit,
+    maxBatches = defaultRunMaxBatches,
+    maxDurationMs = defaultRunMaxDurationMs,
+    minRemainingMs = defaultRunMinRemainingMs,
     lockedBy = 'automation-runner',
+    getTimeMs = Date.now,
 }: {
     limit?: number;
+    maxBatches?: number;
+    maxDurationMs?: number;
+    minRemainingMs?: number;
     lockedBy?: string;
+    getTimeMs?: () => number;
 } = {}) {
+    const startedAtMs = getTimeMs();
+    const safeLimit = Math.max(0, Math.floor(limit));
+    const safeMaxBatches = Math.max(0, Math.floor(maxBatches));
+    const safeMaxDurationMs = Math.max(0, maxDurationMs);
+    const safeMinRemainingMs = Math.max(0, minRemainingMs);
     const staleBefore = new Date(
         Date.now() - defaultStaleRunMinutes * 60 * 1000,
     );
     const staleResult = await recoverStaleAutomationRuns({ staleBefore });
-    const runs = await claimDueAutomationRuns({ limit, lockedBy });
-    const result = {
-        claimedRuns: runs.length,
+    const result: AutomationProcessingResult = {
+        claimedRuns: 0,
         succeeded: 0,
         skipped: 0,
         failed: 0,
         retrying: 0,
         recoveredStaleRuns: staleResult.recovered,
         failedStaleRuns: staleResult.failed,
+        processedBatches: 0,
+        processingDurationMs: 0,
+        processingTimeBudgetMs: safeMaxDurationMs,
+        processingStopReason: 'queue_empty',
     };
 
-    const runResults = await Promise.all(
-        runs.map((run) => executeAutomationRun(run)),
-    );
+    let currentTimeMs = getTimeMs();
+    result.processingDurationMs = Math.max(0, currentTimeMs - startedAtMs);
+    let lastBatchDurationMs = 0;
 
-    for (const runResult of runResults) {
-        if (runResult.status === 'succeeded') {
-            result.succeeded += 1;
-        } else if (runResult.status === 'skipped') {
-            result.skipped += 1;
-        } else if (runResult.status === 'retrying') {
-            result.retrying += 1;
-        } else {
-            result.failed += 1;
+    while (safeLimit > 0 && result.processedBatches < safeMaxBatches) {
+        if (result.processedBatches > 0) {
+            const elapsedMs = Math.max(0, currentTimeMs - startedAtMs);
+            const estimatedNextBatchMs = Math.max(lastBatchDurationMs, 1);
+            if (
+                elapsedMs + estimatedNextBatchMs + safeMinRemainingMs >
+                safeMaxDurationMs
+            ) {
+                result.processingStopReason = 'time_budget';
+                break;
+            }
         }
+
+        const batchStartedAtMs = currentTimeMs;
+        const runs = await claimDueAutomationRuns({
+            limit: safeLimit,
+            lockedBy,
+        });
+
+        if (runs.length === 0) {
+            result.processingStopReason = 'queue_empty';
+            break;
+        }
+
+        result.claimedRuns += runs.length;
+        result.processedBatches += 1;
+
+        const runResults = await Promise.all(
+            runs.map((run) => executeAutomationRun(run)),
+        );
+
+        for (const runResult of runResults) {
+            if (runResult.status === 'succeeded') {
+                result.succeeded += 1;
+            } else if (runResult.status === 'skipped') {
+                result.skipped += 1;
+            } else if (runResult.status === 'retrying') {
+                result.retrying += 1;
+            } else {
+                result.failed += 1;
+            }
+        }
+
+        currentTimeMs = getTimeMs();
+        lastBatchDurationMs = Math.max(0, currentTimeMs - batchStartedAtMs);
+        result.processingDurationMs = Math.max(0, currentTimeMs - startedAtMs);
+    }
+
+    if (
+        safeLimit > 0 &&
+        result.processedBatches >= safeMaxBatches &&
+        result.processingStopReason === 'queue_empty'
+    ) {
+        result.processingStopReason = 'batch_limit';
     }
 
     return result;
@@ -167,11 +253,17 @@ export async function runAutomations({
     eventBatchLimit = defaultEventBatchLimit,
     scheduleBatchLimit,
     runBatchLimit = defaultRunBatchLimit,
+    runMaxBatches = defaultRunMaxBatches,
+    runMaxDurationMs = defaultRunMaxDurationMs,
+    runMinRemainingMs = defaultRunMinRemainingMs,
     lockedBy = 'automation-runner',
 }: {
     eventBatchLimit?: number;
     scheduleBatchLimit?: number;
     runBatchLimit?: number;
+    runMaxBatches?: number;
+    runMaxDurationMs?: number;
+    runMinRemainingMs?: number;
     lockedBy?: string;
 } = {}): Promise<AutomationRunnerResult> {
     const scheduleResult = await enqueueAutomationRunsFromSchedules({
@@ -182,6 +274,9 @@ export async function runAutomations({
     });
     const processResult = await processDueAutomationRuns({
         limit: runBatchLimit,
+        maxBatches: runMaxBatches,
+        maxDurationMs: runMaxDurationMs,
+        minRemainingMs: runMinRemainingMs,
         lockedBy,
     });
 

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -170,10 +170,53 @@ function raisedBedAiAnalysisImagePlantStatusReviewAutomationGraph(): AutomationG
     };
 }
 
+function monthlyLogAutomationGraph(): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerScheduleMonthly,
+                position: { x: 0, y: 0 },
+                config: {
+                    dayOfMonth: 1,
+                    timeZone: 'Europe/Zagreb',
+                },
+            },
+            {
+                id: 'log',
+                kind: 'action',
+                moduleKey: automationModuleKeys.actionLog,
+                position: { x: 280, y: 0 },
+                config: {
+                    message: 'Quick automation test reached the log action.',
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-log',
+                source: 'trigger',
+                target: 'log',
+            },
+        ],
+    };
+}
+
 function addUtcDays(date: Date, days: number) {
     const nextDate = new Date(date);
     nextDate.setUTCDate(nextDate.getUTCDate() + days);
     return nextDate;
+}
+
+function monthlyScheduleRunInput(index: number) {
+    return {
+        scheduleType: 'monthly',
+        triggerModuleKey: automationModuleKeys.triggerScheduleMonthly,
+        occurrenceKey: `test.monthly-log:${index}`,
+        period: '2026-06',
+        occurrenceDate: '2026-06-01T08:00:00.000Z',
+    };
 }
 
 test('automation definitions persist graph trigger metadata and event-run idempotency', async () => {
@@ -545,6 +588,83 @@ test('automation run claiming scans past saturated definition backlog', async ()
 
     assert.strictEqual(claimedRuns.length, 1);
     assert.strictEqual(claimedRuns[0]?.id, otherRun.id);
+});
+
+test('automation processor drains quick single-concurrency runs across batches', async () => {
+    createTestDb();
+    const definition = await createAutomationDefinition({
+        key: 'test.quick-batch-automation',
+        name: 'Quick batch automation',
+        status: 'enabled',
+        maxConcurrentRuns: 1,
+        graph: monthlyLogAutomationGraph(),
+    });
+
+    for (let index = 0; index < 3; index += 1) {
+        const run = await createAutomationRun({
+            automationDefinition: definition,
+            source: 'test',
+            input: monthlyScheduleRunInput(index),
+        });
+        assert.ok(run);
+    }
+
+    const result = await processDueAutomationRuns({
+        limit: 1,
+        maxBatches: 5,
+        maxDurationMs: 10_000,
+        minRemainingMs: 1_000,
+        lockedBy: 'automations-test',
+    });
+
+    assert.strictEqual(result.claimedRuns, 3);
+    assert.strictEqual(result.processedBatches, 3);
+    assert.strictEqual(result.succeeded, 3);
+    assert.strictEqual(result.processingStopReason, 'queue_empty');
+});
+
+test('automation processor waits for next cron cycle when measured batches are slow', async () => {
+    createTestDb();
+    const definition = await createAutomationDefinition({
+        key: 'test.slow-measured-batch-automation',
+        name: 'Slow measured batch automation',
+        status: 'enabled',
+        maxConcurrentRuns: 1,
+        graph: monthlyLogAutomationGraph(),
+    });
+
+    for (let index = 0; index < 3; index += 1) {
+        const run = await createAutomationRun({
+            automationDefinition: definition,
+            source: 'test',
+            input: monthlyScheduleRunInput(index),
+        });
+        assert.ok(run);
+    }
+
+    const observedTimes = [0, 0, 6_000];
+    let timeIndex = 0;
+    const result = await processDueAutomationRuns({
+        limit: 1,
+        maxBatches: 5,
+        maxDurationMs: 10_000,
+        minRemainingMs: 2_000,
+        lockedBy: 'automations-test',
+        getTimeMs: () =>
+            observedTimes[Math.min(timeIndex++, observedTimes.length - 1)] ?? 0,
+    });
+
+    assert.strictEqual(result.claimedRuns, 1);
+    assert.strictEqual(result.processedBatches, 1);
+    assert.strictEqual(result.succeeded, 1);
+    assert.strictEqual(result.processingDurationMs, 6_000);
+    assert.strictEqual(result.processingStopReason, 'time_budget');
+
+    const remainingRuns = await listAutomationRuns({
+        automationDefinitionId: definition.id,
+        status: 'queued',
+    });
+    assert.strictEqual(remainingRuns.length, 2);
 });
 
 test('monthly schedule automation enqueues once per configured period', async () => {


### PR DESCRIPTION
## Summary
- process automation runs across multiple measured batches in one cron invocation
- stop claiming more work when the estimated next batch would exceed the processing budget
- expose processing batch/time stop details in the cron result and document the bounded behavior

## Validation
- pnpm --filter @gredice/storage test:node tests/automationsRepo.node.spec.ts
- pnpm lint --filter @gredice/storage
- pnpm lint --filter api
- pnpm build --filter api
- git diff --check