### PR TITLE
Group items HUD entries

### DIFF
--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -223,6 +223,42 @@ test('pots are listed under the decoration picker without mulch blocks', async (
     ).toBeVisible();
 });
 
+test('trees are listed under the decoration tree picker', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<ItemsHudAlignmentStory />);
+
+    await expect(page.getByRole('button', { name: 'Drveće' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Dekoracija' }).click();
+
+    await expect(
+        page
+            .locator('[data-items-picker-group-label]')
+            .filter({ hasText: 'Drveće' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Tree', exact: true }),
+    ).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'PalmTree' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Drveće' }).click();
+
+    await expect(
+        page.getByRole('button', { name: 'Tree', exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Pine' })).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'DeadTreeTall' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'DeadTreeStump' }),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'PalmTree' })).toBeVisible();
+});
+
 test('tool picker lists functional garden boxes outside sandbox', async ({
     mount,
     page,
@@ -269,8 +305,31 @@ test('sandbox decoration picker includes special blocks', async ({
     await expect(page.getByRole('button', { name: '🌻 0' })).not.toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Snowman' })).toBeVisible();
     await expect(
+        page
+            .locator('[data-items-picker-group-label]')
+            .filter({ hasText: 'Poklon kutije' }),
+    ).toBeVisible();
+    await expect(
+        page
+            .locator('[data-items-picker-group-label]')
+            .filter({ hasText: 'Drveće' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'GiftBox RedWhite' }),
+    ).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'PineAdvent' })).toHaveCount(
+        0,
+    );
+
+    await page.getByRole('button', { name: 'Poklon kutije' }).click();
+
+    await expect(
         page.getByRole('button', { name: 'GiftBox RedWhite' }),
     ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Natrag' }).click();
+    await page.getByRole('button', { name: 'Drveće' }).click();
+
     await expect(
         page.getByRole('button', { name: 'PineAdvent' }),
     ).toBeVisible();

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -57,6 +57,25 @@ const rockItems: HudItemEntity[] = [
     { type: 'entity', name: 'DesertStoneLarge' },
 ];
 
+const treeItems: HudItemEntity[] = [
+    { type: 'entity', name: 'PalmTree' },
+    { type: 'entity', name: 'Tree' },
+    { type: 'entity', name: 'Pine' },
+    { type: 'entity', name: 'DeadTreeTall' },
+    { type: 'entity', name: 'DeadTreeStump' },
+];
+
+const treeGroupEntityNames = new Set([
+    ...treeItems.map((item) => item.name),
+    'PineAdvent',
+]);
+
+const treePickerLabel = 'Drveće';
+const treePickerImageSrc = 'https://www.gredice.com/assets/blocks/Tree.webp';
+const giftBoxPickerLabel = 'Poklon kutije';
+const giftBoxPickerImageSrc =
+    'https://www.gredice.com/assets/blocks/GiftBox_RedWhite.webp';
+
 const items: HudItem[] = [
     {
         type: 'picker',
@@ -97,6 +116,12 @@ const items: HudItem[] = [
                     'https://www.gredice.com/assets/blocks/StoneMedium.webp',
                 items: rockItems,
             },
+            {
+                type: 'picker',
+                label: treePickerLabel,
+                imageSrc: treePickerImageSrc,
+                items: treeItems,
+            },
             { type: 'entity', name: 'Shade' },
             { type: 'entity', name: 'BeachUmbrella' },
             { type: 'entity', name: 'Stool' },
@@ -108,7 +133,6 @@ const items: HudItem[] = [
             { type: 'entity', name: 'BeachTowelStriped' },
             { type: 'entity', name: 'InflatablePoolSmall' },
             { type: 'entity', name: 'BeachChair' },
-            { type: 'entity', name: 'PalmTree' },
             { type: 'entity', name: 'BeachBall' },
             { type: 'entity', name: 'SandcastleSmallA' },
             { type: 'entity', name: 'BirdHouse' },
@@ -116,10 +140,6 @@ const items: HudItem[] = [
             { type: 'entity', name: 'CatPillow' },
             { type: 'entity', name: 'DogHouse' },
             { type: 'entity', name: 'Bush' },
-            { type: 'entity', name: 'Tree' },
-            { type: 'entity', name: 'Pine' },
-            { type: 'entity', name: 'DeadTreeTall' },
-            { type: 'entity', name: 'DeadTreeStump' },
             { type: 'entity', name: 'Tulip' },
             { type: 'entity', name: 'Sunflower' },
             { type: 'entity', name: 'CactusBarrel' },
@@ -177,11 +197,13 @@ function getSandboxExtraItemsByPicker(
     blockData: BlockData[] | null | undefined,
 ) {
     const extraItemsByPicker: Record<
-        'Blokovi' | 'Dekoracija',
+        'Blokovi' | 'Dekoracija' | 'Drvece' | 'PoklonKutije',
         HudItemEntity[]
     > = {
         Blokovi: [],
         Dekoracija: [],
+        Drvece: [],
+        PoklonKutije: [],
     };
 
     if (!blockData) {
@@ -202,13 +224,89 @@ function getSandboxExtraItemsByPicker(
         }
 
         names.add(name);
-        const pickerLabel = name.startsWith('Block_')
-            ? 'Blokovi'
-            : 'Dekoracija';
-        extraItemsByPicker[pickerLabel].push({ type: 'entity', name });
+        if (name.startsWith('Block_')) {
+            extraItemsByPicker.Blokovi.push({ type: 'entity', name });
+        } else if (name.startsWith('GiftBox_')) {
+            extraItemsByPicker.PoklonKutije.push({ type: 'entity', name });
+        } else if (treeGroupEntityNames.has(name)) {
+            extraItemsByPicker.Drvece.push({ type: 'entity', name });
+        } else {
+            extraItemsByPicker.Dekoracija.push({ type: 'entity', name });
+        }
     }
 
     return extraItemsByPicker;
+}
+
+function addItemsToNestedPicker({
+    hudItems,
+    label,
+    imageSrc,
+    extraItems,
+}: {
+    hudItems: HudItem[];
+    label: string;
+    imageSrc: string;
+    extraItems: HudItemEntity[];
+}): HudItem[] {
+    if (extraItems.length === 0) {
+        return hudItems;
+    }
+
+    let foundPicker = false;
+    const nextItems = hudItems.map((item) => {
+        if (item.type !== 'picker' || item.label !== label) {
+            return item;
+        }
+
+        foundPicker = true;
+        return {
+            ...item,
+            items: [...item.items, ...extraItems],
+        };
+    });
+
+    if (foundPicker) {
+        return nextItems;
+    }
+
+    return [
+        ...nextItems,
+        {
+            type: 'picker',
+            label,
+            imageSrc,
+            items: extraItems,
+        },
+    ];
+}
+
+function getDecorationItemsWithSandboxExtras({
+    decorationItems,
+    treeExtraItems,
+    giftBoxItems,
+    decorationExtraItems,
+}: {
+    decorationItems: HudItem[];
+    treeExtraItems: HudItemEntity[];
+    giftBoxItems: HudItemEntity[];
+    decorationExtraItems: HudItemEntity[];
+}): HudItem[] {
+    const itemsWithTreeExtras = addItemsToNestedPicker({
+        hudItems: decorationItems,
+        label: treePickerLabel,
+        imageSrc: treePickerImageSrc,
+        extraItems: treeExtraItems,
+    });
+
+    const itemsWithGiftBoxes = addItemsToNestedPicker({
+        hudItems: itemsWithTreeExtras,
+        label: giftBoxPickerLabel,
+        imageSrc: giftBoxPickerImageSrc,
+        extraItems: giftBoxItems,
+    });
+
+    return [...itemsWithGiftBoxes, ...decorationExtraItems];
 }
 
 function getSandboxHudItems(hudItems: HudItem[]): HudItem[] {
@@ -249,24 +347,34 @@ function getHudItems({
     const sandboxExtraItemsByPicker = getSandboxExtraItemsByPicker(blockData);
     if (
         sandboxExtraItemsByPicker.Blokovi.length === 0 &&
-        sandboxExtraItemsByPicker.Dekoracija.length === 0
+        sandboxExtraItemsByPicker.Dekoracija.length === 0 &&
+        sandboxExtraItemsByPicker.Drvece.length === 0 &&
+        sandboxExtraItemsByPicker.PoklonKutije.length === 0
     ) {
         return sandboxItems;
     }
 
     return sandboxItems.map((item) => {
-        if (
-            item.type === 'picker' &&
-            (item.label === 'Blokovi' || item.label === 'Dekoracija')
-        ) {
-            const sandboxExtraItems = sandboxExtraItemsByPicker[item.label];
-            if (sandboxExtraItems.length === 0) {
-                return item;
-            }
+        if (item.type !== 'picker') {
+            return item;
+        }
 
+        if (item.label === 'Blokovi') {
             return {
                 ...item,
-                items: [...item.items, ...sandboxExtraItems],
+                items: [...item.items, ...sandboxExtraItemsByPicker.Blokovi],
+            };
+        }
+
+        if (item.label === 'Dekoracija') {
+            return {
+                ...item,
+                items: getDecorationItemsWithSandboxExtras({
+                    decorationItems: item.items,
+                    treeExtraItems: sandboxExtraItemsByPicker.Drvece,
+                    giftBoxItems: sandboxExtraItemsByPicker.PoklonKutije,
+                    decorationExtraItems: sandboxExtraItemsByPicker.Dekoracija,
+                }),
             };
         }
 


### PR DESCRIPTION
## Summary
- Group tree-like decoration HUD items under `Drveće`.
- Group sandbox gift boxes under `Poklon kutije` when those sandbox-only blocks are available.
- Route sandbox tree extras such as `PineAdvent` into the tree group and cover the behavior in the Items HUD spec.

## Validation
- `corepack pnpm lint --filter @gredice/game --filter garden`
- `corepack pnpm --filter garden run test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/items-hud.spec.tsx` (post-rebase: 17 passed)
- `corepack pnpm typecheck --filter @gredice/game --filter garden`
- Browser smoke: `http://localhost:3001/debug/sandbox` showed `Drveće`, `Poklon kutije`, `GiftBox RedWhite`, `PineAdvent`, `Tree`, and `PalmTree` with no console errors.