### PR TITLE
[codex] Apply auth login choice pattern across apps

### DIFF
--- a/apps/app/components/admin/navigation/LoginDialog.tsx
+++ b/apps/app/components/admin/navigation/LoginDialog.tsx
@@ -9,19 +9,19 @@ import {
     useLastLoginProvider,
 } from '@gredice/ui/auth';
 import { Button } from '@gredice/ui/Button';
-import { Divider } from '@gredice/ui/Divider';
 import { Input } from '@gredice/ui/Input';
-import { Warning } from '@gredice/ui/icons';
+import { Mail, Warning } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { usePostHog } from '@posthog/next';
-import { useActionState, useCallback } from 'react';
+import { useActionState, useCallback, useState } from 'react';
 import { invalidatePage } from '../../../app/(actions)/sharedActions';
 import { queryClient } from '../../providers/ClientAppProvider';
 
 export function LoginDialog() {
     const posthog = usePostHog();
+    const [emailExpanded, setEmailExpanded] = useState(false);
     const fetchLastLogin = useCallback(
         () => fetch('/api/gredice/api/auth/last-login'),
         [],
@@ -105,65 +105,73 @@ export function LoginDialog() {
                     <Typography level="h4" component="p">
                         Prijava
                     </Typography>
-                    <Stack spacing={4}>
+                    {!emailExpanded ? (
                         <Stack spacing={2}>
-                            <FacebookLoginButton
-                                onClick={() => handleOAuthLogin('facebook')}
-                                lastUsed={lastLoginProvider === 'facebook'}
-                            />
                             <GoogleLoginButton
                                 onClick={() => handleOAuthLogin('google')}
                                 lastUsed={lastLoginProvider === 'google'}
-                            />
-                        </Stack>
-                        <div className="relative">
-                            <div className="absolute inset-0 flex items-center">
-                                <Divider />
-                            </div>
-                            <div className="relative flex justify-center">
-                                <span className="bg-background px-2 text-xs rounded-xs">
-                                    ili nastavi emailom
-                                </span>
-                            </div>
-                        </div>
-                    </Stack>
-                    <form action={submitAction} className="w-full">
-                        <Stack spacing={8}>
-                            <Stack spacing={2}>
-                                <Input
-                                    name="email"
-                                    label="Email"
-                                    placeholder="email@email.com"
-                                    type="email"
-                                    autoComplete="email"
-                                    fullWidth
-                                />
-                                <Input
-                                    name="password"
-                                    label="Zaporka"
-                                    type="password"
-                                    autoComplete="current-password"
-                                    fullWidth
-                                />
-                            </Stack>
-                            <Button
-                                type="submit"
-                                loading={isPending}
-                                variant="solid"
-                                fullWidth
                             >
-                                Prijavi se
+                                Google prijava
+                            </GoogleLoginButton>
+                            <FacebookLoginButton
+                                onClick={() => handleOAuthLogin('facebook')}
+                                lastUsed={lastLoginProvider === 'facebook'}
+                            >
+                                Facebook prijava
+                            </FacebookLoginButton>
+                            <Button
+                                type="button"
+                                variant="outlined"
+                                color="neutral"
+                                fullWidth
+                                startDecorator={
+                                    <Mail className="h-4 w-4 shrink-0" />
+                                }
+                                onClick={() => setEmailExpanded(true)}
+                            >
+                                Email prijava
                             </Button>
-                            {error && (
-                                <Alert
-                                    color="danger"
-                                    startDecorator={<Warning />}
-                                >
-                                    Greška prilikom prijave. Pokušajte ponovo.
-                                </Alert>
-                            )}
                         </Stack>
-                    </form>
+                    ) : (
+                        <form action={submitAction} className="w-full">
+                            <Stack spacing={8}>
+                                <Stack spacing={2}>
+                                    <Input
+                                        name="email"
+                                        label="Email"
+                                        placeholder="email@email.com"
+                                        type="email"
+                                        autoComplete="email"
+                                        fullWidth
+                                    />
+                                    <Input
+                                        name="password"
+                                        label="Zaporka"
+                                        type="password"
+                                        autoComplete="current-password"
+                                        fullWidth
+                                    />
+                                </Stack>
+                                <Button
+                                    type="submit"
+                                    loading={isPending}
+                                    variant="solid"
+                                    fullWidth
+                                >
+                                    Prijavi se
+                                </Button>
+                                {error && (
+                                    <Alert
+                                        color="danger"
+                                        startDecorator={<Warning />}
+                                    >
+                                        Greška prilikom prijave. Pokušajte
+                                        ponovo.
+                                    </Alert>
+                                )}
+                            </Stack>
+                        </form>
+                    )}
                 </Stack>
             </Modal>
         </div>

--- a/apps/app/tests/landing.spec.ts
+++ b/apps/app/tests/landing.spec.ts
@@ -15,6 +15,16 @@ test('shows login on admin page when signed out', async ({ page, request }) => {
 
     await page.goto('/admin');
     await expect(
+        page.getByRole('button', { name: 'Google prijava' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Facebook prijava' }),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Email prijava' }).click();
+
+    await expect(
         page.getByRole('button', { name: 'Prijavi se' }),
     ).toBeVisible();
+    await expect(page.getByLabel('Email')).toBeVisible();
 });

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -8,16 +8,15 @@ import {
     useLastLoginProvider,
 } from '@gredice/ui/auth';
 import { Button } from '@gredice/ui/Button';
-import { Divider } from '@gredice/ui/Divider';
 import { Input } from '@gredice/ui/Input';
-import { Warning } from '@gredice/ui/icons';
+import { Mail, Warning } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { usePostHog } from '@posthog/next';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useActionState, useCallback } from 'react';
+import { useActionState, useCallback, useState } from 'react';
 import { queryClient } from '../providers/ClientAppProvider';
 
 type OAuthProvider = 'google' | 'facebook';
@@ -25,6 +24,7 @@ type OAuthProvider = 'google' | 'facebook';
 export function LoginDialog() {
     const posthog = usePostHog();
     const router = useRouter();
+    const [emailExpanded, setEmailExpanded] = useState(false);
     const fetchLastLogin = useCallback(
         () => fetch('/api/gredice/api/auth/last-login'),
         [],
@@ -142,69 +142,79 @@ export function LoginDialog() {
                             svojom farmom.
                         </Typography>
                     </Stack>
-                    <Stack spacing={4}>
+                    {!emailExpanded ? (
                         <Stack spacing={2}>
-                            <FacebookLoginButton
-                                onClick={() => handleOAuthLogin('facebook')}
-                                lastUsed={lastLoginProvider === 'facebook'}
-                            />
                             <GoogleLoginButton
                                 onClick={() => handleOAuthLogin('google')}
                                 lastUsed={lastLoginProvider === 'google'}
-                            />
-                        </Stack>
-                        <div className="relative">
-                            <div className="absolute inset-0 flex items-center">
-                                <Divider />
-                            </div>
-                            <div className="relative flex justify-center">
-                                <span className="bg-background px-2 text-xs rounded-xs">
-                                    ili nastavi emailom
-                                </span>
-                            </div>
-                        </div>
-                    </Stack>
-                    <form action={submitAction} className="w-full space-y-4">
-                        <Stack spacing={6}>
-                            <Stack spacing={2}>
-                                <Input
-                                    name="email"
-                                    label="Email"
-                                    placeholder="ime@primjer.com"
-                                    type="email"
-                                    autoComplete="email"
-                                    fullWidth
-                                    required
-                                />
-                                <Input
-                                    name="password"
-                                    label="Zaporka"
-                                    type="password"
-                                    autoComplete="current-password"
-                                    fullWidth
-                                    required
-                                />
-                            </Stack>
-                            <Button
-                                type="submit"
-                                loading={isPending}
-                                variant="solid"
-                                fullWidth
                             >
-                                Prijavi se
+                                Google prijava
+                            </GoogleLoginButton>
+                            <FacebookLoginButton
+                                onClick={() => handleOAuthLogin('facebook')}
+                                lastUsed={lastLoginProvider === 'facebook'}
+                            >
+                                Facebook prijava
+                            </FacebookLoginButton>
+                            <Button
+                                type="button"
+                                variant="outlined"
+                                color="neutral"
+                                fullWidth
+                                startDecorator={
+                                    <Mail className="h-4 w-4 shrink-0" />
+                                }
+                                onClick={() => setEmailExpanded(true)}
+                            >
+                                Email prijava
                             </Button>
-                            {error && (
-                                <Alert
-                                    color="danger"
-                                    startDecorator={
-                                        <Warning className="size-5" />
-                                    }
-                                >
-                                    {error}
-                                </Alert>
-                            )}
                         </Stack>
-                    </form>
+                    ) : (
+                        <form
+                            action={submitAction}
+                            className="w-full space-y-4"
+                        >
+                            <Stack spacing={6}>
+                                <Stack spacing={2}>
+                                    <Input
+                                        name="email"
+                                        label="Email"
+                                        placeholder="ime@primjer.com"
+                                        type="email"
+                                        autoComplete="email"
+                                        fullWidth
+                                        required
+                                    />
+                                    <Input
+                                        name="password"
+                                        label="Zaporka"
+                                        type="password"
+                                        autoComplete="current-password"
+                                        fullWidth
+                                        required
+                                    />
+                                </Stack>
+                                <Button
+                                    type="submit"
+                                    loading={isPending}
+                                    variant="solid"
+                                    fullWidth
+                                >
+                                    Prijavi se
+                                </Button>
+                                {error && (
+                                    <Alert
+                                        color="danger"
+                                        startDecorator={
+                                            <Warning className="size-5" />
+                                        }
+                                    >
+                                        {error}
+                                    </Alert>
+                                )}
+                            </Stack>
+                        </form>
+                    )}
                 </Stack>
             </Modal>
         </div>


### PR DESCRIPTION
## Summary
- applies the collapsed email-login choice pattern to the farm login dialog
- applies the same collapsed email-login choice pattern to the admin app login dialog
- keeps Google first, social/email labels aligned, and hides the email form until Email prijava is selected

## Validation
- `corepack pnpm lint --filter @gredice/ui --filter garden --filter farm --filter app`
- `corepack pnpm typecheck --filter @gredice/ui --filter garden --filter farm --filter app`
- `corepack pnpm --filter farm exec next typegen && corepack pnpm --filter farm exec tsc --noEmit --pretty false`
- `corepack pnpm --filter app exec next typegen`

Note: full direct `corepack pnpm --filter app exec tsc --noEmit --pretty false` still fails on existing unrelated admin/fiscalization errors outside the touched login dialog.