### PR TITLE
Remove legacy plant automation actions

### DIFF
--- a/apps/app/app/admin/automations/AutomationFlowEditor.tsx
+++ b/apps/app/app/admin/automations/AutomationFlowEditor.tsx
@@ -186,8 +186,6 @@ const automationModuleIcons = new Map<string, IconComponent>([
     [automationModuleKeys.actionCreateOperation, Hammer],
     [automationModuleKeys.actionCreateFarmInventoryOperations, Store],
     [automationModuleKeys.actionUpdateRaisedBedFieldPlantAttributes, Sprout],
-    [automationModuleKeys.actionUpdateRaisedBedFieldPlantStatus, Sprout],
-    [automationModuleKeys.actionUpdateRaisedBedFieldSowingLocation, Sprout],
     [automationModuleKeys.actionCreatePlantStatusRequestsFromImageAnalysis, AI],
     [automationModuleKeys.actionLog, Text],
 ]);

--- a/apps/app/app/admin/automations/presentation.ts
+++ b/apps/app/app/admin/automations/presentation.ts
@@ -28,10 +28,6 @@ export const automationModuleKeys = {
         'action.queueSeasonalSowingOfferOperations',
     actionUpdateRaisedBedFieldPlantAttributes:
         'action.updateRaisedBedFieldPlantAttributes',
-    actionUpdateRaisedBedFieldPlantStatus:
-        'action.updateRaisedBedFieldPlantStatus',
-    actionUpdateRaisedBedFieldSowingLocation:
-        'action.updateRaisedBedFieldSowingLocation',
     conditionEventDataEquals: 'condition.eventDataEquals',
     conditionOperationMatches: 'condition.operationMatches',
     conditionPlantStatusEquals: 'condition.plantStatusEquals',
@@ -180,26 +176,6 @@ const automationModulePresentations: Record<
                     greenhouse: 'Staklenik',
                 },
                 placeholder: 'direct',
-            },
-        },
-    },
-    [automationModuleKeys.actionUpdateRaisedBedFieldPlantStatus]: {
-        title: 'Ažuriraj status biljke',
-        description: 'Upisuje novi status biljke za ciljano polje gredice.',
-        fields: {
-            targetStatus: { label: 'Ciljani status' },
-        },
-    },
-    [automationModuleKeys.actionUpdateRaisedBedFieldSowingLocation]: {
-        title: 'Ažuriraj lokaciju sijanja',
-        description: 'Upisuje novu lokaciju sijanja za ciljano polje gredice.',
-        fields: {
-            targetSowingLocation: {
-                label: 'Ciljana lokacija',
-                options: {
-                    direct: 'Direktno',
-                    greenhouse: 'Staklenik',
-                },
             },
         },
     },

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -109,13 +109,6 @@ MVP modules:
 - `action.updateRaisedBedFieldPlantAttributes`: writes plant status and/or
   sowing location events for the operation target field. Use this for new
   no-code plant-state automations.
-- `action.updateRaisedBedFieldPlantStatus`: writes a
-  `raisedBedField.plantUpdate` event for an operation target. Existing
-  automations with this module key remain supported.
-- `action.updateRaisedBedFieldSowingLocation`: writes a
-  `raisedBedField.plantSchedule` event for an operation target, preserving the
-  scheduled date while changing `sowingLocation`. Existing automations with
-  this module key remain supported.
 - `action.createPlantStatusRequestsFromImageAnalysis`: reviews hosted
   raised-bed images from operation completion or raised-bed AI analysis events,
   then creates pending plant-status approval requests when the visual evidence

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -49,10 +49,6 @@ const createFarmInventoryOperationsActionKey =
     'action.createFarmInventoryOperations';
 const updateRaisedBedFieldPlantAttributesActionKey =
     'action.updateRaisedBedFieldPlantAttributes';
-const updateRaisedBedFieldPlantStatusActionKey =
-    'action.updateRaisedBedFieldPlantStatus';
-const updateRaisedBedFieldSowingLocationActionKey =
-    'action.updateRaisedBedFieldSowingLocation';
 const createPlantStatusRequestsFromImageAnalysisActionKey =
     'action.createPlantStatusRequestsFromImageAnalysis';
 const logActionKey = 'action.log';
