### PR TITLE
[codex] Use payout request time for balance cutoff

### DIFF
--- a/packages/storage/src/repositories/payoutsRepo.ts
+++ b/packages/storage/src/repositories/payoutsRepo.ts
@@ -194,12 +194,18 @@ async function getOperationEffectiveFarmIds(operationIds: number[]) {
     );
 }
 
-function getLastPaidPayoutAt(payouts: SelectFarmerPayoutRequest[]) {
-    return payouts
-        .filter((payout) => payout.status === 'paid')
-        .map((payout) => payout.paidAt ?? payout.updatedAt ?? payout.createdAt)
-        .filter((paidAt): paidAt is Date => paidAt instanceof Date)
-        .sort((left, right) => right.getTime() - left.getTime())[0];
+function getLastPaidPayoutRequestedAt(payouts: SelectFarmerPayoutRequest[]) {
+    return (
+        payouts
+            .filter((payout) => payout.status === 'paid')
+            // A completed payout closes the earning window at request time, not payment time.
+            .map((payout) => payout.createdAt)
+            .filter(
+                (requestedAt): requestedAt is Date =>
+                    requestedAt instanceof Date,
+            )
+            .sort((left, right) => right.getTime() - left.getTime())[0]
+    );
 }
 
 function getOperationPayoutEligibleAt(operation: {
@@ -346,17 +352,19 @@ export async function getFarmerBalance(
         getFarmPayoutRequestsWithAdjustments(farmId),
         getEntitiesFormatted<OperationData>('operation'),
     ]);
-    const lastPaidPayoutAt = getLastPaidPayoutAt(payouts);
+    const lastPaidPayoutRequestedAt = getLastPaidPayoutRequestedAt(payouts);
     const [completedOperations, verifiedSowings] = await Promise.all([
         getFarmAcceptedOperations(farmId, { status: 'completed' }),
-        getVerifiedSowingsForFarm(farmId, lastPaidPayoutAt),
+        getVerifiedSowingsForFarm(farmId, lastPaidPayoutRequestedAt),
     ]);
     const payableOperations = completedOperations.filter((operation) => {
-        if (!lastPaidPayoutAt) {
+        if (!lastPaidPayoutRequestedAt) {
             return true;
         }
 
-        return getOperationPayoutEligibleAt(operation) > lastPaidPayoutAt;
+        return (
+            getOperationPayoutEligibleAt(operation) > lastPaidPayoutRequestedAt
+        );
     });
     const completedOperationFarmIds = await getOperationEffectiveFarmIds(
         payableOperations.map((operation) => operation.id),

--- a/packages/storage/tests/payoutsRepo.node.spec.ts
+++ b/packages/storage/tests/payoutsRepo.node.spec.ts
@@ -400,7 +400,7 @@ test('getFarmerBalance includes farm sowing cycles regardless assignment', async
     assert.equal(balance.totalDurationMinutes, 5);
 });
 
-test('getFarmerBalance counts payable work after the last paid farm payout', async () => {
+test('getFarmerBalance counts payable work after the last paid farm payout request', async () => {
     createTestDb();
 
     const userId = randomUUID();
@@ -464,9 +464,9 @@ test('getFarmerBalance counts payable work after the last paid farm payout', asy
             requestedAmount: '0.50',
             currency: 'eur',
             status: 'paid',
-            paidAt: new Date('2026-01-02T10:00:00.000Z'),
+            paidAt: new Date('2026-01-04T10:00:00.000Z'),
             createdAt: new Date('2026-01-02T09:00:00.000Z'),
-            updatedAt: new Date('2026-01-02T10:00:00.000Z'),
+            updatedAt: new Date('2026-01-04T10:00:00.000Z'),
         });
 
     await createVerifiedAcceptedOperation({


### PR DESCRIPTION
## Summary

- change paid payout cutoff logic to use the payout request timestamp (`createdAt`) instead of payment/completion time
- keep farm balance earnings payable for work completed after the request while the payout is waiting for approval/payment
- update the payout repository regression test so delayed payout completion still leaves later work payable

## Root Cause

The farm balance window used the latest paid payout's `paidAt`/`updatedAt` timestamp. When admins completed an older payout later, all work completed between the farmer's request and the eventual payment was treated as already covered, so the farmer payout page could show zero new earnings.

## Validation

- `pnpm --filter @gredice/storage test payoutsRepo.node.spec.ts`
- `pnpm lint --filter @gredice/storage`
- `pnpm typecheck --filter @gredice/storage` (no typecheck tasks configured for this package)
- `git diff --check`