### PR TITLE
Contain CMS images in news and asset blocks

### DIFF
--- a/apps/news/components/NewsDetail.tsx
+++ b/apps/news/components/NewsDetail.tsx
@@ -35,12 +35,12 @@ export function NewsDetail({ entry }: { entry: NewsDetailEntry }) {
                 ) : null}
             </header>
             {entry.metaImageUrl ? (
-                <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
-                    <div className="overflow-hidden rounded-md border bg-muted/20">
+                <div className="mx-auto flex w-full max-w-5xl justify-center px-4 sm:px-6 lg:px-8">
+                    <div className="inline-flex max-w-full overflow-hidden rounded-md border bg-muted/20">
                         {/* biome-ignore lint/performance/noImgElement: CMS images are remote author content. */}
                         <img
                             alt=""
-                            className="max-h-[520px] w-full object-cover"
+                            className="h-auto max-h-[520px] max-w-full object-contain"
                             src={entry.metaImageUrl}
                         />
                     </div>

--- a/packages/ui/src/cms/CmsSections.tsx
+++ b/packages/ui/src/cms/CmsSections.tsx
@@ -270,10 +270,10 @@ function AssetBlock({
     }
 
     return (
-        <div className="overflow-hidden rounded-lg border bg-muted/20">
+        <div className="flex max-w-full justify-center overflow-hidden rounded-lg border bg-muted/20">
             <CmsMediaImage
                 alt={assetAlt ?? ''}
-                className="h-auto w-full object-cover"
+                className="h-auto max-w-full object-contain"
                 darkSrc={assetDarkUrl}
                 src={assetUrl}
             />

--- a/packages/ui/src/cms/CmsSections.tsx
+++ b/packages/ui/src/cms/CmsSections.tsx
@@ -273,7 +273,7 @@ function AssetBlock({
         <div className="flex max-w-full justify-center overflow-hidden rounded-lg border bg-muted/20">
             <CmsMediaImage
                 alt={assetAlt ?? ''}
-                className="h-auto max-w-full object-contain"
+                className="h-auto w-full object-contain"
                 darkSrc={assetDarkUrl}
                 src={assetUrl}
             />


### PR DESCRIPTION
## Summary
- center CMS images within their containers on news detail pages
- switch news and CMS asset images to `object-contain` so full images remain visible
- preserve existing max-height and border treatment while preventing unwanted cropping

## Testing
- Not run (not requested)