### PR TITLE
[codex] Fix water height over edge blocks

### DIFF
--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -52,7 +52,9 @@ import {
 import {
     createMergedWaterSideGeometry,
     createWaterBlockGeometry,
+    getWaterBlockYOffset,
 } from './waterBlockGeometry';
+import { getWaterBlockVisualHeight } from './waterBlockHeight';
 
 type CommonWeatherProps = Pick<
     EntityInstancesBlockBaseProps,
@@ -87,6 +89,9 @@ type LoadedAssetBlockMaterialProps = Omit<
     gltf: GLTFResult;
     groundPatch?: GroundPatchSurface;
     material: (gltf: GLTFResult) => Material | Material[];
+};
+type WaterBlockInstance = EntityBlockInstance & {
+    waterHeight: number;
 };
 
 const potBlockNames = [
@@ -394,11 +399,35 @@ function BlockGroundInstances({
 
 function WaterBlockInstances({ stacks }: { stacks: Stack[] | undefined }) {
     const { data: blockData } = useBlockData();
-    const waterInstances = useEntityBlockInstances({
+    const baseWaterInstances = useEntityBlockInstances({
         name: 'Block_Water',
         stacks,
-        yOffset: 0.14,
     });
+    const waterInstances = useMemo(
+        () =>
+            baseWaterInstances?.map((instance): WaterBlockInstance => {
+                const waterHeight = getWaterBlockVisualHeight({
+                    block: instance.block,
+                    blockData,
+                    stack: instance.stack,
+                });
+                const previewYOffset =
+                    instance.position[1] - instance.stackHeight;
+
+                return {
+                    ...instance,
+                    position: [
+                        instance.position[0],
+                        instance.stackHeight +
+                            getWaterBlockYOffset(waterHeight) +
+                            previewYOffset,
+                        instance.position[2],
+                    ],
+                    waterHeight,
+                };
+            }),
+        [baseWaterInstances, blockData],
+    );
 
     if (!waterInstances?.length) {
         return null;
@@ -420,6 +449,7 @@ function WaterBlockInstances({ stacks }: { stacks: Stack[] | undefined }) {
                     foamEdges={mask.foamEdges}
                     instances={mask.instances}
                     maskKey={mask.key}
+                    waterHeight={mask.waterHeight}
                 />
             ))}
             <WaterBlockMergedSides instances={waterInstances} />
@@ -438,11 +468,13 @@ function foamEdgeKey(foamEdges: Vector4) {
 function waterFoamMaskKey({
     foamCorners,
     foamEdges,
+    waterHeight,
 }: {
     foamCorners: Vector4;
     foamEdges: Vector4;
+    waterHeight: number;
 }) {
-    return `${foamEdgeKey(foamEdges)}-${foamEdgeKey(foamCorners)}`;
+    return `${foamEdgeKey(foamEdges)}-${foamEdgeKey(foamCorners)}-${waterHeight}`;
 }
 
 function resolveWaterBlockInstanceGroups({
@@ -451,7 +483,7 @@ function resolveWaterBlockInstanceGroups({
     stacks,
 }: {
     blockData: Parameters<typeof resolveWaterFoamEdges>[0]['blockData'];
-    instances: EntityBlockInstance[];
+    instances: WaterBlockInstance[];
     stacks: Stack[] | undefined;
 }) {
     const groupedInstances = new Map<
@@ -459,12 +491,14 @@ function resolveWaterBlockInstanceGroups({
         {
             foamCorners: Vector4;
             foamEdges: Vector4;
-            instances: EntityBlockInstance[];
+            instances: WaterBlockInstance[];
             key: string;
+            waterHeight: number;
         }
     >();
 
     for (const instance of instances) {
+        const { waterHeight } = instance;
         const foamEdges = resolveWaterFoamEdges({
             block: instance.block,
             blockData,
@@ -477,7 +511,11 @@ function resolveWaterBlockInstanceGroups({
             stack: instance.stack,
             stacks,
         });
-        const key = waterFoamMaskKey({ foamCorners, foamEdges });
+        const key = waterFoamMaskKey({
+            foamCorners,
+            foamEdges,
+            waterHeight,
+        });
         const group = groupedInstances.get(key);
 
         if (group) {
@@ -488,6 +526,7 @@ function resolveWaterBlockInstanceGroups({
                 foamEdges,
                 instances: [instance],
                 key,
+                waterHeight,
             });
         }
     }
@@ -500,16 +539,22 @@ function WaterBlockMaskInstances({
     foamEdges,
     instances,
     maskKey,
+    waterHeight,
 }: {
     foamCorners: Vector4;
     foamEdges: Vector4;
-    instances: EntityBlockInstance[];
+    instances: WaterBlockInstance[];
     maskKey: string;
+    waterHeight: number;
 }) {
     const material = useWaterBlockMaterial(foamEdges, true, foamCorners);
     const geometry = useMemo(
-        () => createWaterBlockGeometry(foamEdges, { includeSides: false }),
-        [foamEdges],
+        () =>
+            createWaterBlockGeometry(foamEdges, {
+                height: waterHeight,
+                includeSides: false,
+            }),
+        [foamEdges, waterHeight],
     );
 
     useEffect(() => () => geometry.dispose(), [geometry]);
@@ -535,7 +580,7 @@ const mergedWaterSideFoamEdges = new Vector4(0, 0, 0, 0);
 function WaterBlockMergedSides({
     instances,
 }: {
-    instances: EntityBlockInstance[];
+    instances: WaterBlockInstance[];
 }) {
     const material = useWaterBlockMaterial(mergedWaterSideFoamEdges, false);
     const geometry = useMemo(

--- a/packages/game/src/entities/BlockWater.tsx
+++ b/packages/game/src/entities/BlockWater.tsx
@@ -11,7 +11,11 @@ import {
     resolveWaterFoamCorners,
     resolveWaterFoamEdges,
 } from './waterBlockFoam';
-import { createWaterBlockGeometry } from './waterBlockGeometry';
+import {
+    createWaterBlockGeometry,
+    getWaterBlockYOffset,
+} from './waterBlockGeometry';
+import { getWaterBlockVisualHeight } from './waterBlockHeight';
 
 const waterVertexShader = `
 varying vec3 vLocalPosition;
@@ -205,6 +209,11 @@ export function useWaterBlockMaterial(
 export function BlockWater({ stack, block, stacks }: EntityInstanceProps) {
     const { data: blockData } = useBlockData();
     const currentStackHeight = getStackHeight(blockData, stack, block);
+    const waterHeight = getWaterBlockVisualHeight({
+        block,
+        blockData,
+        stack,
+    });
     const foamEdges = useMemo(
         () => resolveWaterFoamEdges({ block, blockData, stack, stacks }),
         [block, blockData, stack, stacks],
@@ -217,8 +226,12 @@ export function BlockWater({ stack, block, stacks }: EntityInstanceProps) {
     const includeTop =
         waterBlockIndex < 0 || waterBlockIndex === stack.blocks.length - 1;
     const geometry = useMemo(
-        () => createWaterBlockGeometry(foamEdges, { includeTop }),
-        [foamEdges, includeTop],
+        () =>
+            createWaterBlockGeometry(foamEdges, {
+                height: waterHeight,
+                includeTop,
+            }),
+        [foamEdges, includeTop, waterHeight],
     );
     const material = useWaterBlockMaterial(foamEdges, true, foamCorners);
 
@@ -226,7 +239,9 @@ export function BlockWater({ stack, block, stacks }: EntityInstanceProps) {
 
     return (
         <animated.group
-            position={stack.position.clone().setY(currentStackHeight + 0.14)}
+            position={stack.position
+                .clone()
+                .setY(currentStackHeight + getWaterBlockYOffset(waterHeight))}
         >
             <mesh
                 receiveShadow

--- a/packages/game/src/entities/waterBlockGeometry.ts
+++ b/packages/game/src/entities/waterBlockGeometry.ts
@@ -6,8 +6,8 @@ import {
 } from 'three';
 
 const waterBlockHalfSize = 0.5;
-const waterBlockMinY = -0.2;
-const waterBlockMaxY = 0.2;
+export const defaultWaterBlockVisualHeight = 0.4;
+export const waterBlockBottomOverlap = 0.06;
 const segmentMergeEpsilon = 1e-6;
 
 type WaterFoamEdge = 'x' | 'y' | 'z' | 'w';
@@ -23,12 +23,14 @@ type WaterFace = {
 };
 
 type WaterBlockGeometryOptions = {
+    height?: number;
     includeSides?: boolean;
     includeTop?: boolean;
 };
 
 type WaterSideInstance = {
     position: [number, number, number];
+    waterHeight?: number;
 };
 
 type WaterSideSegment = {
@@ -41,58 +43,79 @@ type WaterSideSegment = {
     yMin: number;
 };
 
-const topFace: WaterFace = {
-    normal: [0, 1, 0],
-    vertices: [
-        [-waterBlockHalfSize, waterBlockMaxY, -waterBlockHalfSize],
-        [-waterBlockHalfSize, waterBlockMaxY, waterBlockHalfSize],
-        [waterBlockHalfSize, waterBlockMaxY, waterBlockHalfSize],
-        [waterBlockHalfSize, waterBlockMaxY, -waterBlockHalfSize],
-    ],
-};
+export function getWaterBlockYOffset(height = defaultWaterBlockVisualHeight) {
+    return height / 2 - waterBlockBottomOverlap;
+}
 
-const waterSideFaces = [
-    {
-        edge: 'x',
-        normal: [-1, 0, 0],
+function waterBlockMinY(height: number) {
+    return -height / 2;
+}
+
+function waterBlockMaxY(height: number) {
+    return height / 2;
+}
+
+function createTopFace(height: number): WaterFace {
+    const y = waterBlockMaxY(height);
+
+    return {
+        normal: [0, 1, 0],
         vertices: [
-            [-waterBlockHalfSize, waterBlockMinY, waterBlockHalfSize],
-            [-waterBlockHalfSize, waterBlockMaxY, waterBlockHalfSize],
-            [-waterBlockHalfSize, waterBlockMaxY, -waterBlockHalfSize],
-            [-waterBlockHalfSize, waterBlockMinY, -waterBlockHalfSize],
+            [-waterBlockHalfSize, y, -waterBlockHalfSize],
+            [-waterBlockHalfSize, y, waterBlockHalfSize],
+            [waterBlockHalfSize, y, waterBlockHalfSize],
+            [waterBlockHalfSize, y, -waterBlockHalfSize],
         ],
-    },
-    {
-        edge: 'y',
-        normal: [1, 0, 0],
-        vertices: [
-            [waterBlockHalfSize, waterBlockMinY, -waterBlockHalfSize],
-            [waterBlockHalfSize, waterBlockMaxY, -waterBlockHalfSize],
-            [waterBlockHalfSize, waterBlockMaxY, waterBlockHalfSize],
-            [waterBlockHalfSize, waterBlockMinY, waterBlockHalfSize],
-        ],
-    },
-    {
-        edge: 'z',
-        normal: [0, 0, -1],
-        vertices: [
-            [waterBlockHalfSize, waterBlockMinY, -waterBlockHalfSize],
-            [waterBlockHalfSize, waterBlockMaxY, -waterBlockHalfSize],
-            [-waterBlockHalfSize, waterBlockMaxY, -waterBlockHalfSize],
-            [-waterBlockHalfSize, waterBlockMinY, -waterBlockHalfSize],
-        ],
-    },
-    {
-        edge: 'w',
-        normal: [0, 0, 1],
-        vertices: [
-            [-waterBlockHalfSize, waterBlockMinY, waterBlockHalfSize],
-            [-waterBlockHalfSize, waterBlockMaxY, waterBlockHalfSize],
-            [waterBlockHalfSize, waterBlockMaxY, waterBlockHalfSize],
-            [waterBlockHalfSize, waterBlockMinY, waterBlockHalfSize],
-        ],
-    },
-] satisfies Array<WaterFace & { edge: WaterFoamEdge }>;
+    };
+}
+
+function createWaterSideFaces(height: number) {
+    const yMin = waterBlockMinY(height);
+    const yMax = waterBlockMaxY(height);
+
+    return [
+        {
+            edge: 'x',
+            normal: [-1, 0, 0],
+            vertices: [
+                [-waterBlockHalfSize, yMin, waterBlockHalfSize],
+                [-waterBlockHalfSize, yMax, waterBlockHalfSize],
+                [-waterBlockHalfSize, yMax, -waterBlockHalfSize],
+                [-waterBlockHalfSize, yMin, -waterBlockHalfSize],
+            ],
+        },
+        {
+            edge: 'y',
+            normal: [1, 0, 0],
+            vertices: [
+                [waterBlockHalfSize, yMin, -waterBlockHalfSize],
+                [waterBlockHalfSize, yMax, -waterBlockHalfSize],
+                [waterBlockHalfSize, yMax, waterBlockHalfSize],
+                [waterBlockHalfSize, yMin, waterBlockHalfSize],
+            ],
+        },
+        {
+            edge: 'z',
+            normal: [0, 0, -1],
+            vertices: [
+                [waterBlockHalfSize, yMin, -waterBlockHalfSize],
+                [waterBlockHalfSize, yMax, -waterBlockHalfSize],
+                [-waterBlockHalfSize, yMax, -waterBlockHalfSize],
+                [-waterBlockHalfSize, yMin, -waterBlockHalfSize],
+            ],
+        },
+        {
+            edge: 'w',
+            normal: [0, 0, 1],
+            vertices: [
+                [-waterBlockHalfSize, yMin, waterBlockHalfSize],
+                [-waterBlockHalfSize, yMax, waterBlockHalfSize],
+                [waterBlockHalfSize, yMax, waterBlockHalfSize],
+                [waterBlockHalfSize, yMin, waterBlockHalfSize],
+            ],
+        },
+    ] satisfies Array<WaterFace & { edge: WaterFoamEdge }>;
+}
 
 function pushFace({
     face,
@@ -143,12 +166,16 @@ function createGeometryFromFaces(faces: WaterFace[]) {
 
 export function createWaterBlockGeometry(
     foamEdges: Vector4,
-    { includeSides = true, includeTop = true }: WaterBlockGeometryOptions = {},
+    {
+        height = defaultWaterBlockVisualHeight,
+        includeSides = true,
+        includeTop = true,
+    }: WaterBlockGeometryOptions = {},
 ) {
-    const faces = includeTop ? [topFace] : [];
+    const faces = includeTop ? [createTopFace(height)] : [];
 
     if (includeSides) {
-        for (const face of waterSideFaces) {
+        for (const face of createWaterSideFaces(height)) {
             if (foamEdges[face.edge] > 0.5) {
                 faces.push(face);
             }
@@ -341,8 +368,9 @@ export function createMergedWaterSideGeometry(instances: WaterSideInstance[]) {
 
     for (const instance of instances) {
         const [x, y, z] = instance.position;
-        const yMin = y + waterBlockMinY;
-        const yMax = y + waterBlockMaxY;
+        const height = instance.waterHeight ?? defaultWaterBlockVisualHeight;
+        const yMin = y + waterBlockMinY(height);
+        const yMax = y + waterBlockMaxY(height);
 
         if (!waterPositions.has(positionKey(x - 1, y, z))) {
             sideSegments.push({

--- a/packages/game/src/entities/waterBlockGeometry.unit.ts
+++ b/packages/game/src/entities/waterBlockGeometry.unit.ts
@@ -4,6 +4,7 @@ import { Vector4 } from 'three';
 import {
     createMergedWaterSideGeometry,
     createWaterBlockGeometry,
+    getWaterBlockYOffset,
 } from './waterBlockGeometry';
 
 describe('createWaterBlockGeometry', () => {
@@ -44,6 +45,16 @@ describe('createWaterBlockGeometry', () => {
             ['-1,0,0', '0,0,-1'],
         );
     });
+
+    it('uses the requested visual height for water faces', () => {
+        const geometry = createWaterBlockGeometry(new Vector4(1, 1, 1, 1), {
+            height: 0.25,
+        });
+
+        assert.deepEqual(geometryYExtents(geometry), [-0.125, 0.125]);
+
+        geometry.dispose();
+    });
 });
 
 function geometryNormals(
@@ -66,6 +77,19 @@ function geometryNormals(
 
     geometry.dispose();
     return [...normals].sort();
+}
+
+function geometryYExtents(
+    geometry: ReturnType<typeof createWaterBlockGeometry>,
+) {
+    const positionAttribute = geometry.getAttribute('position');
+    const yValues = new Set<number>();
+
+    for (let index = 0; index < positionAttribute.count; index += 1) {
+        yValues.add(Number(positionAttribute.getY(index).toFixed(6)));
+    }
+
+    return [...yValues].sort((left, right) => left - right);
 }
 
 describe('createMergedWaterSideGeometry', () => {
@@ -107,6 +131,19 @@ describe('createMergedWaterSideGeometry', () => {
 
         assert.equal(positionAttribute.count, 16);
         assert.equal(indexAttribute?.count, 24);
+
+        geometry.dispose();
+    });
+
+    it('uses per-instance water heights for merged side walls', () => {
+        const geometry = createMergedWaterSideGeometry([
+            {
+                position: [0, getWaterBlockYOffset(0.25), 0],
+                waterHeight: 0.25,
+            },
+        ]);
+
+        assert.deepEqual(geometryYExtents(geometry), [-0.06, 0.19]);
 
         geometry.dispose();
     });

--- a/packages/game/src/entities/waterBlockHeight.ts
+++ b/packages/game/src/entities/waterBlockHeight.ts
@@ -1,0 +1,35 @@
+import type { BlockData } from '@gredice/client';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { getBlockDataByName } from '../utils/stackHeightCore';
+import { defaultWaterBlockVisualHeight } from './waterBlockGeometry';
+
+function isEdgeOrCornerTerrainBlock(blockName: string) {
+    return (
+        blockName.startsWith('Block_') &&
+        (blockName.endsWith('_Angle') || blockName.endsWith('_Corner'))
+    );
+}
+
+export function getWaterBlockVisualHeight({
+    block,
+    blockData,
+    stack,
+}: {
+    block: Block;
+    blockData: BlockData[] | null | undefined;
+    stack: Stack;
+}) {
+    const waterBlockIndex = stack.blocks.indexOf(block);
+    const supportBlock =
+        waterBlockIndex > 0 ? stack.blocks[waterBlockIndex - 1] : null;
+
+    if (!supportBlock || !isEdgeOrCornerTerrainBlock(supportBlock.name)) {
+        return defaultWaterBlockVisualHeight;
+    }
+
+    return (
+        getBlockDataByName(blockData, supportBlock.name)?.attributes.height ??
+        defaultWaterBlockVisualHeight
+    );
+}

--- a/packages/game/src/entities/waterBlockHeight.unit.ts
+++ b/packages/game/src/entities/waterBlockHeight.unit.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import { getLocalSandboxBlockData } from '../localSandboxBlockData';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { defaultWaterBlockVisualHeight } from './waterBlockGeometry';
+import { getWaterBlockVisualHeight } from './waterBlockHeight';
+
+function block(id: string, name: string): Block {
+    return { id, name, rotation: 0 };
+}
+
+function stack(blocks: Block[]): Stack {
+    return {
+        blocks,
+        position: new Vector3(0, 0, 0),
+    };
+}
+
+describe('getWaterBlockVisualHeight', () => {
+    it('uses the default height for unsupported water blocks', () => {
+        const water = block('water-a', 'Block_Water');
+        const currentStack = stack([water]);
+
+        assert.equal(
+            getWaterBlockVisualHeight({
+                block: water,
+                blockData: getLocalSandboxBlockData(),
+                stack: currentStack,
+            }),
+            defaultWaterBlockVisualHeight,
+        );
+    });
+
+    it('matches water height to the angle block directly below it', () => {
+        const water = block('water-a', 'Block_Water');
+        const currentStack = stack([
+            block('angle-a', 'Block_Grass_Angle'),
+            water,
+        ]);
+
+        assert.equal(
+            getWaterBlockVisualHeight({
+                block: water,
+                blockData: getLocalSandboxBlockData(),
+                stack: currentStack,
+            }),
+            0.25,
+        );
+    });
+
+    it('matches water height to the corner block directly below it', () => {
+        const water = block('water-a', 'Block_Water');
+        const currentStack = stack([
+            block('corner-a', 'Block_Sand_Reverse_Corner'),
+            water,
+        ]);
+
+        assert.equal(
+            getWaterBlockVisualHeight({
+                block: water,
+                blockData: getLocalSandboxBlockData(),
+                stack: currentStack,
+            }),
+            0.25,
+        );
+    });
+
+    it('keeps the default height when the support block is not an edge or corner terrain block', () => {
+        const water = block('water-a', 'Block_Water');
+        const currentStack = stack([block('grass-a', 'Block_Grass'), water]);
+
+        assert.equal(
+            getWaterBlockVisualHeight({
+                block: water,
+                blockData: getLocalSandboxBlockData(),
+                stack: currentStack,
+            }),
+            defaultWaterBlockVisualHeight,
+        );
+    });
+});


### PR DESCRIPTION
## What changed

- Added a water visual-height resolver for water blocks placed directly on angle/corner terrain blocks.
- Parameterized water geometry and merged side-wall geometry so those water blocks render at the support block height instead of the default full water height.
- Covered the height resolver and variable water geometry with focused unit tests.

## Why

Water placed on corner or edge terrain blocks looked too tall and did not read as filling the shaped block space. Matching the water visual height to the block directly below fixes that visual mismatch while preserving default-height water elsewhere.

## Validation

- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game exec biome check src/entities/AdditionalEntityInstances.tsx src/entities/BlockWater.tsx src/entities/waterBlockGeometry.ts src/entities/waterBlockGeometry.unit.ts src/entities/waterBlockHeight.ts src/entities/waterBlockHeight.unit.ts`
- `git diff --check`
- Visual smoke: garden debug sandbox at `http://localhost:4431/debug/entities`, seeded with water on angle/corner/flat blocks; desktop and mobile canvas screenshots were nonblank and visually inspected.
