### PR TITLE
Fix tutorial checklist claimability refresh

### DIFF
--- a/packages/game/src/hooks/useAbandonRaisedBed.ts
+++ b/packages/game/src/hooks/useAbandonRaisedBed.ts
@@ -7,6 +7,7 @@ import {
 } from '../raisedBedConstants';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 const mutationKey = ['gardens', 'current', 'raisedBedAbandon'];
 const SINGLE_MUTATION = 1;
@@ -90,6 +91,9 @@ export function useAbandonRaisedBed(gardenId: number, raisedBedId: number) {
                 });
                 await queryClient.invalidateQueries({
                     queryKey: ['garden-operations', gardenId],
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: tutorialChecklistKeys,
                 });
             }
         },

--- a/packages/game/src/hooks/useBlockDelete.ts
+++ b/packages/game/src/hooks/useBlockDelete.ts
@@ -5,6 +5,7 @@ import { persistLocalSandboxGarden } from '../localSandboxGarden';
 import { useGameState } from '../useGameState';
 import { currentAccountKeys } from './useCurrentAccount';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 const mutationKey = ['gardens', 'current', 'blockDelete'];
 
@@ -116,6 +117,9 @@ export function useBlockDelete() {
                 });
                 await queryClient.invalidateQueries({
                     queryKey: currentAccountKeys,
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: tutorialChecklistKeys,
                 });
             }
         },

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -16,6 +16,7 @@ import {
     type useCurrentAccount,
 } from './useCurrentAccount';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 const mutationKey = ['gardens', 'current', 'blockPlace'];
 const optimisticBlockIdPrefix = 'optimistic-block';
@@ -310,6 +311,9 @@ export function useBlockPlace() {
                 });
                 await queryClient.invalidateQueries({
                     queryKey: gardenQueryKey,
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: tutorialChecklistKeys,
                 });
             }
         },

--- a/packages/game/src/hooks/useBlockRecycle.ts
+++ b/packages/game/src/hooks/useBlockRecycle.ts
@@ -10,6 +10,7 @@ import {
     useShoppingCart,
     useShoppingCartQueryKey,
 } from './useShoppingCart';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 const mutationKey = ['gardens', 'current', 'useBlockRecycle'];
 
@@ -209,6 +210,9 @@ export function useBlockRecycle() {
                         queryKey: useShoppingCartQueryKey,
                     });
                 }
+                queryClient.invalidateQueries({
+                    queryKey: tutorialChecklistKeys,
+                });
             }
         },
     });

--- a/packages/game/src/hooks/useCancelDiaryEntry.ts
+++ b/packages/game/src/hooks/useCancelDiaryEntry.ts
@@ -6,6 +6,7 @@ import { notificationsQueryKey } from './useNotifications';
 import { queryKeys as raisedBedDiaryQueryKeys } from './useRaisedBedDiaryEntries';
 import { queryKeys as raisedBedFieldDiaryQueryKeys } from './useRaisedBedFieldDiaryEntries';
 import type { DiaryRescheduleTarget } from './useRescheduleDiaryEntry';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 export type DiaryCancelTarget = DiaryRescheduleTarget;
 
@@ -187,6 +188,9 @@ export function useCancelDiaryEntry(gardenId: number) {
             });
             await queryClient.invalidateQueries({
                 queryKey: notificationsQueryKey,
+            });
+            await queryClient.invalidateQueries({
+                queryKey: tutorialChecklistKeys,
             });
         },
     });

--- a/packages/game/src/hooks/useClaimDailyReward.ts
+++ b/packages/game/src/hooks/useClaimDailyReward.ts
@@ -2,6 +2,7 @@ import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { currentAccountKeys } from './useCurrentAccount';
 import { dailyRewardKeys } from './useDailyReward';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 export function useClaimDailyReward() {
     const queryClient = useQueryClient();
@@ -12,6 +13,7 @@ export function useClaimDailyReward() {
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: currentAccountKeys });
             queryClient.invalidateQueries({ queryKey: dailyRewardKeys });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
     });
 }

