### PR TITLE
Hide opening HUD during impersonation

### DIFF
--- a/apps/garden/app/page.tsx
+++ b/apps/garden/app/page.tsx
@@ -1,4 +1,5 @@
 import { SignedIn, SignedOut } from '@gredice/ui/auth';
+import { cookies } from 'next/headers';
 import type { ComponentProps } from 'react';
 import LoginModal from '../components/auth/LoginModal';
 import { GameSceneWithAnalytics } from '../components/game/GameSceneWithAnalytics';
@@ -11,7 +12,12 @@ import {
     tutorialChecklistFlag,
 } from './flags';
 
+const impersonationFlagCookieName = 'gredice_impersonating';
+
 export default async function Home() {
+    const cookieStore = await cookies();
+    const suppressOpeningHud =
+        cookieStore.get(impersonationFlagCookieName)?.value === '1';
     const flags: ComponentProps<typeof GameSceneWithAnalytics>['flags'] = {
         enableDebugHudFlag: await enableDebugHudFlag(),
         enablePlantGeneratorFlag: await lsystemPlantsFlag(),
@@ -24,7 +30,11 @@ export default async function Home() {
     return (
         <div className="grid grid-cols-1 h-[100dvh] relative overflow-hidden">
             <SignedIn>
-                <GameSceneWithAnalytics flags={flags} deferDetails />
+                <GameSceneWithAnalytics
+                    flags={flags}
+                    deferDetails
+                    suppressOpeningHud={suppressOpeningHud}
+                />
             </SignedIn>
             <SignedOut>
                 <GameSceneWithAnalytics

--- a/apps/garden/tests/GardenVisitSummaryModalStory.tsx
+++ b/apps/garden/tests/GardenVisitSummaryModalStory.tsx
@@ -269,20 +269,32 @@ function OpeningFlowProviders({
     );
 }
 
-function OpeningFlowHarness() {
+function OpeningFlowSequence({
+    suppressOpeningHud = false,
+}: {
+    suppressOpeningHud?: boolean;
+}) {
     const [welcomeConfirmed, setWelcomeConfirmed] = useState(false);
     const [visitSummaryConfirmed, setVisitSummaryConfirmed] = useState(false);
-    const summaryEnabled = welcomeConfirmed && !visitSummaryConfirmed;
-    const openingFlowComplete = welcomeConfirmed && visitSummaryConfirmed;
+    const summaryEnabled =
+        !suppressOpeningHud && welcomeConfirmed && !visitSummaryConfirmed;
+    const openingFlowComplete =
+        !suppressOpeningHud && welcomeConfirmed && visitSummaryConfirmed;
 
     return (
         <div className="relative h-[640px] w-[720px] bg-background">
-            <WelcomeMessage onClosed={() => setWelcomeConfirmed(true)} />
-            <GardenVisitSummaryModal
-                enabled={summaryEnabled}
-                onClosed={() => setVisitSummaryConfirmed(true)}
-            />
-            <WhatsNewWidget enabled={openingFlowComplete} />
+            {!suppressOpeningHud && (
+                <>
+                    <WelcomeMessage
+                        onClosed={() => setWelcomeConfirmed(true)}
+                    />
+                    <GardenVisitSummaryModal
+                        enabled={summaryEnabled}
+                        onClosed={() => setVisitSummaryConfirmed(true)}
+                    />
+                    <WhatsNewWidget enabled={openingFlowComplete} />
+                </>
+            )}
             <output data-testid="opening-flow-state" className="sr-only">
                 {[
                     welcomeConfirmed ? 'welcome:closed' : 'welcome:open',
@@ -333,10 +345,12 @@ export function VisitSummaryOpeningFlowFixture({
     dailyRewardCanClaim = false,
     facts = summaryFacts,
     factsHash = 'summary-fixture-hash',
+    suppressOpeningHud = false,
 }: {
     dailyRewardCanClaim?: boolean;
     facts?: GardenVisitSummaryFact[];
     factsHash?: string | null;
+    suppressOpeningHud?: boolean;
 }) {
     return (
         <OpeningFlowProviders
@@ -344,7 +358,7 @@ export function VisitSummaryOpeningFlowFixture({
             facts={facts}
             factsHash={factsHash}
         >
-            <OpeningFlowHarness />
+            <OpeningFlowSequence suppressOpeningHud={suppressOpeningHud} />
         </OpeningFlowProviders>
     );
 }

--- a/apps/garden/tests/garden-visit-summary-modal.spec.tsx
+++ b/apps/garden/tests/garden-visit-summary-modal.spec.tsx
@@ -188,6 +188,32 @@ test('opening flow shows daily reward, visit summary, then what is new', async (
         .toEqual([{ factsHash: 'summary-fixture-hash' }]);
 });
 
+test('opening flow stays hidden during admin impersonation', async ({
+    mount,
+    page,
+}) => {
+    const recorded = await mockOpeningFlowMutations(page);
+
+    await mount(
+        <VisitSummaryOpeningFlowFixture
+            dailyRewardCanClaim
+            suppressOpeningHud
+        />,
+    );
+
+    await expect(
+        page.getByRole('button', { name: /Kreni u avanturu/u }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('dialog', { name: 'Od zadnjeg posjeta' }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('button', { name: /Vrt je življi/u }),
+    ).toHaveCount(0);
+    await expect.poll(() => recorded.claimRequests.length).toBe(0);
+    await expect.poll(() => recorded.seenRequests).toEqual([]);
+});
+
 test('opening flow shows the visit summary when there is no daily reward', async ({
     mount,
     page,

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -45,10 +45,12 @@ export function GameHud({
     debugHud,
     flags,
     noWeather,
+    suppressOpeningHud,
 }: {
     debugHud?: boolean;
     flags: GameSceneProps['flags'];
     noWeather?: boolean;
+    suppressOpeningHud?: boolean;
 }) {
     const [welcomeConfirmed, setWelcomeConfirmed] = useState(false);
     const [visitSummaryConfirmation, setVisitSummaryConfirmation] = useState<{
@@ -87,15 +89,21 @@ export function GameHud({
         (raisedBedOnboardingConfirmation.confirmed &&
             raisedBedOnboardingConfirmation.gardenId === currentGardenId);
     const visitSummaryEnabled =
-        welcomeConfirmed && !visitSummaryConfirmed && !isSandbox;
+        !suppressOpeningHud &&
+        welcomeConfirmed &&
+        !visitSummaryConfirmed &&
+        !isSandbox;
     const visitSummaryStageComplete =
-        welcomeConfirmed && (isSandbox || visitSummaryConfirmed);
+        !suppressOpeningHud &&
+        welcomeConfirmed &&
+        (isSandbox || visitSummaryConfirmed);
     const raisedBedOnboardingEnabled =
         raisedBedOnboardingChecklistEnabled &&
         visitSummaryStageComplete &&
         !raisedBedOnboardingChecklistResolved &&
         !isSandbox;
     const openingFlowComplete =
+        !suppressOpeningHud &&
         visitSummaryStageComplete &&
         (isSandbox || raisedBedOnboardingChecklistResolved);
 
@@ -175,7 +183,7 @@ export function GameHud({
             {!isLocalSandbox && <OverviewModal />}
             {!isLocalSandbox && <AdventModal />}
             {!isLocalSandbox && <GiftBoxModal />}
-            {!isLocalSandbox && (
+            {!isLocalSandbox && !suppressOpeningHud && (
                 <>
                     <WelcomeMessage
                         onClosed={() => setWelcomeConfirmed(true)}

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -77,6 +77,7 @@ export type GameSceneProps = HTMLAttributes<HTMLDivElement> & {
     noBackground?: boolean;
     noControls?: boolean;
     hideHud?: boolean;
+    suppressOpeningHud?: boolean;
     debugHud?: boolean;
     noWeather?: boolean;
     noSound?: boolean;
@@ -177,6 +178,7 @@ export function GameScene({
     noBackground,
     noSound,
     hideHud,
+    suppressOpeningHud,
     className,
     flags,
     debugHud,
@@ -415,6 +417,7 @@ export function GameScene({
                     debugHud={showDebugHud}
                     flags={flags}
                     noWeather={noWeather}
+                    suppressOpeningHud={suppressOpeningHud}
                 />
             )}
             {hideHud && showDebugHud && <DebugHud />}


### PR DESCRIPTION
## Summary
- Suppress the opening HUD flow when the impersonation cookie is present
- Thread the suppression flag through `GameScene` and `GameHud`
- Cover the impersonation path in the opening-flow story test with a hidden-state assertion

## Testing
- UI testing framework coverage added for the impersonation-hidden opening flow