@@ -74,10 +70,6 @@ export const automationModuleKeys = {
     actionCreateFarmInventoryOperations: createFarmInventoryOperationsActionKey,
     actionUpdateRaisedBedFieldPlantAttributes:
         updateRaisedBedFieldPlantAttributesActionKey,
-    actionUpdateRaisedBedFieldPlantStatus:
-        updateRaisedBedFieldPlantStatusActionKey,
-    actionUpdateRaisedBedFieldSowingLocation:
-        updateRaisedBedFieldSowingLocationActionKey,
     actionCreatePlantStatusRequestsFromImageAnalysis:
         createPlantStatusRequestsFromImageAnalysisActionKey,
     actionLog: logActionKey,
@@ -1399,68 +1391,6 @@ const updateRaisedBedFieldPlantAttributesActionModule: AutomationModule = {
         updateRaisedBedFieldPlantAttributes({ context, node }),
 };
 
-const updateRaisedBedFieldPlantStatusActionModule: AutomationModule = {
-    key: updateRaisedBedFieldPlantStatusActionKey,
-    kind: 'action',
-    title: 'Update plant status',
-    description:
-        'Writes a raised-bed field plant status update for the operation target.',
-    category: 'Raised-bed fields',
-    configFields: [
-        {
-            key: 'targetStatus',
-            label: 'Target status',
-            type: 'string',
-            required: true,
-            placeholder: 'sprouted',
-        },
-    ],
-    dryRunSupported: true,
-    mutatesData: true,
-    retryable: true,
-    validateConfig: (config) => requiredString(config, 'targetStatus'),
-    execute: async (context, node) =>
-        updateRaisedBedFieldPlantAttributes({
-            context,
-            node,
-            noChangeReason: 'Plant already has the target status.',
-        }),
-};
-
-const updateRaisedBedFieldSowingLocationActionModule: AutomationModule = {
-    key: updateRaisedBedFieldSowingLocationActionKey,
-    kind: 'action',
-    title: 'Update sowing location',
-    description:
-        'Writes a raised-bed field sowing location update for the operation target.',
-    category: 'Raised-bed fields',
-    configFields: [
-        {
-            key: 'targetSowingLocation',
-            label: 'Target sowing location',
-            type: 'select',
-            required: true,
-            options: [
-                { value: 'direct', label: 'Direct' },
-                { value: 'greenhouse', label: 'Greenhouse' },
-            ],
-        },
-    ],
-    dryRunSupported: true,
-    mutatesData: true,
-    retryable: true,
-    validateConfig: (config) =>
-        parseSowingLocation(config.targetSowingLocation)
-            ? []
-            : ['targetSowingLocation must be direct or greenhouse.'],
-    execute: async (context, node) =>
-        updateRaisedBedFieldPlantAttributes({
-            context,
-            node,
-            noChangeReason: 'Plant already has the target sowing location.',
-        }),
-};
-
 const createPlantStatusRequestsFromImageAnalysisActionModule: AutomationModule =
     {
         key: createPlantStatusRequestsFromImageAnalysisActionKey,
@@ -1588,8 +1518,6 @@ export const automationModules = [
     createOperationActionModule,
     createFarmInventoryOperationsActionModule,
     updateRaisedBedFieldPlantAttributesActionModule,
-    updateRaisedBedFieldPlantStatusActionModule,
-    updateRaisedBedFieldSowingLocationActionModule,
     createPlantStatusRequestsFromImageAnalysisActionModule,
     logActionModule,
 ] as const satisfies readonly AutomationModule[];

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -874,7 +874,7 @@ test('default sowed automation queues seasonal watering operations through execu
     );
 });
 
-test('plant-status automation skips replay when target status already exists', async () => {
+test('plant-attributes automation skips replay when target status already exists', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =
         await createAutomationRaisedBedContext();
@@ -920,7 +920,8 @@ test('plant-status automation skips replay when target status already exists', a
             },
             {
                 id: 'update-plant-status',
-                moduleKey: 'action.updateRaisedBedFieldPlantStatus',
+                moduleKey:
+                    automationModuleKeys.actionUpdateRaisedBedFieldPlantAttributes,
                 kind: 'action' as const,
                 position: { x: 280, y: 0 },
                 config: {


### PR DESCRIPTION
## Summary

- remove deprecated plant-status and sowing-location automation action modules
- keep the generic `action.updateRaisedBedFieldPlantAttributes` as the single plant-field mutation action
- remove the old actions from the admin module presentation and docs

## Live data migration

- verified the API production deployment was ready before changing DB definitions
- migrated 2 existing automation definitions to `action.updateRaisedBedFieldPlantAttributes`
- verified 0 remaining automation definition graph references to the old module keys

## Validation

- `pnpm --filter @gredice/storage test -- automationsRepo.node.spec.ts`
- `pnpm lint --filter @gredice/storage`
- `pnpm lint --filter app`
- `pnpm build --filter app`
- `git diff --check`
