### PR TITLE
[codex] Show garden box validation tooltip

### DIFF
--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -1,3 +1,4 @@
+import { Html } from '@react-three/drei';
 import { type ReactNode, Suspense, useEffect, useMemo } from 'react';
 import {
     Color,
@@ -96,6 +97,9 @@ type LoadedAssetBlockMaterialProps = Omit<
 type WaterBlockInstance = EntityBlockInstance & {
     waterHeight: number;
 };
+
+const gardenBoxTooltipDurationMs = 3600;
+const gardenBoxTooltipYOffset = 1.25;
 
 const potBlockNames = [
     'PotLowBowl',
@@ -1293,7 +1297,66 @@ function GardenBoxInstances({
                 openGardenBoxBlockId={openGardenBoxBlockId}
                 hoveredGardenBoxBlockId={hoveredGardenBoxBlockId}
             />
+            <GardenBoxTooltip instances={bodyInstances} />
         </>
+    );
+}
+
+function GardenBoxTooltip({ instances }: { instances: EntityBlockInstance[] }) {
+    const tooltip = useGameState((state) => state.gardenBoxTooltip);
+    const clearGardenBoxTooltip = useGameState(
+        (state) => state.clearGardenBoxTooltip,
+    );
+    const tooltipSequence = tooltip?.sequence;
+
+    useEffect(() => {
+        if (tooltipSequence === undefined) {
+            return;
+        }
+
+        const timeout = window.setTimeout(
+            clearGardenBoxTooltip,
+            gardenBoxTooltipDurationMs,
+        );
+
+        return () => window.clearTimeout(timeout);
+    }, [clearGardenBoxTooltip, tooltipSequence]);
+
+    if (!tooltip) {
+        return null;
+    }
+
+    const tooltipInstance = instances.find(
+        (instance) => instance.block.id === tooltip.blockId,
+    );
+
+    if (!tooltipInstance) {
+        return null;
+    }
+
+    const position: [number, number, number] = [
+        tooltipInstance.position[0],
+        tooltipInstance.position[1] + gardenBoxTooltipYOffset,
+        tooltipInstance.position[2],
+    ];
+
+    return (
+        <Html
+            center
+            distanceFactor={8}
+            position={position}
+            style={{ pointerEvents: 'none' }}
+            zIndexRange={[60, 0]}
+        >
+            <div
+                aria-live="polite"
+                className="relative max-w-[min(18rem,70vw)] rounded-md border border-red-200 bg-white/95 px-3 py-2 text-center text-xs font-semibold leading-snug text-red-800 shadow-lg backdrop-blur-sm dark:border-red-800/80 dark:bg-neutral-950/95 dark:text-red-100"
+                role="status"
+            >
+                {tooltip.message}
+                <span className="absolute top-full left-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-r border-b border-red-200 bg-white/95 dark:border-red-800/80 dark:bg-neutral-950/95" />
+            </div>
+        </Html>
     );
 }
 

--- a/packages/game/src/hooks/useGardenBoxStoreBlock.ts
+++ b/packages/game/src/hooks/useGardenBoxStoreBlock.ts
@@ -94,6 +94,12 @@ export function useGardenBoxStoreBlock() {
     const queryClient = useQueryClient();
     const { data: garden } = useCurrentGarden();
     const winterMode = useGameState((state) => state.winterMode);
+    const showGardenBoxTooltip = useGameState(
+        (state) => state.showGardenBoxTooltip,
+    );
+    const clearGardenBoxTooltip = useGameState(
+        (state) => state.clearGardenBoxTooltip,
+    );
     const gardenQueryKey = currentGardenKeys(winterMode, garden?.id);
 
     return useMutation({
@@ -138,6 +144,8 @@ export function useGardenBoxStoreBlock() {
             if (!garden) {
                 return;
             }
+
+            clearGardenBoxTooltip();
 
             const updatedStacks = garden.stacks.map((stack) => {
                 const isSourceStack =
@@ -186,8 +194,15 @@ export function useGardenBoxStoreBlock() {
                 previousInventory,
             };
         },
-        onError: (error, _variables, context) => {
+        onError: (error, variables, context) => {
             console.error('Error storing block in garden box', error);
+            showGardenBoxTooltip({
+                blockId: variables.gardenBoxBlockId,
+                message:
+                    error instanceof Error
+                        ? error.message
+                        : 'Failed to store block in garden box',
+            });
             if (context?.previousGarden) {
                 queryClient.setQueryData(
                     gardenQueryKey,

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -67,6 +67,13 @@ export type ActiveDragPreview = {
     isOverRecycler: boolean;
 };
 
+export type GardenBoxTooltip = {
+    blockId: string;
+    createdAt: number;
+    message: string;
+    sequence: number;
+};
+
 export type PlacedBlockEffect = {
     kind: 'sunflowers';
     amount: number;
@@ -217,6 +224,11 @@ export type GameState = {
     setActiveDragPreview: (dragPreview: ActiveDragPreview | null) => void;
     openGardenBoxBlockId: string | null;
     setOpenGardenBoxBlockId: (blockId: string | null) => void;
+    gardenBoxTooltip: GardenBoxTooltip | null;
+    showGardenBoxTooltip: (
+        tooltip: Omit<GardenBoxTooltip, 'createdAt' | 'sequence'>,
+    ) => void;
+    clearGardenBoxTooltip: () => void;
     placedBlockEffects: Record<string, PlacedBlockEffect>;
     queuePlacedBlockEffect: (
         blockId: string,
@@ -445,6 +457,16 @@ export function createGameState({
         openGardenBoxBlockId: null,
         setOpenGardenBoxBlockId: (openGardenBoxBlockId) =>
             set({ openGardenBoxBlockId }),
+        gardenBoxTooltip: null,
+        showGardenBoxTooltip: (tooltip) =>
+            set((state) => ({
+                gardenBoxTooltip: {
+                    ...tooltip,
+                    createdAt: Date.now(),
+                    sequence: (state.gardenBoxTooltip?.sequence ?? 0) + 1,
+                },
+            })),
+        clearGardenBoxTooltip: () => set({ gardenBoxTooltip: null }),
         placedBlockEffects: {},
         queuePlacedBlockEffect: (blockId, effect) =>
             set((state) => ({


### PR DESCRIPTION
## Summary
- Capture garden-box store mutation errors in transient game state.
- Render the validation message as an in-game tooltip above the matching GardenBox instance.
- Clear stale garden-box tooltips when a new store attempt starts.

## Root Cause
Garden-box store failures rolled back optimistic state and logged the error, but the server validation message was not surfaced in the 3D game scene.

## Validation
- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter garden typecheck`
- `git diff --check`