### PR TITLE
[codex] Add accessible modal descriptions

### DIFF
--- a/apps/storybook/stories/packages/ui/primitives/Modal.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/Modal.stories.tsx
@@ -18,6 +18,8 @@ const meta = {
     },
     args: {
         title: 'Potvrdi radnju',
+        description:
+            'Kratka potvrda prije spremanja promjene u aktivnom prikazu.',
     },
     render: (args) => (
         <Modal {...args} trigger={<Button>Otvori modal</Button>}>
@@ -25,7 +27,8 @@ const meta = {
                 <Stack spacing={1}>
                     <Typography level="h5">Potvrdi radnju</Typography>
                     <Typography level="body2" secondary>
-                        Koristi se za kratke tokove koji traze jasnu potvrdu.
+                        Kratka potvrda prije spremanja promjene u aktivnom
+                        prikazu.
                     </Typography>
                 </Stack>
                 <div className="flex justify-end gap-2">
@@ -58,6 +61,8 @@ export const NotDismissible: Story = {
 export const LongContent: Story = {
     args: {
         title: 'Dugacki modal',
+        description:
+            'Modal s visim sadrzajem koji se skrola unutar dostupnog viewporta.',
         className: 'max-w-5xl',
     },
     render: (args) => (

--- a/apps/storybook/stories/packages/ui/primitives/ModalConfirm.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/ModalConfirm.stories.tsx
@@ -48,6 +48,8 @@ export const WithPrompt: Story = {
 
 export const RichContent: Story = {
     args: {
+        description:
+            'Brisanjem se uklanjaju povezani podaci iz aktivnog prikaza.',
         children: (
             <Typography level="body2">
                 Brisanjem se uklanjaju povezani podaci iz aktivnog prikaza.

--- a/packages/ui/src/Modal/Modal.tsx
+++ b/packages/ui/src/Modal/Modal.tsx
@@ -17,6 +17,7 @@ export type ModalProps = Omit<HTMLAttributes<HTMLDivElement>, 'title'> & {
     onOpenChange?: (open: boolean) => void;
     modal?: boolean;
     title: string;
+    description?: ReactNode;
     hideClose?: boolean;
     disableMobile?: boolean;
     mobileOverride?: boolean;
@@ -27,6 +28,7 @@ export type ModalProps = Omit<HTMLAttributes<HTMLDivElement>, 'title'> & {
 export function Modal({
     children,
     className,
+    description,
     dismissible = true,
     hideClose,
     modal,
@@ -46,6 +48,7 @@ export function Modal({
         return (
             <MobileModal
                 className={className}
+                description={description}
                 dismissible={dismissible}
                 modal={modal}
                 onOpenChange={onOpenChange}
@@ -63,6 +66,7 @@ export function Modal({
     return (
         <DesktopModal
             className={className}
+            description={description}
             dismissible={dismissible}
             hideClose={hideClose}
             modal={modal}
@@ -81,6 +85,7 @@ export function Modal({
 function DesktopModal({
     children,
     className,
+    description,
     dismissible = true,
     hideClose,
     modal,
@@ -91,6 +96,8 @@ function DesktopModal({
     trigger,
     ...rest
 }: Omit<ModalProps, 'disableMobile' | 'mobileOverride'>) {
+    const hasDescription = hasAccessibleDescription(description);
+
     function preventDismiss(event: Event) {
         if (!dismissible) {
             event.preventDefault();
@@ -116,7 +123,9 @@ function DesktopModal({
                     )}
                 />
                 <DialogPrimitive.Content
-                    aria-describedby={undefined}
+                    {...(hasDescription
+                        ? {}
+                        : { 'aria-describedby': undefined })}
                     className={cx(
                         'fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-lg min-w-0 -translate-x-1/2 -translate-y-1/2 gap-4 overflow-x-auto overflow-y-auto overscroll-contain border bg-background p-6 shadow-lg duration-200 [overflow-wrap:anywhere] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:rounded-lg',
                         className,
@@ -128,6 +137,11 @@ function DesktopModal({
                     <DialogPrimitive.Title className="sr-only">
                         {title}
                     </DialogPrimitive.Title>
+                    {hasDescription ? (
+                        <DialogPrimitive.Description className="sr-only">
+                            {description}
+                        </DialogPrimitive.Description>
+                    ) : null}
                     {children}
                     {dismissible && !hideClose ? (
                         <DialogPrimitive.Close className="absolute right-4 top-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
@@ -144,6 +158,7 @@ function DesktopModal({
 function MobileModal({
     children,
     className,
+    description,
     dismissible = true,
     modal,
     onOpenChange,
@@ -153,6 +168,8 @@ function MobileModal({
     trigger,
     ...rest
 }: Omit<ModalProps, 'disableMobile' | 'hideClose' | 'mobileOverride'>) {
+    const hasDescription = hasAccessibleDescription(description);
+
     return (
         <Drawer.Root
             dismissible={dismissible}
@@ -172,6 +189,9 @@ function MobileModal({
                     )}
                 />
                 <Drawer.Content
+                    {...(hasDescription
+                        ? {}
+                        : { 'aria-describedby': undefined })}
                     className={cx(
                         'fixed inset-x-0 bottom-0 z-50 mt-4 flex max-h-[calc(100dvh-1rem)] w-full max-w-full min-w-0 flex-col overflow-hidden rounded-t-[10px] border bg-background',
                         className,
@@ -179,6 +199,11 @@ function MobileModal({
                     {...rest}
                 >
                     <Drawer.Title className="sr-only">{title}</Drawer.Title>
+                    {hasDescription ? (
+                        <Drawer.Description className="sr-only">
+                            {description}
+                        </Drawer.Description>
+                    ) : null}
                     <Drawer.Handle className="mx-auto mt-4 h-2 w-[100px] shrink-0 rounded-full bg-muted" />
                     <div className="min-h-0 min-w-0 max-w-full overflow-x-auto overflow-y-auto p-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] [overflow-wrap:anywhere]">
                         {children}
@@ -208,4 +233,13 @@ function useViewport() {
     }, []);
 
     return viewport;
+}
+
+function hasAccessibleDescription(description: ReactNode) {
+    return (
+        description !== undefined &&
+        description !== null &&
+        description !== false &&
+        description !== ''
+    );
 }

--- a/packages/ui/src/ModalConfirm/ModalConfirm.tsx
+++ b/packages/ui/src/ModalConfirm/ModalConfirm.tsx
@@ -26,6 +26,7 @@ export type ModalConfirmPromptProps = {
 
 type ModalConfirmBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'title'> & {
     title: string;
+    description?: ReactNode;
     trigger?: ReactNode;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
@@ -46,6 +47,7 @@ export function ModalConfirm({
     children,
     className,
     confirmLabel = 'Potvrdi',
+    description,
     disableMobile: _disableMobile,
     dismissible: _dismissible,
     expectedConfirm,
@@ -65,6 +67,12 @@ export function ModalConfirm({
     const [promptValue, setPromptValue] = useState('');
     const currentOpen = open ?? internalOpen;
     const canConfirm = !expectedConfirm || promptValue === expectedConfirm;
+    const hasExplicitDescription = hasAccessibleDescription(description);
+    const useChildrenAsDescription =
+        !hasExplicitDescription &&
+        typeof children === 'string' &&
+        children.trim().length > 0;
+    const hiddenDescription = hasExplicitDescription ? description : title;
 
     useEffect(() => {
         if (!currentOpen) {
@@ -100,7 +108,6 @@ export function ModalConfirm({
             <AlertDialogPrimitive.Portal>
                 <AlertDialogPrimitive.Overlay className="fixed inset-0 z-50 bg-background/80 backdrop-blur-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
                 <AlertDialogPrimitive.Content
-                    aria-describedby={undefined}
                     className={cx(
                         'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] data-[state=open]:zoom-in-95 sm:rounded-lg md:w-full',
                         className,
@@ -119,13 +126,25 @@ export function ModalConfirm({
                                         <div>{header}</div>
                                     )}
                                 </AlertDialogPrimitive.Title>
-                                <Typography className="sr-only" component="p">
-                                    {title}
-                                </Typography>
+                                {!useChildrenAsDescription ? (
+                                    <AlertDialogPrimitive.Description className="sr-only">
+                                        {hiddenDescription}
+                                    </AlertDialogPrimitive.Description>
+                                ) : null}
                                 {typeof children === 'string' ? (
-                                    <Typography level="body1">
-                                        {children}
-                                    </Typography>
+                                    useChildrenAsDescription ? (
+                                        <AlertDialogPrimitive.Description
+                                            asChild
+                                        >
+                                            <Typography level="body1">
+                                                {children}
+                                            </Typography>
+                                        </AlertDialogPrimitive.Description>
+                                    ) : (
+                                        <Typography level="body1">
+                                            {children}
+                                        </Typography>
+                                    )
                                 ) : (
                                     children
                                 )}
@@ -160,5 +179,14 @@ export function ModalConfirm({
                 </AlertDialogPrimitive.Content>
             </AlertDialogPrimitive.Portal>
         </AlertDialogPrimitive.Root>
+    );
+}
+
+function hasAccessibleDescription(description: ReactNode) {
+    return (
+        description !== undefined &&
+        description !== null &&
+        description !== false &&
+        description !== ''
     );
 }


### PR DESCRIPTION
## Summary
- Add an explicit `description` prop to the shared `Modal` wrapper and wire it to Radix/Vaul descriptions when supplied.
- Keep the intentional `aria-describedby={undefined}` opt-out for generic modals that do not have a concise description.
- Ensure `ModalConfirm` always exposes a Radix alert-dialog description, using explicit descriptions, simple string body text, or the existing title fallback.
- Update Storybook primitive stories to document the accessible description path.

## Root cause
Mobile `Modal` renders through Vaul `Drawer.Content`, which forwards to Radix `DialogContent`. Without a Radix description or an explicit `aria-describedby={undefined}` opt-out, Radix logs the missing description warning seen on `vrt.gredice.com` and other apps.

## Validation
- `pnpm lint --filter @gredice/ui`
- `pnpm typecheck --filter @gredice/ui`
- `pnpm typecheck --filter storybook`
- `pnpm --filter storybook lint`
- `pnpm --filter garden typecheck`
- `git diff --check`