### PR TITLE
[codex] Filter game changelog updates by audience

### DIFF
--- a/apps/garden/tests/whats-new-widget.spec.tsx
+++ b/apps/garden/tests/whats-new-widget.spec.tsx
@@ -54,12 +54,13 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
 }
 
 async function mockWhatsNewApi(page: Page) {
+    const changelogListQueries: Record<string, string>[] = [];
     const userPatches: unknown[] = [];
 
     await page.route('**/api/**', async (route) => {
         const request = route.request();
         const method = request.method();
-        const { pathname } = new URL(request.url());
+        const { pathname, searchParams } = new URL(request.url());
 
         if (pathname.includes('/api/users/current')) {
             await fulfillJson(route, {
@@ -97,6 +98,9 @@ async function mockWhatsNewApi(page: Page) {
         }
 
         if (pathname.endsWith('/api/news/changelog') && method === 'GET') {
+            changelogListQueries.push(
+                Object.fromEntries(searchParams.entries()),
+            );
             await fulfillJson(route, { items: changelogEntries });
             return;
         }
@@ -126,7 +130,7 @@ async function mockWhatsNewApi(page: Page) {
         );
     });
 
-    return { userPatches };
+    return { changelogListQueries, userPatches };
 }
 
 test('what is new widget opens the latest changelog entry expanded', async ({
@@ -144,7 +148,10 @@ test('what is new widget opens the latest changelog entry expanded', async ({
     ).toBeVisible();
     await expect(
         page.getByRole('link', { name: /Sve novosti/u }),
-    ).toHaveAttribute('href', 'https://www.gredice.com/novosti/sto-je-novo');
+    ).toHaveAttribute(
+        'href',
+        'https://www.gredice.com/novosti/sto-je-novo?tag=Korisnici',
+    );
     await expect(
         page.getByText('Timski dokumenti sada su dostupni izravno u igri.'),
     ).toBeVisible();
@@ -153,6 +160,10 @@ test('what is new widget opens the latest changelog entry expanded', async ({
         page.getByText('Podsjetnici su brzi i pregledni.'),
     ).toHaveCount(0);
     await expect.poll(() => recorded.userPatches.length).toBe(1);
+    expect(recorded.changelogListQueries[0]).toMatchObject({
+        limit: '8',
+        tag: 'Korisnici',
+    });
     expect(recorded.userPatches[0]).toMatchObject({
         whatsNewLastSeenAt: latestPublishedAt,
     });

--- a/packages/game/src/hooks/useWhatsNewEntries.ts
+++ b/packages/game/src/hooks/useWhatsNewEntries.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 export const whatsNewEntriesQueryKey = ['whatsNewEntries'];
 export const whatsNewEntryQueryKey = ['whatsNewEntry'];
+export const whatsNewEntriesAudienceTag = 'Korisnici';
 
 export function useWhatsNewEntries({
     enabled = true,
@@ -19,6 +20,7 @@ export function useWhatsNewEntries({
             {
                 limit,
                 since: since?.toISOString() ?? null,
+                tag: whatsNewEntriesAudienceTag,
             },
         ],
         queryFn: async () => {
@@ -26,6 +28,7 @@ export function useWhatsNewEntries({
                 query: {
                     limit: limit.toString(),
                     since: since?.toISOString(),
+                    tag: whatsNewEntriesAudienceTag,
                 },
             });
             if (!response.ok) {

--- a/packages/game/src/hud/WhatsNewWidget.tsx
+++ b/packages/game/src/hud/WhatsNewWidget.tsx
@@ -18,6 +18,7 @@ import { useUpdateUser } from '../hooks/useUpdateUser';
 import {
     useWhatsNewEntries,
     useWhatsNewEntry,
+    whatsNewEntriesAudienceTag,
 } from '../hooks/useWhatsNewEntries';
 import { KnownPages } from '../knownPages';
 
@@ -182,6 +183,10 @@ function renderEntryContent(
     );
 }
 
+const audienceWhatsNewHref = `${KnownPages.GrediceWhatsNew}?tag=${encodeURIComponent(
+    whatsNewEntriesAudienceTag,
+)}`;
+
 export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
     const { track } = useGameAnalytics();
     const { data: currentUser } = useCurrentUser(enabled);
@@ -290,7 +295,7 @@ export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
                             <Typography semiBold>Što je novo</Typography>
                         </Stack>
                         <Button
-                            href={KnownPages.GrediceWhatsNew}
+                            href={audienceWhatsNewHref}
                             size="sm"
                             startDecorator={<ExternalLink className="size-4" />}
                             variant="plain"


### PR DESCRIPTION
## Summary

Filter the in-game What's New widget to changelog entries tagged `Korisnici`, so farmer-only release notes do not appear in the game HUD. The modal CTA now opens the public changelog page with the same audience tag selected.

The widget component test now records the changelog list request and asserts `tag=Korisnici` together with the filtered public link.

Operational note: I also updated existing draft CMS changelog metadata in the DB so dated non-farmer drafts carry `Korisnici`; farmer-only drafts remain tagged only for `Farma`.

## Validation

- `pnpm bootstrap`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden test:run tests/whats-new-widget.spec.tsx`
- `pnpm --filter garden lint`
- targeted Biome checks for the changed files
- `git diff --check`