### PR TITLE
[codex] Add shared timeline UI for news

### DIFF
--- a/apps/news/app/sto-je-novo/page.tsx
+++ b/apps/news/app/sto-je-novo/page.tsx
@@ -1,3 +1,4 @@
+import { Timeline, TimelineEntry, TimelineGroup } from '@gredice/ui/Timeline';
 import Link from 'next/link';
 import { EmptyNewsState } from '../../components/EmptyNewsState';
 import {
@@ -7,6 +8,61 @@ import {
 } from '../../lib/news';
 
 export const dynamic = 'force-dynamic';
+
+const monthFormatter = new Intl.DateTimeFormat('hr-HR', {
+    month: 'long',
+    year: 'numeric',
+});
+
+type ChangelogEntry = Awaited<ReturnType<typeof getChangelogEntries>>[number];
+
+type ChangelogTimelineGroup = {
+    entries: ChangelogEntry[];
+    monthKey: string;
+    monthLabel: string;
+};
+
+function paddedDatePart(value: number) {
+    return value.toString().padStart(2, '0');
+}
+
+function getEntryDate(entry: ChangelogEntry) {
+    if (!entry.publishedAt) {
+        return null;
+    }
+
+    const date = new Date(entry.publishedAt);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getMonthKey(date: Date) {
+    return [date.getFullYear(), paddedDatePart(date.getMonth() + 1)].join('-');
+}
+
+function groupEntriesByMonth(entries: ChangelogEntry[]) {
+    const groups: ChangelogTimelineGroup[] = [];
+    const groupsByKey = new Map<string, ChangelogTimelineGroup>();
+
+    for (const entry of entries) {
+        const date = getEntryDate(entry);
+        const monthKey = date ? getMonthKey(date) : 'unknown';
+        let group = groupsByKey.get(monthKey);
+
+        if (!group) {
+            group = {
+                entries: [],
+                monthKey,
+                monthLabel: date ? monthFormatter.format(date) : 'Bez datuma',
+            };
+            groupsByKey.set(monthKey, group);
+            groups.push(group);
+        }
+
+        group.entries.push(entry);
+    }
+
+    return groups;
+}
 
 export default async function WhatsNewPage({
     searchParams,
@@ -19,6 +75,9 @@ export default async function WhatsNewPage({
         tag ? getChangelogEntries({ tag }) : getChangelogEntries(),
     ]);
     const tags = uniqueNewsValues(allEntries, (item) => item.tags);
+    const timelineGroups = groupEntriesByMonth(entries);
+    const totalEntries = entries.length;
+    let entryIndex = 0;
 
     return (
         <div className="mx-auto grid w-full max-w-6xl gap-8 px-4 py-10 sm:px-6 lg:px-8">
@@ -62,36 +121,57 @@ export default async function WhatsNewPage({
                 </div>
             ) : null}
             {entries.length > 0 ? (
-                <ol className="relative grid gap-4 border-l pl-5">
-                    {entries.map((entry) => (
-                        <li key={entry.id} className="relative">
-                            <span className="absolute -left-[1.82rem] top-5 size-3 rounded-full border-2 border-background bg-primary" />
-                            <Link
-                                className="grid gap-3 rounded-md border bg-card p-5 shadow-xs transition-colors hover:bg-muted/20"
-                                href={`/sto-je-novo/${entry.slug}`}
-                            >
-                                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
-                                    {entry.publishedAt ? (
-                                        <span>
-                                            {formatNewsDate(entry.publishedAt)}
-                                        </span>
-                                    ) : null}
-                                    {entry.tags.map((entryTag) => (
-                                        <span key={entryTag}>{entryTag}</span>
-                                    ))}
-                                </div>
-                                <h2 className="text-xl font-bold leading-tight">
-                                    {entry.title}
-                                </h2>
-                                {entry.excerpt ? (
-                                    <p className="text-sm leading-6 text-muted-foreground">
-                                        {entry.excerpt}
-                                    </p>
-                                ) : null}
-                            </Link>
-                        </li>
+                <Timeline>
+                    {timelineGroups.map((group, groupIndex) => (
+                        <TimelineGroup
+                            hasItems={group.entries.length > 0}
+                            isFirst={groupIndex === 0}
+                            key={group.monthKey}
+                            label={group.monthLabel}
+                        >
+                            {group.entries.map((entry) => {
+                                const currentEntryIndex = entryIndex;
+                                const dateLabel = entry.publishedAt
+                                    ? formatNewsDate(entry.publishedAt)
+                                    : null;
+                                entryIndex += 1;
+
+                                return (
+                                    <TimelineEntry
+                                        index={currentEntryIndex}
+                                        isLast={
+                                            currentEntryIndex ===
+                                            totalEntries - 1
+                                        }
+                                        key={entry.id}
+                                        label={dateLabel ?? 'Bez datuma'}
+                                    >
+                                        <Link
+                                            className="grid gap-3 rounded-md border bg-card p-5 shadow-xs transition-colors hover:bg-muted/20"
+                                            href={`/sto-je-novo/${entry.slug}`}
+                                        >
+                                            <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+                                                {entry.tags.map((entryTag) => (
+                                                    <span key={entryTag}>
+                                                        {entryTag}
+                                                    </span>
+                                                ))}
+                                            </div>
+                                            <h2 className="text-xl font-bold leading-tight">
+                                                {entry.title}
+                                            </h2>
+                                            {entry.excerpt ? (
+                                                <p className="text-sm leading-6 text-muted-foreground">
+                                                    {entry.excerpt}
+                                                </p>
+                                            ) : null}
+                                        </Link>
+                                    </TimelineEntry>
+                                );
+                            })}
+                        </TimelineGroup>
                     ))}
-                </ol>
+                </Timeline>
             ) : (
                 <EmptyNewsState title="Još nema zapisa">
                     Trenutačno nema objavljenih novosti.

--- a/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
@@ -157,6 +157,7 @@ import {
     TIME_FILTER_OPTIONS,
 } from '@gredice/ui/TableFilter';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
+import { Timeline, TimelineEntry, TimelineGroup } from '@gredice/ui/Timeline';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@gredice/ui/Tooltip';
 import { Typography } from '@gredice/ui/Typography';
 import { UserAvatar } from '@gredice/ui/UserAvatar';
@@ -268,6 +269,42 @@ const galleryPlants: GalleryPlant[] = [
         name: 'Paprika',
         state: 'Presadnica',
         imageUrl: 'https://cdn.gredice.com/avatars/farmer-male.png',
+    },
+];
+
+const publicReleaseTimelineGroups = [
+    {
+        id: '2026-06',
+        label: 'lipanj 2026.',
+        entries: [
+            {
+                id: 'delivery-slots',
+                date: '12. lipnja 2026.',
+                title: 'Jasniji status dostave',
+                description:
+                    'Korisnici vide sto je pripremljeno, sto je na putu i koji je sljedeci korak.',
+            },
+            {
+                id: 'harvest-traces',
+                date: '5. lipnja 2026.',
+                title: 'QR trag berbe',
+                description:
+                    'Javna vremenska crta povezuje radnje, fotografije i status biljke.',
+            },
+        ],
+    },
+    {
+        id: '2026-05',
+        label: 'svibanj 2026.',
+        entries: [
+            {
+                id: 'garden-summary',
+                date: '24. svibnja 2026.',
+                title: 'Tjedni pregled vrta',
+                description:
+                    'Vlasnici vrta imaju mirniji pregled nedavnih promjena i nadolazecih zadataka.',
+            },
+        ],
     },
 ];
 
@@ -828,6 +865,58 @@ function OperationsDashboardShowcase() {
     );
 }
 
+function PublicReleaseTimeline() {
+    let entryIndex = 0;
+    const totalEntries = publicReleaseTimelineGroups.reduce(
+        (total, group) => total + group.entries.length,
+        0,
+    );
+
+    return (
+        <section className="rounded-lg bg-background py-5 sm:py-7">
+            <Timeline>
+                {publicReleaseTimelineGroups.map((group, groupIndex) => (
+                    <TimelineGroup
+                        isFirst={groupIndex === 0}
+                        key={group.id}
+                        label={group.label}
+                    >
+                        {group.entries.map((entry) => {
+                            const currentEntryIndex = entryIndex;
+                            entryIndex += 1;
+
+                            return (
+                                <TimelineEntry
+                                    index={currentEntryIndex}
+                                    isLast={
+                                        currentEntryIndex === totalEntries - 1
+                                    }
+                                    key={entry.id}
+                                    label={entry.date}
+                                >
+                                    <Card className="p-5">
+                                        <Stack spacing={2}>
+                                            <Typography
+                                                level="h3"
+                                                className="text-xl"
+                                            >
+                                                {entry.title}
+                                            </Typography>
+                                            <Typography className="text-muted-foreground">
+                                                {entry.description}
+                                            </Typography>
+                                        </Stack>
+                                    </Card>
+                                </TimelineEntry>
+                            );
+                        })}
+                    </TimelineGroup>
+                ))}
+            </Timeline>
+        </section>
+    );
+}
+
 function PublicContentShowcase() {
     return (
         <div className="min-h-screen">
@@ -854,6 +943,8 @@ function PublicContentShowcase() {
                         header="Vodic kroz proljetnu sadnju"
                         description="Public content composition with CMS sections, media, text rendering, and navigation controls."
                     />
+
+                    <PublicReleaseTimeline />
 
                     <Heading1
                         tagline="Sezonski vodic"

--- a/apps/storybook/stories/packages/ui/Timeline.stories.tsx
+++ b/apps/storybook/stories/packages/ui/Timeline.stories.tsx
@@ -1,0 +1,149 @@
+import { Card } from '@gredice/ui/Card';
+import { Stack } from '@gredice/ui/Stack';
+import { Timeline, TimelineEntry, TimelineGroup } from '@gredice/ui/Timeline';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const timelineGroups = [
+    {
+        id: '2026-06',
+        label: 'lipanj 2026.',
+        entries: [
+            {
+                id: 'delivery-windows',
+                date: '12. lipnja 2026.',
+                title: 'Precizniji termini dostave',
+                body: 'Korisnici vide jasniji status dostave i sljedeci korak nakon pripreme.',
+            },
+            {
+                id: 'trace-labels',
+                date: '5. lipnja 2026.',
+                title: 'QR trag berbe',
+                body: 'Svaka naljepnica moze voditi na javni trag berbe s radnjama i fotografijama.',
+            },
+        ],
+    },
+    {
+        id: '2026-05',
+        label: 'svibanj 2026.',
+        entries: [
+            {
+                id: 'garden-activity',
+                date: '24. svibnja 2026.',
+                title: 'Pregled aktivnosti vrta',
+                body: 'Tjedni pregled grupira radnje, fotografije i status biljaka u citljiv vremenski tijek.',
+            },
+        ],
+    },
+];
+
+const meta = {
+    title: 'packages/ui/Timeline',
+    component: Timeline,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Timeline renders a responsive connected rail with grouped markers, date chips, and alternating desktop entries.',
+            },
+        },
+    },
+} satisfies Meta<typeof Timeline>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ReleaseTimeline: Story = {
+    render: () => {
+        let entryIndex = 0;
+        const totalEntries = timelineGroups.reduce(
+            (total, group) => total + group.entries.length,
+            0,
+        );
+
+        return (
+            <div className="max-w-5xl rounded-lg bg-background p-6">
+                <Timeline>
+                    {timelineGroups.map((group, groupIndex) => (
+                        <TimelineGroup
+                            isFirst={groupIndex === 0}
+                            key={group.id}
+                            label={group.label}
+                        >
+                            {group.entries.map((entry) => {
+                                const currentEntryIndex = entryIndex;
+                                entryIndex += 1;
+
+                                return (
+                                    <TimelineEntry
+                                        index={currentEntryIndex}
+                                        isLast={
+                                            currentEntryIndex ===
+                                            totalEntries - 1
+                                        }
+                                        key={entry.id}
+                                        label={entry.date}
+                                    >
+                                        <Card className="p-5">
+                                            <Stack spacing={2}>
+                                                <Typography
+                                                    level="h3"
+                                                    className="text-xl"
+                                                >
+                                                    {entry.title}
+                                                </Typography>
+                                                <Typography className="text-muted-foreground">
+                                                    {entry.body}
+                                                </Typography>
+                                            </Stack>
+                                        </Card>
+                                    </TimelineEntry>
+                                );
+                            })}
+                        </TimelineGroup>
+                    ))}
+                </Timeline>
+            </div>
+        );
+    },
+};
+
+export const LongContent: Story = {
+    render: () => (
+        <div className="max-w-5xl rounded-lg bg-background p-6">
+            <Timeline>
+                <TimelineGroup isFirst label="srpanj 2026.">
+                    <TimelineEntry
+                        index={0}
+                        isLast={false}
+                        label="1. srpnja 2026."
+                    >
+                        <Card className="p-5">
+                            <Stack spacing={2}>
+                                <Typography level="h3" className="text-xl">
+                                    Dugi naslov koji se mora prelomiti bez
+                                    pomicanja vremenske crte
+                                </Typography>
+                                <Typography className="text-muted-foreground">
+                                    Ovaj primjer pokriva vise redaka teksta,
+                                    dulji opis i stabilne razmake na mobilnom i
+                                    desktop prikazu.
+                                </Typography>
+                            </Stack>
+                        </Card>
+                    </TimelineEntry>
+                    <TimelineEntry index={1} isLast label="Bez datuma">
+                        <Card className="p-5">
+                            <Typography className="text-muted-foreground">
+                                Zapisi bez datuma ostaju povezani s istom osi i
+                                ne lome raspored.
+                            </Typography>
+                        </Card>
+                    </TimelineEntry>
+                </TimelineGroup>
+            </Timeline>
+        </div>
+    ),
+};

--- a/apps/www/app/trag/[token]/page.tsx
+++ b/apps/www/app/trag/[token]/page.tsx
@@ -24,6 +24,7 @@ import {
 import { OperationCategoryIcon } from '@gredice/ui/OperationImage';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
+import { Timeline, TimelineEntry, TimelineGroup } from '@gredice/ui/Timeline';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import type { Metadata } from 'next';
@@ -982,99 +983,6 @@ function TimelineWeekCard({ week }: { week: TimelineWeekGroup }) {
     );
 }
 
-function TimelineDateChip({ label }: { label: string }) {
-    return (
-        <Typography
-            component="span"
-            level="body2"
-            semiBold
-            className="inline-flex rounded-md bg-foreground px-3 py-1 text-background"
-        >
-            {label}
-        </Typography>
-    );
-}
-
-function TimelineMonthMarker({
-    hasWeeks,
-    isFirst,
-    label,
-}: {
-    hasWeeks: boolean;
-    isFirst: boolean;
-    label: string;
-}) {
-    return (
-        <div className="relative flex pl-9 sm:justify-center sm:pl-0">
-            {!isFirst ? (
-                <span className="absolute left-[5px] -top-10 bottom-1/2 w-px bg-border sm:left-1/2 sm:-translate-x-1/2" />
-            ) : null}
-            {hasWeeks ? (
-                <span className="absolute left-[5px] top-1/2 -bottom-8 w-px bg-border sm:left-1/2 sm:-translate-x-1/2" />
-            ) : null}
-            <Typography
-                component="span"
-                level="body2"
-                semiBold
-                className="relative z-10 inline-flex rounded-full bg-background px-3 py-1 capitalize text-primary shadow-sm ring-1 ring-border/70"
-            >
-                {label}
-            </Typography>
-        </div>
-    );
-}
-
-function TimelineWeek({
-    index,
-    isLast,
-    week,
-}: {
-    index: number;
-    isLast: boolean;
-    week: TimelineWeekGroup;
-}) {
-    const side = index % 2 === 0 ? 'right' : 'left';
-    const dateChip = <TimelineDateChip label={week.weekLabel} />;
-    const card = <TimelineWeekCard week={week} />;
-
-    return (
-        <li className="relative pl-9 sm:grid sm:grid-cols-[minmax(0,1fr)_2.5rem_minmax(0,1fr)] sm:items-start sm:pl-0">
-            <span className="absolute left-[5px] -top-8 h-[calc(2rem+0.875rem)] w-px bg-border sm:left-1/2 sm:-translate-x-1/2" />
-            <span className="absolute left-0 top-2 z-10 flex size-3 items-center justify-center rounded-full bg-foreground ring-4 ring-background sm:left-1/2 sm:-translate-x-1/2" />
-            {!isLast ? (
-                <span className="absolute left-[5px] top-[0.875rem] -bottom-8 w-px bg-border sm:left-1/2 sm:-translate-x-1/2" />
-            ) : null}
-
-            <div className="flex flex-col items-start gap-4 sm:hidden">
-                {dateChip}
-                {card}
-            </div>
-
-            <div
-                className={
-                    side === 'left'
-                        ? 'hidden sm:col-start-1 sm:block sm:pr-7'
-                        : 'hidden sm:col-start-1 sm:flex sm:justify-end sm:pr-5'
-                }
-            >
-                {side === 'left' ? card : dateChip}
-            </div>
-
-            <div className="hidden sm:col-start-2 sm:block" />
-
-            <div
-                className={
-                    side === 'right'
-                        ? 'hidden sm:col-start-3 sm:block sm:pl-7'
-                        : 'hidden sm:col-start-3 sm:flex sm:justify-start sm:pl-5'
-                }
-            >
-                {side === 'right' ? card : dateChip}
-            </div>
-        </li>
-    );
-}
-
 function TraceTimeline({ trace }: { trace: PublicHarvestTrace }) {
     const monthGroups = groupTimelineByWeek(trace.timeline);
     const totalWeeks = monthGroups.reduce(
@@ -1086,40 +994,34 @@ function TraceTimeline({ trace }: { trace: PublicHarvestTrace }) {
     return (
         <section className="rounded-lg bg-background py-5 sm:py-7">
             {monthGroups.length > 0 ? (
-                <div className="relative">
-                    <div className="space-y-10">
-                        {monthGroups.map((month, monthIndex) => (
-                            <div
-                                key={month.monthKey}
-                                className="relative space-y-6"
-                            >
-                                <TimelineMonthMarker
-                                    hasWeeks={month.weeks.length > 0}
-                                    isFirst={monthIndex === 0}
-                                    label={month.monthLabel}
-                                />
-                                <ol className="space-y-8">
-                                    {month.weeks.map((week) => {
-                                        const currentWeekIndex = weekIndex;
-                                        weekIndex += 1;
+                <Timeline>
+                    {monthGroups.map((month, monthIndex) => (
+                        <TimelineGroup
+                            hasItems={month.weeks.length > 0}
+                            isFirst={monthIndex === 0}
+                            key={month.monthKey}
+                            label={month.monthLabel}
+                        >
+                            {month.weeks.map((week) => {
+                                const currentWeekIndex = weekIndex;
+                                weekIndex += 1;
 
-                                        return (
-                                            <TimelineWeek
-                                                key={week.weekKey}
-                                                index={currentWeekIndex}
-                                                isLast={
-                                                    currentWeekIndex ===
-                                                    totalWeeks - 1
-                                                }
-                                                week={week}
-                                            />
-                                        );
-                                    })}
-                                </ol>
-                            </div>
-                        ))}
-                    </div>
-                </div>
+                                return (
+                                    <TimelineEntry
+                                        index={currentWeekIndex}
+                                        isLast={
+                                            currentWeekIndex === totalWeeks - 1
+                                        }
+                                        key={week.weekKey}
+                                        label={week.weekLabel}
+                                    >
+                                        <TimelineWeekCard week={week} />
+                                    </TimelineEntry>
+                                );
+                            })}
+                        </TimelineGroup>
+                    ))}
+                </Timeline>
             ) : (
                 <div className="rounded-lg bg-muted/30 p-4">
                     <Typography className="text-muted-foreground">

--- a/packages/ui/src/Timeline/Timeline.tsx
+++ b/packages/ui/src/Timeline/Timeline.tsx
@@ -1,0 +1,19 @@
+import type { HTMLAttributes } from 'react';
+import { cx } from '../utils';
+
+export type TimelineProps = HTMLAttributes<HTMLDivElement> & {
+    contentClassName?: string;
+};
+
+export function Timeline({
+    children,
+    className,
+    contentClassName,
+    ...props
+}: TimelineProps) {
+    return (
+        <div className={cx('relative', className)} {...props}>
+            <div className={cx('space-y-10', contentClassName)}>{children}</div>
+        </div>
+    );
+}

--- a/packages/ui/src/Timeline/TimelineDateChip.tsx
+++ b/packages/ui/src/Timeline/TimelineDateChip.tsx
@@ -1,0 +1,17 @@
+import type { HTMLAttributes } from 'react';
+import { cx } from '../utils';
+
+export function TimelineDateChip({
+    className,
+    ...props
+}: HTMLAttributes<HTMLSpanElement>) {
+    return (
+        <span
+            className={cx(
+                'inline-flex rounded-md bg-foreground px-3 py-1 text-sm font-semibold text-background',
+                className,
+            )}
+            {...props}
+        />
+    );
+}

--- a/packages/ui/src/Timeline/TimelineEntry.tsx
+++ b/packages/ui/src/Timeline/TimelineEntry.tsx
@@ -1,0 +1,69 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from '../utils';
+import { TimelineDateChip } from './TimelineDateChip';
+
+export type TimelineEntryProps = HTMLAttributes<HTMLLIElement> & {
+    index: number;
+    isLast: boolean;
+    label: ReactNode;
+    labelClassName?: string;
+    markerClassName?: string;
+};
+
+export function TimelineEntry({
+    children,
+    className,
+    index,
+    isLast,
+    label,
+    labelClassName,
+    markerClassName,
+    ...props
+}: TimelineEntryProps) {
+    const side = index % 2 === 0 ? 'right' : 'left';
+    const labelContainerClassName =
+        side === 'left'
+            ? 'sm:col-start-3 sm:row-start-1 sm:flex sm:justify-start sm:pl-5'
+            : 'sm:col-start-1 sm:row-start-1 sm:flex sm:justify-end sm:pr-5';
+    const contentContainerClassName =
+        side === 'left'
+            ? 'sm:col-start-1 sm:row-start-1 sm:pr-7'
+            : 'sm:col-start-3 sm:row-start-1 sm:pl-7';
+
+    return (
+        <li
+            className={cx(
+                'relative pl-9 sm:grid sm:grid-cols-[minmax(0,1fr)_2.5rem_minmax(0,1fr)] sm:items-start sm:pl-0',
+                className,
+            )}
+            {...props}
+        >
+            <span
+                aria-hidden
+                className="absolute left-[5px] -top-8 h-[calc(2rem+0.875rem)] w-px bg-border sm:left-1/2 sm:-translate-x-1/2"
+            />
+            <span
+                aria-hidden
+                className={cx(
+                    'absolute left-0 top-2 z-10 flex size-3 items-center justify-center rounded-full bg-foreground ring-4 ring-background sm:left-1/2 sm:-translate-x-1/2',
+                    markerClassName,
+                )}
+            />
+            {!isLast ? (
+                <span
+                    aria-hidden
+                    className="absolute left-[5px] top-[0.875rem] -bottom-8 w-px bg-border sm:left-1/2 sm:-translate-x-1/2"
+                />
+            ) : null}
+
+            <div className="flex flex-col items-start gap-4 sm:contents">
+                <div className={labelContainerClassName}>
+                    <TimelineDateChip className={labelClassName}>
+                        {label}
+                    </TimelineDateChip>
+                </div>
+                <div className={contentContainerClassName}>{children}</div>
+            </div>
+        </li>
+    );
+}

--- a/packages/ui/src/Timeline/TimelineGroup.tsx
+++ b/packages/ui/src/Timeline/TimelineGroup.tsx
@@ -1,0 +1,38 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from '../utils';
+import { TimelineGroupMarker } from './TimelineGroupMarker';
+
+export type TimelineGroupProps = HTMLAttributes<HTMLDivElement> & {
+    hasItems?: boolean;
+    isFirst: boolean;
+    label: ReactNode;
+    listClassName?: string;
+    markerClassName?: string;
+    markerContainerClassName?: string;
+};
+
+export function TimelineGroup({
+    children,
+    className,
+    hasItems = true,
+    isFirst,
+    label,
+    listClassName,
+    markerClassName,
+    markerContainerClassName,
+    ...props
+}: TimelineGroupProps) {
+    return (
+        <div className={cx('relative space-y-6', className)} {...props}>
+            <TimelineGroupMarker
+                className={markerClassName}
+                containerClassName={markerContainerClassName}
+                hasItems={hasItems}
+                isFirst={isFirst}
+            >
+                {label}
+            </TimelineGroupMarker>
+            <ol className={cx('space-y-8', listClassName)}>{children}</ol>
+        </div>
+    );
+}

--- a/packages/ui/src/Timeline/TimelineGroupMarker.tsx
+++ b/packages/ui/src/Timeline/TimelineGroupMarker.tsx
@@ -1,0 +1,45 @@
+import type { HTMLAttributes } from 'react';
+import { cx } from '../utils';
+
+export type TimelineGroupMarkerProps = HTMLAttributes<HTMLSpanElement> & {
+    containerClassName?: string;
+    hasItems: boolean;
+    isFirst: boolean;
+};
+
+export function TimelineGroupMarker({
+    className,
+    containerClassName,
+    hasItems,
+    isFirst,
+    ...props
+}: TimelineGroupMarkerProps) {
+    return (
+        <div
+            className={cx(
+                'relative flex pl-9 sm:justify-center sm:pl-0',
+                containerClassName,
+            )}
+        >
+            {!isFirst ? (
+                <span
+                    aria-hidden
+                    className="absolute left-[5px] -top-10 bottom-1/2 w-px bg-border sm:left-1/2 sm:-translate-x-1/2"
+                />
+            ) : null}
+            {hasItems ? (
+                <span
+                    aria-hidden
+                    className="absolute left-[5px] top-1/2 -bottom-8 w-px bg-border sm:left-1/2 sm:-translate-x-1/2"
+                />
+            ) : null}
+            <span
+                className={cx(
+                    'relative z-10 inline-flex rounded-full bg-background px-3 py-1 text-sm font-semibold capitalize text-primary shadow-sm ring-1 ring-border/70',
+                    className,
+                )}
+                {...props}
+            />
+        </div>
+    );
+}

--- a/packages/ui/src/Timeline/index.ts
+++ b/packages/ui/src/Timeline/index.ts
@@ -1,0 +1,5 @@
+export * from './Timeline';
+export * from './TimelineDateChip';
+export * from './TimelineEntry';
+export * from './TimelineGroup';
+export * from './TimelineGroupMarker';


### PR DESCRIPTION
## Summary
- Add shared `@gredice/ui/Timeline` primitives for grouped markers, date chips, and responsive alternating entries.
- Reuse the shared timeline on the harvest trace page and the news Whats New changelog page.
- Add Storybook coverage plus a public content showcase example for the new timeline.

## Validation
- `corepack pnpm lint --filter @gredice/ui`
- `corepack pnpm lint --filter news`
- `corepack pnpm lint --filter www`
- `corepack pnpm lint --filter storybook`
- `corepack pnpm typecheck --filter @gredice/ui`
- `corepack pnpm typecheck --filter news`
- `corepack pnpm typecheck --filter www`
- `corepack pnpm typecheck --filter storybook`
- `git diff --cached --check`
- Browser check: local news page at `http://localhost:3797/novosti/sto-je-novo` with production public API data; desktop and 390px mobile layouts rendered six changelog entries with no horizontal overflow.