### PR TITLE
[codex] Polish auth email button

### DIFF
--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -158,8 +158,7 @@ export default function LoginModal() {
         }
     };
 
-    const emailButtonLabel =
-        activeTab === 'login' ? 'Prijava emailom' : 'Registracija emailom';
+    const authActionLabel = activeTab === 'login' ? 'prijava' : 'registracija';
 
     return (
         <>
@@ -189,11 +188,15 @@ export default function LoginModal() {
                                 <GoogleLoginButton
                                     onClick={() => handleOAuthLogin('google')}
                                     lastUsed={lastLoginProvider === 'google'}
-                                />
+                                >
+                                    Google {authActionLabel}
+                                </GoogleLoginButton>
                                 <FacebookLoginButton
                                     onClick={() => handleOAuthLogin('facebook')}
                                     lastUsed={lastLoginProvider === 'facebook'}
-                                />
+                                >
+                                    Facebook {authActionLabel}
+                                </FacebookLoginButton>
                                 <Button
                                     type="button"
                                     variant="outlined"
@@ -204,7 +207,7 @@ export default function LoginModal() {
                                     }
                                     onClick={() => setEmailExpanded(true)}
                                 >
-                                    {emailButtonLabel}
+                                    Email {authActionLabel}
                                 </Button>
                             </Stack>
                         )}

--- a/apps/garden/components/auth/LoginModal.tsx
+++ b/apps/garden/components/auth/LoginModal.tsx
@@ -8,6 +8,7 @@ import {
     useLastLoginProvider,
 } from '@gredice/ui/auth';
 import { Button } from '@gredice/ui/Button';
+import { Mail } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
@@ -184,35 +185,28 @@ export default function LoginModal() {
                     </div>
                     <Stack spacing={4} className="mt-4">
                         {!emailExpanded && (
-                            <>
-                                <Stack spacing={2}>
-                                    <GoogleLoginButton
-                                        onClick={() =>
-                                            handleOAuthLogin('google')
-                                        }
-                                        lastUsed={
-                                            lastLoginProvider === 'google'
-                                        }
-                                    />
-                                    <FacebookLoginButton
-                                        onClick={() =>
-                                            handleOAuthLogin('facebook')
-                                        }
-                                        lastUsed={
-                                            lastLoginProvider === 'facebook'
-                                        }
-                                    />
-                                </Stack>
+                            <Stack spacing={2}>
+                                <GoogleLoginButton
+                                    onClick={() => handleOAuthLogin('google')}
+                                    lastUsed={lastLoginProvider === 'google'}
+                                />
+                                <FacebookLoginButton
+                                    onClick={() => handleOAuthLogin('facebook')}
+                                    lastUsed={lastLoginProvider === 'facebook'}
+                                />
                                 <Button
                                     type="button"
                                     variant="outlined"
                                     color="neutral"
                                     fullWidth
+                                    startDecorator={
+                                        <Mail className="h-4 w-4 shrink-0" />
+                                    }
                                     onClick={() => setEmailExpanded(true)}
                                 >
                                     {emailButtonLabel}
                                 </Button>
-                            </>
+                            </Stack>
                         )}
                         {emailExpanded && (
                             <>

--- a/packages/ui/src/auth/FacebookLoginButton.tsx
+++ b/packages/ui/src/auth/FacebookLoginButton.tsx
@@ -2,6 +2,7 @@ import { Button, type ButtonProps } from '../Button';
 import { Chip } from '../Chip';
 
 export function FacebookLoginButton({
+    children,
     className,
     lastUsed,
     ...props
@@ -26,15 +27,15 @@ export function FacebookLoginButton({
             {...props}
         >
             <svg
+                aria-hidden="true"
                 className="h-4 w-4 shrink-0 text-[#1877F2]"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"
             >
-                <title>Facebook</title>
                 <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
             </svg>
-            Prijava Facebook računom
+            {children ?? 'Facebook prijava'}
         </Button>
     );
 }

--- a/packages/ui/src/auth/GoogleLoginButton.tsx
+++ b/packages/ui/src/auth/GoogleLoginButton.tsx
@@ -2,6 +2,7 @@ import { Button, type ButtonProps } from '../Button';
 import { Chip } from '../Chip';
 
 export function GoogleLoginButton({
+    children,
     className,
     lastUsed,
     ...props
@@ -25,8 +26,11 @@ export function GoogleLoginButton({
             }
             {...props}
         >
-            <svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24">
-                <title>Google</title>
+            <svg
+                aria-hidden="true"
+                className="h-4 w-4 shrink-0"
+                viewBox="0 0 24 24"
+            >
                 <path
                     fill="#4285F4"
                     d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
@@ -44,7 +48,7 @@ export function GoogleLoginButton({
                     d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
                 />
             </svg>
-            Google prijava
+            {children ?? 'Google prijava'}
         </Button>
     );
 }


### PR DESCRIPTION
## Summary
- move the email auth button into the same button stack as Google and Facebook so the spacing matches
- add the shared mail icon to the email auth button

## Validation
- `corepack pnpm lint --filter garden`
- `corepack pnpm typecheck --filter garden`
- Local Playwright visual check at `http://localhost:3001`: confirmed equal button spacing and visible mail icon

## Notes
- PR #3545 had already merged, so this is a small follow-up PR on top of `main`.
- Local browser verification ran without the API dev server, so unrelated API proxy calls to `localhost:3005` returned connection errors while the auth modal UI rendered correctly.