### PR TITLE
[codex] Fix notification settings double scroll

### DIFF
--- a/apps/garden/tests/notifications-tab.spec.tsx
+++ b/apps/garden/tests/notifications-tab.spec.tsx
@@ -421,6 +421,37 @@ test('notification settings keeps switch thumbs inside their tracks', async ({
     expect(overflowingSwitches).toEqual([]);
 });
 
+test('notification settings does not add a nested scroll region', async ({
+    mount,
+    page,
+}) => {
+    await mockNotificationSettingsApi(page);
+
+    await mount(<NotificationsTabStory />);
+    await page.getByRole('tab', { name: 'Postavke' }).click();
+
+    await expect(page.getByText('Vrste obavijesti')).toBeVisible();
+
+    const nestedScrollRegions = await page
+        .locator('[role="tabpanel"][data-state="active"]')
+        .evaluate((tabpanel) =>
+            Array.from(tabpanel.querySelectorAll('*'))
+                .filter((element) => {
+                    const style = window.getComputedStyle(element);
+                    return (
+                        style.overflowY === 'auto' ||
+                        style.overflowY === 'scroll'
+                    );
+                })
+                .map((element) => ({
+                    className: element.getAttribute('class'),
+                    tagName: element.tagName.toLowerCase(),
+                })),
+        );
+
+    expect(nestedScrollRegions).toEqual([]);
+});
+
 test('notification settings toggles the what is new widget', async ({
     mount,
     page,

--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -192,7 +192,7 @@ export function OverviewModal() {
                         ))}
                     </List>
                 </Stack>
-                <div className="min-h-0 overflow-y-auto md:pl-6">
+                <div className="min-h-0 overflow-visible md:overflow-y-auto md:pl-6">
                     {settingsMode === 'generalno' && <GeneralTab />}
                     {settingsMode === 'vrt' && <GardenTab />}
                     {settingsMode === 'igra' && <GameTab />}

--- a/packages/game/src/modals/components/NotificationsTab.tsx
+++ b/packages/game/src/modals/components/NotificationsTab.tsx
@@ -575,10 +575,7 @@ export function NotificationsTab({
                     </Stack>
                 </TabsContent>
                 <TabsContent value="settings" className="mt-3 min-h-0">
-                    <Stack
-                        spacing={2}
-                        className="max-h-[calc(100dvh-13rem)] overflow-y-auto pr-1 md:max-h-[calc(90dvh-10rem)]"
-                    >
+                    <Stack spacing={2}>
                         <WhatsNewNotificationToggle />
                         <Card className="bg-card p-2">
                             <Stack spacing={1.5}>


### PR DESCRIPTION
## Summary
- remove the notification settings tab's nested scroll container
- make the overview modal use one scroll owner per breakpoint: outer grid on mobile, content pane on desktop
- add a component regression test that fails if notification settings adds a nested scroll region again

## Validation
- `corepack pnpm lint --filter @gredice/game --filter garden`
- `corepack pnpm typecheck --filter @gredice/game --filter garden`
- `corepack pnpm --filter garden run test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/notifications-tab.spec.tsx`
- `git diff --check`