### PR TITLE
[codex] Enable tutorial checklist by default

### DIFF
--- a/apps/api/lib/tutorialChecklist/featureFlag.node.spec.ts
+++ b/apps/api/lib/tutorialChecklist/featureFlag.node.spec.ts
@@ -10,9 +10,9 @@ describe('tutorialChecklistFlag', () => {
         assert.equal(tutorialChecklistFlag.key, 'tutorialChecklist');
     });
 
-    it('defaults to disabled until the API and garden rollout are flipped together', async () => {
+    it('defaults to enabled without an override', async () => {
         const request = new Request('https://api.gredice.test/api/accounts');
 
-        assert.equal(await isTutorialChecklistEnabled(request), false);
+        assert.equal(await isTutorialChecklistEnabled(request), true);
     });
 });

--- a/apps/api/lib/tutorialChecklist/featureFlag.ts
+++ b/apps/api/lib/tutorialChecklist/featureFlag.ts
@@ -13,7 +13,7 @@ type FlagRequest = IncomingMessage & {
 export const tutorialChecklistFlag = flag<boolean>({
     key: 'tutorialChecklist',
     description: 'Enable the tutorial checklist HUD and reward claims.',
-    decide: () => false,
+    decide: () => true,
     options: booleanOptions,
 });
 


### PR DESCRIPTION
## Summary

Enable the API-side `tutorialChecklist` feature flag by default and update the API unit test to lock in the enabled default.

## Root cause

Current `main` already enables the garden HUD flag by default, but the API route still gates `/current/tutorial-checklist` and reward claims behind its own `tutorialChecklist` flag defaulting to `false`. That lets the in-game checklist render while its data request receives `404`, producing the checklist load failure.

## Validation

- `pnpm --filter api test:node`
- `pnpm --filter api exec biome check lib/tutorialChecklist/featureFlag.ts lib/tutorialChecklist/featureFlag.node.spec.ts`
- `git diff --check origin/main...HEAD`
