### PR TITLE
[codex] Thicken pickup outline

### DIFF
--- a/packages/game/src/entities/helpers/blockPickupOutlineStyle.ts
+++ b/packages/game/src/entities/helpers/blockPickupOutlineStyle.ts
@@ -2,5 +2,5 @@ export const blockPickupOutlineStyle = {
     color: '#86efac',
     opacity: 0.55,
     priority: 1,
-    thickness: 2,
+    thickness: 3,
 } as const;


### PR DESCRIPTION
## Summary
- Increase the in-game pickup outline thickness from 2 to 3.
- Keep the existing green color, opacity, priority, and pickup behavior unchanged.

## Validation
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm test --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`