### PR TITLE
Add beach ball bounce interaction

### DIFF
--- a/packages/game/src/entities/BeachBall.tsx
+++ b/packages/game/src/entities/BeachBall.tsx
@@ -1,10 +1,21 @@
 import { animated } from '@react-spring/three';
+import { type ThreeEvent, useFrame } from '@react-three/fiber';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Group } from 'three';
+import { useBlockData } from '../hooks/useBlockData';
 import type { GLTFResult } from '../models/GameAssets';
 import { RainWetOverlay } from '../rain/RainWetOverlay';
 import { SnowOverlay } from '../snow/SnowOverlay';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useStackHeight } from '../utils/getStackHeight';
 import { useGameGLTF } from '../utils/useGameGLTF';
+import {
+    advanceBeachBallBounce,
+    beachBallCollisionRadius,
+    createBeachBallBounceEnvironment,
+    createBeachBallBounceState,
+} from './beachBallBounce';
+import { HoverOutline } from './helpers/HoverOutline';
 import { useAnimatedEntityRotation } from './helpers/useAnimatedEntityRotation';
 
 type BeachBallNodeName = Extract<
@@ -14,6 +25,11 @@ type BeachBallNodeName = Extract<
 type BeachBallNode = GLTFResult['nodes'][BeachBallNodeName];
 
 const beachBallScale = 0.1565;
+const beachBallKickSpeed = 2.85;
+const beachBallKickSpeedVariance = 0.18;
+const beachBallSpinFallbackAngle = Math.PI * 0.765;
+const beachBallBounceFrequency = Math.PI * 5.8;
+const beachBallMaxBounceLift = 0.16;
 
 const beachBallNodeNames = [
     'BeachBall_Cap',
@@ -55,21 +71,178 @@ function BeachBallPart({ node }: { node: BeachBallNode }) {
     );
 }
 
