### PR TITLE
Add a reusable split button component for primary actions with dropdown alternatives

### DIFF
--- a/apps/app/app/admin/cms/pages/CmsPageCreateDropdownButton.tsx
+++ b/apps/app/app/admin/cms/pages/CmsPageCreateDropdownButton.tsx
@@ -1,48 +1,17 @@
 'use client';
 
-import { Button } from '@gredice/ui/Button';
-import { ButtonGroup, buttonGroupItemClassName } from '@gredice/ui/ButtonGroup';
-import { Add, Channel, Down, FileText } from '@gredice/ui/icons';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from '@gredice/ui/Menu';
+import { Add, Channel, FileText } from '@gredice/ui/icons';
+import { DropdownMenuItem } from '@gredice/ui/Menu';
+import { SplitButton } from '@gredice/ui/SplitButton';
 import { KnownPages } from '../../../../src/KnownPages';
 
 export function CmsPageCreateDropdownButton() {
     return (
-        <ButtonGroup legend="Kreiranje CMS stranice" size="md">
-            <Button
-                href={KnownPages.CmsPageCreate}
-                size="md"
-                startDecorator={<Add className="size-4 shrink-0" />}
-                className={buttonGroupItemClassName({
-                    size: 'md',
-                    className: 'rounded-r-none pr-3',
-                })}
-            >
-                Nova stranica
-            </Button>
-            <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                    <Button
-                        type="button"
-                        size="md"
-                        aria-label="Odaberi vrstu CMS stranice"
-                        title="Odaberi vrstu CMS stranice"
-                        className={buttonGroupItemClassName({
-                            iconOnly: true,
-                            size: 'md',
-                            className:
-                                'rounded-l-none border-l border-primary-foreground/20',
-                        })}
-                    >
-                        <Down className="size-4" />
-                    </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
+        <SplitButton
+            dropdownLabel="Odaberi vrstu CMS stranice"
+            href={KnownPages.CmsPageCreate}
+            menuContent={
+                <>
                     <DropdownMenuItem
                         href={KnownPages.CmsPageCreateTemplate('blog')}
                         startDecorator={<FileText className="size-4" />}
@@ -55,8 +24,12 @@ export function CmsPageCreateDropdownButton() {
                     >
                         Changelog zapis
                     </DropdownMenuItem>
-                </DropdownMenuContent>
-            </DropdownMenu>
-        </ButtonGroup>
+                </>
+            }
+            size="md"
+            startDecorator={<Add className="size-4 shrink-0" />}
+        >
+            Nova stranica
+        </SplitButton>
     );
 }

--- a/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
@@ -66,6 +66,7 @@ import { ImageGallery } from '@gredice/ui/ImageGallery';
 import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { Input } from '@gredice/ui/Input';
 import {
+    Add,
     Approved,
     Calendar,
     Check,
@@ -144,6 +145,7 @@ import { ShovelIcon } from '@gredice/ui/ShovelIcon';
 import { Skeleton } from '@gredice/ui/Skeleton';
 import { Slider } from '@gredice/ui/Slider';
 import { Spinner } from '@gredice/ui/Spinner';
+import { SplitButton } from '@gredice/ui/SplitButton';
 import { SplitView } from '@gredice/ui/SplitView';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
@@ -623,6 +625,29 @@ function OperationsDashboardShowcase() {
                                     </Typography>
                                 </Stack>
                                 <Row className="flex-wrap" spacing={2}>
+                                    <SplitButton
+                                        dropdownLabel="Odaberi vrstu nove radnje"
+                                        href="/"
+                                        menuContent={
+                                            <>
+                                                <DropdownMenuItem>
+                                                    Berba
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem>
+                                                    Sadnja
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem>
+                                                    Zalijevanje
+                                                </DropdownMenuItem>
+                                            </>
+                                        }
+                                        size="sm"
+                                        startDecorator={
+                                            <Add className="size-4 shrink-0" />
+                                        }
+                                    >
+                                        Nova radnja
+                                    </SplitButton>
                                     <ExpandableSearchDemo />
                                     <ControlledTableFilter />
                                     <StatusMenu />

--- a/apps/storybook/stories/packages/ui/CorePrimitives.stories.tsx
+++ b/apps/storybook/stories/packages/ui/CorePrimitives.stories.tsx
@@ -7,10 +7,12 @@ import { IconButton } from '@gredice/ui/IconButton';
 import { Input } from '@gredice/ui/Input';
 import { Check, Search } from '@gredice/ui/icons';
 import { Link } from '@gredice/ui/Link';
+import { DropdownMenuItem } from '@gredice/ui/Menu';
 import { Progress } from '@gredice/ui/Progress';
 import { Row } from '@gredice/ui/Row';
 import { Skeleton } from '@gredice/ui/Skeleton';
 import { Spinner } from '@gredice/ui/Spinner';
+import { SplitButton } from '@gredice/ui/SplitButton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
@@ -51,6 +53,23 @@ const meta = {
                         <Button startDecorator={<Check className="size-4" />}>
                             Primary
                         </Button>
+                        <SplitButton
+                            dropdownLabel="Odaberi dodatnu akciju"
+                            href="/"
+                            menuContent={
+                                <>
+                                    <DropdownMenuItem>
+                                        Iz predloska
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem>
+                                        Prazan zapis
+                                    </DropdownMenuItem>
+                                </>
+                            }
+                            startDecorator={<Check className="size-4" />}
+                        >
+                            Split action
+                        </SplitButton>
                         <Button color="secondary" variant="soft">
                             Secondary
                         </Button>

--- a/apps/storybook/stories/packages/ui/primitives/SplitButton.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/SplitButton.stories.tsx
@@ -1,0 +1,150 @@
+import { Add, Channel, Duplicate, FileText, Upload } from '@gredice/ui/icons';
+import {
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+} from '@gredice/ui/Menu';
+import { Row } from '@gredice/ui/Row';
+import { SplitButton } from '@gredice/ui/SplitButton';
+import { Stack } from '@gredice/ui/Stack';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+function CmsPageMenuItems() {
+    return (
+        <>
+            <DropdownMenuItem
+                href="/"
+                startDecorator={<FileText className="size-4" />}
+            >
+                Blog objava
+            </DropdownMenuItem>
+            <DropdownMenuItem
+                href="/"
+                startDecorator={<Channel className="size-4" />}
+            >
+                Changelog zapis
+            </DropdownMenuItem>
+        </>
+    );
+}
+
+const meta = {
+    title: 'packages/ui/Foundation/SplitButton',
+    component: SplitButton,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'SplitButton combines a primary action with a compact dropdown for alternate actions without rebuilding grouped button styling in apps.',
+            },
+        },
+    },
+    args: {
+        children: 'Nova stranica',
+        dropdownLabel: 'Odaberi vrstu CMS stranice',
+        href: '/',
+        menuContent: <CmsPageMenuItems />,
+        size: 'md',
+        startDecorator: <Add className="size-4 shrink-0" />,
+    },
+} satisfies Meta<typeof SplitButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+    render: () => (
+        <Stack spacing={3}>
+            <Row className="flex-wrap" spacing={3}>
+                <SplitButton
+                    dropdownLabel="Odaberi vrstu CMS stranice"
+                    href="/"
+                    menuContent={<CmsPageMenuItems />}
+                    startDecorator={<Add className="size-4 shrink-0" />}
+                >
+                    Nova stranica
+                </SplitButton>
+                <SplitButton
+                    color="neutral"
+                    dropdownLabel="Odaberi izvoz"
+                    href="/"
+                    menuContent={
+                        <>
+                            <DropdownMenuLabel>Izvoz</DropdownMenuLabel>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem>CSV</DropdownMenuItem>
+                            <DropdownMenuItem>XLSX</DropdownMenuItem>
+                        </>
+                    }
+                    startDecorator={<Upload className="size-4 shrink-0" />}
+                    variant="outlined"
+                >
+                    Izvezi
+                </SplitButton>
+                <SplitButton
+                    dropdownLabel="Odaberi akciju dupliciranja"
+                    href="/"
+                    menuContent={
+                        <>
+                            <DropdownMenuItem>
+                                Dupliciraj naslov
+                            </DropdownMenuItem>
+                            <DropdownMenuItem>
+                                Dupliciraj s medijima
+                            </DropdownMenuItem>
+                        </>
+                    }
+                    startDecorator={<Duplicate className="size-4 shrink-0" />}
+                    variant="soft"
+                >
+                    Dupliciraj
+                </SplitButton>
+            </Row>
+        </Stack>
+    ),
+};
+
+export const Sizes: Story = {
+    render: () => (
+        <Stack spacing={3}>
+            {(['xs', 'sm', 'md', 'lg'] as const).map((size) => (
+                <SplitButton
+                    dropdownLabel={`${size} dodatne akcije`}
+                    href="/"
+                    key={size}
+                    menuContent={<CmsPageMenuItems />}
+                    size={size}
+                    startDecorator={<Add className="size-4 shrink-0" />}
+                >
+                    {size}
+                </SplitButton>
+            ))}
+        </Stack>
+    ),
+};
+
+export const Disabled: Story = {
+    args: {
+        disabled: true,
+    },
+};
+
+export const LongContent: Story = {
+    render: () => (
+        <div className="max-w-64">
+            <SplitButton
+                dropdownLabel="Odaberi vrstu vrlo dugog zapisa"
+                fullWidth
+                href="/"
+                menuContent={<CmsPageMenuItems />}
+                startDecorator={<Add className="size-4 shrink-0" />}
+            >
+                Kreiraj novu internu CMS stranicu
+            </SplitButton>
+        </div>
+    ),
+};

