### PR TITLE
Fix garden test mocks

### DIFF
--- a/apps/garden/tests/landing.spec.ts
+++ b/apps/garden/tests/landing.spec.ts
@@ -26,6 +26,17 @@ const adventCalendar = {
     year: 2025,
 };
 
+const tutorialChecklist = {
+    groups: [],
+    totals: {
+        availableSunflowers: 0,
+        claimableCount: 0,
+        completedCount: 0,
+        earnedSunflowers: 0,
+        totalCount: 0,
+    },
+};
+
 const crashPatterns = [
     /Maximum update depth exceeded/u,
     /The result of getSnapshot should be cached/u,
@@ -116,6 +127,10 @@ async function mockGardenApi(page: Page, signedIn: boolean) {
             body = adventCalendar;
         } else if (pathname.endsWith('/api/accounts/current/sunflowers')) {
             body = { amount: 0 };
+        } else if (
+            pathname.endsWith('/api/accounts/current/tutorial-checklist')
+        ) {
+            body = tutorialChecklist;
         } else if (pathname.endsWith('/api/accounts/current')) {
             body = signedIn
                 ? { id: 'test-account', name: 'Test Account' }

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1501,13 +1501,18 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
         await expect(moreButton).toBeVisible();
         await expect(tabList).toBeVisible();
 
-        const moreBox = await moreButton.boundingBox();
-        const tabListBox = await tabList.boundingBox();
-        expect(moreBox).not.toBeNull();
-        expect(tabListBox).not.toBeNull();
-        expect((moreBox?.y ?? 0) + (moreBox?.height ?? 0)).toBeLessThanOrEqual(
-            tabListBox?.y ?? 0,
-        );
+        await expect
+            .poll(async () => {
+                const moreBox = await moreButton.boundingBox();
+                const tabListBox = await tabList.boundingBox();
+
+                if (!moreBox || !tabListBox) {
+                    return Number.POSITIVE_INFINITY;
+                }
+
+                return moreBox.y + moreBox.height - tabListBox.y;
+            })
+            .toBeLessThanOrEqual(0);
 
         await moreButton.click();
         await expect(


### PR DESCRIPTION
## Summary
- mock the tutorial checklist endpoint in the garden landing smoke test so feature-flagged HUD requests do not fail CI
- make the raised-bed mobile header position assertion poll until the drawer layout has settled

## Root cause
Feature branches that enabled the tutorial checklist HUD introduced a signed-in landing-page request to `/api/accounts/current/tutorial-checklist`, but the smoke test route mock still treated that request as unexpected. A separate mobile layout assertion also sampled bounding boxes before the drawer finished settling, which could fail intermittently in the full suite.

## Validation
- `pnpm --filter garden test:run tests/landing.spec.ts`
- `pnpm lint --filter garden`
- `pnpm --filter garden test:run tests/landing.spec.ts tests/raised-bed-field-hud.spec.tsx -g "raised bed more action sits in the header above the tabs|landing page"`
- `pnpm test --filter garden`