### PR TITLE
Add generated block image URLs for block entities

### DIFF
--- a/packages/js/src/blocks/index.ts
+++ b/packages/js/src/blocks/index.ts
@@ -4,6 +4,24 @@ export type BlockPurchaseAvailability = {
     } | null;
 };
 
+const defaultBlockImageBaseUrl = 'https://www.gredice.com/assets/blocks';
+
+export function getBlockImageUrl(
+    blockName: string | null | undefined,
+    options?: { baseUrl?: string },
+) {
+    const normalizedBlockName = blockName?.trim();
+    if (!normalizedBlockName) {
+        return null;
+    }
+
+    const baseUrl = (options?.baseUrl ?? defaultBlockImageBaseUrl).replace(
+        /\/+$/u,
+        '',
+    );
+    return `${baseUrl}/${encodeURIComponent(normalizedBlockName)}.webp`;
+}
+
 export function isNightOnlyBlockPurchase(
     block: BlockPurchaseAvailability | null | undefined,
 ) {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -28,6 +28,8 @@
         "notifications:backfill-rollout": "tsx --env-file=.env ./scripts/backfillNotificationRolloutDefaults.ts",
         "plant-relationships:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantRelationships.ts",
         "plant-health:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillPlantHealthDirectory.ts",
+        "generated-images:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/upsertGeneratedImageAttributes.ts",
+        "blocks:images:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/upsertGeneratedImageAttributes.ts --entity-type block --source information.name --target image.cover --template 'https://www.gredice.com/assets/blocks/{encodedValue}.webp' --label Slika --description 'Public block image generated from the in-game block name and used by admin previews, directory cards, search results, and compact block UI.' --order aa",
         "harvest-traces:backfill": "tsx --conditions=react-server --env-file=.env ./scripts/backfillHarvestTraceLinks.ts"
     },
     "devDependencies": {

--- a/packages/storage/scripts/upsertGeneratedImageAttributes.ts
+++ b/packages/storage/scripts/upsertGeneratedImageAttributes.ts
@@ -1,0 +1,501 @@
+import {
+    attributeDefinitionPath,
+    attributeValues,
+    closeStorage,
+    createAttributeDefinition,
+    generatedImageAttributeValue,
+    generatedImageUrlDefaultValue,
+    getAttributeDefinitions,
+    getEntitiesRaw,
+    imageUrlFromAttributeValue,
+    type SelectAttributeDefinition,
+    storage,
+    updateAttributeDefinition,
+    upsertAttributeValue,
+} from '@gredice/storage';
+import { and, eq } from 'drizzle-orm';
+
+type DirectoryEntity = Awaited<ReturnType<typeof getEntitiesRaw>>[number];
+
+type AttributePath = {
+    category: string;
+    name: string;
+};
+
+type ExistingTargetValue = {
+    id?: number;
+    value?: string | null;
+};
+
+type Options = {
+    apply: boolean;
+    description: string | null;
+    display: boolean;
+    entityTypeName: string;
+    excludeValues: Set<string>;
+    label: string;
+    order: string | null;
+    source: string;
+    target: string;
+    template: string;
+};
+
+const actor = {
+    id: 'codex',
+    name: 'Codex',
+};
+
+function readOptionValue(argv: string[], index: number, option: string) {
+    const value = argv[index + 1];
+    if (!value) {
+        throw new Error(`${option} requires a value.`);
+    }
+    return value;
+}
+
+function parseArgs(argv: string[]): Options {
+    const options: Options = {
+        apply: false,
+        description: null,
+        display: true,
+        entityTypeName: '',
+        excludeValues: new Set(),
+        label: 'Image',
+        order: null,
+        source: '',
+        target: '',
+        template: '',
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (arg === '--') {
+            continue;
+        }
+        if (arg === '--apply') {
+            options.apply = true;
+            continue;
+        }
+        if (arg === '--no-display') {
+            options.display = false;
+            continue;
+        }
+        if (arg === '--entity-type') {
+            options.entityTypeName = readOptionValue(argv, index, arg);
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith('--entity-type=')) {
+            options.entityTypeName = arg.slice('--entity-type='.length);
+            continue;
+        }
+        if (arg === '--source') {
+            options.source = readOptionValue(argv, index, arg);
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith('--source=')) {
+            options.source = arg.slice('--source='.length);
+            continue;
+        }
+        if (arg === '--target') {
+            options.target = readOptionValue(argv, index, arg);
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith('--target=')) {
+            options.target = arg.slice('--target='.length);
+            continue;
+        }
+        if (arg === '--template') {
+            options.template = readOptionValue(argv, index, arg);
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith('--template=')) {
+            options.template = arg.slice('--template='.length);
+            continue;
+        }
+        if (arg === '--label') {
+            options.label = readOptionValue(argv, index, arg);
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith('--label=')) {
+            options.label = arg.slice('--label='.length);
+            continue;
+        }
+        if (arg === '--description') {
+            options.description = readOptionValue(argv, index, arg);
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith('--description=')) {
+            options.description = arg.slice('--description='.length);
+            continue;
+        }
+        if (arg === '--order') {
+            options.order = readOptionValue(argv, index, arg);
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith('--order=')) {
+            options.order = arg.slice('--order='.length);
+            continue;
+        }
+        if (arg === '--exclude-value' || arg === '--exclude-name') {
+            options.excludeValues.add(readOptionValue(argv, index, arg));
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith('--exclude-value=')) {
+            options.excludeValues.add(arg.slice('--exclude-value='.length));
+            continue;
+        }
+        if (arg.startsWith('--exclude-name=')) {
+            options.excludeValues.add(arg.slice('--exclude-name='.length));
+            continue;
+        }
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+
+    if (!options.entityTypeName) {
+        throw new Error('--entity-type is required.');
+    }
+    if (!options.source) {
+        throw new Error('--source is required.');
+    }
+    if (!options.target) {
+        throw new Error('--target is required.');
+    }
+    if (!options.template) {
+        throw new Error('--template is required.');
+    }
+
+    return options;
+}
+
+function parseAttributePath(path: string): AttributePath {
+    const [category, ...nameParts] = path.split('.');
+    const name = nameParts.join('.');
+    if (!category || !name) {
+        throw new Error(`Invalid attribute path: ${path}`);
+    }
+    return { category, name };
+}
+
+async function getDefinitionsByPath(entityTypeName: string) {
+    const definitions = await getAttributeDefinitions(entityTypeName);
+    return new Map(
+        definitions.map((definition) => [
+            attributeDefinitionPath(definition),
+            definition,
+        ]),
+    );
+}
+
+function targetDefinitionConfig(options: Options) {
+    const target = parseAttributePath(options.target);
+    return {
+        category: target.category,
+        dataType: 'image',
+        defaultValue: generatedImageUrlDefaultValue({
+            source: options.source,
+            template: options.template,
+        }),
+        description: options.description,
+        display: options.display,
+        entityTypeName: options.entityTypeName,
+        label: options.label,
+        multiple: false,
+        name: target.name,
+        order: options.order,
+        required: false,
+    };
+}
+
+function definitionNeedsUpdate(
+    definition: SelectAttributeDefinition,
+    options: Options,
+) {
+    const config = targetDefinitionConfig(options);
+    return (
+        definition.dataType !== config.dataType ||
+        definition.defaultValue !== config.defaultValue ||
+        definition.description !== config.description ||
+        definition.display !== config.display ||
+        definition.label !== config.label ||
+        definition.multiple !== config.multiple ||
+        definition.order !== config.order ||
+        definition.required !== config.required
+    );
+}
+
+async function ensureTargetDefinition(options: Options) {
+    const definitionsByPath = await getDefinitionsByPath(
+        options.entityTypeName,
+    );
+    const existingDefinition = definitionsByPath.get(options.target);
+    const config = targetDefinitionConfig(options);
+    if (existingDefinition) {
+        if (!options.apply) {
+            return {
+                created: false,
+                definition: existingDefinition,
+                updated: false,
+                wouldCreate: false,
+                wouldUpdate: definitionNeedsUpdate(existingDefinition, options),
+            };
+        }
+
+        if (definitionNeedsUpdate(existingDefinition, options)) {
+            await updateAttributeDefinition({
+                id: existingDefinition.id,
+                ...config,
+            });
+        }
+        const refreshedDefinitionsByPath = await getDefinitionsByPath(
+            options.entityTypeName,
+        );
+        const updatedDefinition = refreshedDefinitionsByPath.get(
+            options.target,
+        );
+        if (!updatedDefinition) {
+            throw new Error(
+                `Failed to update ${options.entityTypeName}.${options.target} definition.`,
+            );
+        }
+        return {
+            created: false,
+            definition: updatedDefinition,
+            updated: definitionNeedsUpdate(existingDefinition, options),
+            wouldCreate: false,
+            wouldUpdate: false,
+        };
+    }
+
+    if (!options.apply) {
+        return {
+            created: false,
+            definition: null,
+            updated: false,
+            wouldCreate: true,
+            wouldUpdate: false,
+        };
+    }
+
+    const id = await createAttributeDefinition(config);
+    const refreshedDefinitionsByPath = await getDefinitionsByPath(
+        options.entityTypeName,
+    );
+    const createdDefinition = refreshedDefinitionsByPath.get(options.target);
+    if (!createdDefinition || createdDefinition.id !== id) {
+        throw new Error(
+            `Failed to create ${options.entityTypeName}.${options.target} definition.`,
+        );
+    }
+    return {
+        created: true,
+        definition: createdDefinition,
+        updated: false,
+        wouldCreate: false,
+        wouldUpdate: false,
+    };
+}
+
+function attributeValue(entity: DirectoryEntity, path: string) {
+    return (
+        entity.attributes.find(
+            (attribute) =>
+                attributeDefinitionPath(attribute.attributeDefinition) === path,
+        )?.value ?? null
+    );
+}
+
+async function getExistingTargetValue({
+    attributeDefinitionId,
+    entityId,
+}: {
+    attributeDefinitionId: number | null;
+    entityId: number;
+}): Promise<ExistingTargetValue | null> {
+    if (!attributeDefinitionId) {
+        return null;
+    }
+
+    const existing = await storage().query.attributeValues.findFirst({
+        where: and(
+            eq(attributeValues.attributeDefinitionId, attributeDefinitionId),
+            eq(attributeValues.entityId, entityId),
+            eq(attributeValues.isDeleted, false),
+        ),
+    });
+
+    return existing ? { id: existing.id, value: existing.value } : null;
+}
+
+async function main() {
+    const options = parseArgs(process.argv.slice(2));
+    const sourcePath = parseAttributePath(options.source);
+    const targetPath = parseAttributePath(options.target);
+    const definitionsByPath = await getDefinitionsByPath(
+        options.entityTypeName,
+    );
+    const sourceDefinition = definitionsByPath.get(options.source);
+    if (!sourceDefinition) {
+        throw new Error(
+            `Missing source definition ${options.entityTypeName}.${sourcePath.category}.${sourcePath.name}.`,
+        );
+    }
+
+    const targetDefinitionResult = await ensureTargetDefinition(options);
+    const entities = await getEntitiesRaw(options.entityTypeName);
+    const generatedConfig = {
+        kind: 'generated-image-url',
+        source: options.source,
+        template: options.template,
+    } as const;
+    const planned: Array<{
+        entityId: number;
+        sourceValue: string | null;
+        url: string | null;
+        action:
+            | 'create'
+            | 'update'
+            | 'unchanged'
+            | 'missing-source'
+            | 'excluded';
+    }> = [];
+
+    for (const entity of entities) {
+        const sourceValue =
+            attributeValue(entity, options.source)?.trim() ?? '';
+        if (!sourceValue) {
+            planned.push({
+                entityId: entity.id,
+                sourceValue: null,
+                url: null,
+                action: 'missing-source',
+            });
+            continue;
+        }
+
+        if (options.excludeValues.has(sourceValue)) {
+            planned.push({
+                entityId: entity.id,
+                sourceValue,
+                url: null,
+                action: 'excluded',
+            });
+            continue;
+        }
+
+        const nextValue = generatedImageAttributeValue(
+            generatedConfig,
+            sourceValue,
+        );
+        const url = imageUrlFromAttributeValue(nextValue);
+        if (!nextValue || !url) {
+            planned.push({
+                entityId: entity.id,
+                sourceValue,
+                url: null,
+                action: 'missing-source',
+            });
+            continue;
+        }
+
+        const existingValue = await getExistingTargetValue({
+            attributeDefinitionId:
+                targetDefinitionResult.definition?.id ?? null,
+            entityId: entity.id,
+        });
+        const currentUrl = imageUrlFromAttributeValue(existingValue?.value);
+        planned.push({
+            entityId: entity.id,
+            sourceValue,
+            url,
+            action: currentUrl
+                ? currentUrl === url
+                    ? 'unchanged'
+                    : 'update'
+                : 'create',
+        });
+    }
+
+    const mutations = planned.filter(
+        (item) => item.action === 'create' || item.action === 'update',
+    );
+    if (options.apply) {
+        if (!targetDefinitionResult.definition) {
+            throw new Error(
+                `Cannot apply without ${options.target} definition.`,
+            );
+        }
+
+        for (const mutation of mutations) {
+            if (!mutation.url) {
+                continue;
+            }
+            const existingValue = await getExistingTargetValue({
+                attributeDefinitionId: targetDefinitionResult.definition.id,
+                entityId: mutation.entityId,
+            });
+            await upsertAttributeValue(
+                {
+                    id: existingValue?.id,
+                    attributeDefinitionId: targetDefinitionResult.definition.id,
+                    entityId: mutation.entityId,
+                    entityTypeName: options.entityTypeName,
+                    order: targetDefinitionResult.definition.order,
+                    value: generatedImageAttributeValue(
+                        generatedConfig,
+                        mutation.sourceValue,
+                    ),
+                },
+                actor,
+            );
+        }
+    }
+
+    const summary = {
+        mode: options.apply ? 'apply' : 'dry-run',
+        entityTypeName: options.entityTypeName,
+        excludedValues: Array.from(options.excludeValues),
+        source: options.source,
+        target: options.target,
+        targetDefinition: {
+            created: targetDefinitionResult.created,
+            exists: Boolean(targetDefinitionResult.definition),
+            updated: targetDefinitionResult.updated,
+            wouldCreate: targetDefinitionResult.wouldCreate,
+            wouldUpdate: targetDefinitionResult.wouldUpdate,
+        },
+        template: options.template,
+        total: entities.length,
+        create: planned.filter((item) => item.action === 'create').length,
+        update: planned.filter((item) => item.action === 'update').length,
+        unchanged: planned.filter((item) => item.action === 'unchanged').length,
+        missingSource: planned.filter(
+            (item) => item.action === 'missing-source',
+        ).length,
+        excluded: planned.filter((item) => item.action === 'excluded').length,
+        examples: planned
+            .filter(
+                (item) => item.action === 'create' || item.action === 'update',
+            )
+            .slice(0, 10),
+        targetPath,
+    };
+
+    console.log(JSON.stringify(summary, null, 2));
+}
+
+main()
+    .catch((error: unknown) => {
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(async () => {
+        await closeStorage();
+    });

--- a/packages/storage/src/helpers/generatedAttributeValues.ts
+++ b/packages/storage/src/helpers/generatedAttributeValues.ts
@@ -1,0 +1,117 @@
+import type { SelectAttributeDefinition } from '../schema';
+
+export const generatedImageUrlDefaultKind = 'generated-image-url';
+
+export type GeneratedImageUrlDefault = {
+    kind: typeof generatedImageUrlDefaultKind;
+    source: string;
+    template: string;
+};
+
+type AttributeDefinitionPath = Pick<
+    SelectAttributeDefinition,
+    'category' | 'name'
+>;
+
+export function attributeDefinitionPath(
+    definition: AttributeDefinitionPath,
+): string {
+    return `${definition.category}.${definition.name}`;
+}
+
+export function generatedImageUrlDefaultValue(
+    config: Omit<GeneratedImageUrlDefault, 'kind'>,
+) {
+    return JSON.stringify({
+        kind: generatedImageUrlDefaultKind,
+        source: config.source,
+        template: config.template,
+    } satisfies GeneratedImageUrlDefault);
+}
+
+export function parseGeneratedImageUrlDefaultValue(
+    value: string | null | undefined,
+): GeneratedImageUrlDefault | null {
+    if (!value) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(value);
+        if (
+            typeof parsed === 'object' &&
+            parsed !== null &&
+            'kind' in parsed &&
+            parsed.kind === generatedImageUrlDefaultKind &&
+            'source' in parsed &&
+            typeof parsed.source === 'string' &&
+            parsed.source.trim().length > 0 &&
+            'template' in parsed &&
+            typeof parsed.template === 'string' &&
+            parsed.template.trim().length > 0
+        ) {
+            return {
+                kind: generatedImageUrlDefaultKind,
+                source: parsed.source.trim(),
+                template: parsed.template.trim(),
+            };
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+export function imageAttributeValueFromUrl(url: string) {
+    return JSON.stringify({ url });
+}
+
+export function imageUrlFromAttributeValue(
+    value: string | null | undefined,
+): string | null {
+    if (!value) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(value);
+        if (
+            typeof parsed === 'object' &&
+            parsed !== null &&
+            'url' in parsed &&
+            typeof parsed.url === 'string'
+        ) {
+            return parsed.url;
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+export function generatedImageUrlFromSourceValue(
+    config: GeneratedImageUrlDefault,
+    sourceValue: string | null | undefined,
+) {
+    const value = sourceValue?.trim();
+    if (!value) {
+        return null;
+    }
+
+    const encodedValue = encodeURIComponent(value);
+    return config.template
+        .replaceAll(`{${config.source}}`, value)
+        .replaceAll(`{encoded:${config.source}}`, encodedValue)
+        .replaceAll('{value}', value)
+        .replaceAll('{encodedValue}', encodedValue);
+}
+
+export function generatedImageAttributeValue(
+    config: GeneratedImageUrlDefault,
+    sourceValue: string | null | undefined,
+) {
+    const url = generatedImageUrlFromSourceValue(config, sourceValue);
+    return url ? imageAttributeValueFromUrl(url) : null;
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -14,6 +14,7 @@ export * from './helpers/communityEditableFields';
 export * from './helpers/deliveryEmail';
 export * from './helpers/entityCompleteness';
 export * from './helpers/entityPageSections';
+export * from './helpers/generatedAttributeValues';
 export * from './helpers/plantHealth';
 export * from './helpers/plantRelationships';
 export * from './helpers/timeSlotAutomation';

--- a/packages/storage/src/repositories/attributeValuesRepo.ts
+++ b/packages/storage/src/repositories/attributeValuesRepo.ts
@@ -7,6 +7,11 @@ import {
     cacheKeys,
 } from '../cache/directoriesCached';
 import {
+    attributeDefinitionPath,
+    generatedImageAttributeValue,
+    parseGeneratedImageUrlDefaultValue,
+} from '../helpers/generatedAttributeValues';
+import {
     isPlantHealthAffectedPlantAttributeDefinition,
     isPlantHealthIssueEntityTypeName,
     parsePlantHealthReferenceTargetId,
@@ -22,6 +27,8 @@ import {
     attributeValues,
     entityRevisions,
     type InsertAttributeValue,
+    type SelectAttributeDefinition,
+    type SelectAttributeValue,
 } from '../schema';
 
 type StorageClient = ReturnType<typeof storage>;
@@ -118,6 +125,209 @@ async function refreshEntitySearchDocumentAfterMutation(
             entityId,
             error,
         });
+    }
+}
+
+async function getExistingAttributeValue({
+    db,
+    attributeDefinitionId,
+    entityId,
+}: {
+    db: DatabaseClient;
+    attributeDefinitionId: number;
+    entityId: number;
+}) {
+    return db.query.attributeValues.findFirst({
+        where: and(
+            eq(attributeValues.attributeDefinitionId, attributeDefinitionId),
+            eq(attributeValues.entityId, entityId),
+            eq(attributeValues.isDeleted, false),
+        ),
+    });
+}
+
+async function upsertGeneratedAttributeValue({
+    db,
+    entityId,
+    definition,
+    existingValue,
+    nextValue,
+    actor,
+}: {
+    db: DatabaseClient;
+    entityId: number;
+    definition: SelectAttributeDefinition;
+    existingValue: SelectAttributeValue | undefined;
+    nextValue: string | null;
+    actor?: { id?: string; name?: string };
+}) {
+    if (existingValue?.value === nextValue) {
+        return false;
+    }
+
+    if (!existingValue && nextValue === null) {
+        return false;
+    }
+
+    if (existingValue) {
+        await Promise.all([
+            db
+                .update(attributeValues)
+                .set({
+                    order: definition.order,
+                    value: nextValue,
+                })
+                .where(eq(attributeValues.id, existingValue.id)),
+            db.insert(entityRevisions).values({
+                entityId,
+                entityTypeName: definition.entityTypeName,
+                action: 'attribute.updated',
+                actorId: actor?.id,
+                actorName: actor?.name,
+                attributeValueId: existingValue.id,
+                attributeDefinitionId: definition.id,
+                previousValue: existingValue.value,
+                nextValue,
+            }),
+        ]);
+        return true;
+    }
+
+    const [createdValue] = await db
+        .insert(attributeValues)
+        .values({
+            attributeDefinitionId: definition.id,
+            entityId,
+            entityTypeName: definition.entityTypeName,
+            order: definition.order,
+            value: nextValue,
+        })
+        .returning({ id: attributeValues.id });
+    await db.insert(entityRevisions).values({
+        entityId,
+        entityTypeName: definition.entityTypeName,
+        action: 'attribute.created',
+        actorId: actor?.id,
+        actorName: actor?.name,
+        attributeValueId: createdValue.id,
+        attributeDefinitionId: definition.id,
+        previousValue: null,
+        nextValue,
+    });
+    return true;
+}
+
+async function generatedAttributeValueForMutation({
+    db,
+    definition,
+    entityId,
+}: {
+    db: DatabaseClient;
+    definition: SelectAttributeDefinition;
+    entityId: number | null | undefined;
+}) {
+    const config = parseGeneratedImageUrlDefaultValue(definition.defaultValue);
+    if (!config) {
+        return definition.defaultValue ?? null;
+    }
+    if (!entityId || definition.dataType !== 'image') {
+        return null;
+    }
+
+    const [sourceCategory, ...sourceNameParts] = config.source.split('.');
+    const sourceName = sourceNameParts.join('.');
+    if (!sourceCategory || !sourceName) {
+        return null;
+    }
+
+    const sourceDefinition = await db.query.attributeDefinitions.findFirst({
+        where: and(
+            eq(attributeDefinitions.entityTypeName, definition.entityTypeName),
+            eq(attributeDefinitions.category, sourceCategory),
+            eq(attributeDefinitions.name, sourceName),
+            eq(attributeDefinitions.isDeleted, false),
+        ),
+    });
+    if (!sourceDefinition) {
+        return null;
+    }
+
+    const sourceValue = await getExistingAttributeValue({
+        db,
+        attributeDefinitionId: sourceDefinition.id,
+        entityId,
+    });
+    return generatedImageAttributeValue(config, sourceValue?.value);
+}
+
+async function syncGeneratedAttributesForSource({
+    db,
+    sideEffects,
+    entityId,
+    sourceDefinition,
+    sourceValue,
+    actor,
+}: {
+    db: DatabaseClient;
+    sideEffects: AttributeValueMutationSideEffects;
+    entityId: number | null | undefined;
+    sourceDefinition: SelectAttributeDefinition;
+    sourceValue: string | null | undefined;
+    actor?: { id?: string; name?: string };
+}) {
+    if (!entityId) {
+        return;
+    }
+
+    const sourcePath = attributeDefinitionPath(sourceDefinition);
+    const targetDefinitions = (
+        await db.query.attributeDefinitions.findMany({
+            where: and(
+                eq(
+                    attributeDefinitions.entityTypeName,
+                    sourceDefinition.entityTypeName,
+                ),
+                eq(attributeDefinitions.dataType, 'image'),
+                eq(attributeDefinitions.isDeleted, false),
+            ),
+        })
+    ).filter((definition) => {
+        const config = parseGeneratedImageUrlDefaultValue(
+            definition.defaultValue,
+        );
+        return config?.source === sourcePath;
+    });
+
+    for (const definition of targetDefinitions) {
+        const config = parseGeneratedImageUrlDefaultValue(
+            definition.defaultValue,
+        );
+        if (!config) {
+            continue;
+        }
+
+        const nextValue = generatedImageAttributeValue(config, sourceValue);
+
+        const existingValue = await getExistingAttributeValue({
+            db,
+            attributeDefinitionId: definition.id,
+            entityId,
+        });
+        const changed = await upsertGeneratedAttributeValue({
+            db,
+            entityId,
+            definition,
+            existingValue,
+            nextValue,
+            actor,
+        });
+
+        if (changed) {
+            addAttributeValueMutationSideEffects(sideEffects, {
+                entityId,
+                entityTypeName: definition.entityTypeName,
+            });
+        }
     }
 }
 
@@ -219,17 +429,21 @@ export async function upsertAttributeValue(
         db,
         attributeValue.attributeDefinitionId,
     );
-
-    // Handle default value - assign default value if value is not provided
-    if (!value && definition?.defaultValue) {
-        value = definition.defaultValue;
-    }
-
     const existingValue = attributeValue.id
         ? await db.query.attributeValues.findFirst({
               where: eq(attributeValues.id, attributeValue.id),
           })
         : undefined;
+
+    // Handle default value - assign default value if value is not provided
+    if (!value && definition?.defaultValue) {
+        value = await generatedAttributeValueForMutation({
+            db,
+            definition,
+            entityId: attributeValue.entityId ?? existingValue?.entityId,
+        });
+    }
+
     const previousRelationshipTargetId = definition
         ? plantRelationshipTargetIdForAttributeValue(
               definition,
@@ -307,6 +521,16 @@ export async function upsertAttributeValue(
     }
     if (definition && isPlantRelationshipAttributeDefinition(definition)) {
         sideEffects.entityTypeNames.add('plantSort');
+    }
+    if (definition) {
+        await syncGeneratedAttributesForSource({
+            db,
+            sideEffects,
+            entityId: attributeValue.entityId ?? existingValue?.entityId,
+            sourceDefinition: definition,
+            sourceValue: value,
+            actor,
+        });
     }
     if (!options?.sideEffects) {
         await flushAttributeValueMutationSideEffects(sideEffects);
@@ -388,6 +612,16 @@ export async function deleteAttributeValue(
     }
     if (definition && isPlantRelationshipAttributeDefinition(definition)) {
         sideEffects.entityTypeNames.add('plantSort');
+    }
+    if (definition) {
+        await syncGeneratedAttributesForSource({
+            db,
+            sideEffects,
+            entityId: existingValue?.entityId,
+            sourceDefinition: definition,
+            sourceValue: null,
+            actor,
+        });
     }
     if (!options?.sideEffects) {
         await flushAttributeValueMutationSideEffects(sideEffects);

--- a/packages/storage/src/repositories/attributeValuesRepo.ts
+++ b/packages/storage/src/repositories/attributeValuesRepo.ts
@@ -152,6 +152,7 @@ async function upsertGeneratedAttributeValue({
     definition,
     existingValue,
     nextValue,
+    missingValueBehavior = 'clear',
     actor,
 }: {
     db: DatabaseClient;
@@ -159,8 +160,34 @@ async function upsertGeneratedAttributeValue({
     definition: SelectAttributeDefinition;
     existingValue: SelectAttributeValue | undefined;
     nextValue: string | null;
+    missingValueBehavior?: 'clear' | 'delete';
     actor?: { id?: string; name?: string };
 }) {
+    if (nextValue === null && missingValueBehavior === 'delete') {
+        if (!existingValue) {
+            return false;
+        }
+
+        await Promise.all([
+            db
+                .update(attributeValues)
+                .set({ isDeleted: true })
+                .where(eq(attributeValues.id, existingValue.id)),
+            db.insert(entityRevisions).values({
+                entityId,
+                entityTypeName: definition.entityTypeName,
+                action: 'attribute.deleted',
+                actorId: actor?.id,
+                actorName: actor?.name,
+                attributeValueId: existingValue.id,
+                attributeDefinitionId: definition.id,
+                previousValue: existingValue.value,
+                nextValue: null,
+            }),
+        ]);
+        return true;
+    }
+
     if (existingValue?.value === nextValue) {
         return false;
     }
@@ -266,6 +293,7 @@ async function syncGeneratedAttributesForSource({
     entityId,
     sourceDefinition,
     sourceValue,
+    missingValueBehavior,
     actor,
 }: {
     db: DatabaseClient;
@@ -273,6 +301,7 @@ async function syncGeneratedAttributesForSource({
     entityId: number | null | undefined;
     sourceDefinition: SelectAttributeDefinition;
     sourceValue: string | null | undefined;
+    missingValueBehavior?: 'clear' | 'delete';
     actor?: { id?: string; name?: string };
 }) {
     if (!entityId) {
@@ -319,6 +348,7 @@ async function syncGeneratedAttributesForSource({
             definition,
             existingValue,
             nextValue,
+            missingValueBehavior,
             actor,
         });
 
@@ -620,6 +650,7 @@ export async function deleteAttributeValue(
             entityId: existingValue?.entityId,
             sourceDefinition: definition,
             sourceValue: null,
+            missingValueBehavior: 'delete',
             actor,
         });
     }

--- a/packages/storage/src/repositories/entitiesRepo.ts
+++ b/packages/storage/src/repositories/entitiesRepo.ts
@@ -22,6 +22,11 @@ import {
 } from '../cache/directoriesCached';
 import { getEntityCompleteness } from '../helpers/entityCompleteness';
 import {
+    attributeDefinitionPath,
+    generatedImageAttributeValue,
+    parseGeneratedImageUrlDefaultValue,
+} from '../helpers/generatedAttributeValues';
+import {
     buildPlantHealthReadModels,
     isPlantHealthAffectedPlantAttributeDefinition,
     isPlantHealthIssueEntityTypeName,
@@ -182,17 +187,14 @@ function populateMissingAttributes(
             (a) => a.attributeDefinition.id === definition.id && !a.isDeleted,
         );
         // If attribute is missing and we have default defined, create a default one
-        if (
-            !hasAtleastOneAttributeValue &&
-            typeof definition.defaultValue !== 'undefined' &&
-            definition.defaultValue !== null
-        ) {
+        const defaultValue = resolveAttributeDefaultValue(entity, definition);
+        if (!hasAtleastOneAttributeValue && defaultValue !== null) {
             entity.attributes.push({
                 entityId: entity.id,
                 entityTypeName: entity.entityType.name,
                 attributeDefinitionId: definition.id,
                 attributeDefinition: definition,
-                value: definition.defaultValue ?? null,
+                value: defaultValue,
                 order: definition.order,
                 createdAt: new Date(),
                 updatedAt: new Date(),
@@ -210,6 +212,39 @@ function populateMissingAttributes(
     });
 
     return entity;
+}
+
+function resolveAttributeDefaultValue(
+    entity: EntityWithAttributesAndDefinitions,
+    definition: SelectAttributeDefinition,
+) {
+    if (
+        typeof definition.defaultValue === 'undefined' ||
+        definition.defaultValue === null
+    ) {
+        return null;
+    }
+
+    const generatedImageConfig = parseGeneratedImageUrlDefaultValue(
+        definition.defaultValue,
+    );
+    if (!generatedImageConfig) {
+        return definition.defaultValue;
+    }
+
+    if (definition.dataType !== 'image') {
+        return null;
+    }
+
+    const sourceValue =
+        entity.attributes.find(
+            (attribute) =>
+                !attribute.isDeleted &&
+                attributeDefinitionPath(attribute.attributeDefinition) ===
+                    generatedImageConfig.source,
+        )?.value ?? null;
+
+    return generatedImageAttributeValue(generatedImageConfig, sourceValue);
 }
 
 export async function getEntitiesRaw(entityTypeName: string, state?: string) {

--- a/packages/storage/src/repositories/entitySearchRepo.ts
+++ b/packages/storage/src/repositories/entitySearchRepo.ts
@@ -3,6 +3,7 @@ import {
     publicSearchCategoryForDirectoryEntityType,
     resolveDirectoryEntityPublicPathFromParts,
 } from '@gredice/directory-types';
+import { getBlockImageUrl } from '@gredice/js/blocks';
 import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
 import {
     attributeValues,
@@ -184,8 +185,13 @@ function blockImageMetadata(entity: EntitySearchSource): ImageMetadata | null {
         return null;
     }
 
+    const imageUrl = getBlockImageUrl(blockName);
+    if (!imageUrl) {
+        return null;
+    }
+
     return {
-        url: `https://www.gredice.com/assets/blocks/${encodeURIComponent(blockName)}.webp`,
+        url: imageUrl,
         alt: entityTitle(entity),
     };
 }
@@ -467,6 +473,12 @@ async function entityImageMetadata(
 ): Promise<ImageMetadata | null> {
     const direct = directEntityImageMetadata(entity);
     if (direct) {
+        if (entity.entityTypeName === 'block') {
+            return {
+                url: direct.url,
+                alt: direct.alt ?? entityTitle(entity),
+            };
+        }
         return direct;
     }
 

--- a/packages/storage/tests/entitiesRepo.node.spec.ts
+++ b/packages/storage/tests/entitiesRepo.node.spec.ts
@@ -8,6 +8,7 @@ import {
     deleteEntity,
     generatedImageUrlDefaultValue,
     getEntitiesFormatted,
+    getEntitiesRaw,
     getEntityFormatted,
     getEntityIncomingLinks,
     getEntityRaw,
@@ -1080,7 +1081,61 @@ test('CMS generated image attributes are configured by attribute definitions', a
             attribute.attributeDefinition.category === 'image' &&
             attribute.attributeDefinition.name === 'cover',
     );
-    assert.equal(imageAttribute?.value, null);
+    assert.equal(imageAttribute, undefined);
+
+    const parentEntityId = await createEntity(entityTypeName);
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityTypeName,
+        entityId: parentEntityId,
+        value: 'Parent Block',
+    });
+
+    const childEntityId = await createEntity(entityTypeName);
+    await updateEntity({ id: childEntityId, parentId: parentEntityId });
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityTypeName,
+        entityId: childEntityId,
+        value: 'Child Block',
+    });
+
+    const childRawEntity = await getEntityRaw(childEntityId);
+    imageAttribute = childRawEntity?.attributes.find(
+        (attribute) =>
+            attribute.attributeDefinition.category === 'image' &&
+            attribute.attributeDefinition.name === 'cover',
+    );
+    assert.equal(
+        imageAttribute?.value,
+        JSON.stringify({
+            url: 'https://cdn.example.test/assets/Child%20Block.webp',
+        }),
+    );
+
+    const childNameAttribute = childRawEntity?.attributes.find(
+        (attribute) =>
+            attribute.attributeDefinitionId === nameDefinitionId &&
+            attribute.entityId === childEntityId,
+    );
+    assert.ok(childNameAttribute);
+
+    await deleteAttributeValue(childNameAttribute.id);
+
+    const effectiveChildEntity = (await getEntitiesRaw(entityTypeName)).find(
+        (entity) => entity.id === childEntityId,
+    );
+    imageAttribute = effectiveChildEntity?.attributes.find(
+        (attribute) =>
+            attribute.attributeDefinition.category === 'image' &&
+            attribute.attributeDefinition.name === 'cover',
+    );
+    assert.equal(
+        imageAttribute?.value,
+        JSON.stringify({
+            url: 'https://cdn.example.test/assets/Parent%20Block.webp',
+        }),
+    );
 });
 
 test('CMS entity variants inherit parent attributes and allow override reset', async () => {

--- a/packages/storage/tests/entitiesRepo.node.spec.ts
+++ b/packages/storage/tests/entitiesRepo.node.spec.ts
@@ -6,6 +6,7 @@ import {
     createEntity,
     deleteAttributeValue,
     deleteEntity,
+    generatedImageUrlDefaultValue,
     getEntitiesFormatted,
     getEntityFormatted,
     getEntityIncomingLinks,
@@ -996,6 +997,90 @@ test('plant health issue formatting filters duplicate, draft, deleted, and inval
             },
         ],
     );
+});
+
+test('CMS generated image attributes are configured by attribute definitions', async () => {
+    createTestDb();
+    const suffix = randomUUID();
+    const entityTypeName = `generated-image-${suffix}`;
+
+    await upsertEntityType({
+        name: entityTypeName,
+        label: `Generated Image ${suffix}`,
+    });
+
+    const nameDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'name',
+        label: 'Name',
+        entityTypeName,
+        dataType: 'text',
+    });
+    await createAttributeDefinition({
+        category: 'image',
+        name: 'cover',
+        label: 'Cover',
+        entityTypeName,
+        dataType: 'image',
+        defaultValue: generatedImageUrlDefaultValue({
+            source: 'information.name',
+            template: 'https://cdn.example.test/assets/{encodedValue}.webp',
+        }),
+        display: true,
+    });
+
+    const entityId = await createEntity(entityTypeName);
+    await upsertAttributeValue({
+        attributeDefinitionId: nameDefinitionId,
+        entityTypeName,
+        entityId,
+        value: 'Snow Block',
+    });
+
+    const snowImageValue = JSON.stringify({
+        url: 'https://cdn.example.test/assets/Snow%20Block.webp',
+    });
+    let rawEntity = await getEntityRaw(entityId);
+    let imageAttribute = rawEntity?.attributes.find(
+        (attribute) =>
+            attribute.attributeDefinition.category === 'image' &&
+            attribute.attributeDefinition.name === 'cover',
+    );
+    assert.equal(imageAttribute?.value, snowImageValue);
+
+    const nameAttribute = rawEntity?.attributes.find(
+        (attribute) => attribute.attributeDefinitionId === nameDefinitionId,
+    );
+    assert.ok(nameAttribute);
+
+    await upsertAttributeValue({
+        id: nameAttribute.id,
+        attributeDefinitionId: nameDefinitionId,
+        entityTypeName,
+        entityId,
+        value: 'Water Block',
+    });
+
+    const waterImageValue = JSON.stringify({
+        url: 'https://cdn.example.test/assets/Water%20Block.webp',
+    });
+    rawEntity = await getEntityRaw(entityId);
+    imageAttribute = rawEntity?.attributes.find(
+        (attribute) =>
+            attribute.attributeDefinition.category === 'image' &&
+            attribute.attributeDefinition.name === 'cover',
+    );
+    assert.equal(imageAttribute?.value, waterImageValue);
+
+    await deleteAttributeValue(nameAttribute.id);
+
+    rawEntity = await getEntityRaw(entityId);
+    imageAttribute = rawEntity?.attributes.find(
+        (attribute) =>
+            attribute.attributeDefinition.category === 'image' &&
+            attribute.attributeDefinition.name === 'cover',
+    );
+    assert.equal(imageAttribute?.value, null);
 });
 
 test('CMS entity variants inherit parent attributes and allow override reset', async () => {

--- a/packages/ui/src/BlockImage/BlockImage.tsx
+++ b/packages/ui/src/BlockImage/BlockImage.tsx
@@ -1,3 +1,4 @@
+import { getBlockImageUrl } from '@gredice/js/blocks';
 import Image, { type ImageProps } from 'next/image';
 
 type BlockImageProps = Omit<ImageProps, 'src' | 'alt'> & {
@@ -6,11 +7,7 @@ type BlockImageProps = Omit<ImageProps, 'src' | 'alt'> & {
 };
 
 export function BlockImage({ alt, blockName, ...rest }: BlockImageProps) {
-    return (
-        <Image
-            src={`https://www.gredice.com/assets/blocks/${blockName}.webp`}
-            alt={alt || blockName}
-            {...rest}
-        />
-    );
+    const src = getBlockImageUrl(blockName) ?? '';
+
+    return <Image src={src} alt={alt || blockName} {...rest} />;
 }


### PR DESCRIPTION
## Summary
- Add a shared block image URL helper and use it in `BlockImage` and entity search metadata
- Backfill block image attributes from block names through generated attribute definitions
- Keep generated image attributes in sync when source values change or are deleted
- Cover the generated image flow with repository tests

## Testing
- Added node repository tests for generated image attribute creation, update, and deletion
- Not run (not requested)