### PR TITLE
Tighten water block top inset for edge alignment

### DIFF
--- a/packages/game/src/entities/waterBlockHeight.ts
+++ b/packages/game/src/entities/waterBlockHeight.ts
@@ -7,7 +7,7 @@ import {
     waterBlockBottomOverlap,
 } from './waterBlockGeometry';
 
-export const shapedTerrainWaterTopInset = waterBlockBottomOverlap / 2;
+export const shapedTerrainWaterTopInset = 0.01;
 
 export type WaterBlockVerticalRange = {
     max: number;


### PR DESCRIPTION
## Summary
- Reduce the shaped terrain water top inset to `0.01` to improve edge alignment
- Remove the dependency on half the bottom overlap for this inset value

## Testing
- Not run (not requested)