### PR TITLE
[codex] Fix water edge joining for shaped blocks

### DIFF
--- a/packages/game/src/entities/waterBlockFoam.ts
+++ b/packages/game/src/entities/waterBlockFoam.ts
@@ -3,11 +3,25 @@ import { Vector4 } from 'three';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
 import { getStackHeight } from '../utils/stackHeightCore';
+import { waterBlockBottomOverlap } from './waterBlockGeometry';
+import { getWaterBlockVisualHeight } from './waterBlockHeight';
 
 export const waterBlockName = 'Block_Water';
-const waterLevelEpsilon = 1e-6;
+const waterRangeOverlapEpsilon = 1e-6;
 
-function getWaterBlockLevel({
+type WaterVerticalRange = {
+    max: number;
+    min: number;
+};
+
+function getFallbackWaterBlockVerticalRange(blockIndex: number) {
+    return {
+        min: blockIndex,
+        max: blockIndex + 1,
+    } satisfies WaterVerticalRange;
+}
+
+function getWaterBlockVerticalRange({
     block,
     blockData,
     stack,
@@ -21,22 +35,40 @@ function getWaterBlockLevel({
         return null;
     }
 
-    return blockData ? getStackHeight(blockData, stack, block) : blockIndex;
+    if (!blockData) {
+        return getFallbackWaterBlockVerticalRange(blockIndex);
+    }
+
+    const stackHeight = getStackHeight(blockData, stack, block);
+    const waterHeight = getWaterBlockVisualHeight({
+        block,
+        blockData,
+        stack,
+    });
+
+    return {
+        min: stackHeight - waterBlockBottomOverlap,
+        max: stackHeight + waterHeight - waterBlockBottomOverlap,
+    } satisfies WaterVerticalRange;
 }
 
-function isSameWaterLevel(left: number | null, right: number | null) {
+function doWaterRangesOverlap(
+    left: WaterVerticalRange | null,
+    right: WaterVerticalRange | null,
+) {
     return (
         left !== null &&
         right !== null &&
-        Math.abs(left - right) <= waterLevelEpsilon
+        Math.min(left.max, right.max) - Math.max(left.min, right.min) >
+            waterRangeOverlapEpsilon
     );
 }
 
-function hasWaterAtLevel(
+function hasOverlappingWater(
     stacks: Stack[] | undefined,
     x: number,
     z: number,
-    level: number | null,
+    range: WaterVerticalRange | null,
     blockData: BlockData[] | null | undefined,
 ) {
     return stacks?.some((candidate) => {
@@ -47,9 +79,13 @@ function hasWaterAtLevel(
         return candidate.blocks.some(
             (block) =>
                 block.name === waterBlockName &&
-                isSameWaterLevel(
-                    getWaterBlockLevel({ block, blockData, stack: candidate }),
-                    level,
+                doWaterRangesOverlap(
+                    getWaterBlockVerticalRange({
+                        block,
+                        blockData,
+                        stack: candidate,
+                    }),
+                    range,
                 ),
         );
     });
@@ -72,12 +108,12 @@ export function resolveWaterFoamEdges({
     }
 
     const { x, z } = stack.position;
-    const level = getWaterBlockLevel({ block, blockData, stack });
+    const range = getWaterBlockVerticalRange({ block, blockData, stack });
     return new Vector4(
-        hasWaterAtLevel(allStacks, x - 1, z, level, blockData) ? 0 : 1,
-        hasWaterAtLevel(allStacks, x + 1, z, level, blockData) ? 0 : 1,
-        hasWaterAtLevel(allStacks, x, z - 1, level, blockData) ? 0 : 1,
-        hasWaterAtLevel(allStacks, x, z + 1, level, blockData) ? 0 : 1,
+        hasOverlappingWater(allStacks, x - 1, z, range, blockData) ? 0 : 1,
+        hasOverlappingWater(allStacks, x + 1, z, range, blockData) ? 0 : 1,
+        hasOverlappingWater(allStacks, x, z - 1, range, blockData) ? 0 : 1,
+        hasOverlappingWater(allStacks, x, z + 1, range, blockData) ? 0 : 1,
     );
 }
 
@@ -98,29 +134,53 @@ export function resolveWaterFoamCorners({
     }
 
     const { x, z } = stack.position;
-    const level = getWaterBlockLevel({ block, blockData, stack });
-    const hasNegXWater = hasWaterAtLevel(allStacks, x - 1, z, level, blockData);
-    const hasPosXWater = hasWaterAtLevel(allStacks, x + 1, z, level, blockData);
-    const hasNegZWater = hasWaterAtLevel(allStacks, x, z - 1, level, blockData);
-    const hasPosZWater = hasWaterAtLevel(allStacks, x, z + 1, level, blockData);
+    const range = getWaterBlockVerticalRange({ block, blockData, stack });
+    const hasNegXWater = hasOverlappingWater(
+        allStacks,
+        x - 1,
+        z,
+        range,
+        blockData,
+    );
+    const hasPosXWater = hasOverlappingWater(
+        allStacks,
+        x + 1,
+        z,
+        range,
+        blockData,
+    );
+    const hasNegZWater = hasOverlappingWater(
+        allStacks,
+        x,
+        z - 1,
+        range,
+        blockData,
+    );
+    const hasPosZWater = hasOverlappingWater(
+        allStacks,
+        x,
+        z + 1,
+        range,
+        blockData,
+    );
 
     return new Vector4(
-        !hasWaterAtLevel(allStacks, x - 1, z - 1, level, blockData) &&
+        !hasOverlappingWater(allStacks, x - 1, z - 1, range, blockData) &&
             hasNegXWater &&
             hasNegZWater
             ? 1
             : 0,
-        !hasWaterAtLevel(allStacks, x + 1, z - 1, level, blockData) &&
+        !hasOverlappingWater(allStacks, x + 1, z - 1, range, blockData) &&
             hasPosXWater &&
             hasNegZWater
             ? 1
             : 0,
-        !hasWaterAtLevel(allStacks, x - 1, z + 1, level, blockData) &&
+        !hasOverlappingWater(allStacks, x - 1, z + 1, range, blockData) &&
             hasNegXWater &&
             hasPosZWater
             ? 1
             : 0,
-        !hasWaterAtLevel(allStacks, x + 1, z + 1, level, blockData) &&
+        !hasOverlappingWater(allStacks, x + 1, z + 1, range, blockData) &&
             hasPosXWater &&
             hasPosZWater
             ? 1

--- a/packages/game/src/entities/waterBlockFoam.unit.ts
+++ b/packages/game/src/entities/waterBlockFoam.unit.ts
@@ -21,6 +21,10 @@ function sandBlock(id: string): Block {
     return { id, name: 'Block_Sand', rotation: 0 };
 }
 
+function grassAngleBlock(id: string): Block {
+    return { id, name: 'Block_Grass_Angle', rotation: 0 };
+}
+
 function stack(x: number, z: number, blocks: Block[]): Stack {
     return {
         position: new Vector3(x, 0, z),
@@ -110,6 +114,29 @@ describe('resolveWaterFoamEdges', () => {
                 stacks,
             }).toArray(),
             [1, 1, 1, 1],
+        );
+    });
+
+    it('removes foam when shaped and full-height water ranges overlap', () => {
+        const blockData = getLocalSandboxBlockData();
+        const currentWater = waterBlock('water-shaped');
+        const currentStack = stack(0, 0, [
+            grassAngleBlock('angle-a'),
+            currentWater,
+        ]);
+        const stacks = [
+            currentStack,
+            stack(1, 0, [grassBlock('grass-a'), waterBlock('water-east')]),
+        ];
+
+        assert.deepEqual(
+            resolveWaterFoamEdges({
+                block: currentWater,
+                blockData,
+                stack: currentStack,
+                stacks,
+            }).toArray(),
+            [1, 0, 1, 1],
         );
     });
 

--- a/packages/game/src/entities/waterBlockGeometry.ts
+++ b/packages/game/src/entities/waterBlockGeometry.ts
@@ -373,16 +373,6 @@ function getWaterSideInstanceRange(instance: WaterSideInstance) {
     } satisfies WaterSideInstanceRange;
 }
 
-function doWaterSideRangesOverlap(
-    left: WaterSideInstanceRange,
-    right: WaterSideInstanceRange,
-) {
-    return (
-        Math.min(left.max, right.max) - Math.max(left.min, right.min) >
-        segmentMergeEpsilon
-    );
-}
-
 function groupWaterSideInstancesByStackPosition(
     instances: WaterSideInstance[],
 ) {
@@ -403,7 +393,37 @@ function groupWaterSideInstancesByStackPosition(
     return groups;
 }
 
-function hasOverlappingWaterSideInstance({
+function clipWaterSideRange(
+    range: WaterSideInstanceRange,
+    clipRange: WaterSideInstanceRange,
+) {
+    const clipMin = Math.max(range.min, clipRange.min);
+    const clipMax = Math.min(range.max, clipRange.max);
+
+    if (clipMax - clipMin <= segmentMergeEpsilon) {
+        return [range];
+    }
+
+    const remainingRanges: WaterSideInstanceRange[] = [];
+
+    if (clipMin - range.min > segmentMergeEpsilon) {
+        remainingRanges.push({
+            min: range.min,
+            max: clipMin,
+        });
+    }
+
+    if (range.max - clipMax > segmentMergeEpsilon) {
+        remainingRanges.push({
+            min: clipMax,
+            max: range.max,
+        });
+    }
+
+    return remainingRanges;
+}
+
+function getVisibleWaterSideRanges({
     range,
     stackGroups,
     x,
@@ -414,16 +434,65 @@ function hasOverlappingWaterSideInstance({
     x: number;
     z: number;
 }) {
-    return (
+    const neighborRanges =
         stackGroups
             .get(stackPositionKey(x, z))
-            ?.some((instance) =>
-                doWaterSideRangesOverlap(
-                    range,
-                    getWaterSideInstanceRange(instance),
-                ),
-            ) ?? false
-    );
+            ?.map(getWaterSideInstanceRange)
+            .sort((left, right) => left.min - right.min) ?? [];
+    let visibleRanges = [range];
+
+    for (const neighborRange of neighborRanges) {
+        visibleRanges = visibleRanges.flatMap((visibleRange) =>
+            clipWaterSideRange(visibleRange, neighborRange),
+        );
+
+        if (visibleRanges.length === 0) {
+            break;
+        }
+    }
+
+    return visibleRanges;
+}
+
+function pushVisibleWaterSideSegments({
+    axis,
+    end,
+    line,
+    normal,
+    range,
+    sideSegments,
+    stackGroups,
+    start,
+    x,
+    z,
+}: {
+    axis: 'x' | 'z';
+    end: number;
+    line: number;
+    normal: [number, number, number];
+    range: WaterSideInstanceRange;
+    sideSegments: WaterSideSegment[];
+    stackGroups: Map<string, WaterSideInstance[]>;
+    start: number;
+    x: number;
+    z: number;
+}) {
+    for (const visibleRange of getVisibleWaterSideRanges({
+        range,
+        stackGroups,
+        x,
+        z,
+    })) {
+        sideSegments.push({
+            axis,
+            line,
+            normal,
+            start,
+            end,
+            yMin: visibleRange.min,
+            yMax: visibleRange.max,
+        });
+    }
 }
 
 export function createMergedWaterSideGeometry(instances: WaterSideInstance[]) {
@@ -437,81 +506,57 @@ export function createMergedWaterSideGeometry(instances: WaterSideInstance[]) {
         const yMax = y + waterBlockMaxY(height);
         const range = { min: yMin, max: yMax };
 
-        if (
-            !hasOverlappingWaterSideInstance({
-                range,
-                stackGroups,
-                x: x - 1,
-                z,
-            })
-        ) {
-            sideSegments.push({
-                axis: 'x',
-                line: x - waterBlockHalfSize,
-                normal: [-1, 0, 0],
-                start: z - waterBlockHalfSize,
-                end: z + waterBlockHalfSize,
-                yMin,
-                yMax,
-            });
-        }
+        pushVisibleWaterSideSegments({
+            axis: 'x',
+            line: x - waterBlockHalfSize,
+            normal: [-1, 0, 0],
+            start: z - waterBlockHalfSize,
+            end: z + waterBlockHalfSize,
+            range,
+            sideSegments,
+            stackGroups,
+            x: x - 1,
+            z,
+        });
 
-        if (
-            !hasOverlappingWaterSideInstance({
-                range,
-                stackGroups,
-                x: x + 1,
-                z,
-            })
-        ) {
-            sideSegments.push({
-                axis: 'x',
-                line: x + waterBlockHalfSize,
-                normal: [1, 0, 0],
-                start: z - waterBlockHalfSize,
-                end: z + waterBlockHalfSize,
-                yMin,
-                yMax,
-            });
-        }
+        pushVisibleWaterSideSegments({
+            axis: 'x',
+            line: x + waterBlockHalfSize,
+            normal: [1, 0, 0],
+            start: z - waterBlockHalfSize,
+            end: z + waterBlockHalfSize,
+            range,
+            sideSegments,
+            stackGroups,
+            x: x + 1,
+            z,
+        });
 
-        if (
-            !hasOverlappingWaterSideInstance({
-                range,
-                stackGroups,
-                x,
-                z: z - 1,
-            })
-        ) {
-            sideSegments.push({
-                axis: 'z',
-                line: z - waterBlockHalfSize,
-                normal: [0, 0, -1],
-                start: x - waterBlockHalfSize,
-                end: x + waterBlockHalfSize,
-                yMin,
-                yMax,
-            });
-        }
+        pushVisibleWaterSideSegments({
+            axis: 'z',
+            line: z - waterBlockHalfSize,
+            normal: [0, 0, -1],
+            start: x - waterBlockHalfSize,
+            end: x + waterBlockHalfSize,
+            range,
+            sideSegments,
+            stackGroups,
+            x,
+            z: z - 1,
+        });
 
-        if (
-            !hasOverlappingWaterSideInstance({
-                range,
-                stackGroups,
-                x,
-                z: z + 1,
-            })
-        ) {
-            sideSegments.push({
-                axis: 'z',
-                line: z + waterBlockHalfSize,
-                normal: [0, 0, 1],
-                start: x - waterBlockHalfSize,
-                end: x + waterBlockHalfSize,
-                yMin,
-                yMax,
-            });
-        }
+        pushVisibleWaterSideSegments({
+            axis: 'z',
+            line: z + waterBlockHalfSize,
+            normal: [0, 0, 1],
+            start: x - waterBlockHalfSize,
+            end: x + waterBlockHalfSize,
+            range,
+            sideSegments,
+            stackGroups,
+            x,
+            z: z + 1,
+        });
     }
 
     return createGeometryFromFaces(

--- a/packages/game/src/entities/waterBlockGeometry.ts
+++ b/packages/game/src/entities/waterBlockGeometry.ts
@@ -33,6 +33,11 @@ type WaterSideInstance = {
     waterHeight?: number;
 };
 
+type WaterSideInstanceRange = {
+    max: number;
+    min: number;
+};
+
 type WaterSideSegment = {
     axis: 'x' | 'z';
     line: number;
@@ -185,8 +190,8 @@ export function createWaterBlockGeometry(
     return createGeometryFromFaces(faces);
 }
 
-function positionKey(x: number, y: number, z: number) {
-    return `${x}|${y}|${z}`;
+function stackPositionKey(x: number, z: number) {
+    return `${x}|${z}`;
 }
 
 function segmentGroupKey(segment: WaterSideSegment) {
@@ -354,25 +359,92 @@ function waterSideSegmentToFace(segment: WaterSideSegment): WaterFace {
     };
 }
 
-export function createMergedWaterSideGeometry(instances: WaterSideInstance[]) {
-    const waterPositions = new Set(
-        instances.map((instance) =>
-            positionKey(
-                instance.position[0],
-                instance.position[1],
-                instance.position[2],
-            ),
-        ),
+function getWaterSideInstanceHeight(instance: WaterSideInstance) {
+    return instance.waterHeight ?? defaultWaterBlockVisualHeight;
+}
+
+function getWaterSideInstanceRange(instance: WaterSideInstance) {
+    const [, y] = instance.position;
+    const halfHeight = getWaterSideInstanceHeight(instance) / 2;
+
+    return {
+        min: y - halfHeight,
+        max: y + halfHeight,
+    } satisfies WaterSideInstanceRange;
+}
+
+function doWaterSideRangesOverlap(
+    left: WaterSideInstanceRange,
+    right: WaterSideInstanceRange,
+) {
+    return (
+        Math.min(left.max, right.max) - Math.max(left.min, right.min) >
+        segmentMergeEpsilon
     );
+}
+
+function groupWaterSideInstancesByStackPosition(
+    instances: WaterSideInstance[],
+) {
+    const groups = new Map<string, WaterSideInstance[]>();
+
+    for (const instance of instances) {
+        const [x, , z] = instance.position;
+        const key = stackPositionKey(x, z);
+        const group = groups.get(key);
+
+        if (group) {
+            group.push(instance);
+        } else {
+            groups.set(key, [instance]);
+        }
+    }
+
+    return groups;
+}
+
+function hasOverlappingWaterSideInstance({
+    range,
+    stackGroups,
+    x,
+    z,
+}: {
+    range: WaterSideInstanceRange;
+    stackGroups: Map<string, WaterSideInstance[]>;
+    x: number;
+    z: number;
+}) {
+    return (
+        stackGroups
+            .get(stackPositionKey(x, z))
+            ?.some((instance) =>
+                doWaterSideRangesOverlap(
+                    range,
+                    getWaterSideInstanceRange(instance),
+                ),
+            ) ?? false
+    );
+}
+
+export function createMergedWaterSideGeometry(instances: WaterSideInstance[]) {
+    const stackGroups = groupWaterSideInstancesByStackPosition(instances);
     const sideSegments: WaterSideSegment[] = [];
 
     for (const instance of instances) {
         const [x, y, z] = instance.position;
-        const height = instance.waterHeight ?? defaultWaterBlockVisualHeight;
+        const height = getWaterSideInstanceHeight(instance);
         const yMin = y + waterBlockMinY(height);
         const yMax = y + waterBlockMaxY(height);
+        const range = { min: yMin, max: yMax };
 
-        if (!waterPositions.has(positionKey(x - 1, y, z))) {
+        if (
+            !hasOverlappingWaterSideInstance({
+                range,
+                stackGroups,
+                x: x - 1,
+                z,
+            })
+        ) {
             sideSegments.push({
                 axis: 'x',
                 line: x - waterBlockHalfSize,
@@ -384,7 +456,14 @@ export function createMergedWaterSideGeometry(instances: WaterSideInstance[]) {
             });
         }
 
-        if (!waterPositions.has(positionKey(x + 1, y, z))) {
+        if (
+            !hasOverlappingWaterSideInstance({
+                range,
+                stackGroups,
+                x: x + 1,
+                z,
+            })
+        ) {
             sideSegments.push({
                 axis: 'x',
                 line: x + waterBlockHalfSize,
@@ -396,7 +475,14 @@ export function createMergedWaterSideGeometry(instances: WaterSideInstance[]) {
             });
         }
 
-        if (!waterPositions.has(positionKey(x, y, z - 1))) {
+        if (
+            !hasOverlappingWaterSideInstance({
+                range,
+                stackGroups,
+                x,
+                z: z - 1,
+            })
+        ) {
             sideSegments.push({
                 axis: 'z',
                 line: z - waterBlockHalfSize,
@@ -408,7 +494,14 @@ export function createMergedWaterSideGeometry(instances: WaterSideInstance[]) {
             });
         }
 
-        if (!waterPositions.has(positionKey(x, y, z + 1))) {
+        if (
+            !hasOverlappingWaterSideInstance({
+                range,
+                stackGroups,
+                x,
+                z: z + 1,
+            })
+        ) {
             sideSegments.push({
                 axis: 'z',
                 line: z + waterBlockHalfSize,

--- a/packages/game/src/entities/waterBlockGeometry.unit.ts
+++ b/packages/game/src/entities/waterBlockGeometry.unit.ts
@@ -121,6 +121,26 @@ describe('createMergedWaterSideGeometry', () => {
         geometry.dispose();
     });
 
+    it('hides side walls when adjacent water ranges overlap', () => {
+        const geometry = createMergedWaterSideGeometry([
+            {
+                position: [0, 0.25 + getWaterBlockYOffset(0.25), 0],
+                waterHeight: 0.25,
+            },
+            {
+                position: [1, 0.4 + getWaterBlockYOffset(0.4), 0],
+                waterHeight: 0.4,
+            },
+        ]);
+        const positionAttribute = geometry.getAttribute('position');
+        const indexAttribute = geometry.getIndex();
+
+        assert.equal(positionAttribute.count, 24);
+        assert.equal(indexAttribute?.count, 36);
+
+        geometry.dispose();
+    });
+
     it('merges continuous exterior side walls across stacked water blocks', () => {
         const geometry = createMergedWaterSideGeometry([
             { position: [0, 0, 0] },

--- a/packages/game/src/entities/waterBlockGeometry.unit.ts
+++ b/packages/game/src/entities/waterBlockGeometry.unit.ts
@@ -121,7 +121,7 @@ describe('createMergedWaterSideGeometry', () => {
         geometry.dispose();
     });
 
-    it('hides side walls when adjacent water ranges overlap', () => {
+    it('clips side walls to adjacent water range overlaps', () => {
         const geometry = createMergedWaterSideGeometry([
             {
                 position: [0, 0.25 + getWaterBlockYOffset(0.25), 0],
@@ -135,8 +135,9 @@ describe('createMergedWaterSideGeometry', () => {
         const positionAttribute = geometry.getAttribute('position');
         const indexAttribute = geometry.getIndex();
 
-        assert.equal(positionAttribute.count, 24);
-        assert.equal(indexAttribute?.count, 36);
+        assert.equal(positionAttribute.count, 32);
+        assert.equal(indexAttribute?.count, 48);
+        assert.deepEqual(geometryYExtents(geometry), [0.19, 0.34, 0.44, 0.74]);
 
         geometry.dispose();
     });


### PR DESCRIPTION
## What changed

- Updated water foam/edge detection to treat neighboring water blocks as connected when their vertical water ranges overlap, instead of requiring identical water levels.
- Updated merged water side-wall generation to hide internal side faces for overlapping mixed-height water blocks.
- Added regressions for shaped-height water next to full-height water so those shared edges stay transparent while non-overlapping stacked water still keeps side walls.

## Why

The previous height fix made water on edge/corner terrain render at the right height, but the edge-joining logic still used exact vertical level equality. That left visible internal edges between adjacent water blocks that should read as one connected water surface.

## Validation

- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game exec tsx --test src/entities/waterBlockFoam.unit.ts src/entities/waterBlockGeometry.unit.ts`
- `corepack pnpm --filter @gredice/game exec biome check src/entities/waterBlockFoam.ts src/entities/waterBlockFoam.unit.ts src/entities/waterBlockGeometry.ts src/entities/waterBlockGeometry.unit.ts`
- `git diff --check`
- Visual smoke: garden debug sandbox at `http://localhost:4431/debug/entities`, seeded with shaped-height water next to full-height water; desktop and mobile canvas screenshots were nonblank and visually inspected.
