### PR TITLE
Handle auth interrupts for unauthorized admin access

### DIFF
--- a/apps/app/app/admin/layout.tsx
+++ b/apps/app/app/admin/layout.tsx
@@ -6,15 +6,12 @@ import {
     getSetting,
     SettingsKeys,
 } from '@gredice/storage';
-import { SignedOut } from '@gredice/ui/auth';
-import { AuthProtectedSection } from '@gredice/ui/auth/server';
 import { type PropsWithChildren, Suspense } from 'react';
 import {
     AdminDesktopFrame,
     AdminPageCardHeader,
     AdminPageHeaderProvider,
     DesktopNavProvider,
-    LoginDialog,
 } from '../../components/admin/navigation';
 import { AdminClientProvider } from '../../components/admin/providers';
 import { AuthAppProvider } from '../../components/providers/AuthAppProvider';
@@ -30,22 +27,7 @@ export const dynamic = 'force-dynamic';
 
 export default async function AdminLayout({ children }: PropsWithChildren) {
     const authAdmin = auth.bind(null, ['admin']);
-    const isAdmin = await authAdmin().then(
-        () => true,
-        () => false,
-    );
-
-    if (!isAdmin) {
-        return (
-            <AuthAppProvider>
-                <div className="grow bg-secondary/40">
-                    <main className="relative h-full min-h-screen">
-                        <LoginDialog />
-                    </main>
-                </div>
-            </AuthAppProvider>
-        );
-    }
+    await authAdmin();
 
     const [
         { categorizedTypes, uncategorizedTypes, shadowTypes },
@@ -106,20 +88,15 @@ export default async function AdminLayout({ children }: PropsWithChildren) {
                                     className="min-h-full border bg-[var(--admin-page-content-background)] p-3 md:rounded-2xl md:p-4"
                                     data-gredice-admin-content-panel
                                 >
-                                    <AuthProtectedSection auth={authAdmin}>
-                                        <Suspense>
-                                            <AdminPageHeaderProvider>
-                                                <AdminPageCardHeader />
-                                                {children}
-                                            </AdminPageHeaderProvider>
-                                        </Suspense>
-                                    </AuthProtectedSection>
+                                    <Suspense>
+                                        <AdminPageHeaderProvider>
+                                            <AdminPageCardHeader />
+                                            {children}
+                                        </AdminPageHeaderProvider>
+                                    </Suspense>
                                 </div>
                             </AdminDesktopFrame>
                         </DesktopNavProvider>
-                        <SignedOut>
-                            <LoginDialog />
-                        </SignedOut>
                     </main>
                 </div>
             </AdminClientProvider>

--- a/apps/app/app/forbidden.tsx
+++ b/apps/app/app/forbidden.tsx
@@ -1,0 +1,43 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Lock, LogOut } from '@gredice/ui/icons';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { KnownPages } from '../src/KnownPages';
+
+export default function ForbiddenPage() {
+    return (
+        <div className="grow bg-secondary/40">
+            <main className="flex min-h-screen items-center justify-center p-4">
+                <section className="w-full max-w-md rounded-lg border bg-background p-6 shadow-sm">
+                    <Stack spacing={5}>
+                        <Stack spacing={2} alignItems="center">
+                            <span className="flex h-12 w-12 items-center justify-center rounded-full border bg-muted">
+                                <Lock className="h-5 w-5" aria-hidden />
+                            </span>
+                            <Typography level="h4" component="h1" center>
+                                Pristup nije dozvoljen
+                            </Typography>
+                            <Typography secondary center>
+                                Nemate ovlasti za otvaranje ove stranice.
+                            </Typography>
+                        </Stack>
+                        <Alert color="warning">
+                            Prijavite se s korisnikom koji ima odgovarajuću
+                            ulogu.
+                        </Alert>
+                        <Button
+                            href={KnownPages.Logout}
+                            variant="solid"
+                            color="neutral"
+                            fullWidth
+                            startDecorator={<LogOut className="h-4 w-4" />}
+                        >
+                            Odjava
+                        </Button>
+                    </Stack>
+                </section>
+            </main>
+        </div>
+    );
+}

--- a/apps/app/app/logout/page.tsx
+++ b/apps/app/app/logout/page.tsx
@@ -1,0 +1,11 @@
+import { LogoutForm } from '../admin/logout/LogoutForm';
+
+export default function LogoutPage() {
+    return (
+        <div className="grow bg-secondary/40">
+            <main className="flex min-h-screen items-center justify-center p-4">
+                <LogoutForm />
+            </main>
+        </div>
+    );
+}

--- a/apps/app/app/unauthorized.tsx
+++ b/apps/app/app/unauthorized.tsx
@@ -1,0 +1,14 @@
+import { LoginDialog } from '../components/admin/navigation';
+import { AuthAppProvider } from '../components/providers/AuthAppProvider';
+
+export default function UnauthorizedPage() {
+    return (
+        <AuthAppProvider>
+            <div className="grow bg-secondary/40">
+                <main className="relative h-full min-h-screen">
+                    <LoginDialog />
+                </main>
+            </div>
+        </AuthAppProvider>
+    );
+}

--- a/apps/app/components/admin/dashboard/AdminDashboard.tsx
+++ b/apps/app/components/admin/dashboard/AdminDashboard.tsx
@@ -20,7 +20,7 @@ type AdminDashboardProps = {
 };
 
 export async function AdminDashboard({ searchParams }: AdminDashboardProps) {
-    auth(['admin']);
+    await auth(['admin']);
     const params = await searchParams;
     const selectedPeriod = params?.period || '7';
 

--- a/apps/app/lib/auth/auth.ts
+++ b/apps/app/lib/auth/auth.ts
@@ -1,7 +1,6 @@
 import 'server-only';
 import { getUser as storageGetUser } from '@gredice/storage';
 import { cookies } from 'next/headers';
-import { forbidden, unauthorized } from 'next/navigation';
 import {
     baseAuth,
     baseWithAuth,
@@ -71,16 +70,19 @@ function isUnauthenticatedError(error: unknown) {
     );
 }
 
-function interruptExpectedAuthError(error: unknown): never {
+async function interruptExpectedAuthError(error: unknown): Promise<never> {
     if (isAuthError(error, 'Unauthorized')) {
+        const { forbidden } = await import('next/navigation');
         forbidden();
     }
 
     if (isAuthError(error, 'Account not found')) {
+        const { forbidden } = await import('next/navigation');
         forbidden();
     }
 
     if (isUnauthenticatedError(error)) {
+        const { unauthorized } = await import('next/navigation');
         unauthorized();
     }
 
@@ -147,7 +149,7 @@ export async function auth(...args: Parameters<typeof baseAuth>) {
 
         return await baseAuth(...args);
     } catch (error) {
-        interruptExpectedAuthError(error);
+        return await interruptExpectedAuthError(error);
     }
 }
 

--- a/apps/app/lib/auth/auth.ts
+++ b/apps/app/lib/auth/auth.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import { getUser as storageGetUser } from '@gredice/storage';
 import { cookies } from 'next/headers';
+import { forbidden, unauthorized } from 'next/navigation';
 import {
     baseAuth,
     baseWithAuth,
@@ -57,6 +58,35 @@ function resolveAccountId(
     return accountIds[0];
 }
 
+function isAuthError(error: unknown, message: string) {
+    return error instanceof Error && error.message === message;
+}
+
+function isUnauthenticatedError(error: unknown) {
+    return (
+        error instanceof Error &&
+        (error.name === 'UnauthorizedError' ||
+            error.message.startsWith('Unauthorized:') ||
+            error.message === 'User not found')
+    );
+}
+
+function interruptExpectedAuthError(error: unknown): never {
+    if (isAuthError(error, 'Unauthorized')) {
+        forbidden();
+    }
+
+    if (isAuthError(error, 'Account not found')) {
+        forbidden();
+    }
+
+    if (isUnauthenticatedError(error)) {
+        unauthorized();
+    }
+
+    throw error;
+}
+
 async function authFromToken(token: string, roles: string[]) {
     const { result, error } = await verifyJwt(token);
     const payload = result?.payload as TokenClaims | undefined;
@@ -105,16 +135,20 @@ async function authFromToken(token: string, roles: string[]) {
 }
 
 export async function auth(...args: Parameters<typeof baseAuth>) {
-    const [roles] = args;
-    const accessToken = await refreshSessionIfNeeded({
-        // auth() is used during Server Component rendering, where cookies are read-only.
-        persistCookies: false,
-    });
-    if (accessToken) {
-        return await authFromToken(accessToken, roles);
-    }
+    try {
+        const [roles] = args;
+        const accessToken = await refreshSessionIfNeeded({
+            // auth() is used during Server Component rendering, where cookies are read-only.
+            persistCookies: false,
+        });
+        if (accessToken) {
+            return await authFromToken(accessToken, roles);
+        }
 
-    return await baseAuth(...args);
+        return await baseAuth(...args);
+    } catch (error) {
+        interruptExpectedAuthError(error);
+    }
 }
 
 export async function withAuth(...args: Parameters<typeof baseWithAuth>) {

--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -13,6 +13,7 @@ const nextConfig: NextConfig = {
         browserToTerminal: true,
     },
     experimental: {
+        authInterrupts: true,
         typedEnv: true,
         turbopackFileSystemCacheForDev: true,
         optimizePackageImports: [

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -70,7 +70,7 @@ export const KnownPages = {
     Feedback: '/admin/feedback',
     Notifications: '/admin/communication/notifications',
     Surveys: '/admin/surveys',
-    Logout: '/admin/logout',
+    Logout: '/logout',
     RaisedBeds: '/admin/raised-beds',
     RaisedBed: (raisedBedId: number) =>
         `/admin/raised-beds/${raisedBedId}` as Route,

--- a/apps/app/tests/landing.spec.ts
+++ b/apps/app/tests/landing.spec.ts
@@ -10,7 +10,7 @@ test('redirects root to admin login page', async ({ request }) => {
 test('shows login on admin page when signed out', async ({ page, request }) => {
     const response = await request.get('/admin', { maxRedirects: 0 });
 
-    expect(response.status()).toBe(200);
+    expect(response.status()).toBe(401);
     expect(response.headers().location).toBeUndefined();
 
     await page.goto('/admin');
@@ -27,4 +27,11 @@ test('shows login on admin page when signed out', async ({ page, request }) => {
         page.getByRole('button', { name: 'Prijavi se' }),
     ).toBeVisible();
     await expect(page.getByLabel('Email')).toBeVisible();
+});
+
+test('renders logout outside the admin shell', async ({ request }) => {
+    const response = await request.get('/logout', { maxRedirects: 0 });
+
+    expect(response.status()).toBe(200);
+    expect(response.headers().location).toBeUndefined();
 });


### PR DESCRIPTION
## Summary
- Enable `authInterrupts` in the app config so auth helpers can route expected failures through Next.js interrupts
- Map unauthenticated token and session errors to `unauthorized()` or `forbidden()` in the auth wrapper
- Split admin access handling into dedicated unauthorized and forbidden pages
- Await admin dashboard auth checks before rendering content

## Testing
- Not run (not requested)