--- a/packages/game/src/hooks/useCreateGarden.ts
+++ b/packages/game/src/hooks/useCreateGarden.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys } from './useCurrentGarden';
 import { useGardensKeys } from './useGardens';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 type CreateGardenVariables = {
     name?: string;
@@ -31,6 +32,9 @@ export function useCreateGarden() {
         onSuccess: async () => {
             await queryClient.invalidateQueries({ queryKey: useGardensKeys });
             await queryClient.invalidateQueries({ queryKey: gardenQueryKey });
+            await queryClient.invalidateQueries({
+                queryKey: tutorialChecklistKeys,
+            });
         },
         onError: (error) => {
             console.error('Failed to create garden:', error);

--- a/packages/game/src/hooks/useDeliveryAddressMutations.ts
+++ b/packages/game/src/hooks/useDeliveryAddressMutations.ts
@@ -1,6 +1,7 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deliveryAddressesQueryKey } from './useDeliveryAddresses';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 export function useCreateDeliveryAddress() {
     const queryClient = useQueryClient();
@@ -30,6 +31,7 @@ export function useCreateDeliveryAddress() {
             queryClient.invalidateQueries({
                 queryKey: deliveryAddressesQueryKey,
             });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
     });
 }
@@ -66,6 +68,7 @@ export function useUpdateDeliveryAddress() {
             queryClient.invalidateQueries({
                 queryKey: deliveryAddressesQueryKey,
             });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
     });
 }
@@ -89,6 +92,7 @@ export function useDeleteDeliveryAddress() {
             queryClient.invalidateQueries({
                 queryKey: deliveryAddressesQueryKey,
             });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
     });
 }

--- a/packages/game/src/hooks/useFavorites.ts
+++ b/packages/game/src/hooks/useFavorites.ts
@@ -8,6 +8,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { useCurrentUser } from './useCurrentUser';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 export const favoritesQueryKey = ['favorites'];
 
@@ -110,6 +111,7 @@ export function useSetFavorite() {
         },
         onSettled: () => {
             queryClient.invalidateQueries({ queryKey: favoritesQueryKey });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
     });
 }

--- a/packages/game/src/hooks/useGardenBoxPlaceBlock.ts
+++ b/packages/game/src/hooks/useGardenBoxPlaceBlock.ts
@@ -8,6 +8,7 @@ import {
 import { useBlockData } from './useBlockData';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
 import { inventoryQueryKey } from './useInventory';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 const mutationKey = ['inventory', 'gardenBoxPlaceBlock'];
 const optimisticBlockIdPrefix = 'optimistic-garden-box-block';
@@ -221,6 +222,9 @@ export function useGardenBoxPlaceBlock() {
                 });
                 await queryClient.invalidateQueries({
                     queryKey: gardenQueryKey,
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: tutorialChecklistKeys,
                 });
             }
         },

--- a/packages/game/src/hooks/useGardenBoxStoreBlock.ts
+++ b/packages/game/src/hooks/useGardenBoxStoreBlock.ts
@@ -5,6 +5,7 @@ import { handleOptimisticUpdate } from '../helpers/queryHelpers';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
 import { inventoryQueryKey } from './useInventory';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 const mutationKey = ['gardens', 'current', 'gardenBoxStoreBlock'];
 
@@ -207,6 +208,9 @@ export function useGardenBoxStoreBlock() {
                 });
                 await queryClient.invalidateQueries({
                     queryKey: inventoryQueryKey,
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: tutorialChecklistKeys,
                 });
             }
         },

--- a/packages/game/src/hooks/useInvitationMutations.ts
+++ b/packages/game/src/hooks/useInvitationMutations.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { accountInvitationsKeys } from './useAccountInvitations';
 import { currentAccountUsersKeys } from './useCurrentAccountUsers';
 import { pendingInvitationsKeys } from './usePendingInvitations';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 export class InvitationError extends Error {
     code: string;
@@ -53,6 +54,7 @@ export function useSendInvitation() {
             queryClient.invalidateQueries({
                 queryKey: accountInvitationsKeys,
             });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
     });
 }
@@ -77,6 +79,7 @@ export function useCancelInvitation() {
             queryClient.invalidateQueries({
                 queryKey: accountInvitationsKeys,
             });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
     });
 }
