### PR TITLE
Silence anonymous current claims warning

### DIFF
--- a/apps/garden/components/providers/ClientAppProvider.tsx
+++ b/apps/garden/components/providers/ClientAppProvider.tsx
@@ -22,6 +22,10 @@ async function currentUserFactory() {
     const response = await fetch('/api/gredice/api/auth/current-claims', {
         cache: 'no-store',
     });
+    if (response.status === 401) {
+        return null;
+    }
+
     if (!response.ok) {
         console.warn('Failed to fetch current user claims:', response.status);
         return null;


### PR DESCRIPTION
## Summary
- Treat `401` from the garden current-claims probe as the expected anonymous state.
- Keep warning logs for unexpected non-OK current-claims responses.

## Root Cause
The garden auth provider logged every non-OK `/api/auth/current-claims` response as a warning, but the API intentionally returns `401` when no session or refresh cookie resolves to a current user.

## Validation
- `git diff --check`
- `corepack pnpm typecheck --filter garden`