### PR TITLE
[codex] Update inventory PDF layout

### DIFF
--- a/apps/app/app/admin/inventory/[inventoryId]/inventoryPrintoutPdf.ts
+++ b/apps/app/app/admin/inventory/[inventoryId]/inventoryPrintoutPdf.ts
@@ -10,7 +10,7 @@ export type InventoryPrintoutPdfItem = {
     label: string;
     details: string[];
     quantity: number;
-    currentStatus: string;
+    notes: string | null;
 };
 
 export type InventoryPrintoutPdfData = {
@@ -30,6 +30,7 @@ type PdfColor = {
 
 const colors = {
     brand: { r: 0.18, g: 0.44, b: 0.25 },
+    iconBackground: { r: 0.07, g: 0.07, b: 0.07 },
     text: { r: 0.09, g: 0.1, b: 0.12 },
     muted: { r: 0.42, g: 0.45, b: 0.5 },
     lightText: { r: 0.3, g: 0.34, b: 0.38 },
@@ -40,8 +41,8 @@ const colors = {
     white: { r: 1, g: 1, b: 1 },
 };
 
-const pageWidth = 841.89;
-const pageHeight = 595.28;
+const pageWidth = 595.28;
+const pageHeight = 841.89;
 const margin = 36;
 const footerY = 18;
 const footerLineY = 34;
@@ -57,11 +58,31 @@ const detailLineHeight = 9;
 const bodyLineHeight = 11;
 
 const columns = [
-    { key: 'number', label: '#', width: 34 },
-    { key: 'item', label: 'Stavka i detalji', width: 370 },
-    { key: 'quantity', label: 'Trenutno', width: 90 },
-    { key: 'currentStatus', label: 'Status', width: 128 },
-    { key: 'newStatus', label: 'Novo stanje', width: 148 },
+    { key: 'number', label: '#', width: 28 },
+    { key: 'item', label: 'Stavka i detalji', width: 232 },
+    { key: 'quantity', label: 'Trenutno', width: 60 },
+    { key: 'notes', label: 'Biljeska', width: 115 },
+    { key: 'newStatus', label: 'Novo stanje', width: 88 },
+] as const;
+
+const logoMarkPaths = [
+    '0 19 m 0 18.448 0.264 18 0.591 18 c 29.41 18 l 29.736 18 30 18.448 30 19 c 30 19.552 29.736 20 29.41 20 c 0.591 20 l 0.264 20 0 19.552 0 19 c h',
+    '0 24 m 0 23.448 0.264 23 0.591 23 c 29.41 23 l 29.736 23 30 23.448 30 24 c 30 24.552 29.736 25 29.41 25 c 0.591 25 l 0.264 25 0 24.552 0 24 c h',
+    '0 29 m 0 28.448 0.264 28 0.591 28 c 29.41 28 l 29.736 28 30 28.448 30 29 c 30 29.552 29.736 30 29.41 30 c 0.591 30 l 0.264 30 0 29.552 0 29 c h',
+    '6.914 6.986 m 6.914 18.47 l 5.742 18.47 l 5.742 6.986 l 6.914 6.986 l h',
+    '6.226 1 m 6.707 1.468 l 7.195 1.941 7.571 2.361 7.81 2.819 c 8.061 3.301 8.14 3.783 8.115 4.346 c 8.114 4.374 l 8.11 4.401 l 8.038 4.915 7.947 5.371 7.733 5.83 c 7.519 6.291 7.199 6.717 6.722 7.215 c 6.305 7.65 l 5.882 7.221 l 5.431 6.764 5.117 6.35 4.913 5.877 c 4.711 5.405 4.639 4.92 4.601 4.359 c 4.599 4.326 l 4.6 4.293 l 4.646 3.283 5.036 2.613 5.827 1.54 c 6.226 1 l h 6.368 2.803 m 5.937 3.446 5.8 3.82 5.773 4.314 c 5.807 4.807 5.868 5.13 5.99 5.415 c 6.06 5.577 6.156 5.742 6.297 5.926 c 6.47 5.706 6.586 5.517 6.671 5.336 c 6.808 5.042 6.879 4.731 6.945 4.266 c 6.96 3.875 6.903 3.614 6.771 3.361 c 6.684 3.193 6.556 3.015 6.368 2.803 c h',
+    '1.592 5.524 m 1.617 6.194 l 1.643 6.874 1.703 7.434 1.884 7.918 c 2.074 8.427 2.379 8.809 2.815 9.167 c 2.836 9.184 l 2.859 9.199 l 3.289 9.49 3.688 9.727 4.173 9.876 c 4.658 10.025 5.189 10.073 5.879 10.051 c 6.481 10.032 l 6.445 9.431 l 6.408 8.79 6.31 8.279 6.094 7.812 c 5.879 7.346 5.567 6.967 5.175 6.564 c 5.152 6.54 l 5.127 6.519 l 4.345 5.877 3.587 5.719 2.26 5.589 c 1.592 5.524 l h 2.836 6.836 m 3.603 6.946 3.973 7.094 4.358 7.405 c 4.702 7.76 4.901 8.022 5.03 8.303 c 5.105 8.463 5.162 8.645 5.205 8.873 c 4.926 8.855 4.708 8.814 4.517 8.756 c 4.206 8.661 3.927 8.506 3.538 8.244 c 3.238 7.993 3.082 7.776 2.982 7.509 c 2.916 7.332 2.869 7.118 2.836 6.836 c h',
+    '10.436 8.51 m 10.469 9.181 l 10.503 9.86 10.492 10.423 10.354 10.921 c 10.209 11.445 9.938 11.852 9.535 12.246 c 9.516 12.265 l 9.494 12.282 l 9.091 12.61 8.714 12.881 8.244 13.071 c 7.774 13.262 7.249 13.356 6.56 13.394 c 5.959 13.428 l 5.942 12.826 l 5.923 12.184 5.976 11.667 6.15 11.182 c 6.324 10.699 6.602 10.295 6.957 9.859 c 6.978 9.833 l 7.001 9.81 l 7.724 9.103 8.466 8.879 9.776 8.634 c 10.436 8.51 l h 9.311 9.926 m 8.556 10.102 8.201 10.282 7.844 10.625 c 7.533 11.01 7.358 11.287 7.253 11.579 c 7.193 11.745 7.151 11.931 7.129 12.162 c 7.405 12.119 7.619 12.06 7.804 11.985 c 8.105 11.863 8.369 11.684 8.735 11.39 c 9.012 11.114 9.148 10.884 9.225 10.609 c 9.275 10.427 9.303 10.21 9.311 9.926 c h',
+    '0.585 14.028 m 0.881 14.631 l 1.181 15.241 1.464 15.729 1.826 16.097 c 2.206 16.485 2.64 16.709 3.184 16.859 c 3.21 16.866 l 3.237 16.871 l 3.749 16.962 4.21 17.016 4.713 16.955 c 5.217 16.893 5.722 16.721 6.343 16.421 c 6.885 16.159 l 6.608 15.624 l 6.313 15.054 6.016 14.627 5.629 14.287 c 5.243 13.949 4.804 13.73 4.281 13.521 c 4.251 13.509 l 4.219 13.5 l 3.244 13.232 2.487 13.396 1.222 13.816 c 0.585 14.028 l h 2.255 14.721 m 3.001 14.509 3.399 14.495 3.877 14.622 c 4.336 14.807 4.624 14.965 4.857 15.169 c 4.99 15.285 5.116 15.428 5.248 15.619 c 4.985 15.715 4.77 15.767 4.571 15.791 c 4.249 15.831 3.931 15.803 3.469 15.722 c 3.093 15.615 2.862 15.481 2.662 15.277 c 2.53 15.142 2.4 14.966 2.255 14.721 c h',
+    '26.426 6.986 m 26.426 18.47 l 25.254 18.47 l 25.254 6.986 l 26.426 6.986 l h',
+    '25.738 1 m 26.219 1.468 l 26.706 1.941 27.083 2.361 27.322 2.819 c 27.573 3.301 27.652 3.783 27.627 4.346 c 27.625 4.374 l 27.621 4.401 l 27.549 4.915 27.459 5.371 27.245 5.83 c 27.031 6.291 26.711 6.717 26.234 7.215 c 25.817 7.65 l 25.394 7.221 l 24.942 6.764 24.628 6.35 24.425 5.877 c 24.223 5.405 24.15 4.92 24.113 4.359 c 24.111 4.326 l 24.112 4.293 l 24.158 3.283 24.548 2.613 25.339 1.54 c 25.738 1 l h 25.88 2.803 m 25.448 3.446 25.312 3.82 25.284 4.314 c 25.319 4.807 25.38 5.13 25.502 5.415 c 25.572 5.577 25.668 5.742 25.809 5.926 c 25.982 5.706 26.098 5.517 26.182 5.336 c 26.319 5.042 26.391 4.731 26.457 4.266 c 26.472 3.875 26.415 3.614 26.283 3.361 c 26.195 3.193 26.068 3.015 25.88 2.803 c h',
+    '21.104 5.524 m 21.129 6.194 l 21.155 6.874 21.215 7.434 21.396 7.918 c 21.585 8.427 21.891 8.809 22.327 9.167 c 22.348 9.184 l 22.371 9.199 l 22.801 9.49 23.2 9.727 23.685 9.876 c 24.17 10.025 24.701 10.073 25.391 10.051 c 25.993 10.032 l 25.957 9.431 l 25.92 8.79 25.822 8.279 25.606 7.812 c 25.391 7.346 25.079 6.967 24.687 6.564 c 24.664 6.54 l 24.639 6.519 l 23.857 5.877 23.099 5.719 21.772 5.589 c 21.104 5.524 l h 22.348 6.836 m 23.115 6.946 23.485 7.094 23.87 7.405 c 24.213 7.76 24.413 8.022 24.542 8.303 c 24.616 8.463 24.674 8.645 24.717 8.873 c 24.438 8.855 24.22 8.814 24.029 8.756 c 23.718 8.661 23.439 8.506 23.05 8.244 c 22.75 7.993 22.593 7.776 22.494 7.509 c 22.427 7.332 22.381 7.118 22.348 6.836 c h',
+    '29.948 8.51 m 29.981 9.181 l 30.015 9.86 30.003 10.423 29.866 10.921 c 29.721 11.445 29.45 11.852 29.047 12.246 c 29.027 12.265 l 29.006 12.282 l 28.602 12.61 28.226 12.881 27.756 13.071 c 27.285 13.262 26.76 13.356 26.072 13.394 c 25.47 13.428 l 25.453 12.826 l 25.435 12.184 25.488 11.667 25.662 11.182 c 25.835 10.699 26.113 10.295 26.469 9.859 c 26.49 9.833 l 26.513 9.81 l 27.236 9.103 27.978 8.879 29.288 8.634 c 29.948 8.51 l h 28.823 9.926 m 28.068 10.102 27.713 10.282 27.356 10.625 c 27.045 11.01 26.869 11.287 26.765 11.579 c 26.705 11.745 26.663 11.931 26.64 12.162 c 26.917 12.119 27.131 12.06 27.316 11.985 c 27.617 11.863 27.881 11.684 28.246 11.39 c 28.524 11.114 28.66 10.884 28.736 10.609 c 28.787 10.427 28.815 10.21 28.823 9.926 c h',
+    '20.097 14.028 m 20.393 14.631 l 20.692 15.241 20.976 15.729 21.337 16.097 c 21.718 16.485 22.152 16.709 22.695 16.859 c 22.722 16.866 l 22.749 16.871 l 23.261 16.962 23.722 17.016 24.225 16.955 c 24.729 16.893 25.234 16.721 25.855 16.421 c 26.397 16.159 l 26.12 15.624 l 25.825 15.054 25.528 14.627 25.14 14.287 c 24.755 13.949 24.315 13.73 23.793 13.521 c 23.763 13.509 l 23.731 13.5 l 22.756 13.232 21.998 13.396 20.734 13.816 c 20.097 14.028 l h 21.767 14.721 m 22.513 14.509 22.91 14.495 23.389 14.622 c 23.847 14.807 24.135 14.965 24.368 15.169 c 24.501 15.285 24.628 15.428 24.76 15.619 c 24.497 15.715 24.282 15.767 24.083 15.791 c 23.761 15.831 23.443 15.803 22.981 15.722 c 22.605 15.615 22.374 15.481 22.174 15.277 c 22.041 15.142 21.912 14.966 21.767 14.721 c h',
+    '15.943 9.97 m 15.943 18.47 l 14.771 18.47 l 14.771 9.97 l 15.943 9.97 l h',
+    '15.249 4.164 m 15.73 4.632 l 16.218 5.105 16.595 5.525 16.833 5.983 c 17.084 6.465 17.163 6.947 17.138 7.51 c 17.137 7.538 l 17.133 7.565 l 17.061 8.079 16.97 8.535 16.756 8.995 c 16.542 9.455 16.223 9.882 15.745 10.379 c 15.328 10.814 l 14.905 10.385 l 14.454 9.928 14.14 9.514 13.937 9.041 c 13.734 8.57 13.662 8.084 13.624 7.523 c 13.622 7.49 l 13.624 7.457 l 13.669 6.447 14.059 5.777 14.851 4.704 c 15.249 4.164 l h 15.392 5.967 m 14.96 6.61 14.823 6.984 14.796 7.478 c 14.831 7.972 14.891 8.294 15.014 8.579 c 15.083 8.741 15.179 8.906 15.32 9.09 c 15.494 8.87 15.61 8.681 15.694 8.5 c 15.831 8.206 15.902 7.895 15.968 7.43 c 15.983 7.039 15.926 6.778 15.794 6.525 c 15.707 6.357 15.579 6.179 15.392 5.967 c h',
+    '10.361 10.036 m 10.445 10.702 l 10.529 11.376 10.638 11.929 10.86 12.396 c 11.094 12.886 11.431 13.24 11.896 13.558 c 11.919 13.574 l 11.943 13.587 l 12.398 13.839 12.816 14.041 13.312 14.147 c 13.808 14.252 14.341 14.254 15.026 14.172 c 15.624 14.101 l 15.537 13.505 l 15.443 12.87 15.301 12.37 15.046 11.922 c 14.791 11.477 14.447 11.127 14.021 10.759 c 13.996 10.738 l 13.969 10.719 l 13.135 10.148 12.365 10.056 11.032 10.043 c 10.361 10.036 l h 11.715 11.235 m 12.489 11.277 12.869 11.393 13.28 11.668 c 13.654 11.993 13.875 12.236 14.028 12.505 c 14.116 12.658 14.19 12.834 14.252 13.057 c 13.972 13.063 13.752 13.042 13.556 13.001 c 13.239 12.933 12.947 12.803 12.537 12.576 c 12.216 12.353 12.041 12.15 11.918 11.892 c 11.837 11.721 11.772 11.512 11.715 11.235 c h',
+    '20.486 13.455 m 20.334 14.108 l 20.179 14.77 20.013 15.309 19.743 15.75 c 19.46 16.213 19.087 16.529 18.591 16.797 c 18.567 16.811 l 18.542 16.821 l 18.063 17.025 17.627 17.181 17.122 17.235 c 16.617 17.288 16.087 17.234 15.414 17.081 c 14.827 16.948 l 14.976 16.364 l 15.136 15.742 15.329 15.26 15.63 14.842 c 15.93 14.426 16.309 14.113 16.771 13.792 c 16.798 13.773 l 16.827 13.758 l 17.716 13.277 18.491 13.266 19.818 13.392 c 20.486 13.455 l h 19.015 14.506 m 18.241 14.467 17.85 14.542 17.412 14.774 c 17.007 15.057 16.762 15.276 16.581 15.527 c 16.477 15.671 16.386 15.838 16.301 16.053 c 16.578 16.088 16.8 16.091 16.999 16.07 c 17.322 16.035 17.625 15.936 18.057 15.754 c 18.4 15.565 18.594 15.382 18.744 15.138 c 18.842 14.977 18.929 14.776 19.015 14.506 c h',
 ] as const;
 
 const croatianReplacements: Record<string, string> = {
@@ -159,6 +180,87 @@ class PdfCanvas {
         );
     }
 
+    path({
+        commands,
+        color,
+        transform,
+    }: {
+        commands: string;
+        color: PdfColor;
+        transform?: PdfTransform;
+    }) {
+        const transformOperation = transform
+            ? `${formatNumber(transform.a)} ${formatNumber(
+                  transform.b,
+              )} ${formatNumber(transform.c)} ${formatNumber(
+                  transform.d,
+              )} ${formatNumber(transform.e)} ${formatNumber(transform.f)} cm`
+            : null;
+        this.operations.push(
+            [
+                'q',
+                `${formatColor(color)} rg`,
+                transformOperation,
+                commands,
+                'f',
+                'Q',
+            ]
+                .filter((operation): operation is string => operation !== null)
+                .join(' '),
+        );
+    }
+
+    fillRoundedRect({
+        x,
+        y,
+        width,
+        height,
+        radius,
+        color,
+    }: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+        radius: number;
+        color: PdfColor;
+    }) {
+        const right = x + width;
+        const top = y + height;
+        const curve = radius * 0.5522847498;
+        this.path({
+            commands: [
+                `${formatNumber(x + radius)} ${formatNumber(y)} m`,
+                `${formatNumber(right - radius)} ${formatNumber(y)} l`,
+                `${formatNumber(right - radius + curve)} ${formatNumber(
+                    y,
+                )} ${formatNumber(right)} ${formatNumber(
+                    y + radius - curve,
+                )} ${formatNumber(right)} ${formatNumber(y + radius)} c`,
+                `${formatNumber(right)} ${formatNumber(top - radius)} l`,
+                `${formatNumber(right)} ${formatNumber(
+                    top - radius + curve,
+                )} ${formatNumber(right - radius + curve)} ${formatNumber(
+                    top,
+                )} ${formatNumber(right - radius)} ${formatNumber(top)} c`,
+                `${formatNumber(x + radius)} ${formatNumber(top)} l`,
+                `${formatNumber(x + radius - curve)} ${formatNumber(
+                    top,
+                )} ${formatNumber(x)} ${formatNumber(
+                    top - radius + curve,
+                )} ${formatNumber(x)} ${formatNumber(top - radius)} c`,
+                `${formatNumber(x)} ${formatNumber(y + radius)} l`,
+                `${formatNumber(x)} ${formatNumber(
+                    y + radius - curve,
+                )} ${formatNumber(x + radius - curve)} ${formatNumber(
+                    y,
+                )} ${formatNumber(x + radius)} ${formatNumber(y)} c`,
+                'h',
+            ].join(' '),
+            color,
+        });
+    }
+
     toString() {
         return this.operations.join('\n');
     }
@@ -166,10 +268,19 @@ class PdfCanvas {
 
 type TableColumnKey = (typeof columns)[number]['key'];
 
+type PdfTransform = {
+    a: number;
+    b: number;
+    c: number;
+    d: number;
+    e: number;
+    f: number;
+};
+
 type RowLayout = {
     labelLines: string[];
     detailLines: string[];
-    statusLines: string[];
+    noteLines: string[];
     height: number;
 };
 
@@ -183,6 +294,13 @@ export function generateInventoryPrintoutPdf(
     function startPage() {
         page = new PdfCanvas();
         pages.push(page);
+        page.fillRect({
+            x: 0,
+            y: 0,
+            width: pageWidth,
+            height: pageHeight,
+            color: colors.white,
+        });
         y =
             pages.length === 1
                 ? drawFirstPageHeader(page, data)
@@ -267,26 +385,33 @@ function drawFirstPageHeader(page: PdfCanvas, data: InventoryPrintoutPdfData) {
         page,
         metaX,
         pageHeight - margin - 56,
+        'Inventuru obavio/la',
+        '____________________',
+    );
+    drawMetaLabelValue(
+        page,
+        metaX,
+        pageHeight - margin - 78,
         'Stavke / kolicina',
         `${data.summary.totalItems} / ${data.summary.totalQuantity}`,
     );
     drawMetaLabelValue(
         page,
         metaX,
-        pageHeight - margin - 78,
+        pageHeight - margin - 100,
         'Prazno / nisko / uredno',
         `${data.summary.emptyItems} / ${data.summary.lowItems} / ${data.summary.normalItems}`,
     );
 
     page.line({
         x1: margin,
-        y1: pageHeight - margin - 98,
+        y1: pageHeight - margin - 120,
         x2: pageWidth - margin,
-        y2: pageHeight - margin - 98,
+        y2: pageHeight - margin - 120,
         color: colors.line,
     });
 
-    return pageHeight - margin - 118;
+    return pageHeight - margin - 140;
 }
 
 function drawContinuationHeader(
@@ -315,32 +440,36 @@ function drawContinuationHeader(
 
 function drawLogo(page: PdfCanvas, x: number, y: number, scale = 1) {
     const markSize = 25 * scale;
-    const barX = x + 5 * scale;
-    const barWidth = 15 * scale;
-    const barHeight = 1.4 * scale;
+    const iconScale = markSize / 30;
 
-    page.fillRect({
+    page.fillRoundedRect({
         x,
         y,
         width: markSize,
         height: markSize,
-        color: colors.brand,
+        radius: 5 * scale,
+        color: colors.iconBackground,
     });
 
-    for (let index = 0; index < 3; index += 1) {
-        page.fillRect({
-            x: barX,
-            y: y + (8 + index * 5) * scale,
-            width: barWidth,
-            height: barHeight,
+    for (const commands of logoMarkPaths) {
+        page.path({
+            commands,
             color: colors.white,
+            transform: {
+                a: iconScale,
+                b: 0,
+                c: 0,
+                d: -iconScale,
+                e: x,
+                f: y + markSize,
+            },
         });
     }
 
     page.text({
         x: x + 35 * scale,
         y: y + 8.2 * scale,
-        value: 'GREDICE',
+        value: 'Gredice',
         size: 12 * scale,
         font: 'F2',
         color: colors.brand,
@@ -429,25 +558,25 @@ function drawEmptyItemsRow(page: PdfCanvas, topY: number) {
 
 function buildRowLayout(item: InventoryPrintoutPdfItem): RowLayout {
     const itemWidth = columnWidth('item') - 12;
-    const statusWidth = columnWidth('currentStatus') - 12;
+    const notesWidth = columnWidth('notes') - 12;
     const labelLines = wrapText(item.label, itemWidth, labelFontSize);
     const detailLines = wrapText(
         item.details.filter(Boolean).join('  |  '),
         itemWidth,
         detailFontSize,
     ).slice(0, 2);
-    const statusLines = wrapText(item.currentStatus, statusWidth, bodyFontSize);
+    const noteLines = wrapText(item.notes ?? '', notesWidth, bodyFontSize);
     const itemHeight =
         rowPaddingY * 2 +
         labelLines.length * labelLineHeight +
         detailLines.length * detailLineHeight;
-    const statusHeight = rowPaddingY * 2 + statusLines.length * bodyLineHeight;
-    const height = Math.max(38, itemHeight, statusHeight);
+    const notesHeight = rowPaddingY * 2 + noteLines.length * bodyLineHeight;
+    const height = Math.max(38, itemHeight, notesHeight);
 
     return {
         labelLines,
         detailLines,
-        statusLines,
+        noteLines,
         height,
     };
 }
@@ -474,7 +603,7 @@ function drawTableRow(
     const numberX = columnX('number') + 6;
     const itemX = columnX('item') + 6;
     const quantityX = columnX('quantity') + 6;
-    const statusX = columnX('currentStatus') + 6;
+    const notesX = columnX('notes') + 6;
     const newStatusX = columnX('newStatus') + 6;
 
     page.text({
@@ -517,9 +646,9 @@ function drawTableRow(
         color: colors.text,
     });
 
-    row.statusLines.forEach((line, lineIndex) => {
+    row.noteLines.forEach((line, lineIndex) => {
         page.text({
-            x: statusX,
+            x: notesX,
             y: rowTop - lineIndex * bodyLineHeight,
             value: line,
             size: bodyFontSize,

--- a/apps/app/app/admin/inventory/[inventoryId]/printout/route.ts
+++ b/apps/app/app/admin/inventory/[inventoryId]/printout/route.ts
@@ -4,16 +4,12 @@ import {
     getInventoryItemsByConfig,
 } from '@gredice/storage';
 import { auth } from '../../../../../lib/auth/auth';
-import { getInventorySelectOptions } from '../../../../../lib/inventoryFieldTypes';
 import {
     generateInventoryPrintoutPdf,
     type InventoryPrintoutPdfItem,
     inventoryPrintoutFilename,
 } from '../inventoryPrintoutPdf';
-import {
-    getInventoryItemState,
-    type InventoryStateFilter,
-} from '../inventoryStatus';
+import { getInventoryItemState } from '../inventoryStatus';
 
 export const dynamic = 'force-dynamic';
 
@@ -43,18 +39,11 @@ export async function GET(
     );
     const printoutItems = items
         .map((item) => {
-            const quantityStatus = inventoryStateLabel(
-                getInventoryItemState(item, config.lowCountThreshold),
-            );
-            const configuredStatus = configuredInventoryStatus(item, config);
-
             return {
                 label: itemLabel(item, config.entityTypeName, entityLabels),
                 details: itemDetails(item, config),
                 quantity: item.quantity,
-                currentStatus: configuredStatus
-                    ? `${configuredStatus} / ${quantityStatus}`
-                    : quantityStatus,
+                notes: item.notes,
             };
         })
         .sort(comparePrintoutItems);
@@ -120,10 +109,12 @@ function comparePrintoutItems(
         return labelComparison;
     }
 
-    return left.currentStatus.localeCompare(right.currentStatus, 'hr-HR', {
-        numeric: true,
-        sensitivity: 'base',
-    });
+    return left.details
+        .join(' ')
+        .localeCompare(right.details.join(' '), 'hr-HR', {
+            numeric: true,
+            sensitivity: 'base',
+        });
 }
 
 function itemLabel(
@@ -139,51 +130,6 @@ function itemLabel(
     }
 
     return `Stavka #${item.id}`;
-}
-
-function configuredInventoryStatus(
-    item: InventoryItem,
-    config: InventoryConfig,
-) {
-    const statusAttributeName = config.statusAttributeName;
-    if (!statusAttributeName) {
-        return null;
-    }
-
-    const value = item.additionalFields?.[statusAttributeName];
-    if (value === null || value === undefined || value === '') {
-        return null;
-    }
-
-    const fieldDefinition = config.fieldDefinitions.find(
-        (field) => field.name === statusAttributeName,
-    );
-
-    return formatAdditionalFieldValue(value, fieldDefinition?.dataType);
-}
-
-function formatAdditionalFieldValue(value: unknown, dataType?: string) {
-    if (typeof value === 'string') {
-        if (dataType) {
-            const option = getInventorySelectOptions(dataType).find(
-                (selectOption) => selectOption.value === value,
-            );
-            return option?.label ?? value;
-        }
-
-        return value;
-    }
-
-    if (typeof value === 'number') {
-        return String(value);
-    }
-
-    if (typeof value === 'boolean') {
-        return value ? 'Da' : 'Ne';
-    }
-
-    const jsonValue = JSON.stringify(value);
-    return jsonValue ?? null;
 }
 
 function itemDetails(item: InventoryItem, config: InventoryConfig) {
@@ -203,10 +149,6 @@ function itemDetails(item: InventoryItem, config: InventoryConfig) {
 
     details.push(`Dodano: ${formatItemDate(item.createdAt)}`);
 
-    if (item.notes) {
-        details.push(`Biljeska: ${item.notes}`);
-    }
-
     return details;
 }
 
@@ -221,17 +163,6 @@ function formatItemDate(date: Date) {
         month: '2-digit',
         day: '2-digit',
     }).format(date);
-}
-
-function inventoryStateLabel(state: InventoryStateFilter) {
-    if (state === 'critical') {
-        return 'Prazno';
-    }
-    if (state === 'warning') {
-        return 'Nisko';
-    }
-
-    return 'Uredno';
 }
 
 function entityDisplayName(entity: InventoryEntity) {

--- a/apps/app/app/admin/inventory/inventoryPrintoutPdf.unit.ts
+++ b/apps/app/app/admin/inventory/inventoryPrintoutPdf.unit.ts
@@ -19,30 +19,41 @@ test('generates an inventory worksheet PDF with printable inventory fields', () 
         items: [
             {
                 label: 'Raj\u010dica cherry',
-                details: ['ID #1', 'Serijski br.: LOT-7', 'Minimum: 4'],
+                details: [
+                    'ID #1',
+                    'Pracenje: komadi',
+                    'Minimum: 4',
+                    'Dodano: 12. 06. 2026.',
+                ],
                 quantity: 13,
-                currentStatus: 'Uredno',
+                notes: 'Paket otvoren',
             },
             {
                 label: 'Bosiljak',
-                details: ['ID #2', 'Pracenje: komadi'],
+                details: ['ID #2', 'Pracenje: komadi', 'Dodano: 12. 06. 2026.'],
                 quantity: 0,
-                currentStatus: 'Prazno',
+                notes: null,
             },
         ],
     });
     const content = new TextDecoder().decode(pdf);
 
     assert.match(content, /^%PDF-1\.4/);
-    assert.match(content, /GREDICE/);
+    assert.match(content, /\/MediaBox \[0 0 595\.28 841\.89\]/);
+    assert.match(content, /Gredice/);
+    assert.doesNotMatch(content, /GREDICE/);
     assert.match(content, /INVENTURNI LIST/);
     assert.match(content, /Sjeme rajcice/);
     assert.match(content, /DATUM ISPISA/);
     assert.match(content, /INVENTURA OBAVLJENA/);
+    assert.match(content, /INVENTURU OBAVIO\/LA/);
     assert.match(content, /STAVKA I DETALJI/);
+    assert.match(content, /BILJESKA/);
     assert.match(content, /NOVO STANJE/);
+    assert.doesNotMatch(content, /STATUS/);
     assert.match(content, /Rajcica cherry/);
-    assert.match(content, /Serijski br.: LOT-7/);
+    assert.match(content, /Pracenje: komadi/);
+    assert.match(content, /Paket otvoren/);
     assert.match(content, /Stranica 1 \/ 1/);
     assert.doesNotMatch(content, /Raj\u010dica/);
 });


### PR DESCRIPTION
## Summary

- Update the app inventory printout PDF to portrait A4 and keep the worksheet table compact for the narrower page.
- Replace the placeholder logo drawing with the app icon vector mark and sentence-case `Gredice` label.
- Move item notes into a dedicated `Biljeska` column, remove the `Status` column, keep item details to ID/tracking/minimum/added metadata, and add an `Inventuru obavio/la` header line.

## Validation

- `corepack pnpm --filter app exec biome check --write 'app/admin/inventory/[inventoryId]/inventoryPrintoutPdf.ts' 'app/admin/inventory/[inventoryId]/printout/route.ts' 'app/admin/inventory/inventoryPrintoutPdf.unit.ts'`
- `corepack pnpm --filter app exec node --import tsx --test 'app/admin/inventory/inventoryPrintoutPdf.unit.ts'`
- `corepack pnpm --filter app run test:unit`
- `git diff --check`
- Rendered a temporary sample PDF to PNG to verify portrait layout and logo treatment.

Note: a direct `tsc --project tsconfig.json` from `apps/app` is currently blocked by existing app-wide type errors outside this PDF change.