### PR TITLE
[codex] Enable tutorial onboarding flags by default

### DIFF
--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -64,6 +64,6 @@ export const plantHistoryFlag = flag<boolean>({
 export const tutorialChecklistFlag = flag<boolean>({
     key: 'tutorialChecklist',
     description: 'Enable the tutorial checklist HUD and reward claims.',
-    decide: () => false,
+    decide: () => true,
     options: booleanOptions,
 });


### PR DESCRIPTION
## Summary

- Enable the garden tutorial checklist flag by default.
- This also makes the first raised-bed onboarding flow available by default, because it is mounted behind the tutorial checklist feature flag.

## Validation

- `corepack pnpm lint --filter garden`
- `corepack pnpm typecheck --filter garden`