### PR TITLE
Improve admin automation tables

### DIFF
--- a/apps/app/app/admin/automations/AutomationDefinitionsList.tsx
+++ b/apps/app/app/admin/automations/AutomationDefinitionsList.tsx
@@ -1,6 +1,5 @@
 import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
-import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../src/KnownPages';
@@ -19,9 +18,6 @@ export function AutomationDefinitionsList({
         <Card className="h-full">
             <CardHeader>
                 <CardTitle>Definicije</CardTitle>
-                <Typography level="body3" className="text-muted-foreground">
-                    Aktivne automatizacije i njihova zadnja učitana izvođenja.
-                </Typography>
             </CardHeader>
             <CardOverflow>
                 {definitions.length === 0 ? (

--- a/apps/app/app/admin/automations/AutomationFilters.tsx
+++ b/apps/app/app/admin/automations/AutomationFilters.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type {
+    AutomationDefinitionStatus,
+    AutomationRunStatus,
+} from '@gredice/storage';
+import { FilterInput } from '@gredice/ui/FilterInput';
+import { TableFilter } from '../../../components/shared/filters';
+import {
+    automationDefinitionStatusFilterOption,
+    automationRunStatusFilterOption,
+} from './automationFilterOptions';
+
+export function AutomationFilters({
+    definitionStatuses,
+    runStatuses,
+}: {
+    definitionStatuses: AutomationDefinitionStatus[];
+    runStatuses: AutomationRunStatus[];
+}) {
+    return (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <TableFilter
+                filters={[
+                    automationDefinitionStatusFilterOption(definitionStatuses),
+                    automationRunStatusFilterOption(runStatuses),
+                ]}
+                defaultValues={{
+                    status: 'enabled',
+                    runStatus: 'withoutSkipped',
+                }}
+                className="flex"
+            />
+            <FilterInput
+                searchParamName="triggerEventType"
+                fieldName="triggerEventType"
+                instant
+                className="sm:ml-auto"
+            />
+        </div>
+    );
+}

--- a/apps/app/app/admin/automations/AutomationJobsQueueTable.tsx
+++ b/apps/app/app/admin/automations/AutomationJobsQueueTable.tsx
@@ -1,70 +1,53 @@
 import { Button } from '@gredice/ui/Button';
 import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
-import { Chip } from '@gredice/ui/Chip';
 import { LoaderSpinner } from '@gredice/ui/icons';
-import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import Link from 'next/link';
-import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../src/KnownPages';
-import { AutomationRunStatusIndicator } from './AutomationStatusIndicator';
+import {
+    AutomationRunsCompactTable,
+    type AutomationRunsCompactTableRow,
+} from './AutomationRunsCompactTable';
+import { automationRunSourceLabel } from './presentation';
 import type { AutomationRunListItem } from './types';
 
-function sourceLabel(source: AutomationRunListItem['source']) {
-    switch (source) {
-        case 'event':
-            return 'Event';
-        case 'manual':
-            return 'Ručno';
-        case 'schedule':
-            return 'Raspored';
-        case 'test':
-            return 'Test';
-        case 'replay':
-            return 'Ponovljeno';
-    }
-}
-
-function DateTimeValue({ value }: { value: string | null }) {
-    if (!value) {
-        return <span>-</span>;
-    }
-
-    return <LocalDateTime>{value}</LocalDateTime>;
-}
-
-function QueueTiming({ run }: { run: AutomationRunListItem }) {
+function queueTiming(run: AutomationRunListItem) {
     if (run.status === 'queued' || run.status === 'retrying') {
-        return (
-            <>
-                Sljedeće <LocalDateTime>{run.nextRunAt}</LocalDateTime>
-            </>
-        );
+        return { timeLabel: 'Sljedeće', timeValue: run.nextRunAt };
     }
 
     if (run.status === 'running') {
-        return (
-            <>
-                Zaključano <DateTimeValue value={run.lockedAt} />
-            </>
-        );
+        return { timeLabel: 'Zaključano', timeValue: run.lockedAt };
     }
 
     if (run.completedAt) {
-        return (
-            <>
-                Završeno <LocalDateTime>{run.completedAt}</LocalDateTime>
-            </>
-        );
+        return { timeLabel: 'Završeno', timeValue: run.completedAt };
     }
 
-    return (
-        <>
-            Kreirano <LocalDateTime>{run.createdAt}</LocalDateTime>
-        </>
-    );
+    return { timeLabel: 'Kreirano', timeValue: run.createdAt };
+}
+
+function queueRunToTableRow(
+    run: AutomationRunListItem,
+): AutomationRunsCompactTableRow {
+    const timing = queueTiming(run);
+
+    return {
+        id: run.id,
+        title: `#${run.id} ${run.automationDefinitionName}`,
+        href: KnownPages.Automation(run.automationDefinitionId),
+        subtitle: run.automationDefinitionKey,
+        status: run.status,
+        dryRun: run.dryRun,
+        sourceLabel: automationRunSourceLabel(run.source),
+        sourceDetail: run.parentRunId ? `Roditelj #${run.parentRunId}` : null,
+        attempt: run.attempt,
+        maxAttempts: run.maxAttempts,
+        timeLabel: timing.timeLabel,
+        timeValue: timing.timeValue,
+        errorMessage: run.errorMessage,
+    };
 }
 
 export function AutomationJobsQueueList({
@@ -80,6 +63,8 @@ export function AutomationJobsQueueList({
     loadMore: () => void;
     runs: AutomationRunListItem[];
 }) {
+    const rows = runs.map(queueRunToTableRow);
+
     return (
         <Card className="h-full">
             <CardHeader>
@@ -106,76 +91,10 @@ export function AutomationJobsQueueList({
                 </div>
             </CardHeader>
             <CardOverflow>
-                {runs.length === 0 ? (
-                    <div className="p-4">
-                        <NoDataPlaceholder>
-                            Nema poslova za odabrane filtere.
-                        </NoDataPlaceholder>
-                    </div>
-                ) : (
-                    <ul className="divide-y">
-                        {runs.map((run) => (
-                            <li key={run.id} className="px-4 py-3">
-                                <div className="grid min-w-0 gap-1.5">
-                                    <div className="flex min-w-0 items-start justify-between gap-3">
-                                        <Link
-                                            href={KnownPages.Automation(
-                                                run.automationDefinitionId,
-                                            )}
-                                            className="min-w-0 truncate font-medium text-primary hover:underline"
-                                        >
-                                            #{run.id}{' '}
-                                            {run.automationDefinitionName}
-                                        </Link>
-                                        <div className="flex shrink-0 items-center gap-2">
-                                            <AutomationRunStatusIndicator
-                                                className="text-xs sm:text-sm"
-                                                status={run.status}
-                                            />
-                                            {run.dryRun ? (
-                                                <Chip
-                                                    size="sm"
-                                                    color="info"
-                                                    variant="soft"
-                                                >
-                                                    Probno
-                                                </Chip>
-                                            ) : null}
-                                        </div>
-                                    </div>
-
-                                    {run.errorMessage ? (
-                                        <Typography
-                                            level="body3"
-                                            className="line-clamp-2 rounded-md bg-red-50 p-2 text-red-700 dark:bg-red-950 dark:text-red-300"
-                                        >
-                                            {run.errorMessage}
-                                        </Typography>
-                                    ) : null}
-
-                                    <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                                        <span className="min-w-0 max-w-full truncate">
-                                            {run.automationDefinitionKey}
-                                        </span>
-                                        <span>{sourceLabel(run.source)}</span>
-                                        <span>
-                                            Pokušaj {run.attempt} /{' '}
-                                            {run.maxAttempts}
-                                        </span>
-                                        <span>
-                                            <QueueTiming run={run} />
-                                        </span>
-                                        {run.parentRunId ? (
-                                            <span>
-                                                Roditelj #{run.parentRunId}
-                                            </span>
-                                        ) : null}
-                                    </div>
-                                </div>
-                            </li>
-                        ))}
-                    </ul>
-                )}
+                <AutomationRunsCompactTable
+                    rows={rows}
+                    emptyMessage="Nema poslova za odabrane filtere."
+                />
 
                 {hasMore ? (
                     <div className="border-t p-4">

--- a/apps/app/app/admin/automations/AutomationOverviewPanels.tsx
+++ b/apps/app/app/admin/automations/AutomationOverviewPanels.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import type { AutomationRunStatus } from '@gredice/storage';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { AutomationDefinitionsList } from './AutomationDefinitionsList';
 import { AutomationJobsQueueList } from './AutomationJobsQueueTable';
 import { isAutomationRunLive } from './AutomationStatusIndicator';
+import type { AutomationRunStatusFilter } from './automationRunFilters';
 import type { AutomationDefinitionListItem, AutomationRunsPage } from './types';
 
 function activeRunsInPages(pages: AutomationRunsPage[] | undefined) {
@@ -16,28 +16,19 @@ function activeRunsInPages(pages: AutomationRunsPage[] | undefined) {
 }
 
 async function fetchAutomationRunsPage({
-    failedOnly,
     limit,
     offset,
-    runStatus,
+    runStatusFilter,
 }: {
-    failedOnly: boolean;
     limit: number;
     offset: number;
-    runStatus?: AutomationRunStatus;
+    runStatusFilter: AutomationRunStatusFilter;
 }) {
     const searchParams = new URLSearchParams({
         limit: String(limit),
         offset: String(offset),
+        runStatus: runStatusFilter,
     });
-
-    if (runStatus) {
-        searchParams.set('runStatus', runStatus);
-    }
-
-    if (failedOnly) {
-        searchParams.set('failedOnly', '1');
-    }
 
     const response = await fetch(
         `/api/admin/automations/runs?${searchParams.toString()}`,
@@ -53,23 +44,20 @@ async function fetchAutomationRunsPage({
 
 export function AutomationOverviewPanels({
     definitions,
-    failedOnly,
     initialRunsPage,
-    runStatus,
+    runStatusFilter,
 }: {
     definitions: AutomationDefinitionListItem[];
-    failedOnly: boolean;
     initialRunsPage: AutomationRunsPage;
-    runStatus?: AutomationRunStatus;
+    runStatusFilter: AutomationRunStatusFilter;
 }) {
     const runsQuery = useInfiniteQuery({
-        queryKey: ['automation-runs', { failedOnly, runStatus }],
+        queryKey: ['automation-runs', { runStatusFilter }],
         queryFn: ({ pageParam }) =>
             fetchAutomationRunsPage({
-                failedOnly,
                 limit: initialRunsPage.pageSize,
                 offset: pageParam,
-                runStatus,
+                runStatusFilter,
             }),
         initialData: {
             pages: [initialRunsPage],

--- a/apps/app/app/admin/automations/AutomationRunStatusFilter.tsx
+++ b/apps/app/app/admin/automations/AutomationRunStatusFilter.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import type { AutomationRunStatus } from '@gredice/storage';
+import { TableFilter } from '../../../components/shared/filters';
+import { automationRunStatusFilterOption } from './automationFilterOptions';
+
+export function AutomationRunStatusFilter({
+    statusOptions,
+}: {
+    statusOptions: AutomationRunStatus[];
+}) {
+    return (
+        <TableFilter
+            filters={[automationRunStatusFilterOption(statusOptions)]}
+            defaultValues={{ runStatus: 'withoutSkipped' }}
+            className="flex"
+        />
+    );
+}

--- a/apps/app/app/admin/automations/AutomationRunsCompactTable.tsx
+++ b/apps/app/app/admin/automations/AutomationRunsCompactTable.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import type { AutomationRunStatus } from '@gredice/storage';
+import { Chip } from '@gredice/ui/Chip';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Table } from '@gredice/ui/Table';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import type { Route } from 'next';
+import Link from 'next/link';
+import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
+import { AutomationRunStatusIndicator } from './AutomationStatusIndicator';
+
+export type AutomationRunsCompactTableRow = {
+    id: number;
+    title: string;
+    href?: Route;
+    subtitle?: string | null;
+    status: AutomationRunStatus;
+    dryRun: boolean;
+    sourceLabel?: string | null;
+    sourceDetail?: string | null;
+    attempt: number;
+    maxAttempts: number;
+    timeLabel: string;
+    timeValue: string | null;
+    timeFallback?: string;
+    secondaryTime?: string | null;
+    errorMessage?: string | null;
+};
+
+function TimeValue({
+    fallback = '-',
+    label,
+    value,
+}: {
+    fallback?: string;
+    label: string;
+    value: string | null;
+}) {
+    return (
+        <span>
+            {label} {value ? <LocalDateTime>{value}</LocalDateTime> : fallback}
+        </span>
+    );
+}
+
+export function AutomationRunsCompactTable({
+    emptyMessage,
+    onRunSelect,
+    rows,
+    selectedRunId,
+}: {
+    emptyMessage: string;
+    onRunSelect?: (runId: number) => void;
+    rows: AutomationRunsCompactTableRow[];
+    selectedRunId?: number | null;
+}) {
+    return (
+        <Table>
+            <Table.Header>
+                <Table.Row className="hover:bg-transparent">
+                    <Table.Head className="h-9 px-3 py-2 text-xs uppercase tracking-wide">
+                        Posao
+                    </Table.Head>
+                    <Table.Head className="h-9 px-3 py-2 text-xs uppercase tracking-wide">
+                        Status
+                    </Table.Head>
+                    <Table.Head className="h-9 px-3 py-2 text-xs uppercase tracking-wide">
+                        Izvor
+                    </Table.Head>
+                    <Table.Head className="h-9 px-3 py-2 text-xs uppercase tracking-wide">
+                        Pokušaj
+                    </Table.Head>
+                    <Table.Head className="h-9 px-3 py-2 text-xs uppercase tracking-wide">
+                        Vrijeme
+                    </Table.Head>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {rows.length === 0 ? (
+                    <Table.Row>
+                        <Table.Cell colSpan={5}>
+                            <NoDataPlaceholder>
+                                {emptyMessage}
+                            </NoDataPlaceholder>
+                        </Table.Cell>
+                    </Table.Row>
+                ) : null}
+                {rows.map((row) => {
+                    const isSelected = selectedRunId === row.id;
+
+                    return (
+                        <Table.Row
+                            key={row.id}
+                            className={cx(isSelected && 'bg-muted/70')}
+                        >
+                            <Table.Cell className="min-w-72 px-3 py-2 text-sm">
+                                <div className="grid min-w-0 gap-1">
+                                    {onRunSelect ? (
+                                        <button
+                                            type="button"
+                                            aria-pressed={isSelected}
+                                            className="min-w-0 truncate text-left font-medium text-primary hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                                            onClick={() => onRunSelect(row.id)}
+                                        >
+                                            {row.title}
+                                        </button>
+                                    ) : row.href ? (
+                                        <Link
+                                            href={row.href}
+                                            className="min-w-0 truncate font-medium text-primary hover:underline"
+                                        >
+                                            {row.title}
+                                        </Link>
+                                    ) : (
+                                        <span className="min-w-0 truncate font-medium">
+                                            {row.title}
+                                        </span>
+                                    )}
+                                    {row.subtitle ? (
+                                        <Typography
+                                            level="body3"
+                                            className="truncate text-muted-foreground"
+                                        >
+                                            {row.subtitle}
+                                        </Typography>
+                                    ) : null}
+                                    {row.errorMessage ? (
+                                        <Typography
+                                            level="body3"
+                                            className="line-clamp-2 rounded-md bg-red-50 px-2 py-1 text-red-700 dark:bg-red-950 dark:text-red-300"
+                                        >
+                                            {row.errorMessage}
+                                        </Typography>
+                                    ) : null}
+                                </div>
+                            </Table.Cell>
+                            <Table.Cell className="px-3 py-2 text-sm">
+                                <div className="flex min-w-36 flex-wrap items-center gap-2">
+                                    <AutomationRunStatusIndicator
+                                        className="text-xs"
+                                        status={row.status}
+                                    />
+                                    {row.dryRun ? (
+                                        <Chip
+                                            size="sm"
+                                            color="info"
+                                            variant="soft"
+                                        >
+                                            Probno
+                                        </Chip>
+                                    ) : null}
+                                </div>
+                            </Table.Cell>
+                            <Table.Cell className="px-3 py-2 text-sm">
+                                <div className="grid min-w-32 gap-0.5">
+                                    <span>{row.sourceLabel ?? '-'}</span>
+                                    {row.sourceDetail ? (
+                                        <Typography
+                                            level="body3"
+                                            className="truncate text-muted-foreground"
+                                        >
+                                            {row.sourceDetail}
+                                        </Typography>
+                                    ) : null}
+                                </div>
+                            </Table.Cell>
+                            <Table.Cell className="whitespace-nowrap px-3 py-2 text-sm">
+                                {row.attempt} / {row.maxAttempts}
+                            </Table.Cell>
+                            <Table.Cell className="px-3 py-2 text-sm">
+                                <div className="grid min-w-44 gap-0.5 text-muted-foreground">
+                                    <TimeValue
+                                        fallback={row.timeFallback}
+                                        label={row.timeLabel}
+                                        value={row.timeValue}
+                                    />
+                                    {row.secondaryTime ? (
+                                        <Typography level="body3">
+                                            {row.secondaryTime}
+                                        </Typography>
+                                    ) : null}
+                                </div>
+                            </Table.Cell>
+                        </Table.Row>
+                    );
+                })}
+            </Table.Body>
+        </Table>
+    );
+}

--- a/apps/app/app/admin/automations/AutomationRunsTable.tsx
+++ b/apps/app/app/admin/automations/AutomationRunsTable.tsx
@@ -9,15 +9,16 @@ import type {
 import { Chip } from '@gredice/ui/Chip';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
-import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { cx } from '@gredice/ui/utils';
-import type { Route } from 'next';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
+import { AutomationRunStatusFilter } from './AutomationRunStatusFilter';
+import {
+    AutomationRunsCompactTable,
+    type AutomationRunsCompactTableRow,
+} from './AutomationRunsCompactTable';
 import { AutomationSlidePanel } from './AutomationSlidePanel';
 import {
     AutomationRunStatusIndicator,
@@ -29,11 +30,6 @@ import {
     automationModuleKindLabel,
     automationRunStatusMeta,
 } from './presentation';
-
-export type AutomationRunStatusFilter =
-    | 'withoutSkipped'
-    | 'all'
-    | AutomationRunStatus;
 
 export type AutomationRunsTableRun = {
     run: {
@@ -112,35 +108,14 @@ function DetailItem({
     );
 }
 
-function ListDetailItem({
-    children,
-    label,
-}: {
-    children: ReactNode;
-    label: string;
-}) {
-    return (
-        <div className="min-w-0">
-            <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {label}
-            </dt>
-            <dd className="mt-1 min-w-0 break-words">{children}</dd>
-        </div>
-    );
-}
-
 export function AutomationRunsTable({
-    currentStatusFilter,
     runs,
     statusOptions,
 }: {
-    currentStatusFilter: AutomationRunStatusFilter;
     runs: AutomationRunsTableRun[];
     statusOptions: AutomationRunStatus[];
 }) {
     const router = useRouter();
-    const pathname = usePathname();
-    const searchParams = useSearchParams();
     const [selectedRunId, setSelectedRunId] = useState<number | null>(null);
     const selectedRun = useMemo(
         () => runs.find(({ run }) => run.id === selectedRunId) ?? null,
@@ -150,34 +125,25 @@ export function AutomationRunsTable({
         () => runs.some(({ run }) => isAutomationRunLive(run.status)),
         [runs],
     );
-    const filterItems = useMemo<
-        Array<{ value: AutomationRunStatusFilter; label: string }>
-    >(
-        () => [
-            { value: 'withoutSkipped', label: 'Svi osim preskočenih' },
-            { value: 'all', label: 'Svi statusi' },
-            ...statusOptions.map((status) => ({
-                value: status,
-                label: automationRunStatusMeta(status).label,
+    const tableRows = useMemo<AutomationRunsCompactTableRow[]>(
+        () =>
+            runs.map(({ run, steps }) => ({
+                id: run.id,
+                title: `#${run.id}`,
+                subtitle: `${steps.length} koraka`,
+                status: run.status,
+                dryRun: run.dryRun,
+                sourceLabel: run.sourceEventType,
+                sourceDetail: run.sourceAggregateId,
+                attempt: run.attempt,
+                maxAttempts: run.maxAttempts,
+                timeLabel: 'Kreirano',
+                timeValue: run.createdAt,
+                secondaryTime: formatDuration(run.startedAt, run.completedAt),
+                errorMessage: run.errorMessage,
             })),
-        ],
-        [statusOptions],
+        [runs],
     );
-
-    function updateStatusFilter(nextFilter: AutomationRunStatusFilter) {
-        const nextSearchParams = new URLSearchParams(searchParams.toString());
-        if (nextFilter === 'withoutSkipped') {
-            nextSearchParams.delete('runStatus');
-        } else {
-            nextSearchParams.set('runStatus', nextFilter);
-        }
-
-        const queryString = nextSearchParams.toString();
-        setSelectedRunId(null);
-        router.replace(
-            (queryString ? `${pathname}?${queryString}` : pathname) as Route,
-        );
-    }
 
     useEffect(() => {
         if (!hasLiveRuns) {
@@ -194,115 +160,18 @@ export function AutomationRunsTable({
     return (
         <>
             <div className="min-w-0 overflow-hidden rounded-md border bg-background">
-                <div className="flex flex-col gap-3 border-b px-4 py-3 sm:flex-row sm:items-end sm:justify-between">
-                    <Stack spacing={1}>
-                        <Typography level="h5" component="h2">
-                            Izvršavanja
-                        </Typography>
-                        <Typography
-                            level="body3"
-                            className="text-muted-foreground"
-                        >
-                            Preskočena izvođenja su skrivena dok ih ne uključite
-                            filtrom.
-                        </Typography>
-                    </Stack>
-                    <SelectItems<AutomationRunStatusFilter>
-                        className="w-full sm:w-64"
-                        label="Status"
-                        value={currentStatusFilter}
-                        items={filterItems}
-                        searchable={false}
-                        onValueChange={updateStatusFilter}
-                    />
+                <div className="flex flex-col gap-3 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                    <Typography level="h5" component="h2">
+                        Izvršavanja
+                    </Typography>
+                    <AutomationRunStatusFilter statusOptions={statusOptions} />
                 </div>
-                {runs.length === 0 ? (
-                    <div className="p-4">
-                        <NoDataPlaceholder>
-                            Automatizacija nema izvođenja za odabrani filter.
-                        </NoDataPlaceholder>
-                    </div>
-                ) : (
-                    <ul className="divide-y">
-                        {runs.map(({ run, steps }) => (
-                            <li key={run.id}>
-                                <button
-                                    type="button"
-                                    aria-pressed={selectedRunId === run.id}
-                                    className={cx(
-                                        'grid w-full gap-3 p-4 text-left transition-colors hover:bg-muted/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
-                                        selectedRunId === run.id &&
-                                            'bg-muted/70',
-                                    )}
-                                    onClick={() => setSelectedRunId(run.id)}
-                                >
-                                    <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                                        <Stack spacing={1} className="min-w-0">
-                                            <Row
-                                                spacing={2}
-                                                className="flex-wrap items-center"
-                                            >
-                                                <AutomationRunStatusIndicator
-                                                    status={run.status}
-                                                />
-                                                {run.dryRun ? (
-                                                    <Chip
-                                                        size="sm"
-                                                        color="info"
-                                                        variant="soft"
-                                                    >
-                                                        Probno
-                                                    </Chip>
-                                                ) : null}
-                                            </Row>
-                                            <Typography
-                                                level="body3"
-                                                className="text-muted-foreground"
-                                            >
-                                                {steps.length} koraka
-                                            </Typography>
-                                        </Stack>
-                                        <Stack
-                                            spacing={1}
-                                            className="text-muted-foreground sm:items-end"
-                                        >
-                                            <LocalDateTime>
-                                                {run.createdAt}
-                                            </LocalDateTime>
-                                            <Typography level="body3">
-                                                {formatDuration(
-                                                    run.startedAt,
-                                                    run.completedAt,
-                                                )}
-                                            </Typography>
-                                        </Stack>
-                                    </div>
-
-                                    <dl className="grid gap-3 text-sm sm:grid-cols-3">
-                                        <ListDetailItem label="Tip eventa">
-                                            {run.sourceEventType ?? '-'}
-                                        </ListDetailItem>
-                                        <ListDetailItem label="Agregat">
-                                            {run.sourceAggregateId ?? '-'}
-                                        </ListDetailItem>
-                                        <ListDetailItem label="Pokušaj">
-                                            {run.attempt} / {run.maxAttempts}
-                                        </ListDetailItem>
-                                    </dl>
-
-                                    {run.errorMessage ? (
-                                        <Typography
-                                            level="body3"
-                                            className="break-words rounded-md bg-red-50 p-2 text-red-700 dark:bg-red-950 dark:text-red-300"
-                                        >
-                                            {run.errorMessage}
-                                        </Typography>
-                                    ) : null}
-                                </button>
-                            </li>
-                        ))}
-                    </ul>
-                )}
+                <AutomationRunsCompactTable
+                    rows={tableRows}
+                    emptyMessage="Automatizacija nema izvođenja za odabrani filter."
+                    selectedRunId={selectedRunId}
+                    onRunSelect={setSelectedRunId}
+                />
             </div>
 
             <AutomationSlidePanel

--- a/apps/app/app/admin/automations/[automationId]/page.tsx
+++ b/apps/app/app/admin/automations/[automationId]/page.tsx
@@ -1,6 +1,5 @@
 import {
     type AutomationGraph,
-    type AutomationRunStatus,
     automationModuleKeys,
     automationRunStatusValues,
     getAutomationDefinitionById,
@@ -16,7 +15,6 @@ import { AdminPageTitle } from '../../../../components/admin/navigation';
 import { auth } from '../../../../lib/auth/auth';
 import { AutomationFlowEditor } from '../AutomationFlowEditor';
 import {
-    type AutomationRunStatusFilter,
     AutomationRunsTable,
     type AutomationRunsTableRun,
 } from '../AutomationRunsTable';
@@ -24,6 +22,10 @@ import {
     AutomationTestPanel,
     type RecentAutomationEvent,
 } from '../AutomationTestPanel';
+import {
+    normalizeAutomationRunStatusFilter,
+    statusesForAutomationRunFilter,
+} from '../automationRunFilters';
 
 export const dynamic = 'force-dynamic';
 
@@ -44,36 +46,6 @@ function getTriggerModuleKey(graph: AutomationGraph) {
 
 function firstSearchParam(value: string | string[] | undefined) {
     return Array.isArray(value) ? value[0] : value;
-}
-
-function normalizeRunStatusFilter(
-    value: string | undefined,
-): AutomationRunStatusFilter {
-    if (value === 'all') {
-        return 'all';
-    }
-
-    const status = automationRunStatusValues.find(
-        (candidate) => candidate === value,
-    );
-
-    return status ?? 'withoutSkipped';
-}
-
-function statusesForRunFilter(
-    filter: AutomationRunStatusFilter,
-): AutomationRunStatus | AutomationRunStatus[] | undefined {
-    if (filter === 'all') {
-        return undefined;
-    }
-
-    if (filter === 'withoutSkipped') {
-        return automationRunStatusValues.filter(
-            (status) => status !== 'skipped',
-        );
-    }
-
-    return filter;
 }
 
 function dateToIso(value: Date | null) {
@@ -110,10 +82,12 @@ export default async function AutomationDetailPage({
             : triggerModuleKey === automationModuleKeys.triggerScheduleMonthly
               ? 'schedule'
               : 'unsupported';
-    const currentRunStatusFilter = normalizeRunStatusFilter(
+    const currentRunStatusFilter = normalizeAutomationRunStatusFilter(
         firstSearchParam(resolvedSearchParams.runStatus),
     );
-    const runStatusFilter = statusesForRunFilter(currentRunStatusFilter);
+    const runStatusFilter = statusesForAutomationRunFilter(
+        currentRunStatusFilter,
+    );
     const [runs, recentEvents] = await Promise.all([
         listAutomationRuns({
             automationDefinitionId: definition.id,
@@ -198,7 +172,6 @@ export default async function AutomationDetailPage({
             />
 
             <AutomationRunsTable
-                currentStatusFilter={currentRunStatusFilter}
                 runs={tableRuns}
                 statusOptions={[...automationRunStatusValues]}
             />

--- a/apps/app/app/admin/automations/automationFilterOptions.tsx
+++ b/apps/app/app/admin/automations/automationFilterOptions.tsx
@@ -1,0 +1,47 @@
+import type {
+    AutomationDefinitionStatus,
+    AutomationRunStatus,
+} from '@gredice/storage';
+import { Check, History } from '@gredice/ui/icons';
+import type { FilterOption } from '../../../components/shared/filters';
+import { automationRunStatusMeta, automationStatusMeta } from './presentation';
+
+export function automationDefinitionStatusFilterOption(
+    statuses: AutomationDefinitionStatus[],
+): FilterOption {
+    return {
+        key: 'status',
+        label: 'Status definicije',
+        activeLabel: null,
+        icon: <Check className="size-4" />,
+        options: [
+            { value: 'enabled', label: 'Uključene' },
+            { value: 'all', label: 'Svi statusi' },
+            ...statuses
+                .filter((status) => status !== 'enabled')
+                .map((status) => ({
+                    value: status,
+                    label: automationStatusMeta(status).label,
+                })),
+        ],
+    };
+}
+
+export function automationRunStatusFilterOption(
+    statuses: AutomationRunStatus[],
+): FilterOption {
+    return {
+        key: 'runStatus',
+        label: 'Status izvođenja',
+        activeLabel: null,
+        icon: <History className="size-4" />,
+        options: [
+            { value: 'withoutSkipped', label: 'Bez preskočenih' },
+            { value: 'all', label: 'Svi statusi' },
+            ...statuses.map((status) => ({
+                value: status,
+                label: automationRunStatusMeta(status).label,
+            })),
+        ],
+    };
+}

--- a/apps/app/app/admin/automations/automationRunFilters.ts
+++ b/apps/app/app/admin/automations/automationRunFilters.ts
@@ -1,0 +1,39 @@
+import {
+    type AutomationRunStatus,
+    automationRunStatusValues,
+} from '@gredice/storage';
+
+export type AutomationRunStatusFilter =
+    | 'withoutSkipped'
+    | 'all'
+    | AutomationRunStatus;
+
+export function normalizeAutomationRunStatusFilter(
+    value: string | undefined,
+): AutomationRunStatusFilter {
+    if (value === 'all' || value === 'withoutSkipped') {
+        return value;
+    }
+
+    const status = automationRunStatusValues.find(
+        (candidate) => candidate === value,
+    );
+
+    return status ?? 'withoutSkipped';
+}
+
+export function statusesForAutomationRunFilter(
+    filter: AutomationRunStatusFilter,
+): AutomationRunStatus | AutomationRunStatus[] | undefined {
+    if (filter === 'all') {
+        return undefined;
+    }
+
+    if (filter === 'withoutSkipped') {
+        return automationRunStatusValues.filter(
+            (status) => status !== 'skipped',
+        );
+    }
+
+    return filter;
+}

--- a/apps/app/app/admin/automations/automationRunsData.ts
+++ b/apps/app/app/admin/automations/automationRunsData.ts
@@ -90,7 +90,7 @@ export async function listAutomationRunsPage({
     failedOnly?: boolean;
     limit?: number;
     offset?: number;
-    status?: AutomationRunStatus;
+    status?: AutomationRunStatus | AutomationRunStatus[];
 }): Promise<AutomationRunsPage> {
     const pageSize = normalizeLimit(limit);
     const rows = await listAutomationRuns({

--- a/apps/app/app/admin/automations/page.tsx
+++ b/apps/app/app/admin/automations/page.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent } from '@gredice/ui/Card';
 import { Add } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { redirect } from 'next/navigation';
 import { AdminPageHeader } from '../../../components/admin/navigation';
 import { auth } from '../../../lib/auth/auth';
 import { KnownPages } from '../../../src/KnownPages';
@@ -35,6 +36,7 @@ import {
 export const dynamic = 'force-dynamic';
 
 type AutomationsSearchParams = {
+    failedOnly?: string | string[];
     status?: string | string[];
     triggerEventType?: string | string[];
     runStatus?: string | string[];
@@ -42,6 +44,42 @@ type AutomationsSearchParams = {
 
 function firstParam(value: string | string[] | undefined) {
     return Array.isArray(value) ? value[0] : value;
+}
+
+function appendSearchParam(
+    searchParams: URLSearchParams,
+    key: string,
+    value: string | string[] | undefined,
+) {
+    if (Array.isArray(value)) {
+        value.forEach((item) => {
+            searchParams.append(key, item);
+        });
+        return;
+    }
+
+    if (value !== undefined) {
+        searchParams.set(key, value);
+    }
+}
+
+function legacyFailedOnlyRedirectUrl(params: AutomationsSearchParams) {
+    if (firstParam(params.failedOnly) !== '1') {
+        return null;
+    }
+
+    const searchParams = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+        if (key === 'failedOnly' || key === 'runStatus') {
+            return;
+        }
+
+        appendSearchParam(searchParams, key, value);
+    });
+    searchParams.set('runStatus', 'failed');
+
+    const query = searchParams.toString();
+    return `/admin/automations${query ? `?${query}` : ''}`;
 }
 
 function parseDefinitionStatusFilter(
@@ -63,10 +101,15 @@ export default async function AutomationsPage({
 }: {
     searchParams: Promise<AutomationsSearchParams>;
 }) {
+    const params = await searchParams;
+    const redirectUrl = legacyFailedOnlyRedirectUrl(params);
+    if (redirectUrl) {
+        redirect(redirectUrl);
+    }
+
     await auth(['admin']);
     await ensureDefaultAutomationDefinitions();
 
-    const params = await searchParams;
     const definitionStatusFilter = parseDefinitionStatusFilter(params.status);
     const definitionStatus =
         definitionStatusFilter === 'all' ? undefined : definitionStatusFilter;

--- a/apps/app/app/admin/automations/page.tsx
+++ b/apps/app/app/admin/automations/page.tsx
@@ -1,6 +1,5 @@
 import {
     type AutomationDefinitionStatus,
-    type AutomationRunStatus,
     automationDefinitionStatusValues,
     automationRunStatusValues,
     ensureDefaultAutomationDefinitions,
@@ -10,14 +9,18 @@ import {
 } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
-import { Add, Search } from '@gredice/ui/icons';
-import { Row } from '@gredice/ui/Row';
+import { Add } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { AdminPageHeader } from '../../../components/admin/navigation';
 import { auth } from '../../../lib/auth/auth';
 import { KnownPages } from '../../../src/KnownPages';
+import { AutomationFilters } from './AutomationFilters';
 import { AutomationOverviewPanels } from './AutomationOverviewPanels';
+import {
+    normalizeAutomationRunStatusFilter,
+    statusesForAutomationRunFilter,
+} from './automationRunFilters';
 import {
     automationQueuePageSize,
     listAutomationRunsPage,
@@ -25,8 +28,6 @@ import {
 } from './automationRunsData';
 import {
     automationActionSummary,
-    automationRunStatusMeta,
-    automationStatusMeta,
     automationTriggerSummary,
     moduleMetadataByKey,
 } from './presentation';
@@ -37,25 +38,24 @@ type AutomationsSearchParams = {
     status?: string | string[];
     triggerEventType?: string | string[];
     runStatus?: string | string[];
-    failedOnly?: string | string[];
 };
 
 function firstParam(value: string | string[] | undefined) {
     return Array.isArray(value) ? value[0] : value;
 }
 
-function parseDefinitionStatus(
+function parseDefinitionStatusFilter(
     value: string | string[] | undefined,
-): AutomationDefinitionStatus | undefined {
+): AutomationDefinitionStatus | 'all' {
     const status = firstParam(value);
-    return automationDefinitionStatusValues.find((item) => item === status);
-}
+    if (status === 'all') {
+        return 'all';
+    }
 
-function parseRunStatus(
-    value: string | string[] | undefined,
-): AutomationRunStatus | undefined {
-    const status = firstParam(value);
-    return automationRunStatusValues.find((item) => item === status);
+    return (
+        automationDefinitionStatusValues.find((item) => item === status) ??
+        'enabled'
+    );
 }
 
 export default async function AutomationsPage({
@@ -67,11 +67,15 @@ export default async function AutomationsPage({
     await ensureDefaultAutomationDefinitions();
 
     const params = await searchParams;
-    const definitionStatus = parseDefinitionStatus(params.status);
-    const runStatus = parseRunStatus(params.runStatus);
+    const definitionStatusFilter = parseDefinitionStatusFilter(params.status);
+    const definitionStatus =
+        definitionStatusFilter === 'all' ? undefined : definitionStatusFilter;
+    const runStatusFilter = normalizeAutomationRunStatusFilter(
+        firstParam(params.runStatus),
+    );
+    const runStatus = statusesForAutomationRunFilter(runStatusFilter);
     const triggerEventType =
         firstParam(params.triggerEventType)?.trim() || undefined;
-    const failedOnly = firstParam(params.failedOnly) === '1';
     const modules = getAutomationModuleMetadata();
     const modulesByKey = moduleMetadataByKey(modules);
     const [definitions, runs] = await Promise.all([
@@ -81,8 +85,7 @@ export default async function AutomationsPage({
             limit: 200,
         }),
         listAutomationRunsPage({
-            failedOnly,
-            status: failedOnly ? 'failed' : runStatus,
+            status: runStatus,
             limit: automationQueuePageSize,
         }),
     ]);
@@ -117,8 +120,9 @@ export default async function AutomationsPage({
     );
 
     return (
-        <Stack spacing={5}>
+        <Stack spacing={4}>
             <AdminPageHeader
+                heading="Automatizacije"
                 actions={
                     <Button
                         href={KnownPages.AutomationCreate}
@@ -129,99 +133,10 @@ export default async function AutomationsPage({
                 }
             />
 
-            <Stack spacing={1}>
-                <Typography level="h4" component="h1">
-                    Automatizacije
-                </Typography>
-                <Typography level="body2" className="text-muted-foreground">
-                    Definicije, zadnja izvođenja i greške za asinkrone Gredice
-                    tijekove rada.
-                </Typography>
-            </Stack>
-
-            <Card>
-                <CardContent>
-                    <form className="grid gap-3 md:grid-cols-[160px_1fr_160px_auto] md:items-end">
-                        <Stack spacing={1}>
-                            <label
-                                className="text-sm font-medium"
-                                htmlFor="status"
-                            >
-                                Status
-                            </label>
-                            <select
-                                id="status"
-                                name="status"
-                                defaultValue={definitionStatus ?? ''}
-                                className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-                            >
-                                <option value="">Svi</option>
-                                {automationDefinitionStatusValues.map(
-                                    (status) => (
-                                        <option key={status} value={status}>
-                                            {automationStatusMeta(status).label}
-                                        </option>
-                                    ),
-                                )}
-                            </select>
-                        </Stack>
-                        <Stack spacing={1}>
-                            <label
-                                className="text-sm font-medium"
-                                htmlFor="triggerEventType"
-                            >
-                                Tip eventa okidača
-                            </label>
-                            <input
-                                id="triggerEventType"
-                                name="triggerEventType"
-                                defaultValue={triggerEventType ?? ''}
-                                className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-                                placeholder="raisedBedField.plantUpdate"
-                            />
-                        </Stack>
-                        <Stack spacing={1}>
-                            <label
-                                className="text-sm font-medium"
-                                htmlFor="runStatus"
-                            >
-                                Status izvođenja
-                            </label>
-                            <select
-                                id="runStatus"
-                                name="runStatus"
-                                defaultValue={runStatus ?? ''}
-                                className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-                            >
-                                <option value="">Svi</option>
-                                {automationRunStatusValues.map((status) => (
-                                    <option key={status} value={status}>
-                                        {automationRunStatusMeta(status).label}
-                                    </option>
-                                ))}
-                            </select>
-                        </Stack>
-                        <Row spacing={2} className="items-center">
-                            <label className="flex items-center gap-2 text-sm">
-                                <input
-                                    type="checkbox"
-                                    name="failedOnly"
-                                    value="1"
-                                    defaultChecked={failedOnly}
-                                />
-                                Samo greške
-                            </label>
-                            <Button
-                                type="submit"
-                                variant="outlined"
-                                startDecorator={<Search className="size-4" />}
-                            >
-                                Filtriraj
-                            </Button>
-                        </Row>
-                    </form>
-                </CardContent>
-            </Card>
+            <AutomationFilters
+                definitionStatuses={[...automationDefinitionStatusValues]}
+                runStatuses={[...automationRunStatusValues]}
+            />
 
             <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
                 <Card>
@@ -293,9 +208,8 @@ export default async function AutomationsPage({
 
             <AutomationOverviewPanels
                 definitions={definitionItems}
-                failedOnly={failedOnly}
                 initialRunsPage={runs}
-                runStatus={failedOnly ? 'failed' : runStatus}
+                runStatusFilter={runStatusFilter}
             />
         </Stack>
     );

--- a/apps/app/app/admin/automations/presentation.ts
+++ b/apps/app/app/admin/automations/presentation.ts
@@ -3,6 +3,7 @@ import type {
     AutomationGraph,
     AutomationModuleKind,
     AutomationModuleMetadata,
+    AutomationRunSource,
     AutomationRunStatus,
     AutomationStepStatus,
 } from '@gredice/storage';
@@ -261,6 +262,21 @@ export function automationRunStatusMeta(status: AutomationRunStatus): {
             return { label: 'Ponavlja se', color: 'warning' };
         case 'canceled':
             return { label: 'Otkazana', color: 'neutral' };
+    }
+}
+
+export function automationRunSourceLabel(source: AutomationRunSource) {
+    switch (source) {
+        case 'event':
+            return 'Event';
+        case 'manual':
+            return 'Ručno';
+        case 'schedule':
+            return 'Raspored';
+        case 'test':
+            return 'Test';
+        case 'replay':
+            return 'Ponovljeno';
     }
 }
 

--- a/apps/app/app/api/admin/automations/runs/route.ts
+++ b/apps/app/app/api/admin/automations/runs/route.ts
@@ -1,8 +1,8 @@
-import {
-    type AutomationRunStatus,
-    automationRunStatusValues,
-} from '@gredice/storage';
 import { withAuth } from '../../../../../lib/auth/auth';
+import {
+    normalizeAutomationRunStatusFilter,
+    statusesForAutomationRunFilter,
+} from '../../../../admin/automations/automationRunFilters';
 import {
     automationQueuePageSize,
     listAutomationRunsPage,
@@ -10,10 +10,14 @@ import {
 
 export const dynamic = 'force-dynamic';
 
-function parseAutomationRunStatus(
-    value: string | null,
-): AutomationRunStatus | undefined {
-    return automationRunStatusValues.find((status) => status === value);
+function parseAutomationRunStatus(value: string | null) {
+    if (!value) {
+        return undefined;
+    }
+
+    return statusesForAutomationRunFilter(
+        normalizeAutomationRunStatusFilter(value),
+    );
 }
 
 function parseInteger(value: string | null, fallback: number) {

--- a/apps/app/components/shared/filters/TableFilter.tsx
+++ b/apps/app/components/shared/filters/TableFilter.tsx
@@ -47,7 +47,7 @@ export function TableFilter({
     const updateFilters = useCallback(
         (key: string, value: string) => {
             const params = new URLSearchParams(searchParams.toString());
-            if (value && value !== 'all') {
+            if (value) {
                 params.set(key, value);
             } else {
                 params.delete(key);
@@ -60,7 +60,7 @@ export function TableFilter({
             filters.forEach((filter: FilterOption) => {
                 const filterValue =
                     key === filter.key ? value : searchParams.get(filter.key);
-                if (filterValue && filterValue !== 'all') {
+                if (filterValue) {
                     newFilters[filter.key] = filterValue;
                 }
             });

--- a/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
@@ -194,6 +194,7 @@ const tableFilters: FilterOption[] = [
     {
         key: 'status',
         label: 'Status',
+        activeLabel: null,
         icon: <Filter className="size-4" />,
         options: [
             { value: '', label: 'Svi statusi' },

--- a/apps/storybook/stories/packages/ui/TableFilter.stories.tsx
+++ b/apps/storybook/stories/packages/ui/TableFilter.stories.tsx
@@ -66,6 +66,7 @@ export const MultipleFilters: Story = {
             {
                 key: 'status',
                 label: 'Status',
+                activeLabel: null,
                 icon: <Filter className="size-4" />,
                 options: [
                     { value: '', label: 'Svi statusi' },

--- a/packages/ui/src/TableFilter/TableFilter.tsx
+++ b/packages/ui/src/TableFilter/TableFilter.tsx
@@ -18,6 +18,7 @@ import { Row } from '../Row';
 export interface FilterOption {
     key: string;
     label: string;
+    activeLabel?: string | null;
     icon?: ReactNode;
     options: Array<{
         value: string;
@@ -155,6 +156,10 @@ export function TableFilter({
                 {Object.entries(currentFilters).map(([key, value]) => {
                     const filter = filters.find((f) => f.key === key);
                     if (!filter) return null;
+                    const activeLabel =
+                        filter.activeLabel === undefined
+                            ? filter.label
+                            : filter.activeLabel;
 
                     return (
                         <Chip
@@ -166,7 +171,7 @@ export function TableFilter({
                             <Row spacing={2} className="items-center">
                                 {filter.icon}
                                 <span>
-                                    {filter.label}:{' '}
+                                    {activeLabel ? `${activeLabel}: ` : null}
                                     {getOptionLabel(filter, value)}
                                 </span>
                                 <Close className="size-3" />


### PR DESCRIPTION
## Summary
- Replace the custom admin automation filter form with shared `TableFilter` controls and a trigger-event search input.
- Default automation definitions to enabled, support an explicit all-status override, and keep run-status filtering consistent across the overview and detail pages.
- Extract a compact automation runs table used by both the overview queue and automation detail run history, while preserving the detail slide-out inspector.
- Add compact active-chip labels to `@gredice/ui/TableFilter` and document the behavior in Storybook stories.

## Validation
- `git diff --check`
- `corepack pnpm typecheck --filter app`
- `corepack pnpm --filter @gredice/ui typecheck`
- `corepack pnpm --filter storybook typecheck`
- `corepack pnpm lint --filter app --filter @gredice/ui --filter storybook`
- Browser smoke on `http://localhost:4013/admin/automations` and `/admin/automations/981`: both routes compiled and reached the expected admin auth wall without a token.

## Notes
- Direct `corepack pnpm --filter app exec tsc --noEmit --pretty false` still fails on existing unrelated app-wide type errors outside this change set.