### PR TITLE
Require admin auth for account deletion email action

### DIFF
--- a/apps/app/app/(actions)/accountsActions.ts
+++ b/apps/app/app/(actions)/accountsActions.ts
@@ -3,9 +3,11 @@
 import { sendEmail } from '@gredice/email/acs';
 import { getAccountUsers } from '@gredice/storage';
 import AccountDeleteConfirmationTemplate from '@gredice/transactional/emails/Account/delete-confirmation';
-import { createJwt } from '../../lib/auth/auth';
+import { auth, createJwt } from '../../lib/auth/auth';
 
 export async function sendDeleteAccountEmail(accountId: string) {
+    await auth(['admin']);
+
     // Only allow if account has one user
     const users = await getAccountUsers(accountId);
     if (users?.length !== 1) {


### PR DESCRIPTION
## Summary
- require `admin` auth before `sendDeleteAccountEmail` reads account users or creates the deletion JWT
- align the action with sibling admin server actions that start with `await auth(['admin'])`

Fixes #3406

## Validation
- `grep -c "await auth(" "apps/app/app/(actions)/accountsActions.ts"` -> `1`
- `corepack pnpm typecheck --filter app`
- `corepack pnpm lint --filter app`