### PR TITLE
[codex] Add shared switch control

### DIFF
--- a/apps/app/app/admin/operations/BulkOperationCreateModal.tsx
+++ b/apps/app/app/admin/operations/BulkOperationCreateModal.tsx
@@ -4,8 +4,8 @@ import { Button } from '@gredice/ui/Button';
 import { Input } from '@gredice/ui/Input';
 import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
+import { Switch } from '@gredice/ui/Switch';
 import { Typography } from '@gredice/ui/Typography';
-import { cx } from '@gredice/ui/utils';
 import { useActionState, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 import { getEntities } from '../../../components/shared/attributes/actions/entitiesActions';
@@ -166,33 +166,11 @@ export function BulkOperationCreateModal({
                         <span className="text-sm font-medium">
                             Odobri odmah
                         </span>
-                        <button
-                            type="button"
-                            role="switch"
-                            aria-checked={approveOnCreate}
+                        <Switch
                             aria-label="Odobri odmah"
-                            onClick={() =>
-                                setApproveOnCreate((current) => !current)
-                            }
-                            className={cx(
-                                'relative flex h-6 w-11 shrink-0 items-center rounded-full border transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                                approveOnCreate
-                                    ? 'border-primary/60 bg-primary'
-                                    : 'border-border bg-muted/70 hover:bg-muted',
-                            )}
-                        >
-                            <span
-                                className={cx(
-                                    'inline-block size-5 rounded-full shadow-xs transition-transform',
-                                    approveOnCreate
-                                        ? 'translate-x-5 bg-primary-foreground'
-                                        : 'translate-x-0.5 bg-muted-foreground',
-                                )}
-                            />
-                            <span className="sr-only">
-                                {approveOnCreate ? 'Da' : 'Ne'}
-                            </span>
-                        </button>
+                            checked={approveOnCreate}
+                            onCheckedChange={setApproveOnCreate}
+                        />
                     </div>
                     <input
                         type="hidden"

--- a/apps/app/components/admin/details/EntityDetailsPropertyList.tsx
+++ b/apps/app/components/admin/details/EntityDetailsPropertyList.tsx
@@ -31,6 +31,7 @@ import {
     Warning,
 } from '@gredice/ui/icons';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Switch } from '@gredice/ui/Switch';
 import { cx } from '@gredice/ui/utils';
 import type { ReactNode } from 'react';
 
@@ -339,26 +340,12 @@ function isCompactValue(value: EntityDetailsPropertyListItem['value']) {
 
 function renderBooleanValueToggle(value: boolean) {
     return (
-        <button
-            type="button"
-            role="switch"
-            aria-checked={value}
+        <Switch
+            aria-label={value ? 'Da' : 'Ne'}
+            checked={value}
+            className="disabled:cursor-default disabled:opacity-100"
             disabled
-            className={cx(
-                'relative flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors disabled:cursor-default disabled:opacity-100',
-                value
-                    ? 'border-primary/60 bg-primary'
-                    : 'border-border bg-muted/70',
-            )}
-        >
-            <span
-                className={cx(
-                    'inline-block size-4 rounded-full shadow-xs transition-transform',
-                    value ? 'bg-primary-foreground' : 'bg-muted-foreground',
-                    value ? 'translate-x-4' : 'translate-x-0.5',
-                )}
-            />
-            <span className="sr-only">{value ? 'Da' : 'Ne'}</span>
-        </button>
+            size="sm"
+        />
     );
 }

--- a/apps/app/components/shared/attributes/typed/BooleanInput.tsx
+++ b/apps/app/components/shared/attributes/typed/BooleanInput.tsx
@@ -1,4 +1,4 @@
-import { cx } from '@gredice/ui/utils';
+import { Switch } from '@gredice/ui/Switch';
 import { useState } from 'react';
 import type { AttributeInputProps } from '../AttributeInputProps';
 
@@ -13,27 +13,10 @@ export function BooleanInput({ value, onChange }: AttributeInputProps) {
     };
 
     return (
-        <button
-            type="button"
-            role="switch"
-            aria-checked={checked}
-            onClick={handleToggle}
-            className={cx(
-                'relative flex h-6 w-11 shrink-0 items-center rounded-full border transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                checked
-                    ? 'border-primary/60 bg-primary'
-                    : 'border-border bg-muted/70 hover:bg-muted',
-            )}
-        >
-            <span
-                className={cx(
-                    'inline-block size-5 rounded-full shadow-xs transition-transform',
-                    checked
-                        ? 'translate-x-5 bg-primary-foreground'
-                        : 'translate-x-0.5 bg-muted-foreground',
-                )}
-            />
-            <span className="sr-only">{checked ? 'Da' : 'Ne'}</span>
-        </button>
+        <Switch
+            aria-label={checked ? 'Da' : 'Ne'}
+            checked={checked}
+            onCheckedChange={handleToggle}
+        />
     );
 }

--- a/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
@@ -147,6 +147,7 @@ import { Spinner } from '@gredice/ui/Spinner';
 import { SplitView } from '@gredice/ui/SplitView';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
+import { Switch } from '@gredice/ui/Switch';
 import { Table } from '@gredice/ui/Table';
 import {
     type FilterOption,
@@ -749,6 +750,10 @@ function OperationsDashboardShowcase() {
                                     <Checkbox
                                         checked="indeterminate"
                                         label="Djelomicno odabrane zone"
+                                    />
+                                    <Switch
+                                        defaultChecked
+                                        label="Obavijesti o promjenama"
                                     />
                                     <ControlledSlider />
                                 </Stack>

--- a/apps/storybook/stories/packages/ui/primitives/Switch.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Switch.stories.tsx
@@ -1,0 +1,63 @@
+import { Switch } from '@gredice/ui/Switch';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta = {
+    title: 'packages/ui/Inputs/Switch',
+    component: Switch,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Switch provides the shared binary on/off control for settings that take effect immediately.',
+            },
+        },
+    },
+    args: {
+        label: 'Ukljuci obavijesti',
+    },
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Checked: Story = {
+    args: {
+        defaultChecked: true,
+        label: 'Prikazi widget',
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        disabled: true,
+        label: 'Nedostupna postavka',
+    },
+};
+
+export const ReadOnly: Story = {
+    args: {
+        defaultChecked: true,
+        label: 'Zakljucana postavka',
+        readOnly: true,
+    },
+};
+
+export const Small: Story = {
+    args: {
+        defaultChecked: true,
+        label: 'Kompaktni prikaz',
+        size: 'sm',
+    },
+};
+
+export const WithDescription: Story = {
+    args: {
+        defaultChecked: true,
+        description: 'Koristi se za postavke koje se spremaju odmah.',
+        label: 'Tihi nacin',
+    },
+};

--- a/packages/game/src/modals/components/WhatsNewNotificationToggle.tsx
+++ b/packages/game/src/modals/components/WhatsNewNotificationToggle.tsx
@@ -3,8 +3,8 @@
 import { Card } from '@gredice/ui/Card';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
+import { Switch } from '@gredice/ui/Switch';
 import { Typography } from '@gredice/ui/Typography';
-import { cx } from '@gredice/ui/utils';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import { useUpdateUser } from '../../hooks/useUpdateUser';
 
@@ -39,33 +39,16 @@ export function WhatsNewNotificationToggle() {
                         </Typography>
                     ) : null}
                 </Stack>
-                <button
-                    aria-checked={widgetEnabled}
+                <Switch
                     aria-label="Prikaži widget Što je novo u vrtu"
-                    className={cx(
-                        'relative h-6 w-11 shrink-0 rounded-full border transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-                        widgetEnabled
-                            ? 'border-primary bg-primary'
-                            : 'border-border bg-muted',
-                    )}
+                    checked={widgetEnabled}
                     disabled={disabled}
-                    onClick={() =>
+                    onCheckedChange={(checked) =>
                         updateUser.mutate({
-                            whatsNewPopupDisabled: widgetEnabled,
+                            whatsNewPopupDisabled: !checked,
                         })
                     }
-                    role="switch"
-                    type="button"
-                >
-                    <span
-                        className={cx(
-                            'absolute top-0.5 size-5 rounded-full bg-background shadow-xs transition-transform',
-                            widgetEnabled
-                                ? 'translate-x-[1.25rem]'
-                                : 'translate-x-0.5',
-                        )}
-                    />
-                </button>
+                />
             </Row>
         </Card>
     );

--- a/packages/ui/src/Switch/Switch.tsx
+++ b/packages/ui/src/Switch/Switch.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import type { ComponentPropsWithoutRef, MouseEvent, ReactNode } from 'react';
+import { useId, useState } from 'react';
+import { cx } from '../utils';
+
+type SwitchSize = 'sm' | 'md';
+
+const switchSizeClassNames = {
+    sm: {
+        root: 'h-5 w-9',
+        thumb: 'size-4 data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0.5',
+    },
+    md: {
+        root: 'h-6 w-11',
+        thumb: 'size-5 data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0.5',
+    },
+} satisfies Record<SwitchSize, { root: string; thumb: string }>;
+
+export type SwitchProps = Omit<
+    ComponentPropsWithoutRef<'button'>,
+    'defaultChecked'
+> & {
+    checked?: boolean;
+    defaultChecked?: boolean;
+    description?: ReactNode;
+    label?: ReactNode;
+    onCheckedChange?: (checked: boolean) => void;
+    readOnly?: boolean;
+    size?: SwitchSize;
+};
+
+export function Switch({
+    'aria-describedby': ariaDescribedBy,
+    checked,
+    className,
+    defaultChecked,
+    description,
+    disabled,
+    id,
+    label,
+    onClick,
+    onCheckedChange,
+    readOnly,
+    size = 'md',
+    type = 'button',
+    ...props
+}: SwitchProps) {
+    const generatedId = useId();
+    const switchId = id ?? generatedId;
+    const descriptionId = description ? `${switchId}-description` : undefined;
+    const describedBy = [ariaDescribedBy, descriptionId]
+        .filter(Boolean)
+        .join(' ');
+    const [internalChecked, setInternalChecked] = useState(
+        defaultChecked ?? false,
+    );
+    const isChecked = checked ?? internalChecked;
+    const state = isChecked ? 'checked' : 'unchecked';
+
+    function handleClick(event: MouseEvent<HTMLButtonElement>) {
+        onClick?.(event);
+
+        if (event.defaultPrevented || readOnly) {
+            return;
+        }
+
+        const nextChecked = !isChecked;
+        if (checked === undefined) {
+            setInternalChecked(nextChecked);
+        }
+        onCheckedChange?.(nextChecked);
+    }
+
+    const control = (
+        <button
+            {...props}
+            aria-describedby={describedBy || undefined}
+            aria-checked={isChecked}
+            aria-readonly={readOnly || undefined}
+            className={cx(
+                'peer inline-flex shrink-0 cursor-pointer items-center rounded-full border border-border bg-muted/70 ring-offset-background transition-colors hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 data-[readonly]:cursor-default data-[state=checked]:border-primary/60 data-[state=checked]:bg-primary data-[state=checked]:hover:bg-primary/90',
+                switchSizeClassNames[size].root,
+                className,
+            )}
+            data-readonly={readOnly ? '' : undefined}
+            data-state={state}
+            disabled={disabled}
+            id={switchId}
+            onClick={handleClick}
+            role="switch"
+            type={type}
+        >
+            <span
+                data-state={state}
+                className={cx(
+                    'pointer-events-none block rounded-full border border-border/70 bg-background shadow-xs ring-0 transition-transform data-[state=checked]:border-primary-foreground/20 data-[state=checked]:bg-primary-foreground',
+                    switchSizeClassNames[size].thumb,
+                )}
+            />
+        </button>
+    );
+
+    if (!label && !description) {
+        return control;
+    }
+
+    return (
+        <div className="flex items-center gap-2">
+            {control}
+            <span
+                className={cx(
+                    'grid gap-0.5',
+                    disabled && 'cursor-not-allowed opacity-70',
+                )}
+            >
+                {label ? (
+                    <label
+                        className="text-sm font-medium leading-none"
+                        htmlFor={switchId}
+                    >
+                        {label}
+                    </label>
+                ) : null}
+                {description ? (
+                    <span
+                        className="text-muted-foreground text-xs leading-snug"
+                        id={descriptionId}
+                    >
+                        {description}
+                    </span>
+                ) : null}
+            </span>
+        </div>
+    );
+}

--- a/packages/ui/src/Switch/index.ts
+++ b/packages/ui/src/Switch/index.ts
@@ -1,0 +1,1 @@
+export { Switch, type SwitchProps } from './Switch';


### PR DESCRIPTION
## Summary
- Add a shared `@gredice/ui/Switch` primitive with small/default sizes, labels, descriptions, disabled, read-only, controlled, and uncontrolled states.
- Replace plain custom switch implementations in the game notification settings and admin boolean controls.
- Document the new primitive in Storybook and add it to the component showcase.

## Root Cause
The in-game "Što je novo u vrtu" toggle was hand-rolled with an absolutely positioned thumb that could render without a visible knob on the settings surface. Similar plain switch implementations existed elsewhere, so this centralizes the standard behavior and styling.

## Validation
- `corepack pnpm lint --filter @gredice/ui --filter @gredice/game --filter app --filter storybook`
- `corepack pnpm typecheck --filter @gredice/ui --filter @gredice/game --filter app --filter storybook`
- `corepack pnpm --filter garden typecheck`
- `GREDICE_PLAYWRIGHT_REUSE_SERVER=true corepack pnpm --filter garden exec playwright test tests/notifications-tab.spec.tsx -g "notification settings toggles the what is new widget"`
- `corepack pnpm --filter app build`