### PR TITLE
Add manual retry support for failed automations

### DIFF
--- a/apps/app/app/admin/automations/actions.ts
+++ b/apps/app/app/admin/automations/actions.ts
@@ -16,6 +16,7 @@ import {
     getDomainEventById,
     listAutomationRunSteps,
     maxAutomationMaxConcurrentRuns,
+    retryFailedAutomationRun,
     updateAutomationDefinition,
     validateAutomationGraph,
 } from '@gredice/storage';
@@ -574,6 +575,23 @@ async function runAutomationRunAgain({
             ok: false,
             errors: ['Samo neuspjela izvođenja mogu se ponovno pokrenuti.'],
         };
+    }
+
+    if (actionName === 'retry') {
+        const run = await retryFailedAutomationRun({
+            id: originalRun.id,
+            manualRequestedByUserId: userId,
+        });
+
+        if (!run) {
+            return {
+                ok: false,
+                errors: ['Ponovno pokretanje nije zakazano.'],
+            };
+        }
+
+        revalidateAutomationPages(originalRun.automationDefinitionId);
+        return { ok: true, runId: run.id, status: run.status };
     }
 
     const definition = await getAutomationDefinitionById(

--- a/packages/storage/src/repositories/automationsRepo.ts
+++ b/packages/storage/src/repositories/automationsRepo.ts
@@ -75,6 +75,12 @@ export type CompleteAutomationRunInput = {
     retryAt?: Date | null;
 };
 
+export type RetryFailedAutomationRunInput = {
+    id: number;
+    manualRequestedByUserId?: string | null;
+    retryAt?: Date;
+};
+
 export type RecordAutomationRunStepInput = {
     runId: number;
     nodeId: string;
@@ -784,6 +790,33 @@ export async function completeAutomationRun(
             updatedAt: now,
         })
         .where(eq(automationRuns.id, input.id))
+        .returning();
+
+    return updated ?? null;
+}
+
+export async function retryFailedAutomationRun(
+    input: RetryFailedAutomationRunInput,
+): Promise<SelectAutomationRun | null> {
+    const now = new Date();
+    const [updated] = await storage()
+        .update(automationRuns)
+        .set({
+            status: 'retrying',
+            maxAttempts: sql<number>`${automationRuns.maxAttempts} + 1`,
+            nextRunAt: input.retryAt ?? now,
+            lockedAt: null,
+            lockedBy: null,
+            completedAt: null,
+            manualRequestedByUserId: input.manualRequestedByUserId ?? null,
+            updatedAt: now,
+        })
+        .where(
+            and(
+                eq(automationRuns.id, input.id),
+                eq(automationRuns.status, 'failed'),
+            ),
+        )
         .returning();
 
     return updated ?? null;

--- a/packages/storage/src/repositories/automationsRepo.ts
+++ b/packages/storage/src/repositories/automationsRepo.ts
@@ -802,7 +802,9 @@ export async function retryFailedAutomationRun(
     const [updated] = await storage()
         .update(automationRuns)
         .set({
+            source: 'manual',
             status: 'retrying',
+            dryRun: false,
             maxAttempts: sql<number>`${automationRuns.maxAttempts} + 1`,
             nextRunAt: input.retryAt ?? now,
             lockedAt: null,

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -41,6 +41,7 @@ import {
     processDueAutomationRuns,
     RAISED_BED_WATERING_50L_OPERATION_ID,
     recordAutomationRunStep,
+    retryFailedAutomationRun,
     seasonalSowedWateringAutomationGraph,
     seedlingTransplantDirectSowingLocationAutomationGraph,
     seedlingTransplantWateringAutomationGraph,
@@ -463,6 +464,90 @@ test('automation definition run summaries are independent per definition', async
         latestRun: null,
         failedRunsCount: 0,
     });
+});
+
+test('manual retry reuses a failed automation run and clears failed summary after success', async () => {
+    createTestDb();
+    const definition = await createAutomationDefinition({
+        key: 'test.manual-retry-automation',
+        name: 'Manual retry automation',
+        status: 'enabled',
+        graph: seasonalSowedWateringAutomationGraph(),
+    });
+    const createdRun = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'test',
+        input: { order: 'manual-retry' },
+        maxAttempts: 1,
+    });
+    assert.ok(createdRun);
+
+    const startedRun = await startAutomationRun(createdRun.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedRun);
+    assert.strictEqual(startedRun.attempt, 1);
+    assert.strictEqual(startedRun.maxAttempts, 1);
+
+    await completeAutomationRun({
+        id: startedRun.id,
+        status: 'failed',
+        errorMessage: 'Expected retry test failure.',
+    });
+
+    const [failedSummary] = await listAutomationDefinitionRunSummaries([
+        definition.id,
+    ]);
+    assert.strictEqual(failedSummary?.failedRunsCount, 1);
+
+    const retryAt = new Date('2026-06-13T10:00:00.000Z');
+    const retriedRun = await retryFailedAutomationRun({
+        id: startedRun.id,
+        manualRequestedByUserId: null,
+        retryAt,
+    });
+
+    assert.ok(retriedRun);
+    assert.strictEqual(retriedRun.id, startedRun.id);
+    assert.strictEqual(retriedRun.status, 'retrying');
+    assert.strictEqual(retriedRun.attempt, 1);
+    assert.strictEqual(retriedRun.maxAttempts, 2);
+    assert.strictEqual(retriedRun.completedAt, null);
+    assert.strictEqual(
+        retriedRun.nextRunAt.toISOString(),
+        retryAt.toISOString(),
+    );
+
+    const [claimedRetry] = await claimDueAutomationRuns({
+        limit: 1,
+        now: retryAt,
+        lockedBy: 'automations-test',
+    });
+    assert.ok(claimedRetry);
+    assert.strictEqual(claimedRetry.id, startedRun.id);
+    assert.strictEqual(claimedRetry.attempt, 2);
+    assert.strictEqual(claimedRetry.maxAttempts, 2);
+
+    await completeAutomationRun({
+        id: claimedRetry.id,
+        status: 'succeeded',
+        output: { ok: true },
+    });
+
+    const [succeededSummary] = await listAutomationDefinitionRunSummaries([
+        definition.id,
+    ]);
+    assert.strictEqual(succeededSummary?.latestRun?.id, startedRun.id);
+    assert.strictEqual(succeededSummary?.latestRun?.status, 'succeeded');
+    assert.strictEqual(succeededSummary?.failedRunsCount, 0);
+
+    const runs = await listAutomationRuns({
+        automationDefinitionId: definition.id,
+    });
+    assert.deepStrictEqual(
+        runs.map((run) => run.id),
+        [startedRun.id],
+    );
 });
 
 test('automation run claiming respects definition concurrency', async () => {

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -486,6 +486,8 @@ test('manual retry reuses a failed automation run and clears failed summary afte
         lockedBy: 'automations-test',
     });
     assert.ok(startedRun);
+    assert.strictEqual(startedRun.source, 'test');
+    assert.strictEqual(startedRun.dryRun, true);
     assert.strictEqual(startedRun.attempt, 1);
     assert.strictEqual(startedRun.maxAttempts, 1);
 
@@ -509,7 +511,9 @@ test('manual retry reuses a failed automation run and clears failed summary afte
 
     assert.ok(retriedRun);
     assert.strictEqual(retriedRun.id, startedRun.id);
+    assert.strictEqual(retriedRun.source, 'manual');
     assert.strictEqual(retriedRun.status, 'retrying');
+    assert.strictEqual(retriedRun.dryRun, false);
     assert.strictEqual(retriedRun.attempt, 1);
     assert.strictEqual(retriedRun.maxAttempts, 2);
     assert.strictEqual(retriedRun.completedAt, null);
@@ -525,6 +529,8 @@ test('manual retry reuses a failed automation run and clears failed summary afte
     });
     assert.ok(claimedRetry);
     assert.strictEqual(claimedRetry.id, startedRun.id);
+    assert.strictEqual(claimedRetry.source, 'manual');
+    assert.strictEqual(claimedRetry.dryRun, false);
     assert.strictEqual(claimedRetry.attempt, 2);
     assert.strictEqual(claimedRetry.maxAttempts, 2);
 


### PR DESCRIPTION
## Summary
- Add a storage helper to retry failed automation runs by moving them back to the queue with an incremented attempt count
- Wire the admin automation action to trigger the retry path for failed runs and revalidate affected pages
- Add repo coverage for retrying a failed run and completing it successfully on the next attempt

## Testing
- Unit tests added for the retry flow in `packages/storage/tests/automationsRepo.node.spec.ts`
- Not run (not requested)