### PR TITLE
Open plant picker for favorite checklist task

### DIFF
--- a/apps/garden/tests/TutorialChecklistHudStory.tsx
+++ b/apps/garden/tests/TutorialChecklistHudStory.tsx
@@ -9,6 +9,10 @@ import {
     tutorialChecklistKeys,
 } from '../../../packages/game/src/hooks/useTutorialChecklist';
 import { TutorialChecklistHud } from '../../../packages/game/src/hud/TutorialChecklistHud';
+import {
+    createGameState,
+    GameStateContext,
+} from '../../../packages/game/src/useGameState';
 
 function createTask({
     claimable = false,
@@ -129,15 +133,27 @@ function createTutorialChecklistQueryClient() {
 
 export function TutorialChecklistHudStory() {
     const queryClient = useMemo(() => createTutorialChecklistQueryClient(), []);
+    const gameStore = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: 'http://localhost',
+                freezeTime: new Date('2026-05-13T12:00:00.000Z'),
+                isMock: true,
+                winterMode: 'summer',
+            }),
+        [],
+    );
 
     return (
         <NuqsTestingAdapter>
             <ReactQuery.QueryClientProvider client={queryClient}>
-                <GameAnalyticsProvider capture={() => undefined}>
-                    <div className="min-h-48 bg-green-950/20 p-8">
-                        <TutorialChecklistHud />
-                    </div>
-                </GameAnalyticsProvider>
+                <GameStateContext.Provider value={gameStore}>
+                    <GameAnalyticsProvider capture={() => undefined}>
+                        <div className="min-h-48 bg-green-950/20 p-8">
+                            <TutorialChecklistHud />
+                        </div>
+                    </GameAnalyticsProvider>
+                </GameStateContext.Provider>
             </ReactQuery.QueryClientProvider>
         </NuqsTestingAdapter>
     );

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -15,6 +15,7 @@ import Image from 'next/image';
 import { parseAsString, useQueryState } from 'nuqs';
 import { useMemo, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import {
     type TutorialChecklistGroup,
     type TutorialChecklistTask,
@@ -24,13 +25,26 @@ import {
     useTutorialChecklist,
 } from '../hooks/useTutorialChecklist';
 import { KnownPages } from '../knownPages';
+import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
 import { useBackpackOpenParam, useShoppingCartOpenParam } from '../useUrlState';
+import { getRaisedBedBlockIds } from '../utils/raisedBedBlocks';
+import { isRaisedBedFieldOccupied } from '../utils/raisedBedFields';
 import { formatSunflowers } from '../utils/sunflowerPricing';
 import { HudCard } from './components/HudCard';
 import { RAISED_BED_ONBOARDING_OPEN_EVENT } from './RaisedBedOnboardingModal';
 import styles from './TutorialChecklistHud.module.css';
 
 const tutorialTaskListIconSrc = '/assets/hud/tutorial-task-list.png';
+
+type CurrentGardenData = NonNullable<
+    ReturnType<typeof useCurrentGarden>['data']
+>;
+
+type EmptyRaisedBedFieldTarget = {
+    positionIndex: number;
+    raisedBedId: number;
+    raisedBedName: string;
+};
 
 function RewardText({ task }: { task: TutorialChecklistTask }) {
     if (task.rewardLabel) {
@@ -145,6 +159,87 @@ function waitForChecklistClose() {
     });
 }
 
+function waitForPlantPickerTrigger({
+    positionIndex,
+    raisedBedId,
+}: EmptyRaisedBedFieldTarget) {
+    if (typeof document === 'undefined') {
+        return Promise.resolve(null);
+    }
+
+    const selector = [
+        'button[data-raised-bed-plant-picker-trigger="true"]',
+        `[data-raised-bed-id="${raisedBedId.toString()}"]`,
+        `[data-position-index="${positionIndex.toString()}"]`,
+    ].join('');
+
+    return new Promise<HTMLButtonElement | null>((resolve) => {
+        const deadline = Date.now() + 2500;
+
+        function check() {
+            const button = document.querySelector<HTMLButtonElement>(selector);
+            if (button) {
+                resolve(button);
+                return;
+            }
+
+            if (Date.now() >= deadline) {
+                resolve(null);
+                return;
+            }
+
+            window.requestAnimationFrame(check);
+        }
+
+        check();
+    });
+}
+
+function findFirstEmptyRaisedBedField(
+    garden: CurrentGardenData | null | undefined,
+): EmptyRaisedBedFieldTarget | null {
+    if (!garden || garden.isSandbox) {
+        return null;
+    }
+
+    for (const raisedBed of garden.raisedBeds) {
+        const raisedBedName = raisedBed.name?.trim();
+        if (
+            !raisedBedName ||
+            raisedBed.status !== 'active' ||
+            !raisedBed.isValid
+        ) {
+            continue;
+        }
+
+        const blockCount = Math.max(
+            getRaisedBedBlockIds(garden, raisedBed.id).length,
+            1,
+        );
+        const occupiedPositionIndices = new Set(
+            raisedBed.fields
+                .filter(isRaisedBedFieldOccupied)
+                .map((field) => field.positionIndex),
+        );
+
+        for (
+            let positionIndex = 0;
+            positionIndex < blockCount * 9;
+            positionIndex += 1
+        ) {
+            if (!occupiedPositionIndices.has(positionIndex)) {
+                return {
+                    positionIndex,
+                    raisedBedId: raisedBed.id,
+                    raisedBedName,
+                };
+            }
+        }
+    }
+
+    return null;
+}
+
 function openExternalTaskTarget(task: TutorialChecklistTask) {
     switch (task.actionTarget) {
         case 'contact':
@@ -173,9 +268,28 @@ function shouldCloseChecklistBeforeOpen(task: TutorialChecklistTask) {
 }
 
 function useOpenTaskTarget(onChecklistOpenChange: (open: boolean) => void) {
+    const { data: currentGarden } = useCurrentGarden();
     const [, setBackpackOpen] = useBackpackOpenParam();
     const [, setCartOpen] = useShoppingCartOpenParam();
     const [, setOverviewTab] = useQueryState('pregled', parseAsString);
+    const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
+
+    async function openFirstEmptyRaisedBedPlantPicker() {
+        const target = findFirstEmptyRaisedBedField(currentGarden);
+        if (!target) {
+            return false;
+        }
+
+        await Promise.resolve(
+            setRaisedBedCloseupParam(
+                target.raisedBedName,
+                target.positionIndex,
+            ),
+        );
+        const trigger = await waitForPlantPickerTrigger(target);
+        trigger?.click();
+        return Boolean(trigger);
+    }
 
     return async (task: TutorialChecklistTask) => {
         const target = task.actionTarget;
@@ -219,6 +333,11 @@ function useOpenTaskTarget(onChecklistOpenChange: (open: boolean) => void) {
                 break;
             case 'operations':
                 clickHudButton('Status radnji');
+                break;
+            case 'plantPicker':
+                if (!(await openFirstEmptyRaisedBedPlantPicker())) {
+                    clickHudButton('Status radnji');
+                }
                 break;
             case 'profile':
                 await setOverviewTab('generalno');

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -101,6 +101,9 @@ export function RaisedBedFieldItemEmpty({
                             isDragging &&
                                 'opacity-50 ring-2 ring-lime-500 scale-105',
                         )}
+                        data-position-index={positionIndex}
+                        data-raised-bed-id={raisedBedId}
+                        data-raised-bed-plant-picker-trigger="true"
                     >
                         {(isLoading || !cartPlantItem) && (
                             <PlantingSeedIcon className="size-8 text-green-800" />

--- a/packages/storage/src/repositories/tutorialChecklistRepo.ts
+++ b/packages/storage/src/repositories/tutorialChecklistRepo.ts
@@ -45,6 +45,7 @@ export type TutorialChecklistActionTarget =
     | 'inventory'
     | 'notifications'
     | 'operations'
+    | 'plantPicker'
     | 'plantDatabase'
     | 'profile'
     | 'raisedBedOnboarding'
@@ -351,7 +352,7 @@ const taskDefinitions = [
         rewardSunflowers: 25,
         completion: 'derived',
         signal: 'favoriteAdded',
-        actionTarget: 'operations',
+        actionTarget: 'plantPicker',
     },
     {
         key: 'claim-daily-reward-day-3',

--- a/packages/storage/tests/tutorialChecklistRepo.node.spec.ts
+++ b/packages/storage/tests/tutorialChecklistRepo.node.spec.ts
@@ -160,6 +160,7 @@ test('tutorial checklist treats saved favorites as favorite progress', async () 
     const task = findChecklistTask(state, 'favorite-one-item');
 
     assert.ok(task);
+    assert.strictEqual(task.actionTarget, 'plantPicker');
     assert.strictEqual(task.status, 'ready');
     assert.strictEqual(task.claimable, true);
 });


### PR DESCRIPTION
## Summary
- route the `Spremi favorit` checklist action to a dedicated plant picker target
- open the first empty active raised-bed field so users can favorite a plant or sort directly from the picker
- keep the operations HUD fallback when no suitable empty field is available

## Validation
- `corepack pnpm --filter @gredice/storage test -- tutorialChecklistRepo.node.spec.ts`
- `corepack pnpm --filter garden test:run -- tests/tutorial-checklist-hud.spec.tsx`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter @gredice/game exec biome check src/hud/TutorialChecklistHud.tsx src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx`
- `corepack pnpm --filter garden exec biome check tests/TutorialChecklistHudStory.tsx`
- `corepack pnpm --filter @gredice/storage exec biome check src/repositories/tutorialChecklistRepo.ts tests/tutorialChecklistRepo.node.spec.ts`
- `git diff --check`

Note: `@gredice/storage` does not define a `typecheck` script.