@@ -104,6 +107,7 @@ export function useAcceptInvitation() {
             queryClient.invalidateQueries({
                 queryKey: currentAccountUsersKeys,
             });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
     });
 }

--- a/packages/game/src/hooks/useNotificationPreferences.ts
+++ b/packages/game/src/hooks/useNotificationPreferences.ts
@@ -1,5 +1,6 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 type ApiClient = ReturnType<typeof clientAuthenticated>;
 
@@ -34,10 +35,12 @@ export function useSaveNotificationPreferences() {
             if (!response.ok)
                 throw new Error('Postavke obavijesti nisu spremljene');
         },
-        onSuccess: () =>
+        onSuccess: () => {
             queryClient.invalidateQueries({
                 queryKey: notificationPreferencesKey,
-            }),
+            });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
+        },
     });
 }
 

--- a/packages/game/src/hooks/useRaisedBedFieldRemove.ts
+++ b/packages/game/src/hooks/useRaisedBedFieldRemove.ts
@@ -7,6 +7,7 @@ import {
     isRaisedBedFieldOccupied,
 } from '../utils/raisedBedFields';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 const mutationKey = ['gardens', 'current', 'raisedBedFieldRemove'];
 
@@ -124,6 +125,9 @@ export function useRaisedBedFieldRemove() {
             if (queryClient.isMutating({ mutationKey }) === 1) {
                 await queryClient.invalidateQueries({
                     queryKey: gardenQueryKey,
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: tutorialChecklistKeys,
                 });
             }
         },

--- a/packages/game/src/hooks/useRaisedBedFieldUpdateStatus.ts
+++ b/packages/game/src/hooks/useRaisedBedFieldUpdateStatus.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { handleOptimisticUpdate } from '../helpers/queryHelpers';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 const mutationKey = ['gardens', 'current', 'raisedBedFieldUpdateStatus'];
 
@@ -112,6 +113,9 @@ export function useRaisedBedFieldUpdateStatus() {
             if (queryClient.isMutating({ mutationKey }) === 1) {
                 await queryClient.invalidateQueries({
                     queryKey: gardenQueryKey,
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: tutorialChecklistKeys,
                 });
             }
         },

--- a/packages/game/src/hooks/useRenameGarden.ts
+++ b/packages/game/src/hooks/useRenameGarden.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys } from './useCurrentGarden';
 import { useGardensKeys } from './useGardens';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 type RenameGardenVariables = {
     name: string;
@@ -32,6 +33,7 @@ export function useRenameGarden(gardenId?: number) {
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: gardenQueryKey });
             queryClient.invalidateQueries({ queryKey: useGardensKeys });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
         onError: (error) => {
             console.error('Failed to rename garden:', error);

--- a/packages/game/src/hooks/useRescheduleDiaryEntry.ts
+++ b/packages/game/src/hooks/useRescheduleDiaryEntry.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGardensKeys } from './useGardens';
 import { queryKeys as raisedBedDiaryQueryKeys } from './useRaisedBedDiaryEntries';
 import { queryKeys as raisedBedFieldDiaryQueryKeys } from './useRaisedBedFieldDiaryEntries';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 export type DiaryRescheduleTarget =
     | {
@@ -233,6 +234,9 @@ export function useRescheduleDiaryEntry(gardenId: number) {
             });
             await queryClient.invalidateQueries({
                 queryKey: useGardensKeys,
+            });
+            await queryClient.invalidateQueries({
+                queryKey: tutorialChecklistKeys,
             });
         },
     });

