### PR TITLE
Add sunflower to the local sandbox item picker

### DIFF
--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -13,6 +13,7 @@ import { currentAccountKeys } from '../../../packages/game/src/hooks/useCurrentA
 import { ControlsTooltipHud } from '../../../packages/game/src/hud/ControlsTooltipHud';
 import { ItemsHud } from '../../../packages/game/src/hud/ItemsHud';
 import { SandboxBlockTrashDropTarget } from '../../../packages/game/src/hud/SandboxBlockTrashDropTarget';
+import { defaultLocalSandboxStorageKey } from '../../../packages/game/src/localSandboxGarden';
 import {
     createGameState,
     GameStateContext,
@@ -131,6 +132,7 @@ type ItemsHudStoryOptions = {
     accountSunflowers?: number;
     closeup?: boolean;
     isSandbox?: boolean;
+    localSandboxStorageKey?: string;
     pickupBlock?: boolean;
     trashTargetActive?: boolean;
 };
@@ -172,6 +174,7 @@ function ItemsHudTestProviders({
     children,
     accountSunflowers,
     isSandbox = false,
+    localSandboxStorageKey,
     closeup = false,
     pickupBlock = false,
     trashTargetActive = false,
@@ -185,6 +188,7 @@ function ItemsHudTestProviders({
             appBaseUrl: 'http://localhost',
             freezeTime: new Date('2026-05-13T12:00:00.000Z'),
             isMock: false,
+            localSandboxStorageKey,
             winterMode: 'summer',
         });
         if (pickupBlock) {
@@ -201,7 +205,7 @@ function ItemsHudTestProviders({
             store.setState({ view: 'closeup' });
         }
         return store;
-    }, [closeup, pickupBlock, trashTargetActive]);
+    }, [closeup, localSandboxStorageKey, pickupBlock, trashTargetActive]);
 
     return (
         <NuqsTestingAdapter>
@@ -306,6 +310,25 @@ export function ItemsHudControlsTooltipStory() {
 export function SandboxItemsHudStory() {
     return (
         <ItemsHudTestProviders isSandbox>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <BottomControlsTestFrame />
+                    <ItemsHudTestFrame />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}
+
+export function LocalSandboxItemsHudStory() {
+    return (
+        <ItemsHudTestProviders
+            isSandbox
+            localSandboxStorageKey={`${defaultLocalSandboxStorageKey}.items-hud-test`}
+        >
             <div className="relative h-screen w-screen overflow-hidden">
                 <div
                     data-testid="bottom-hud"

--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -3,6 +3,7 @@ import {
     CloseupBottomHudStory,
     ItemsHudAlignmentStory,
     ItemsHudControlsTooltipStory,
+    LocalSandboxItemsHudStory,
     LowSunflowerBalanceItemsHudStory,
     SandboxBlockTrashDropTargetStory,
     SandboxItemsHudStory,
@@ -340,6 +341,18 @@ test('sandbox decoration picker includes special blocks', async ({
     await expect(
         page.getByRole('button', { name: 'Block Snow Falling' }),
     ).toBeVisible();
+});
+
+test('local sandbox decoration picker includes sunflower', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<LocalSandboxItemsHudStory />);
+
+    await page.getByRole('button', { name: 'Dekoracija' }).click();
+
+    await expect(page.getByRole('button', { name: 'Sunflower' })).toBeVisible();
 });
 
 test('item picker price buttons use the soft surface', async ({

--- a/packages/game/src/localSandboxBlockData.ts
+++ b/packages/game/src/localSandboxBlockData.ts
@@ -56,6 +56,7 @@ export const localSandboxBlockNames = [
     'DeadTreeTall',
     'DeadTreeStump',
     'Tulip',
+    'Sunflower',
     'CactusBarrel',
     'CactusColumnCluster',
     'CactusPricklyPear',
@@ -123,6 +124,7 @@ const localSandboxStackHeights: Partial<Record<LocalSandboxBlockName, number>> =
         PineAdvent: 2.6,
         Raised_Bed: 0.35,
         Snowman: 0.5,
+        Sunflower: 1,
     };
 
 type LocalSandboxHitboxAttributes = Partial<

--- a/packages/game/src/localSandboxBlockData.unit.ts
+++ b/packages/game/src/localSandboxBlockData.unit.ts
@@ -70,6 +70,20 @@ test('local sandbox exposes animal home blocks used by the item HUD', () => {
     assert.equal(blockNames.has('DogHouse'), true);
 });
 
+test('local sandbox exposes flower decorations used by the item HUD', () => {
+    const blockData = getLocalSandboxBlockData();
+    const blockNames = new Set(
+        blockData.map((block) => block.information.name),
+    );
+    const sunflower = blockData.find(
+        (block) => block.information.name === 'Sunflower',
+    );
+
+    assert.equal(blockNames.has('Tulip'), true);
+    assert.equal(blockNames.has('Sunflower'), true);
+    assert.equal(sunflower?.attributes.height, 1);
+});
+
 test('local sandbox does not expose mulch as placeable blocks', () => {
     const blockData = getLocalSandboxBlockData();
     const blockNames = new Set(


### PR DESCRIPTION
## Summary
- Add Sunflower to the local sandbox block set with the correct stack height
- Wire the item HUD story to a dedicated local sandbox storage key so the picker reflects the local sandbox inventory
- Add unit and Playwright coverage for the new sunflower entry in the decoration picker

## Testing
- Unit tests added for local sandbox block data coverage
- Playwright UI test added for the local sandbox decoration picker