### PR TITLE
[codex] Update game HUD info and news icons

### DIFF
--- a/apps/garden/tests/WhatsNewWidgetStory.tsx
+++ b/apps/garden/tests/WhatsNewWidgetStory.tsx
@@ -1,5 +1,5 @@
 import * as ReactQuery from '@tanstack/react-query';
-import { type PropsWithChildren, useMemo } from 'react';
+import { type PropsWithChildren, useMemo, useState } from 'react';
 import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
 import { WhatsNewWidget } from '../../../packages/game/src/hud/WhatsNewWidget';
 
@@ -78,6 +78,30 @@ export function WhatsNewWidgetStory({
         <Providers currentUserOverride={currentUserOverride}>
             <div className="relative h-[420px] w-[640px] bg-background">
                 <WhatsNewWidget enabled />
+            </div>
+        </Providers>
+    );
+}
+
+export function WhatsNewWidgetHudRequestStory() {
+    const [openRequestId, setOpenRequestId] = useState(0);
+    const currentUserOverride = useMemo(
+        () => ({
+            whatsNewLastSeenAt: new Date('2026-06-04T08:00:00.000Z'),
+        }),
+        [],
+    );
+
+    return (
+        <Providers currentUserOverride={currentUserOverride}>
+            <div className="relative h-[420px] w-[640px] bg-background">
+                <button
+                    onClick={() => setOpenRequestId((current) => current + 1)}
+                    type="button"
+                >
+                    Otvori novosti
+                </button>
+                <WhatsNewWidget enabled openRequestId={openRequestId} />
             </div>
         </Providers>
     );

--- a/apps/garden/tests/whats-new-widget.spec.tsx
+++ b/apps/garden/tests/whats-new-widget.spec.tsx
@@ -1,6 +1,9 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Page, Route } from '@playwright/test';
-import { WhatsNewWidgetStory } from './WhatsNewWidgetStory';
+import {
+    WhatsNewWidgetHudRequestStory,
+    WhatsNewWidgetStory,
+} from './WhatsNewWidgetStory';
 
 const latestPublishedAt = '2026-06-04T08:00:00.000Z';
 
@@ -232,4 +235,29 @@ test('what is new widget stays hidden for already seen changelog entries', async
     await expect(
         page.getByRole('button', { name: /Timski dokumenti/u }),
     ).toHaveCount(0);
+});
+
+test('what is new modal opens from a hud request after latest entry is seen', async ({
+    mount,
+    page,
+}) => {
+    const recorded = await mockWhatsNewApi(page, {
+        initialWhatsNewLastSeenAt: latestPublishedAt,
+    });
+
+    await mount(<WhatsNewWidgetHudRequestStory />);
+
+    await expect(
+        page.getByRole('button', { name: /Timski dokumenti/u }),
+    ).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Otvori novosti' }).click();
+
+    await expect(
+        page.getByRole('dialog', { name: 'Što je novo' }),
+    ).toBeVisible();
+    await expect(
+        page.getByText('Timski dokumenti sada su dostupni izravno u igri.'),
+    ).toBeVisible();
+    expect(recorded.userPatches).toHaveLength(0);
 });

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { IconButton } from '@gredice/ui/IconButton';
+import { Megaphone } from '@gredice/ui/icons';
 import { cx } from '@gredice/ui/utils';
 import { useState } from 'react';
 import type { GameSceneProps } from './GameScene';