--- a/packages/game/src/hooks/useShoppingCartDelete.ts
+++ b/packages/game/src/hooks/useShoppingCartDelete.ts
@@ -1,6 +1,7 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useShoppingCartQueryKey } from './useShoppingCart';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 export function useShoppingCartDelete() {
     const queryClient = useQueryClient();
@@ -10,6 +11,7 @@ export function useShoppingCartDelete() {
             queryClient.invalidateQueries({
                 queryKey: useShoppingCartQueryKey,
             });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
         scope: {
             id: 'shoppingCartDelete',

--- a/packages/game/src/hooks/useSwapShoppingCartPositions.ts
+++ b/packages/game/src/hooks/useSwapShoppingCartPositions.ts
@@ -6,6 +6,7 @@ import {
     useShoppingCart,
     useShoppingCartQueryKey,
 } from './useShoppingCart';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 export function useSwapShoppingCartPositions() {
     const queryClient = useQueryClient();
@@ -110,6 +111,7 @@ export function useSwapShoppingCartPositions() {
             queryClient.invalidateQueries({
                 queryKey: useShoppingCartQueryKey,
             });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
         scope: {
             id: 'swapShoppingCartPositions',

--- a/packages/game/src/hooks/useUpdateRaisedBed.ts
+++ b/packages/game/src/hooks/useUpdateRaisedBed.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGameState } from '../useGameState';
 import { currentGardenKeys } from './useCurrentGarden';
 import { useCurrentUser } from './useCurrentUser';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 export function useUpdateRaisedBed(gardenId: number, raisedBedId: number) {
     const queryClient = useQueryClient();
@@ -33,6 +34,7 @@ export function useUpdateRaisedBed(gardenId: number, raisedBedId: number) {
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: gardenQueryKey });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
     });
 }

--- a/packages/game/src/hooks/useUpdateUser.ts
+++ b/packages/game/src/hooks/useUpdateUser.ts
@@ -1,6 +1,7 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKey, useCurrentUser } from './useCurrentUser';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
 
 export type UpdateUserVariables = {
     displayName?: string;
@@ -74,6 +75,7 @@ export function useUpdateUser({ enabled = true }: { enabled?: boolean } = {}) {
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: queryKey.currentUser });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
         },
     });
 }

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -396,7 +396,7 @@ function TutorialChecklistContent({
         );
     }
 
