### PR TITLE
Add edge autopan while dragging blocks

### DIFF
--- a/packages/game/src/controls/GameCameraRig.tsx
+++ b/packages/game/src/controls/GameCameraRig.tsx
@@ -13,6 +13,10 @@ import {
     findRaisedBedByBlockId,
     getRaisedBedBlockIds,
 } from '../utils/raisedBedBlocks';
+import {
+    getDragEdgeAutopanDelta,
+    hasDragEdgeAutopanDelta,
+} from './dragEdgeAutopan';
 import type { GameCameraRigApi, GameCameraSnapshot } from './GameCameraRigApi';
 
 const closeupZoom = 300;
@@ -461,6 +465,25 @@ export function GameCameraRig({
                     version: snapshotVersionRef.current,
                     zoom: isOrthographicCamera ? camera.zoom : 1,
                 }),
+            panByDragEdge: (pointer, frameDeltaSeconds) => {
+                if (!isOrthographicCamera) {
+                    return false;
+                }
+
+                const rect = gl.domElement.getBoundingClientRect();
+                const screenDelta = getDragEdgeAutopanDelta({
+                    frameDeltaSeconds,
+                    pointer,
+                    viewport: rect,
+                });
+
+                if (!hasDragEdgeAutopanDelta(screenDelta)) {
+                    return false;
+                }
+
+                panByScreenPixels(screenDelta.x, screenDelta.y);
+                return true;
+            },
             projectToScreen: (position) => {
                 const rect = gl.domElement.getBoundingClientRect();
                 if (rect.width <= 0 || rect.height <= 0) {

--- a/packages/game/src/controls/GameCameraRigApi.ts
+++ b/packages/game/src/controls/GameCameraRigApi.ts
@@ -1,4 +1,5 @@
 import type { Camera, Vector3 } from 'three';
+import type { DragEdgeAutopanPointer } from './dragEdgeAutopan';
 
 export type GameCameraSnapshot = {
     position: [x: number, y: number, z: number];
@@ -16,6 +17,10 @@ export type GameCameraRigApi = {
     getCamera: () => Camera | null;
     getDomElement: () => HTMLElement | null;
     getSnapshot: () => GameCameraSnapshot;
+    panByDragEdge: (
+        pointer: DragEdgeAutopanPointer,
+        frameDeltaSeconds: number,
+    ) => boolean;
     projectToScreen: (position: Vector3) => { x: number; y: number } | null;
     subscribe: (listener: (snapshot: GameCameraSnapshot) => void) => () => void;
 };

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -6,6 +6,7 @@ import { type ThreeEvent, useThree } from '@react-three/fiber';
 import {
     type PropsWithChildren,
     Suspense,
+    useCallback,
     useContext,
     useEffect,
     useLayoutEffect,
@@ -101,6 +102,8 @@ type PointerSession = {
     hintVisible: boolean;
     hintTimer: number | null;
     holdTimer: number | null;
+    dragAutopanFrame: number | null;
+    dragAutopanPreviousTime: number | null;
     latestPreview: ResolvedPlacementPreview | null;
 };
 
@@ -177,6 +180,7 @@ export function PickableGroup({
     const currentStackHeight = useStackHeight(stack, block);
 
     const effectsAudioMixer = useGameState((state) => state.audio.effects);
+    const gameCamera = useGameState((state) => state.gameCamera);
     const setIsDragging = useGameState((state) => state.setIsDragging);
     const pickupSound = effectsAudioMixer.useSoundEffect(
         'https://cdn.gredice.com/sounds/effects/Pick Grass 01.mp3',
@@ -278,6 +282,14 @@ export function PickableGroup({
     const pointerSession = useRef<PointerSession | null>(null);
     const pointerSessionCleanup = useRef<(() => void) | null>(null);
 
+    const stopDragAutopan = useCallback((session: PointerSession) => {
+        if (session.dragAutopanFrame !== null) {
+            window.cancelAnimationFrame(session.dragAutopanFrame);
+            session.dragAutopanFrame = null;
+        }
+        session.dragAutopanPreviousTime = null;
+    }, []);
+
     useEffect(() => {
         const hasStackPositionChanged =
             previousStackPosition.current.x !== stack.position.x ||
@@ -357,10 +369,11 @@ export function PickableGroup({
             if (session.holdTimer) {
                 window.clearTimeout(session.holdTimer);
             }
+            stopDragAutopan(session);
             pointerSessionCleanup.current?.();
             pointerSessionCleanup.current = null;
         };
-    }, []);
+    }, [stopDragAutopan]);
 
     function getMovingSegments(): MovingSegment[] {
         if (blockIndex < 0) {
@@ -648,6 +661,7 @@ export function PickableGroup({
 
         session.cancelled = true;
         clearSessionTimers(session);
+        stopDragAutopan(session);
         pointerSession.current = null;
         cleanupPointerSessionListeners();
         setPickupOutlineVisible(false);
@@ -655,6 +669,61 @@ export function PickableGroup({
         if (resetSpring) {
             dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
         }
+    }
+
+    function refreshPlacementPreviewFromSession(session: PointerSession) {
+        const preview = resolvePlacementPreview(
+            session.lastClientX,
+            session.lastClientY,
+            session.pickupAnchorOffset,
+        );
+        if (!preview) {
+            return;
+        }
+
+        session.latestPreview = preview;
+        applyActivePreview(preview);
+    }
+
+    function startDragAutopan(session: PointerSession) {
+        if (session.dragAutopanFrame !== null || !gameCamera) {
+            return;
+        }
+
+        const tick = (timestamp: number) => {
+            const activeSession = pointerSession.current;
+            if (
+                activeSession !== session ||
+                activeSession.cancelled ||
+                !activeSession.activated
+            ) {
+                stopDragAutopan(session);
+                return;
+            }
+
+            const previousTime =
+                activeSession.dragAutopanPreviousTime ?? timestamp;
+            activeSession.dragAutopanPreviousTime = timestamp;
+            const frameDeltaSeconds = Math.max(
+                0,
+                (timestamp - previousTime) / 1000,
+            );
+            const didPan = gameCamera.panByDragEdge(
+                {
+                    clientX: activeSession.lastClientX,
+                    clientY: activeSession.lastClientY,
+                },
+                frameDeltaSeconds,
+            );
+
+            if (didPan) {
+                refreshPlacementPreviewFromSession(activeSession);
+            }
+
+            activeSession.dragAutopanFrame = window.requestAnimationFrame(tick);
+        };
+
+        session.dragAutopanFrame = window.requestAnimationFrame(tick);
     }
 
     function applyActivePreview(preview: ResolvedPlacementPreview) {
@@ -946,23 +1015,14 @@ export function PickableGroup({
             }
 
             session.hasDraggedAfterPickup = true;
+            startDragAutopan(session);
         }
 
         setSandboxBlockTrashDropTargetActive(
             isPointerOverSandboxTrash(event.clientX, event.clientY),
         );
 
-        const preview = resolvePlacementPreview(
-            event.clientX,
-            event.clientY,
-            session.pickupAnchorOffset,
-        );
-        if (!preview) {
-            return;
-        }
-
-        session.latestPreview = preview;
-        applyActivePreview(preview);
+        refreshPlacementPreviewFromSession(session);
     }
 
     function handleWindowPointerUp(event: PointerEvent) {
@@ -972,6 +1032,7 @@ export function PickableGroup({
         }
 
         clearSessionTimers(session);
+        stopDragAutopan(session);
         cleanupPointerSessionListeners();
         pointerSession.current = null;
 
@@ -1048,6 +1109,8 @@ export function PickableGroup({
             hintVisible: false,
             hintTimer: null,
             holdTimer: null,
+            dragAutopanFrame: null,
+            dragAutopanPreviousTime: null,
             latestPreview: null,
         };
         pointerSession.current = session;

--- a/packages/game/src/controls/dragEdgeAutopan.ts
+++ b/packages/game/src/controls/dragEdgeAutopan.ts
@@ -1,0 +1,91 @@
+export type DragEdgeAutopanPointer = {
+    clientX: number;
+    clientY: number;
+};
+
+export type DragEdgeAutopanViewport = {
+    height: number;
+    left: number;
+    top: number;
+    width: number;
+};
+
+export type DragEdgeAutopanDelta = {
+    x: number;
+    y: number;
+};
+
+type DragEdgeAutopanOptions = {
+    edgeInsetPx?: number;
+    maxFrameDeltaSeconds?: number;
+    maxSpeedPxPerSecond?: number;
+};
+
+const defaultEdgeInsetPx = 96;
+const defaultMaxFrameDeltaSeconds = 0.05;
+const defaultMaxSpeedPxPerSecond = 520;
+const autopanEpsilon = 0.01;
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function getEdgeStrength(distanceToEdge: number, edgeInsetPx: number) {
+    if (edgeInsetPx <= 0) {
+        return 0;
+    }
+
+    return 1 - clamp(distanceToEdge / edgeInsetPx, 0, 1);
+}
+
+export function getDragEdgeAutopanDelta({
+    frameDeltaSeconds,
+    pointer,
+    viewport,
+    edgeInsetPx = defaultEdgeInsetPx,
+    maxFrameDeltaSeconds = defaultMaxFrameDeltaSeconds,
+    maxSpeedPxPerSecond = defaultMaxSpeedPxPerSecond,
+}: {
+    frameDeltaSeconds: number;
+    pointer: DragEdgeAutopanPointer;
+    viewport: DragEdgeAutopanViewport;
+} & DragEdgeAutopanOptions): DragEdgeAutopanDelta {
+    if (
+        frameDeltaSeconds <= 0 ||
+        viewport.width <= 0 ||
+        viewport.height <= 0 ||
+        maxSpeedPxPerSecond <= 0
+    ) {
+        return { x: 0, y: 0 };
+    }
+
+    const xInset = Math.min(edgeInsetPx, viewport.width / 2);
+    const yInset = Math.min(edgeInsetPx, viewport.height / 2);
+    const frameDelta = Math.min(frameDeltaSeconds, maxFrameDeltaSeconds);
+    const frameSpeed = maxSpeedPxPerSecond * frameDelta;
+
+    const leftStrength = getEdgeStrength(
+        pointer.clientX - viewport.left,
+        xInset,
+    );
+    const rightStrength = getEdgeStrength(
+        viewport.left + viewport.width - pointer.clientX,
+        xInset,
+    );
+    const topStrength = getEdgeStrength(pointer.clientY - viewport.top, yInset);
+    const bottomStrength = getEdgeStrength(
+        viewport.top + viewport.height - pointer.clientY,
+        yInset,
+    );
+
+    return {
+        x: (leftStrength - rightStrength) * frameSpeed,
+        y: (topStrength - bottomStrength) * frameSpeed,
+    };
+}
+
+export function hasDragEdgeAutopanDelta(delta: DragEdgeAutopanDelta) {
+    return (
+        Math.abs(delta.x) > autopanEpsilon || Math.abs(delta.y) > autopanEpsilon
+    );
+}

--- a/packages/game/src/controls/dragEdgeAutopan.unit.ts
+++ b/packages/game/src/controls/dragEdgeAutopan.unit.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    getDragEdgeAutopanDelta,
+    hasDragEdgeAutopanDelta,
+} from './dragEdgeAutopan';
+
+const viewport = {
+    height: 300,
+    left: 10,
+    top: 20,
+    width: 400,
+};
+
+function getDelta(pointer: { clientX: number; clientY: number }) {
+    return getDragEdgeAutopanDelta({
+        edgeInsetPx: 100,
+        frameDeltaSeconds: 0.1,
+        maxFrameDeltaSeconds: 1,
+        maxSpeedPxPerSecond: 600,
+        pointer,
+        viewport,
+    });
+}
+
+describe('getDragEdgeAutopanDelta', () => {
+    it('stays idle when the pointer is away from the viewport edge', () => {
+        const delta = getDelta({ clientX: 210, clientY: 170 });
+
+        assert.deepEqual(delta, { x: 0, y: 0 });
+        assert.equal(hasDragEdgeAutopanDelta(delta), false);
+    });
+
+    it('returns screen deltas that pan toward the right and bottom edges', () => {
+        const delta = getDelta({ clientX: 360, clientY: 270 });
+
+        assert.deepEqual(delta, { x: -30, y: -30 });
+        assert.equal(hasDragEdgeAutopanDelta(delta), true);
+    });
+
+    it('returns screen deltas that pan toward the left and top edges', () => {
+        const delta = getDelta({ clientX: 60, clientY: 70 });
+
+        assert.deepEqual(delta, { x: 30, y: 30 });
+    });
+
+    it('continues at full speed when the pointer is outside the viewport', () => {
+        const delta = getDelta({ clientX: 430, clientY: 340 });
+
+        assert.deepEqual(delta, { x: -60, y: -60 });
+    });
+
+    it('caps large frame deltas to avoid jumps after a paused frame', () => {
+        const delta = getDragEdgeAutopanDelta({
+            edgeInsetPx: 100,
+            frameDeltaSeconds: 1,
+            maxFrameDeltaSeconds: 0.05,
+            maxSpeedPxPerSecond: 600,
+            pointer: { clientX: 430, clientY: 340 },
+            viewport,
+        });
+
+        assert.deepEqual(delta, { x: -30, y: -30 });
+    });
+});

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -10,7 +10,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import Image from 'next/image';
-import { type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useGameFlags } from '../../GameFlagsContext';
 import { isDiaryCancelTargetEligible } from '../../hooks/useCancelDiaryEntry';
 import { useRaisedBedDiaryEntries } from '../../hooks/useRaisedBedDiaryEntries';


### PR DESCRIPTION
## Summary
- add camera edge-autopan support for active block drag sessions
- keep the dragged block placement preview refreshed while the camera pans under a stationary edge pointer
- cover edge direction, outside-viewport, and frame-delta clamping math with unit tests

## Validation
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm lint --filter @gredice/game`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter www`
- `git diff --check`
- browser smoke on `http://localhost:4831/debug/sandbox`: timed block drag to the right edge continued moving the scene while held at the edge (`diffRatio=0.1879`, no unexpected console errors)