### PR TITLE
Include payout adjustments in farmer balance totals

### DIFF
--- a/apps/farm/app/payouts/page.tsx
+++ b/apps/farm/app/payouts/page.tsx
@@ -100,6 +100,10 @@ function formatWage(amount: number | null, unit: string) {
     return `${formatPrice(amount)} / ${unit}`;
 }
 
+function formatSignedPrice(amount: number) {
+    return amount > 0 ? `+${formatPrice(amount)}` : formatPrice(amount);
+}
+
 function mergeEarnings(earnings: FarmerEarning[]) {
     const merged = new Map<string, FarmerEarning>();
 
@@ -156,6 +160,7 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
     ]);
 
     const totalEarned = balance.totalEarned;
+    const totalAdjustment = balance.totalAdjustment;
     const totalPaid = balance.totalPaid;
     const totalPending = balance.totalPending;
     const availableBalance = balance.availableBalance;
@@ -361,6 +366,25 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
                                         </Table.Cell>
                                     </Table.Row>
                                 ))}
+                                {totalAdjustment !== 0 && (
+                                    <Table.Row>
+                                        <Table.Cell>
+                                            Korekcije isplata
+                                        </Table.Cell>
+                                        <Table.Cell className="text-right tabular-nums">
+                                            {balance.adjustmentCount}
+                                        </Table.Cell>
+                                        <Table.Cell className="text-right">
+                                            —
+                                        </Table.Cell>
+                                        <Table.Cell className="text-right">
+                                            —
+                                        </Table.Cell>
+                                        <Table.Cell className="text-right tabular-nums font-medium">
+                                            {formatSignedPrice(totalAdjustment)}
+                                        </Table.Cell>
+                                    </Table.Row>
+                                )}
                                 <Table.Row className="bg-muted/40 font-medium hover:bg-muted/40">
                                     <Table.Cell>Ukupno</Table.Cell>
                                     <Table.Cell className="text-right tabular-nums">

--- a/apps/farm/app/payouts/page.tsx
+++ b/apps/farm/app/payouts/page.tsx
@@ -160,6 +160,7 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
     ]);
 
     const totalEarned = balance.totalEarned;
+    const totalOperationEarned = balance.totalOperationEarned;
     const totalAdjustment = balance.totalAdjustment;
     const totalPaid = balance.totalPaid;
     const totalPending = balance.totalPending;
@@ -176,7 +177,9 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
         0,
     );
     const minuteWage =
-        totalDurationMinutes > 0 ? totalEarned / totalDurationMinutes : null;
+        totalDurationMinutes > 0
+            ? totalOperationEarned / totalDurationMinutes
+            : null;
     const hourlyWage = minuteWage === null ? null : minuteWage * 60;
 
     const farmWithBalance = selectedFarm;

