### PR TITLE
[codex] Refine news card thumbnails

### DIFF
--- a/apps/news/app/page.tsx
+++ b/apps/news/app/page.tsx
@@ -154,7 +154,7 @@ export default async function NewsHomePage({
                 ) : null}
             </aside>
             {visibleItems.length > 0 ? (
-                <section className="grid gap-4 md:grid-cols-2">
+                <section className="grid items-start gap-4 md:grid-cols-2">
                     {visibleItems.map((item) => (
                         <NewsCard
                             key={`${item.kind}-${item.href}`}

--- a/apps/news/components/NewsCard.tsx
+++ b/apps/news/components/NewsCard.tsx
@@ -38,12 +38,16 @@ export function NewsCard({
     const hasMetadata = showKindLabel || entry.category || dateLabel;
 
     return (
-        <article className="h-full">
+        <article className="w-full">
             <Link
-                className="grid h-full overflow-hidden rounded-md border bg-card shadow-xs transition-colors hover:bg-muted/20 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                className={`grid overflow-hidden rounded-md border bg-card shadow-xs transition-colors hover:bg-muted/20 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ${
+                    entry.metaImageUrl
+                        ? 'md:grid-cols-[minmax(0,1fr)_10rem]'
+                        : ''
+                }`}
                 href={href}
             >
-                <div className="grid content-start gap-3 p-5 md:p-6">
+                <div className="grid content-start gap-3 p-5">
                     {entry.tags.length > 0 ? (
                         <div className="flex flex-wrap items-center gap-2">
                             {entry.tags.map((tag) => (
@@ -81,7 +85,7 @@ export function NewsCard({
                     </div>
                 </div>
                 {entry.metaImageUrl ? (
-                    <div className="aspect-[16/9] border-t bg-muted/30">
+                    <div className="aspect-[16/9] border-t bg-muted/30 md:aspect-auto md:min-h-36 md:border-l md:border-t-0">
                         {/* biome-ignore lint/performance/noImgElement: CMS images are remote author content. */}
                         <img
                             alt=""


### PR DESCRIPTION
## Summary

- Make news card images compact right-side thumbnails on desktop instead of full-width poster blocks.
- Stop text-only cards from stretching to match neighboring image-card height in the two-column `/novosti` grid.
- Keep mobile as a single-column card with the image below the text.

## Validation

- `pnpm --filter news run typecheck`
- `pnpm --filter news run lint`
- `pnpm --filter news run build`
- `git diff --check`
- Local built-app browser check: `/novosti` renders two desktop columns with `454px + 160px` image-card split, text-only cards without reserved image space, one mobile column, and no framework error overlay. Localhost still logs the existing Vercel Analytics `404` and unauthenticated header claims `401` requests.
- Local redirect smoke check: `/novosti?tag=Korisnici` returns `307` to `/novosti/sto-je-novo?tag=Korisnici`.