--- a/packages/ui/src/Button/index.ts
+++ b/packages/ui/src/Button/index.ts
@@ -1,6 +1,7 @@
 export {
     Button,
     type ButtonButtonProps,
+    type ButtonColor,
     type ButtonLinkProps,
     type ButtonProps,
     type VariantKeys,

--- a/packages/ui/src/SplitButton/SplitButton.tsx
+++ b/packages/ui/src/SplitButton/SplitButton.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import {
+    Button,
+    type ButtonButtonProps,
+    type ButtonColor,
+    type ButtonLinkProps,
+    type VariantKeys,
+} from '../Button';
+import { Down } from '../icons';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuTrigger,
+} from '../Menu';
+import { cx } from '../utils';
+
+type SplitButtonSize = NonNullable<ButtonButtonProps['size']>;
+
+type SplitButtonActionProps =
+    | Omit<
+          ButtonButtonProps,
+          | 'className'
+          | 'color'
+          | 'endDecorator'
+          | 'fullWidth'
+          | 'size'
+          | 'variant'
+      >
+    | Omit<
+          ButtonLinkProps,
+          | 'className'
+          | 'color'
+          | 'endDecorator'
+          | 'fullWidth'
+          | 'size'
+          | 'variant'
+      >;
+
+type SplitButtonDropdownContentProps = Omit<
+    ComponentPropsWithoutRef<typeof DropdownMenuContent>,
+    'children'
+>;
+
+export type SplitButtonProps = SplitButtonActionProps & {
+    actionClassName?: string;
+    children: ReactNode;
+    className?: string;
+    color?: ButtonColor;
+    dropdownContentProps?: SplitButtonDropdownContentProps;
+    dropdownLabel: string;
+    dropdownTitle?: string;
+    fullWidth?: boolean;
+    menuContent: ReactNode;
+    menuDisabled?: boolean;
+    size?: SplitButtonSize;
+    triggerClassName?: string;
+    variant?: VariantKeys;
+};
+
+const triggerSizeClassNames = {
+    xs: 'w-7',
+    sm: 'w-8',
+    md: 'w-10',
+    lg: 'w-11',
+} satisfies Record<SplitButtonSize, string>;
+
+const triggerIconSizeClassNames = {
+    xs: 'size-3.5',
+    sm: 'size-4',
+    md: 'size-4',
+    lg: 'size-5',
+} satisfies Record<SplitButtonSize, string>;
+
+function splitButtonActionClassName(variant: VariantKeys) {
+    return variant === 'outlined' ? 'border-r-0' : '';
+}
+
+function splitButtonTriggerClassName(variant: VariantKeys) {
+    if (variant === 'outlined') {
+        return 'border-l border-input';
+    }
+
+    if (variant === 'plain') {
+        return 'border-l border-input';
+    }
+
+    return 'border-l border-current/20';
+}
+
+export function SplitButton({
+    actionClassName,
+    children,
+    className,
+    color,
+    disabled,
+    dropdownContentProps,
+    dropdownLabel,
+    dropdownTitle,
+    fullWidth,
+    loading,
+    menuContent,
+    menuDisabled,
+    size = 'md',
+    triggerClassName,
+    variant = 'solid',
+    ...actionProps
+}: SplitButtonProps) {
+    const dropdownDisabled = disabled || loading || menuDisabled;
+
+    return (
+        <div
+            className={cx(
+                'inline-flex shrink-0 items-stretch rounded-md',
+                fullWidth && 'w-full',
+                className,
+            )}
+        >
+            <Button
+                {...actionProps}
+                className={cx(
+                    'overflow-hidden whitespace-nowrap rounded-r-none',
+                    splitButtonActionClassName(variant),
+                    fullWidth && 'min-w-0 flex-1',
+                    actionClassName,
+                )}
+                color={color}
+                disabled={disabled}
+                loading={loading}
+                size={size}
+                variant={variant}
+            >
+                <span className="min-w-0 truncate">{children}</span>
+            </Button>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button
+                        aria-label={dropdownLabel}
+                        className={cx(
+                            'shrink-0 rounded-l-none px-0',
+                            triggerSizeClassNames[size],
+                            splitButtonTriggerClassName(variant),
+                            triggerClassName,
+                        )}
+                        color={color}
+                        disabled={dropdownDisabled}
+                        size={size}
+                        title={dropdownTitle ?? dropdownLabel}
+                        type="button"
+                        variant={variant}
+                    >
+                        <Down
+                            aria-hidden
+                            className={cx(
+                                'shrink-0',
+                                triggerIconSizeClassNames[size],
+                            )}
+                        />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" {...dropdownContentProps}>
+                    {menuContent}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    );
+}

--- a/packages/ui/src/SplitButton/index.ts
+++ b/packages/ui/src/SplitButton/index.ts
@@ -1,0 +1,1 @@
+export { SplitButton, type SplitButtonProps } from './SplitButton';


### PR DESCRIPTION
## Summary
- Add a reusable `SplitButton` primitive to `@gredice/ui` for paired primary actions and compact alternate-action menus.
- Update the CMS page creation control to use the new component instead of hand-rolled grouped button markup.
- Add Storybook coverage for the new primitive and showcase it in existing component showcases.

## Testing
- Not run (not requested)
- Storybook stories added for default, variant, size, disabled, and long-content states to support manual UI verification.