--- a/packages/storage/src/repositories/payoutsRepo.ts
+++ b/packages/storage/src/repositories/payoutsRepo.ts
@@ -234,6 +234,9 @@ export type FarmerEarning = {
 
 export type FarmerBalance = {
     totalEarned: number;
+    totalOperationEarned: number;
+    totalAdjustment: number;
+    adjustmentCount: number;
     totalPaid: number;
     totalPending: number;
     availableBalance: number;
@@ -280,6 +283,27 @@ function getAdjustmentTotalCents(
     );
 }
 
+function getActivePayoutAdjustmentTotal(
+    payouts: (SelectFarmerPayoutRequest & {
+        adjustments: Pick<SelectFarmerPayoutRequestAdjustment, 'amount'>[];
+    })[],
+) {
+    return payouts
+        .filter(
+            (payout) =>
+                payout.status === 'pending' || payout.status === 'approved',
+        )
+        .reduce(
+            (result, payout) => ({
+                amountCents:
+                    result.amountCents +
+                    getAdjustmentTotalCents(payout.adjustments),
+                count: result.count + payout.adjustments.length,
+            }),
+            { amountCents: 0, count: 0 },
+        );
+}
+
 function normalizePayoutAdjustments(
     adjustments: readonly PayoutAdjustmentInput[] | undefined,
     currency: string,
@@ -319,7 +343,7 @@ export async function getFarmerBalance(
 ): Promise<FarmerBalance> {
     const [prices, payouts, operationsData] = await Promise.all([
         getOperationPrices(farmId),
-        getFarmPayoutRequests(farmId),
+        getFarmPayoutRequestsWithAdjustments(farmId),
         getEntitiesFormatted<OperationData>('operation'),
     ]);
     const lastPaidPayoutAt = getLastPaidPayoutAt(payouts);
@@ -434,7 +458,7 @@ export async function getFarmerBalance(
         }
     }
 
-    const totalEarned = Array.from(earningsByKey.values()).reduce(
+    const totalOperationEarned = Array.from(earningsByKey.values()).reduce(
         (acc, e) => acc + e.totalEarned,
         0,
     );
@@ -443,21 +467,31 @@ export async function getFarmerBalance(
         0,
     );
 
-    const totalPaid = payouts
+    const totalPaidCents = payouts
         .filter((p) => p.status === 'paid')
-        .reduce((acc, p) => acc + parseFloat(p.requestedAmount), 0);
+        .reduce((acc, p) => acc + moneyToCents(p.requestedAmount), 0);
 
-    const totalPending = payouts
+    const totalPendingCents = payouts
         .filter((p) => p.status === 'pending' || p.status === 'approved')
-        .reduce((acc, p) => acc + parseFloat(p.requestedAmount), 0);
+        .reduce((acc, p) => acc + moneyToCents(p.requestedAmount), 0);
 
-    const availableBalance = Math.max(0, totalEarned - totalPending);
+    const activeAdjustments = getActivePayoutAdjustmentTotal(payouts);
+    const totalOperationEarnedCents = moneyToCents(totalOperationEarned);
+    const totalEarnedCents =
+        totalOperationEarnedCents + activeAdjustments.amountCents;
+    const availableBalanceCents = Math.max(
+        0,
+        totalEarnedCents - totalPendingCents,
+    );
 
     return {
-        totalEarned,
-        totalPaid,
-        totalPending,
-        availableBalance,
+        totalEarned: totalEarnedCents / 100,
+        totalOperationEarned: totalOperationEarnedCents / 100,
+        totalAdjustment: activeAdjustments.amountCents / 100,
+        adjustmentCount: activeAdjustments.count,
+        totalPaid: totalPaidCents / 100,
+        totalPending: totalPendingCents / 100,
+        availableBalance: availableBalanceCents / 100,
         totalDurationMinutes,
         currency,
         earningsByType: Array.from(earningsByKey.values()),
@@ -545,6 +579,24 @@ export async function getFarmPayoutRequests(
     return storage().query.farmerPayoutRequests.findMany({
         where: eq(farmerPayoutRequests.farmId, farmId),
         orderBy: desc(farmerPayoutRequests.createdAt),
+    });
+}
+
+async function getFarmPayoutRequestsWithAdjustments(farmId: number): Promise<
+    (SelectFarmerPayoutRequest & {
+        adjustments: Pick<SelectFarmerPayoutRequestAdjustment, 'amount'>[];
+    })[]
+> {
+    return storage().query.farmerPayoutRequests.findMany({
+        where: eq(farmerPayoutRequests.farmId, farmId),
+        orderBy: desc(farmerPayoutRequests.createdAt),
+        with: {
+            adjustments: {
+                columns: {
+                    amount: true,
+                },
+            },
+        },
     });
 }
 

--- a/packages/storage/tests/payoutsRepo.node.spec.ts
+++ b/packages/storage/tests/payoutsRepo.node.spec.ts
@@ -504,6 +504,84 @@ test('getFarmerBalance counts payable work after the last paid farm payout', asy
     assert.equal(balance.availableBalance, 0.3);
 });
 
+test('getFarmerBalance applies open payout adjustments to payable balance', async () => {
+    createTestDb();
+
+    const userId = randomUUID();
+    const adminUserId = randomUUID();
+    await storage()
+        .insert(users)
+        .values([
+            {
+                id: userId,
+                userName: `payout-balance-adjustment-${userId}@example.com`,
+                displayName: 'Payout Balance Adjustment Farmer',
+                role: 'farmer',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            {
+                id: adminUserId,
+                userName: `payout-balance-adjustment-admin-${adminUserId}@example.com`,
+                displayName: 'Payout Balance Adjustment Admin',
+                role: 'admin',
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+        ]);
+
+    const farmId = await createFarm({
+        name: `Balance Adjustment Payout Farm ${randomUUID()}`,
+        longitude: 0,
+        latitude: 0,
+    });
+    await assignUserToFarm(farmId, userId);
+
+    const operationEntityId = await createPublishedOperationEntity(
+        'Berba za korekciju',
+        30,
+    );
+    await upsertOperationPrice({
+        farmId,
+        entityTypeName: 'operation',
+        entityId: operationEntityId,
+        pricePerUnit: '100.00',
+        currency: 'eur',
+    });
+    await createVerifiedAcceptedOperation({
+        farmId,
+        entityId: operationEntityId,
+        completedBy: userId,
+    });
+
+    const [request] = await storage()
+        .insert(farmerPayoutRequests)
+        .values({
+            farmId,
+            userId,
+            requestedAmount: '100.00',
+            currency: 'eur',
+            status: 'pending',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        })
+        .returning();
+    assert.ok(request);
+
+    await approvePayoutRequest(request.id, adminUserId, undefined, [
+        { label: 'Korekcija duplikata', amount: -20 },
+    ]);
+
+    const balance = await getFarmerBalance(userId, farmId);
+
+    assert.equal(balance.totalOperationEarned, 100);
+    assert.equal(balance.totalAdjustment, -20);
+    assert.equal(balance.adjustmentCount, 1);
+    assert.equal(balance.totalEarned, 80);
+    assert.equal(balance.totalPending, 80);
+    assert.equal(balance.availableBalance, 0);
+});
+
 test('approvePayoutRequest stores adjustment items and updates final amount', async () => {
     createTestDb();
 


### PR DESCRIPTION
## Summary
- Add payout adjustment totals and counts to farmer balance calculation
- Include active adjustments in available balance and show them in the payouts table
- Add a regression test covering open payout adjustments

## Testing
- Unit test added for payout balance calculations with active adjustments