### PR TITLE
[codex] Fix notification setting switches

### DIFF
--- a/apps/garden/tests/notifications-tab.spec.tsx
+++ b/apps/garden/tests/notifications-tab.spec.tsx
@@ -356,16 +356,18 @@ test('notification settings explains required groups and hydrates saved preferen
     ).toBeVisible();
     await expect(page.getByText('Vrste obavijesti')).toBeVisible();
     await expect(
-        page.getByRole('checkbox', { name: /sigurnost računa/u }),
-    ).toHaveCount(0);
+        page.getByRole('switch', {
+            name: /Obavezna obavijest sigurnost računa/u,
+        }),
+    ).toBeChecked();
     await expect(
         page.getByText('Promotivne ponude i sezonske preporuke'),
     ).toBeVisible();
     await expect(
-        page.getByRole('checkbox', { name: 'Uključi podsjetnici i zadaci' }),
+        page.getByRole('switch', { name: 'Isključi podsjetnici i zadaci' }),
     ).toBeChecked();
     await expect(
-        page.getByRole('checkbox', { name: 'Ne ometaj' }),
+        page.getByRole('switch', { name: 'Isključi ne ometaj' }),
     ).toBeChecked();
     await expect(page.getByRole('textbox', { name: 'Od' })).toHaveValue(
         '22:00',
@@ -374,6 +376,49 @@ test('notification settings explains required groups and hydrates saved preferen
         '07:00',
     );
     await expect(page.getByText('Tjedno')).toBeVisible();
+});
+
+test('notification settings keeps switch thumbs inside their tracks', async ({
+    mount,
+    page,
+}) => {
+    await mockNotificationSettingsApi(page);
+    await page.evaluate(() =>
+        window.localStorage.setItem('game:push:device-id', 'current-device'),
+    );
+
+    await mount(<NotificationsTabStory />);
+    await page.getByRole('tab', { name: 'Postavke' }).click();
+
+    await expect(page.getByText('Vrste obavijesti')).toBeVisible();
+
+    const overflowingSwitches = await page
+        .locator('button[role="switch"]')
+        .evaluateAll((switches) =>
+            switches
+                .map((control) => {
+                    const thumb = control.querySelector('span');
+                    if (!thumb) {
+                        return null;
+                    }
+
+                    const controlRect = control.getBoundingClientRect();
+                    const thumbRect = thumb.getBoundingClientRect();
+                    const tolerance = 1;
+                    const isContained =
+                        thumbRect.left >= controlRect.left - tolerance &&
+                        thumbRect.right <= controlRect.right + tolerance &&
+                        thumbRect.top >= controlRect.top - tolerance &&
+                        thumbRect.bottom <= controlRect.bottom + tolerance;
+
+                    return isContained
+                        ? null
+                        : control.getAttribute('aria-label');
+                })
+                .filter(Boolean),
+        );
+
+    expect(overflowingSwitches).toEqual([]);
 });
 
 test('notification settings toggles the what is new widget', async ({
@@ -465,7 +510,7 @@ test('notification settings calls preference, device, and test notification APIs
     await expect(page.getByText('Ovaj uređaj')).toBeVisible();
     await expect(page.getByText('Chrome test browser')).toHaveCount(0);
     await page
-        .getByRole('checkbox', { name: 'Uključi radovi i berba u vrtu' })
+        .getByRole('switch', { name: 'Uključi radovi i berba u vrtu' })
         .click();
 
     await expect

--- a/apps/storybook/stories/packages/ui/primitives/Switch.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Switch.stories.tsx
@@ -61,3 +61,14 @@ export const WithDescription: Story = {
         label: 'Tihi nacin',
     },
 };
+
+export const InConstrainedRow: Story = {
+    render: () => (
+        <div className="flex w-64 items-center justify-between gap-4 rounded-md border p-3">
+            <span className="min-w-0 flex-1 text-sm">
+                Vrlo duga postavka koja ne smije izgurati prekidac izvan reda
+            </span>
+            <Switch aria-label="Ukljuci dugu postavku" defaultChecked />
+        </div>
+    ),
+};

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -1,7 +1,6 @@
 import { clientAuthenticated } from '@gredice/client';
 import { Button } from '@gredice/ui/Button';
 import { Card } from '@gredice/ui/Card';
-import { Checkbox } from '@gredice/ui/Checkbox';
 import { Input } from '@gredice/ui/Input';
 import {
     Approved,
@@ -15,9 +14,9 @@ import {
 import { Row } from '@gredice/ui/Row';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
+import { Switch } from '@gredice/ui/Switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Typography } from '@gredice/ui/Typography';
-import { cx } from '@gredice/ui/utils';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
@@ -588,7 +587,10 @@ export function NotificationsTab({
                                     className="gap-4"
                                     justifyContent="space-between"
                                 >
-                                    <Stack spacing={0.5}>
+                                    <Stack
+                                        spacing={0.5}
+                                        className="min-w-0 flex-1"
+                                    >
                                         <Typography level="body1" semiBold>
                                             Obavijesti na ovom uređaju
                                         </Typography>
@@ -596,35 +598,20 @@ export function NotificationsTab({
                                             {currentDeviceStatusLabel}
                                         </Typography>
                                     </Stack>
-                                    <button
-                                        aria-checked={
-                                            currentDeviceNotificationsEnabled
-                                        }
+                                    <Switch
                                         aria-label={
                                             currentDeviceNotificationsEnabled
                                                 ? 'Isključi obavijesti na ovom uređaju'
                                                 : 'Uključi obavijesti na ovom uređaju'
                                         }
-                                        className={cx(
-                                            'relative h-6 w-11 shrink-0 rounded-full border transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+                                        checked={
                                             currentDeviceNotificationsEnabled
-                                                ? 'border-primary bg-primary'
-                                                : 'border-border bg-muted',
-                                        )}
+                                        }
                                         disabled={currentDeviceToggleDisabled}
-                                        onClick={handleCurrentDeviceToggle}
-                                        role="switch"
-                                        type="button"
-                                    >
-                                        <span
-                                            className={cx(
-                                                'absolute top-0.5 size-5 rounded-full bg-background shadow-xs transition-transform',
-                                                currentDeviceNotificationsEnabled
-                                                    ? 'translate-x-[1.25rem]'
-                                                    : 'translate-x-0.5',
-                                            )}
-                                        />
-                                    </button>
+                                        onCheckedChange={
+                                            handleCurrentDeviceToggle
+                                        }
+                                    />
                                 </Row>
                                 {pushStatusQuery.isError && (
                                     <Typography level="body3" secondary>
@@ -668,18 +655,20 @@ export function NotificationsTab({
                                                 Omogući sve
                                             </Button>
                                         </Row>
-                                        {requiredNotificationGroups.map(
-                                            (item) => (
-                                                <div
-                                                    key={item.category}
-                                                    className="rounded border border-border/60 p-2"
-                                                >
+                                        <Stack spacing={0.5}>
+                                            {requiredNotificationGroups.map(
+                                                (item) => (
                                                     <Row
+                                                        key={item.category}
                                                         justifyContent="space-between"
                                                         alignItems="start"
                                                         spacing={4}
+                                                        className="py-2"
                                                     >
-                                                        <Stack spacing={0.5}>
+                                                        <Stack
+                                                            spacing={0.5}
+                                                            className="min-w-0 flex-1"
+                                                        >
                                                             <Typography
                                                                 semiBold
                                                             >
@@ -694,88 +683,114 @@ export function NotificationsTab({
                                                                 }
                                                             </Typography>
                                                         </Stack>
-                                                        <Typography
-                                                            level="body3"
-                                                            semiBold
+                                                        <Stack
+                                                            spacing={0.5}
+                                                            alignItems="center"
                                                             className="shrink-0"
                                                         >
-                                                            Obavezno
-                                                        </Typography>
-                                                    </Row>
-                                                </div>
-                                            ),
-                                        )}
-                                        {preferencesQuery.isPending ? (
-                                            <Typography level="body2" secondary>
-                                                Postavke se učitavaju.
-                                            </Typography>
-                                        ) : preferencesQuery.isError ? (
-                                            <Typography level="body2" secondary>
-                                                Postavke obavijesti nisu
-                                                učitane.
-                                            </Typography>
-                                        ) : (
-                                            categoryPreferences.map((item) => {
-                                                const preference =
-                                                    findPreference(item);
-                                                const checked =
-                                                    preference?.enabled ??
-                                                    item.defaultEnabled;
-                                                return (
-                                                    <div
-                                                        key={item.category}
-                                                        className="rounded border border-border/60 p-2"
-                                                    >
-                                                        <Row
-                                                            justifyContent="space-between"
-                                                            alignItems="start"
-                                                            spacing={4}
-                                                        >
-                                                            <Stack
-                                                                spacing={0.5}
+                                                            <Switch
+                                                                aria-label={`Obavezna obavijest ${item.label.toLowerCase()}`}
+                                                                checked
+                                                                readOnly
+                                                            />
+                                                            <Typography
+                                                                level="body3"
+                                                                secondary
                                                             >
-                                                                <Typography
-                                                                    semiBold
-                                                                >
-                                                                    {item.label}
-                                                                </Typography>
-                                                                <Typography
-                                                                    level="body3"
-                                                                    secondary
-                                                                >
-                                                                    {
-                                                                        item.description
+                                                                Obavezno
+                                                            </Typography>
+                                                        </Stack>
+                                                    </Row>
+                                                ),
+                                            )}
+                                            {preferencesQuery.isPending ? (
+                                                <Typography
+                                                    level="body2"
+                                                    secondary
+                                                >
+                                                    Postavke se učitavaju.
+                                                </Typography>
+                                            ) : preferencesQuery.isError ? (
+                                                <Typography
+                                                    level="body2"
+                                                    secondary
+                                                >
+                                                    Postavke obavijesti nisu
+                                                    učitane.
+                                                </Typography>
+                                            ) : (
+                                                categoryPreferences.map(
+                                                    (item) => {
+                                                        const preference =
+                                                            findPreference(
+                                                                item,
+                                                            );
+                                                        const checked =
+                                                            preference?.enabled ??
+                                                            item.defaultEnabled;
+                                                        return (
+                                                            <Row
+                                                                key={
+                                                                    item.category
+                                                                }
+                                                                justifyContent="space-between"
+                                                                alignItems="start"
+                                                                spacing={4}
+                                                                className="py-2"
+                                                            >
+                                                                <Stack
+                                                                    spacing={
+                                                                        0.5
                                                                     }
-                                                                </Typography>
-                                                            </Stack>
-                                                            <Checkbox
-                                                                aria-label={`Uključi ${item.label.toLowerCase()}`}
-                                                                checked={
-                                                                    checked
-                                                                }
-                                                                disabled={
-                                                                    settingsBusy
-                                                                }
-                                                                onCheckedChange={(
-                                                                    checked: boolean,
-                                                                ) =>
-                                                                    savePreferencesMutation.mutate(
-                                                                        [
-                                                                            buildPreferenceUpdate(
-                                                                                item,
-                                                                                Boolean(
+                                                                    className="min-w-0 flex-1"
+                                                                >
+                                                                    <Typography
+                                                                        semiBold
+                                                                    >
+                                                                        {
+                                                                            item.label
+                                                                        }
+                                                                    </Typography>
+                                                                    <Typography
+                                                                        level="body3"
+                                                                        secondary
+                                                                    >
+                                                                        {
+                                                                            item.description
+                                                                        }
+                                                                    </Typography>
+                                                                </Stack>
+                                                                <Switch
+                                                                    aria-label={`${
+                                                                        checked
+                                                                            ? 'Isključi'
+                                                                            : 'Uključi'
+                                                                    } ${item.label.toLowerCase()}`}
+                                                                    checked={
+                                                                        checked
+                                                                    }
+                                                                    disabled={
+                                                                        settingsBusy
+                                                                    }
+                                                                    onCheckedChange={(
+                                                                        checked,
+                                                                    ) =>
+                                                                        savePreferencesMutation.mutate(
+                                                                            [
+                                                                                buildPreferenceUpdate(
+                                                                                    item,
                                                                                     checked,
                                                                                 ),
-                                                                            ),
-                                                                        ],
-                                                                    )
-                                                                }
-                                                            />
-                                                        </Row>
-                                                    </div>
-                                                );
-                                            })
-                                        )}
+                                                                            ],
+                                                                        )
+                                                                    }
+                                                                />
+                                                            </Row>
+                                                        );
+                                                    },
+                                                )
+                                            )}
+                                        </Stack>
                                         {savePreferencesMutation.isError && (
                                             <Typography level="body3" secondary>
                                                 Postavke obavijesti nisu
@@ -787,118 +802,149 @@ export function NotificationsTab({
 
                                 <Card className="bg-card p-2">
                                     <Stack spacing={2}>
-                                        <Checkbox
-                                            label="Ne ometaj"
-                                            checked={quietHoursEnabled}
-                                            disabled={settingsBusy}
-                                            onCheckedChange={(
-                                                checked: boolean,
-                                            ) => {
-                                                const enabled =
-                                                    Boolean(checked);
-                                                setQuietHoursEnabled(enabled);
-                                                saveAllPreferenceSettings({
-                                                    quietEnabled: enabled,
-                                                });
-                                            }}
-                                        />
-                                        {quietHoursEnabled && (
-                                            <>
-                                                <Typography
-                                                    level="body3"
-                                                    secondary
-                                                >
-                                                    Vrijedi samo za
-                                                    prilagodljive obavijesti
-                                                    koje podržavaju tihi period.
+                                        <Row
+                                            justifyContent="space-between"
+                                            alignItems="start"
+                                            spacing={4}
+                                        >
+                                            <Stack
+                                                spacing={0.5}
+                                                className="min-w-0 flex-1"
+                                            >
+                                                <Typography semiBold>
+                                                    Ne ometaj
                                                 </Typography>
-                                                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                                                    <Input
-                                                        label="Od"
-                                                        type="time"
-                                                        value={minuteToTimeValue(
-                                                            quietHoursStartMinute,
-                                                        )}
-                                                        disabled={settingsBusy}
-                                                        onChange={(event) => {
-                                                            const minute =
-                                                                timeValueToMinute(
-                                                                    event.target
-                                                                        .value,
-                                                                );
-                                                            if (
-                                                                minute === null
-                                                            ) {
-                                                                return;
-                                                            }
-                                                            setQuietHoursStartMinute(
-                                                                minute,
+                                                {quietHoursEnabled ? (
+                                                    <Typography
+                                                        level="body3"
+                                                        secondary
+                                                    >
+                                                        Vrijedi samo za
+                                                        prilagodljive obavijesti
+                                                        koje podržavaju tihi
+                                                        period.
+                                                    </Typography>
+                                                ) : null}
+                                            </Stack>
+                                            <Switch
+                                                aria-label={
+                                                    quietHoursEnabled
+                                                        ? 'Isključi ne ometaj'
+                                                        : 'Uključi ne ometaj'
+                                                }
+                                                checked={quietHoursEnabled}
+                                                disabled={settingsBusy}
+                                                onCheckedChange={(checked) => {
+                                                    setQuietHoursEnabled(
+                                                        checked,
+                                                    );
+                                                    saveAllPreferenceSettings({
+                                                        quietEnabled: checked,
+                                                    });
+                                                }}
+                                            />
+                                        </Row>
+                                        {quietHoursEnabled && (
+                                            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                                                <Input
+                                                    label="Od"
+                                                    type="time"
+                                                    value={minuteToTimeValue(
+                                                        quietHoursStartMinute,
+                                                    )}
+                                                    disabled={settingsBusy}
+                                                    onChange={(event) => {
+                                                        const minute =
+                                                            timeValueToMinute(
+                                                                event.target
+                                                                    .value,
                                                             );
-                                                            saveAllPreferenceSettings(
-                                                                {
-                                                                    quietStart:
-                                                                        minute,
-                                                                },
+                                                        if (minute === null) {
+                                                            return;
+                                                        }
+                                                        setQuietHoursStartMinute(
+                                                            minute,
+                                                        );
+                                                        saveAllPreferenceSettings(
+                                                            {
+                                                                quietStart:
+                                                                    minute,
+                                                            },
+                                                        );
+                                                    }}
+                                                />
+                                                <Input
+                                                    label="Do"
+                                                    type="time"
+                                                    value={minuteToTimeValue(
+                                                        quietHoursEndMinute,
+                                                    )}
+                                                    disabled={settingsBusy}
+                                                    onChange={(event) => {
+                                                        const minute =
+                                                            timeValueToMinute(
+                                                                event.target
+                                                                    .value,
                                                             );
-                                                        }}
-                                                    />
-                                                    <Input
-                                                        label="Do"
-                                                        type="time"
-                                                        value={minuteToTimeValue(
-                                                            quietHoursEndMinute,
-                                                        )}
-                                                        disabled={settingsBusy}
-                                                        onChange={(event) => {
-                                                            const minute =
-                                                                timeValueToMinute(
-                                                                    event.target
-                                                                        .value,
-                                                                );
-                                                            if (
-                                                                minute === null
-                                                            ) {
-                                                                return;
-                                                            }
-                                                            setQuietHoursEndMinute(
-                                                                minute,
-                                                            );
-                                                            saveAllPreferenceSettings(
-                                                                {
-                                                                    quietEnd:
-                                                                        minute,
-                                                                },
-                                                            );
-                                                        }}
-                                                    />
-                                                </div>
-                                            </>
+                                                        if (minute === null) {
+                                                            return;
+                                                        }
+                                                        setQuietHoursEndMinute(
+                                                            minute,
+                                                        );
+                                                        saveAllPreferenceSettings(
+                                                            {
+                                                                quietEnd:
+                                                                    minute,
+                                                            },
+                                                        );
+                                                    }}
+                                                />
+                                            </div>
                                         )}
                                     </Stack>
                                 </Card>
 
                                 <Card className="bg-card p-2">
                                     <Stack spacing={2}>
-                                        <Checkbox
-                                            label="Primaj sažetak obavijesti"
-                                            checked={digestEnabled}
-                                            disabled={settingsBusy}
-                                            onCheckedChange={(
-                                                checked: boolean,
-                                            ) => {
-                                                const enabled =
-                                                    Boolean(checked);
-                                                setDigestEnabled(enabled);
-                                                saveAllPreferenceSettings({
-                                                    summaryEnabled: enabled,
-                                                });
-                                            }}
-                                        />
-                                        <Typography level="body3" secondary>
-                                            Sažetak vrijedi za prilagodljive
-                                            kategorije; obavezne poruke ne
-                                            čekaju sažetak.
-                                        </Typography>
+                                        <Row
+                                            justifyContent="space-between"
+                                            alignItems="start"
+                                            spacing={4}
+                                        >
+                                            <Stack
+                                                spacing={0.5}
+                                                className="min-w-0 flex-1"
+                                            >
+                                                <Typography semiBold>
+                                                    Primaj sažetak obavijesti
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    secondary
+                                                >
+                                                    Sažetak vrijedi za
+                                                    prilagodljive kategorije;
+                                                    obavezne poruke ne čekaju
+                                                    sažetak.
+                                                </Typography>
+                                            </Stack>
+                                            <Switch
+                                                aria-label={
+                                                    digestEnabled
+                                                        ? 'Isključi primanje sažetka obavijesti'
+                                                        : 'Uključi primanje sažetka obavijesti'
+                                                }
+                                                checked={digestEnabled}
+                                                disabled={settingsBusy}
+                                                onCheckedChange={(checked) => {
+                                                    setDigestEnabled(checked);
+                                                    saveAllPreferenceSettings({
+                                                        summaryEnabled: checked,
+                                                    });
+                                                }}
+                                            />
+                                        </Row>
                                         {digestEnabled && (
                                             <Stack spacing={1}>
                                                 <Typography
@@ -1014,25 +1060,17 @@ export function NotificationsTab({
                                                             : 'Isključeno'}
                                                     </Typography>
                                                 </Stack>
-                                                <button
-                                                    aria-checked={
-                                                        device.enabled
-                                                    }
+                                                <Switch
                                                     aria-label={`${
                                                         device.enabled
                                                             ? 'Isključi'
                                                             : 'Uključi'
                                                     } ${label}`}
-                                                    className={cx(
-                                                        'relative h-6 w-11 shrink-0 rounded-full border transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-                                                        device.enabled
-                                                            ? 'border-primary bg-primary'
-                                                            : 'border-border bg-muted',
-                                                    )}
+                                                    checked={device.enabled}
                                                     disabled={
                                                         deviceMutationBusy
                                                     }
-                                                    onClick={() =>
+                                                    onCheckedChange={() =>
                                                         updateDeviceMutation.mutate(
                                                             {
                                                                 id: device.id,
@@ -1043,18 +1081,7 @@ export function NotificationsTab({
                                                             },
                                                         )
                                                     }
-                                                    role="switch"
-                                                    type="button"
-                                                >
-                                                    <span
-                                                        className={cx(
-                                                            'absolute top-0.5 size-5 rounded-full bg-background shadow-xs transition-transform',
-                                                            device.enabled
-                                                                ? 'translate-x-[1.25rem]'
-                                                                : 'translate-x-0.5',
-                                                        )}
-                                                    />
-                                                </button>
+                                                />
                                             </div>
                                         );
                                     })

--- a/packages/game/src/modals/components/WhatsNewNotificationToggle.tsx
+++ b/packages/game/src/modals/components/WhatsNewNotificationToggle.tsx
@@ -21,7 +21,7 @@ export function WhatsNewNotificationToggle() {
                 className="gap-4"
                 justifyContent="space-between"
             >
-                <Stack spacing={0.5}>
+                <Stack spacing={0.5} className="min-w-0 flex-1">
                     <Typography level="body1" semiBold>
                         Što je novo u vrtu
                     </Typography>

--- a/packages/ui/src/Switch/Switch.tsx
+++ b/packages/ui/src/Switch/Switch.tsx
@@ -8,12 +8,12 @@ type SwitchSize = 'sm' | 'md';
 
 const switchSizeClassNames = {
     sm: {
-        root: 'h-5 w-9',
-        thumb: 'size-4 data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0.5',
+        root: 'h-5 w-9 min-w-9',
+        thumb: 'size-4 data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
     },
     md: {
-        root: 'h-6 w-11',
-        thumb: 'size-5 data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0.5',
+        root: 'h-6 w-11 min-w-11',
+        thumb: 'size-5 data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0',
     },
 } satisfies Record<SwitchSize, { root: string; thumb: string }>;
 
@@ -79,7 +79,7 @@ export function Switch({
             aria-checked={isChecked}
             aria-readonly={readOnly || undefined}
             className={cx(
-                'peer inline-flex shrink-0 cursor-pointer items-center rounded-full border border-border bg-muted/70 ring-offset-background transition-colors hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 data-[readonly]:cursor-default data-[state=checked]:border-primary/60 data-[state=checked]:bg-primary data-[state=checked]:hover:bg-primary/90',
+                'peer relative inline-flex shrink-0 cursor-pointer items-center overflow-hidden rounded-full border border-border bg-muted/70 p-0 ring-offset-background transition-colors hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 data-[readonly]:cursor-default data-[state=checked]:border-primary/60 data-[state=checked]:bg-primary data-[state=checked]:hover:bg-primary/90',
                 switchSizeClassNames[size].root,
                 className,
             )}
@@ -94,7 +94,7 @@ export function Switch({
             <span
                 data-state={state}
                 className={cx(
-                    'pointer-events-none block rounded-full border border-border/70 bg-background shadow-xs ring-0 transition-transform data-[state=checked]:border-primary-foreground/20 data-[state=checked]:bg-primary-foreground',
+                    'pointer-events-none absolute left-0.5 top-1/2 block -translate-y-1/2 rounded-full border border-border/70 bg-background shadow-xs ring-0 transition-transform data-[state=checked]:border-primary-foreground/20 data-[state=checked]:bg-primary-foreground',
                     switchSizeClassNames[size].thumb,
                 )}
             />


### PR DESCRIPTION
## Summary
- harden the shared `Switch` primitive so its thumb stays anchored inside the track in tight rows
- replace notification settings checkboxes and custom switch markup with the shared switch
- flatten notification category rows by removing item borders and keep quiet-hours/summary details conditional

## Root cause
The notification tab mixed the shared `Switch` with copied custom switch markup. The copied version did not anchor the thumb robustly, and tight rows could make the control look broken.

## Validation
- `corepack pnpm lint --filter @gredice/ui --filter @gredice/game --filter garden --filter storybook`
- `corepack pnpm typecheck --filter @gredice/ui --filter @gredice/game --filter garden --filter storybook`
- `corepack pnpm --filter garden run test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/notifications-tab.spec.tsx`
- Storybook browser check: Switch / In Constrained Row
- `git diff --check`