### PR TITLE
[Operation Covers] Verify generated cover assets

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -24,6 +24,8 @@
         "generate-playwright:plants": "playwright test --config playwright-generate.config.ts generate/plants-snapshots.specgen.tsx",
         "generate-playwright:ui": "node ./generate/populate-test-cases.js && playwright test --config playwright-generate.config.ts --ui",
         "operation-covers:sync-urls": "pnpm --dir ../../packages/storage exec tsx --conditions=react-server --env-file=.env ../../apps/www/generate/sync-operation-cover-urls.ts",
+        "operation-covers:verify": "pnpm --dir ../../packages/storage exec tsx --conditions=react-server ../../apps/www/generate/verify-operation-cover-assets.ts",
+        "operation-covers:verify-public": "pnpm run test:prepare && OPERATION_COVER_PUBLIC_QA=1 playwright test --project=chromium tests/operation-cover-public.spec.ts",
         "test:local": "pnpm run test:prepare && pnpm run test:run",
         "test:llms": "node --experimental-strip-types --test ./app/llms-routes.spec.ts"
     },

--- a/apps/www/tests/operation-cover-public.spec.ts
+++ b/apps/www/tests/operation-cover-public.spec.ts
@@ -1,0 +1,141 @@
+import type { Locator, Page } from '@playwright/test';
+import { directoryOperationCoverRecipes } from '../generate/operation-cover-recipes';
+import { KnownPages } from '../src/KnownPages';
+import { expect, test } from './fixtures';
+
+const publicQaEnabled = process.env.OPERATION_COVER_PUBLIC_QA === '1';
+
+function escapeRegExp(value: string) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function decodedSrc(src: string | null) {
+    if (!src) return '';
+
+    try {
+        return decodeURIComponent(src);
+    } catch {
+        return src;
+    }
+}
+
+async function expectGeneratedCoverImage(
+    image: Locator,
+    outputFileName: string,
+) {
+    await expect(image).toBeVisible();
+    await expect
+        .poll(async () => decodedSrc(await image.getAttribute('src')))
+        .toContain(`/assets/operation-icons/${outputFileName}`);
+}
+
+async function expectOperationCardCover({
+    page,
+    operationLabel,
+    outputFileName,
+}: {
+    page: Page;
+    operationLabel: string;
+    outputFileName: string;
+}) {
+    const card = page
+        .locator('a')
+        .filter({
+            hasText: new RegExp(escapeRegExp(operationLabel)),
+        })
+        .first();
+
+    await expect(card).toBeVisible();
+    await expectGeneratedCoverImage(
+        card.getByRole('img', { name: operationLabel }).first(),
+        outputFileName,
+    );
+}
+
+test.describe('operation cover public surfaces', () => {
+    test.skip(
+        !publicQaEnabled,
+        'Set OPERATION_COVER_PUBLIC_QA=1 after DB cover URL sync is approved/applied.',
+    );
+
+    test.setTimeout(180_000);
+
+    test('operation list cards use generated covers', async ({ page }) => {
+        for (const recipe of directoryOperationCoverRecipes) {
+            await page.goto(
+                `/radnje?pretraga=${encodeURIComponent(recipe.operationLabel)}`,
+                { waitUntil: 'domcontentloaded' },
+            );
+
+            await expectOperationCardCover({
+                page,
+                operationLabel: recipe.operationLabel,
+                outputFileName: recipe.outputFileName,
+            });
+        }
+    });
+
+    test('operation detail pages use generated covers', async ({ page }) => {
+        for (const recipe of directoryOperationCoverRecipes) {
+            await page.goto(KnownPages.Operation(recipe.operationLabel), {
+                waitUntil: 'domcontentloaded',
+            });
+
+            await expect(
+                page.getByRole('heading', {
+                    name: recipe.operationLabel,
+                    exact: true,
+                }),
+            ).toBeVisible();
+            await expectGeneratedCoverImage(
+                page.getByRole('img', { name: recipe.operationLabel }).first(),
+                recipe.outputFileName,
+            );
+        }
+    });
+
+    test('search results use generated covers for representative operations', async ({
+        page,
+    }) => {
+        const representativeRecipes = [
+            directoryOperationCoverRecipes[0],
+            directoryOperationCoverRecipes.find(
+                (recipe) => recipe.operationId === 'rinsePestsFromPlant',
+            ),
+            directoryOperationCoverRecipes.find(
+                (recipe) => recipe.operationId === 'formative-pruning',
+            ),
+            directoryOperationCoverRecipes.find(
+                (recipe) => recipe.operationId === 'plantingPlantSupport',
+            ),
+            directoryOperationCoverRecipes.at(-1),
+        ].filter(
+            (
+                recipe,
+            ): recipe is (typeof directoryOperationCoverRecipes)[number] =>
+                Boolean(recipe),
+        );
+
+        for (const recipe of representativeRecipes) {
+            await page.goto(
+                `/pretraga?pretraga=${encodeURIComponent(recipe.operationLabel)}`,
+                { waitUntil: 'domcontentloaded' },
+            );
+
+            const result = page
+                .getByRole('link', {
+                    name: new RegExp(escapeRegExp(recipe.operationLabel)),
+                })
+                .first();
+
+            await expect(result).toBeVisible();
+            await expect(
+                result.locator('[data-search-result-icon]'),
+            ).toHaveCount(0);
+            await expectGeneratedCoverImage(
+                result.locator('img').first(),
+                recipe.outputFileName,
+            );
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Add `pnpm --filter www run operation-covers:verify` for generated operation cover assets
- Add `pnpm --filter www run operation-covers:verify-public` for post-sync public checks across `/radnje`, operation detail pages, and search
- Export `directoryOperationCoverRecipes` so QA and URL sync use the same 53 target recipes
- Verify every target WebP exists, has the expected 640x640 generated resolution, remains nonblank at 160/72/48px preview sizes, and does not touch the image edge

## Validation
- `corepack pnpm --filter www run operation-covers:verify` (after bootstrap; 53 checked, 0 failures, 0 warnings, tightest visible pixels 4650)
- `corepack pnpm --filter www run operation-covers:sync-urls` (after bootstrap; dry run: 53 creates, cover definition exists, 0 updates/skips)
- `corepack pnpm --filter www exec playwright test --project=chromium tests/operation-cover-public.spec.ts --list` (3 tests discovered; full run deferred until URL sync is applied)
- `corepack pnpm --filter www run typecheck`
- `corepack pnpm lint --filter www`
- `git diff --check`

## Deferred verification
The public-surface Playwright verifier now exists, but running `pnpm --filter www run operation-covers:verify-public` still requires the draft model/snapshot stack to be approved/deployed and the URL sync command to be applied.

## Review gallery

<details>
<summary>53 generated operation covers</summary>

|  |  |  |  |
| --- | --- | --- | --- |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/abandonRaisedBed.webp" width="80" alt="abandonRaisedBed"><br><sub>abandonRaisedBed</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/decapitation.webp" width="80" alt="decapitation"><br><sub>decapitation</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/formative-pruning.webp" width="80" alt="formative-pruning"><br><sub>formative-pruning</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/freshSoil10L.webp" width="80" alt="freshSoil10L"><br><sub>freshSoil10L</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/freshSoil20L.webp" width="80" alt="freshSoil20L"><br><sub>freshSoil20L</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/freshSoil50L.webp" width="80" alt="freshSoil50L"><br><sub>freshSoil50L</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/freshSoil70L.webp" width="80" alt="freshSoil70L"><br><sub>freshSoil70L</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/green-pruning.webp" width="80" alt="green-pruning"><br><sub>green-pruning</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/growthPlantSupport.webp" width="80" alt="growthPlantSupport"><br><sub>growthPlantSupport</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/harvest25Mature.webp" width="80" alt="harvest25Mature"><br><sub>harvest25Mature</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/harvest50Mature.webp" width="80" alt="harvest50Mature"><br><sub>harvest50Mature</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/harvestAll.webp" width="80" alt="harvestAll"><br><sub>harvestAll</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/harvestMature.webp" width="80" alt="harvestMature"><br><sub>harvestMature</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/harvestPlant.webp" width="80" alt="harvestPlant"><br><sub>harvestPlant</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/hillingPlant.webp" width="80" alt="hillingPlant"><br><sub>hillingPlant</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/hygiene-pruning.webp" width="80" alt="hygiene-pruning"><br><sub>hygiene-pruning</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventoryFertilizers.webp" width="80" alt="inventoryFertilizers"><br><sub>inventoryFertilizers</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventoryGreenhouses.webp" width="80" alt="inventoryGreenhouses"><br><sub>inventoryGreenhouses</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventoryPaperDeliveryBags.webp" width="80" alt="inventoryPaperDeliveryBags"><br><sub>inventoryPaperDeliveryBags</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventoryPlantProtectionProducts.webp" width="80" alt="inventoryPlantProtectionProducts"><br><sub>inventoryPlantProtectionProducts</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventoryPlantSupports.webp" width="80" alt="inventoryPlantSupports"><br><sub>inventoryPlantSupports</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventoryPlasticDeliveryBags.webp" width="80" alt="inventoryPlasticDeliveryBags"><br><sub>inventoryPlasticDeliveryBags</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventoryPrinterLabels.webp" width="80" alt="inventoryPrinterLabels"><br><sub>inventoryPrinterLabels</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventoryProtectiveFabrics.webp" width="80" alt="inventoryProtectiveFabrics"><br><sub>inventoryProtectiveFabrics</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventoryRaisedBedBoards.webp" width="80" alt="inventoryRaisedBedBoards"><br><sub>inventoryRaisedBedBoards</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventoryRaisedBedSoil.webp" width="80" alt="inventoryRaisedBedSoil"><br><sub>inventoryRaisedBedSoil</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventorySeedlingSoil.webp" width="80" alt="inventorySeedlingSoil"><br><sub>inventorySeedlingSoil</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/inventorySeeds.webp" width="80" alt="inventorySeeds"><br><sub>inventorySeeds</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/maintenance-pruning.webp" width="80" alt="maintenance-pruning"><br><sub>maintenance-pruning</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/pinching.webp" width="80" alt="pinching"><br><sub>pinching</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/plantPhoto.webp" width="80" alt="plantPhoto"><br><sub>plantPhoto</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/plantRemoval.webp" width="80" alt="plantRemoval"><br><sub>plantRemoval</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/plantingPlantSupport.webp" width="80" alt="plantingPlantSupport"><br><sub>plantingPlantSupport</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/pruning.webp" width="80" alt="pruning"><br><sub>pruning</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/pullingWeedsPlant.webp" width="80" alt="pullingWeedsPlant"><br><sub>pullingWeedsPlant</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/pullingWeedsRaisedBed.webp" width="80" alt="pullingWeedsRaisedBed"><br><sub>pullingWeedsRaisedBed</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/raisedBedFullPhoto.webp" width="80" alt="raisedBedFullPhoto"><br><sub>raisedBedFullPhoto</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/readSeedStorageHumidityTemperature.webp" width="80" alt="readSeedStorageHumidityTemperature"><br><sub>readSeedStorageHumidityTemperature</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/rejuvenation-pruning.webp" width="80" alt="rejuvenation-pruning"><br><sub>rejuvenation-pruning</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/removeAgrotextileWhite.webp" width="80" alt="removeAgrotextileWhite"><br><sub>removeAgrotextileWhite</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/removeFlowers.webp" width="80" alt="removeFlowers"><br><sub>removeFlowers</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/removeFlowersMaintenance.webp" width="80" alt="removeFlowersMaintenance"><br><sub>removeFlowersMaintenance</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/riasedBedCleanup.webp" width="80" alt="riasedBedCleanup"><br><sub>riasedBedCleanup</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/rinsePestsFromPlant.webp" width="80" alt="rinsePestsFromPlant"><br><sub>rinsePestsFromPlant</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/seedlingTranslanting.webp" width="80" alt="seedlingTranslanting"><br><sub>seedlingTranslanting</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/sensor.webp" width="80" alt="sensor"><br><sub>sensor</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/setAgrotextileWhite.webp" width="80" alt="setAgrotextileWhite"><br><sub>setAgrotextileWhite</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/storeGreenhouse.webp" width="80" alt="storeGreenhouse"><br><sub>storeGreenhouse</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/supportTying.webp" width="80" alt="supportTying"><br><sub>supportTying</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/thinning.webp" width="80" alt="thinning"><br><sub>thinning</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/watterRaisedBed.webp" width="80" alt="watterRaisedBed"><br><sub>watterRaisedBed</sub> | <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/watterSurfaceRaisedBed.webp" width="80" alt="watterSurfaceRaisedBed"><br><sub>watterSurfaceRaisedBed</sub> |
| <img src="https://raw.githubusercontent.com/gredice/gredice/feat/gre-3432-operation-cover-qa/apps/www/public/assets/operation-icons/watteringSystemSprinkler2.webp" width="80" alt="watteringSystemSprinkler2"><br><sub>watteringSystemSprinkler2</sub> |

</details>

Part of #3432
Part of #3422


