### PR TITLE
Left-align plant details calendar tabs

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantCalendarPicker.tsx
+++ b/apps/www/app/biljke/[alias]/PlantCalendarPicker.tsx
@@ -28,7 +28,7 @@ export function PlantCalendarPicker({
                 {hasCalendarData ? (
                     <Tabs defaultValue="year">
                         <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
-                            <TabsList className="grid w-full min-w-0 max-w-full grid-cols-2 overflow-hidden">
+                            <TabsList className="grid w-fit min-w-0 max-w-full grid-cols-2 overflow-hidden">
                                 <TabsTrigger
                                     value="year"
                                     className="flex min-w-0 gap-1 overflow-hidden px-2"


### PR DESCRIPTION
## Summary
- Change the plant calendar tabs container to `w-fit` so the tab group left-aligns instead of stretching full width.
- Keep the existing two-tab layout and overflow handling intact.

## Testing
- Not run (not requested)