-    if (checklistQuery.isError || !checklistQuery.data) {
+    if (!checklistQuery.data) {
         return (
             <Stack spacing={3}>
                 <Typography level="h3">Zadaci za novi vrt</Typography>

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -10,6 +10,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
+import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { parseAsString, useQueryState } from 'nuqs';
 import { useMemo, useState } from 'react';
@@ -17,6 +18,7 @@ import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import {
     type TutorialChecklistGroup,
     type TutorialChecklistTask,
+    tutorialChecklistKeys,
     useClaimTutorialChecklistTask,
     useMarkTutorialChecklistTaskReady,
     useTutorialChecklist,
@@ -164,6 +166,12 @@ function openExternalTaskTarget(task: TutorialChecklistTask) {
     }
 }
 
+function shouldCloseChecklistBeforeOpen(task: TutorialChecklistTask) {
+    return (
+        task.actionTarget !== 'contact' && task.actionTarget !== 'plantDatabase'
+    );
+}
+
 function useOpenTaskTarget(onChecklistOpenChange: (open: boolean) => void) {
     const [, setBackpackOpen] = useBackpackOpenParam();
     const [, setCartOpen] = useShoppingCartOpenParam();
@@ -179,14 +187,7 @@ function useOpenTaskTarget(onChecklistOpenChange: (open: boolean) => void) {
             return;
         }
 
-        if (
-            target === 'field' ||
-            target === 'diary' ||
-            target === 'operations' ||
-            target === 'raisedBedOnboarding' ||
-            target === 'weather' ||
-            target === 'forecast'
-        ) {
+        if (shouldCloseChecklistBeforeOpen(task)) {
             onChecklistOpenChange(false);
             await waitForChecklistClose();
         }
@@ -541,6 +542,7 @@ function TutorialChecklistContent({
 
 export function TutorialChecklistHud() {
     const [isOpen, setIsOpen] = useState(false);
+    const queryClient = useQueryClient();
     const { data } = useTutorialChecklist();
     const { track } = useGameAnalytics();
     const claimableCount = data?.totals.claimableCount ?? 0;
@@ -570,6 +572,9 @@ export function TutorialChecklistHud() {
                     if (open) {
                         track('game_tutorial_checklist_opened', {
                             claimable_count: claimableCount,
+                        });
+                        void queryClient.invalidateQueries({
+                            queryKey: tutorialChecklistKeys,
                         });
                     }
                     setIsOpen(open);

--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -5,8 +5,9 @@ import { Modal } from '@gredice/ui/Modal';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { Fragment, useEffect } from 'react';
+import { Fragment, useEffect, useRef } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import { useMarkTutorialChecklistTaskReady } from '../hooks/useTutorialChecklist';
 import {
     isNotificationsFilter,
     isNotificationsView,
@@ -127,6 +128,28 @@ export function OverviewModal() {
     const notificationsView = isNotificationsView(notificationsViewParam)
         ? notificationsViewParam
         : 'notifications';
+    const { mutate: markNotificationsTaskReady } =
+        useMarkTutorialChecklistTaskReady();
+    const { mutate: markConfigureNotificationsTaskReady } =
+        useMarkTutorialChecklistTaskReady();
+    const markedNotificationChecklistTasksRef = useRef(false);
+
+    useEffect(() => {
+        if (
+            settingsMode !== 'obavijesti' ||
+            markedNotificationChecklistTasksRef.current
+        ) {
+            return;
+        }
+
+        markedNotificationChecklistTasksRef.current = true;
+        markNotificationsTaskReady('open-notifications');
+        markConfigureNotificationsTaskReady('configure-notifications');
+    }, [
+        markConfigureNotificationsTaskReady,
+        markNotificationsTaskReady,
+        settingsMode,
+    ]);
 
     useEffect(() => {
         if (!settingsMode) {

--- a/packages/game/src/modals/components/ReferralsTab.tsx
+++ b/packages/game/src/modals/components/ReferralsTab.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from 'react';
 import Confetti from 'react-confetti-boom';
 import { currentAccountKeys } from '../../hooks/useCurrentAccount';
 import { useReferrals } from '../../hooks/useReferrals';
+import { tutorialChecklistKeys } from '../../hooks/useTutorialChecklist';
 import { KnownPages } from '../../knownPages';
 
 async function errorMessageFromResponse(response: Response, fallback: string) {
@@ -162,6 +163,9 @@ export function ReferralsTab() {
                 setUseCode('');
             }
             await refetch();
+            await queryClient.invalidateQueries({
+                queryKey: tutorialChecklistKeys,
+            });
         } finally {
             setIsUsingCode(false);
         }

--- a/packages/storage/src/repositories/tutorialChecklistRepo.ts
+++ b/packages/storage/src/repositories/tutorialChecklistRepo.ts
@@ -1,10 +1,7 @@
 import 'server-only';
 
 import { and, eq } from 'drizzle-orm';
-import {
-    tutorialChecklistTaskClaims,
-    userNotificationSettings,
-} from '../schema';
+import { tutorialChecklistTaskClaims } from '../schema';
 import { storage } from '../storage';
 import { getAccountInvitations } from './accountInvitationsRepo';
 import {
@@ -57,6 +54,7 @@ export type TutorialChecklistActionTarget =
 
 type TutorialChecklistSignal =
     | 'accountUserInvited'
+    | 'activeRaisedBed'
     | 'cartItemAdded'
     | 'dailyRewardClaimedDay2'
     | 'dailyRewardClaimedDay3'
@@ -65,7 +63,6 @@ type TutorialChecklistSignal =
     | 'futureOperationScheduled'
     | 'gardenRenamed'
     | 'hasOperationHistory'
-    | 'notificationSettingsCreated'
     | 'paidOrder'
     | 'plantingAchievement10'
     | 'plantedField'
@@ -165,6 +162,7 @@ const taskDefinitions = [
         description: 'Odaberi prijedlog i dodaj plan sadnje u košaru.',
         rewardSunflowers: 100,
         completion: 'manual',
+        signal: 'activeRaisedBed',
         actionTarget: 'raisedBedOnboarding',
     },
     {
@@ -348,11 +346,12 @@ const taskDefinitions = [
         key: 'favorite-one-item',
         groupId: 'day-2',
         title: 'Spremi favorit',
-        description: 'Označi barem jednu biljku, sortu ili radnju kao favorit.',
+        description:
+            'U gredici ili popisu radnji označi biljku, sortu ili radnju kao favorit.',
         rewardSunflowers: 25,
         completion: 'derived',
         signal: 'favoriteAdded',
-        actionTarget: 'plantDatabase',
+        actionTarget: 'operations',
     },
     {
         key: 'claim-daily-reward-day-3',
@@ -397,10 +396,9 @@ const taskDefinitions = [
         key: 'configure-notifications',
         groupId: 'day-3',
         title: 'Podesi obavijesti',
-        description: 'Spremi postavke obavijesti za svoj korisnički račun.',
+        description: 'Otvori postavke obavijesti za svoj korisnički račun.',
         rewardSunflowers: 50,
-        completion: 'derived',
-        signal: 'notificationSettingsCreated',
+        completion: 'manual',
         actionTarget: 'notifications',
     },
     {
@@ -564,6 +562,7 @@ export class TutorialChecklistTaskNotClaimableError extends Error {
 function emptySignals(): TutorialChecklistSignals {
     return {
         accountUserInvited: false,
+        activeRaisedBed: false,
         cartItemAdded: false,
         dailyRewardClaimedDay2: false,
         dailyRewardClaimedDay3: false,
@@ -573,7 +572,6 @@ function emptySignals(): TutorialChecklistSignals {
         gardenRenamed: false,
         harvestAchievement1: false,
         hasOperationHistory: false,
-        notificationSettingsCreated: false,
         paidOrder: false,
         plantingAchievement10: false,
         plantedField: false,
@@ -679,7 +677,6 @@ async function getTutorialChecklistSignals({
         gardens,
         history,
         invitations,
-        notificationSettings,
         operations,
         referralState,
         user,
@@ -692,9 +689,6 @@ async function getTutorialChecklistSignals({
         getAccountGardens(accountId),
         getSunflowersHistory(accountId, 0, 10000),
         getAccountInvitations(accountId),
-        storage().query.userNotificationSettings.findFirst({
-            where: eq(userNotificationSettings.userId, userId),
-        }),
         getOperations(accountId),
         getAccountReferralState(accountId, { createDefaultCode: false }),
         getUser(userId),
@@ -709,6 +703,9 @@ async function getTutorialChecklistSignals({
                 gardens.filter((candidate) => !candidate.isSandbox).length >= 2;
         }
         for (const raisedBed of garden.raisedBeds) {
+            signals.activeRaisedBed ||=
+                !garden.isSandbox && raisedBed.status === 'active';
+
             for (const field of raisedBed.fields) {
                 if (!hasPlant(field)) {
                     continue;
@@ -820,7 +817,6 @@ async function getTutorialChecklistSignals({
                 user.avatarUrl),
     );
     signals.favoriteAdded = favorites.length > 0;
-    signals.notificationSettingsCreated = Boolean(notificationSettings);
     signals.deliveryAddressAdded = deliveryAddresses.length > 0;
     signals.accountUserInvited =
         accountUsers.length > 1 || invitations.length > 0;

--- a/packages/storage/tests/tutorialChecklistRepo.node.spec.ts
+++ b/packages/storage/tests/tutorialChecklistRepo.node.spec.ts
@@ -3,13 +3,18 @@ import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
     claimTutorialChecklistTask,
+    createAccountInvitation,
+    createEntity,
+    createRaisedBed,
     createUserWithPassword,
     getOrCreateShoppingCart,
     getSunflowers,
     getTutorialChecklistState,
     getUser,
     markTutorialChecklistTaskReady,
+    setUserFavorite,
     TutorialChecklistTaskNotClaimableError,
+    upsertEntityType,
     upsertOrRemoveCartItem,
 } from '@gredice/storage';
 import {
@@ -32,6 +37,15 @@ async function createChecklistTestUser() {
     return { accountId, userId };
 }
 
+function findChecklistTask(
+    state: Awaited<ReturnType<typeof getTutorialChecklistState>>,
+    taskKey: string,
+) {
+    return state.groups
+        .flatMap((group) => group.tasks)
+        .find((task) => task.key === taskKey);
+}
+
 test('tutorial checklist returns day groups and open tasks', async () => {
     createTestDb();
     const { accountId, userId } = await createChecklistTestUser();
@@ -49,8 +63,9 @@ test('tutorial checklist returns day groups and open tasks', async () => {
             .some((task) => task.key === 'order-watering'),
     );
     const allTasks = state.groups.flatMap((group) => group.tasks);
-    const onboardingTask = allTasks.find(
-        (task) => task.key === 'complete-first-raised-bed-onboarding',
+    const onboardingTask = findChecklistTask(
+        state,
+        'complete-first-raised-bed-onboarding',
     );
     assert.ok(onboardingTask);
     assert.strictEqual(onboardingTask.status, 'available');
@@ -66,6 +81,87 @@ test('tutorial checklist returns day groups and open tasks', async () => {
             ?.tasks.some((task) => task.key === 'enter-referral-code'),
     );
     assert.strictEqual(state.totals.claimableCount, 0);
+});
+
+test('tutorial checklist treats an active raised bed as first plan progress', async () => {
+    createTestDb();
+    const { accountId, userId } = await createChecklistTestUser();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'checklist-active-bed');
+
+    await createRaisedBed({
+        accountId,
+        gardenId,
+        blockId,
+        status: 'active',
+    });
+
+    const state = await getTutorialChecklistState({ accountId, userId });
+    const task = findChecklistTask(
+        state,
+        'complete-first-raised-bed-onboarding',
+    );
+
+    assert.ok(task);
+    assert.strictEqual(task.status, 'ready');
+    assert.strictEqual(task.claimable, true);
+    assert.strictEqual(task.completed, false);
+});
+
+test('tutorial checklist notification settings task becomes claimable after visiting settings', async () => {
+    createTestDb();
+    const { accountId, userId } = await createChecklistTestUser();
+
+    const state = await markTutorialChecklistTaskReady({
+        accountId,
+        userId,
+        taskKey: 'configure-notifications',
+    });
+    const task = findChecklistTask(state, 'configure-notifications');
+
+    assert.ok(task);
+    assert.strictEqual(task.status, 'ready');
+    assert.strictEqual(task.claimable, true);
+});
+
+test('tutorial checklist treats pending account invitations as invite progress', async () => {
+    createTestDb();
+    const { accountId, userId } = await createChecklistTestUser();
+
+    await createAccountInvitation(
+        accountId,
+        `invite-${randomUUID()}@example.test`,
+        userId,
+    );
+
+    const state = await getTutorialChecklistState({ accountId, userId });
+    const task = findChecklistTask(state, 'invite-account-user');
+
+    assert.ok(task);
+    assert.strictEqual(task.status, 'ready');
+    assert.strictEqual(task.claimable, true);
+});
+
+test('tutorial checklist treats saved favorites as favorite progress', async () => {
+    createTestDb();
+    const { accountId, userId } = await createChecklistTestUser();
+    await upsertEntityType({ name: 'plant', label: 'Plant' });
+    const plantId = await createEntity('plant');
+
+    await setUserFavorite({
+        userId,
+        entityType: 'plant',
+        entityId: plantId,
+        favorited: true,
+    });
+
+    const state = await getTutorialChecklistState({ accountId, userId });
+    const task = findChecklistTask(state, 'favorite-one-item');
+
+    assert.ok(task);
+    assert.strictEqual(task.status, 'ready');
+    assert.strictEqual(task.claimable, true);
 });
 
 test('tutorial checklist manual task becomes claimable before reward claim', async () => {


### PR DESCRIPTION
## Summary
- update tutorial checklist task signals for active raised beds, favorites, notification settings visits, and pending account invitations
- close the checklist modal before opening in-app targets so Overview popovers do not immediately lose focus
- invalidate and refetch the tutorial checklist query from task-relevant mutations so claimable state appears without a page refresh

## Root Cause
Some checklist tasks depended on stale or unreachable signals, and several mutations refreshed their local feature queries without refreshing the tutorial checklist query. The checklist modal also stayed open while opening Overview-driven targets such as notifications, which could fight the next modal/popover focus state.

## Validation
- `corepack pnpm --filter @gredice/storage test -- tutorialChecklistRepo.node.spec.ts`
- `corepack pnpm --filter @gredice/storage exec biome check src/repositories/tutorialChecklistRepo.ts tests/tutorialChecklistRepo.node.spec.ts`
- `corepack pnpm --filter @gredice/game exec biome check ...`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter garden typecheck`
- `git diff --check`