### PR TITLE
Fix birthday input sizing

### DIFF
--- a/apps/garden/tests/UserBirthdayCardStory.tsx
+++ b/apps/garden/tests/UserBirthdayCardStory.tsx
@@ -1,0 +1,51 @@
+import * as ReactQuery from '@tanstack/react-query';
+import { type PropsWithChildren, useMemo } from 'react';
+import { queryKey as currentUserQueryKey } from '../../../packages/game/src/hooks/useCurrentUser';
+import { UserBirthdayCard } from '../../../packages/game/src/modals/components/UserBirthdayCard';
+
+const currentUser = {
+    avatarUrl: null,
+    birthday: null,
+    birthdayLastRewardAt: null,
+    birthdayLastUpdatedAt: null,
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    displayName: 'Aleks Tutorial',
+    email: 'aleks.tutorial@example.com',
+    id: 'test-user',
+    userName: 'aleks.tutorial@example.com',
+    whatsNewLastSeenAt: null,
+    whatsNewPopupDisabled: false,
+};
+
+function createQueryClient() {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            mutations: { retry: false },
+            queries: { retry: false },
+        },
+    });
+
+    queryClient.setQueryData(currentUserQueryKey.currentUser, currentUser);
+
+    return queryClient;
+}
+
+function Providers({ children }: PropsWithChildren) {
+    const queryClient = useMemo(createQueryClient, []);
+
+    return (
+        <ReactQuery.QueryClientProvider client={queryClient}>
+            {children}
+        </ReactQuery.QueryClientProvider>
+    );
+}
+
+export function UserBirthdayCardStory() {
+    return (
+        <Providers>
+            <div className="w-[600px] p-4" data-testid="birthday-card-frame">
+                <UserBirthdayCard />
+            </div>
+        </Providers>
+    );
+}

--- a/apps/garden/tests/user-birthday-card.spec.tsx
+++ b/apps/garden/tests/user-birthday-card.spec.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { UserBirthdayCardStory } from './UserBirthdayCardStory';
+
+test.describe('User birthday card', () => {
+    test('sizes birthday inputs across the profile modal width', async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width: 1000, height: 700 });
+        await mount(<UserBirthdayCardStory />);
+
+        const dayBox = await page.getByLabel('Dan').boundingBox();
+        const monthBox = await page.getByLabel('Mjesec').boundingBox();
+        const yearBox = await page
+            .getByLabel('Godina (nije obavezna)')
+            .boundingBox();
+        const frameBox = await page
+            .getByTestId('birthday-card-frame')
+            .boundingBox();
+
+        expect(dayBox).not.toBeNull();
+        expect(monthBox).not.toBeNull();
+        expect(yearBox).not.toBeNull();
+        expect(frameBox).not.toBeNull();
+
+        if (!dayBox || !monthBox || !yearBox || !frameBox) {
+            throw new Error('Birthday card fields did not render.');
+        }
+
+        expect(dayBox.width).toBeGreaterThanOrEqual(100);
+        expect(monthBox.width).toBeGreaterThanOrEqual(100);
+        expect(yearBox.width).toBeGreaterThanOrEqual(200);
+        expect(yearBox.x + yearBox.width).toBeLessThanOrEqual(
+            frameBox.x + frameBox.width,
+        );
+    });
+});

--- a/packages/game/src/modals/components/UserBirthdayCard.tsx
+++ b/packages/game/src/modals/components/UserBirthdayCard.tsx
@@ -113,10 +113,11 @@ export function UserBirthdayCard() {
             <CardContent noHeader>
                 <form onSubmit={handleBirthdayUpdate}>
                     <Stack spacing={4}>
-                        <div className="grid grid-cols-[1fr_1fr_2fr] gap-2">
+                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(5.5rem,1fr)_minmax(5.5rem,1fr)_minmax(10rem,2fr)]">
                             <Input
                                 name="birthdayDay"
                                 label="Dan"
+                                fullWidth
                                 type="number"
                                 min={1}
                                 max={31}
@@ -129,6 +130,7 @@ export function UserBirthdayCard() {
                             <Input
                                 name="birthdayMonth"
                                 label="Mjesec"
+                                fullWidth
                                 type="number"
                                 min={1}
                                 max={12}
@@ -141,6 +143,7 @@ export function UserBirthdayCard() {
                             <Input
                                 name="birthdayYear"
                                 label="Godina (nije obavezna)"
+                                fullWidth
                                 type="number"
                                 min={MIN_BIRTH_YEAR}
                                 max={currentYear}


### PR DESCRIPTION
## Summary
- make the profile birthday inputs fill their responsive grid columns instead of shrinking to placeholder width
- stack the birthday fields on narrow screens and keep desktop modal columns roomy
- add a focused garden component test that measures the rendered input widths

## Validation
- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter garden exec biome check --write tests/UserBirthdayCardStory.tsx tests/user-birthday-card.spec.tsx`
- `corepack pnpm --filter @gredice/game exec biome check --write src/modals/components/UserBirthdayCard.tsx`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/user-birthday-card.spec.tsx`
- `git diff --check`
