### PR TITLE
Track game onboarding analytics

### DIFF
--- a/packages/game/src/hud/RaisedBedOnboardingModal.tsx
+++ b/packages/game/src/hud/RaisedBedOnboardingModal.tsx
@@ -260,6 +260,20 @@ function onboardingStepIndex(step: RaisedBedOnboardingStep) {
     return onboardingSteps.findIndex((item) => item.id === step);
 }
 
+function onboardingStepAnalyticsProperties(step: RaisedBedOnboardingStep) {
+    const stepIndex = onboardingStepIndex(step);
+
+    return {
+        step_id: step,
+        step_index: stepIndex + 1,
+        step_count: onboardingSteps.length,
+        step_label: onboardingSteps[stepIndex]?.label,
+        progress_percent: Math.round(
+            ((stepIndex + 1) / onboardingSteps.length) * 100,
+        ),
+    };
+}
+
 function LayoutSuggestionCard({
     active,
     direction,
@@ -581,6 +595,7 @@ export function RaisedBedOnboardingModal({
     const [isApplying, setIsApplying] = useState(false);
     const resolvedRef = useRef(false);
     const openedRef = useRef(false);
+    const lastTrackedStepViewRef = useRef<string | null>(null);
     const currentGarden = gardenQuery.data;
     const dismissedKey = currentGarden?.id
         ? dismissedStorageKey(currentGarden.id)
@@ -649,6 +664,37 @@ export function RaisedBedOnboardingModal({
         );
     }, [currentGarden, targetRaisedBed]);
 
+    const onboardingAnalyticsProperties = useCallback(
+        (analyticsStep: RaisedBedOnboardingStep = step) => {
+            const layoutIndex =
+                selectedLayout && layouts.length > 0
+                    ? layouts.findIndex(
+                          (layout) => layout.id === selectedLayout.id,
+                      )
+                    : -1;
+
+            return {
+                garden_id: currentGarden?.id,
+                raised_bed_id: targetRaisedBed?.id,
+                goal,
+                care,
+                layout_id: selectedLayout?.id,
+                layout_index: layoutIndex >= 0 ? layoutIndex + 1 : undefined,
+                layout_count: layouts.length || undefined,
+                ...onboardingStepAnalyticsProperties(analyticsStep),
+            };
+        },
+        [
+            care,
+            currentGarden?.id,
+            goal,
+            layouts,
+            selectedLayout,
+            step,
+            targetRaisedBed?.id,
+        ],
+    );
+
     const dataReady =
         gardenQuery.isFetched &&
         sortsQuery.isFetched &&
@@ -688,23 +734,30 @@ export function RaisedBedOnboardingModal({
 
     const dismiss = useCallback(
         (source: 'applied' | 'closed') => {
+            const analyticsProperties = onboardingAnalyticsProperties();
             writeDismissed(dismissedKey);
             setDismissedSnapshot({ dismissed: true, key: dismissedKey });
             setOpen(false);
             focusRaisedBed();
             track('game_raised_bed_onboarding_dismissed', {
-                garden_id: currentGarden?.id,
-                raised_bed_id: targetRaisedBed?.id,
+                ...analyticsProperties,
                 source,
             });
+            if (source === 'closed') {
+                track('game_raised_bed_onboarding_closed', {
+                    ...analyticsProperties,
+                    abandoned_step_id: analyticsProperties.step_id,
+                    abandoned_step_index: analyticsProperties.step_index,
+                    abandoned_step_label: analyticsProperties.step_label,
+                });
+            }
             reportResolved();
         },
         [
-            currentGarden?.id,
             dismissedKey,
             focusRaisedBed,
+            onboardingAnalyticsProperties,
             reportResolved,
-            targetRaisedBed?.id,
             track,
         ],
     );
@@ -722,6 +775,7 @@ export function RaisedBedOnboardingModal({
         setApplyError(null);
         setLayoutCarouselDirection('next');
         setSelectedLayoutId(null);
+        lastTrackedStepViewRef.current = null;
     }, [dismissedKey]);
 
     useEffect(() => {
@@ -742,18 +796,17 @@ export function RaisedBedOnboardingModal({
         if (!openedRef.current) {
             openedRef.current = true;
             track('game_raised_bed_onboarding_opened', {
-                garden_id: currentGarden?.id,
-                raised_bed_id: targetRaisedBed?.id,
+                ...onboardingAnalyticsProperties('goal'),
+                source: 'auto',
             });
         }
     }, [
         canAutoOpenOnboarding,
-        currentGarden?.id,
         dataReady,
         enabled,
+        onboardingAnalyticsProperties,
         reportResolved,
         shouldAutoOpen,
-        targetRaisedBed?.id,
         track,
     ]);
 
@@ -761,6 +814,30 @@ export function RaisedBedOnboardingModal({
         setLayoutCarouselDirection('next');
         setSelectedLayoutId(layouts[0]?.id ?? null);
     }, [layouts]);
+
+    useEffect(() => {
+        if (!open || !canRenderOnboarding) {
+            lastTrackedStepViewRef.current = null;
+            return;
+        }
+
+        const stepViewKey = `${dismissedKey ?? 'onboarding'}:${step}`;
+        if (lastTrackedStepViewRef.current === stepViewKey) {
+            return;
+        }
+
+        lastTrackedStepViewRef.current = stepViewKey;
+        track('game_raised_bed_onboarding_step_viewed', {
+            ...onboardingAnalyticsProperties(),
+        });
+    }, [
+        canRenderOnboarding,
+        dismissedKey,
+        onboardingAnalyticsProperties,
+        open,
+        step,
+        track,
+    ]);
 
     useEffect(() => {
         if (typeof window === 'undefined') {
@@ -777,8 +854,7 @@ export function RaisedBedOnboardingModal({
             setApplyError(null);
             setOpen(true);
             track('game_raised_bed_onboarding_opened', {
-                garden_id: currentGarden?.id,
-                raised_bed_id: targetRaisedBed?.id,
+                ...onboardingAnalyticsProperties('goal'),
                 source: 'tutorial',
             });
         }
@@ -792,13 +868,7 @@ export function RaisedBedOnboardingModal({
                 RAISED_BED_ONBOARDING_OPEN_EVENT,
                 openFromTutorial,
             );
-    }, [
-        canRenderOnboarding,
-        currentGarden?.id,
-        enabled,
-        targetRaisedBed?.id,
-        track,
-    ]);
+    }, [canRenderOnboarding, enabled, onboardingAnalyticsProperties, track]);
 
     function selectLayoutAtIndex(
         nextIndex: number,
@@ -809,16 +879,33 @@ export function RaisedBedOnboardingModal({
         }
 
         const normalizedIndex = (nextIndex + layouts.length) % layouts.length;
+        const nextLayout = layouts[normalizedIndex];
         setLayoutCarouselDirection(direction);
-        setSelectedLayoutId(layouts[normalizedIndex]?.id ?? null);
+        setSelectedLayoutId(nextLayout?.id ?? null);
+        track('game_raised_bed_onboarding_layout_viewed', {
+            ...onboardingAnalyticsProperties('layouts'),
+            direction,
+            layout_id: nextLayout?.id,
+            layout_index: normalizedIndex + 1,
+            layout_count: layouts.length,
+        });
     }
 
     function goToStep(nextStep: RaisedBedOnboardingStep) {
-        setStepDirection(
+        const direction =
             onboardingStepIndex(nextStep) < onboardingStepIndex(step)
                 ? 'backward'
-                : 'forward',
-        );
+                : 'forward';
+        track('game_raised_bed_onboarding_step_changed', {
+            ...onboardingAnalyticsProperties(step),
+            direction,
+            from_step_id: step,
+            from_step_index: onboardingStepAnalyticsProperties(step).step_index,
+            to_step_id: nextStep,
+            to_step_index:
+                onboardingStepAnalyticsProperties(nextStep).step_index,
+        });
+        setStepDirection(direction);
         setStep(nextStep);
     }
 
@@ -876,6 +963,7 @@ export function RaisedBedOnboardingModal({
             }
 
             track('game_raised_bed_onboarding_applied', {
+                ...onboardingAnalyticsProperties('tasks'),
                 garden_id: currentGarden.id,
                 layout_id: selectedLayout.id,
                 raised_bed_id: targetRaisedBed.id,
@@ -991,8 +1079,7 @@ export function RaisedBedOnboardingModal({
                 if (nextOpen) {
                     setOpen(true);
                     track('game_raised_bed_onboarding_opened', {
-                        garden_id: currentGarden?.id,
-                        raised_bed_id: targetRaisedBed?.id,
+                        ...onboardingAnalyticsProperties(),
                         source: 'trigger',
                     });
                     return;
@@ -1081,9 +1168,20 @@ export function RaisedBedOnboardingModal({
                                                             'border-green-500 bg-green-50/80 ring-1 ring-green-500 dark:bg-green-950/40',
                                                     )}
                                                     key={option.value}
-                                                    onClick={() =>
-                                                        setGoal(option.value)
-                                                    }
+                                                    onClick={() => {
+                                                        track(
+                                                            'game_raised_bed_onboarding_goal_selected',
+                                                            {
+                                                                ...onboardingAnalyticsProperties(
+                                                                    'goal',
+                                                                ),
+                                                                previous_goal:
+                                                                    goal,
+                                                                goal: option.value,
+                                                            },
+                                                        );
+                                                        setGoal(option.value);
+                                                    }}
                                                     type="button"
                                                 >
                                                     <Row
@@ -1139,9 +1237,20 @@ export function RaisedBedOnboardingModal({
                                                             'border-green-500 bg-green-50/80 ring-1 ring-green-500 dark:bg-green-950/40',
                                                     )}
                                                     key={option.value}
-                                                    onClick={() =>
-                                                        setCare(option.value)
-                                                    }
+                                                    onClick={() => {
+                                                        track(
+                                                            'game_raised_bed_onboarding_care_selected',
+                                                            {
+                                                                ...onboardingAnalyticsProperties(
+                                                                    'care',
+                                                                ),
+                                                                previous_care:
+                                                                    care,
+                                                                care: option.value,
+                                                            },
+                                                        );
+                                                        setCare(option.value);
+                                                    }}
                                                     type="button"
                                                 >
                                                     <Stack spacing={1}>
@@ -1368,6 +1477,14 @@ export function RaisedBedOnboardingModal({
                                     className="w-fit px-0 text-sm"
                                     color="success"
                                     href={KnownPages.GrediceFirstRaisedBedGuide}
+                                    onClick={() =>
+                                        track(
+                                            'game_raised_bed_onboarding_guide_opened',
+                                            {
+                                                ...onboardingAnalyticsProperties(),
+                                            },
+                                        )
+                                    }
                                     rel="noreferrer"
                                     size="sm"
                                     target="_blank"

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -195,6 +195,20 @@ function checklistTaskProperties(task: TutorialChecklistTask) {
     };
 }
 
+function findChecklistTask(
+    state: TutorialChecklistState,
+    taskKey: string,
+): TutorialChecklistTask | undefined {
+    for (const group of state.groups) {
+        const task = group.tasks.find((item) => item.key === taskKey);
+        if (task) {
+            return task;
+        }
+    }
+
+    return undefined;
+}
+
 function isTaskReadyAfterOpen(task: TutorialChecklistTask) {
     return (
         task.completion === 'manual' &&
@@ -545,9 +559,10 @@ function TutorialChecklistContent({
 
         if (task.claimable) {
             const nextState = await claimTask.mutateAsync(task.key);
+            const claimedTask = findChecklistTask(nextState, task.key) ?? task;
             track('game_tutorial_checklist_task_claimed', {
                 ...checklistProgressProperties(nextState),
-                ...checklistTaskProperties(task),
+                ...checklistTaskProperties(claimedTask),
             });
         }
     }
@@ -562,9 +577,10 @@ function TutorialChecklistContent({
 
         if (isTaskReadyAfterOpen(task)) {
             const nextState = await markTaskReady.mutateAsync(task.key);
+            const readyTask = findChecklistTask(nextState, task.key) ?? task;
             track('game_tutorial_checklist_task_ready_marked', {
                 ...checklistProgressProperties(nextState),
-                ...checklistTaskProperties(task),
+                ...checklistTaskProperties(readyTask),
             });
         }
     }

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -18,6 +18,7 @@ import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import {
     type TutorialChecklistGroup,
+    type TutorialChecklistState,
     type TutorialChecklistTask,
     tutorialChecklistKeys,
     useClaimTutorialChecklistTask,
@@ -134,6 +135,64 @@ function sortChecklistTasks(tasks: TutorialChecklistTask[]) {
             return a.index - b.index;
         })
         .map(({ task }) => task);
+}
+
+function checklistProgressProperties(
+    state: TutorialChecklistState | null | undefined,
+) {
+    const groups = state?.groups ?? [];
+    const activeGroupIndex = groups.findIndex(
+        (group) => !isGroupComplete(group),
+    );
+    const activeGroup =
+        activeGroupIndex >= 0 ? groups[activeGroupIndex] : undefined;
+    const completedCount = state?.totals.completedCount;
+    const totalCount = state?.totals.totalCount;
+
+    return {
+        completed_count: completedCount,
+        total_count: totalCount,
+        claimable_count: state?.totals.claimableCount,
+        available_sunflowers: state?.totals.availableSunflowers,
+        earned_sunflowers: state?.totals.earnedSunflowers,
+        completion_percent:
+            totalCount && completedCount !== undefined
+                ? Math.round((completedCount / totalCount) * 100)
+                : undefined,
+        group_count: groups.length || undefined,
+        active_group_id: activeGroup?.id,
+        active_group_index:
+            activeGroupIndex >= 0 ? activeGroupIndex + 1 : undefined,
+        active_group_completed_count: activeGroup?.completedCount,
+        active_group_total_count: activeGroup?.totalCount,
+    };
+}
+
+function checklistGroupProperties(
+    group: TutorialChecklistGroup,
+    groupIndex: number,
+) {
+    return {
+        group_id: group.id,
+        group_index: groupIndex + 1,
+        group_completed: isGroupComplete(group),
+        group_completed_count: group.completedCount,
+        group_total_count: group.totalCount,
+        group_claimable_count: group.claimableCount,
+    };
+}
+
+function checklistTaskProperties(task: TutorialChecklistTask) {
+    return {
+        task_key: task.key,
+        group_id: task.groupId,
+        status: task.status,
+        claimable: task.claimable,
+        completed: task.completed,
+        action_target: task.actionTarget,
+        completion_type: task.completion,
+        reward_sunflowers: task.rewardSunflowers,
+    };
 }
 
 function isTaskReadyAfterOpen(task: TutorialChecklistTask) {
@@ -480,27 +539,33 @@ function TutorialChecklistContent({
 
     async function handleTaskAction(task: TutorialChecklistTask) {
         track('game_tutorial_checklist_task_clicked', {
-            task_key: task.key,
-            status: task.status,
-            claimable: task.claimable,
+            ...checklistProgressProperties(checklistQuery.data),
+            ...checklistTaskProperties(task),
         });
 
         if (task.claimable) {
-            await claimTask.mutateAsync(task.key);
+            const nextState = await claimTask.mutateAsync(task.key);
+            track('game_tutorial_checklist_task_claimed', {
+                ...checklistProgressProperties(nextState),
+                ...checklistTaskProperties(task),
+            });
         }
     }
 
     async function handleTaskOpen(task: TutorialChecklistTask) {
         track('game_tutorial_checklist_task_opened', {
-            task_key: task.key,
-            status: task.status,
-            claimable: task.claimable,
+            ...checklistProgressProperties(checklistQuery.data),
+            ...checklistTaskProperties(task),
         });
 
         await openTarget(task);
 
         if (isTaskReadyAfterOpen(task)) {
-            await markTaskReady.mutateAsync(task.key);
+            const nextState = await markTaskReady.mutateAsync(task.key);
+            track('game_tutorial_checklist_task_ready_marked', {
+                ...checklistProgressProperties(nextState),
+                ...checklistTaskProperties(task),
+            });
         }
     }
 
@@ -561,7 +626,7 @@ function TutorialChecklistContent({
                 </Typography>
             </Stack>
             <Stack spacing={4}>
-                {sortedGroups.map((group) => {
+                {sortedGroups.map((group, groupIndex) => {
                     const complete = isGroupComplete(group);
                     const expanded = expandedGroups[group.id] ?? !complete;
                     const sortedTasks = sortChecklistTasks(group.tasks);
@@ -577,12 +642,26 @@ function TutorialChecklistContent({
                             <button
                                 aria-expanded={expanded}
                                 className="-mx-px flex w-[calc(100%+2px)] items-start justify-between gap-4 px-4 py-3 text-left outline-hidden transition-colors hover:bg-muted/60 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-                                onClick={() =>
+                                onClick={() => {
+                                    const nextExpanded = !expanded;
                                     setExpandedGroups((current) => ({
                                         ...current,
-                                        [group.id]: !expanded,
-                                    }))
-                                }
+                                        [group.id]: nextExpanded,
+                                    }));
+                                    track(
+                                        'game_tutorial_checklist_group_toggled',
+                                        {
+                                            ...checklistProgressProperties(
+                                                checklistQuery.data,
+                                            ),
+                                            ...checklistGroupProperties(
+                                                group,
+                                                groupIndex,
+                                            ),
+                                            expanded: nextExpanded,
+                                        },
+                                    );
+                                }}
                                 type="button"
                             >
                                 <Stack spacing={0.5} className="min-w-0">
@@ -674,6 +753,23 @@ export function TutorialChecklistHud() {
         return `${firstActiveGroup.completedCount}/${firstActiveGroup.totalCount}`;
     }, [data]);
 
+    function handleOpenChange(open: boolean) {
+        if (open) {
+            track('game_tutorial_checklist_opened', {
+                ...checklistProgressProperties(data),
+            });
+            void queryClient.invalidateQueries({
+                queryKey: tutorialChecklistKeys,
+            });
+        } else if (isOpen) {
+            track('game_tutorial_checklist_closed', {
+                ...checklistProgressProperties(data),
+            });
+        }
+
+        setIsOpen(open);
+    }
+
     return (
         <HudCard open position="floating" className="relative grid">
             {claimableCount > 0 && (
@@ -687,17 +783,7 @@ export function TutorialChecklistHud() {
             )}
             <Modal
                 className="z-[46] border-tertiary border-b-4 md:max-w-3xl"
-                onOpenChange={(open) => {
-                    if (open) {
-                        track('game_tutorial_checklist_opened', {
-                            claimable_count: claimableCount,
-                        });
-                        void queryClient.invalidateQueries({
-                            queryKey: tutorialChecklistKeys,
-                        });
-                    }
-                    setIsOpen(open);
-                }}
+                onOpenChange={handleOpenChange}
                 open={isOpen}
                 overlayClassName="z-[46]"
                 title="Zadaci za novi vrt"
@@ -734,7 +820,7 @@ export function TutorialChecklistHud() {
                     </IconButton>
                 }
             >
-                <TutorialChecklistContent onOpenChange={setIsOpen} />
+                <TutorialChecklistContent onOpenChange={handleOpenChange} />
             </Modal>
         </HudCard>
     );


### PR DESCRIPTION
## Summary
- Add funnel-friendly PostHog events for the raised-bed onboarding modal, including open source, step views, step transitions, choices, guide clicks, apply, and explicit close/falloff data.
- Add richer tutorial checklist analytics for open/close progress snapshots, group toggles, task opens, task claims, and ready-after-open updates.
- Include step/page, progress, garden, raised-bed, layout, group, and task properties so onboarding funnels can identify where users stop.

## Validation
- `corepack pnpm lint --filter @gredice/game`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter www`
- `git diff --check`