### PR TITLE
[codex] include plant sorts in farmer documentation

### DIFF
--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.ts
@@ -1,6 +1,11 @@
 import 'server-only';
 
 import {
+    calculatePlantsPerField,
+    FIELD_SIZE_LABEL,
+    getHarvestPlantRemovalDisclaimer,
+} from '@gredice/js/plants';
+import {
     type EntityStandardized,
     entityRevisions,
     getAttributeDefinitions,
@@ -8,32 +13,47 @@ import {
     type SelectEntityRevision,
     storage,
 } from '@gredice/storage';
-import { and, desc, eq, gte } from 'drizzle-orm';
+import { and, desc, gte, inArray } from 'drizzle-orm';
 
 export type FarmerDocumentationChangeType = 'insert' | 'replace' | 'discard';
-
-export type FarmerDocumentationOperation = {
-    id: number;
-    code: string;
-    label: string;
-    name: string | null;
-    description: string | null;
-    instructions: string | null;
-    durationLabel: string;
-    photoProofLabel: string;
-    attributes: FarmerDocumentationAttribute[];
-    changedAt: Date | null;
-    changeType: Exclude<FarmerDocumentationChangeType, 'discard'>;
-    revisionActions: string[];
-};
+export type FarmerDocumentationEntityTypeName = 'operation' | 'plantSort';
 
 export type FarmerDocumentationAttribute = {
     label: string;
     value: string;
 };
 
+export type FarmerDocumentationSection = {
+    title: string;
+    lines: string[];
+};
+
+export type FarmerDocumentationPage = {
+    id: number;
+    entityTypeName: FarmerDocumentationEntityTypeName;
+    documentTypeLabel: string;
+    code: string;
+    label: string;
+    appPath: string;
+    summaryRows: FarmerDocumentationAttribute[];
+    sections: FarmerDocumentationSection[];
+    changedAt: Date | null;
+    changeType: Exclude<FarmerDocumentationChangeType, 'discard'>;
+    revisionActions: string[];
+};
+
+export type FarmerDocumentationOperation = FarmerDocumentationPage & {
+    entityTypeName: 'operation';
+};
+
+export type FarmerDocumentationPlantSort = FarmerDocumentationPage & {
+    entityTypeName: 'plantSort';
+};
+
 export type FarmerDocumentationDiscard = {
+    entityTypeName: FarmerDocumentationEntityTypeName;
     entityId: number;
+    documentTypeLabel: string;
     code: string;
     label: string;
     changedAt: Date;
@@ -44,8 +64,11 @@ export type FarmerDocumentationPackage = {
     since: Date | null;
     generatedAt: Date;
     totalOperations: number;
+    totalPlantSorts: number;
     includedOperations: FarmerDocumentationOperation[];
+    includedPlantSorts: FarmerDocumentationPlantSort[];
     discardedOperations: FarmerDocumentationDiscard[];
+    discardedPlantSorts: FarmerDocumentationDiscard[];
 };
 
 export type FarmerDocumentationRevision = Pick<
@@ -62,6 +85,34 @@ export type FarmerDocumentationRevision = Pick<
     | 'nextState'
     | 'createdAt'
 >;
+
+const documentationEntityTypeNames: FarmerDocumentationEntityTypeName[] = [
+    'operation',
+    'plantSort',
+];
+
+const documentationEntityConfig: Record<
+    FarmerDocumentationEntityTypeName,
+    {
+        codePrefix: string;
+        documentTypeLabel: string;
+        fallbackLabel: string;
+        noun: string;
+    }
+> = {
+    operation: {
+        codePrefix: 'OP',
+        documentTypeLabel: 'Radnja',
+        fallbackLabel: 'Radnja',
+        noun: 'radnja',
+    },
+    plantSort: {
+        codePrefix: 'PS',
+        documentTypeLabel: 'Sorta',
+        fallbackLabel: 'Sorta',
+        noun: 'sorta',
+    },
+};
 
 const operationAttributeLabels: Record<string, string> = {
     application: 'Primjena',
@@ -87,18 +138,53 @@ const operationAttributeValueLabels: Record<string, Record<string, string>> = {
     },
 };
 
-const revisionActionLabels: Record<string, string> = {
-    'attribute.created': 'dodani podaci',
-    'attribute.deleted': 'uklonjeni podaci',
-    'attribute.updated': 'promijenjeni podaci',
-    'entity.created': 'nova radnja',
-    'entity.deleted': 'obrisana radnja',
-    'entity.state_changed': 'promijenjen status',
-    'entity.updated': 'azurirana radnja',
+const reproductionTypeLabels: Record<string, string> = {
+    bulb: 'Lukovica',
+    seed: 'Sjeme',
 };
 
-export function getFarmerDocumentationCode(entityId: number) {
-    return `OP-${entityId.toString().padStart(4, '0')}`;
+const monthNames = [
+    'sijecanj',
+    'veljaca',
+    'ozujak',
+    'travanj',
+    'svibanj',
+    'lipanj',
+    'srpanj',
+    'kolovoz',
+    'rujan',
+    'listopad',
+    'studeni',
+    'prosinac',
+];
+
+const plantSortTextFields = [
+    { key: 'description', title: 'Opis' },
+    { key: 'soilPreparation', title: 'Priprema tla' },
+    { key: 'sowing', title: 'Sjetva' },
+    { key: 'planting', title: 'Sadnja' },
+    { key: 'growth', title: 'Rast' },
+    { key: 'maintenance', title: 'Odrzavanje' },
+    { key: 'watering', title: 'Zalijevanje' },
+    { key: 'flowering', title: 'Cvatnja' },
+    { key: 'harvest', title: 'Berba' },
+    { key: 'storage', title: 'Cuvanje' },
+    { key: 'origin', title: 'Podrijetlo' },
+];
+
+const calendarDetails = [
+    { key: 'propagating', title: 'Sjetva u zatvorenom' },
+    { key: 'sowing', title: 'Sjetva na otvorenom' },
+    { key: 'planting', title: 'Presadivanje' },
+    { key: 'harvest', title: 'Berba' },
+];
+
+export function getFarmerDocumentationCode(
+    entityTypeName: FarmerDocumentationEntityTypeName,
+    entityId: number,
+) {
+    const config = documentationEntityConfig[entityTypeName];
+    return `${config.codePrefix}-${entityId.toString().padStart(4, '0')}`;
 }
 
 export function getFarmerAppOrigin() {
@@ -155,32 +241,59 @@ export function documentationChangeLabel(type: FarmerDocumentationChangeType) {
     }
 }
 
+export function includedDocumentationPages(
+    documentationPackage: FarmerDocumentationPackage,
+) {
+    return [
+        ...documentationPackage.includedOperations,
+        ...documentationPackage.includedPlantSorts,
+    ].sort(compareDocumentationPage);
+}
+
+export function discardedDocumentationPages(
+    documentationPackage: FarmerDocumentationPackage,
+) {
+    return [
+        ...documentationPackage.discardedOperations,
+        ...documentationPackage.discardedPlantSorts,
+    ].sort(compareDocumentationPage);
+}
+
 export async function getFarmerDocumentationPackage({
     since,
 }: {
     since: Date | null;
 }): Promise<FarmerDocumentationPackage> {
-    const [operations, revisions, attributeDefinitions] = await Promise.all([
+    const [
+        operations,
+        plantSorts,
+        revisions,
+        operationAttributeDefinitions,
+        plantSortAttributeDefinitions,
+    ] = await Promise.all([
         getEntitiesFormatted<EntityStandardized>('operation').catch(
             (): EntityStandardized[] => [],
         ),
-        getOperationRevisionsSince(since),
+        getEntitiesFormatted<EntityStandardized>('plantSort').catch(
+            (): EntityStandardized[] => [],
+        ),
+        getDocumentationRevisionsSince(since),
         getAttributeDefinitions('operation').catch(() => []),
+        getAttributeDefinitions('plantSort').catch(() => []),
     ]);
 
     return buildFarmerDocumentationPackage({
         operations,
+        plantSorts,
         revisions,
-        labelAttributeDefinitionIds: new Set(
-            attributeDefinitions
-                .filter(
-                    (definition) =>
-                        definition.category === 'information' &&
-                        (definition.name === 'label' ||
-                            definition.name === 'name'),
-                )
-                .map((definition) => definition.id),
-        ),
+        labelAttributeDefinitionIds: {
+            operation: labelAttributeDefinitionIds(
+                operationAttributeDefinitions,
+            ),
+            plantSort: labelAttributeDefinitionIds(
+                plantSortAttributeDefinitions,
+            ),
+        },
         generatedAt: new Date(),
         since,
     });
@@ -190,59 +303,89 @@ export function buildFarmerDocumentationPackage({
     generatedAt,
     labelAttributeDefinitionIds,
     operations,
+    plantSorts,
     revisions,
     since,
 }: {
     generatedAt: Date;
-    labelAttributeDefinitionIds: ReadonlySet<number>;
+    labelAttributeDefinitionIds: Record<
+        FarmerDocumentationEntityTypeName,
+        ReadonlySet<number>
+    >;
     operations: EntityStandardized[];
+    plantSorts: EntityStandardized[];
     revisions: FarmerDocumentationRevision[];
     since: Date | null;
 }): FarmerDocumentationPackage {
     const sortedOperations = [...operations].sort(
         (left, right) => left.id - right.id,
     );
-    const currentOperationIds = new Set(
-        sortedOperations.map((operation) => operation.id),
+    const sortedPlantSorts = [...plantSorts].sort((left, right) =>
+        getPlantSortLabel(left).localeCompare(getPlantSortLabel(right), 'hr', {
+            numeric: true,
+        }),
     );
-    const revisionsByEntityId = groupRevisionsByEntityId(revisions);
+    const revisionsByEntityKey = groupRevisionsByEntityKey(revisions);
     const includedOperations = sortedOperations
-        .filter((operation) => !since || revisionsByEntityId.has(operation.id))
+        .filter((operation) =>
+            shouldIncludeCurrentEntity(
+                operation,
+                'operation',
+                since,
+                revisionsByEntityKey,
+            ),
+        )
         .map((operation) =>
             toDocumentationOperation(
                 operation,
-                revisionsByEntityId.get(operation.id) ?? [],
+                revisionsByEntityKey.get(
+                    documentationEntityKey('operation', operation.id),
+                ) ?? [],
                 since,
             ),
         );
-    const discardedOperations = Array.from(revisionsByEntityId.entries())
-        .filter(([entityId]) => !currentOperationIds.has(entityId))
-        .filter(([, entityRevisions]) =>
-            entityRevisions.some(isDiscardRevision),
-        )
-        .map(([entityId, entityRevisions]) => ({
-            entityId,
-            code: getFarmerDocumentationCode(entityId),
-            label: revisionEntityLabel(
-                entityId,
-                entityRevisions,
-                labelAttributeDefinitionIds,
+    const includedPlantSorts = sortedPlantSorts
+        .filter((plantSort) =>
+            shouldIncludeCurrentEntity(
+                plantSort,
+                'plantSort',
+                since,
+                revisionsByEntityKey,
             ),
-            changedAt: latestRevisionDate(entityRevisions),
-            revisionActions: revisionActionSummary(entityRevisions),
-        }))
-        .sort((left, right) => left.entityId - right.entityId);
+        )
+        .map((plantSort) =>
+            toDocumentationPlantSort(
+                plantSort,
+                revisionsByEntityKey.get(
+                    documentationEntityKey('plantSort', plantSort.id),
+                ) ?? [],
+                since,
+            ),
+        );
 
     return {
         since,
         generatedAt,
         totalOperations: sortedOperations.length,
+        totalPlantSorts: sortedPlantSorts.length,
         includedOperations,
-        discardedOperations,
+        includedPlantSorts,
+        discardedOperations: discardedPagesForType({
+            currentEntities: sortedOperations,
+            entityTypeName: 'operation',
+            labelAttributeDefinitionIds: labelAttributeDefinitionIds.operation,
+            revisionsByEntityKey,
+        }),
+        discardedPlantSorts: discardedPagesForType({
+            currentEntities: sortedPlantSorts,
+            entityTypeName: 'plantSort',
+            labelAttributeDefinitionIds: labelAttributeDefinitionIds.plantSort,
+            revisionsByEntityKey,
+        }),
     };
 }
 
-function getOperationRevisionsSince(since: Date | null) {
+function getDocumentationRevisionsSince(since: Date | null) {
     if (!since) {
         return Promise.resolve<FarmerDocumentationRevision[]>([]);
     }
@@ -262,23 +405,136 @@ function getOperationRevisionsSince(since: Date | null) {
             createdAt: true,
         },
         where: and(
-            eq(entityRevisions.entityTypeName, 'operation'),
+            inArray(
+                entityRevisions.entityTypeName,
+                documentationEntityTypeNames,
+            ),
             gte(entityRevisions.createdAt, since),
         ),
-        orderBy: (revisions) => [desc(revisions.createdAt), desc(revisions.id)],
+        orderBy: (revisionRows) => [
+            desc(revisionRows.createdAt),
+            desc(revisionRows.id),
+        ],
     });
 }
 
-function groupRevisionsByEntityId(revisions: FarmerDocumentationRevision[]) {
-    const grouped = new Map<number, FarmerDocumentationRevision[]>();
+function labelAttributeDefinitionIds(
+    attributeDefinitions: Array<{
+        id: number;
+        category: string | null;
+        name: string;
+    }>,
+) {
+    return new Set(
+        attributeDefinitions
+            .filter(
+                (definition) =>
+                    definition.category === 'information' &&
+                    (definition.name === 'label' || definition.name === 'name'),
+            )
+            .map((definition) => definition.id),
+    );
+}
+
+function groupRevisionsByEntityKey(revisions: FarmerDocumentationRevision[]) {
+    const grouped = new Map<string, FarmerDocumentationRevision[]>();
 
     for (const revision of revisions) {
-        const entityRevisions = grouped.get(revision.entityId) ?? [];
+        const entityTypeName = normalizeDocumentationEntityTypeName(
+            revision.entityTypeName,
+        );
+        if (!entityTypeName) {
+            continue;
+        }
+
+        const key = documentationEntityKey(entityTypeName, revision.entityId);
+        const entityRevisions = grouped.get(key) ?? [];
         entityRevisions.push(revision);
-        grouped.set(revision.entityId, entityRevisions);
+        grouped.set(key, entityRevisions);
     }
 
     return grouped;
+}
+
+function normalizeDocumentationEntityTypeName(
+    value: string,
+): FarmerDocumentationEntityTypeName | null {
+    if (value === 'operation' || value === 'plantSort') {
+        return value;
+    }
+
+    return null;
+}
+
+function documentationEntityKey(
+    entityTypeName: FarmerDocumentationEntityTypeName,
+    entityId: number,
+) {
+    return `${entityTypeName}:${entityId}`;
+}
+
+function shouldIncludeCurrentEntity(
+    entity: EntityStandardized,
+    entityTypeName: FarmerDocumentationEntityTypeName,
+    since: Date | null,
+    revisionsByEntityKey: ReadonlyMap<string, FarmerDocumentationRevision[]>,
+) {
+    return (
+        !since ||
+        revisionsByEntityKey.has(
+            documentationEntityKey(entityTypeName, entity.id),
+        )
+    );
+}
+
+function discardedPagesForType({
+    currentEntities,
+    entityTypeName,
+    labelAttributeDefinitionIds,
+    revisionsByEntityKey,
+}: {
+    currentEntities: EntityStandardized[];
+    entityTypeName: FarmerDocumentationEntityTypeName;
+    labelAttributeDefinitionIds: ReadonlySet<number>;
+    revisionsByEntityKey: ReadonlyMap<string, FarmerDocumentationRevision[]>;
+}) {
+    const currentIds = new Set(currentEntities.map((entity) => entity.id));
+    const config = documentationEntityConfig[entityTypeName];
+
+    return Array.from(revisionsByEntityKey.entries())
+        .filter(([, entityRevisions]) =>
+            entityRevisions.some(
+                (revision) => revision.entityTypeName === entityTypeName,
+            ),
+        )
+        .filter(([, entityRevisions]) => {
+            const entityId = entityRevisions[0]?.entityId;
+            return entityId !== undefined && !currentIds.has(entityId);
+        })
+        .filter(([, entityRevisions]) =>
+            entityRevisions.some(isDiscardRevision),
+        )
+        .map(([, entityRevisions]) => {
+            const entityId = entityRevisions[0]?.entityId ?? 0;
+
+            return {
+                entityTypeName,
+                entityId,
+                documentTypeLabel: config.documentTypeLabel,
+                code: getFarmerDocumentationCode(entityTypeName, entityId),
+                label: revisionEntityLabel(
+                    entityTypeName,
+                    entityId,
+                    entityRevisions,
+                    labelAttributeDefinitionIds,
+                ),
+                changedAt: latestRevisionDate(entityRevisions),
+                revisionActions: revisionActionSummary(
+                    entityRevisions,
+                    entityTypeName,
+                ),
+            };
+        });
 }
 
 function toDocumentationOperation(
@@ -286,19 +542,91 @@ function toDocumentationOperation(
     revisions: FarmerDocumentationRevision[],
     since: Date | null,
 ): FarmerDocumentationOperation {
+    const changedAt =
+        revisions.length > 0 ? latestRevisionDate(revisions) : null;
+    const changeType = isInsertPage(revisions, since) ? 'insert' : 'replace';
+
     return {
         id: operation.id,
-        code: getFarmerDocumentationCode(operation.id),
+        entityTypeName: 'operation',
+        documentTypeLabel:
+            documentationEntityConfig.operation.documentTypeLabel,
+        code: getFarmerDocumentationCode('operation', operation.id),
         label: getOperationLabel(operation),
-        name: operation.information?.name ?? null,
-        description: operation.information?.description?.trim() || null,
-        instructions: operation.information?.instructions?.trim() || null,
-        durationLabel: operationDurationLabel(operation),
-        photoProofLabel: operationPhotoProofLabel(operation),
-        attributes: operationAttributes(operation),
-        changedAt: revisions.length > 0 ? latestRevisionDate(revisions) : null,
-        changeType: isInsertOperation(revisions, since) ? 'insert' : 'replace',
-        revisionActions: revisionActionSummary(revisions),
+        appPath: `/operations/${operation.id}`,
+        summaryRows: compactRows([
+            ['Kod', getFarmerDocumentationCode('operation', operation.id)],
+            ['Vrsta', documentationEntityConfig.operation.documentTypeLabel],
+            ['Trajanje', operationDurationLabel(operation)],
+            ['Dokaz fotografijom', operationPhotoProofLabel(operation)],
+            [
+                'Promjena',
+                changedAt
+                    ? formatDocumentationDateTime(changedAt)
+                    : 'Cijeli prirucnik',
+            ],
+        ]),
+        sections: [
+            documentationSection('Opis', [
+                operation.information?.description?.trim() ||
+                    'Opis nije definiran.',
+            ]),
+            documentationSection('Upute', [
+                operation.information?.instructions?.trim() ||
+                    'Upute nisu definirane.',
+            ]),
+            documentationSection(
+                'Podaci radnje',
+                operationAttributes(operation).map(
+                    (attribute) => `${attribute.label}: ${attribute.value}`,
+                ),
+            ),
+        ].filter((section): section is FarmerDocumentationSection =>
+            Boolean(section),
+        ),
+        changedAt,
+        changeType,
+        revisionActions: revisionActionSummary(revisions, 'operation'),
+    };
+}
+
+function toDocumentationPlantSort(
+    plantSort: EntityStandardized,
+    revisions: FarmerDocumentationRevision[],
+    since: Date | null,
+): FarmerDocumentationPlantSort {
+    const plant = getPlantSortPlant(plantSort);
+    const plantInformation = recordProperty(plant, 'information');
+    const latinName = textProperty(plantInformation, 'latinName');
+    const plantLabel = getPlantLabel(plant);
+    const changedAt =
+        revisions.length > 0 ? latestRevisionDate(revisions) : null;
+    const changeType = isInsertPage(revisions, since) ? 'insert' : 'replace';
+
+    return {
+        id: plantSort.id,
+        entityTypeName: 'plantSort',
+        documentTypeLabel:
+            documentationEntityConfig.plantSort.documentTypeLabel,
+        code: getFarmerDocumentationCode('plantSort', plantSort.id),
+        label: getPlantSortLabel(plantSort),
+        appPath: `/plants/${plantSort.id}`,
+        summaryRows: compactRows([
+            ['Kod', getFarmerDocumentationCode('plantSort', plantSort.id)],
+            ['Vrsta', documentationEntityConfig.plantSort.documentTypeLabel],
+            ['Biljka', plantLabel],
+            ['Latinski naziv', latinName],
+            [
+                'Promjena',
+                changedAt
+                    ? formatDocumentationDateTime(changedAt)
+                    : 'Cijeli prirucnik',
+            ],
+        ]),
+        sections: plantSortSections(plantSort),
+        changedAt,
+        changeType,
+        revisionActions: revisionActionSummary(revisions, 'plantSort'),
     };
 }
 
@@ -306,7 +634,27 @@ function getOperationLabel(operation: EntityStandardized) {
     return (
         operation.information?.label?.trim() ||
         operation.information?.name?.trim() ||
-        `Radnja #${operation.id}`
+        `${documentationEntityConfig.operation.fallbackLabel} #${operation.id}`
+    );
+}
+
+function getPlantSortLabel(plantSort: EntityStandardized) {
+    return (
+        plantSort.information?.label?.trim() ||
+        plantSort.information?.name?.trim() ||
+        `${documentationEntityConfig.plantSort.fallbackLabel} #${plantSort.id}`
+    );
+}
+
+function getPlantSortPlant(plantSort: EntityStandardized) {
+    return plantSort.information?.plant ?? null;
+}
+
+function getPlantLabel(plant: EntityStandardized | null) {
+    return (
+        plant?.information?.label?.trim() ||
+        plant?.information?.name?.trim() ||
+        null
     );
 }
 
@@ -362,6 +710,188 @@ function operationAttributes(operation: EntityStandardized) {
         );
 }
 
+function plantSortSections(plantSort: EntityStandardized) {
+    const plant = getPlantSortPlant(plantSort);
+    const sortInformation = isRecord(plantSort.information)
+        ? plantSort.information
+        : null;
+    const plantInformation = recordProperty(plant, 'information');
+    const plantAttributes = recordProperty(plant, 'attributes');
+    const plantCalendar = recordProperty(plant, 'calendar');
+    const sortAttributes = isRecord(plantSort.attributes)
+        ? plantSort.attributes
+        : null;
+
+    return [
+        ...plantSortTextFields
+            .map(({ key, title }) => {
+                const text =
+                    textProperty(sortInformation, key) ??
+                    textProperty(plantInformation, key);
+
+                return documentationSection(title, text ? [text] : []);
+            })
+            .filter((section): section is FarmerDocumentationSection =>
+                Boolean(section),
+            ),
+        detailSection('Sorta', buildSortRows(sortAttributes)),
+        detailSection('Sjetva', buildSowingRows(plantAttributes)),
+        detailSection('Rast', buildGrowthRows(plantAttributes)),
+        detailSection('Zalijevanje', buildWateringRows(plantAttributes)),
+        detailSection('Berba', buildHarvestRows(plantAttributes)),
+        detailSection('Kalendar uzgoja', buildCalendarRows(plantCalendar)),
+    ].filter((section): section is FarmerDocumentationSection =>
+        Boolean(section),
+    );
+}
+
+function buildSortRows(attributes: Record<string, unknown> | null) {
+    const reproductionType = stringProperty(attributes, 'reproductionType');
+
+    return compactRows([
+        [
+            'Vrsta reprodukcije',
+            reproductionType
+                ? (reproductionTypeLabels[reproductionType] ?? reproductionType)
+                : null,
+        ],
+    ]);
+}
+
+function buildSowingRows(attributes: Record<string, unknown> | null) {
+    const seedingDistance = numberProperty(attributes, 'seedingDistance');
+    const totalPlants =
+        seedingDistance == null
+            ? null
+            : calculatePlantsPerField(seedingDistance).totalPlants;
+    const germinationTemperature = numberProperty(
+        attributes,
+        'gernimationTemperature',
+    );
+
+    return compactRows([
+        [
+            `Broj biljaka na ${FIELD_SIZE_LABEL}`,
+            totalPlants == null ? null : formatInteger(totalPlants),
+        ],
+        [
+            'Razmak sijanja/sadnje',
+            seedingDistance == null
+                ? null
+                : `${formatNumber(seedingDistance)} cm`,
+        ],
+        [
+            'Dubina sijanja',
+            numberProperty(attributes, 'seedingDepth') == null
+                ? null
+                : `${formatNumber(numberProperty(attributes, 'seedingDepth') ?? 0)} cm`,
+        ],
+        ['Klijanje', stringProperty(attributes, 'germinationType')],
+        [
+            'Temperatura klijanja',
+            germinationTemperature == null
+                ? null
+                : `${formatNumber(germinationTemperature)} C`,
+        ],
+        [
+            'Vrijeme klijanja',
+            formatDayRange(
+                numberProperty(attributes, 'germinationWindowMin'),
+                numberProperty(attributes, 'germinationWindowMax'),
+            ),
+        ],
+    ]);
+}
+
+function buildGrowthRows(attributes: Record<string, unknown> | null) {
+    return compactRows([
+        ['Svjetlost', formatLight(numberProperty(attributes, 'light'))],
+        ['Zemlja', stringProperty(attributes, 'soil')],
+        ['Nutrijenti', stringProperty(attributes, 'nutrients')],
+        [
+            'Vrijeme rasta',
+            formatDayRange(
+                numberProperty(attributes, 'growthWindowMin'),
+                numberProperty(attributes, 'growthWindowMax'),
+            ),
+        ],
+    ]);
+}
+
+function buildWateringRows(attributes: Record<string, unknown> | null) {
+    return compactRows([['Voda', stringProperty(attributes, 'water')]]);
+}
+
+function buildHarvestRows(attributes: Record<string, unknown> | null) {
+    const yieldMin = numberProperty(attributes, 'yieldMin');
+    const yieldMax = numberProperty(attributes, 'yieldMax');
+    const yieldType = stringProperty(attributes, 'yieldType');
+    const yieldRange = formatWeightRange(yieldMin, yieldMax);
+    const cleanHarvest = booleanProperty(attributes, 'cleanHarvest');
+
+    return compactRows([
+        [
+            'Vrijeme berbe',
+            formatDayRange(
+                numberProperty(attributes, 'harvestWindowMin'),
+                numberProperty(attributes, 'harvestWindowMax'),
+            ),
+        ],
+        [
+            'Ocekivani prinos',
+            yieldRange
+                ? `${yieldRange} ${yieldType === 'perPlant' ? 'po biljci' : 'po polju'}`
+                : null,
+        ],
+        [
+            'Nakon berbe',
+            cleanHarvest == null
+                ? null
+                : getHarvestPlantRemovalDisclaimer(cleanHarvest),
+        ],
+    ]);
+}
+
+function buildCalendarRows(calendar: Record<string, unknown> | null) {
+    if (!calendar) {
+        return [];
+    }
+
+    return calendarDetails
+        .map(({ key, title }) => [title, formatCalendarValue(calendar[key])])
+        .filter(
+            (row): row is [string, string] =>
+                typeof row[1] === 'string' && row[1].trim().length > 0,
+        )
+        .map(([label, value]) => ({ label, value }));
+}
+
+function documentationSection(title: string, lines: string[]) {
+    const visibleLines = lines
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+
+    return visibleLines.length > 0 ? { title, lines: visibleLines } : null;
+}
+
+function detailSection(title: string, rows: FarmerDocumentationAttribute[]) {
+    return documentationSection(
+        title,
+        rows.map((row) => `${row.label}: ${row.value}`),
+    );
+}
+
+function compactRows(
+    rows: Array<[label: string, value: string | null | undefined]>,
+) {
+    return rows
+        .filter(
+            (row): row is [string, string] =>
+                typeof row[1] === 'string' && row[1].trim().length > 0,
+        )
+        .map(([label, value]) => ({ label, value }));
+}
+
 function formatAttributeLabel(attributeName: string) {
     return (
         operationAttributeLabels[attributeName] ??
@@ -401,7 +931,160 @@ function formatAttributeValue(value: unknown, attributeName: string) {
     return null;
 }
 
-function isInsertOperation(
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function recordProperty(value: unknown, propertyName: string) {
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    const propertyValue = value[propertyName];
+    return isRecord(propertyValue) ? propertyValue : null;
+}
+
+function textProperty(value: unknown, propertyName: string) {
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    const propertyValue = value[propertyName];
+    return typeof propertyValue === 'string' && propertyValue.trim()
+        ? propertyValue
+        : null;
+}
+
+function numberProperty(value: Record<string, unknown> | null, key: string) {
+    const propertyValue = value?.[key];
+    return typeof propertyValue === 'number' && !Number.isNaN(propertyValue)
+        ? propertyValue
+        : null;
+}
+
+function stringProperty(value: Record<string, unknown> | null, key: string) {
+    const propertyValue = value?.[key];
+    return typeof propertyValue === 'string' && propertyValue.trim()
+        ? propertyValue
+        : null;
+}
+
+function booleanProperty(value: Record<string, unknown> | null, key: string) {
+    const propertyValue = value?.[key];
+    return typeof propertyValue === 'boolean' ? propertyValue : null;
+}
+
+function formatInteger(value: number) {
+    return value.toLocaleString('hr-HR', { maximumFractionDigits: 0 });
+}
+
+function formatNumber(value: number) {
+    return value.toLocaleString('hr-HR');
+}
+
+function formatDayRange(min: number | null, max: number | null) {
+    if (min == null && max == null) {
+        return null;
+    }
+
+    if (min != null && max != null) {
+        if (min === max) {
+            return `${formatNumber(min)} ${min === 1 ? 'dan' : 'dana'}`;
+        }
+
+        return `${formatNumber(min)}-${formatNumber(max)} dana`;
+    }
+
+    const value = min ?? max;
+    return value == null
+        ? null
+        : `${formatNumber(value)} ${value === 1 ? 'dan' : 'dana'}`;
+}
+
+function formatWeightRange(min: number | null, max: number | null) {
+    if (min == null && max == null) {
+        return null;
+    }
+
+    if (min != null && max != null) {
+        if (min === max) {
+            return `${formatNumber(min)} g`;
+        }
+
+        return `${formatNumber(min)}-${formatNumber(max)} g`;
+    }
+
+    const value = min ?? max;
+    return value == null ? null : `${formatNumber(value)} g`;
+}
+
+function formatLight(value: number | null) {
+    if (value == null) {
+        return null;
+    }
+
+    if (value >= 0.7) {
+        return 'Sunce';
+    }
+
+    if (value >= 0.3) {
+        return 'Polusjena';
+    }
+
+    return 'Hlad';
+}
+
+function formatMonthPoint(value: number) {
+    const monthIndex = Math.floor(value) - 1;
+    const monthName = monthNames[monthIndex];
+
+    if (!monthName) {
+        return formatNumber(value);
+    }
+
+    return value % 1 === 0 ? monthName : `sredina ${monthName}`;
+}
+
+function formatCalendarPeriod(value: unknown) {
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    const start = numberProperty(value, 'start');
+    const end = numberProperty(value, 'end');
+
+    if (start == null && end == null) {
+        return null;
+    }
+
+    if (start != null && end != null) {
+        const formattedStart = formatMonthPoint(start);
+        const formattedEnd = formatMonthPoint(end);
+        return formattedStart === formattedEnd
+            ? formattedStart
+            : `${formattedStart} - ${formattedEnd}`;
+    }
+
+    return formatMonthPoint(start ?? end ?? 0);
+}
+
+function formatCalendarValue(value: unknown) {
+    if (!Array.isArray(value)) {
+        return null;
+    }
+
+    const periods = value
+        .map((period) => formatCalendarPeriod(period))
+        .filter((period): period is string => Boolean(period));
+
+    if (periods.length === 0) {
+        return null;
+    }
+
+    return periods.join('; ');
+}
+
+function isInsertPage(
     revisions: FarmerDocumentationRevision[],
     since: Date | null,
 ) {
@@ -428,6 +1111,7 @@ function isDiscardRevision(revision: FarmerDocumentationRevision) {
 }
 
 function revisionEntityLabel(
+    entityTypeName: FarmerDocumentationEntityTypeName,
     entityId: number,
     revisions: FarmerDocumentationRevision[],
     labelAttributeDefinitionIds: ReadonlySet<number>,
@@ -444,7 +1128,7 @@ function revisionEntityLabel(
         }
     }
 
-    return `Radnja #${entityId}`;
+    return `${documentationEntityConfig[entityTypeName].fallbackLabel} #${entityId}`;
 }
 
 function latestRevisionDate(revisions: FarmerDocumentationRevision[]) {
@@ -455,13 +1139,41 @@ function latestRevisionDate(revisions: FarmerDocumentationRevision[]) {
     );
 }
 
-function revisionActionSummary(revisions: FarmerDocumentationRevision[]) {
+function revisionActionSummary(
+    revisions: FarmerDocumentationRevision[],
+    entityTypeName: FarmerDocumentationEntityTypeName,
+) {
+    const noun = documentationEntityConfig[entityTypeName].noun;
+
     return Array.from(
         new Set(
-            revisions.map(
-                (revision) =>
-                    revisionActionLabels[revision.action] ?? revision.action,
-            ),
+            revisions.map((revision) => {
+                switch (revision.action) {
+                    case 'attribute.created':
+                        return 'dodani podaci';
+                    case 'attribute.deleted':
+                        return 'uklonjeni podaci';
+                    case 'attribute.updated':
+                        return 'promijenjeni podaci';
+                    case 'entity.created':
+                        return `nova ${noun}`;
+                    case 'entity.deleted':
+                        return `obrisana ${noun}`;
+                    case 'entity.state_changed':
+                        return 'promijenjen status';
+                    case 'entity.updated':
+                        return `azurirana ${noun}`;
+                    default:
+                        return revision.action;
+                }
+            }),
         ),
     );
+}
+
+function compareDocumentationPage(
+    left: { code: string },
+    right: { code: string },
+) {
+    return left.code.localeCompare(right.code, 'hr', { numeric: true });
 }

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
@@ -10,11 +10,14 @@ import { generateFarmerDocumentationPdf } from './farmerDocumentationPdf';
 const generatedAt = new Date('2026-06-13T10:00:00.000Z');
 const since = new Date('2026-06-01T00:00:00.000Z');
 
-test('builds insert, replace, and discard instructions from operation revisions', () => {
+test('builds insert, replace, and discard instructions from manual revisions', () => {
     const documentationPackage = buildFarmerDocumentationPackage({
         generatedAt,
         since,
-        labelAttributeDefinitionIds: new Set([10]),
+        labelAttributeDefinitionIds: {
+            operation: new Set([10]),
+            plantSort: new Set([20]),
+        },
         operations: [
             operationFixture(4, 'Zalijevanje', {
                 duration: 25,
@@ -23,6 +26,11 @@ test('builds insert, replace, and discard instructions from operation revisions'
             operationFixture(8, 'Čišćenje gredice', {
                 duration: 40,
                 frequency: 'required',
+            }),
+        ],
+        plantSorts: [
+            plantSortFixture(14, 'Cherry rajčica', {
+                reproductionType: 'seed',
             }),
         ],
         revisions: [
@@ -55,10 +63,37 @@ test('builds insert, replace, and discard instructions from operation revisions'
                 nextState: 'published',
                 createdAt: new Date('2026-06-10T12:30:00.000Z'),
             }),
+            revisionFixture({
+                id: 5,
+                entityId: 14,
+                entityTypeName: 'plantSort',
+                action: 'entity.created',
+                createdAt: new Date('2026-06-11T12:00:00.000Z'),
+            }),
+            revisionFixture({
+                id: 6,
+                entityId: 16,
+                entityTypeName: 'plantSort',
+                action: 'attribute.updated',
+                attributeDefinitionId: 20,
+                previousValue: 'Stara sorta',
+                nextValue: 'Stara sorta',
+                createdAt: new Date('2026-06-12T12:00:00.000Z'),
+            }),
+            revisionFixture({
+                id: 7,
+                entityId: 16,
+                entityTypeName: 'plantSort',
+                action: 'entity.deleted',
+                previousState: 'published',
+                nextState: 'published',
+                createdAt: new Date('2026-06-12T12:30:00.000Z'),
+            }),
         ],
     });
 
     assert.equal(documentationPackage.totalOperations, 2);
+    assert.equal(documentationPackage.totalPlantSorts, 1);
     assert.deepEqual(
         documentationPackage.includedOperations.map((operation) => [
             operation.code,
@@ -70,11 +105,25 @@ test('builds insert, replace, and discard instructions from operation revisions'
         ],
     );
     assert.deepEqual(
+        documentationPackage.includedPlantSorts.map((plantSort) => [
+            plantSort.code,
+            plantSort.changeType,
+        ]),
+        [['PS-0014', 'insert']],
+    );
+    assert.deepEqual(
         documentationPackage.discardedOperations.map((operation) => [
             operation.code,
             operation.label,
         ]),
         [['OP-0011', 'Stara radnja']],
+    );
+    assert.deepEqual(
+        documentationPackage.discardedPlantSorts.map((plantSort) => [
+            plantSort.code,
+            plantSort.label,
+        ]),
+        [['PS-0016', 'Stara sorta']],
     );
 });
 
@@ -82,11 +131,19 @@ test('generates a guide-first PDF without page numbering text', () => {
     const documentationPackage = buildFarmerDocumentationPackage({
         generatedAt,
         since,
-        labelAttributeDefinitionIds: new Set(),
+        labelAttributeDefinitionIds: {
+            operation: new Set(),
+            plantSort: new Set(),
+        },
         operations: [
             operationFixture(4, 'Zalijevanje', {
                 duration: 25,
                 application: 'raisedBedFull',
+            }),
+        ],
+        plantSorts: [
+            plantSortFixture(14, 'Cherry rajčica', {
+                reproductionType: 'seed',
             }),
         ],
         revisions: [
@@ -95,6 +152,13 @@ test('generates a guide-first PDF without page numbering text', () => {
                 entityId: 4,
                 action: 'attribute.updated',
                 createdAt: new Date('2026-06-08T12:00:00.000Z'),
+            }),
+            revisionFixture({
+                id: 2,
+                entityId: 14,
+                entityTypeName: 'plantSort',
+                action: 'attribute.updated',
+                createdAt: new Date('2026-06-08T13:00:00.000Z'),
             }),
         ],
     });
@@ -105,7 +169,9 @@ test('generates a guide-first PDF without page numbering text', () => {
     assert.match(content, /^%PDF-1\.4/);
     assert.match(content, /ORG-GUIDE/);
     assert.match(content, /OP-0004/);
+    assert.match(content, /PS-0014/);
     assert.match(content, /Zalijevanje/);
+    assert.match(content, /Cherry rajcica/);
     assert.doesNotMatch(content, /Stranica \d/);
 });
 
@@ -130,11 +196,48 @@ function operationFixture(
     };
 }
 
+function plantSortFixture(
+    id: number,
+    label: string,
+    attributes: EntityStandardized['attributes'],
+): EntityStandardized {
+    return {
+        id,
+        information: {
+            label,
+            name: label,
+            description: 'Kratak opis sorte.',
+            plant: {
+                id: 1000 + id,
+                information: {
+                    label: 'Rajčica',
+                    name: 'Rajčica',
+                    description: 'Opis biljke.',
+                },
+                attributes: {
+                    seedingDistance: 30,
+                    germinationWindowMin: 7,
+                    germinationWindowMax: 10,
+                    growthWindowMin: 60,
+                    growthWindowMax: 80,
+                    water: 'Vlažno tlo',
+                    yieldMin: 100,
+                    yieldMax: 200,
+                    yieldType: 'perPlant',
+                    cleanHarvest: false,
+                },
+            },
+        },
+        attributes,
+    };
+}
+
 function revisionFixture({
     action,
     attributeDefinitionId = null,
     createdAt,
     entityId,
+    entityTypeName = 'operation',
     id,
     nextState = null,
     nextValue = null,
@@ -145,6 +248,7 @@ function revisionFixture({
     attributeDefinitionId?: number | null;
     createdAt: Date;
     entityId: number;
+    entityTypeName?: 'operation' | 'plantSort';
     id: number;
     nextState?: string | null;
     nextValue?: string | null;
@@ -158,7 +262,7 @@ function revisionFixture({
         attributeDefinitionId,
         createdAt,
         entityId,
-        entityTypeName: 'operation',
+        entityTypeName,
         nextState,
         nextValue,
         previousState,

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
@@ -1,10 +1,12 @@
 import { create as createQrCode } from 'qrcode';
 import {
+    discardedDocumentationPages,
     documentationChangeLabel,
-    type FarmerDocumentationOperation,
     type FarmerDocumentationPackage,
+    type FarmerDocumentationPage,
     formatDocumentationDateTime,
     getFarmerAppOrigin,
+    includedDocumentationPages,
 } from './farmerDocumentationData';
 
 type PdfFontKey = 'F1' | 'F2';
@@ -162,8 +164,8 @@ export function generateFarmerDocumentationPdf(
 
     drawOrganizationGuide({ data, farmOrigin, pages, version });
 
-    for (const operation of data.includedOperations) {
-        drawOperationManual({ farmOrigin, operation, pages, version, data });
+    for (const page of includedDocumentationPages(data)) {
+        drawDocumentationPage({ data, farmOrigin, pages, version, page });
     }
 
     return writePdf(pages.map((page) => page.toString()));
@@ -217,40 +219,39 @@ function drawOrganizationGuide({
         subtitle: data.since
             ? `Promjene od ${formatDocumentationDateTime(data.since)}`
             : 'Cijeli prirucnik',
-        qrUrl: `${farmOrigin}/operations`,
+        qrUrl: farmOrigin,
         version,
         generatedAt: data.generatedAt,
     });
     const packageType = data.since
-        ? 'Paket sadrzi organizacijski vodic i sve radnje promijenjene od zadnjeg ispisa.'
-        : 'Paket sadrzi organizacijski vodic i sve trenutno objavljene radnje.';
+        ? 'Paket sadrzi organizacijski vodic i sve prirucnike promijenjene od zadnjeg ispisa.'
+        : 'Paket sadrzi organizacijski vodic i sve trenutno objavljene prirucnike.';
+    const includedPages = includedDocumentationPages(data);
+    const discardedPages = discardedDocumentationPages(data);
 
     context = drawSection(context, 'Svrha paketa', [
         packageType,
-        'Stranice radnji nisu numerirane. U registratoru ih drzi po rastucem kodu OP-0001, OP-0002, OP-0003 i tako dalje.',
-        'Kod dodavanja novih radnji umetni ih na mjesto prema kodu, bez pomicanja ili prepisivanja brojeva stranica.',
+        'Stranice nisu numerirane. U registratoru ih drzi u odjeljcima prema kodu: OP za radnje i PS za sorte.',
+        'U svakom odjeljku stranice slozi po rastucem kodu, primjerice OP-0001, OP-0002 ili PS-0001, PS-0002.',
+        'Kod dodavanja novih prirucnika umetni ih na mjesto prema kodu, bez pomicanja ili prepisivanja brojeva stranica.',
     ]);
 
     context = drawActionList(
         context,
         'Umetni nove stranice',
-        data.includedOperations.filter(
-            (operation) => operation.changeType === 'insert',
-        ),
+        includedPages.filter((page) => page.changeType === 'insert'),
     );
     context = drawActionList(
         context,
         'Zamijeni postojece stranice',
-        data.includedOperations.filter(
-            (operation) => operation.changeType === 'replace',
-        ),
+        includedPages.filter((page) => page.changeType === 'replace'),
     );
-    context = drawDiscardList(context, data.discardedOperations);
+    context = drawDiscardList(context, discardedPages);
     context = drawSection(context, 'Kontrola nakon umetanja', [
-        '1. Provjeri da je svaka nova ili zamijenjena stranica umetnuta pod istim OP kodom kao u ovom vodicu.',
+        '1. Provjeri da je svaka nova ili zamijenjena stranica umetnuta pod istim kodom kao u ovom vodicu.',
         '2. Stare stranice iz odjeljka za zamjenu izdvoji i odbaci nakon sto nova verzija stoji u registratoru.',
         '3. Stranice iz odjeljka za uklanjanje izvadi iz registratora bez zamjenske stranice.',
-        '4. QR kod na svakoj stranici vodi na farmer aplikaciju za aktualnu digitalnu verziju radnje.',
+        '4. QR kod na svakoj stranici vodi na farmer aplikaciju za aktualnu digitalnu verziju prirucnika.',
     ]);
 
     drawFooter(context.page);
@@ -259,27 +260,27 @@ function drawOrganizationGuide({
 function drawActionList(
     context: FlowContext,
     title: string,
-    operations: FarmerDocumentationOperation[],
+    pages: FarmerDocumentationPage[],
 ) {
-    if (operations.length === 0) {
+    if (pages.length === 0) {
         return drawSection(context, title, ['Nema stranica u ovoj skupini.']);
     }
 
     return drawSection(
         context,
         title,
-        operations.map(
-            (operation) =>
-                `${operation.code} - ${operation.label} (${operation.revisionActions.join(', ') || 'aktualna verzija'})`,
+        pages.map(
+            (page) =>
+                `${page.code} - ${page.label} [${page.documentTypeLabel}] (${page.revisionActions.join(', ') || 'aktualna verzija'})`,
         ),
     );
 }
 
 function drawDiscardList(
     context: FlowContext,
-    discardedOperations: FarmerDocumentationPackage['discardedOperations'],
+    discardedPages: ReturnType<typeof discardedDocumentationPages>,
 ) {
-    if (discardedOperations.length === 0) {
+    if (discardedPages.length === 0) {
         return drawSection(context, 'Ukloni bez zamjene', [
             'Nema stranica za uklanjanje.',
         ]);
@@ -288,80 +289,52 @@ function drawDiscardList(
     return drawSection(
         context,
         'Ukloni bez zamjene',
-        discardedOperations.map(
-            (operation) =>
-                `${operation.code} - ${operation.label} (${operation.revisionActions.join(', ')})`,
+        discardedPages.map(
+            (page) =>
+                `${page.code} - ${page.label} [${page.documentTypeLabel}] (${page.revisionActions.join(', ')})`,
         ),
     );
 }
 
-function drawOperationManual({
+function drawDocumentationPage({
     data,
     farmOrigin,
-    operation,
+    page,
     pages,
     version,
 }: {
     data: FarmerDocumentationPackage;
     farmOrigin: string;
-    operation: FarmerDocumentationOperation;
+    page: FarmerDocumentationPage;
     pages: PdfCanvas[];
     version: string;
 }) {
-    const operationUrl = `${farmOrigin}/operations/${operation.id}`;
     let context = startPage(pages, {
-        code: operation.code,
-        title: operation.label,
+        code: page.code,
+        title: page.label,
         subtitle: data.since
-            ? documentationChangeLabel(operation.changeType)
-            : 'Cijeli prirucnik',
-        qrUrl: operationUrl,
+            ? `${page.documentTypeLabel} - ${documentationChangeLabel(page.changeType)}`
+            : page.documentTypeLabel,
+        qrUrl: `${farmOrigin}${page.appPath}`,
         version,
         generatedAt: data.generatedAt,
     });
 
-    context = drawOperationSummary(context, operation);
-    context = drawSection(
-        context,
-        'Opis',
-        markdownToPlainLines(operation.description ?? 'Opis nije definiran.'),
-    );
-    context = drawSection(
-        context,
-        'Upute',
-        markdownToPlainLines(
-            operation.instructions ?? 'Upute nisu definirane.',
-        ),
-    );
+    context = drawPageSummary(context, page);
 
-    if (operation.attributes.length > 0) {
+    for (const section of page.sections) {
         context = drawSection(
             context,
-            'Podaci radnje',
-            operation.attributes.map(
-                (attribute) => `${attribute.label}: ${attribute.value}`,
-            ),
+            section.title,
+            section.lines.flatMap((line) => markdownToPlainLines(line)),
         );
     }
 
     drawFooter(context.page);
 }
 
-function drawOperationSummary(
-    context: FlowContext,
-    operation: FarmerDocumentationOperation,
-) {
-    const rows = [
-        ['Kod', operation.code],
-        ['Trajanje', operation.durationLabel],
-        ['Dokaz fotografijom', operation.photoProofLabel],
-        [
-            'Promjena',
-            operation.changedAt
-                ? formatDocumentationDateTime(operation.changedAt)
-                : 'Cijeli prirucnik',
-        ],
-    ];
+function drawPageSummary(context: FlowContext, page: FarmerDocumentationPage) {
+    const rows = page.summaryRows;
     const boxHeight = rows.length * 21 + 18;
     context = ensureSpace(context, boxHeight);
     context.page.fillRect({
@@ -373,11 +346,11 @@ function drawOperationSummary(
     });
 
     let y = context.y - 25;
-    for (const [label, value] of rows) {
+    for (const row of rows) {
         context.page.text({
             x: margin + 12,
             y,
-            value: label.toUpperCase(),
+            value: row.label.toUpperCase(),
             size: 6.9,
             font: 'F2',
             color: colors.muted,
@@ -385,7 +358,7 @@ function drawOperationSummary(
         context.page.text({
             x: margin + 142,
             y,
-            value,
+            value: row.value,
             size: 9,
             font: 'F2',
             color: colors.text,

--- a/apps/app/app/admin/farmers/documentation/page.tsx
+++ b/apps/app/app/admin/farmers/documentation/page.tsx
@@ -10,9 +10,11 @@ import { KnownPages } from '../../../../src/KnownPages';
 import { DocumentationChangeTypeBadge } from './DocumentationChangeTypeBadge';
 import { DocumentationSummaryCard } from './DocumentationSummaryCard';
 import {
+    discardedDocumentationPages,
     type FarmerDocumentationChangeType,
     formatDocumentationDateTime,
     getFarmerDocumentationPackage,
+    includedDocumentationPages,
     parseDocumentationSince,
 } from './farmerDocumentationData';
 
@@ -21,6 +23,7 @@ export const dynamic = 'force-dynamic';
 type PackageRow = {
     code: string;
     label: string;
+    documentTypeLabel: string;
     changeType: FarmerDocumentationChangeType;
     changedAt: Date | null;
     detail: string;
@@ -70,8 +73,8 @@ export default async function FarmerDocumentationPage({
                     Dokumentacija farmera
                 </Typography>
                 <Typography level="body2" className="text-muted-foreground">
-                    Ispis priručnika radnji iz farmer aplikacije, organiziran po
-                    stabilnim OP kodovima.
+                    Ispis priručnika radnji i sorti iz farmer aplikacije,
+                    organiziran po stabilnim OP i PS kodovima.
                 </Typography>
             </Stack>
 
@@ -114,18 +117,35 @@ export default async function FarmerDocumentationPage({
                 </CardContent>
             </Card>
 
-            <div className="grid gap-3 md:grid-cols-4">
+            <div className="grid gap-3 md:grid-cols-6">
                 <DocumentationSummaryCard
-                    label="Trenutnih radnji"
+                    label="Trenutnih priručnika"
+                    value={
+                        documentationPackage.totalOperations +
+                        documentationPackage.totalPlantSorts
+                    }
+                />
+                <DocumentationSummaryCard
+                    label="Radnji"
                     value={documentationPackage.totalOperations}
                 />
                 <DocumentationSummaryCard
+                    label="Sorti"
+                    value={documentationPackage.totalPlantSorts}
+                />
+                <DocumentationSummaryCard
                     label="Stranica u paketu"
-                    value={documentationPackage.includedOperations.length}
+                    value={
+                        documentationPackage.includedOperations.length +
+                        documentationPackage.includedPlantSorts.length
+                    }
                 />
                 <DocumentationSummaryCard
                     label="Za uklanjanje"
-                    value={documentationPackage.discardedOperations.length}
+                    value={
+                        documentationPackage.discardedOperations.length +
+                        documentationPackage.discardedPlantSorts.length
+                    }
                 />
                 <DocumentationSummaryCard
                     label="Od zadnjeg ispisa"
@@ -149,7 +169,8 @@ export default async function FarmerDocumentationPage({
                             <Table.Header>
                                 <Table.Row>
                                     <Table.Head>Kod</Table.Head>
-                                    <Table.Head>Radnja</Table.Head>
+                                    <Table.Head>Priručnik</Table.Head>
+                                    <Table.Head>Vrsta</Table.Head>
                                     <Table.Head>Status</Table.Head>
                                     <Table.Head>Promjena</Table.Head>
                                     <Table.Head>Sažetak</Table.Head>
@@ -164,6 +185,9 @@ export default async function FarmerDocumentationPage({
                                             {row.code}
                                         </Table.Cell>
                                         <Table.Cell>{row.label}</Table.Cell>
+                                        <Table.Cell className="text-muted-foreground">
+                                            {row.documentTypeLabel}
+                                        </Table.Cell>
                                         <Table.Cell>
                                             <DocumentationChangeTypeBadge
                                                 type={row.changeType}
@@ -220,23 +244,24 @@ function packageTableRows(
     >,
 ): PackageRow[] {
     return [
-        ...documentationPackage.includedOperations.map(
-            (operation): PackageRow => ({
-                code: operation.code,
-                label: operation.label,
-                changeType: operation.changeType,
-                changedAt: operation.changedAt,
-                detail:
-                    operation.revisionActions.join(', ') || 'Aktualna verzija',
+        ...includedDocumentationPages(documentationPackage).map(
+            (page): PackageRow => ({
+                code: page.code,
+                label: page.label,
+                documentTypeLabel: page.documentTypeLabel,
+                changeType: page.changeType,
+                changedAt: page.changedAt,
+                detail: page.revisionActions.join(', ') || 'Aktualna verzija',
             }),
         ),
-        ...documentationPackage.discardedOperations.map(
-            (operation): PackageRow => ({
-                code: operation.code,
-                label: operation.label,
+        ...discardedDocumentationPages(documentationPackage).map(
+            (page): PackageRow => ({
+                code: page.code,
+                label: page.label,
+                documentTypeLabel: page.documentTypeLabel,
                 changeType: 'discard',
-                changedAt: operation.changedAt,
-                detail: operation.revisionActions.join(', '),
+                changedAt: page.changedAt,
+                detail: page.revisionActions.join(', '),
             }),
         ),
     ].sort((left, right) => left.code.localeCompare(right.code));


### PR DESCRIPTION
## Summary
- Add plant sort manuals to the farmer documentation package alongside operation manuals.
- Split printed documentation codes into `OP-####` and `PS-####` so new pages can be inserted by type without page numbering.
- Update the print guide, PDF generation, admin summary, and tests to cover mixed operation and plant sort insert/replace/discard flows.

## Validation
- `corepack pnpm exec biome check app/admin/farmers/documentation`
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server" corepack pnpm exec node --import tsx --test app/admin/farmers/documentation/farmerDocumentationData.unit.ts`
- `corepack pnpm --filter app run test:unit`
- `git diff --check`
- `corepack pnpm --filter app build`

## Notes
- PR #3590 was already merged, so this follow-up is opened from current `main` with only the plant-sort documentation change.