### PR TITLE
[codex] Adjust inventory PDF notes and logo

### DIFF
--- a/apps/app/app/admin/inventory/[inventoryId]/inventoryPrintoutPdf.ts
+++ b/apps/app/app/admin/inventory/[inventoryId]/inventoryPrintoutPdf.ts
@@ -10,7 +10,6 @@ export type InventoryPrintoutPdfItem = {
     label: string;
     details: string[];
     quantity: number;
-    notes: string | null;
 };
 
 export type InventoryPrintoutPdfData = {
@@ -30,7 +29,6 @@ type PdfColor = {
 
 const colors = {
     brand: { r: 0.18, g: 0.44, b: 0.25 },
-    iconBackground: { r: 0.07, g: 0.07, b: 0.07 },
     text: { r: 0.09, g: 0.1, b: 0.12 },
     muted: { r: 0.42, g: 0.45, b: 0.5 },
     lightText: { r: 0.3, g: 0.34, b: 0.38 },
@@ -55,7 +53,6 @@ const detailFontSize = 7.4;
 const bodyFontSize = 9;
 const labelLineHeight = 11.2;
 const detailLineHeight = 9;
-const bodyLineHeight = 11;
 
 const columns = [
     { key: 'number', label: '#', width: 28 },
@@ -210,57 +207,6 @@ class PdfCanvas {
         );
     }
 
-    fillRoundedRect({
-        x,
-        y,
-        width,
-        height,
-        radius,
-        color,
-    }: {
-        x: number;
-        y: number;
-        width: number;
-        height: number;
-        radius: number;
-        color: PdfColor;
-    }) {
-        const right = x + width;
-        const top = y + height;
-        const curve = radius * 0.5522847498;
-        this.path({
-            commands: [
-                `${formatNumber(x + radius)} ${formatNumber(y)} m`,
-                `${formatNumber(right - radius)} ${formatNumber(y)} l`,
-                `${formatNumber(right - radius + curve)} ${formatNumber(
-                    y,
-                )} ${formatNumber(right)} ${formatNumber(
-                    y + radius - curve,
-                )} ${formatNumber(right)} ${formatNumber(y + radius)} c`,
-                `${formatNumber(right)} ${formatNumber(top - radius)} l`,
-                `${formatNumber(right)} ${formatNumber(
-                    top - radius + curve,
-                )} ${formatNumber(right - radius + curve)} ${formatNumber(
-                    top,
-                )} ${formatNumber(right - radius)} ${formatNumber(top)} c`,
-                `${formatNumber(x + radius)} ${formatNumber(top)} l`,
-                `${formatNumber(x + radius - curve)} ${formatNumber(
-                    top,
-                )} ${formatNumber(x)} ${formatNumber(
-                    top - radius + curve,
-                )} ${formatNumber(x)} ${formatNumber(top - radius)} c`,
-                `${formatNumber(x)} ${formatNumber(y + radius)} l`,
-                `${formatNumber(x)} ${formatNumber(
-                    y + radius - curve,
-                )} ${formatNumber(x + radius - curve)} ${formatNumber(
-                    y,
-                )} ${formatNumber(x + radius)} ${formatNumber(y)} c`,
-                'h',
-            ].join(' '),
-            color,
-        });
-    }
-
     toString() {
         return this.operations.join('\n');
     }
@@ -280,7 +226,6 @@ type PdfTransform = {
 type RowLayout = {
     labelLines: string[];
     detailLines: string[];
-    noteLines: string[];
     height: number;
 };
 
@@ -442,19 +387,10 @@ function drawLogo(page: PdfCanvas, x: number, y: number, scale = 1) {
     const markSize = 25 * scale;
     const iconScale = markSize / 30;
 
-    page.fillRoundedRect({
-        x,
-        y,
-        width: markSize,
-        height: markSize,
-        radius: 5 * scale,
-        color: colors.iconBackground,
-    });
-
     for (const commands of logoMarkPaths) {
         page.path({
             commands,
-            color: colors.white,
+            color: colors.brand,
             transform: {
                 a: iconScale,
                 b: 0,
@@ -558,25 +494,21 @@ function drawEmptyItemsRow(page: PdfCanvas, topY: number) {
 
 function buildRowLayout(item: InventoryPrintoutPdfItem): RowLayout {
     const itemWidth = columnWidth('item') - 12;
-    const notesWidth = columnWidth('notes') - 12;
     const labelLines = wrapText(item.label, itemWidth, labelFontSize);
     const detailLines = wrapText(
         item.details.filter(Boolean).join('  |  '),
         itemWidth,
         detailFontSize,
     ).slice(0, 2);
-    const noteLines = wrapText(item.notes ?? '', notesWidth, bodyFontSize);
     const itemHeight =
         rowPaddingY * 2 +
         labelLines.length * labelLineHeight +
         detailLines.length * detailLineHeight;
-    const notesHeight = rowPaddingY * 2 + noteLines.length * bodyLineHeight;
-    const height = Math.max(38, itemHeight, notesHeight);
+    const height = Math.max(38, itemHeight);
 
     return {
         labelLines,
         detailLines,
-        noteLines,
         height,
     };
 }
@@ -646,14 +578,13 @@ function drawTableRow(
         color: colors.text,
     });
 
-    row.noteLines.forEach((line, lineIndex) => {
-        page.text({
-            x: notesX,
-            y: rowTop - lineIndex * bodyLineHeight,
-            value: line,
-            size: bodyFontSize,
-            color: colors.lightText,
-        });
+    page.line({
+        x1: notesX,
+        y1: topY - row.height + 13,
+        x2: columnX('newStatus') - 8,
+        y2: topY - row.height + 13,
+        color: colors.line,
+        width: 0.7,
     });
 
     page.line({

--- a/apps/app/app/admin/inventory/[inventoryId]/inventoryPrintoutPdf.ts
+++ b/apps/app/app/admin/inventory/[inventoryId]/inventoryPrintoutPdf.ts
@@ -499,7 +499,7 @@ function buildRowLayout(item: InventoryPrintoutPdfItem): RowLayout {
         item.details.filter(Boolean).join('  |  '),
         itemWidth,
         detailFontSize,
-    ).slice(0, 2);
+    );
     const itemHeight =
         rowPaddingY * 2 +
         labelLines.length * labelLineHeight +

--- a/apps/app/app/admin/inventory/[inventoryId]/printout/route.ts
+++ b/apps/app/app/admin/inventory/[inventoryId]/printout/route.ts
@@ -41,9 +41,8 @@ export async function GET(
         .map((item) => {
             return {
                 label: itemLabel(item, config.entityTypeName, entityLabels),
-                details: itemDetails(item, config),
+                details: itemDetails(item),
                 quantity: item.quantity,
-                notes: item.notes,
             };
         })
         .sort(comparePrintoutItems);
@@ -89,9 +88,6 @@ export async function GET(
     });
 }
 
-type InventoryConfig = NonNullable<
-    Awaited<ReturnType<typeof getInventoryConfig>>
->;
 type InventoryEntity = Awaited<ReturnType<typeof getEntitiesRaw>>[number];
 type InventoryItem = Awaited<
     ReturnType<typeof getInventoryItemsByConfig>
@@ -132,37 +128,8 @@ function itemLabel(
     return `Stavka #${item.id}`;
 }
 
-function itemDetails(item: InventoryItem, config: InventoryConfig) {
-    const details = [
-        `ID #${item.id}`,
-        `Pracenje: ${trackingTypeLabel(item.trackingType)}`,
-    ];
-    if (item.serialNumber) {
-        details.push(`Serijski br.: ${item.serialNumber}`);
-    }
-
-    const lowCountThreshold =
-        item.lowCountThreshold ?? config.lowCountThreshold;
-    if (lowCountThreshold !== null) {
-        details.push(`Minimum: ${lowCountThreshold}`);
-    }
-
-    details.push(`Dodano: ${formatItemDate(item.createdAt)}`);
-
-    return details;
-}
-
-function trackingTypeLabel(trackingType: string) {
-    return trackingType === 'serialNumber' ? 'serijski broj' : 'komadi';
-}
-
-function formatItemDate(date: Date) {
-    return new Intl.DateTimeFormat('hr-HR', {
-        timeZone: 'Europe/Zagreb',
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-    }).format(date);
+function itemDetails(item: InventoryItem) {
+    return item.notes ? [`Biljeska: ${item.notes}`] : [];
 }
 
 function entityDisplayName(entity: InventoryEntity) {

--- a/apps/app/app/admin/inventory/[inventoryId]/printout/route.ts
+++ b/apps/app/app/admin/inventory/[inventoryId]/printout/route.ts
@@ -129,7 +129,10 @@ function itemLabel(
 }
 
 function itemDetails(item: InventoryItem) {
-    return item.notes ? [`Biljeska: ${item.notes}`] : [];
+    return [
+        ...(item.serialNumber ? [`Serijski br.: ${item.serialNumber}`] : []),
+        ...(item.notes ? [`Biljeska: ${item.notes}`] : []),
+    ];
 }
 
 function entityDisplayName(entity: InventoryEntity) {

--- a/apps/app/app/admin/inventory/inventoryPrintoutPdf.unit.ts
+++ b/apps/app/app/admin/inventory/inventoryPrintoutPdf.unit.ts
@@ -19,20 +19,13 @@ test('generates an inventory worksheet PDF with printable inventory fields', () 
         items: [
             {
                 label: 'Raj\u010dica cherry',
-                details: [
-                    'ID #1',
-                    'Pracenje: komadi',
-                    'Minimum: 4',
-                    'Dodano: 12. 06. 2026.',
-                ],
+                details: ['Biljeska: Paket otvoren'],
                 quantity: 13,
-                notes: 'Paket otvoren',
             },
             {
                 label: 'Bosiljak',
-                details: ['ID #2', 'Pracenje: komadi', 'Dodano: 12. 06. 2026.'],
+                details: [],
                 quantity: 0,
-                notes: null,
             },
         ],
     });
@@ -52,8 +45,11 @@ test('generates an inventory worksheet PDF with printable inventory fields', () 
     assert.match(content, /NOVO STANJE/);
     assert.doesNotMatch(content, /STATUS/);
     assert.match(content, /Rajcica cherry/);
-    assert.match(content, /Pracenje: komadi/);
-    assert.match(content, /Paket otvoren/);
+    assert.match(content, /Biljeska: Paket otvoren/);
+    assert.doesNotMatch(content, /ID #1/);
+    assert.doesNotMatch(content, /Pracenje/);
+    assert.doesNotMatch(content, /Minimum/);
+    assert.doesNotMatch(content, /Dodano/);
     assert.match(content, /Stranica 1 \/ 1/);
     assert.doesNotMatch(content, /Raj\u010dica/);
 });

--- a/apps/app/app/admin/inventory/inventoryPrintoutPdf.unit.ts
+++ b/apps/app/app/admin/inventory/inventoryPrintoutPdf.unit.ts
@@ -19,7 +19,10 @@ test('generates an inventory worksheet PDF with printable inventory fields', () 
         items: [
             {
                 label: 'Raj\u010dica cherry',
-                details: ['Biljeska: Paket otvoren'],
+                details: [
+                    'Serijski br.: SN-42',
+                    'Biljeska: Paket otvoren s dugom operativnom napomenom za inventuru. Druga recenica mora ostati vidljiva u PDF-u. Treca recenica takoder ostaje u PDF-u.',
+                ],
                 quantity: 13,
             },
             {
@@ -45,7 +48,9 @@ test('generates an inventory worksheet PDF with printable inventory fields', () 
     assert.match(content, /NOVO STANJE/);
     assert.doesNotMatch(content, /STATUS/);
     assert.match(content, /Rajcica cherry/);
+    assert.match(content, /Serijski br\.: SN-42/);
     assert.match(content, /Biljeska: Paket otvoren/);
+    assert.match(content, /Treca recenica/);
     assert.doesNotMatch(content, /ID #1/);
     assert.doesNotMatch(content, /Pracenje/);
     assert.doesNotMatch(content, /Minimum/);


### PR DESCRIPTION
## Summary
- Render the inventory PDF header logo as a green transparent brand mark with `Gredice` casing.
- Make the table `Biljeska` column a blank write-in field while keeping existing item notes under the item name.
- Remove ID, tracking, minimum, and added-date details from the item subheader.

## Validation
- `corepack pnpm --filter app run test:unit`
- `git diff --check`