### PR TITLE
[game] Hide bottom HUD in closeup view

### DIFF
--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -1,10 +1,13 @@
 import type { BlockData } from '@gredice/client';
+import { cx } from '@gredice/ui/utils';
 import * as ReactQuery from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { type PropsWithChildren, useMemo } from 'react';
 import {
     gameHudBottomBarClassName,
     gameHudBottomControlsClassName,
+    gameHudBottomItemsClassName,
+    getGameHudBottomCloseupClassName,
 } from '../../../packages/game/src/GameHud';
 import { currentAccountKeys } from '../../../packages/game/src/hooks/useCurrentAccount';
 import { ControlsTooltipHud } from '../../../packages/game/src/hud/ControlsTooltipHud';
@@ -126,6 +129,7 @@ const blockNames = [
 
 type ItemsHudStoryOptions = {
     accountSunflowers?: number;
+    closeup?: boolean;
     isSandbox?: boolean;
     pickupBlock?: boolean;
     trashTargetActive?: boolean;
@@ -168,6 +172,7 @@ function ItemsHudTestProviders({
     children,
     accountSunflowers,
     isSandbox = false,
+    closeup = false,
     pickupBlock = false,
     trashTargetActive = false,
 }: PropsWithChildren<ItemsHudStoryOptions>) {
@@ -192,8 +197,11 @@ function ItemsHudTestProviders({
                 sandboxBlockTrashDropTargetActive: trashTargetActive,
             });
         }
+        if (closeup) {
+            store.setState({ view: 'closeup' });
+        }
         return store;
-    }, [pickupBlock, trashTargetActive]);
+    }, [closeup, pickupBlock, trashTargetActive]);
 
     return (
         <NuqsTestingAdapter>
@@ -206,6 +214,38 @@ function ItemsHudTestProviders({
     );
 }
 
+function BottomControlsTestFrame({ closeup = false }: { closeup?: boolean }) {
+    return (
+        <div
+            data-testid="bottom-controls"
+            aria-hidden={closeup}
+            inert={closeup ? true : undefined}
+            className={cx(
+                gameHudBottomControlsClassName,
+                getGameHudBottomCloseupClassName(closeup),
+            )}
+        >
+            <div className="h-10 w-40 rounded-lg border bg-muted" />
+        </div>
+    );
+}
+
+function ItemsHudTestFrame({ closeup = false }: { closeup?: boolean }) {
+    return (
+        <div
+            data-testid="bottom-items"
+            aria-hidden={closeup}
+            inert={closeup ? true : undefined}
+            className={cx(
+                gameHudBottomItemsClassName,
+                getGameHudBottomCloseupClassName(closeup),
+            )}
+        >
+            <ItemsHud />
+        </div>
+    );
+}
+
 export function ItemsHudAlignmentStory() {
     return (
         <ItemsHudTestProviders>
@@ -214,13 +254,8 @@ export function ItemsHudAlignmentStory() {
                     data-testid="bottom-hud"
                     className={gameHudBottomBarClassName}
                 >
-                    <div
-                        data-testid="bottom-controls"
-                        className={gameHudBottomControlsClassName}
-                    >
-                        <div className="h-10 w-40 rounded-lg border bg-muted" />
-                    </div>
-                    <ItemsHud />
+                    <BottomControlsTestFrame />
+                    <ItemsHudTestFrame />
                 </div>
             </div>
         </ItemsHudTestProviders>
@@ -235,13 +270,8 @@ export function LowSunflowerBalanceItemsHudStory() {
                     data-testid="bottom-hud"
                     className={gameHudBottomBarClassName}
                 >
-                    <div
-                        data-testid="bottom-controls"
-                        className={gameHudBottomControlsClassName}
-                    >
-                        <div className="h-10 w-40 rounded-lg border bg-muted" />
-                    </div>
-                    <ItemsHud />
+                    <BottomControlsTestFrame />
+                    <ItemsHudTestFrame />
                 </div>
             </div>
         </ItemsHudTestProviders>
@@ -258,12 +288,15 @@ export function ItemsHudControlsTooltipStory() {
                 >
                     <div
                         data-testid="bottom-controls"
-                        className={gameHudBottomControlsClassName}
+                        className={cx(
+                            gameHudBottomControlsClassName,
+                            getGameHudBottomCloseupClassName(false),
+                        )}
                     >
                         <div className="h-10 w-40 rounded-lg border bg-muted" />
                         <ControlsTooltipHud />
                     </div>
-                    <ItemsHud />
+                    <ItemsHudTestFrame />
                 </div>
             </div>
         </ItemsHudTestProviders>
@@ -278,13 +311,8 @@ export function SandboxItemsHudStory() {
                     data-testid="bottom-hud"
                     className={gameHudBottomBarClassName}
                 >
-                    <div
-                        data-testid="bottom-controls"
-                        className={gameHudBottomControlsClassName}
-                    >
-                        <div className="h-10 w-40 rounded-lg border bg-muted" />
-                    </div>
-                    <ItemsHud />
+                    <BottomControlsTestFrame />
+                    <ItemsHudTestFrame />
                 </div>
             </div>
         </ItemsHudTestProviders>
@@ -299,14 +327,25 @@ export function SandboxBlockTrashDropTargetStory() {
                     data-testid="bottom-hud"
                     className={gameHudBottomBarClassName}
                 >
-                    <div
-                        data-testid="bottom-controls"
-                        className={gameHudBottomControlsClassName}
-                    >
-                        <div className="h-10 w-40 rounded-lg border bg-muted" />
-                    </div>
+                    <BottomControlsTestFrame />
                     <SandboxBlockTrashDropTarget />
-                    <ItemsHud />
+                    <ItemsHudTestFrame />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}
+
+export function CloseupBottomHudStory() {
+    return (
+        <ItemsHudTestProviders closeup>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <BottomControlsTestFrame closeup />
+                    <ItemsHudTestFrame closeup />
                 </div>
             </div>
         </ItemsHudTestProviders>

--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import {
+    CloseupBottomHudStory,
     ItemsHudAlignmentStory,
     ItemsHudControlsTooltipStory,
     LowSunflowerBalanceItemsHudStory,
@@ -101,6 +102,36 @@ test('bottom helper controls are left aligned', async ({ mount, page }) => {
     const controlsBox = await controls.boundingBox();
     expect(controlsBox).not.toBeNull();
     expect(Math.round(controlsBox?.x ?? 0)).toBe(0);
+});
+
+test('bottom hud slides out and disables controls in closeup view', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(SHORT_MOBILE_VIEWPORT);
+    await mount(<CloseupBottomHudStory />);
+
+    const controls = page.getByTestId('bottom-controls');
+    const items = page.getByTestId('bottom-items');
+
+    await expect(controls).toHaveAttribute('aria-hidden', 'true');
+    await expect(items).toHaveAttribute('aria-hidden', 'true');
+    await expect(controls).toHaveCSS('opacity', '0');
+    await expect(items).toHaveCSS('opacity', '0');
+    await expect(controls).toHaveCSS('pointer-events', 'none');
+    await expect(items).toHaveCSS('pointer-events', 'none');
+
+    await expect
+        .poll(async () => {
+            const boxes = await Promise.all([
+                controls.boundingBox(),
+                items.boundingBox(),
+            ]);
+            return boxes.every(
+                (box) => box !== null && box.y >= SHORT_MOBILE_VIEWPORT.height,
+            );
+        })
+        .toBe(true);
 });
 
 test('controls instructions clear the item picker on tablet layouts', async ({

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -38,8 +38,22 @@ export const gameHudBottomBarClassName =
 export const gameHudBottomControlsClassName =
     'self-start flex flex-row items-end justify-start p-2 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-300 motion-safe:ease-out md:absolute md:bottom-0 md:left-0';
 
+export const gameHudBottomItemsClassName = 'flex w-full justify-center';
+
 const gameHudEntranceClassName =
     'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-300 motion-safe:ease-out';
+
+const gameHudCloseupBottomTransitionClassName =
+    'motion-safe:transition-[opacity,transform] motion-safe:duration-300 motion-safe:ease-in-out motion-reduce:transition-none';
+
+export function getGameHudBottomCloseupClassName(isCloseup: boolean) {
+    return cx(
+        gameHudCloseupBottomTransitionClassName,
+        isCloseup
+            ? 'pointer-events-none translate-y-[100dvh] opacity-0'
+            : 'translate-y-0 opacity-100',
+    );
+}
 
 export function GameHud({
     debugHud,
@@ -171,13 +185,31 @@ export function GameHud({
                 {!isSandbox && <SunflowersHud />}
             </div>
             <div className={gameHudBottomBarClassName}>
-                <div className={gameHudBottomControlsClassName}>
+                <div
+                    data-game-hud-bottom-controls
+                    aria-hidden={isCloseup}
+                    inert={isCloseup ? true : undefined}
+                    className={cx(
+                        gameHudBottomControlsClassName,
+                        getGameHudBottomCloseupClassName(isCloseup),
+                    )}
+                >
                     <CameraHud />
                     <AudioHud />
                     <ControlsTooltipHud />
                 </div>
                 <SandboxBlockTrashDropTarget />
-                <ItemsHud />
+                <div
+                    data-game-hud-bottom-items
+                    aria-hidden={isCloseup}
+                    inert={isCloseup ? true : undefined}
+                    className={cx(
+                        gameHudBottomItemsClassName,
+                        getGameHudBottomCloseupClassName(isCloseup),
+                    )}
+                >
+                    <ItemsHud />
+                </div>
             </div>
             {!isLocalSandbox && <RaisedBedFieldHud flags={flags} />}
             {!isLocalSandbox && <OverviewModal />}


### PR DESCRIPTION
## What changed
- Hide the bottom items HUD when the game enters closeup view.
- Hide the scene controls row (rotate, mute, controls/help) in the same closeup state.
- Use a downward slide plus fade and disable hidden controls with `inert`/`aria-hidden`.

## Why
Closeup mode should keep the raised-bed/detail interaction clear without the persistent bottom HUD competing for space.

## Validation
- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter garden lint`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter garden run test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/items-hud.spec.tsx`