### PR TITLE
[codex] Refine auth modal provider choices

### DIFF
--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -7,7 +7,7 @@ import {
     GoogleLoginButton,
     useLastLoginProvider,
 } from '@gredice/ui/auth';
-import { Divider } from '@gredice/ui/Divider';
+import { Button } from '@gredice/ui/Button';
 import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
@@ -18,11 +18,15 @@ import { useCallback, useState } from 'react';
 import { EmailPasswordForm } from './EmailPasswordForm';
 import LoginBanner from './LoginBanner';
 
+type AuthTab = 'login' | 'register';
+
 export default function LoginModal() {
     const posthog = usePostHog();
     const router = useRouter();
     const queryClient = useQueryClient();
     const [error, setError] = useState<string>();
+    const [activeTab, setActiveTab] = useState<AuthTab>('login');
+    const [emailExpanded, setEmailExpanded] = useState(false);
     const fetchLastLogin = useCallback(
         () => clientPublic().api.auth['last-login'].$get(),
         [],
@@ -145,6 +149,17 @@ export default function LoginModal() {
         window.location.href = authUrl.toString();
     };
 
+    const handleTabChange = (value: string) => {
+        if (value === 'login' || value === 'register') {
+            setActiveTab(value);
+            setEmailExpanded(false);
+            setError(undefined);
+        }
+    };
+
+    const emailButtonLabel =
+        activeTab === 'login' ? 'Prijava emailom' : 'Registracija emailom';
+
     return (
         <>
             <LoginBanner />
@@ -154,7 +169,11 @@ export default function LoginModal() {
                 className="bg-card z-[60] border-tertiary border-b-4 rounded-lg shadow-2xl"
                 dismissible={false}
             >
-                <Tabs defaultValue="login" className="w-full">
+                <Tabs
+                    value={activeTab}
+                    onValueChange={handleTabChange}
+                    className="w-full"
+                >
                     <div className="flex justify-center w-full">
                         <TabsList className="grid grid-cols-2">
                             <TabsTrigger value="login">Prijava</TabsTrigger>
@@ -163,54 +182,73 @@ export default function LoginModal() {
                             </TabsTrigger>
                         </TabsList>
                     </div>
-                    <Stack spacing={4}>
-                        <Stack spacing={2}>
-                            <FacebookLoginButton
-                                onClick={() => handleOAuthLogin('facebook')}
-                                lastUsed={lastLoginProvider === 'facebook'}
-                            />
-                            <GoogleLoginButton
-                                onClick={() => handleOAuthLogin('google')}
-                                lastUsed={lastLoginProvider === 'google'}
-                            />
-                        </Stack>
-                        <div className="relative">
-                            <div className="absolute inset-0 flex items-center">
-                                <Divider />
-                            </div>
-                            <div className="relative flex justify-center">
-                                <span className="bg-background px-2 text-xs rounded-xs">
-                                    ili nastavi emailom
-                                </span>
-                            </div>
-                        </div>
-                        <TabsContent value="login">
-                            <div className="px-1">
-                                <Stack spacing={4}>
-                                    <EmailPasswordForm
-                                        onSubmit={handleLogin}
-                                        submitText="Prijava"
+                    <Stack spacing={4} className="mt-4">
+                        {!emailExpanded && (
+                            <>
+                                <Stack spacing={2}>
+                                    <GoogleLoginButton
+                                        onClick={() =>
+                                            handleOAuthLogin('google')
+                                        }
+                                        lastUsed={
+                                            lastLoginProvider === 'google'
+                                        }
                                     />
-                                    {error && (
-                                        <Alert color="danger">{error}</Alert>
-                                    )}
-                                </Stack>
-                            </div>
-                        </TabsContent>
-                        <TabsContent value="register">
-                            <div className="px-1">
-                                <Stack spacing={4}>
-                                    <EmailPasswordForm
-                                        onSubmit={handleRegister}
-                                        submitText="Registriraj se"
-                                        registration
+                                    <FacebookLoginButton
+                                        onClick={() =>
+                                            handleOAuthLogin('facebook')
+                                        }
+                                        lastUsed={
+                                            lastLoginProvider === 'facebook'
+                                        }
                                     />
-                                    {error && (
-                                        <Alert color="danger">{error}</Alert>
-                                    )}
                                 </Stack>
-                            </div>
-                        </TabsContent>
+                                <Button
+                                    type="button"
+                                    variant="outlined"
+                                    color="neutral"
+                                    fullWidth
+                                    onClick={() => setEmailExpanded(true)}
+                                >
+                                    {emailButtonLabel}
+                                </Button>
+                            </>
+                        )}
+                        {emailExpanded && (
+                            <>
+                                <TabsContent value="login" className="mt-0">
+                                    <div className="px-1">
+                                        <Stack spacing={4}>
+                                            <EmailPasswordForm
+                                                onSubmit={handleLogin}
+                                                submitText="Prijava"
+                                            />
+                                            {error && (
+                                                <Alert color="danger">
+                                                    {error}
+                                                </Alert>
+                                            )}
+                                        </Stack>
+                                    </div>
+                                </TabsContent>
+                                <TabsContent value="register" className="mt-0">
+                                    <div className="px-1">
+                                        <Stack spacing={4}>
+                                            <EmailPasswordForm
+                                                onSubmit={handleRegister}
+                                                submitText="Registriraj se"
+                                                registration
+                                            />
+                                            {error && (
+                                                <Alert color="danger">
+                                                    {error}
+                                                </Alert>
+                                            )}
+                                        </Stack>
+                                    </div>
+                                </TabsContent>
+                            </>
+                        )}
                     </Stack>
                 </Tabs>
             </Modal>

--- a/packages/ui/src/auth/FacebookLoginButton.tsx
+++ b/packages/ui/src/auth/FacebookLoginButton.tsx
@@ -1,6 +1,5 @@
 import { Button, type ButtonProps } from '../Button';
 import { Chip } from '../Chip';
-import { cx } from '../utils';
 
 export function FacebookLoginButton({
     className,
@@ -12,10 +11,7 @@ export function FacebookLoginButton({
             type="button"
             color="neutral"
             variant="outlined"
-            className={cx(
-                'border-transparent bg-[#1877F2] text-white hover:bg-[#166FE5] dark:border-transparent dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800',
-                className,
-            )}
+            className={className}
             fullWidth
             endDecorator={
                 lastUsed && (
@@ -30,7 +26,7 @@ export function FacebookLoginButton({
             {...props}
         >
             <svg
-                className="h-4 w-4 shrink-0 text-white"
+                className="h-4 w-4 shrink-0 text-[#1877F2]"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"

--- a/packages/ui/src/auth/GoogleLoginButton.tsx
+++ b/packages/ui/src/auth/GoogleLoginButton.tsx
@@ -1,6 +1,5 @@
 import { Button, type ButtonProps } from '../Button';
 import { Chip } from '../Chip';
-import { cx } from '../utils';
 
 export function GoogleLoginButton({
     className,
@@ -12,10 +11,7 @@ export function GoogleLoginButton({
             type="button"
             color="neutral"
             variant="outlined"
-            className={cx(
-                'bg-white text-black hover:bg-white/90 dark:text-black dark:hover:bg-white/80',
-                className,
-            )}
+            className={className}
             fullWidth
             endDecorator={
                 lastUsed && (


### PR DESCRIPTION
## Summary
- reorder garden auth providers so Google appears before Facebook
- make shared Google and Facebook auth buttons use the same outlined treatment
- collapse login and registration email forms behind a tab-aware email button, hiding social providers once email auth is expanded

## Validation
- `corepack pnpm lint --filter @gredice/ui --filter garden`
- `corepack pnpm typecheck --filter @gredice/ui --filter garden`
- Browser check at `http://localhost:3001`: verified initial provider order, outlined buttons, email expansion for login, and email expansion for registration

## Notes
- Local browser verification ran without the API dev server, so unrelated API proxy calls to `localhost:3005` returned connection errors while the auth modal UI itself rendered and interacted correctly.