### PR TITLE
[codex] Fix plant detail calendar tab width

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantCalendarPicker.tsx
+++ b/apps/www/app/biljke/[alias]/PlantCalendarPicker.tsx
@@ -28,7 +28,7 @@ export function PlantCalendarPicker({
                 {hasCalendarData ? (
                     <Tabs defaultValue="year">
                         <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
-                            <TabsList className="grid w-full min-w-0 max-w-full grid-cols-2 overflow-hidden">
+                            <TabsList className="grid w-fit min-w-0 max-w-full grid-cols-2 overflow-hidden">
                                 <TabsTrigger
                                     value="year"
                                     className="flex min-w-0 gap-1 overflow-hidden px-2"


### PR DESCRIPTION
## Summary
- Keep the plant detail calendar tabs sized to their labels instead of stretching across the header.
- Preserve the existing max-width/truncation behavior for narrow layouts.

## Why
The plant detail calendar picker used `w-full` on the tab list, which made the tabs fill the available header column even when the control should be left-aligned.

## Validation
- `corepack pnpm --filter www exec biome check 'app/biljke/[alias]/PlantCalendarPicker.tsx'`
- `corepack pnpm --filter www typecheck`
- `git diff --check`