### PR TITLE
[codex] Update news tag routing and cards

### DIFF
--- a/apps/news/app/page.tsx
+++ b/apps/news/app/page.tsx
@@ -1,5 +1,6 @@
 import { Container } from '@gredice/ui/Container';
 import type { Route } from 'next';
+import { redirect } from 'next/navigation';
 import { EmptyNewsState } from '../components/EmptyNewsState';
 import { FilterPills } from '../components/FilterPills';
 import {
@@ -7,9 +8,11 @@ import {
     type NewsCardEntry,
     type NewsCardKind,
 } from '../components/NewsCard';
+import { NewsTagFilters } from '../components/NewsTagFilters';
 import {
     getBlogPosts,
     getChangelogEntries,
+    getPrimaryNewsTags,
     uniqueNewsValues,
 } from '../lib/news';
 
@@ -44,16 +47,24 @@ function normalizeFilterValue(value: string | undefined) {
     return value?.trim().toLocaleLowerCase('hr-HR');
 }
 
+function changelogTagRedirectPath(tag: string): Route {
+    return `/sto-je-novo?tag=${encodeURIComponent(tag)}` as Route;
+}
+
 export default async function NewsHomePage({
     searchParams,
 }: {
     searchParams: Promise<{ category?: string; tag?: string; type?: string }>;
 }) {
     const { category, tag, type } = await searchParams;
+    const requestedTag = tag?.trim();
+    if (requestedTag) {
+        redirect(changelogTagRedirectPath(requestedTag));
+    }
+
     const activeType = normalizeNewsTypeFilter(type);
     const activeCategory = activeType === 'changelog' ? undefined : category;
     const normalizedCategory = normalizeFilterValue(activeCategory);
-    const normalizedTag = normalizeFilterValue(tag);
     const [allPosts, allChangelogEntries] = await Promise.all([
         getBlogPosts(),
         getChangelogEntries(),
@@ -72,29 +83,18 @@ export default async function NewsHomePage({
             sortTime: normalizedTime(entry.publishedAt),
         })),
     ].sort((left, right) => right.sortTime - left.sortTime);
-    const currentFilters = { category: activeCategory, tag, type: activeType };
+    const currentFilters = { category: activeCategory, type: activeType };
     const categories =
         activeType === 'changelog'
             ? []
             : uniqueNewsValues(allPosts, (item) => item.category);
-    const itemsForTagFilters = allItems.filter((item) => {
-        if (activeType && item.kind !== activeType) {
-            return false;
-        }
-
-        if (
-            normalizedCategory &&
-            normalizeFilterValue(item.entry.category ?? undefined) !==
-                normalizedCategory
-        ) {
-            return false;
-        }
-
-        return true;
-    });
-    const tags = uniqueNewsValues(
-        itemsForTagFilters,
-        (item) => item.entry.tags,
+    const tags = uniqueNewsValues(allChangelogEntries, (item) => item.tags);
+    const primaryTags = getPrimaryNewsTags(allChangelogEntries);
+    const primaryTagKeys = new Set(
+        primaryTags.map((value) => value.toLocaleLowerCase('hr-HR')),
+    );
+    const dropdownTags = tags.filter(
+        (value) => !primaryTagKeys.has(value.toLocaleLowerCase('hr-HR')),
     );
     const visibleItems = allItems.filter((item) => {
         if (activeType && item.kind !== activeType) {
@@ -105,15 +105,6 @@ export default async function NewsHomePage({
             normalizedCategory &&
             normalizeFilterValue(item.entry.category ?? undefined) !==
                 normalizedCategory
-        ) {
-            return false;
-        }
-
-        if (
-            normalizedTag &&
-            !item.entry.tags.some(
-                (itemTag) => normalizeFilterValue(itemTag) === normalizedTag,
-            )
         ) {
             return false;
         }
@@ -150,16 +141,20 @@ export default async function NewsHomePage({
                     param="category"
                     values={categories}
                 />
-                <FilterPills
-                    active={tag}
-                    currentFilters={currentFilters}
-                    label="Tagovi"
-                    param="tag"
-                    values={tags}
-                />
+                {tags.length > 0 ? (
+                    <div className="grid gap-2">
+                        <p className="text-xs font-semibold uppercase text-muted-foreground">
+                            Tagovi
+                        </p>
+                        <NewsTagFilters
+                            dropdownTags={dropdownTags}
+                            primaryTags={primaryTags}
+                        />
+                    </div>
+                ) : null}
             </aside>
             {visibleItems.length > 0 ? (
-                <section className="grid gap-4">
+                <section className="grid gap-4 md:grid-cols-2">
                     {visibleItems.map((item) => (
                         <NewsCard
                             key={`${item.kind}-${item.href}`}

--- a/apps/news/app/sto-je-novo/page.tsx
+++ b/apps/news/app/sto-je-novo/page.tsx
@@ -1,11 +1,13 @@
 import { Container } from '@gredice/ui/Container';
 import { Timeline, TimelineEntry, TimelineGroup } from '@gredice/ui/Timeline';
-import Link from 'next/link';
-import { ChangelogTagFilters } from '../../components/ChangelogTagFilters';
+import type { Route } from 'next';
 import { EmptyNewsState } from '../../components/EmptyNewsState';
+import { NewsCard } from '../../components/NewsCard';
+import { NewsTagFilters } from '../../components/NewsTagFilters';
 import {
     formatNewsDate,
     getChangelogEntries,
+    getPrimaryNewsTags,
     uniqueNewsValues,
 } from '../../lib/news';
 
@@ -15,9 +17,6 @@ const monthFormatter = new Intl.DateTimeFormat('hr-HR', {
     month: 'long',
     year: 'numeric',
 });
-const primaryTagLimit = 8;
-const recentPrimaryTagLimit = 4;
-
 type ChangelogEntry = Awaited<ReturnType<typeof getChangelogEntries>>[number];
 
 type ChangelogTimelineGroup = {
@@ -68,65 +67,8 @@ function groupEntriesByMonth(entries: ChangelogEntry[]) {
     return groups;
 }
 
-function getPrimaryTags(entries: ChangelogEntry[]) {
-    const primaryTags = new Map<string, string>();
-    const tagStats = new Map<
-        string,
-        {
-            count: number;
-            latestTime: number;
-            value: string;
-        }
-    >();
-
-    for (const entry of entries) {
-        const latestTime = getEntryDate(entry)?.getTime() ?? 0;
-
-        for (const tag of entry.tags) {
-            const normalized = tag.trim();
-            if (!normalized) {
-                continue;
-            }
-
-            const key = normalized.toLocaleLowerCase('hr-HR');
-            if (primaryTags.size < recentPrimaryTagLimit) {
-                primaryTags.set(key, normalized);
-            }
-
-            const current = tagStats.get(key);
-            tagStats.set(key, {
-                count: (current?.count ?? 0) + 1,
-                latestTime: Math.max(current?.latestTime ?? 0, latestTime),
-                value: current?.value ?? normalized,
-            });
-        }
-    }
-
-    const popularTags = Array.from(tagStats.values())
-        .sort((left, right) => {
-            const countDiff = right.count - left.count;
-            if (countDiff !== 0) {
-                return countDiff;
-            }
-
-            const latestDiff = right.latestTime - left.latestTime;
-            if (latestDiff !== 0) {
-                return latestDiff;
-            }
-
-            return left.value.localeCompare(right.value, 'hr-HR');
-        })
-        .map((item) => item.value);
-
-    for (const tag of popularTags) {
-        if (primaryTags.size >= primaryTagLimit) {
-            break;
-        }
-
-        primaryTags.set(tag.toLocaleLowerCase('hr-HR'), tag);
-    }
-
-    return Array.from(primaryTags.values());
+function changelogEntryPath(slug: string): Route {
+    return `/sto-je-novo/${slug}` as Route;
 }
 
 export default async function WhatsNewPage({
@@ -140,7 +82,7 @@ export default async function WhatsNewPage({
         tag ? getChangelogEntries({ tag }) : getChangelogEntries(),
     ]);
     const tags = uniqueNewsValues(allEntries, (item) => item.tags);
-    const primaryTags = getPrimaryTags(allEntries);
+    const primaryTags = getPrimaryNewsTags(allEntries);
     const primaryTagKeys = new Set(
         primaryTags.map((value) => value.toLocaleLowerCase('hr-HR')),
     );
@@ -166,7 +108,7 @@ export default async function WhatsNewPage({
                 </p>
             </section>
             {tags.length > 0 ? (
-                <ChangelogTagFilters
+                <NewsTagFilters
                     activeTag={tag}
                     dropdownTags={dropdownTags}
                     primaryTags={primaryTags}
@@ -198,47 +140,15 @@ export default async function WhatsNewPage({
                                         key={entry.id}
                                         label={dateLabel ?? 'Bez datuma'}
                                     >
-                                        <Link
-                                            className={`grid overflow-hidden rounded-md border bg-card shadow-xs transition-colors hover:bg-muted/20 ${
-                                                entry.metaImageUrl
-                                                    ? 'md:grid-cols-[minmax(0,1fr)_220px]'
-                                                    : ''
-                                            }`}
-                                            href={`/sto-je-novo/${entry.slug}`}
-                                        >
-                                            <div className="grid gap-3 p-5">
-                                                <div className="flex flex-wrap items-center gap-2">
-                                                    {entry.tags.map(
-                                                        (entryTag) => (
-                                                            <span
-                                                                key={entryTag}
-                                                                className="rounded-sm border bg-secondary px-2 py-1 text-xs font-semibold uppercase tracking-normal text-secondary-foreground"
-                                                            >
-                                                                {entryTag}
-                                                            </span>
-                                                        ),
-                                                    )}
-                                                </div>
-                                                <h2 className="text-xl font-bold leading-tight">
-                                                    {entry.title}
-                                                </h2>
-                                                {entry.excerpt ? (
-                                                    <p className="text-sm leading-6 text-muted-foreground">
-                                                        {entry.excerpt}
-                                                    </p>
-                                                ) : null}
-                                            </div>
-                                            {entry.metaImageUrl ? (
-                                                <div className="min-h-48 border-t bg-muted/30 md:border-l md:border-t-0">
-                                                    {/* biome-ignore lint/performance/noImgElement: CMS images are remote author content. */}
-                                                    <img
-                                                        alt=""
-                                                        className="h-full min-h-48 w-full object-cover"
-                                                        src={entry.metaImageUrl}
-                                                    />
-                                                </div>
-                                            ) : null}
-                                        </Link>
+                                        <NewsCard
+                                            entry={entry}
+                                            href={changelogEntryPath(
+                                                entry.slug,
+                                            )}
+                                            kind="changelog"
+                                            showDate={false}
+                                            showKindLabel={false}
+                                        />
                                     </TimelineEntry>
                                 );
                             })}

--- a/apps/news/components/NewsCard.tsx
+++ b/apps/news/components/NewsCard.tsx
@@ -22,64 +22,75 @@ export function NewsCard({
     entry,
     href,
     kind,
+    showDate = true,
+    showKindLabel = true,
 }: {
     entry: NewsCardEntry;
     href: Route;
     kind: NewsCardKind;
+    showDate?: boolean;
+    showKindLabel?: boolean;
 }) {
+    const dateLabel =
+        showDate && entry.publishedAt
+            ? formatNewsDate(entry.publishedAt)
+            : null;
+    const hasMetadata = showKindLabel || entry.category || dateLabel;
+
     return (
-        <article
-            className={`grid overflow-hidden rounded-md border bg-card shadow-xs ${
-                entry.metaImageUrl ? 'md:grid-cols-[minmax(0,1fr)_220px]' : ''
-            }`}
-        >
-            <Link className="grid gap-4 p-5 md:p-6" href={href}>
-                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
-                    <span className="rounded-sm border bg-secondary px-2 py-1 text-secondary-foreground">
-                        {kindLabels[kind]}
-                    </span>
-                    {entry.category ? <span>{entry.category}</span> : null}
-                    {entry.publishedAt ? (
-                        <span>{formatNewsDate(entry.publishedAt)}</span>
+        <article className="h-full">
+            <Link
+                className="grid h-full overflow-hidden rounded-md border bg-card shadow-xs transition-colors hover:bg-muted/20 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                href={href}
+            >
+                <div className="grid content-start gap-3 p-5 md:p-6">
+                    {entry.tags.length > 0 ? (
+                        <div className="flex flex-wrap items-center gap-2">
+                            {entry.tags.map((tag) => (
+                                <span
+                                    key={tag}
+                                    className="rounded-sm border bg-secondary px-2 py-1 text-xs font-semibold uppercase tracking-normal text-secondary-foreground"
+                                >
+                                    {tag}
+                                </span>
+                            ))}
+                        </div>
                     ) : null}
-                </div>
-                <div className="grid gap-2">
-                    <h2 className="text-xl font-bold leading-tight">
-                        {entry.title}
-                    </h2>
-                    {entry.excerpt ? (
-                        <p className="line-clamp-3 text-sm leading-6 text-muted-foreground">
-                            {entry.excerpt}
-                        </p>
+                    {hasMetadata ? (
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs font-semibold uppercase text-muted-foreground">
+                            {showKindLabel ? (
+                                <span className="rounded-sm border bg-background px-2 py-1 text-foreground">
+                                    {kindLabels[kind]}
+                                </span>
+                            ) : null}
+                            {entry.category ? (
+                                <span>{entry.category}</span>
+                            ) : null}
+                            {dateLabel ? <span>{dateLabel}</span> : null}
+                        </div>
                     ) : null}
+                    <div className="grid gap-2">
+                        <h2 className="text-xl font-bold leading-tight">
+                            {entry.title}
+                        </h2>
+                        {entry.excerpt ? (
+                            <p className="line-clamp-3 text-sm leading-6 text-muted-foreground">
+                                {entry.excerpt}
+                            </p>
+                        ) : null}
+                    </div>
                 </div>
-                {entry.tags.length > 0 ? (
-                    <div className="flex flex-wrap gap-2">
-                        {entry.tags.map((tag) => (
-                            <span
-                                key={tag}
-                                className="rounded-sm bg-secondary px-2 py-1 text-xs font-medium text-secondary-foreground"
-                            >
-                                {tag}
-                            </span>
-                        ))}
+                {entry.metaImageUrl ? (
+                    <div className="aspect-[16/9] border-t bg-muted/30">
+                        {/* biome-ignore lint/performance/noImgElement: CMS images are remote author content. */}
+                        <img
+                            alt=""
+                            className="h-full w-full object-cover"
+                            src={entry.metaImageUrl}
+                        />
                     </div>
                 ) : null}
             </Link>
-            {entry.metaImageUrl ? (
-                <Link
-                    aria-label={`Pročitaj: ${entry.title}`}
-                    className="block min-h-48 border-t bg-muted/30 md:border-l md:border-t-0"
-                    href={href}
-                >
-                    {/* biome-ignore lint/performance/noImgElement: CMS images are remote author content. */}
-                    <img
-                        alt=""
-                        className="h-full min-h-48 w-full object-cover"
-                        src={entry.metaImageUrl}
-                    />
-                </Link>
-            ) : null}
         </article>
     );
 }

--- a/apps/news/components/NewsTagFilters.tsx
+++ b/apps/news/components/NewsTagFilters.tsx
@@ -4,18 +4,20 @@ import type { Route } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
-const changelogPath = '/sto-je-novo' satisfies Route;
+const defaultTagPath = '/sto-je-novo' satisfies Route;
 
-function tagPath(tag: string): Route {
-    return `${changelogPath}?tag=${encodeURIComponent(tag)}` as Route;
+function tagPath(basePath: Route, tag: string): Route {
+    return `${basePath}?tag=${encodeURIComponent(tag)}` as Route;
 }
 
-export function ChangelogTagFilters({
+export function NewsTagFilters({
     activeTag,
+    basePath = defaultTagPath,
     dropdownTags,
     primaryTags,
 }: {
     activeTag?: string;
+    basePath?: Route;
     dropdownTags: string[];
     primaryTags: string[];
 }) {
@@ -29,7 +31,7 @@ export function ChangelogTagFilters({
                         ? 'bg-background text-muted-foreground'
                         : 'bg-primary text-primary-foreground'
                 }`}
-                href={changelogPath}
+                href={basePath}
             >
                 Sve
             </Link>
@@ -41,7 +43,7 @@ export function ChangelogTagFilters({
                             ? 'bg-primary text-primary-foreground'
                             : 'bg-background text-muted-foreground hover:text-foreground'
                     }`}
-                    href={tagPath(value)}
+                    href={tagPath(basePath, value)}
                 >
                     {value}
                 </Link>
@@ -53,7 +55,9 @@ export function ChangelogTagFilters({
                     onChange={(event) => {
                         const selectedTag = event.currentTarget.value;
                         router.push(
-                            selectedTag ? tagPath(selectedTag) : changelogPath,
+                            selectedTag
+                                ? tagPath(basePath, selectedTag)
+                                : basePath,
                         );
                     }}
                     value={

--- a/apps/news/lib/news.ts
+++ b/apps/news/lib/news.ts
@@ -8,6 +8,14 @@ type NewsListQuery = {
     limit?: number;
 };
 
+const primaryTagLimit = 8;
+const recentPrimaryTagLimit = 4;
+
+type NewsTagSource = {
+    publishedAt?: string | null;
+    tags: string[];
+};
+
 function newsQuery(input: NewsListQuery = {}) {
     return {
         ...(input.category ? { category: input.category } : {}),
@@ -101,4 +109,74 @@ export function uniqueNewsValues<T>(
     return Array.from(values.values()).sort((left, right) =>
         left.localeCompare(right, 'hr-HR'),
     );
+}
+
+function normalizedNewsTime(value: string | null | undefined) {
+    if (!value) {
+        return 0;
+    }
+
+    const time = new Date(value).getTime();
+    return Number.isNaN(time) ? 0 : time;
+}
+
+export function getPrimaryNewsTags<T extends NewsTagSource>(entries: T[]) {
+    const primaryTags = new Map<string, string>();
+    const tagStats = new Map<
+        string,
+        {
+            count: number;
+            latestTime: number;
+            value: string;
+        }
+    >();
+
+    for (const entry of entries) {
+        const latestTime = normalizedNewsTime(entry.publishedAt);
+
+        for (const tag of entry.tags) {
+            const normalized = tag.trim();
+            if (!normalized) {
+                continue;
+            }
+
+            const key = normalized.toLocaleLowerCase('hr-HR');
+            if (primaryTags.size < recentPrimaryTagLimit) {
+                primaryTags.set(key, normalized);
+            }
+
+            const current = tagStats.get(key);
+            tagStats.set(key, {
+                count: (current?.count ?? 0) + 1,
+                latestTime: Math.max(current?.latestTime ?? 0, latestTime),
+                value: current?.value ?? normalized,
+            });
+        }
+    }
+
+    const popularTags = Array.from(tagStats.values())
+        .sort((left, right) => {
+            const countDiff = right.count - left.count;
+            if (countDiff !== 0) {
+                return countDiff;
+            }
+
+            const latestDiff = right.latestTime - left.latestTime;
+            if (latestDiff !== 0) {
+                return latestDiff;
+            }
+
+            return left.value.localeCompare(right.value, 'hr-HR');
+        })
+        .map((item) => item.value);
+
+    for (const tag of popularTags) {
+        if (primaryTags.size >= primaryTagLimit) {
+            break;
+        }
+
+        primaryTags.set(tag.toLocaleLowerCase('hr-HR'), tag);
+    }
+
+    return Array.from(primaryTags.values());
 }


### PR DESCRIPTION
## Summary

- Redirect `/novosti?tag=...` to the changelog tag view instead of filtering the mixed news landing page.
- Reuse the same tag selector on `/novosti` and `/novosti/sto-je-novo`, with `/novosti` tag links pointing at `/sto-je-novo`.
- Consolidate news/changelog card styling so tags sit above titles, and render `/novosti` cards in two columns on desktop.

## Validation

- `pnpm --filter news run typecheck`
- `pnpm --filter news run lint`
- `pnpm --filter news run build`
- `git diff --check`
- Local built app smoke check: `/novosti?tag=Korisnici` returns `307` to `/novosti/sto-je-novo?tag=Korisnici`.
- Local browser check: `/novosti` renders with two desktop columns and one mobile column; `/novosti/sto-je-novo?tag=Farma` renders without a framework error overlay. Localhost still logs the existing Vercel Analytics `404` and unauthenticated header claims `401` requests.