### PR TITLE
Improve news filtering and changelog tag presentation

### DIFF
--- a/apps/news/app/page.tsx
+++ b/apps/news/app/page.tsx
@@ -1,4 +1,5 @@
 import { Container } from '@gredice/ui/Container';
+import type { Route } from 'next';
 import { EmptyNewsState } from '../components/EmptyNewsState';
 import { FilterPills } from '../components/FilterPills';
 import {
@@ -21,7 +22,7 @@ const newsTypeFilters = [
 
 type NewsLandingItem = {
     entry: NewsCardEntry;
-    href: string;
+    href: Route;
     kind: NewsCardKind;
     sortTime: number;
 };
@@ -50,7 +51,8 @@ export default async function NewsHomePage({
 }) {
     const { category, tag, type } = await searchParams;
     const activeType = normalizeNewsTypeFilter(type);
-    const normalizedCategory = normalizeFilterValue(category);
+    const activeCategory = activeType === 'changelog' ? undefined : category;
+    const normalizedCategory = normalizeFilterValue(activeCategory);
     const normalizedTag = normalizeFilterValue(tag);
     const [allPosts, allChangelogEntries] = await Promise.all([
         getBlogPosts(),
@@ -59,18 +61,18 @@ export default async function NewsHomePage({
     const allItems: NewsLandingItem[] = [
         ...allPosts.map((entry) => ({
             entry,
-            href: `/${entry.slug}`,
+            href: `/${entry.slug}` as Route,
             kind: 'blog' as const,
             sortTime: normalizedTime(entry.publishedAt),
         })),
         ...allChangelogEntries.map((entry) => ({
             entry,
-            href: `/sto-je-novo/${entry.slug}`,
+            href: `/sto-je-novo/${entry.slug}` as Route,
             kind: 'changelog' as const,
             sortTime: normalizedTime(entry.publishedAt),
         })),
     ].sort((left, right) => right.sortTime - left.sortTime);
-    const currentFilters = { category, tag, type: activeType };
+    const currentFilters = { category: activeCategory, tag, type: activeType };
     const categories =
         activeType === 'changelog'
             ? []
@@ -142,7 +144,7 @@ export default async function NewsHomePage({
                     values={newsTypeFilters}
                 />
                 <FilterPills
-                    active={category}
+                    active={activeCategory}
                     currentFilters={currentFilters}
                     label="Kategorije"
                     param="category"

--- a/apps/news/app/page.tsx
+++ b/apps/news/app/page.tsx
@@ -1,58 +1,169 @@
+import { Container } from '@gredice/ui/Container';
 import { EmptyNewsState } from '../components/EmptyNewsState';
 import { FilterPills } from '../components/FilterPills';
-import { NewsCard } from '../components/NewsCard';
-import { getBlogPosts, uniqueNewsValues } from '../lib/news';
+import {
+    NewsCard,
+    type NewsCardEntry,
+    type NewsCardKind,
+} from '../components/NewsCard';
+import {
+    getBlogPosts,
+    getChangelogEntries,
+    uniqueNewsValues,
+} from '../lib/news';
 
 export const dynamic = 'force-dynamic';
+
+const newsTypeFilters = [
+    { label: 'Blog', value: 'blog' },
+    { label: 'Što je novo', value: 'changelog' },
+] satisfies { label: string; value: NewsCardKind }[];
+
+type NewsLandingItem = {
+    entry: NewsCardEntry;
+    href: string;
+    kind: NewsCardKind;
+    sortTime: number;
+};
+
+function normalizedTime(value: string | null | undefined) {
+    if (!value) {
+        return 0;
+    }
+
+    const time = new Date(value).getTime();
+    return Number.isNaN(time) ? 0 : time;
+}
+
+function normalizeNewsTypeFilter(value: string | undefined) {
+    return value === 'blog' || value === 'changelog' ? value : undefined;
+}
+
+function normalizeFilterValue(value: string | undefined) {
+    return value?.trim().toLocaleLowerCase('hr-HR');
+}
 
 export default async function NewsHomePage({
     searchParams,
 }: {
-    searchParams: Promise<{ category?: string; tag?: string }>;
+    searchParams: Promise<{ category?: string; tag?: string; type?: string }>;
 }) {
-    const { category, tag } = await searchParams;
-    const [allPosts, posts] = await Promise.all([
+    const { category, tag, type } = await searchParams;
+    const activeType = normalizeNewsTypeFilter(type);
+    const normalizedCategory = normalizeFilterValue(category);
+    const normalizedTag = normalizeFilterValue(tag);
+    const [allPosts, allChangelogEntries] = await Promise.all([
         getBlogPosts(),
-        category || tag ? getBlogPosts({ category, tag }) : getBlogPosts(),
+        getChangelogEntries(),
     ]);
-    const categories = uniqueNewsValues(allPosts, (item) => item.category);
-    const tags = uniqueNewsValues(allPosts, (item) => item.tags);
+    const allItems: NewsLandingItem[] = [
+        ...allPosts.map((entry) => ({
+            entry,
+            href: `/${entry.slug}`,
+            kind: 'blog' as const,
+            sortTime: normalizedTime(entry.publishedAt),
+        })),
+        ...allChangelogEntries.map((entry) => ({
+            entry,
+            href: `/sto-je-novo/${entry.slug}`,
+            kind: 'changelog' as const,
+            sortTime: normalizedTime(entry.publishedAt),
+        })),
+    ].sort((left, right) => right.sortTime - left.sortTime);
+    const currentFilters = { category, tag, type: activeType };
+    const categories =
+        activeType === 'changelog'
+            ? []
+            : uniqueNewsValues(allPosts, (item) => item.category);
+    const itemsForTagFilters = allItems.filter((item) => {
+        if (activeType && item.kind !== activeType) {
+            return false;
+        }
+
+        if (
+            normalizedCategory &&
+            normalizeFilterValue(item.entry.category ?? undefined) !==
+                normalizedCategory
+        ) {
+            return false;
+        }
+
+        return true;
+    });
+    const tags = uniqueNewsValues(
+        itemsForTagFilters,
+        (item) => item.entry.tags,
+    );
+    const visibleItems = allItems.filter((item) => {
+        if (activeType && item.kind !== activeType) {
+            return false;
+        }
+
+        if (
+            normalizedCategory &&
+            normalizeFilterValue(item.entry.category ?? undefined) !==
+                normalizedCategory
+        ) {
+            return false;
+        }
+
+        if (
+            normalizedTag &&
+            !item.entry.tags.some(
+                (itemTag) => normalizeFilterValue(itemTag) === normalizedTag,
+            )
+        ) {
+            return false;
+        }
+
+        return true;
+    });
 
     return (
-        <div className="mx-auto grid w-full max-w-6xl gap-8 px-4 py-10 sm:px-6 lg:px-8">
+        <Container className="grid gap-8 py-10">
             <section className="grid gap-3">
                 <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                     Novosti
                 </p>
                 <h1 className="max-w-3xl text-3xl font-bold leading-tight md:text-4xl">
-                    Blog iz Gredica
+                    Novosti iz Gredica
                 </h1>
                 <p className="max-w-2xl text-lg text-muted-foreground">
-                    Savjeti, priče iz vrta i obavijesti koje pomažu pratiti što
-                    se događa u Gredicama.
+                    Blog objave i promjene proizvoda koje pomažu pratiti što se
+                    događa u Gredicama.
                 </p>
             </section>
             <aside className="grid gap-4 rounded-md border bg-muted/15 p-4">
                 <FilterPills
+                    active={activeType}
+                    currentFilters={currentFilters}
+                    label="Vrsta"
+                    param="type"
+                    values={newsTypeFilters}
+                />
+                <FilterPills
                     active={category}
+                    currentFilters={currentFilters}
                     label="Kategorije"
                     param="category"
                     values={categories}
                 />
                 <FilterPills
                     active={tag}
+                    currentFilters={currentFilters}
                     label="Tagovi"
                     param="tag"
                     values={tags}
                 />
             </aside>
-            {posts.length > 0 ? (
+            {visibleItems.length > 0 ? (
                 <section className="grid gap-4">
-                    {posts.map((post) => (
+                    {visibleItems.map((item) => (
                         <NewsCard
-                            key={post.id}
-                            entry={post}
-                            href={`/${post.slug}`}
+                            key={`${item.kind}-${item.href}`}
+                            entry={item.entry}
+                            href={item.href}
+                            kind={item.kind}
                         />
                     ))}
                 </section>
@@ -61,6 +172,6 @@ export default async function NewsHomePage({
                     Trenutačno nema objavljenih novosti.
                 </EmptyNewsState>
             )}
-        </div>
+        </Container>
     );
 }

--- a/apps/news/app/sto-je-novo/page.tsx
+++ b/apps/news/app/sto-je-novo/page.tsx
@@ -1,5 +1,7 @@
+import { Container } from '@gredice/ui/Container';
 import { Timeline, TimelineEntry, TimelineGroup } from '@gredice/ui/Timeline';
 import Link from 'next/link';
+import { ChangelogTagFilters } from '../../components/ChangelogTagFilters';
 import { EmptyNewsState } from '../../components/EmptyNewsState';
 import {
     formatNewsDate,
@@ -13,6 +15,8 @@ const monthFormatter = new Intl.DateTimeFormat('hr-HR', {
     month: 'long',
     year: 'numeric',
 });
+const primaryTagLimit = 8;
+const recentPrimaryTagLimit = 4;
 
 type ChangelogEntry = Awaited<ReturnType<typeof getChangelogEntries>>[number];
 
@@ -64,6 +68,67 @@ function groupEntriesByMonth(entries: ChangelogEntry[]) {
     return groups;
 }
 
+function getPrimaryTags(entries: ChangelogEntry[]) {
+    const primaryTags = new Map<string, string>();
+    const tagStats = new Map<
+        string,
+        {
+            count: number;
+            latestTime: number;
+            value: string;
+        }
+    >();
+
+    for (const entry of entries) {
+        const latestTime = getEntryDate(entry)?.getTime() ?? 0;
+
+        for (const tag of entry.tags) {
+            const normalized = tag.trim();
+            if (!normalized) {
+                continue;
+            }
+
+            const key = normalized.toLocaleLowerCase('hr-HR');
+            if (primaryTags.size < recentPrimaryTagLimit) {
+                primaryTags.set(key, normalized);
+            }
+
+            const current = tagStats.get(key);
+            tagStats.set(key, {
+                count: (current?.count ?? 0) + 1,
+                latestTime: Math.max(current?.latestTime ?? 0, latestTime),
+                value: current?.value ?? normalized,
+            });
+        }
+    }
+
+    const popularTags = Array.from(tagStats.values())
+        .sort((left, right) => {
+            const countDiff = right.count - left.count;
+            if (countDiff !== 0) {
+                return countDiff;
+            }
+
+            const latestDiff = right.latestTime - left.latestTime;
+            if (latestDiff !== 0) {
+                return latestDiff;
+            }
+
+            return left.value.localeCompare(right.value, 'hr-HR');
+        })
+        .map((item) => item.value);
+
+    for (const tag of popularTags) {
+        if (primaryTags.size >= primaryTagLimit) {
+            break;
+        }
+
+        primaryTags.set(tag.toLocaleLowerCase('hr-HR'), tag);
+    }
+
+    return Array.from(primaryTags.values());
+}
+
 export default async function WhatsNewPage({
     searchParams,
 }: {
@@ -75,12 +140,19 @@ export default async function WhatsNewPage({
         tag ? getChangelogEntries({ tag }) : getChangelogEntries(),
     ]);
     const tags = uniqueNewsValues(allEntries, (item) => item.tags);
+    const primaryTags = getPrimaryTags(allEntries);
+    const primaryTagKeys = new Set(
+        primaryTags.map((value) => value.toLocaleLowerCase('hr-HR')),
+    );
+    const dropdownTags = tags.filter(
+        (value) => !primaryTagKeys.has(value.toLocaleLowerCase('hr-HR')),
+    );
     const timelineGroups = groupEntriesByMonth(entries);
     const totalEntries = entries.length;
     let entryIndex = 0;
 
     return (
-        <div className="mx-auto grid w-full max-w-6xl gap-8 px-4 py-10 sm:px-6 lg:px-8">
+        <Container className="grid gap-8 py-10">
             <section className="grid gap-3">
                 <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
                     Što je novo
@@ -94,31 +166,11 @@ export default async function WhatsNewPage({
                 </p>
             </section>
             {tags.length > 0 ? (
-                <div className="flex flex-wrap gap-2">
-                    <Link
-                        className={`rounded-sm border px-3 py-1.5 text-sm font-medium ${
-                            tag
-                                ? 'bg-background text-muted-foreground'
-                                : 'bg-primary text-primary-foreground'
-                        }`}
-                        href="/sto-je-novo"
-                    >
-                        Sve
-                    </Link>
-                    {tags.map((value) => (
-                        <Link
-                            key={value}
-                            className={`rounded-sm border px-3 py-1.5 text-sm font-medium ${
-                                tag === value
-                                    ? 'bg-primary text-primary-foreground'
-                                    : 'bg-background text-muted-foreground hover:text-foreground'
-                            }`}
-                            href={`/sto-je-novo?tag=${encodeURIComponent(value)}`}
-                        >
-                            {value}
-                        </Link>
-                    ))}
-                </div>
+                <ChangelogTagFilters
+                    activeTag={tag}
+                    dropdownTags={dropdownTags}
+                    primaryTags={primaryTags}
+                />
             ) : null}
             {entries.length > 0 ? (
                 <Timeline>
@@ -155,11 +207,12 @@ export default async function WhatsNewPage({
                                             href={`/sto-je-novo/${entry.slug}`}
                                         >
                                             <div className="grid gap-3 p-5">
-                                                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+                                                <div className="flex flex-wrap items-center gap-2">
                                                     {entry.tags.map(
                                                         (entryTag) => (
                                                             <span
                                                                 key={entryTag}
+                                                                className="rounded-sm border bg-secondary px-2 py-1 text-xs font-semibold uppercase tracking-normal text-secondary-foreground"
                                                             >
                                                                 {entryTag}
                                                             </span>
@@ -197,6 +250,6 @@ export default async function WhatsNewPage({
                     Trenutačno nema objavljenih novosti.
                 </EmptyNewsState>
             )}
-        </div>
+        </Container>
     );
 }

--- a/apps/news/components/ChangelogTagFilters.tsx
+++ b/apps/news/components/ChangelogTagFilters.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import type { Route } from 'next';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+const changelogPath = '/sto-je-novo' satisfies Route;
+
+function tagPath(tag: string): Route {
+    return `${changelogPath}?tag=${encodeURIComponent(tag)}` as Route;
+}
+
+export function ChangelogTagFilters({
+    activeTag,
+    dropdownTags,
+    primaryTags,
+}: {
+    activeTag?: string;
+    dropdownTags: string[];
+    primaryTags: string[];
+}) {
+    const router = useRouter();
+
+    return (
+        <div className="flex flex-wrap items-center gap-2">
+            <Link
+                className={`rounded-sm border px-3 py-1.5 text-sm font-medium ${
+                    activeTag
+                        ? 'bg-background text-muted-foreground'
+                        : 'bg-primary text-primary-foreground'
+                }`}
+                href={changelogPath}
+            >
+                Sve
+            </Link>
+            {primaryTags.map((value) => (
+                <Link
+                    key={value}
+                    className={`rounded-sm border px-3 py-1.5 text-sm font-medium ${
+                        activeTag === value
+                            ? 'bg-primary text-primary-foreground'
+                            : 'bg-background text-muted-foreground hover:text-foreground'
+                    }`}
+                    href={tagPath(value)}
+                >
+                    {value}
+                </Link>
+            ))}
+            {dropdownTags.length > 0 ? (
+                <select
+                    aria-label="Ostali tagovi"
+                    className="min-h-9 rounded-sm border bg-background px-3 py-1.5 text-sm font-medium text-muted-foreground outline-hidden transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                    onChange={(event) => {
+                        const selectedTag = event.currentTarget.value;
+                        router.push(
+                            selectedTag ? tagPath(selectedTag) : changelogPath,
+                        );
+                    }}
+                    value={
+                        activeTag && dropdownTags.includes(activeTag)
+                            ? activeTag
+                            : ''
+                    }
+                >
+                    <option value="">Ostali tagovi</option>
+                    {dropdownTags.map((value) => (
+                        <option key={value} value={value}>
+                            {value}
+                        </option>
+                    ))}
+                </select>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/news/components/FilterPills.tsx
+++ b/apps/news/components/FilterPills.tsx
@@ -26,6 +26,10 @@ function filterHref({
     const params = new URLSearchParams();
 
     for (const [key, filterValue] of Object.entries(currentFilters ?? {})) {
+        if (key === 'category' && param === 'type' && value === 'changelog') {
+            continue;
+        }
+
         if (key !== param && filterValue) {
             params.set(key, filterValue);
         }

--- a/apps/news/components/FilterPills.tsx
+++ b/apps/news/components/FilterPills.tsx
@@ -1,15 +1,56 @@
+import type { Route } from 'next';
 import Link from 'next/link';
+
+type FilterParam = 'category' | 'tag' | 'type';
+
+type FilterOption = {
+    label: string;
+    value: string;
+};
+
+type CurrentFilters = Partial<Record<FilterParam, string | undefined>>;
+
+function filterOption(value: string | FilterOption): FilterOption {
+    return typeof value === 'string' ? { label: value, value } : value;
+}
+
+function filterHref({
+    currentFilters,
+    param,
+    value,
+}: {
+    currentFilters?: CurrentFilters;
+    param: FilterParam;
+    value?: string;
+}): Route {
+    const params = new URLSearchParams();
+
+    for (const [key, filterValue] of Object.entries(currentFilters ?? {})) {
+        if (key !== param && filterValue) {
+            params.set(key, filterValue);
+        }
+    }
+
+    if (value) {
+        params.set(param, value);
+    }
+
+    const query = params.toString();
+    return (query ? `/?${query}` : '/') as Route;
+}
 
 export function FilterPills({
     active,
+    currentFilters,
     label,
     param,
     values,
 }: {
     active?: string;
+    currentFilters?: CurrentFilters;
     label: string;
-    param: 'category' | 'tag';
-    values: string[];
+    param: FilterParam;
+    values: (string | FilterOption)[];
 }) {
     if (values.length === 0) {
         return null;
@@ -27,23 +68,31 @@ export function FilterPills({
                             ? 'bg-background text-muted-foreground'
                             : 'bg-primary text-primary-foreground'
                     }`}
-                    href="/"
+                    href={filterHref({ currentFilters, param })}
                 >
                     Sve
                 </Link>
-                {values.map((value) => (
-                    <Link
-                        key={value}
-                        className={`rounded-sm border px-3 py-1.5 text-sm font-medium ${
-                            active === value
-                                ? 'bg-primary text-primary-foreground'
-                                : 'bg-background text-muted-foreground hover:text-foreground'
-                        }`}
-                        href={`/?${param}=${encodeURIComponent(value)}`}
-                    >
-                        {value}
-                    </Link>
-                ))}
+                {values.map((rawValue) => {
+                    const option = filterOption(rawValue);
+
+                    return (
+                        <Link
+                            key={option.value}
+                            className={`rounded-sm border px-3 py-1.5 text-sm font-medium ${
+                                active === option.value
+                                    ? 'bg-primary text-primary-foreground'
+                                    : 'bg-background text-muted-foreground hover:text-foreground'
+                            }`}
+                            href={filterHref({
+                                currentFilters,
+                                param,
+                                value: option.value,
+                            })}
+                        >
+                            {option.label}
+                        </Link>
+                    );
+                })}
             </div>
         </div>
     );

--- a/apps/news/components/NewsCard.tsx
+++ b/apps/news/components/NewsCard.tsx
@@ -1,17 +1,41 @@
-import type { NewsListItem } from '../lib/news';
 import { formatNewsDate } from '../lib/news';
+
+export type NewsCardKind = 'blog' | 'changelog';
+
+export type NewsCardEntry = {
+    category?: string | null;
+    excerpt?: string | null;
+    metaImageUrl?: string | null;
+    publishedAt?: string | null;
+    tags: string[];
+    title: string;
+};
+
+const kindLabels = {
+    blog: 'Blog',
+    changelog: 'Što je novo',
+} satisfies Record<NewsCardKind, string>;
 
 export function NewsCard({
     entry,
     href,
+    kind,
 }: {
-    entry: NewsListItem;
+    entry: NewsCardEntry;
     href: string;
+    kind: NewsCardKind;
 }) {
     return (
-        <article className="grid overflow-hidden rounded-md border bg-card shadow-xs md:grid-cols-[minmax(0,1fr)_220px]">
+        <article
+            className={`grid overflow-hidden rounded-md border bg-card shadow-xs ${
+                entry.metaImageUrl ? 'md:grid-cols-[minmax(0,1fr)_220px]' : ''
+            }`}
+        >
             <a className="grid gap-4 p-5 md:p-6" href={href}>
                 <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
+                    <span className="rounded-sm border bg-secondary px-2 py-1 text-secondary-foreground">
+                        {kindLabels[kind]}
+                    </span>
                     {entry.category ? <span>{entry.category}</span> : null}
                     {entry.publishedAt ? (
                         <span>{formatNewsDate(entry.publishedAt)}</span>

--- a/apps/news/components/NewsCard.tsx
+++ b/apps/news/components/NewsCard.tsx
@@ -1,3 +1,5 @@
+import type { Route } from 'next';
+import Link from 'next/link';
 import { formatNewsDate } from '../lib/news';
 
 export type NewsCardKind = 'blog' | 'changelog';
@@ -22,7 +24,7 @@ export function NewsCard({
     kind,
 }: {
     entry: NewsCardEntry;
-    href: string;
+    href: Route;
     kind: NewsCardKind;
 }) {
     return (
@@ -31,7 +33,7 @@ export function NewsCard({
                 entry.metaImageUrl ? 'md:grid-cols-[minmax(0,1fr)_220px]' : ''
             }`}
         >
-            <a className="grid gap-4 p-5 md:p-6" href={href}>
+            <Link className="grid gap-4 p-5 md:p-6" href={href}>
                 <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
                     <span className="rounded-sm border bg-secondary px-2 py-1 text-secondary-foreground">
                         {kindLabels[kind]}
@@ -63,9 +65,9 @@ export function NewsCard({
                         ))}
                     </div>
                 ) : null}
-            </a>
+            </Link>
             {entry.metaImageUrl ? (
-                <a
+                <Link
                     className="block min-h-48 border-t bg-muted/30 md:border-l md:border-t-0"
                     href={href}
                 >
@@ -75,7 +77,7 @@ export function NewsCard({
                         className="h-full min-h-48 w-full object-cover"
                         src={entry.metaImageUrl}
                     />
-                </a>
+                </Link>
             ) : null}
         </article>
     );

--- a/apps/news/lib/news.ts
+++ b/apps/news/lib/news.ts
@@ -80,9 +80,9 @@ export function formatNewsDate(value: string | Date | null) {
     }).format(new Date(value));
 }
 
-export function uniqueNewsValues(
-    items: NewsListItem[],
-    getter: (item: NewsListItem) => string | string[] | null,
+export function uniqueNewsValues<T>(
+    items: T[],
+    getter: (item: T) => string | string[] | null | undefined,
 ) {
     const values = new Map<string, string>();
     for (const item of items) {


### PR DESCRIPTION
## Summary
- Add type-based filtering to the news landing page and merge blog and changelog items into one sorted feed
- Rework news filter pills so filters preserve each other when switching categories, tags, and type
- Upgrade changelog tag browsing with primary tag pills, an overflow dropdown, and clearer tag badges
- Align the news and changelog pages with the shared container layout

## Testing
- Not run (not requested)