-export function BeachBall({ stack, block, rotation }: EntityInstanceProps) {
+function fallbackKickDirection(blockId: string, clickCount: number) {
+    const angle =
+        blockId.length * 0.53 + clickCount * beachBallSpinFallbackAngle;
+
+    return {
+        x: Math.cos(angle),
+        z: Math.sin(angle),
+    };
+}
+
+export function BeachBall({
+    stack,
+    block,
+    stacks,
+    rotation,
+}: EntityInstanceProps) {
     const { nodes } = useGameGLTF('BeachBall');
+    const { data: blockData } = useBlockData();
     const [animatedRotation] = useAnimatedEntityRotation(rotation);
     const currentStackHeight = useStackHeight(stack, block);
     const position = stack.position.clone().setY(currentStackHeight + 0.008);
+    const motionGroupRef = useRef<Group>(null);
+    const bounceStateRef = useRef(createBeachBallBounceState());
+    const clickCountRef = useRef(0);
+    const [hovered, setHovered] = useState(false);
+    const bounceEnvironment = useMemo(
+        () =>
+            createBeachBallBounceEnvironment({
+                blockData,
+                movingBlockId: block.id,
+                stacks,
+            }),
+        [block.id, blockData, stacks],
+    );
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: reset visual offset when this rendered beach ball moves to another block cell.
+    useEffect(() => {
+        bounceStateRef.current = createBeachBallBounceState();
+
+        const motionGroup = motionGroupRef.current;
+        if (!motionGroup) {
+            return;
+        }
+
+        motionGroup.position.set(0, 0, 0);
+        motionGroup.rotation.set(0, 0, 0);
+    }, [block.id, stack.position.x, stack.position.z]);
+
+    useFrame((_, deltaSeconds) => {
+        const motionGroup = motionGroupRef.current;
+        if (!motionGroup) {
+            return;
+        }
+
+        const currentState = bounceStateRef.current;
+        if (!currentState.active) {
+            motionGroup.position.y = 0;
+            return;
+        }
+
+        const previousOffsetX = currentState.offsetX;
+        const previousOffsetZ = currentState.offsetZ;
+        const nextState = advanceBeachBallBounce(
+            currentState,
+            bounceEnvironment,
+            {
+                baseX: stack.position.x,
+                baseZ: stack.position.z,
+                deltaSeconds,
+            },
+        );
+        bounceStateRef.current = nextState;
+
+        const speed = Math.hypot(nextState.velocityX, nextState.velocityZ);
+        const bounceLift = Math.min(
+            beachBallMaxBounceLift,
+            0.032 + speed * 0.035,
+        );
+        const bounceY = nextState.active
+            ? Math.abs(
+                  Math.sin(nextState.elapsedSeconds * beachBallBounceFrequency),
+              ) * bounceLift
+            : 0;
+        const movementX = nextState.offsetX - previousOffsetX;
+        const movementZ = nextState.offsetZ - previousOffsetZ;
+
+        motionGroup.position.set(nextState.offsetX, bounceY, nextState.offsetZ);
+        motionGroup.rotation.x += movementZ / beachBallCollisionRadius;
+        motionGroup.rotation.z -= movementX / beachBallCollisionRadius;
+    });
+
+    function handlePointerDown(event: ThreeEvent<PointerEvent>) {
+        if (event.button !== 0) {
+            return;
+        }
+
+        event.stopPropagation();
+    }
+
+    function handleClick(event: ThreeEvent<MouseEvent>) {
+        event.stopPropagation();
+        clickCountRef.current += 1;
+
+        const currentState = bounceStateRef.current;
+        const centerX = stack.position.x + currentState.offsetX;
+        const centerZ = stack.position.z + currentState.offsetZ;
+        let directionX = centerX - event.point.x;
+        let directionZ = centerZ - event.point.z;
+        const directionLength = Math.hypot(directionX, directionZ);
+
+        if (directionLength > 0.05) {
+            directionX /= directionLength;
+            directionZ /= directionLength;
+        } else {
+            const fallback = fallbackKickDirection(
+                block.id,
+                clickCountRef.current,
+            );
+            directionX = fallback.x;
+            directionZ = fallback.z;
+        }
+
+        const speed =
+            beachBallKickSpeed +
+            (clickCountRef.current % 3) * beachBallKickSpeedVariance;
+
+        bounceStateRef.current = {
+            active: true,
+            elapsedSeconds: 0,
+            offsetX: currentState.offsetX,
+            offsetZ: currentState.offsetZ,
+            velocityX: directionX * speed + currentState.velocityX * 0.15,
+            velocityZ: directionZ * speed + currentState.velocityZ * 0.15,
+        };
+    }
+
+    function handlePointerEnter(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        setHovered(true);
+    }
+
+    function handlePointerLeave(event: ThreeEvent<PointerEvent>) {
+        event.stopPropagation();
+        setHovered(false);
+    }
 
     return (
-        <animated.group
-            position={position}
-            rotation={animatedRotation as unknown as [number, number, number]}
-            scale={beachBallScale}
-        >
-            {beachBallNodeNames.map((nodeName) => (
-                <BeachBallPart key={nodeName} node={nodes[nodeName]} />
-            ))}
-        </animated.group>
+        <HoverOutline color="white" hovered={hovered} thickness={7}>
+            <animated.group
+                position={position}
+                rotation={
+                    animatedRotation as unknown as [number, number, number]
+                }
+            >
+                {/* biome-ignore lint/a11y/noStaticElementInteractions: Three.js group uses raycast picking for the clickable beach ball. */}
+                <group
+                    ref={motionGroupRef}
+                    onClick={handleClick}
+                    onPointerDown={handlePointerDown}
+                    onPointerEnter={handlePointerEnter}
+                    onPointerLeave={handlePointerLeave}
+                >
+                    <group scale={beachBallScale}>
+                        {beachBallNodeNames.map((nodeName) => (
+                            <BeachBallPart
+                                key={nodeName}
+                                node={nodes[nodeName]}
+                            />
+                        ))}
+                    </group>
+                </group>
+            </animated.group>
+        </HoverOutline>
     );
 }

--- a/packages/game/src/entities/BeachBall.tsx
+++ b/packages/game/src/entities/BeachBall.tsx
@@ -14,6 +14,7 @@ import {
     beachBallCollisionRadius,
     createBeachBallBounceEnvironment,
     createBeachBallBounceState,
+    getBeachBallSurfaceHeight,
 } from './beachBallBounce';
 import { HoverOutline } from './helpers/HoverOutline';
 import { useAnimatedEntityRotation } from './helpers/useAnimatedEntityRotation';
@@ -29,6 +30,7 @@ const beachBallKickSpeed = 2.85;
 const beachBallKickSpeedVariance = 0.18;
 const beachBallSpinFallbackAngle = Math.PI * 0.765;
 const beachBallBounceFrequency = Math.PI * 5.8;
+const beachBallGroundLift = 0.008;
 const beachBallMaxBounceLift = 0.16;
 
 const beachBallNodeNames = [
@@ -91,7 +93,9 @@ export function BeachBall({
     const { data: blockData } = useBlockData();
     const [animatedRotation] = useAnimatedEntityRotation(rotation);
     const currentStackHeight = useStackHeight(stack, block);
-    const position = stack.position.clone().setY(currentStackHeight + 0.008);
+    const position = stack.position
+        .clone()
+        .setY(currentStackHeight + beachBallGroundLift);
     const motionGroupRef = useRef<Group>(null);
     const bounceStateRef = useRef(createBeachBallBounceState());
     const clickCountRef = useRef(0);
@@ -126,8 +130,23 @@ export function BeachBall({
         }
 
         const currentState = bounceStateRef.current;
+
+        const setMotionPosition = (state: typeof currentState, bounceY = 0) => {
+            const surfaceHeight = getBeachBallSurfaceHeight(bounceEnvironment, {
+                fallbackHeight: currentStackHeight,
+                worldX: stack.position.x + state.offsetX,
+                worldZ: stack.position.z + state.offsetZ,
+            });
+
+            motionGroup.position.set(
+                state.offsetX,
+                surfaceHeight - currentStackHeight + bounceY,
+                state.offsetZ,
+            );
+        };
+
         if (!currentState.active) {
-            motionGroup.position.y = 0;
+            setMotionPosition(currentState);
             return;
         }
 
@@ -157,7 +176,7 @@ export function BeachBall({
         const movementX = nextState.offsetX - previousOffsetX;
         const movementZ = nextState.offsetZ - previousOffsetZ;
 
-        motionGroup.position.set(nextState.offsetX, bounceY, nextState.offsetZ);
+        setMotionPosition(nextState, bounceY);
         motionGroup.rotation.x += movementZ / beachBallCollisionRadius;
         motionGroup.rotation.z -= movementX / beachBallCollisionRadius;
     });

--- a/packages/game/src/entities/BeachBall.tsx
+++ b/packages/game/src/entities/BeachBall.tsx
@@ -25,12 +25,19 @@ type BeachBallNodeName = Extract<
 >;
 type BeachBallNode = GLTFResult['nodes'][BeachBallNodeName];
 
+type BeachBallVisualBounce = {
+    amplitude: number;
+    durationSeconds: number;
+    elapsedSeconds: number;
+};
+
 const beachBallScale = 0.1565;
 const beachBallKickSpeed = 2.85;
 const beachBallKickSpeedVariance = 0.18;
 const beachBallSpinFallbackAngle = Math.PI * 0.765;
-const beachBallBounceFrequency = Math.PI * 5.8;
+const beachBallBounceDurationSeconds = 0.58;
 const beachBallGroundLift = 0.008;
+const beachBallMinBounceLift = 0.026;
 const beachBallMaxBounceLift = 0.16;
 
 const beachBallNodeNames = [
@@ -83,6 +90,47 @@ function fallbackKickDirection(blockId: string, clickCount: number) {
     };
 }
 
+function createBeachBallVisualBounce(): BeachBallVisualBounce {
+    return {
+        amplitude: 0,
+        durationSeconds: 0,
+        elapsedSeconds: 0,
+    };
+}
+
+function createBeachBallCollisionBounce(speed: number): BeachBallVisualBounce {
+    return {
+        amplitude: Math.min(
+            beachBallMaxBounceLift,
+            beachBallMinBounceLift + speed * 0.035,
+        ),
+        durationSeconds: beachBallBounceDurationSeconds,
+        elapsedSeconds: 0,
+    };
+}
+
+function isBeachBallVisualBounceActive(bounce: BeachBallVisualBounce) {
+    return bounce.elapsedSeconds < bounce.durationSeconds;
+}
+
+function advanceBeachBallVisualBounce(
+    bounce: BeachBallVisualBounce,
+    deltaSeconds: number,
+) {
+    if (!isBeachBallVisualBounceActive(bounce)) {
+        return 0;
+    }
+
+    bounce.elapsedSeconds = Math.min(
+        bounce.durationSeconds,
+        bounce.elapsedSeconds + deltaSeconds,
+    );
+
+    const progress = bounce.elapsedSeconds / bounce.durationSeconds;
+    const decay = (1 - progress) ** 1.35;
+    return Math.sin(progress * Math.PI) * bounce.amplitude * decay;
+}
+
 export function BeachBall({
     stack,
     block,
@@ -98,6 +146,7 @@ export function BeachBall({
         .setY(currentStackHeight + beachBallGroundLift);
     const motionGroupRef = useRef<Group>(null);
     const bounceStateRef = useRef(createBeachBallBounceState());
+    const visualBounceRef = useRef(createBeachBallVisualBounce());
     const clickCountRef = useRef(0);
     const [hovered, setHovered] = useState(false);
     const bounceEnvironment = useMemo(
@@ -113,6 +162,7 @@ export function BeachBall({
     // biome-ignore lint/correctness/useExhaustiveDependencies: reset visual offset when this rendered beach ball moves to another block cell.
     useEffect(() => {
         bounceStateRef.current = createBeachBallBounceState();
+        visualBounceRef.current = createBeachBallVisualBounce();
 
         const motionGroup = motionGroupRef.current;
         if (!motionGroup) {
@@ -130,6 +180,7 @@ export function BeachBall({
         }
 
         const currentState = bounceStateRef.current;
+        const visualBounce = visualBounceRef.current;
 
         const setMotionPosition = (state: typeof currentState, bounceY = 0) => {
             const surfaceHeight = getBeachBallSurfaceHeight(bounceEnvironment, {
@@ -146,7 +197,10 @@ export function BeachBall({
         };
 
         if (!currentState.active) {
-            setMotionPosition(currentState);
+            setMotionPosition(
+                currentState,
+                advanceBeachBallVisualBounce(visualBounce, deltaSeconds),
+            );
             return;
         }
 
@@ -164,15 +218,13 @@ export function BeachBall({
         bounceStateRef.current = nextState;
 
         const speed = Math.hypot(nextState.velocityX, nextState.velocityZ);
-        const bounceLift = Math.min(
-            beachBallMaxBounceLift,
-            0.032 + speed * 0.035,
+        if (nextState.collisionCount > currentState.collisionCount) {
+            visualBounceRef.current = createBeachBallCollisionBounce(speed);
+        }
+        const bounceY = advanceBeachBallVisualBounce(
+            visualBounceRef.current,
+            deltaSeconds,
         );
-        const bounceY = nextState.active
-            ? Math.abs(
-                  Math.sin(nextState.elapsedSeconds * beachBallBounceFrequency),
-              ) * bounceLift
-            : 0;
         const movementX = nextState.offsetX - previousOffsetX;
         const movementZ = nextState.offsetZ - previousOffsetZ;
 
@@ -191,9 +243,16 @@ export function BeachBall({
 
     function handleClick(event: ThreeEvent<MouseEvent>) {
         event.stopPropagation();
-        clickCountRef.current += 1;
 
         const currentState = bounceStateRef.current;
+        if (
+            currentState.active ||
+            isBeachBallVisualBounceActive(visualBounceRef.current)
+        ) {
+            return;
+        }
+
+        clickCountRef.current += 1;
         const centerX = stack.position.x + currentState.offsetX;
         const centerZ = stack.position.z + currentState.offsetZ;
         let directionX = centerX - event.point.x;
@@ -218,11 +277,12 @@ export function BeachBall({
 
         bounceStateRef.current = {
             active: true,
+            collisionCount: currentState.collisionCount,
             elapsedSeconds: 0,
             offsetX: currentState.offsetX,
             offsetZ: currentState.offsetZ,
-            velocityX: directionX * speed + currentState.velocityX * 0.15,
-            velocityZ: directionZ * speed + currentState.velocityZ * 0.15,
+            velocityX: directionX * speed,
+            velocityZ: directionZ * speed,
         };
     }
 

--- a/packages/game/src/entities/beachBallBounce.ts
+++ b/packages/game/src/entities/beachBallBounce.ts
@@ -31,6 +31,7 @@ export type BeachBallBounceEnvironment = {
 
 export type BeachBallBounceState = {
     active: boolean;
+    collisionCount: number;
     elapsedSeconds: number;
     offsetX: number;
     offsetZ: number;
@@ -78,10 +79,6 @@ function cellKey(position: { x: number; z: number }) {
 
 function clamp(value: number, min: number, max: number) {
     return Math.min(Math.max(value, min), max);
-}
-
-function roundGridCell(value: number) {
-    return value < 0 ? Math.ceil(value - 0.5) : Math.floor(value + 0.5);
 }
 
 function createBounds({
@@ -225,6 +222,7 @@ function resolveAxisMotion({
         )
     ) {
         return {
+            collided: false,
             offset: nextOffset,
             velocity,
         };
@@ -244,12 +242,14 @@ function resolveAxisMotion({
         )
     ) {
         return {
+            collided: true,
             offset: reboundOffset,
             velocity: reflectedVelocity,
         };
     }
 
     return {
+        collided: true,
         offset: axis === 'x' ? currentOffsetX : currentOffsetZ,
         velocity: reflectedVelocity,
     };
@@ -262,6 +262,7 @@ export function isBeachBallPassableTerrainBlockName(name: string) {
 export function createBeachBallBounceState(): BeachBallBounceState {
     return {
         active: false,
+        collisionCount: 0,
         elapsedSeconds: 0,
         offsetX: 0,
         offsetZ: 0,
@@ -350,25 +351,20 @@ export function getBeachBallSurfaceHeight(
         worldZ: number;
     },
 ) {
-    const roundedX = roundGridCell(worldX);
-    const roundedZ = roundGridCell(worldZ);
+    const surfaceReach =
+        obstacleHalfExtent + environment.radius + surfaceCellEpsilon;
 
-    const exactSurface = environment.surfaces.find(
-        (surface) => surface.x === roundedX && surface.z === roundedZ,
+    const overlappingSurfaces = environment.surfaces.filter(
+        (surface) =>
+            Math.abs(surface.x - worldX) <= surfaceReach &&
+            Math.abs(surface.z - worldZ) <= surfaceReach,
     );
-    if (exactSurface) {
-        return exactSurface.height;
+
+    if (overlappingSurfaces.length <= 0) {
+        return fallbackHeight;
     }
 
-    const containingSurface = environment.surfaces.find(
-        (surface) =>
-            Math.abs(surface.x - worldX) <=
-                obstacleHalfExtent + surfaceCellEpsilon &&
-            Math.abs(surface.z - worldZ) <=
-                obstacleHalfExtent + surfaceCellEpsilon,
-    );
-
-    return containingSurface?.height ?? fallbackHeight;
+    return Math.max(...overlappingSurfaces.map((surface) => surface.height));
 }
 
 export function advanceBeachBallBounce(
@@ -390,6 +386,7 @@ export function advanceBeachBallBounce(
     let offsetZ = state.offsetZ;
     let velocityX = state.velocityX;
     let velocityZ = state.velocityZ;
+    let collisionCount = state.collisionCount;
 
     const xMotion = resolveAxisMotion({
         axis: 'x',
@@ -404,6 +401,9 @@ export function advanceBeachBallBounce(
     });
     offsetX = xMotion.offset;
     velocityX = xMotion.velocity;
+    if (xMotion.collided) {
+        collisionCount += 1;
+    }
 
     const zMotion = resolveAxisMotion({
         axis: 'z',
@@ -418,6 +418,9 @@ export function advanceBeachBallBounce(
     });
     offsetZ = zMotion.offset;
     velocityZ = zMotion.velocity;
+    if (zMotion.collided) {
+        collisionCount += 1;
+    }
 
     const damping = velocityDampingPerSecond ** deltaSeconds;
     velocityX *= damping;
@@ -429,6 +432,7 @@ export function advanceBeachBallBounce(
 
     return {
         active,
+        collisionCount,
         elapsedSeconds,
         offsetX,
         offsetZ,

--- a/packages/game/src/entities/beachBallBounce.ts
+++ b/packages/game/src/entities/beachBallBounce.ts
@@ -1,0 +1,334 @@
+import {
+    type GardenBlockDataLike,
+    getGardenBlockFootprintOffsets,
+} from '@gredice/js/gardenBlocks';
+import type { Stack } from '../types/Stack';
+
+export type BeachBallBounceObstacle = {
+    x: number;
+    z: number;
+};
+
+export type BeachBallBounceBounds = {
+    maxX: number;
+    maxZ: number;
+    minX: number;
+    minZ: number;
+};
+
+export type BeachBallBounceEnvironment = {
+    bounds: BeachBallBounceBounds | null;
+    obstacles: BeachBallBounceObstacle[];
+    radius: number;
+};
+
+export type BeachBallBounceState = {
+    active: boolean;
+    elapsedSeconds: number;
+    offsetX: number;
+    offsetZ: number;
+    velocityX: number;
+    velocityZ: number;
+};
+
+type BeachBallBlockDataLike = GardenBlockDataLike & {
+    information: {
+        name: string;
+    };
+};
+
+const obstacleHalfExtent = 0.5;
+const maxFrameDeltaSeconds = 1 / 24;
+const bounceRestitution = 0.82;
+const reboundStepRatio = 0.35;
+const velocityDampingPerSecond = 0.6;
+const minimumActiveSpeed = 0.16;
+const maxMotionSeconds = 5.4;
+
+export const beachBallCollisionRadius = 0.24;
+
+const passableTerrainBlockNames = new Set([
+    'Block_Ground',
+    'Block_Ground_Angle',
+    'Block_Grass',
+    'Block_Grass_Angle',
+    'Block_Grass_Corner',
+    'Block_Grass_Reverse_Corner',
+    'Block_Sand',
+    'Block_Sand_Angle',
+    'Block_Sand_Corner',
+    'Block_Sand_Reverse_Corner',
+    'Block_Snow',
+    'Block_Snow_Angle',
+    'Block_Snow_Falling',
+    'Block_Water',
+]);
+
+function cellKey(position: { x: number; z: number }) {
+    return `${position.x}|${position.z}`;
+}
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function createBounds({
+    maxX,
+    maxZ,
+    minX,
+    minZ,
+    radius,
+}: {
+    maxX: number;
+    maxZ: number;
+    minX: number;
+    minZ: number;
+    radius: number;
+}): BeachBallBounceBounds | null {
+    if (
+        !Number.isFinite(minX) ||
+        !Number.isFinite(maxX) ||
+        !Number.isFinite(minZ) ||
+        !Number.isFinite(maxZ)
+    ) {
+        return null;
+    }
+
+    const left = minX - obstacleHalfExtent + radius;
+    const right = maxX + obstacleHalfExtent - radius;
+    const bottom = minZ - obstacleHalfExtent + radius;
+    const top = maxZ + obstacleHalfExtent - radius;
+
+    return {
+        minX: Math.min(left, right),
+        maxX: Math.max(left, right),
+        minZ: Math.min(bottom, top),
+        maxZ: Math.max(bottom, top),
+    };
+}
+
+function getBlockDataByName(
+    blockData: BeachBallBlockDataLike[] | null | undefined,
+) {
+    return new Map(
+        (blockData ?? []).map((entity) => [entity.information.name, entity]),
+    );
+}
+
+function isPositionBlocked(
+    position: { x: number; z: number },
+    environment: BeachBallBounceEnvironment,
+) {
+    const { bounds, obstacles, radius } = environment;
+
+    if (
+        bounds &&
+        (position.x < bounds.minX ||
+            position.x > bounds.maxX ||
+            position.z < bounds.minZ ||
+            position.z > bounds.maxZ)
+    ) {
+        return true;
+    }
+
+    const expandedHalfExtent = obstacleHalfExtent + radius;
+    return obstacles.some(
+        (obstacle) =>
+            Math.abs(position.x - obstacle.x) < expandedHalfExtent &&
+            Math.abs(position.z - obstacle.z) < expandedHalfExtent,
+    );
+}
+
+function resolveAxisMotion({
+    axis,
+    baseX,
+    baseZ,
+    currentOffsetX,
+    currentOffsetZ,
+    deltaSeconds,
+    environment,
+    nextOffset,
+    velocity,
+}: {
+    axis: 'x' | 'z';
+    baseX: number;
+    baseZ: number;
+    currentOffsetX: number;
+    currentOffsetZ: number;
+    deltaSeconds: number;
+    environment: BeachBallBounceEnvironment;
+    nextOffset: number;
+    velocity: number;
+}) {
+    const nextOffsetX = axis === 'x' ? nextOffset : currentOffsetX;
+    const nextOffsetZ = axis === 'z' ? nextOffset : currentOffsetZ;
+
+    if (
+        !isPositionBlocked(
+            { x: baseX + nextOffsetX, z: baseZ + nextOffsetZ },
+            environment,
+        )
+    ) {
+        return {
+            offset: nextOffset,
+            velocity,
+        };
+    }
+
+    const reflectedVelocity = -velocity * bounceRestitution;
+    const reboundOffset =
+        (axis === 'x' ? currentOffsetX : currentOffsetZ) +
+        reflectedVelocity * deltaSeconds * reboundStepRatio;
+    const reboundOffsetX = axis === 'x' ? reboundOffset : currentOffsetX;
+    const reboundOffsetZ = axis === 'z' ? reboundOffset : currentOffsetZ;
+
+    if (
+        !isPositionBlocked(
+            { x: baseX + reboundOffsetX, z: baseZ + reboundOffsetZ },
+            environment,
+        )
+    ) {
+        return {
+            offset: reboundOffset,
+            velocity: reflectedVelocity,
+        };
+    }
+
+    return {
+        offset: axis === 'x' ? currentOffsetX : currentOffsetZ,
+        velocity: reflectedVelocity,
+    };
+}
+
+export function isBeachBallPassableTerrainBlockName(name: string) {
+    return passableTerrainBlockNames.has(name);
+}
+
+export function createBeachBallBounceState(): BeachBallBounceState {
+    return {
+        active: false,
+        elapsedSeconds: 0,
+        offsetX: 0,
+        offsetZ: 0,
+        velocityX: 0,
+        velocityZ: 0,
+    };
+}
+
+export function createBeachBallBounceEnvironment({
+    blockData,
+    movingBlockId,
+    radius = beachBallCollisionRadius,
+    stacks,
+}: {
+    blockData?: BeachBallBlockDataLike[] | null;
+    movingBlockId: string;
+    radius?: number;
+    stacks?: Stack[];
+}): BeachBallBounceEnvironment {
+    const blockDataByName = getBlockDataByName(blockData);
+    const obstaclesByKey = new Map<string, BeachBallBounceObstacle>();
+    let minX = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let minZ = Number.POSITIVE_INFINITY;
+    let maxZ = Number.NEGATIVE_INFINITY;
+
+    for (const stack of stacks ?? []) {
+        minX = Math.min(minX, stack.position.x);
+        maxX = Math.max(maxX, stack.position.x);
+        minZ = Math.min(minZ, stack.position.z);
+        maxZ = Math.max(maxZ, stack.position.z);
+
+        for (const block of stack.blocks) {
+            if (
+                block.id === movingBlockId ||
+                isBeachBallPassableTerrainBlockName(block.name)
+            ) {
+                continue;
+            }
+
+            for (const offset of getGardenBlockFootprintOffsets(
+                blockDataByName.get(block.name),
+                block.rotation,
+            )) {
+                const obstacle = {
+                    x: stack.position.x + offset.x,
+                    z: stack.position.z + offset.y,
+                };
+                obstaclesByKey.set(cellKey(obstacle), obstacle);
+            }
+        }
+    }
+
+    return {
+        bounds: createBounds({ minX, maxX, minZ, maxZ, radius }),
+        obstacles: Array.from(obstaclesByKey.values()),
+        radius,
+    };
+}
+
+export function advanceBeachBallBounce(
+    state: BeachBallBounceState,
+    environment: BeachBallBounceEnvironment,
+    options: {
+        baseX: number;
+        baseZ: number;
+        deltaSeconds: number;
+    },
+): BeachBallBounceState {
+    if (!state.active) {
+        return state;
+    }
+
+    const deltaSeconds = clamp(options.deltaSeconds, 0, maxFrameDeltaSeconds);
+    const elapsedSeconds = state.elapsedSeconds + deltaSeconds;
+    let offsetX = state.offsetX;
+    let offsetZ = state.offsetZ;
+    let velocityX = state.velocityX;
+    let velocityZ = state.velocityZ;
+
+    const xMotion = resolveAxisMotion({
+        axis: 'x',
+        baseX: options.baseX,
+        baseZ: options.baseZ,
+        currentOffsetX: offsetX,
+        currentOffsetZ: offsetZ,
+        deltaSeconds,
+        environment,
+        nextOffset: offsetX + velocityX * deltaSeconds,
+        velocity: velocityX,
+    });
+    offsetX = xMotion.offset;
+    velocityX = xMotion.velocity;
+
+    const zMotion = resolveAxisMotion({
+        axis: 'z',
+        baseX: options.baseX,
+        baseZ: options.baseZ,
+        currentOffsetX: offsetX,
+        currentOffsetZ: offsetZ,
+        deltaSeconds,
+        environment,
+        nextOffset: offsetZ + velocityZ * deltaSeconds,
+        velocity: velocityZ,
+    });
+    offsetZ = zMotion.offset;
+    velocityZ = zMotion.velocity;
+
+    const damping = velocityDampingPerSecond ** deltaSeconds;
+    velocityX *= damping;
+    velocityZ *= damping;
+
+    const speed = Math.hypot(velocityX, velocityZ);
+    const active =
+        speed > minimumActiveSpeed && elapsedSeconds < maxMotionSeconds;
+
+    return {
+        active,
+        elapsedSeconds,
+        offsetX,
+        offsetZ,
+        velocityX: active ? velocityX : 0,
+        velocityZ: active ? velocityZ : 0,
+    };
+}

--- a/packages/game/src/entities/beachBallBounce.ts
+++ b/packages/game/src/entities/beachBallBounce.ts
@@ -9,6 +9,12 @@ export type BeachBallBounceObstacle = {
     z: number;
 };
 
+export type BeachBallBounceSurface = {
+    height: number;
+    x: number;
+    z: number;
+};
+
 export type BeachBallBounceBounds = {
     maxX: number;
     maxZ: number;
@@ -20,6 +26,7 @@ export type BeachBallBounceEnvironment = {
     bounds: BeachBallBounceBounds | null;
     obstacles: BeachBallBounceObstacle[];
     radius: number;
+    surfaces: BeachBallBounceSurface[];
 };
 
 export type BeachBallBounceState = {
@@ -44,6 +51,7 @@ const reboundStepRatio = 0.35;
 const velocityDampingPerSecond = 0.6;
 const minimumActiveSpeed = 0.16;
 const maxMotionSeconds = 5.4;
+const surfaceCellEpsilon = 0.0001;
 
 export const beachBallCollisionRadius = 0.24;
 
@@ -70,6 +78,10 @@ function cellKey(position: { x: number; z: number }) {
 
 function clamp(value: number, min: number, max: number) {
     return Math.min(Math.max(value, min), max);
+}
+
+function roundGridCell(value: number) {
+    return value < 0 ? Math.ceil(value - 0.5) : Math.floor(value + 0.5);
 }
 
 function createBounds({
@@ -113,6 +125,49 @@ function getBlockDataByName(
     return new Map(
         (blockData ?? []).map((entity) => [entity.information.name, entity]),
     );
+}
+
+function getBlockHeight(
+    blockDataByName: Map<string, BeachBallBlockDataLike>,
+    blockName: string,
+) {
+    const height = blockDataByName.get(blockName)?.attributes?.height;
+    return typeof height === 'number' && Number.isFinite(height)
+        ? height
+        : null;
+}
+
+function getStackSurfaceHeight({
+    blockDataByName,
+    movingBlockId,
+    stack,
+}: {
+    blockDataByName: Map<string, BeachBallBlockDataLike>;
+    movingBlockId: string;
+    stack: Stack;
+}) {
+    let height = 0;
+    let hasPassableTerrain = false;
+
+    for (const block of stack.blocks) {
+        if (block.id === movingBlockId) {
+            return height;
+        }
+
+        if (!isBeachBallPassableTerrainBlockName(block.name)) {
+            break;
+        }
+
+        const blockHeight = getBlockHeight(blockDataByName, block.name);
+        if (blockHeight === null) {
+            return null;
+        }
+
+        height += blockHeight;
+        hasPassableTerrain = true;
+    }
+
+    return hasPassableTerrain ? height : null;
 }
 
 function isPositionBlocked(
@@ -228,6 +283,7 @@ export function createBeachBallBounceEnvironment({
 }): BeachBallBounceEnvironment {
     const blockDataByName = getBlockDataByName(blockData);
     const obstaclesByKey = new Map<string, BeachBallBounceObstacle>();
+    const surfacesByKey = new Map<string, BeachBallBounceSurface>();
     let minX = Number.POSITIVE_INFINITY;
     let maxX = Number.NEGATIVE_INFINITY;
     let minZ = Number.POSITIVE_INFINITY;
@@ -238,6 +294,20 @@ export function createBeachBallBounceEnvironment({
         maxX = Math.max(maxX, stack.position.x);
         minZ = Math.min(minZ, stack.position.z);
         maxZ = Math.max(maxZ, stack.position.z);
+
+        const surfaceHeight = getStackSurfaceHeight({
+            blockDataByName,
+            movingBlockId,
+            stack,
+        });
+        if (surfaceHeight !== null) {
+            const surface = {
+                height: surfaceHeight,
+                x: stack.position.x,
+                z: stack.position.z,
+            };
+            surfacesByKey.set(cellKey(surface), surface);
+        }
 
         for (const block of stack.blocks) {
             if (
@@ -264,7 +334,41 @@ export function createBeachBallBounceEnvironment({
         bounds: createBounds({ minX, maxX, minZ, maxZ, radius }),
         obstacles: Array.from(obstaclesByKey.values()),
         radius,
+        surfaces: Array.from(surfacesByKey.values()),
     };
+}
+
+export function getBeachBallSurfaceHeight(
+    environment: BeachBallBounceEnvironment,
+    {
+        fallbackHeight,
+        worldX,
+        worldZ,
+    }: {
+        fallbackHeight: number;
+        worldX: number;
+        worldZ: number;
+    },
+) {
+    const roundedX = roundGridCell(worldX);
+    const roundedZ = roundGridCell(worldZ);
+
+    const exactSurface = environment.surfaces.find(
+        (surface) => surface.x === roundedX && surface.z === roundedZ,
+    );
+    if (exactSurface) {
+        return exactSurface.height;
+    }
+
+    const containingSurface = environment.surfaces.find(
+        (surface) =>
+            Math.abs(surface.x - worldX) <=
+                obstacleHalfExtent + surfaceCellEpsilon &&
+            Math.abs(surface.z - worldZ) <=
+                obstacleHalfExtent + surfaceCellEpsilon,
+    );
+
+    return containingSurface?.height ?? fallbackHeight;
 }
 
 export function advanceBeachBallBounce(

--- a/packages/game/src/entities/beachBallBounce.unit.ts
+++ b/packages/game/src/entities/beachBallBounce.unit.ts
@@ -7,6 +7,7 @@ import {
     advanceBeachBallBounce,
     type BeachBallBounceState,
     createBeachBallBounceEnvironment,
+    getBeachBallSurfaceHeight,
     isBeachBallPassableTerrainBlockName,
 } from './beachBallBounce';
 
@@ -22,6 +23,17 @@ function stack(x: number, z: number, blocks: Block[]): Stack {
     return {
         blocks,
         position: new Vector3(x, 0, z),
+    };
+}
+
+function blockData(name: string, height: number) {
+    return {
+        attributes: {
+            height,
+        },
+        information: {
+            name,
+        },
     };
 }
 
@@ -146,5 +158,54 @@ describe('beach ball bounce', () => {
 
         assert.ok(nextState.offsetX < 0.22);
         assert.ok(nextState.velocityX < 0);
+    });
+
+    it('follows passable terrain height under the moving beach ball', () => {
+        const environment = createBeachBallBounceEnvironment({
+            blockData: [
+                blockData('Block_Grass', 0.4),
+                blockData('Block_Sand', 0.22),
+            ],
+            movingBlockId: 'ball',
+            stacks: [
+                stack(0, 0, [block('Block_Grass'), block('BeachBall', 'ball')]),
+                stack(1, 0, [block('Block_Sand')]),
+            ],
+        });
+
+        assert.equal(
+            getBeachBallSurfaceHeight(environment, {
+                fallbackHeight: 0.4,
+                worldX: 1.18,
+                worldZ: 0,
+            }),
+            0.22,
+        );
+    });
+
+    it('does not use non-terrain block height as a beach ball surface', () => {
+        const environment = createBeachBallBounceEnvironment({
+            blockData: [
+                blockData('Block_Grass', 0.4),
+                blockData('BeachChair', 0.75),
+            ],
+            movingBlockId: 'ball',
+            stacks: [
+                stack(0, 0, [block('Block_Grass'), block('BeachBall', 'ball')]),
+                stack(1, 0, [
+                    block('Block_Grass'),
+                    block('BeachChair', 'chair'),
+                ]),
+            ],
+        });
+
+        assert.equal(
+            getBeachBallSurfaceHeight(environment, {
+                fallbackHeight: 0.4,
+                worldX: 1,
+                worldZ: 0,
+            }),
+            0.4,
+        );
     });
 });

--- a/packages/game/src/entities/beachBallBounce.unit.ts
+++ b/packages/game/src/entities/beachBallBounce.unit.ts
@@ -42,6 +42,7 @@ function activeState(
 ): BeachBallBounceState {
     return {
         active: true,
+        collisionCount: 0,
         elapsedSeconds: 0,
         offsetX: 0,
         offsetZ: 0,
@@ -77,6 +78,8 @@ describe('beach ball bounce', () => {
 
         assert.ok(nextState.offsetX > 0);
         assert.ok(nextState.velocityX > 0);
+        assert.ok(Math.hypot(nextState.velocityX, nextState.velocityZ) < 1.5);
+        assert.equal(nextState.collisionCount, 0);
     });
 
     it('reflects velocity before entering an occupied block cell', () => {
@@ -103,6 +106,8 @@ describe('beach ball bounce', () => {
 
         assert.ok(nextState.offsetX < 0.25);
         assert.ok(nextState.velocityX < 0);
+        assert.ok(Math.hypot(nextState.velocityX, nextState.velocityZ) < 3);
+        assert.equal(nextState.collisionCount, 1);
     });
 
     it('uses multi-block footprint spans for obstacle cells', () => {
@@ -158,6 +163,7 @@ describe('beach ball bounce', () => {
 
         assert.ok(nextState.offsetX < 0.22);
         assert.ok(nextState.velocityX < 0);
+        assert.equal(nextState.collisionCount, 1);
     });
 
     it('follows passable terrain height under the moving beach ball', () => {
@@ -206,6 +212,29 @@ describe('beach ball bounce', () => {
                 worldZ: 0,
             }),
             0.4,
+        );
+    });
+
+    it('uses the highest terrain surface overlapped by the ball radius', () => {
+        const environment = createBeachBallBounceEnvironment({
+            blockData: [
+                blockData('Block_Grass', 0.4),
+                blockData('Block_Sand', 0.72),
+            ],
+            movingBlockId: 'ball',
+            stacks: [
+                stack(0, 0, [block('Block_Grass'), block('BeachBall', 'ball')]),
+                stack(1, 0, [block('Block_Sand')]),
+            ],
+        });
+
+        assert.equal(
+            getBeachBallSurfaceHeight(environment, {
+                fallbackHeight: 0.4,
+                worldX: 0.32,
+                worldZ: 0,
+            }),
+            0.72,
         );
     });
 });

--- a/packages/game/src/entities/beachBallBounce.unit.ts
+++ b/packages/game/src/entities/beachBallBounce.unit.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import {
+    advanceBeachBallBounce,
+    type BeachBallBounceState,
+    createBeachBallBounceEnvironment,
+    isBeachBallPassableTerrainBlockName,
+} from './beachBallBounce';
+
+function block(name: string, id = name, rotation = 0): Block {
+    return {
+        id,
+        name,
+        rotation,
+    };
+}
+
+function stack(x: number, z: number, blocks: Block[]): Stack {
+    return {
+        blocks,
+        position: new Vector3(x, 0, z),
+    };
+}
+
+function activeState(
+    state: Partial<BeachBallBounceState>,
+): BeachBallBounceState {
+    return {
+        active: true,
+        elapsedSeconds: 0,
+        offsetX: 0,
+        offsetZ: 0,
+        velocityX: 0,
+        velocityZ: 0,
+        ...state,
+    };
+}
+
+describe('beach ball bounce', () => {
+    it('ignores terrain and the moving beach ball block as obstacles', () => {
+        const environment = createBeachBallBounceEnvironment({
+            movingBlockId: 'ball',
+            stacks: [
+                stack(0, 0, [block('Block_Grass'), block('BeachBall', 'ball')]),
+                stack(1, 0, [block('Block_Sand_Corner')]),
+                stack(2, 0, [block('Block_Water')]),
+            ],
+        });
+
+        assert.equal(isBeachBallPassableTerrainBlockName('Block_Water'), true);
+        assert.deepEqual(environment.obstacles, []);
+
+        const nextState = advanceBeachBallBounce(
+            activeState({ velocityX: 1.5 }),
+            environment,
+            {
+                baseX: 0,
+                baseZ: 0,
+                deltaSeconds: 0.2,
+            },
+        );
+
+        assert.ok(nextState.offsetX > 0);
+        assert.ok(nextState.velocityX > 0);
+    });
+
+    it('reflects velocity before entering an occupied block cell', () => {
+        const environment = createBeachBallBounceEnvironment({
+            movingBlockId: 'ball',
+            stacks: [
+                stack(0, 0, [block('Block_Grass'), block('BeachBall', 'ball')]),
+                stack(1, 0, [
+                    block('Block_Grass'),
+                    block('BeachChair', 'chair'),
+                ]),
+            ],
+        });
+
+        const nextState = advanceBeachBallBounce(
+            activeState({ offsetX: 0.25, velocityX: 3 }),
+            environment,
+            {
+                baseX: 0,
+                baseZ: 0,
+                deltaSeconds: 0.2,
+            },
+        );
+
+        assert.ok(nextState.offsetX < 0.25);
+        assert.ok(nextState.velocityX < 0);
+    });
+
+    it('uses multi-block footprint spans for obstacle cells', () => {
+        const environment = createBeachBallBounceEnvironment({
+            blockData: [
+                {
+                    attributes: {
+                        spanDepth: 1,
+                        spanWidth: 2,
+                    },
+                    information: {
+                        name: 'LemonadeStand',
+                    },
+                },
+            ],
+            movingBlockId: 'ball',
+            stacks: [
+                stack(0, 0, [block('Block_Grass'), block('BeachBall', 'ball')]),
+                stack(1, 0, [
+                    block('Block_Grass'),
+                    block('LemonadeStand', 'stand'),
+                ]),
+            ],
+        });
+
+        assert.deepEqual(
+            environment.obstacles.sort((left, right) => left.x - right.x),
+            [
+                { x: 1, z: 0 },
+                { x: 2, z: 0 },
+            ],
+        );
+    });
+
+    it('bounces off the garden bounds', () => {
+        const environment = createBeachBallBounceEnvironment({
+            movingBlockId: 'ball',
+            stacks: [
+                stack(0, 0, [block('Block_Grass')]),
+                stack(1, 0, [block('Block_Grass'), block('BeachBall', 'ball')]),
+            ],
+        });
+
+        const nextState = advanceBeachBallBounce(
+            activeState({ offsetX: 0.22, velocityX: 4 }),
+            environment,
+            {
+                baseX: 1,
+                baseZ: 0,
+                deltaSeconds: 0.2,
+            },
+        );
+
+        assert.ok(nextState.offsetX < 0.22);
+        assert.ok(nextState.velocityX < 0);
+    });
+});


### PR DESCRIPTION
## Summary

- Makes the beach ball clickable in the garden and gives it a short rolling/bouncing motion.
- Bounces the ball off occupied garden cells, garden edges, and multi-cell block footprints using the same footprint span data as placement.
- Adds focused unit coverage for terrain pass-through, occupied-cell reflection, multi-block spans, and garden bounds.

## Validation

- `pnpm lint --filter @gredice/game`
- `pnpm --filter @gredice/game test`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- Browser smoke: opened `http://localhost:3891/debug/entities/BeachBall`, clicked the rendered beach ball, and saw no browser console errors.
