### PR TITLE
[codex] Dismiss whats new prompt

### DIFF
--- a/apps/garden/tests/WhatsNewWidgetStory.tsx
+++ b/apps/garden/tests/WhatsNewWidgetStory.tsx
@@ -3,7 +3,21 @@ import { type PropsWithChildren, useMemo } from 'react';
 import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
 import { WhatsNewWidget } from '../../../packages/game/src/hud/WhatsNewWidget';
 
-const currentUser = {
+type CurrentUserFixture = {
+    avatarUrl: string | null;
+    birthday: null;
+    birthdayLastRewardAt: Date | null;
+    birthdayLastUpdatedAt: Date | null;
+    createdAt: Date;
+    displayName: string;
+    email: string;
+    id: string;
+    userName: string;
+    whatsNewLastSeenAt: Date | null;
+    whatsNewPopupDisabled: boolean;
+};
+
+const currentUser: CurrentUserFixture = {
     avatarUrl: null,
     birthday: null,
     birthdayLastRewardAt: null,
@@ -17,7 +31,9 @@ const currentUser = {
     whatsNewPopupDisabled: false,
 };
 
-function createQueryClient() {
+function createQueryClient(
+    currentUserOverride: Partial<CurrentUserFixture> = {},
+) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
             mutations: { retry: false },
@@ -25,13 +41,24 @@ function createQueryClient() {
         },
     });
 
-    queryClient.setQueryData(['currentUser'], currentUser);
+    queryClient.setQueryData(['currentUser'], {
+        ...currentUser,
+        ...currentUserOverride,
+    });
 
     return queryClient;
 }
 
