### PR TITLE
[codex] Lower shaped terrain water level

### DIFF
--- a/packages/game/src/entities/waterBlockHeight.ts
+++ b/packages/game/src/entities/waterBlockHeight.ts
@@ -7,6 +7,8 @@ import {
     waterBlockBottomOverlap,
 } from './waterBlockGeometry';
 
+export const shapedTerrainWaterTopInset = waterBlockBottomOverlap / 2;
+
 export type WaterBlockVerticalRange = {
     max: number;
     min: number;
@@ -48,10 +50,11 @@ export function getWaterBlockVisualHeight({
         return defaultWaterBlockVisualHeight;
     }
 
-    return (
+    const supportHeight =
         getBlockDataByName(blockData, supportBlock.name)?.attributes.height ??
-        defaultWaterBlockVisualHeight
-    );
+        defaultWaterBlockVisualHeight;
+
+    return Math.max(supportHeight - shapedTerrainWaterTopInset, 0);
 }
 
 export function getWaterBlockVerticalRange({
@@ -83,9 +86,10 @@ export function getWaterBlockVerticalRange({
     });
 
     if (isWaterFillSupportBlock(stack, block)) {
+        const waterTop = stackHeight - shapedTerrainWaterTopInset;
         return {
-            min: stackHeight - waterHeight,
-            max: stackHeight,
+            min: waterTop - waterHeight,
+            max: waterTop,
         } satisfies WaterBlockVerticalRange;
     }
 

--- a/packages/game/src/entities/waterBlockHeight.unit.ts
+++ b/packages/game/src/entities/waterBlockHeight.unit.ts
@@ -9,6 +9,7 @@ import {
     getWaterBlockCenterY,
     getWaterBlockVerticalRange,
     getWaterBlockVisualHeight,
+    shapedTerrainWaterTopInset,
 } from './waterBlockHeight';
 
 function block(id: string, name: string): Block {
@@ -23,6 +24,9 @@ function stack(blocks: Block[]): Stack {
 }
 
 describe('getWaterBlockVisualHeight', () => {
+    const shapedTerrainWaterHeight =
+        defaultWaterBlockVisualHeight - shapedTerrainWaterTopInset;
+
     it('uses the default height for unsupported water blocks', () => {
         const water = block('water-a', 'Block_Water');
         const currentStack = stack([water]);
@@ -50,7 +54,7 @@ describe('getWaterBlockVisualHeight', () => {
                 blockData: getLocalSandboxBlockData(),
                 stack: currentStack,
             }),
-            defaultWaterBlockVisualHeight,
+            shapedTerrainWaterHeight,
         );
     });
 
@@ -67,7 +71,7 @@ describe('getWaterBlockVisualHeight', () => {
                 blockData: getLocalSandboxBlockData(),
                 stack: currentStack,
             }),
-            defaultWaterBlockVisualHeight,
+            shapedTerrainWaterHeight,
         );
     });
 
@@ -85,7 +89,7 @@ describe('getWaterBlockVisualHeight', () => {
         );
     });
 
-    it('keeps shaped terrain water inside the support block height', () => {
+    it('keeps shaped terrain water slightly below the support block edge', () => {
         const water = block('water-a', 'Block_Water');
         const currentStack = stack([
             block('corner-a', 'Block_Sand_Reverse_Corner'),
@@ -96,15 +100,17 @@ describe('getWaterBlockVisualHeight', () => {
             blockData: getLocalSandboxBlockData(),
             stack: currentStack,
         });
+        const waterTop =
+            defaultWaterBlockVisualHeight - shapedTerrainWaterTopInset;
 
-        assert.deepEqual(range, { min: 0, max: 0.4 });
+        assert.deepEqual(range, { min: 0, max: waterTop });
         assert.equal(
             getWaterBlockCenterY({
                 block: water,
                 blockData: getLocalSandboxBlockData(),
                 stack: currentStack,
             }),
-            0.2,
+            waterTop / 2,
         );
     });
 


### PR DESCRIPTION
## Summary

- Lower water that fills shaped terrain by half of the existing water overlap amount, so it sits slightly below the terrain edge instead of reaching the full block top.
- Keep a small vertical overlap with adjacent regular water blocks so shared water edges still resolve as connected.
- Update water height tests to lock the lowered shaped-terrain range.

## Validation

- `corepack pnpm --filter @gredice/game exec tsx --test src/entities/waterBlockHeight.unit.ts src/entities/waterBlockFoam.unit.ts src/entities/waterBlockGeometry.unit.ts src/localSandboxBlockData.unit.ts`
- `corepack pnpm --filter @gredice/game exec biome check src/entities/waterBlockHeight.ts src/entities/waterBlockHeight.unit.ts`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter @gredice/game test`
- `git diff --check`
- Visual smoke on `http://localhost:4431/debug/entities`, screenshot captured at `/tmp/gredice-shaped-water-lowered-clean.png` with the controls popover dismissed