### PR TITLE
Restore automation list views with live durations

### DIFF
--- a/apps/app/app/admin/automations/AutomationJobsQueueTable.tsx
+++ b/apps/app/app/admin/automations/AutomationJobsQueueTable.tsx
@@ -1,53 +1,47 @@
+'use client';
+
 import { Button } from '@gredice/ui/Button';
 import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
 import { LoaderSpinner } from '@gredice/ui/icons';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../src/KnownPages';
+import { AutomationRunStatusIndicator } from './AutomationStatusIndicator';
 import {
-    AutomationRunsCompactTable,
-    type AutomationRunsCompactTableRow,
-} from './AutomationRunsCompactTable';
+    automationRunDurationIsLive,
+    automationRunDurationTiming,
+} from './automationRunDuration';
 import { automationRunSourceLabel } from './presentation';
 import type { AutomationRunListItem } from './types';
 
-function queueTiming(run: AutomationRunListItem) {
-    if (run.status === 'queued' || run.status === 'retrying') {
-        return { timeLabel: 'Sljedeće', timeValue: run.nextRunAt };
-    }
+function useLiveDurationNow(runs: AutomationRunListItem[]) {
+    const hasLiveDurations = useMemo(
+        () => runs.some((run) => automationRunDurationIsLive(run.status)),
+        [runs],
+    );
+    const [nowMs, setNowMs] = useState<number | null>(null);
 
-    if (run.status === 'running') {
-        return { timeLabel: 'Zaključano', timeValue: run.lockedAt };
-    }
+    useEffect(() => {
+        if (!hasLiveDurations) {
+            setNowMs(null);
+            return;
+        }
 
-    if (run.completedAt) {
-        return { timeLabel: 'Završeno', timeValue: run.completedAt };
-    }
+        const updateNow = () => setNowMs(Date.now());
+        updateNow();
 
-    return { timeLabel: 'Kreirano', timeValue: run.createdAt };
-}
+        const intervalId = window.setInterval(updateNow, 1000);
 
-function queueRunToTableRow(
-    run: AutomationRunListItem,
-): AutomationRunsCompactTableRow {
-    const timing = queueTiming(run);
+        return () => window.clearInterval(intervalId);
+    }, [hasLiveDurations]);
 
-    return {
-        id: run.id,
-        title: `#${run.id} ${run.automationDefinitionName}`,
-        href: KnownPages.Automation(run.automationDefinitionId),
-        subtitle: run.automationDefinitionKey,
-        status: run.status,
-        dryRun: run.dryRun,
-        sourceLabel: automationRunSourceLabel(run.source),
-        sourceDetail: run.parentRunId ? `Roditelj #${run.parentRunId}` : null,
-        attempt: run.attempt,
-        maxAttempts: run.maxAttempts,
-        timeLabel: timing.timeLabel,
-        timeValue: timing.timeValue,
-        errorMessage: run.errorMessage,
-    };
+    return nowMs;
 }
 
 export function AutomationJobsQueueList({
@@ -63,7 +57,7 @@ export function AutomationJobsQueueList({
     loadMore: () => void;
     runs: AutomationRunListItem[];
 }) {
-    const rows = runs.map(queueRunToTableRow);
+    const nowMs = useLiveDurationNow(runs);
 
     return (
         <Card className="h-full">
@@ -91,10 +85,93 @@ export function AutomationJobsQueueList({
                 </div>
             </CardHeader>
             <CardOverflow>
-                <AutomationRunsCompactTable
-                    rows={rows}
-                    emptyMessage="Nema poslova za odabrane filtere."
-                />
+                {runs.length === 0 ? (
+                    <div className="p-4">
+                        <NoDataPlaceholder>
+                            Nema poslova za odabrane filtere.
+                        </NoDataPlaceholder>
+                    </div>
+                ) : (
+                    <ul className="divide-y">
+                        {runs.map((run) => {
+                            const timing = automationRunDurationTiming(
+                                run,
+                                nowMs,
+                            );
+
+                            return (
+                                <li key={run.id} className="px-4 py-3">
+                                    <div className="grid min-w-0 gap-1.5">
+                                        <div className="flex min-w-0 items-start justify-between gap-3">
+                                            <Link
+                                                href={KnownPages.Automation(
+                                                    run.automationDefinitionId,
+                                                )}
+                                                className="min-w-0 truncate font-medium text-primary hover:underline"
+                                            >
+                                                #{run.id}{' '}
+                                                {run.automationDefinitionName}
+                                            </Link>
+                                            <div className="flex shrink-0 items-center gap-2">
+                                                <AutomationRunStatusIndicator
+                                                    className="text-xs sm:text-sm"
+                                                    status={run.status}
+                                                />
+                                                {run.dryRun ? (
+                                                    <Chip
+                                                        size="sm"
+                                                        color="info"
+                                                        variant="soft"
+                                                    >
+                                                        Probno
+                                                    </Chip>
+                                                ) : null}
+                                            </div>
+                                        </div>
+
+                                        {run.errorMessage ? (
+                                            <Typography
+                                                level="body3"
+                                                className="line-clamp-2 rounded-md bg-red-50 p-2 text-red-700 dark:bg-red-950 dark:text-red-300"
+                                            >
+                                                {run.errorMessage}
+                                            </Typography>
+                                        ) : null}
+
+                                        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                                            <span className="min-w-0 max-w-full truncate">
+                                                {run.automationDefinitionKey}
+                                            </span>
+                                            <span>
+                                                {automationRunSourceLabel(
+                                                    run.source,
+                                                )}
+                                            </span>
+                                            <span>
+                                                Pokušaj {run.attempt} /{' '}
+                                                {run.maxAttempts}
+                                            </span>
+                                            <span className="tabular-nums">
+                                                {timing.label} {timing.value}
+                                            </span>
+                                            <span>
+                                                Kreirano{' '}
+                                                <LocalDateTime>
+                                                    {run.createdAt}
+                                                </LocalDateTime>
+                                            </span>
+                                            {run.parentRunId ? (
+                                                <span>
+                                                    Roditelj #{run.parentRunId}
+                                                </span>
+                                            ) : null}
+                                        </div>
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
 
                 {hasMore ? (
                     <div className="border-t p-4">

--- a/apps/app/app/admin/automations/AutomationRunsTable.tsx
+++ b/apps/app/app/admin/automations/AutomationRunsTable.tsx
@@ -11,14 +11,12 @@ import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
+import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { AutomationRunStatusFilter } from './AutomationRunStatusFilter';
-import {
-    AutomationRunsCompactTable,
-    type AutomationRunsCompactTableRow,
-} from './AutomationRunsCompactTable';
 import { AutomationSlidePanel } from './AutomationSlidePanel';
 import {
     AutomationRunStatusIndicator,
@@ -26,6 +24,10 @@ import {
     isAutomationRunLive,
 } from './AutomationStatusIndicator';
 import { AutomationRunRetryControls } from './AutomationTestPanel';
+import {
+    automationRunDurationIsLive,
+    automationRunDurationTiming,
+} from './automationRunDuration';
 import {
     automationModuleKindLabel,
     automationRunStatusMeta,
@@ -43,9 +45,11 @@ export type AutomationRunsTableRun = {
         input: AutomationJsonObject;
         output: AutomationJsonObject;
         errorMessage: string | null;
+        lockedAt: string | null;
         startedAt: string | null;
         completedAt: string | null;
         createdAt: string;
+        updatedAt: string;
     };
     steps: Array<{
         id: number;
@@ -61,21 +65,6 @@ export type AutomationRunsTableRun = {
         createdAt: string;
     }>;
 };
-
-function formatDuration(startedAt: string | null, completedAt: string | null) {
-    if (!startedAt || !completedAt) {
-        return '-';
-    }
-
-    const startedAtMs = new Date(startedAt).getTime();
-    const completedAtMs = new Date(completedAt).getTime();
-
-    if (Number.isNaN(startedAtMs) || Number.isNaN(completedAtMs)) {
-        return '-';
-    }
-
-    return `${Math.max(0, completedAtMs - startedAtMs)} ms`;
-}
 
 function JsonPreview({ value }: { value: unknown }) {
     return (
@@ -108,6 +97,47 @@ function DetailItem({
     );
 }
 
+function ListDetailItem({
+    children,
+    label,
+}: {
+    children: ReactNode;
+    label: string;
+}) {
+    return (
+        <div className="min-w-0">
+            <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {label}
+            </dt>
+            <dd className="mt-1 min-w-0 break-words">{children}</dd>
+        </div>
+    );
+}
+
+function useLiveDurationNow(runs: AutomationRunsTableRun[]) {
+    const hasLiveDurations = useMemo(
+        () => runs.some(({ run }) => automationRunDurationIsLive(run.status)),
+        [runs],
+    );
+    const [nowMs, setNowMs] = useState<number | null>(null);
+
+    useEffect(() => {
+        if (!hasLiveDurations) {
+            setNowMs(null);
+            return;
+        }
+
+        const updateNow = () => setNowMs(Date.now());
+        updateNow();
+
+        const intervalId = window.setInterval(updateNow, 1000);
+
+        return () => window.clearInterval(intervalId);
+    }, [hasLiveDurations]);
+
+    return nowMs;
+}
+
 export function AutomationRunsTable({
     runs,
     statusOptions,
@@ -125,25 +155,7 @@ export function AutomationRunsTable({
         () => runs.some(({ run }) => isAutomationRunLive(run.status)),
         [runs],
     );
-    const tableRows = useMemo<AutomationRunsCompactTableRow[]>(
-        () =>
-            runs.map(({ run, steps }) => ({
-                id: run.id,
-                title: `#${run.id}`,
-                subtitle: `${steps.length} koraka`,
-                status: run.status,
-                dryRun: run.dryRun,
-                sourceLabel: run.sourceEventType,
-                sourceDetail: run.sourceAggregateId,
-                attempt: run.attempt,
-                maxAttempts: run.maxAttempts,
-                timeLabel: 'Kreirano',
-                timeValue: run.createdAt,
-                secondaryTime: formatDuration(run.startedAt, run.completedAt),
-                errorMessage: run.errorMessage,
-            })),
-        [runs],
-    );
+    const nowMs = useLiveDurationNow(runs);
 
     useEffect(() => {
         if (!hasLiveRuns) {
@@ -166,12 +178,114 @@ export function AutomationRunsTable({
                     </Typography>
                     <AutomationRunStatusFilter statusOptions={statusOptions} />
                 </div>
-                <AutomationRunsCompactTable
-                    rows={tableRows}
-                    emptyMessage="Automatizacija nema izvođenja za odabrani filter."
-                    selectedRunId={selectedRunId}
-                    onRunSelect={setSelectedRunId}
-                />
+                {runs.length === 0 ? (
+                    <div className="p-4">
+                        <NoDataPlaceholder>
+                            Automatizacija nema izvođenja za odabrani filter.
+                        </NoDataPlaceholder>
+                    </div>
+                ) : (
+                    <ul className="divide-y">
+                        {runs.map(({ run, steps }) => {
+                            const timing = automationRunDurationTiming(
+                                run,
+                                nowMs,
+                            );
+                            const isSelected = selectedRunId === run.id;
+
+                            return (
+                                <li key={run.id}>
+                                    <button
+                                        type="button"
+                                        aria-pressed={isSelected}
+                                        className={cx(
+                                            'grid w-full gap-3 p-4 text-left transition-colors hover:bg-muted/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+                                            isSelected && 'bg-muted/70',
+                                        )}
+                                        onClick={() => setSelectedRunId(run.id)}
+                                    >
+                                        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                            <Stack
+                                                spacing={1}
+                                                className="min-w-0"
+                                            >
+                                                <Row
+                                                    spacing={2}
+                                                    className="flex-wrap items-center"
+                                                >
+                                                    <Typography
+                                                        level="body2"
+                                                        semiBold
+                                                    >
+                                                        #{run.id}
+                                                    </Typography>
+                                                    <AutomationRunStatusIndicator
+                                                        status={run.status}
+                                                    />
+                                                    {run.dryRun ? (
+                                                        <Chip
+                                                            size="sm"
+                                                            color="info"
+                                                            variant="soft"
+                                                        >
+                                                            Probno
+                                                        </Chip>
+                                                    ) : null}
+                                                </Row>
+                                                <Typography
+                                                    level="body3"
+                                                    className="text-muted-foreground"
+                                                >
+                                                    {steps.length} koraka
+                                                </Typography>
+                                            </Stack>
+                                            <Stack
+                                                spacing={1}
+                                                className="text-muted-foreground sm:items-end"
+                                            >
+                                                <Typography level="body3">
+                                                    Kreirano{' '}
+                                                    <LocalDateTime>
+                                                        {run.createdAt}
+                                                    </LocalDateTime>
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    className="tabular-nums"
+                                                >
+                                                    {timing.label}{' '}
+                                                    {timing.value}
+                                                </Typography>
+                                            </Stack>
+                                        </div>
+
+                                        <dl className="grid gap-3 text-sm sm:grid-cols-3">
+                                            <ListDetailItem label="Tip eventa">
+                                                {run.sourceEventType ?? '-'}
+                                            </ListDetailItem>
+                                            <ListDetailItem label="Agregat">
+                                                {run.sourceAggregateId ?? '-'}
+                                            </ListDetailItem>
+                                            <ListDetailItem label="Pokušaj">
+                                                {run.attempt} /{' '}
+                                                {run.maxAttempts}
+                                            </ListDetailItem>
+                                        </dl>
+
+                                        {run.errorMessage ? (
+                                            <Typography
+                                                level="body3"
+                                                className="break-words rounded-md bg-red-50 p-2 text-red-700 dark:bg-red-950 dark:text-red-300"
+                                            >
+                                                {run.errorMessage}
+                                            </Typography>
+                                        ) : null}
+                                    </button>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
             </div>
 
             <AutomationSlidePanel
@@ -217,10 +331,12 @@ export function AutomationRunsTable({
                                     {selectedRun.run.maxAttempts}
                                 </DetailItem>
                                 <DetailItem label="Trajanje">
-                                    {formatDuration(
-                                        selectedRun.run.startedAt,
-                                        selectedRun.run.completedAt,
-                                    )}
+                                    {
+                                        automationRunDurationTiming(
+                                            selectedRun.run,
+                                            nowMs,
+                                        ).value
+                                    }
                                 </DetailItem>
                                 <DetailItem label="Kreirano">
                                     <DateTimeValue

--- a/apps/app/app/admin/automations/[automationId]/page.tsx
+++ b/apps/app/app/admin/automations/[automationId]/page.tsx
@@ -120,9 +120,11 @@ export default async function AutomationDetailPage({
                 input: run.input,
                 output: run.output,
                 errorMessage: run.errorMessage,
+                lockedAt: dateToIso(run.lockedAt),
                 startedAt: dateToIso(run.startedAt),
                 completedAt: dateToIso(run.completedAt),
                 createdAt: run.createdAt.toISOString(),
+                updatedAt: run.updatedAt.toISOString(),
             },
             steps: steps.map((step) => ({
                 id: step.id,

--- a/apps/app/app/admin/automations/automationRunDuration.ts
+++ b/apps/app/app/admin/automations/automationRunDuration.ts
@@ -1,0 +1,121 @@
+import type { AutomationRunStatus } from '@gredice/storage';
+
+export type AutomationRunDurationInput = {
+    status: AutomationRunStatus;
+    createdAt: string;
+    startedAt?: string | null;
+    completedAt?: string | null;
+    lockedAt?: string | null;
+    updatedAt?: string | null;
+};
+
+export type AutomationRunDurationTiming = {
+    label: string;
+    value: string;
+};
+
+function dateTimeMs(value: string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const timeMs = new Date(value).getTime();
+
+    return Number.isNaN(timeMs) ? null : timeMs;
+}
+
+export function automationRunDurationIsLive(status: AutomationRunStatus) {
+    return status === 'queued' || status === 'running' || status === 'retrying';
+}
+
+export function formatAutomationRunDuration(durationMs: number) {
+    const safeDurationMs = Math.max(0, Math.trunc(durationMs));
+
+    if (safeDurationMs < 1000) {
+        return `${safeDurationMs} ms`;
+    }
+
+    const totalSeconds = Math.floor(safeDurationMs / 1000);
+    const seconds = totalSeconds % 60;
+    const totalMinutes = Math.floor(totalSeconds / 60);
+    const minutes = totalMinutes % 60;
+    const totalHours = Math.floor(totalMinutes / 60);
+    const hours = totalHours % 24;
+    const days = Math.floor(totalHours / 24);
+
+    if (days > 0) {
+        return hours > 0 ? `${days} d ${hours} h` : `${days} d`;
+    }
+
+    if (hours > 0) {
+        return minutes > 0 ? `${hours} h ${minutes} min` : `${hours} h`;
+    }
+
+    if (minutes > 0) {
+        return seconds > 0 ? `${minutes} min ${seconds} s` : `${minutes} min`;
+    }
+
+    return `${seconds} s`;
+}
+
+function elapsedTiming(
+    label: string,
+    startAt: string | null | undefined,
+    nowMs: number | null,
+): AutomationRunDurationTiming {
+    const startAtMs = dateTimeMs(startAt);
+
+    if (startAtMs == null || nowMs == null) {
+        return { label, value: '-' };
+    }
+
+    return {
+        label,
+        value: formatAutomationRunDuration(nowMs - startAtMs),
+    };
+}
+
+function completedTiming({
+    completedAt,
+    createdAt,
+    startedAt,
+}: AutomationRunDurationInput): AutomationRunDurationTiming {
+    const completedAtMs = dateTimeMs(completedAt);
+    const startedAtMs = dateTimeMs(startedAt) ?? dateTimeMs(createdAt);
+
+    if (startedAtMs == null || completedAtMs == null) {
+        return { label: 'Trajalo', value: '-' };
+    }
+
+    return {
+        label: 'Trajalo',
+        value: formatAutomationRunDuration(completedAtMs - startedAtMs),
+    };
+}
+
+export function automationRunDurationTiming(
+    run: AutomationRunDurationInput,
+    nowMs: number | null,
+): AutomationRunDurationTiming {
+    switch (run.status) {
+        case 'queued':
+            return elapsedTiming('U redu', run.createdAt, nowMs);
+        case 'running':
+            return elapsedTiming(
+                'Izvodi se',
+                run.startedAt ?? run.lockedAt ?? run.updatedAt ?? run.createdAt,
+                nowMs,
+            );
+        case 'retrying':
+            return elapsedTiming(
+                'Čeka ponavljanje',
+                run.updatedAt ?? run.createdAt,
+                nowMs,
+            );
+        case 'succeeded':
+        case 'skipped':
+        case 'failed':
+        case 'canceled':
+            return completedTiming(run);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the compact automation tables with richer list rows in the queue and runs views
- Add live duration rendering for running and queued items, plus clearer status, timing, and metadata display
- Preserve empty states with the shared no-data placeholder and keep the runs detail panel selection behavior

## Testing
- Not run (not requested)