### PR TITLE
Show placeholders for unknown game entities

### DIFF
--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -24,6 +24,7 @@ import { useStackHeight } from '../utils/getStackHeight';
 import { findRaisedBedByBlockId } from '../utils/raisedBedBlocks';
 import { entityNameMap } from './entityNameMap';
 import { QueuedPlacementDropAnimation } from './helpers/PlacementDropAnimation';
+import { UnknownEntityPlaceholder } from './UnknownEntityPlaceholder';
 
 export type EntityFactoryProps = {
     name: string;
@@ -231,14 +232,6 @@ export function EntityFactory({
           })
         : undefined;
 
-    if (!EntityComponent) {
-        console.error(
-            `Unknown entity: ${name} at ${stack.position.x}, ${stack.position.z}`,
-        );
-        console.debug(stack);
-        return null;
-    }
-
     if (isInstancedInView) {
         if (noControl || view === 'closeup') {
             return (
@@ -282,6 +275,16 @@ export function EntityFactory({
         );
     }
 
+    const entity = EntityComponent ? (
+        <EntityComponent stack={stack} block={block} {...rest} />
+    ) : (
+        <UnknownEntityPlaceholder
+            stack={stack}
+            block={block}
+            rotation={rest.rotation}
+        />
+    );
+
     if (noControl || view === 'closeup') {
         return (
             <>
@@ -290,7 +293,7 @@ export function EntityFactory({
                     block={block}
                     instanced={false}
                 />
-                <EntityComponent stack={stack} block={block} {...rest} />
+                {entity}
             </>
         );
     }
@@ -303,7 +306,7 @@ export function EntityFactory({
                     block={block}
                     instanced={false}
                 />
-                <EntityComponent stack={stack} block={block} {...rest} />
+                {entity}
             </RotatableGroup>
         </EntityPlacementDropAnimation>
     );

--- a/packages/game/src/entities/UnknownEntityPlaceholder.tsx
+++ b/packages/game/src/entities/UnknownEntityPlaceholder.tsx
@@ -1,0 +1,57 @@
+import { Edges } from '@react-three/drei';
+import { useEffect } from 'react';
+import { useBlockData } from '../hooks/useBlockData';
+import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
+import { getBlockHitboxSize } from '../utils/blockHitbox';
+import { useStackHeight } from '../utils/getStackHeight';
+
+function positiveFiniteNumber(value: unknown, fallback: number) {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+        ? value
+        : fallback;
+}
+
+export function UnknownEntityPlaceholder({
+    block,
+    rotation,
+    stack,
+}: Pick<EntityInstanceProps, 'block' | 'rotation' | 'stack'>) {
+    const { data: blockData } = useBlockData();
+    const currentStackHeight = useStackHeight(stack, block);
+    const blockEntity = blockData?.find(
+        (entity) => entity.information.name === block.name,
+    );
+    const hitbox = getBlockHitboxSize(blockEntity);
+    const height = positiveFiniteNumber(
+        blockEntity?.attributes.height,
+        hitbox.height,
+    );
+
+    useEffect(() => {
+        console.warn(
+            `Rendering placeholder for unknown entity: ${block.name} at ${stack.position.x}, ${stack.position.z}`,
+        );
+    }, [block.name, stack.position.x, stack.position.z]);
+
+    return (
+        <group
+            name={`UnknownEntityPlaceholder:${block.name}:${block.id}`}
+            position={[
+                stack.position.x,
+                currentStackHeight + height / 2,
+                stack.position.z,
+            ]}
+            rotation={[0, rotation * (Math.PI / 2), 0]}
+        >
+            <mesh castShadow receiveShadow>
+                <boxGeometry args={[hitbox.width, height, hitbox.depth]} />
+                <meshStandardMaterial
+                    color="#22c55e"
+                    metalness={0.02}
+                    roughness={0.78}
+                />
+                <Edges color="#166534" threshold={1} />
+            </mesh>
+        </group>
+    );
+}


### PR DESCRIPTION
## Summary
- Render a visible placeholder mesh when an entity name is not recognized
- Keep the unknown block aligned to its stack position and estimated hitbox
- Replace the silent null return so missing entities are easier to spot in-game

## Testing
- Not run (not requested)