@@ -67,6 +69,7 @@ export function GameHud({
     suppressOpeningHud?: boolean;
 }) {
     const [welcomeConfirmed, setWelcomeConfirmed] = useState(false);
+    const [whatsNewOpenRequestId, setWhatsNewOpenRequestId] = useState(0);
     const [visitSummaryConfirmation, setVisitSummaryConfirmation] = useState<{
         confirmed: boolean;
         gardenId: number | null;
@@ -120,6 +123,8 @@ export function GameHud({
         !suppressOpeningHud &&
         visitSummaryStageComplete &&
         (isSandbox || raisedBedOnboardingChecklistResolved);
+    const whatsNewHudEnabled =
+        !isLocalSandbox && !suppressOpeningHud && openingFlowComplete;
 
     return (
         <>
@@ -197,6 +202,20 @@ export function GameHud({
                     <CameraHud />
                     <AudioHud />
                     <ControlsTooltipHud />
+                    {whatsNewHudEnabled && (
+                        <IconButton
+                            title="Što je novo"
+                            variant="plain"
+                            onClick={() =>
+                                setWhatsNewOpenRequestId(
+                                    (current) => current + 1,
+                                )
+                            }
+                            className="pointer-events-auto hover:bg-muted"
+                        >
+                            <Megaphone className="size-5" />
+                        </IconButton>
+                    )}
                 </div>
                 <SandboxBlockTrashDropTarget />
                 <div
@@ -230,7 +249,10 @@ export function GameHud({
                         }
                     />
                     <GardenVisitSummaryHighlightHud />
-                    <WhatsNewWidget enabled={openingFlowComplete} />
+                    <WhatsNewWidget
+                        enabled={openingFlowComplete}
+                        openRequestId={whatsNewOpenRequestId}
+                    />
                 </>
             )}
             {!isLocalSandbox && <PaymentSuccessfulMessage />}

--- a/packages/game/src/hud/ControlsTooltipHud.tsx
+++ b/packages/game/src/hud/ControlsTooltipHud.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { IconButton } from '@gredice/ui/IconButton';
-import { Check, Info } from '@gredice/ui/icons';
+import { Check, GamepadDirectional } from '@gredice/ui/icons';
 import { useEffect, useState } from 'react';
 import { ButtonGreen } from '../shared-ui/ButtonGreen';
 import type { DeviceType } from './controls-tooltip';
@@ -102,7 +102,7 @@ export function ControlsTooltipHud() {
                     onClick={() => setOpen(true)}
                     className="hover:bg-muted"
                 >
-                    <Info className="size-5" />
+                    <GamepadDirectional className="size-5" />
                 </IconButton>
             </div>
         );

--- a/packages/game/src/hud/WhatsNewWidget.tsx
+++ b/packages/game/src/hud/WhatsNewWidget.tsx
@@ -221,7 +221,15 @@ function ChangelogCoverImage({
     );
 }
 
-export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
+type WhatsNewWidgetProps = {
+    enabled: boolean;
+    openRequestId?: number;
+};
+
+export function WhatsNewWidget({
+    enabled,
+    openRequestId,
+}: WhatsNewWidgetProps) {
     const { track } = useGameAnalytics();
     const { data: currentUser } = useCurrentUser(enabled);
     const updateUser = useUpdateUser({ enabled });
@@ -231,6 +239,7 @@ export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
         string | null
     >(null);
     const markedLatestRef = useRef<string | null>(null);
+    const handledOpenRequestIdRef = useRef(openRequestId);
     const widgetEnabled = Boolean(
         enabled && currentUser && !currentUser.whatsNewPopupDisabled,
     );
@@ -289,6 +298,25 @@ export function WhatsNewWidget({ enabled }: { enabled: boolean }) {
             whatsNewLastSeenAt: newestPublishedAt,
         });
     }, [currentUser, newestPublishedAt, newestPublishedAtIso, updateUser]);
+
+    useEffect(() => {
+        if (
+            openRequestId === undefined ||
+            handledOpenRequestIdRef.current === openRequestId ||
+            !widgetEnabled ||
+            !latestEntry
+        ) {
+            return;
+        }
+
+        handledOpenRequestIdRef.current = openRequestId;
+        setExpandedEntryId(latestEntry.id);
+        setModalOpen(true);
+        track('game_whats_new_widget_opened', {
+            entryId: latestEntry.id,
+            source: 'hud_button',
+        });
+    }, [latestEntry, openRequestId, track, widgetEnabled]);
 
     useEffect(() => {
         if (!modalOpen) {

--- a/packages/ui/src/icons/index.ts
+++ b/packages/ui/src/icons/index.ts
@@ -58,6 +58,7 @@ export {
     Filter,
     Flame,
     Frown as SmileSad,
+    GamepadDirectional,
     Ghost,
     GitCommit as Channel,
     Globe,


### PR DESCRIPTION
## Summary

- Replace the controls help HUD info icon with the lucide gamepad directional icon.
- Add a bottom HUD megaphone news action that opens the existing "Što je novo" modal.
- Cover the modal-open request path for already-seen changelog entries.

## Validation

- `corepack pnpm lint --filter @gredice/ui --filter @gredice/game --filter garden`
- `corepack pnpm typecheck --filter @gredice/ui`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm --filter garden run test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/whats-new-widget.spec.tsx`
- In-app browser check: `http://127.0.0.1:3001/debug/profile/game?mode=details&profile=dense&controls=1&quality=medium&hud=1` showed the bottom HUD controls button and new `Što je novo` button with no console errors.