### PR TITLE
Adjust tutorial checklist HUD layout

### DIFF
--- a/apps/garden/tests/tutorial-checklist-hud.spec.tsx
+++ b/apps/garden/tests/tutorial-checklist-hud.spec.tsx
@@ -38,10 +38,13 @@ test('tutorial checklist trigger shows icon with progress count below it', async
     expect(dotBox).not.toBeNull();
     expect(iconBox?.y ?? 0).toBeLessThan(triggerBox?.y ?? 0);
     expect(progressBox?.y ?? 0).toBeGreaterThan(iconBox?.y ?? 0);
+    expect((iconBox?.y ?? 0) + (iconBox?.height ?? 0)).toBeLessThanOrEqual(
+        (progressBox?.y ?? 0) + 1,
+    );
     expect(
         (progressBox?.y ?? 0) + (progressBox?.height ?? 0),
     ).toBeLessThanOrEqual((triggerBox?.y ?? 0) + (triggerBox?.height ?? 0) + 1);
-    expect(dotBox?.x ?? 0).toBeGreaterThan(
+    expect(dotBox?.x ?? 0).toBeGreaterThanOrEqual(
         (triggerBox?.x ?? 0) + (triggerBox?.width ?? 0) - 10,
     );
     expect(dotBox?.y ?? 0).toBeLessThan((triggerBox?.y ?? 0) + 2);
@@ -49,6 +52,12 @@ test('tutorial checklist trigger shows icon with progress count below it', async
         (node) => window.getComputedStyle(node).fontSize,
     );
     expect(progressFontSize).toBe('12px');
+    const triggerBorderRadius = await trigger.evaluate((node) =>
+        Number.parseFloat(window.getComputedStyle(node).borderRadius),
+    );
+    expect(triggerBorderRadius).toBeGreaterThanOrEqual(
+        Math.round((triggerBox?.width ?? 0) / 2),
+    );
     await expect(claimDot.locator('.animate-ping')).toHaveCount(1);
 });
 

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -567,7 +567,7 @@ export function TutorialChecklistHud() {
         <HudCard
             open
             position="floating"
-            className="relative overflow-visible p-0.5"
+            className="relative grid size-11 place-items-center overflow-visible rounded-full p-0.5"
         >
             {claimableCount > 0 && (
                 <div
@@ -596,7 +596,7 @@ export function TutorialChecklistHud() {
                         aria-label={
                             progressLabel ? `Zadaci ${progressLabel}` : 'Zadaci'
                         }
-                        className="relative size-10 overflow-visible rounded-full"
+                        className="relative size-10 overflow-visible rounded-full p-0"
                         data-tutorial-checklist-trigger="true"
                         title="Zadaci"
                         variant="plain"
@@ -604,19 +604,19 @@ export function TutorialChecklistHud() {
                         <Image
                             alt=""
                             aria-hidden="true"
-                            className="pointer-events-none absolute left-1/2 top-0 size-11 shrink-0 -translate-x-1/2 -translate-y-5 object-contain drop-shadow-[0_2px_3px_rgb(15_23_42_/_0.35)]"
+                            className="pointer-events-none absolute left-1/2 top-0 size-9 shrink-0 -translate-x-1/2 -translate-y-3.5 object-contain drop-shadow-[0_2px_3px_rgb(15_23_42_/_0.35)]"
                             data-tutorial-checklist-trigger-icon="true"
-                            height={44}
+                            height={36}
                             loading="eager"
                             src={tutorialTaskListIconSrc}
                             unoptimized
-                            width={44}
+                            width={36}
                         />
                         {progressLabel ? (
                             <Typography
                                 aria-hidden="true"
                                 bold
-                                className="pointer-events-none absolute bottom-2 left-1/2 -translate-x-1/2 text-[12px] leading-none text-foreground"
+                                className="pointer-events-none absolute bottom-1 left-1/2 -translate-x-1/2 text-[12px] leading-none text-foreground"
                                 data-tutorial-checklist-progress="true"
                                 level="body3"
                             >


### PR DESCRIPTION
## Summary

- Make the tutorial checklist HUD bubble/button render as a fixed circle.
- Lower the progress text and reduce/lower the task-list model icon to avoid overlap.
- Extend the component test to assert circular shape and icon/text separation.

## Validation

- corepack pnpm --filter garden exec playwright test tests/tutorial-checklist-hud.spec.tsx
- corepack pnpm --filter @gredice/game run typecheck
- corepack pnpm --filter garden run typecheck
- git diff --check

## Visual check

- Captured screenshot: /tmp/gredice-tutorial-checklist-hud-layout.png
