### PR TITLE
Disable iOS selection popovers in the game scene

### DIFF
--- a/packages/game/src/GameScene.module.css
+++ b/packages/game/src/GameScene.module.css
@@ -1,0 +1,39 @@
+.interactionSurface {
+    -webkit-tap-highlight-color: transparent;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+.interactionSurface
+    :where(
+        :not(input):not(textarea):not(select):not([contenteditable="true"]):not(
+            [data-game-text-selectable="true"]
+        )
+    ) {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+.interactionSurface :where(img, svg, canvas) {
+    -webkit-user-drag: none;
+}
+
+.interactionSurface
+    :where(
+        input,
+        textarea,
+        [contenteditable="true"],
+        [data-game-text-selectable="true"]
+    ) {
+    -webkit-touch-callout: default;
+    -webkit-user-select: text;
+    user-select: text;
+}
+
+.interactionSurface :where(select) {
+    -webkit-touch-callout: default;
+    -webkit-user-select: auto;
+    user-select: auto;
+}

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -30,6 +30,7 @@ import {
 import type { GameFeatureFlags } from './GameFlagsContext';
 import { GameHud } from './GameHud';
 import { useGameLoading } from './GameLoadingContext';
+import styles from './GameScene.module.css';
 import { GameSceneDetailContext } from './GameSceneDetailContext';
 import {
     defaultGameCameraPosition,
@@ -266,7 +267,11 @@ export function GameScene({
 
     return (
         <div
-            className={cx('animate-in duration-1000 fade-in', className)}
+            className={cx(
+                styles.interactionSurface,
+                'animate-in duration-1000 fade-in',
+                className,
+            )}
             {...rest}
         >
             <GameSceneDetailContext.Provider value={{ renderDetails }}>


### PR DESCRIPTION
## Summary
- Add an interaction-surface CSS module to suppress tap highlight, touch callout, and accidental text selection in the game scene
- Preserve normal selection behavior for inputs, textareas, selects, and explicit text-selectable content
- Apply the new interaction surface class to `GameScene`

## Testing
- Not run (not requested)