### PR TITLE
[codex] Fix overdue invoice day boundary

### DIFF
--- a/apps/app/app/admin/invoices/[invoiceId]/invoiceUtils.ts
+++ b/apps/app/app/admin/invoices/[invoiceId]/invoiceUtils.ts
@@ -1,6 +1,8 @@
 // Client-safe invoice utility functions
 export type InvoiceStatus = 'draft' | 'pending' | 'sent' | 'paid' | 'cancelled';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 export function isValidStatusTransition(
     currentStatus: InvoiceStatus | string,
     newStatus: InvoiceStatus,
@@ -36,5 +38,8 @@ export function isOverdue(invoice: {
     if (invoice.status === 'paid' || invoice.paidDate) {
         return false;
     }
-    return invoice.status === 'sent' && new Date() > new Date(invoice.dueDate);
+    return (
+        invoice.status === 'sent' &&
+        Date.now() >= new Date(invoice.dueDate).getTime() + DAY_MS
+    );
 }

--- a/packages/storage/src/repositories/invoicesRepo.ts
+++ b/packages/storage/src/repositories/invoicesRepo.ts
@@ -14,6 +14,8 @@ import {
 import { storage } from '../storage';
 import { createEvent, knownEvents } from './eventsRepo';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 // Receipt creation data interface
 export interface ReceiptCreationData {
     paymentMethod: 'card' | 'cash' | 'bank_transfer';
@@ -187,10 +189,10 @@ export async function getInvoicesByStatus(status: string, accountId?: string) {
 }
 
 export async function getOverdueInvoices(accountId?: string) {
-    const today = new Date();
+    const overdueBoundary = new Date(Date.now() - DAY_MS);
     const whereConditions = [
         eq(invoices.status, 'sent'),
-        lte(invoices.dueDate, today),
+        lte(invoices.dueDate, overdueBoundary),
         isNull(invoices.paidDate),
         eq(invoices.isDeleted, false),
     ];
@@ -264,7 +266,10 @@ export function isOverdue(invoice: {
     if (invoice.status === 'paid' || invoice.paidDate) {
         return false;
     }
-    return invoice.status === 'sent' && new Date() > new Date(invoice.dueDate);
+    return (
+        invoice.status === 'sent' &&
+        Date.now() >= new Date(invoice.dueDate).getTime() + DAY_MS
+    );
 }
 
 export async function changeInvoiceStatus(

--- a/packages/storage/tests/invoicesRepo.node.spec.ts
+++ b/packages/storage/tests/invoicesRepo.node.spec.ts
@@ -36,6 +36,8 @@ import {
 import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 async function baseInvoice(transactionId?: number): Promise<InsertInvoice> {
     const accountId = await createTestAccount();
     const currentDate = new Date();
@@ -311,22 +313,37 @@ test('calculateInvoiceTotals', async () => {
     assert.strictEqual(totals.itemCount, 2);
 });
 
-test('getOverdueInvoices finds overdue invoices', async () => {
+test('getOverdueInvoices applies the 24-hour due-day boundary', async () => {
     createTestDb();
 
-    // Create an overdue invoice (due date in the past)
-    const invoiceData = await baseInvoice();
-    const pastDate = new Date();
-    pastDate.setDate(pastDate.getDate() - 5); // 5 days ago
+    const now = new Date();
+    const twoDaysAgo = new Date(now.getTime() - 2 * DAY_MS);
+    const dueTodayUtc = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
 
-    invoiceData.status = 'sent';
-    invoiceData.dueDate = pastDate;
+    const overdueInvoiceData = await baseInvoice();
+    overdueInvoiceData.status = 'sent';
+    overdueInvoiceData.dueDate = twoDaysAgo;
 
-    const invoiceId = await createInvoice(invoiceData);
+    const dueTodayInvoiceData = await baseInvoice();
+    dueTodayInvoiceData.status = 'sent';
+    dueTodayInvoiceData.dueDate = dueTodayUtc;
+
+    const paidInvoiceData = await baseInvoice();
+    paidInvoiceData.status = 'sent';
+    paidInvoiceData.dueDate = twoDaysAgo;
+    paidInvoiceData.paidDate = now;
+
+    const overdueInvoiceId = await createInvoice(overdueInvoiceData);
+    const dueTodayInvoiceId = await createInvoice(dueTodayInvoiceData);
+    const paidInvoiceId = await createInvoice(paidInvoiceData);
 
     const overdueInvoices = await getOverdueInvoices();
     assert.ok(Array.isArray(overdueInvoices));
-    assert.ok(overdueInvoices.some((inv) => inv.id === invoiceId));
+    assert.ok(overdueInvoices.some((inv) => inv.id === overdueInvoiceId));
+    assert.ok(!overdueInvoices.some((inv) => inv.id === dueTodayInvoiceId));
+    assert.ok(!overdueInvoices.some((inv) => inv.id === paidInvoiceId));
 });
 
 test('getReceiptByInvoice returns receipt for paid invoice', async () => {
@@ -502,14 +519,18 @@ test('canCancelInvoice returns correct permissions', async () => {
 });
 
 test('isOverdue correctly identifies overdue invoices', async () => {
-    const today = new Date();
-    const pastDate = new Date();
-    pastDate.setDate(today.getDate() - 5);
-    const futureDate = new Date();
-    futureDate.setDate(today.getDate() + 5);
+    const now = new Date();
+    const pastDate = new Date(now.getTime() - 2 * DAY_MS);
+    const dueTodayUtc = new Date(
+        Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+    const futureDate = new Date(now.getTime() + 5 * DAY_MS);
 
-    // Overdue invoice (sent and past due date)
+    // Overdue invoice (sent and due day fully passed)
     assert.ok(isOverdue({ status: 'sent', dueDate: pastDate }));
+
+    // Not overdue - due date is today
+    assert.ok(!isOverdue({ status: 'sent', dueDate: dueTodayUtc }));
 
     // Not overdue - future due date
     assert.ok(!isOverdue({ status: 'sent', dueDate: futureDate }));


### PR DESCRIPTION
## Summary

- Treat sent invoices as overdue only after their due day has fully passed by comparing against a 24-hour boundary.
- Keep the storage repository predicate and app admin predicate textually parallel with local `DAY_MS` constants.
- Add storage tests for overdue, due-today, and paid-date exclusion behavior.

Closes #3414

## Validation

- `pnpm install`
- `pnpm typecheck --filter @gredice/storage` (exit 0; Turbo reported no storage typecheck task)
- `pnpm typecheck --filter app` (exit 0; replayed dependency typechecks, app has no typecheck script)
- `pnpm test --filter @gredice/storage` (329 passed)
- `pnpm lint --filter @gredice/storage`
- `pnpm lint --filter app`
- `grep -n "lte(invoices.dueDate, today)" packages/storage/src/repositories/invoicesRepo.ts` (no matches)
- `git diff --check`

## Notes

- `plans/README.md` does not exist in this checkout, so there was no plan status row to update.