### PR TITLE
Add CMS page review badge

### DIFF
--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -1,4 +1,5 @@
 import {
+    getCmsPagesReadyForReviewCount,
     getEntityTypesOrganizedByCategories,
     getPendingAchievementsCount,
     getPendingCommunityEditRequestsCount,
@@ -48,12 +49,14 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
 
     const [
         { categorizedTypes, uncategorizedTypes, shadowTypes },
+        pendingCmsPagesReviewCount,
         pendingAchievementsCount,
         pendingApprovalTasksCount,
         pendingCommunityEditRequestsCount,
         dashboardQuickActionsSetting,
     ] = await Promise.all([
         getEntityTypesOrganizedByCategories(),
+        getCmsPagesReadyForReviewCount(),
         getPendingAchievementsCount(),
         getPendingAdminApprovalTaskCount(),
         getPendingCommunityEditRequestsCount(),
@@ -87,6 +90,7 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                 categorizedTypes={categorizedTypes}
                 uncategorizedTypes={uncategorizedTypes}
                 shadowTypes={shadowTypes}
+                pendingCmsPagesReviewCount={pendingCmsPagesReviewCount}
                 pendingAchievementsCount={pendingAchievementsCount}
                 pendingApprovalTasksCount={pendingApprovalTasksCount}
                 pendingCommunityEditRequestsCount={

--- a/apps/app/components/admin/dashboard/AdminDashboard.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboard.tsx
@@ -1,4 +1,5 @@
 import {
+    getCmsPagesReadyForReviewCount,
     getEntityTypes,
     getPendingAchievementsCount,
     getSetting,
@@ -27,6 +28,7 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
         data,
         entityTypes,
         dashboardQuickActionsSetting,
+        pendingCmsPagesReviewCount,
         pendingAchievementsCount,
         pendingApprovalTasksCount,
     ] = await Promise.all([
@@ -37,6 +39,7 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
         ),
         getEntityTypes(),
         getSetting(SettingsKeys.DashboardQuickActions),
+        getCmsPagesReadyForReviewCount(),
         getPendingAchievementsCount(),
         getPendingAdminApprovalTaskCount(),
     ]);
@@ -69,6 +72,7 @@ export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
             initialSunflowersData={data.sunflowers}
             initialQuickActions={quickActions}
             initialQuickActionBadgeCounts={{
+                pendingCmsPagesReviewCount,
                 pendingAchievementsCount,
                 pendingApprovalTasksCount,
             }}

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -243,12 +243,15 @@ export function Nav({
     const categorizedTypes = navContext?.categorizedTypes || [];
     const uncategorizedTypes = navContext?.uncategorizedTypes || [];
     const shadowTypes = navContext?.shadowTypes || [];
+    const pendingCmsPagesReviewCount =
+        navContext?.pendingCmsPagesReviewCount ?? 0;
     const pendingAchievementsCount = navContext?.pendingAchievementsCount ?? 0;
     const pendingApprovalTasksCount =
         navContext?.pendingApprovalTasksCount ?? 0;
     const pendingCommunityEditRequestsCount =
         navContext?.pendingCommunityEditRequestsCount ?? 0;
     const quickActionBadgeCounts = {
+        pendingCmsPagesReviewCount,
         pendingAchievementsCount,
         pendingApprovalTasksCount,
     };
@@ -296,6 +299,7 @@ export function Nav({
                     label={adminPages.CmsPages.label}
                     icon={<File className="size-5" />}
                     onClick={onItemClick}
+                    badge={pendingCmsPagesReviewCount}
                     compact={compact}
                 />
             </NavSection>

--- a/apps/app/components/admin/navigation/NavContext.ts
+++ b/apps/app/components/admin/navigation/NavContext.ts
@@ -7,6 +7,7 @@ import type { DashboardQuickActionOption } from '../../../src/dashboardQuickActi
 export type NavContextType = Awaited<
     ReturnType<typeof getEntityTypesOrganizedByCategories>
 > & {
+    pendingCmsPagesReviewCount: number;
     pendingAchievementsCount: number;
     pendingApprovalTasksCount: number;
     pendingCommunityEditRequestsCount: number;

--- a/apps/app/components/admin/providers/AdminClientProvider.tsx
+++ b/apps/app/components/admin/providers/AdminClientProvider.tsx
@@ -7,6 +7,7 @@ export function AdminClientProvider({
     categorizedTypes,
     uncategorizedTypes,
     shadowTypes,
+    pendingCmsPagesReviewCount,
     pendingAchievementsCount,
     pendingApprovalTasksCount,
     pendingCommunityEditRequestsCount,
@@ -16,6 +17,7 @@ export function AdminClientProvider({
     categorizedTypes: NavContextType['categorizedTypes'];
     uncategorizedTypes: NavContextType['uncategorizedTypes'];
     shadowTypes: NavContextType['shadowTypes'];
+    pendingCmsPagesReviewCount: number;
     pendingAchievementsCount: number;
     pendingApprovalTasksCount: number;
     pendingCommunityEditRequestsCount: number;
@@ -28,6 +30,7 @@ export function AdminClientProvider({
                 categorizedTypes,
                 uncategorizedTypes,
                 shadowTypes,
+                pendingCmsPagesReviewCount,
                 pendingAchievementsCount,
                 pendingApprovalTasksCount,
                 pendingCommunityEditRequestsCount,

--- a/apps/app/src/dashboardQuickActions.ts
+++ b/apps/app/src/dashboardQuickActions.ts
@@ -11,6 +11,7 @@ export type DashboardQuickActionOption = {
 };
 
 export type DashboardQuickActionBadgeCounts = {
+    pendingCmsPagesReviewCount: number;
     pendingAchievementsCount: number;
     pendingApprovalTasksCount: number;
 };
@@ -398,6 +399,8 @@ export function getDashboardQuickActionBadge(
     counts: DashboardQuickActionBadgeCounts,
 ): number | undefined {
     switch (quickAction.href) {
+        case KnownPages.CmsPages:
+            return counts.pendingCmsPagesReviewCount;
         case KnownPages.Achievements:
             return counts.pendingAchievementsCount;
         case KnownPages.Approvals:

--- a/packages/storage/src/repositories/cmsPagesRepo.ts
+++ b/packages/storage/src/repositories/cmsPagesRepo.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { slugify } from '@gredice/js/slug';
-import { and, desc, eq, gt, ne, sql } from 'drizzle-orm';
+import { and, count, desc, eq, gt, ne, sql } from 'drizzle-orm';
 import {
     cmsPageRevisions,
     cmsPages,
@@ -416,6 +416,17 @@ export async function getCmsPages(options: GetCmsPagesOptions = {}) {
 
     const stateKey = options.state ?? 'all';
     return directoriesCached(cacheKeys.cmsPagesList(stateKey), query, 300);
+}
+
+export async function getCmsPagesReadyForReviewCount() {
+    const result = await storage()
+        .select({ count: count() })
+        .from(cmsPages)
+        .where(
+            and(eq(cmsPages.isDeleted, false), eq(cmsPages.state, 'in-review')),
+        );
+
+    return result[0]?.count ?? 0;
 }
 
 function newsPagePublicWhere(options: GetPublishedCmsNewsPagesOptions = {}) {


### PR DESCRIPTION
## Summary
- Add a storage count for active CMS pages in the `in-review` state.
- Show that count as the `Stranice` badge in the admin sidebar.
- Reuse the same badge count for dashboard quick actions when `Stranice` is configured there.

## Validation
- `corepack pnpm lint --filter app --filter @gredice/storage`
- `corepack pnpm --filter app build`
- `corepack pnpm exec tsc --noEmit --pretty false -p apps/app/tsconfig.json` currently fails on existing unrelated app type errors such as missing `PageProps`, notification composer props/actions, sensor Typography imports, and generated fiscalization exports.
- `corepack pnpm exec tsc --noEmit --pretty false -p packages/storage/tsconfig.json` currently fails on existing unrelated storage script/test type errors around `pg` declarations, implicit script row types, and test mocks.