### PR TITLE
[codex] Allow blocks to opt into water placement

### DIFF
--- a/apps/api/lib/garden/blockPlacementService.node.spec.ts
+++ b/apps/api/lib/garden/blockPlacementService.node.spec.ts
@@ -4,7 +4,16 @@ import { resolveGardenBlockPlacement } from './blockPlacementService';
 
 const blockDataByName = new Map([
     ['Block_Grass', { attributes: { stackable: true, height: 1 } }],
-    ['Block_Water', { attributes: { stackable: true, height: 1 } }],
+    [
+        'Block_Water',
+        {
+            attributes: {
+                stackable: true,
+                height: 1,
+                placeableOnWater: true,
+            },
+        },
+    ],
     ['Raised_Bed', { attributes: { stackable: true, height: 1 } }],
     ['Shade', { attributes: { stackable: false, height: 1 } }],
     [
@@ -147,10 +156,25 @@ describe('resolveGardenBlockPlacement', () => {
         });
     });
 
-    it('uses a water stack when no non-water placement is available', () => {
+    it('rejects water stacks when the placed block is not placeable on water', () => {
         const { blockNameById, stacks } = createWaterOnlyPlacementSearch();
         const placement = resolveGardenBlockPlacement({
             blockName: 'Shade',
+            stacks,
+            blockNameById,
+            blockDataByName,
+        });
+
+        assert.deepStrictEqual(placement, {
+            valid: false,
+            error: 'No valid placement position found',
+        });
+    });
+
+    it('uses a water stack when the placed block is placeable on water', () => {
+        const { blockNameById, stacks } = createWaterOnlyPlacementSearch();
+        const placement = resolveGardenBlockPlacement({
+            blockName: 'Block_Water',
             stacks,
             blockNameById,
             blockDataByName,

--- a/apps/api/lib/garden/stacksPatchValidation.node.spec.ts
+++ b/apps/api/lib/garden/stacksPatchValidation.node.spec.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { validateStackPlacement } from './stacksPatchValidation';
+
+const blockDataByName = new Map([
+    ['Block_Grass', { attributes: { stackable: true, height: 1 } }],
+    [
+        'Block_Water',
+        {
+            attributes: {
+                stackable: true,
+                height: 1,
+                placeableOnWater: true,
+            },
+        },
+    ],
+    ['Tree', { attributes: { stackable: true, height: 1 } }],
+]);
+
+describe('validateStackPlacement', () => {
+    it('blocks non-water blocks directly above water', () => {
+        const validation = validateStackPlacement({
+            blockIds: ['water-a', 'tree-a'],
+            blockNameById: new Map([
+                ['water-a', 'Block_Water'],
+                ['tree-a', 'Tree'],
+            ]),
+            blockDataByName,
+        });
+
+        assert.deepEqual(validation, {
+            valid: false,
+            error: 'Invalid stack placement: block water-a cannot support block tree-a',
+        });
+    });
+
+    it('allows water blocks directly above water', () => {
+        const validation = validateStackPlacement({
+            blockIds: ['water-a', 'water-b'],
+            blockNameById: new Map([
+                ['water-a', 'Block_Water'],
+                ['water-b', 'Block_Water'],
+            ]),
+            blockDataByName,
+        });
+
+        assert.deepEqual(validation, { valid: true });
+    });
+});

--- a/apps/api/lib/garden/stacksPatchValidation.ts
+++ b/apps/api/lib/garden/stacksPatchValidation.ts
@@ -1,4 +1,5 @@
 import {
+    canStackBlockOnBlock,
     getGardenBlockFootprintOffsets,
     type GardenBlockDataLike as SharedGardenBlockDataLike,
 } from '@gredice/js/gardenBlocks';
@@ -19,6 +20,7 @@ type BlockDataLike = SharedGardenBlockDataLike;
 
 type OccupiedCell = {
     blockId: string;
+    blockName: string;
     stackable: boolean;
     topHeight: number;
 };
@@ -138,6 +140,7 @@ function createOccupiedCells(params: {
                     const existing = occupiedCells.get(key);
                     const cell = {
                         blockId,
+                        blockName,
                         stackable: blockData?.attributes?.stackable ?? true,
                         topHeight: stackHeight + blockHeight,
                     };
@@ -235,7 +238,23 @@ export function validateStackPlacement(params: {
         }
 
         const belowBlockData = blockDataByName.get(belowBlockName);
-        if (!belowBlockData?.attributes?.stackable) {
+        const aboveBlockName = blockNameById.get(aboveBlockId);
+        if (!aboveBlockName) {
+            return {
+                valid: false,
+                error: `Invalid stack placement: unknown block ${aboveBlockId} above ${belowBlockId}`,
+            };
+        }
+
+        const aboveBlockData = blockDataByName.get(aboveBlockName);
+        if (
+            !canStackBlockOnBlock({
+                aboveBlockData,
+                aboveBlockName,
+                belowBlockData,
+                belowBlockName,
+            })
+        ) {
             return {
                 valid: false,
                 error: `Invalid stack placement: block ${belowBlockId} cannot support block ${aboveBlockId}`,
@@ -438,8 +457,22 @@ export function validateConnectedRaisedBedMove(params: {
         }
 
         const blockUnderData = blockDataByName.get(blockUnderName);
-        const isStackable = blockUnderData?.attributes?.stackable ?? true;
-        if (!isStackable) {
+        const blockName = blockNameById.get(blockId);
+        if (!blockName) {
+            return {
+                valid: false,
+                error: `Invalid connected raised bed move: unknown block ${blockId}`,
+            };
+        }
+
+        if (
+            !canStackBlockOnBlock({
+                aboveBlockData: blockDataByName.get(blockName),
+                aboveBlockName: blockName,
+                belowBlockData: blockUnderData,
+                belowBlockName: blockUnderName,
+            })
+        ) {
             return {
                 valid: false,
                 error: `Invalid connected raised bed move: block ${blockUnderId} cannot support block ${blockId}`,
@@ -538,7 +571,15 @@ export function validateSpanningBlockMove(params: {
         const x = destinationPosition.x + offset.x;
         const y = destinationPosition.y + offset.y;
         const topOccupiedCell = getTopOccupiedCell(occupiedCells, x, y);
-        if (topOccupiedCell && !topOccupiedCell.stackable) {
+        if (
+            topOccupiedCell &&
+            !canStackBlockOnBlock({
+                aboveBlockData: movedBlockData,
+                aboveBlockName: movedBlockName,
+                belowBlockData: blockDataByName.get(topOccupiedCell.blockName),
+                belowBlockName: topOccupiedCell.blockName,
+            })
+        ) {
             return {
                 valid: false,
                 error: `Invalid block placement: block ${topOccupiedCell.blockId} cannot support ${movedBlockName}`,

--- a/packages/game/src/controls/PickupPlacementResolver.ts
+++ b/packages/game/src/controls/PickupPlacementResolver.ts
@@ -1,5 +1,8 @@
 import type { BlockData } from '@gredice/client';
-import { getGardenBlockFootprintOffsets } from '@gredice/js/gardenBlocks';
+import {
+    canStackBlockOnBlock,
+    getGardenBlockFootprintOffsets,
+} from '@gredice/js/gardenBlocks';
 import type { Vector3 } from 'three';
 import {
     type ActiveDragPreviewTargetOffset,
@@ -366,6 +369,10 @@ export function resolvePickupPlacementPreviewForRelative({
             const blockUnderData = blockUnder
                 ? getBlockDataByName(blockData, blockUnder.name)
                 : null;
+            const movingBaseBlock = segment.blocks[0];
+            const movingBaseBlockData = movingBaseBlock
+                ? getBlockDataByName(blockData, movingBaseBlock.name)
+                : null;
             const isRecycler = isRecyclerPlacementTarget({
                 canRecycle: segment.canRecycle,
                 sourcePosition: segment.sourceStack.position,
@@ -390,9 +397,22 @@ export function resolvePickupPlacementPreviewForRelative({
                           ),
                       }
                     : undefined;
+                const occupiedBlockData = occupiedCell
+                    ? getBlockDataByName(blockData, occupiedCell.block.name)
+                    : null;
+                const isSupported =
+                    !occupiedCell ||
+                    (movingBaseBlock
+                        ? canStackBlockOnBlock({
+                              aboveBlockData: movingBaseBlockData ?? undefined,
+                              aboveBlockName: movingBaseBlock.name,
+                              belowBlockData: occupiedBlockData ?? undefined,
+                              belowBlockName: occupiedCell.block.name,
+                          })
+                        : true);
 
                 return {
-                    isBlocked: occupiedCell !== null && !occupiedCell.stackable,
+                    isBlocked: !isSupported,
                     hoverHeight:
                         (occupiedCell?.topHeight ??
                             getStackHeight(

--- a/packages/game/src/controls/PickupPlacementResolver.unit.ts
+++ b/packages/game/src/controls/PickupPlacementResolver.unit.ts
@@ -28,6 +28,7 @@ function createBlockData({
     height = 1,
     id,
     name,
+    placeableOnWater,
     recycler = false,
     stackable = true,
     spanDepth,
@@ -36,6 +37,7 @@ function createBlockData({
     height?: number;
     id: number;
     name: string;
+    placeableOnWater?: boolean;
     recycler?: boolean;
     stackable?: boolean;
     spanDepth?: number;
@@ -58,6 +60,7 @@ function createBlockData({
         attributes: {
             height,
             stackable,
+            ...(placeableOnWater !== undefined ? { placeableOnWater } : {}),
             type: 'decoration',
             nightOnlyPurchase: false,
             ...(spanDepth !== undefined ? { spanDepth } : {}),
@@ -128,6 +131,11 @@ const blockData = [
         stackable: false,
         spanDepth: 1,
         spanWidth: 2,
+    }),
+    createBlockData({
+        id: 8,
+        name: 'Block_Water',
+        placeableOnWater: true,
     }),
 ];
 
@@ -308,5 +316,43 @@ describe('resolvePickupPlacementPreviewForRelative', () => {
         });
 
         assert.equal(preview?.nextIsBlocked, true);
+    });
+
+    it('blocks drops onto water when the moving block is not placeable on water', () => {
+        const tree = createBlock('Tree', 'tree');
+        const water = createBlock('Block_Water', 'water');
+        const sourceStack = createStack(0, 0, [tree]);
+        const waterStack = createStack(1, 0, [water]);
+
+        const preview = resolvePickupPlacementPreviewForRelative({
+            blockData,
+            gardenIsSandbox: false,
+            localSandboxStorageKey: null,
+            movingSegments: [createMovingSegment({ block: tree, sourceStack })],
+            relative: new Vector3(1, 0, 0),
+            stacks: [sourceStack, waterStack],
+        });
+
+        assert.equal(preview?.nextIsBlocked, true);
+    });
+
+    it('allows drops onto water when the moving block is placeable on water', () => {
+        const waterA = createBlock('Block_Water', 'water-a');
+        const waterB = createBlock('Block_Water', 'water-b');
+        const sourceStack = createStack(0, 0, [waterA]);
+        const waterStack = createStack(1, 0, [waterB]);
+
+        const preview = resolvePickupPlacementPreviewForRelative({
+            blockData,
+            gardenIsSandbox: false,
+            localSandboxStorageKey: null,
+            movingSegments: [
+                createMovingSegment({ block: waterA, sourceStack }),
+            ],
+            relative: new Vector3(1, 0, 0),
+            stacks: [sourceStack, waterStack],
+        });
+
+        assert.equal(preview?.nextIsBlocked, false);
     });
 });

--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -57,6 +57,7 @@ import {
     getWaterBlockCenterY,
     getWaterBlockVisualHeight,
 } from './waterBlockHeight';
+import { isWaterBlockTopSurfaceVisible } from './waterBlockSurface';
 
 type CommonWeatherProps = Pick<
     EntityInstancesBlockBaseProps,
@@ -437,7 +438,9 @@ function WaterBlockInstances({ stacks }: { stacks: Stack[] | undefined }) {
         return null;
     }
 
-    const topSurfaceInstances = waterInstances.filter(isWaterTopSurfaceVisible);
+    const topSurfaceInstances = waterInstances.filter(
+        isWaterBlockTopSurfaceVisible,
+    );
     const groupedInstances = resolveWaterBlockInstanceGroups({
         blockData,
         instances: topSurfaceInstances,
@@ -459,10 +462,6 @@ function WaterBlockInstances({ stacks }: { stacks: Stack[] | undefined }) {
             <WaterBlockMergedSides instances={waterInstances} />
         </>
     );
-}
-
-function isWaterTopSurfaceVisible(instance: EntityBlockInstance) {
-    return instance.blockIndex === instance.stack.blocks.length - 1;
 }
 
 function foamEdgeKey(foamEdges: Vector4) {

--- a/packages/game/src/entities/BlockWater.tsx
+++ b/packages/game/src/entities/BlockWater.tsx
@@ -15,6 +15,7 @@ import {
     getWaterBlockCenterY,
     getWaterBlockVisualHeight,
 } from './waterBlockHeight';
+import { isWaterBlockTopSurfaceVisible } from './waterBlockSurface';
 
 const waterVertexShader = `
 varying vec3 vLocalPosition;
@@ -225,9 +226,7 @@ export function BlockWater({ stack, block, stacks }: EntityInstanceProps) {
         () => resolveWaterFoamCorners({ block, blockData, stack, stacks }),
         [block, blockData, stack, stacks],
     );
-    const waterBlockIndex = stack.blocks.indexOf(block);
-    const includeTop =
-        waterBlockIndex < 0 || waterBlockIndex === stack.blocks.length - 1;
+    const includeTop = isWaterBlockTopSurfaceVisible({ block, stack });
     const geometry = useMemo(
         () =>
             createWaterBlockGeometry(foamEdges, {

--- a/packages/game/src/entities/waterBlockFoam.unit.ts
+++ b/packages/game/src/entities/waterBlockFoam.unit.ts
@@ -117,17 +117,14 @@ describe('resolveWaterFoamEdges', () => {
         );
     });
 
-    it('removes foam when shaped and full-height water ranges overlap', () => {
+    it('removes foam when shaped and standalone water ranges overlap', () => {
         const blockData = getLocalSandboxBlockData();
         const currentWater = waterBlock('water-shaped');
         const currentStack = stack(0, 0, [
             grassAngleBlock('angle-a'),
             currentWater,
         ]);
-        const stacks = [
-            currentStack,
-            stack(1, 0, [grassBlock('grass-a'), waterBlock('water-east')]),
-        ];
+        const stacks = [currentStack, stack(1, 0, [waterBlock('water-east')])];
 
         assert.deepEqual(
             resolveWaterFoamEdges({

--- a/packages/game/src/entities/waterBlockHeight.ts
+++ b/packages/game/src/entities/waterBlockHeight.ts
@@ -7,7 +7,7 @@ import {
     waterBlockBottomOverlap,
 } from './waterBlockGeometry';
 
-export const shapedTerrainWaterTopInset = 0.01;
+export const shapedTerrainWaterTopInset = waterBlockBottomOverlap;
 
 export type WaterBlockVerticalRange = {
     max: number;

--- a/packages/game/src/entities/waterBlockHeight.unit.ts
+++ b/packages/game/src/entities/waterBlockHeight.unit.ts
@@ -4,7 +4,10 @@ import { Vector3 } from 'three';
 import { getLocalSandboxBlockData } from '../localSandboxBlockData';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
-import { defaultWaterBlockVisualHeight } from './waterBlockGeometry';
+import {
+    defaultWaterBlockVisualHeight,
+    waterBlockBottomOverlap,
+} from './waterBlockGeometry';
 import {
     getWaterBlockCenterY,
     getWaterBlockVerticalRange,
@@ -89,7 +92,7 @@ describe('getWaterBlockVisualHeight', () => {
         );
     });
 
-    it('keeps shaped terrain water slightly below the support block edge', () => {
+    it('aligns shaped terrain water with a standalone water block top', () => {
         const water = block('water-a', 'Block_Water');
         const currentStack = stack([
             block('corner-a', 'Block_Sand_Reverse_Corner'),
@@ -101,7 +104,7 @@ describe('getWaterBlockVisualHeight', () => {
             stack: currentStack,
         });
         const waterTop =
-            defaultWaterBlockVisualHeight - shapedTerrainWaterTopInset;
+            defaultWaterBlockVisualHeight - waterBlockBottomOverlap;
 
         assert.deepEqual(range, { min: 0, max: waterTop });
         assert.equal(

--- a/packages/game/src/entities/waterBlockSurface.ts
+++ b/packages/game/src/entities/waterBlockSurface.ts
@@ -1,0 +1,19 @@
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { waterBlockName } from './waterBlockFoam';
+
+export function isWaterBlockTopSurfaceVisible({
+    block,
+    stack,
+}: {
+    block: Block;
+    stack: Stack;
+}) {
+    const waterBlockIndex = stack.blocks.indexOf(block);
+
+    if (waterBlockIndex < 0) {
+        return true;
+    }
+
+    return stack.blocks[waterBlockIndex + 1]?.name !== waterBlockName;
+}

--- a/packages/game/src/entities/waterBlockSurface.unit.ts
+++ b/packages/game/src/entities/waterBlockSurface.unit.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { isWaterBlockTopSurfaceVisible } from './waterBlockSurface';
+
+function block(id: string, name: string): Block {
+    return { id, name, rotation: 0 };
+}
+
+function stack(blocks: Block[]): Stack {
+    return {
+        blocks,
+        position: new Vector3(0, 0, 0),
+    };
+}
+
+describe('isWaterBlockTopSurfaceVisible', () => {
+    it('keeps the top visible when a decoration is placed above water', () => {
+        const water = block('water-a', 'Block_Water');
+        const currentStack = stack([water, block('pine-a', 'Pine')]);
+
+        assert.equal(
+            isWaterBlockTopSurfaceVisible({
+                block: water,
+                stack: currentStack,
+            }),
+            true,
+        );
+    });
+
+    it('hides the top only when another water block is directly above', () => {
+        const water = block('water-a', 'Block_Water');
+        const currentStack = stack([water, block('water-b', 'Block_Water')]);
+
+        assert.equal(
+            isWaterBlockTopSurfaceVisible({
+                block: water,
+                stack: currentStack,
+            }),
+            false,
+        );
+    });
+
+    it('keeps the top visible for the uppermost water block', () => {
+        const water = block('water-a', 'Block_Water');
+        const currentStack = stack([block('water-b', 'Block_Water'), water]);
+
+        assert.equal(
+            isWaterBlockTopSurfaceVisible({
+                block: water,
+                stack: currentStack,
+            }),
+            true,
+        );
+    });
+
+    it('keeps the top visible for unplaced water previews', () => {
+        assert.equal(
+            isWaterBlockTopSurfaceVisible({
+                block: block('water-preview', 'Block_Water'),
+                stack: stack([]),
+            }),
+            true,
+        );
+    });
+});

--- a/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
+++ b/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
@@ -15,7 +15,7 @@ const blockData: PlacementBlockData[] = [
     },
     {
         information: { name: 'Block_Water' },
-        attributes: { stackable: true, height: 1 },
+        attributes: { stackable: true, height: 1, placeableOnWater: true },
     },
     {
         information: { name: 'Raised_Bed' },
@@ -26,6 +26,58 @@ const blockData: PlacementBlockData[] = [
         attributes: { stackable: false, height: 1 },
     },
 ];
+
+const maxSpiralSteps = 1000;
+
+function spiral(step: number) {
+    const r = Math.floor((Math.sqrt(step + 1) - 1) / 2) + 1;
+    const p = (8 * r * (r - 1)) / 2;
+    const en = r * 2;
+    const a = (1 + step - p) % (r * 8);
+
+    switch (Math.floor(a / (r * 2))) {
+        case 0:
+            return { x: a - r, z: -r };
+        case 1:
+            return { x: r, z: (a % en) - r };
+        case 2:
+            return { x: r - (a % en), z: r };
+        case 3:
+            return { x: -r, z: r - (a % en) };
+        default:
+            return { x: 0, z: 0 };
+    }
+}
+
+function createWaterOnlyGarden() {
+    return {
+        stacks: [
+            {
+                position: new Vector3(0, 0, 0),
+                blocks: [
+                    {
+                        id: 'water-origin',
+                        name: 'Block_Water',
+                        rotation: 0,
+                    },
+                ],
+            },
+            ...Array.from({ length: maxSpiralSteps }, (_, step) => {
+                const { x, z } = spiral(step);
+                return {
+                    position: new Vector3(x, 0, z),
+                    blocks: [
+                        {
+                            id: `water-${step}`,
+                            name: 'Block_Water',
+                            rotation: 0,
+                        },
+                    ],
+                };
+            }),
+        ],
+    };
+}
 
 describe('createOptimisticBlockPlacement', () => {
     it('uses the shared placement resolver for new block purchases', () => {
@@ -112,6 +164,44 @@ describe('createOptimisticBlockPlacement', () => {
                 {
                     id: 'optimistic-shade',
                     name: 'Shade',
+                    rotation: 0,
+                },
+            ],
+        });
+    });
+
+    it('does not place new non-water blocks on water-only gardens', () => {
+        const placement = createOptimisticBlockPlacement(
+            createWaterOnlyGarden(),
+            blockData,
+            'Shade',
+            'optimistic-shade',
+        );
+
+        assert.equal(placement, null);
+    });
+
+    it('allows new water blocks on water-only gardens', () => {
+        const placement = createOptimisticBlockPlacement(
+            createWaterOnlyGarden(),
+            blockData,
+            'Block_Water',
+            'optimistic-water',
+        );
+
+        assert.ok(placement);
+        assert.deepStrictEqual(placement.position, new Vector3(0, 0, 0));
+        assert.deepStrictEqual(placement.stacks[0], {
+            position: new Vector3(0, 0, 0),
+            blocks: [
+                {
+                    id: 'water-origin',
+                    name: 'Block_Water',
+                    rotation: 0,
+                },
+                {
+                    id: 'optimistic-water',
+                    name: 'Block_Water',
                     rotation: 0,
                 },
             ],

--- a/packages/js/src/gardenBlocks/index.ts
+++ b/packages/js/src/gardenBlocks/index.ts
@@ -10,6 +10,7 @@ export type GardenBlockDataLike = {
         height?: number | null;
         spanWidth?: number | null;
         spanDepth?: number | null;
+        placeableOnWater?: boolean | null;
     } | null;
 };
 
@@ -56,7 +57,7 @@ export type GardenBlockPlacementResult =
 
 const CANDIDATE_BLOCK_ID = '__candidate_block__';
 const MAX_SPIRAL_STEPS = 1000;
-const WATER_BLOCK_NAME = 'Block_Water';
+export const WATER_BLOCK_NAME = 'Block_Water';
 
 function toPositiveGridSpan(value: number | null | undefined) {
     return typeof value === 'number' && Number.isFinite(value) && value > 0
@@ -218,7 +219,7 @@ function getTopOccupiedCell(
 }
 
 function isGroundBlock(blockName: string) {
-    return blockName.startsWith('Block');
+    return blockName.startsWith('Block') && blockName !== WATER_BLOCK_NAME;
 }
 
 function isWaterPlacement(params: {
@@ -241,6 +242,44 @@ function isWaterPlacement(params: {
         return stack?.blocks.some(
             (blockId) => blockNameById.get(blockId) === WATER_BLOCK_NAME,
         );
+    });
+}
+
+export function isBlockPlaceableOnWater({
+    blockData,
+    blockName,
+}: {
+    blockData: GardenBlockDataLike | undefined;
+    blockName: string;
+}) {
+    return (
+        blockData?.attributes?.placeableOnWater ??
+        blockName === WATER_BLOCK_NAME
+    );
+}
+
+export function canStackBlockOnBlock({
+    aboveBlockData,
+    aboveBlockName,
+    belowBlockData,
+    belowBlockName,
+}: {
+    aboveBlockData: GardenBlockDataLike | undefined;
+    aboveBlockName: string;
+    belowBlockData: GardenBlockDataLike | undefined;
+    belowBlockName: string;
+}) {
+    if (!belowBlockData?.attributes?.stackable) {
+        return false;
+    }
+
+    if (belowBlockName !== WATER_BLOCK_NAME) {
+        return true;
+    }
+
+    return isBlockPlaceableOnWater({
+        blockData: aboveBlockData,
+        blockName: aboveBlockName,
     });
 }
 
@@ -269,8 +308,24 @@ export function validateStackPlacement(params: {
             };
         }
 
+        const aboveBlockName = blockNameById.get(aboveBlockId);
+        if (!aboveBlockName) {
+            return {
+                valid: false,
+                error: `Invalid stack placement: unknown block ${aboveBlockId} above ${belowBlockId}`,
+            };
+        }
+
         const belowBlockData = blockDataByName.get(belowBlockName);
-        if (!belowBlockData?.attributes?.stackable) {
+        const aboveBlockData = blockDataByName.get(aboveBlockName);
+        if (
+            !canStackBlockOnBlock({
+                aboveBlockData,
+                aboveBlockName,
+                belowBlockData,
+                belowBlockName,
+            })
+        ) {
             return {
                 valid: false,
                 error: `Invalid stack placement: block ${belowBlockId} cannot support block ${aboveBlockId}`,
@@ -422,7 +477,15 @@ function validatePlacementAtPosition(params: {
             };
         }
 
-        if (topOccupiedCell && !topOccupiedCell.stackable) {
+        if (
+            topOccupiedCell &&
+            !canStackBlockOnBlock({
+                aboveBlockData: blockData,
+                aboveBlockName: blockName,
+                belowBlockData: blockDataByName.get(topOccupiedCell.blockName),
+                belowBlockName: topOccupiedCell.blockName,
+            })
+        ) {
             return {
                 valid: false,
                 error: `Invalid block placement: block ${topOccupiedCell.blockId} cannot support ${blockName}`,

--- a/packages/storage/scripts/upsertBlockHitboxAttributes.ts
+++ b/packages/storage/scripts/upsertBlockHitboxAttributes.ts
@@ -140,6 +140,13 @@ const hitboxDefinitionSpecs = [
     },
 ] as const;
 
+const placeableOnWaterDefinitionSpec = {
+    name: 'placeableOnWater',
+    label: 'Postavljanje na vodu',
+    description: 'Dopušta postavljanje bloka izravno na vodeni blok.',
+    defaultValue: 'false',
+} as const;
+
 async function upsertHitboxDefinition(
     spec: (typeof hitboxDefinitionSpecs)[number],
 ) {
@@ -163,6 +170,49 @@ async function upsertHitboxDefinition(
         entityTypeName: 'block',
         dataType: 'number',
         defaultValue: spec.defaultValue,
+        required: false,
+        display: false,
+    };
+
+    if (!existingDefinition) {
+        const [created] = await storage()
+            .insert(attributeDefinitions)
+            .values(definitionValues)
+            .returning({ id: attributeDefinitions.id });
+        return created.id;
+    }
+
+    await storage()
+        .update(attributeDefinitions)
+        .set(definitionValues)
+        .where(eq(attributeDefinitions.id, existingDefinition.id));
+    return existingDefinition.id;
+}
+
+async function upsertPlaceableOnWaterDefinition() {
+    const [existingDefinition] = await storage()
+        .select()
+        .from(attributeDefinitions)
+        .where(
+            and(
+                eq(attributeDefinitions.entityTypeName, 'block'),
+                eq(attributeDefinitions.category, 'attributes'),
+                eq(
+                    attributeDefinitions.name,
+                    placeableOnWaterDefinitionSpec.name,
+                ),
+                eq(attributeDefinitions.isDeleted, false),
+            ),
+        );
+
+    const definitionValues = {
+        category: 'attributes',
+        name: placeableOnWaterDefinitionSpec.name,
+        label: placeableOnWaterDefinitionSpec.label,
+        description: placeableOnWaterDefinitionSpec.description,
+        entityTypeName: 'block',
+        dataType: 'boolean',
+        defaultValue: placeableOnWaterDefinitionSpec.defaultValue,
         required: false,
         display: false,
     };
@@ -331,6 +381,8 @@ async function main() {
     for (const spec of hitboxDefinitionSpecs) {
         definitionIds.set(spec.name, await upsertHitboxDefinition(spec));
     }
+    const placeableOnWaterDefinitionId =
+        await upsertPlaceableOnWaterDefinition();
 
     const blockIdsByName = await getPublishedBlockIdsByName();
     const missingBlockNames = Object.keys(blockHitboxes).filter(
@@ -391,6 +443,20 @@ async function main() {
         }
     }
 
+    const waterBlockEntityId = blockIdsByName.get('Block_Water');
+    let changedWaterPlacementCount = 0;
+    if (waterBlockEntityId) {
+        const changed = await upsertBlockAttributeValue({
+            attributeDefinitionId: placeableOnWaterDefinitionId,
+            entityId: waterBlockEntityId,
+            nextValue: 'true',
+        });
+        if (changed) {
+            changedEntityIds.add(waterBlockEntityId);
+            changedWaterPlacementCount += 1;
+        }
+    }
+
     await Promise.all([
         bustCached(cacheKeys.entityTypeName('block')),
         bustCachedByPrefixes(['entities:formatted:', 'dashboard:admin:']),
@@ -400,7 +466,7 @@ async function main() {
     ]);
 
     console.log(
-        `Upserted ${hitboxDefinitionSpecs.length} definitions, ${changedValueCount} block hitbox values, and ${changedVisualHeightCount} shaped terrain visual heights across ${changedEntityIds.size} changed entities.`,
+        `Upserted ${hitboxDefinitionSpecs.length + 1} definitions, ${changedValueCount} block hitbox values, ${changedVisualHeightCount} shaped terrain visual heights, and ${changedWaterPlacementCount} water placement values across ${changedEntityIds.size} changed entities.`,
     );
 }
 

--- a/packages/storage/src/helpers/communityEditableFields.ts
+++ b/packages/storage/src/helpers/communityEditableFields.ts
@@ -316,6 +316,18 @@ const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
         pageLevel: true,
         inline: true,
     },
+    {
+        entityTypeName: 'block',
+        fieldKey: 'block.placeable-on-water',
+        sectionKey: 'attributes',
+        category: 'attributes',
+        name: 'placeableOnWater',
+        publicLabel: 'Postavljanje na vodu',
+        helpText: 'Dopušta postavljanje bloka izravno na vodeni blok.',
+        controlType: 'boolean',
+        pageLevel: true,
+        inline: true,
+    },
 ];
 
 export function getCommunityEditableFieldDefinitions(


### PR DESCRIPTION
## What changed

- Added a `placeableOnWater` block attribute and storage/community-editable metadata.
- Marked `Block_Water` as placeable on water through the storage upsert path.
- Centralized stack support checks so water only supports opted-in blocks while ordinary stackable blocks keep their existing behavior.
- Applied the rule to API placement validation, connected/spanning block move validation, optimistic placement, and pickup preview blocking.
- Kept water top surfaces visible under non-water items, hiding them only under stacked water.

## Why

Items placed on top of water were being treated like stacked water in the renderer, and placement rules only had a broad stackable/not-stackable distinction. This adds the missing explicit capability so decorations and other blocks are blocked from water unless they opt in.

## Validation

- `pnpm bootstrap` pulled local env files; health check exited non-zero because port `3101` is in use and the local Caddy cert is missing.
- `pnpm --filter @gredice/storage exec tsx --conditions=react-server --env-file=.env ./scripts/upsertBlockHitboxAttributes.ts`
- `pnpm --filter @gredice/game exec tsx --test src/controls/PickupPlacementResolver.unit.ts src/hooks/optimisticBlockPlacement.unit.ts src/entities/waterBlockSurface.unit.ts src/entities/waterBlockHeight.unit.ts src/entities/waterBlockGeometry.unit.ts src/entities/waterBlockFoam.unit.ts`
- `pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/garden/blockPlacementService.node.spec.ts ./lib/garden/stacksPatchValidation.node.spec.ts`
- `pnpm typecheck --filter @gredice/game`
- focused `biome check --write` on changed package files
- `git diff --check --cached`