-function Providers({ children }: PropsWithChildren) {
-    const queryClient = useMemo(() => createQueryClient(), []);
+function Providers({
+    children,
+    currentUserOverride,
+}: PropsWithChildren<{
+    currentUserOverride?: Partial<CurrentUserFixture>;
+}>) {
+    const queryClient = useMemo(
+        () => createQueryClient(currentUserOverride),
+        [currentUserOverride],
+    );
 
     return (
         <ReactQuery.QueryClientProvider client={queryClient}>
@@ -42,9 +69,13 @@ function Providers({ children }: PropsWithChildren) {
     );
 }
 
-export function WhatsNewWidgetStory() {
+export function WhatsNewWidgetStory({
+    currentUserOverride,
+}: {
+    currentUserOverride?: Partial<CurrentUserFixture>;
+}) {
     return (
-        <Providers>
+        <Providers currentUserOverride={currentUserOverride}>
             <div className="relative h-[420px] w-[640px] bg-background">
                 <WhatsNewWidget enabled />
             </div>

--- a/apps/garden/tests/whats-new-widget.spec.tsx
+++ b/apps/garden/tests/whats-new-widget.spec.tsx
@@ -13,7 +13,7 @@ const changelogEntries = [
         excerpt: 'Dokumenti za tim sada su dostupni iz vrta.',
         id: 101,
         metaDescription: 'Dokumenti za tim sada su dostupni iz vrta.',
-        metaImageUrl: null,
+        metaImageUrl: 'https://www.gredice.com/assets/team-docs.jpg',
         metaTitle: 'Timski dokumenti',
         noIndex: false,
         path: '/novosti/sto-je-novo/timski-dokumenti',
@@ -53,9 +53,15 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
     });
 }
 
-async function mockWhatsNewApi(page: Page) {
+async function mockWhatsNewApi(
+    page: Page,
+    {
+        initialWhatsNewLastSeenAt = null,
+    }: { initialWhatsNewLastSeenAt?: string | null } = {},
+) {
     const changelogListQueries: Record<string, string>[] = [];
     const userPatches: unknown[] = [];
+    let whatsNewLastSeenAt = initialWhatsNewLastSeenAt;
 
     await page.route('**/api/**', async (route) => {
         const request = route.request();
@@ -73,14 +79,16 @@ async function mockWhatsNewApi(page: Page) {
                 email: 'test@example.com',
                 id: 'test-user',
                 userName: 'test-user',
-                whatsNewLastSeenAt: null,
+                whatsNewLastSeenAt,
                 whatsNewPopupDisabled: false,
             });
             return;
         }
 
         if (pathname.includes('/api/users/test-user') && method === 'PATCH') {
-            userPatches.push(request.postDataJSON());
+            const patch = request.postDataJSON();
+            userPatches.push(patch);
+            whatsNewLastSeenAt = patch.whatsNewLastSeenAt;
             await fulfillJson(route, {
                 avatarUrl: null,
                 birthday: null,
@@ -91,7 +99,7 @@ async function mockWhatsNewApi(page: Page) {
                 email: 'test@example.com',
                 id: 'test-user',
                 userName: 'test-user',
-                whatsNewLastSeenAt: request.postDataJSON().whatsNewLastSeenAt,
+                whatsNewLastSeenAt,
                 whatsNewPopupDisabled: false,
             });
             return;
@@ -141,6 +149,10 @@ test('what is new widget opens the latest changelog entry expanded', async ({
 
     await mount(<WhatsNewWidgetStory />);
 
+    await expect(
+        page.locator('img[src="https://www.gredice.com/assets/team-docs.jpg"]'),
+    ).toBeVisible();
+
     await page.getByRole('button', { name: /Timski dokumenti/u }).click();
 
     await expect(
@@ -152,6 +164,11 @@ test('what is new widget opens the latest changelog entry expanded', async ({
         'href',
         'https://www.gredice.com/novosti/sto-je-novo?tag=Korisnici',
     );
+    await expect(
+        page
+            .getByRole('dialog', { name: 'Što je novo' })
+            .locator('img[src="https://www.gredice.com/assets/team-docs.jpg"]'),
+    ).toBeVisible();
     await expect(
         page.getByText('Timski dokumenti sada su dostupni izravno u igri.'),
     ).toBeVisible();
@@ -167,4 +184,52 @@ test('what is new widget opens the latest changelog entry expanded', async ({
     expect(recorded.userPatches[0]).toMatchObject({
         whatsNewLastSeenAt: latestPublishedAt,
     });
+
+    await page.keyboard.press('Escape');
+    await expect(
+        page.getByRole('dialog', { name: 'Što je novo' }),
+    ).toBeHidden();
+    await expect(
+        page.getByRole('button', { name: /Timski dokumenti/u }),
+    ).toHaveCount(0);
+});
+
+test('what is new widget can be dismissed without opening the modal', async ({
+    mount,
+    page,
+}) => {
+    const recorded = await mockWhatsNewApi(page);
+
+    await mount(<WhatsNewWidgetStory />);
+
+    await page.getByRole('button', { name: 'Sakrij novost' }).click();
+
+    await expect(
+        page.getByRole('button', { name: /Timski dokumenti/u }),
+    ).toHaveCount(0);
+    await expect.poll(() => recorded.userPatches.length).toBe(1);
+    expect(recorded.userPatches[0]).toMatchObject({
+        whatsNewLastSeenAt: latestPublishedAt,
+    });
+});
+
+test('what is new widget stays hidden for already seen changelog entries', async ({
+    mount,
+    page,
+}) => {
+    await mockWhatsNewApi(page, {
+        initialWhatsNewLastSeenAt: latestPublishedAt,
+    });
+
+    await mount(
+        <WhatsNewWidgetStory
+            currentUserOverride={{
+                whatsNewLastSeenAt: new Date(latestPublishedAt),
+            }}
+        />,
+    );
+
+    await expect(
+        page.getByRole('button', { name: /Timski dokumenti/u }),
+    ).toHaveCount(0);
 });

--- a/packages/game/src/hud/WhatsNewWidget.tsx
+++ b/packages/game/src/hud/WhatsNewWidget.tsx
@@ -3,7 +3,7 @@
 import { Accordion } from '@gredice/ui/Accordion';
 import { Button } from '@gredice/ui/Button';
 import { CmsMediaImage } from '@gredice/ui/cms';
-import { ExternalLink } from '@gredice/ui/icons';
+import { Close, ExternalLink } from '@gredice/ui/icons';
 import { Markdown } from '@gredice/ui/Markdown';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
@@ -11,7 +11,14 @@ import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    type ReactNode,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useUpdateUser } from '../hooks/useUpdateUser';
@@ -187,12 +194,42 @@ const audienceWhatsNewHref = `${KnownPages.GrediceWhatsNew}?tag=${encodeURICompo
     whatsNewEntriesAudienceTag,
 )}`;
 
+function ChangelogCoverImage({
+    className,
+    src,
+}: {
+    className?: string;
+    src: string | null | undefined;
+}) {
+    if (!src) {
+        return null;
+    }
+
+    return (
+        <div
+            className={cx(
+                'shrink-0 overflow-hidden rounded-md border bg-muted/30',
+                className,
+            )}
+        >
+            <CmsMediaImage
+                alt=""
+                className="h-full w-full object-cover"
+                src={src}
+            />
+        </div>
+    );
+}
+
 export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
     const { track } = useGameAnalytics();
     const { data: currentUser } = useCurrentUser(enabled);
     const updateUser = useUpdateUser({ enabled });
     const [modalOpen, setModalOpen] = useState(false);
     const [expandedEntryId, setExpandedEntryId] = useState<number | null>(null);
+    const [dismissedPublishedAt, setDismissedPublishedAt] = useState<
+        string | null
+    >(null);
     const markedLatestRef = useRef<string | null>(null);
     const widgetEnabled = Boolean(
         enabled && currentUser && !currentUser.whatsNewPopupDisabled,
@@ -213,6 +250,13 @@ export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
         () => latestPublishedAt(entries),
         [entries],
     );
+    const newestPublishedAtIso = newestPublishedAt?.toISOString() ?? null;
+    const hasUnreadEntries = Boolean(
+        newestPublishedAt &&
+            dismissedPublishedAt !== newestPublishedAtIso &&
+            (!currentUser?.whatsNewLastSeenAt ||
+                currentUser.whatsNewLastSeenAt < newestPublishedAt),
+    );
 
     useEffect(() => {
         if (!latestEntry || expandedEntryId !== null) {
@@ -222,12 +266,13 @@ export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
         setExpandedEntryId(latestEntry.id);
     }, [expandedEntryId, latestEntry]);
 
-    useEffect(() => {
-        if (!modalOpen || !currentUser || !newestPublishedAt) {
+    const markNewestEntrySeen = useCallback(() => {
+        if (!currentUser || !newestPublishedAt || !newestPublishedAtIso) {
             return;
         }
 
-        const newestPublishedAtIso = newestPublishedAt.toISOString();
+        setDismissedPublishedAt(newestPublishedAtIso);
+
         if (markedLatestRef.current === newestPublishedAtIso) {
             return;
         }
@@ -243,9 +288,17 @@ export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
         updateUser.mutate({
             whatsNewLastSeenAt: newestPublishedAt,
         });
-    }, [currentUser, modalOpen, newestPublishedAt, updateUser]);
+    }, [currentUser, newestPublishedAt, newestPublishedAtIso, updateUser]);
 
-    if (!widgetEnabled || !latestEntry) {
+    useEffect(() => {
+        if (!modalOpen) {
+            return;
+        }
+
+        markNewestEntrySeen();
+    }, [markNewestEntrySeen, modalOpen]);
+
+    if (!widgetEnabled || !latestEntry || (!hasUnreadEntries && !modalOpen)) {
         return null;
     }
 
@@ -253,29 +306,52 @@ export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
 
     return (
         <>
-            <div className="pointer-events-none absolute bottom-[calc(env(safe-area-inset-bottom)+4.75rem)] left-2 z-20 md:bottom-16">
-                <button
-                    className="pointer-events-auto w-[min(18rem,calc(100vw-1rem))] rounded-lg border bg-background/95 px-3 py-2 text-left text-foreground shadow-lg backdrop-blur transition-colors hover:bg-card focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                    onClick={() => {
-                        setExpandedEntryId(latestEntry.id);
-                        setModalOpen(true);
-                        track('game_whats_new_widget_opened', {
-                            entryId: latestEntry.id,
-                            source: 'hud_widget',
-                        });
-                    }}
-                    type="button"
-                >
-                    <Stack spacing={1}>
-                        <Typography level="body3" secondary>
-                            Što je novo
-                        </Typography>
-                        <Typography className="line-clamp-2" semiBold>
-                            {latestEntry.title}
-                        </Typography>
-                    </Stack>
-                </button>
-            </div>
+            {hasUnreadEntries ? (
+                <div className="pointer-events-none absolute bottom-[calc(env(safe-area-inset-bottom)+4.75rem)] left-2 z-20 md:bottom-16">
+                    <div className="pointer-events-auto relative w-[min(21rem,calc(100vw-1rem))] overflow-hidden rounded-lg border bg-background/95 text-foreground shadow-lg backdrop-blur">
+                        <button
+                            className={cx(
+                                'grid w-full gap-3 px-3 py-2 pr-10 text-left transition-colors hover:bg-card focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                                latestEntry.metaImageUrl
+                                    ? 'grid-cols-[3.5rem_minmax(0,1fr)]'
+                                    : 'grid-cols-1',
+                            )}
+                            onClick={() => {
+                                setExpandedEntryId(latestEntry.id);
+                                setModalOpen(true);
+                                markNewestEntrySeen();
+                                track('game_whats_new_widget_opened', {
+                                    entryId: latestEntry.id,
+                                    source: 'hud_widget',
+                                });
+                            }}
+                            type="button"
+                        >
+                            <ChangelogCoverImage
+                                className="h-14 w-14"
+                                src={latestEntry.metaImageUrl}
+                            />
+                            <Stack className="min-w-0" spacing={1}>
+                                <Typography level="body3" secondary>
+                                    Što je novo
+                                </Typography>
+                                <Typography className="line-clamp-2" semiBold>
+                                    {latestEntry.title}
+                                </Typography>
+                            </Stack>
+                        </button>
+                        <button
+                            aria-label="Sakrij novost"
+                            className="absolute right-2 top-2 rounded-sm p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                            onClick={markNewestEntrySeen}
+                            title="Sakrij novost"
+                            type="button"
+                        >
+                            <Close aria-hidden className="size-4" />
+                        </button>
+                    </div>
+                </div>
+            ) : null}
             <Modal
                 className="max-w-2xl overflow-hidden border-tertiary border-b-4 p-0"
                 onOpenChange={setModalOpen}
@@ -339,26 +415,41 @@ export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
                                         open={isOpen}
                                         unmountOnExit
                                     >
-                                        <Stack className="min-w-0" spacing={1}>
-                                            <Row
-                                                className="flex-wrap text-xs font-semibold uppercase text-muted-foreground"
-                                                spacing={2}
-                                            >
-                                                {entryDate ? (
-                                                    <span>{entryDate}</span>
-                                                ) : null}
-                                                {entry.tags.map((tag) => (
-                                                    <span key={tag}>{tag}</span>
-                                                ))}
-                                            </Row>
-                                            <Typography
+                                        <Row
+                                            alignItems="center"
+                                            className="min-w-0 flex-1"
+                                            spacing={3}
+                                        >
+                                            <ChangelogCoverImage
+                                                className="h-14 w-16"
+                                                src={entry.metaImageUrl}
+                                            />
+                                            <Stack
                                                 className="min-w-0"
-                                                noWrap
-                                                semiBold
+                                                spacing={1}
                                             >
-                                                {entry.title}
-                                            </Typography>
-                                        </Stack>
+                                                <Row
+                                                    className="flex-wrap text-xs font-semibold uppercase text-muted-foreground"
+                                                    spacing={2}
+                                                >
+                                                    {entryDate ? (
+                                                        <span>{entryDate}</span>
+                                                    ) : null}
+                                                    {entry.tags.map((tag) => (
+                                                        <span key={tag}>
+                                                            {tag}
+                                                        </span>
+                                                    ))}
+                                                </Row>
+                                                <Typography
+                                                    className="min-w-0"
+                                                    noWrap
+                                                    semiBold
+                                                >
+                                                    {entry.title}
+                                                </Typography>
+                                            </Stack>
+                                        </Row>
                                         {detail?.isPending ? (
                                             <Typography level="body2" secondary>
                                                 Novost se učitava.


### PR DESCRIPTION
## What changed

- Added a dismiss button to the in-game `Što je novo` prompt.
- Mark the latest changelog entry as seen when the prompt is opened or dismissed, so it stays hidden until a newer published changelog entry exists.
- Render CMS cover images as small thumbnails in the compact prompt and in the modal changelog list.
- Extended the garden component test fixture and spec to cover cover thumbnails, dismiss behavior, and already-seen entries.

## Validation

- `corepack pnpm --filter @gredice/game run typecheck`
- `corepack pnpm --filter garden run typecheck`
- `corepack pnpm --filter garden run test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/whats-new-widget.spec.tsx`