### PR TITLE
Add raised bed watering calendar

### DIFF
--- a/apps/storybook/stories/packages/game/hud/WateringOperationsCalendar.stories.tsx
+++ b/apps/storybook/stories/packages/game/hud/WateringOperationsCalendar.stories.tsx
@@ -1,0 +1,90 @@
+import { WateringOperationsCalendar } from '@packages/game/hud/raisedBed/WateringOperationsCalendar';
+import type { WateringCalendarEntry } from '@packages/game/hud/raisedBed/wateringCalendarModel';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const referenceDate = new Date('2026-06-18T12:00:00.000Z');
+
+const entries: WateringCalendarEntry[] = [
+    {
+        id: 'completed-light',
+        date: '2026-04-29T08:00:00.000Z',
+        label: 'Lagano zalijevanje gredice',
+        source: 'completed',
+        weight: 15,
+    },
+    {
+        id: 'completed-medium',
+        date: '2026-05-10T08:00:00.000Z',
+        label: 'Površinsko zalijevanje gredice',
+        source: 'completed',
+        weight: 35,
+    },
+    {
+        id: 'completed-large',
+        date: '2026-05-24T08:00:00.000Z',
+        label: 'Dubinsko zalijevanje gredice',
+        source: 'completed',
+        weight: 90,
+    },
+    {
+        id: 'scheduled',
+        date: '2026-07-08T08:00:00.000Z',
+        label: 'Zakazano zalijevanje',
+        source: 'scheduled',
+        weight: 45,
+    },
+    {
+        id: 'cart',
+        date: '2026-07-17T08:00:00.000Z',
+        label: 'Zalijevanje u košari',
+        source: 'cart',
+        weight: 30,
+    },
+    {
+        id: 'preview',
+        date: '2026-07-21T08:00:00.000Z',
+        label: 'Novi termin zalijevanja',
+        source: 'preview',
+        weight: 60,
+    },
+    {
+        id: 'future-large',
+        date: '2026-07-25T08:00:00.000Z',
+        label: 'Veliko zakazano zalijevanje',
+        source: 'scheduled',
+        weight: 120,
+    },
+];
+
+const meta = {
+    title: 'packages/game/hud/raisedBed/WateringOperationsCalendar',
+    component: WateringOperationsCalendar,
+    tags: ['autodocs'],
+    args: {
+        entries,
+        referenceDate,
+    },
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Small raised-bed watering calendar for completed, scheduled, cart, and newly previewed watering operations.',
+            },
+        },
+    },
+    render: (args) => (
+        <div className="min-h-screen bg-[#c7be74] p-8">
+            <div className="w-[22rem] max-w-full">
+                <WateringOperationsCalendar {...args} />
+            </div>
+        </div>
+    ),
+} satisfies Meta<typeof WateringOperationsCalendar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const RaisedBedWateringTimeline: Story = {
+    name: 'Raised bed watering timeline',
+};

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -28,6 +28,7 @@ import {
     type ShoppingCartItemData,
     useShoppingCartQueryKey,
 } from '../../../hooks/useShoppingCart';
+import { RaisedBedWateringCalendar } from '../../raisedBed/RaisedBedWateringCalendar';
 import { ButtonPricePickPaymentMethod } from './ButtonPricePickPaymentMethod';
 
 const outletReservationCountdownIntervalMs = 1000;
@@ -189,6 +190,16 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     const removeShoppingCartItem = useSetShoppingCartItem();
     const changeScheduledDateShoppingCartItem = useSetShoppingCartItem();
     const canChangeScheduledDate = !isProcessed && !hasOutletReservation;
+    const parsedOperationId = Number(item.entityId);
+    const operationId =
+        Number.isInteger(parsedOperationId) && parsedOperationId > 0
+            ? parsedOperationId
+            : undefined;
+    const showWateringCalendar =
+        item.entityTypeName === 'operation' &&
+        operationId !== undefined &&
+        typeof item.gardenId === 'number' &&
+        typeof item.raisedBedId === 'number';
 
     useEffect(() => {
         if (
@@ -564,6 +575,16 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                                             >
                                                 {datePickerError}
                                             </Typography>
+                                        ) : null}
+                                        {showWateringCalendar &&
+                                        typeof item.gardenId === 'number' &&
+                                        typeof item.raisedBedId === 'number' ? (
+                                            <RaisedBedWateringCalendar
+                                                className="shadow-none"
+                                                gardenId={item.gardenId}
+                                                operationId={operationId}
+                                                raisedBedId={item.raisedBedId}
+                                            />
                                         ) : null}
                                     </Stack>
                                 </Popper>

--- a/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
@@ -4,6 +4,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
 import { ButtonGreen } from '../../shared-ui/ButtonGreen';
+import { RaisedBedWateringCalendar } from './RaisedBedWateringCalendar';
 import { OperationsList } from './shared/OperationsList';
 
 export function RaisedBedWatering({
@@ -44,6 +45,10 @@ export function RaisedBedWatering({
                 <Typography>
                     Odaberite radnju zalijevanja za ovu gredicu.
                 </Typography>
+                <RaisedBedWateringCalendar
+                    gardenId={gardenId}
+                    raisedBedId={raisedBedId}
+                />
                 <OperationsList
                     gardenId={gardenId}
                     raisedBedId={raisedBedId}

--- a/packages/game/src/hud/raisedBed/RaisedBedWateringCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWateringCalendar.tsx
@@ -16,7 +16,7 @@ import type {
     WateringCalendarEntrySource,
 } from './wateringCalendarModel';
 
-const wateringCalendarPageSize = 100;
+const wateringCalendarPageSize = 50;
 const fallbackOperationWeight = 30;
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/game/src/hud/raisedBed/RaisedBedWateringCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWateringCalendar.tsx
@@ -1,0 +1,329 @@
+import type { OperationData } from '@gredice/client';
+import { useEffect, useMemo } from 'react';
+import {
+    type GardenOperationItem,
+    useGardenOperations,
+} from '../../hooks/useGardenOperations';
+import { useLiveTime } from '../../hooks/useLiveTime';
+import { useOperations } from '../../hooks/useOperations';
+import {
+    type ShoppingCartItemData,
+    useShoppingCart,
+} from '../../hooks/useShoppingCart';
+import { WateringOperationsCalendar } from './WateringOperationsCalendar';
+import type {
+    WateringCalendarEntry,
+    WateringCalendarEntrySource,
+} from './wateringCalendarModel';
+
+const wateringCalendarPageSize = 100;
+const fallbackOperationWeight = 30;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseAdditionalData(additionalData?: string | null) {
+    if (!additionalData) {
+        return {};
+    }
+
+    try {
+        const parsed = JSON.parse(additionalData);
+        return isRecord(parsed) ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
+function dateFromUnknown(value: unknown) {
+    if (typeof value !== 'string' && !(value instanceof Date)) {
+        return null;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getTomorrowDate(referenceDate: Date) {
+    return new Date(
+        referenceDate.getFullYear(),
+        referenceDate.getMonth(),
+        referenceDate.getDate() + 1,
+    );
+}
+
+function parseOperationId(value: string | number) {
+    const operationId = Number(value);
+    return Number.isInteger(operationId) && operationId > 0
+        ? operationId
+        : null;
+}
+
+export function isWateringOperation(
+    operation: OperationData | undefined,
+): operation is OperationData {
+    return operation?.attributes.stage.information?.name === 'watering';
+}
+
+function operationWeight(operation: OperationData | undefined) {
+    const duration = operation?.attributes.duration;
+    return typeof duration === 'number' && duration > 0
+        ? duration
+        : fallbackOperationWeight;
+}
+
+function operationDate(operation: GardenOperationItem) {
+    if (operation.status === 'canceled' || operation.status === 'failed') {
+        return null;
+    }
+
+    if (operation.status === 'completed') {
+        return (
+            dateFromUnknown(operation.verifiedAt) ??
+            dateFromUnknown(operation.completedAt) ??
+            dateFromUnknown(operation.scheduledDate) ??
+            dateFromUnknown(operation.createdAt)
+        );
+    }
+
+    if (operation.status === 'confirmed') {
+        return (
+            dateFromUnknown(operation.completedAt) ??
+            dateFromUnknown(operation.scheduledDate) ??
+            dateFromUnknown(operation.createdAt)
+        );
+    }
+
+    return (
+        dateFromUnknown(operation.scheduledDate) ??
+        dateFromUnknown(operation.scheduledAt)
+    );
+}
+
+function operationSource(
+    operation: GardenOperationItem,
+): WateringCalendarEntrySource {
+    return operation.status === 'completed' || operation.status === 'confirmed'
+        ? 'completed'
+        : 'scheduled';
+}
+
+function cartItemMatchesRaisedBed({
+    gardenId,
+    item,
+    raisedBedId,
+}: {
+    gardenId: number;
+    item: ShoppingCartItemData;
+    raisedBedId: number;
+}) {
+    return (
+        item.entityTypeName === 'operation' &&
+        item.status === 'new' &&
+        item.gardenId === gardenId &&
+        item.raisedBedId === raisedBedId
+    );
+}
+
+function cartItemDate(item: ShoppingCartItemData, referenceDate: Date) {
+    const additionalData = parseAdditionalData(item.additionalData);
+    return (
+        dateFromUnknown(additionalData.scheduledDate) ??
+        getTomorrowDate(referenceDate)
+    );
+}
+
+function buildOperationEntries({
+    operationItems,
+    operationsById,
+}: {
+    operationItems: GardenOperationItem[];
+    operationsById: Map<number, OperationData>;
+}) {
+    return operationItems.flatMap((item): WateringCalendarEntry[] => {
+        const operation = operationsById.get(item.entityId);
+        if (!isWateringOperation(operation)) {
+            return [];
+        }
+
+        const date = operationDate(item);
+        if (!date) {
+            return [];
+        }
+
+        return [
+            {
+                id: `operation-${item.id}`,
+                date,
+                label: `${operation?.information.label ?? 'Zalijevanje'} - ${item.targetLabel}`,
+                source: operationSource(item),
+                weight: operationWeight(operation),
+            },
+        ];
+    });
+}
+
+function buildCartEntries({
+    cartItems,
+    gardenId,
+    operationsById,
+    raisedBedId,
+    referenceDate,
+}: {
+    cartItems: ShoppingCartItemData[];
+    gardenId: number;
+    operationsById: Map<number, OperationData>;
+    raisedBedId: number;
+    referenceDate: Date;
+}) {
+    return cartItems.flatMap((item): WateringCalendarEntry[] => {
+        if (!cartItemMatchesRaisedBed({ gardenId, item, raisedBedId })) {
+            return [];
+        }
+
+        const operationId = parseOperationId(item.entityId);
+        const operation =
+            operationId == null ? undefined : operationsById.get(operationId);
+        if (!isWateringOperation(operation)) {
+            return [];
+        }
+
+        return [
+            {
+                id: `cart-${item.id}`,
+                date: cartItemDate(item, referenceDate),
+                label: `${operation?.information.label ?? 'Zalijevanje'} - u košari`,
+                source: 'cart',
+                weight: operationWeight(operation) * Math.max(1, item.amount),
+            },
+        ];
+    });
+}
+
+function buildPreviewEntry({
+    operation,
+    previewDate,
+}: {
+    operation?: OperationData;
+    previewDate?: Date | null;
+}): WateringCalendarEntry[] {
+    if (!previewDate || !isWateringOperation(operation)) {
+        return [];
+    }
+
+    return [
+        {
+            id: `preview-${operation.id}`,
+            date: previewDate,
+            label: `${operation.information.label} - novi termin`,
+            source: 'preview',
+            weight: operationWeight(operation),
+        },
+    ];
+}
+
+export function RaisedBedWateringCalendar({
+    className,
+    gardenId,
+    operationId,
+    previewDate,
+    previewOperation,
+    raisedBedId,
+}: {
+    className?: string;
+    gardenId: number;
+    operationId?: number;
+    previewDate?: Date | null;
+    previewOperation?: OperationData;
+    raisedBedId: number;
+}) {
+    const referenceDate = useLiveTime();
+    const { data: operations, isError: isOperationsError } = useOperations();
+    const { data: cart } = useShoppingCart();
+    const history = useGardenOperations({
+        includeCompleted: true,
+        pageSize: wateringCalendarPageSize,
+        raisedBedId,
+    });
+
+    const hasNextHistoryPage = history.hasNextPage;
+    const isFetchingNextHistoryPage = history.isFetchingNextPage;
+    const fetchNextHistoryPage = history.fetchNextPage;
+
+    useEffect(() => {
+        if (hasNextHistoryPage && !isFetchingNextHistoryPage) {
+            void fetchNextHistoryPage();
+        }
+    }, [fetchNextHistoryPage, hasNextHistoryPage, isFetchingNextHistoryPage]);
+
+    const operationsById = useMemo(
+        () =>
+            new Map(
+                (operations ?? []).map((operation) => [
+                    operation.id,
+                    operation,
+                ]),
+            ),
+        [operations],
+    );
+    const contextOperation =
+        previewOperation ??
+        (operationId == null ? undefined : operationsById.get(operationId));
+    const shouldHideForContext =
+        contextOperation !== undefined &&
+        !isWateringOperation(contextOperation);
+    const hasMissingContext =
+        operationId != null &&
+        contextOperation === undefined &&
+        operations !== undefined;
+
+    const entries = useMemo(
+        () => [
+            ...buildOperationEntries({
+                operationItems:
+                    history.data?.pages.flatMap((page) => page.items) ?? [],
+                operationsById,
+            }),
+            ...buildCartEntries({
+                cartItems: cart?.items ?? [],
+                gardenId,
+                operationsById,
+                raisedBedId,
+                referenceDate,
+            }),
+            ...buildPreviewEntry({
+                operation: previewOperation,
+                previewDate,
+            }),
+        ],
+        [
+            cart?.items,
+            gardenId,
+            history.data?.pages,
+            operationsById,
+            previewDate,
+            previewOperation,
+            raisedBedId,
+            referenceDate,
+        ],
+    );
+
+    if (shouldHideForContext || hasMissingContext) {
+        return null;
+    }
+
+    return (
+        <WateringOperationsCalendar
+            className={className}
+            entries={entries}
+            error={history.isError || isOperationsError}
+            isLoading={
+                history.isLoading ||
+                history.isFetchingNextPage ||
+                operations === undefined
+            }
+            referenceDate={referenceDate}
+        />
+    );
+}

--- a/packages/game/src/hud/raisedBed/WateringOperationsCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/WateringOperationsCalendar.tsx
@@ -1,10 +1,15 @@
+'use client';
+
 import { Alert } from '@gredice/ui/Alert';
-import { Calendar, Droplets } from '@gredice/ui/icons';
+import { IconButton } from '@gredice/ui/IconButton';
+import { ArrowLeft, ArrowRight, Calendar, Droplets } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Spinner } from '@gredice/ui/Spinner';
 import { Stack } from '@gredice/ui/Stack';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@gredice/ui/Tooltip';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
+import { useEffect, useMemo, useState } from 'react';
 import {
     buildWateringCalendarMonths,
     type WateringCalendarDay,
@@ -22,6 +27,12 @@ const dayFormatter = new Intl.DateTimeFormat('hr-HR', {
     month: '2-digit',
     year: 'numeric',
 });
+const sourceLabels = {
+    cart: 'U košari',
+    completed: 'Obavljeno',
+    preview: 'Novi termin',
+    scheduled: 'Zakazano',
+} satisfies Record<WateringCalendarEntry['source'], string>;
 
 function markerClassName(day: WateringCalendarDay) {
     if (day.tone === 'preview') {
@@ -46,6 +57,81 @@ function dayTitle(day: WateringCalendarDay) {
 
     const labels = day.entries.map((entry) => entry.label).join(', ');
     return `${dayFormatter.format(day.date)}: ${labels}`;
+}
+
+function entryMeta(entry: WateringCalendarEntry) {
+    const roundedWeight =
+        typeof entry.weight === 'number' && entry.weight > 0
+            ? Math.round(entry.weight)
+            : null;
+
+    return [
+        sourceLabels[entry.source],
+        roundedWeight == null ? null : `${roundedWeight} min`,
+    ]
+        .filter(Boolean)
+        .join(' · ');
+}
+
+function WateringCalendarDayView({ day }: { day: WateringCalendarDay }) {
+    if (day.entries.length === 0) {
+        return (
+            <div className="grid size-8 place-items-center text-xs tabular-nums">
+                {day.dayOfMonth}
+            </div>
+        );
+    }
+
+    const content = (
+        <button
+            type="button"
+            className={cx(
+                'relative grid size-8 place-items-center rounded-full text-xs tabular-nums',
+                'font-semibold text-slate-950 dark:text-white',
+            )}
+            aria-label={dayTitle(day)}
+        >
+            <span
+                aria-hidden
+                className={cx(
+                    'absolute rounded-full border-2',
+                    markerClassName(day),
+                )}
+                data-watering-calendar-marker
+                data-watering-calendar-tone={day.tone}
+                style={{
+                    height: day.markerSize,
+                    width: day.markerSize,
+                }}
+            />
+            <span className="relative z-10">{day.dayOfMonth}</span>
+        </button>
+    );
+
+    return (
+        <Tooltip delayDuration={100}>
+            <TooltipTrigger asChild>{content}</TooltipTrigger>
+            <TooltipContent className="max-w-64 p-3">
+                <Stack spacing={2}>
+                    <Typography level="body3" semiBold>
+                        {dayFormatter.format(day.date)}
+                    </Typography>
+                    <Stack spacing={1}>
+                        {day.entries.map((entry) => (
+                            <Stack key={entry.id} spacing={0}>
+                                <Typography level="body3" semiBold>
+                                    {entry.label}
+                                </Typography>
+                                <Typography level="body3" secondary>
+                                    {entryMeta(entry)}
+                                </Typography>
+                            </Stack>
+                        ))}
+                    </Stack>
+                </Stack>
+            </TooltipContent>
+        </Tooltip>
+    );
 }
 
 function WateringCalendarMonthView({
@@ -79,37 +165,7 @@ function WateringCalendarMonthView({
                             }
                             className="grid h-8 place-items-center"
                         >
-                            {day ? (
-                                <div
-                                    className={cx(
-                                        'relative grid size-8 place-items-center rounded-full text-xs tabular-nums',
-                                        day.entries.length > 0 &&
-                                            'font-semibold text-slate-950 dark:text-white',
-                                    )}
-                                    title={dayTitle(day)}
-                                >
-                                    {day.entries.length > 0 ? (
-                                        <span
-                                            aria-hidden
-                                            className={cx(
-                                                'absolute rounded-full border-2',
-                                                markerClassName(day),
-                                            )}
-                                            data-watering-calendar-marker
-                                            data-watering-calendar-tone={
-                                                day.tone
-                                            }
-                                            style={{
-                                                height: day.markerSize,
-                                                width: day.markerSize,
-                                            }}
-                                        />
-                                    ) : null}
-                                    <span className="relative z-10">
-                                        {day.dayOfMonth}
-                                    </span>
-                                </div>
-                            ) : null}
+                            {day ? <WateringCalendarDayView day={day} /> : null}
                         </div>
                     )),
                 )}
@@ -131,8 +187,46 @@ export function WateringOperationsCalendar({
     isLoading?: boolean;
     referenceDate?: Date;
 }) {
-    const months = buildWateringCalendarMonths(entries, referenceDate);
-    const visibleMonths = [...months].reverse();
+    const months = useMemo(
+        () => buildWateringCalendarMonths(entries, referenceDate),
+        [entries, referenceDate],
+    );
+    const [selectedMonthKey, setSelectedMonthKey] = useState<string | null>(
+        null,
+    );
+
+    useEffect(() => {
+        if (months.length === 0) {
+            setSelectedMonthKey(null);
+            return;
+        }
+
+        setSelectedMonthKey((currentKey) => {
+            if (
+                currentKey &&
+                months.some((month) => month.key === currentKey)
+            ) {
+                return currentKey;
+            }
+
+            return months[months.length - 1].key;
+        });
+    }, [months]);
+
+    const requestedMonthIndex = selectedMonthKey
+        ? months.findIndex((month) => month.key === selectedMonthKey)
+        : -1;
+    const selectedMonthIndex =
+        months.length === 0
+            ? -1
+            : requestedMonthIndex >= 0
+              ? requestedMonthIndex
+              : months.length - 1;
+    const selectedMonth =
+        selectedMonthIndex >= 0 ? months[selectedMonthIndex] : null;
+    const canGoBack = selectedMonthIndex > 0;
+    const canGoForward =
+        selectedMonthIndex >= 0 && selectedMonthIndex < months.length - 1;
 
     return (
         <Stack
@@ -151,9 +245,45 @@ export function WateringOperationsCalendar({
                     </Typography>
                 </Row>
                 {entries.length > 0 ? (
-                    <Typography level="body3" className="text-sky-700">
-                        {entries.length}
-                    </Typography>
+                    <Row spacing={1}>
+                        <Typography level="body3" className="text-sky-700">
+                            {entries.length}
+                        </Typography>
+                        <IconButton
+                            aria-label="Prethodni mjesec"
+                            disabled={!canGoBack}
+                            size="xs"
+                            title="Prethodni mjesec"
+                            type="button"
+                            variant="plain"
+                            onClick={() => {
+                                if (canGoBack) {
+                                    setSelectedMonthKey(
+                                        months[selectedMonthIndex - 1].key,
+                                    );
+                                }
+                            }}
+                        >
+                            <ArrowLeft className="size-3.5" />
+                        </IconButton>
+                        <IconButton
+                            aria-label="Sljedeći mjesec"
+                            disabled={!canGoForward}
+                            size="xs"
+                            title="Sljedeći mjesec"
+                            type="button"
+                            variant="plain"
+                            onClick={() => {
+                                if (canGoForward) {
+                                    setSelectedMonthKey(
+                                        months[selectedMonthIndex + 1].key,
+                                    );
+                                }
+                            }}
+                        >
+                            <ArrowRight className="size-3.5" />
+                        </IconButton>
+                    </Row>
                 ) : null}
             </Row>
             {error ? (
@@ -174,15 +304,11 @@ export function WateringOperationsCalendar({
                     Još nema zabilježenih zalijevanja.
                 </Typography>
             ) : null}
-            {months.length > 0 ? (
-                <div className="max-h-72 space-y-4 overflow-y-auto pr-1">
-                    {visibleMonths.map((month) => (
-                        <WateringCalendarMonthView
-                            key={month.key}
-                            month={month}
-                        />
-                    ))}
-                </div>
+            {selectedMonth ? (
+                <WateringCalendarMonthView
+                    key={selectedMonth.key}
+                    month={selectedMonth}
+                />
             ) : null}
         </Stack>
     );

--- a/packages/game/src/hud/raisedBed/WateringOperationsCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/WateringOperationsCalendar.tsx
@@ -1,0 +1,189 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Calendar, Droplets } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Spinner } from '@gredice/ui/Spinner';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import {
+    buildWateringCalendarMonths,
+    type WateringCalendarDay,
+    type WateringCalendarEntry,
+    type WateringCalendarMonth,
+} from './wateringCalendarModel';
+
+const weekDays = ['Pon', 'Uto', 'Sri', 'Čet', 'Pet', 'Sub', 'Ned'];
+const monthFormatter = new Intl.DateTimeFormat('hr-HR', {
+    month: 'long',
+    year: 'numeric',
+});
+const dayFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+});
+
+function markerClassName(day: WateringCalendarDay) {
+    if (day.tone === 'preview') {
+        return 'border-sky-600 bg-sky-100/70 border-dashed';
+    }
+
+    if (day.tone === 'cart') {
+        return 'border-sky-600 bg-sky-200/80 shadow-sm shadow-sky-300/50';
+    }
+
+    if (day.tone === 'scheduled') {
+        return 'border-sky-500 bg-sky-100/70';
+    }
+
+    return 'border-sky-500 bg-sky-500/20';
+}
+
+function dayTitle(day: WateringCalendarDay) {
+    if (day.entries.length === 0) {
+        return dayFormatter.format(day.date);
+    }
+
+    const labels = day.entries.map((entry) => entry.label).join(', ');
+    return `${dayFormatter.format(day.date)}: ${labels}`;
+}
+
+function WateringCalendarMonthView({
+    month,
+}: {
+    month: WateringCalendarMonth;
+}) {
+    return (
+        <section className="space-y-2" data-watering-calendar-month={month.key}>
+            <Row spacing={2} className="text-slate-700 dark:text-slate-200">
+                <Calendar className="size-4 shrink-0 text-sky-600" />
+                <Typography level="body2" semiBold className="capitalize">
+                    {monthFormatter.format(month.date)}
+                </Typography>
+            </Row>
+            <div className="grid grid-cols-7 gap-1 text-center">
+                {weekDays.map((weekDay) => (
+                    <div
+                        key={weekDay}
+                        className="text-[0.65rem] font-semibold uppercase text-muted-foreground"
+                    >
+                        {weekDay}
+                    </div>
+                ))}
+                {month.weeks.flatMap((week, weekIndex) =>
+                    week.map((day, dayIndex) => (
+                        <div
+                            key={
+                                day?.key ??
+                                `${month.key}-${weekIndex}-${dayIndex}`
+                            }
+                            className="grid h-8 place-items-center"
+                        >
+                            {day ? (
+                                <div
+                                    className={cx(
+                                        'relative grid size-8 place-items-center rounded-full text-xs tabular-nums',
+                                        day.entries.length > 0 &&
+                                            'font-semibold text-slate-950 dark:text-white',
+                                    )}
+                                    title={dayTitle(day)}
+                                >
+                                    {day.entries.length > 0 ? (
+                                        <span
+                                            aria-hidden
+                                            className={cx(
+                                                'absolute rounded-full border-2',
+                                                markerClassName(day),
+                                            )}
+                                            data-watering-calendar-marker
+                                            data-watering-calendar-tone={
+                                                day.tone
+                                            }
+                                            style={{
+                                                height: day.markerSize,
+                                                width: day.markerSize,
+                                            }}
+                                        />
+                                    ) : null}
+                                    <span className="relative z-10">
+                                        {day.dayOfMonth}
+                                    </span>
+                                </div>
+                            ) : null}
+                        </div>
+                    )),
+                )}
+            </div>
+        </section>
+    );
+}
+
+export function WateringOperationsCalendar({
+    className,
+    entries,
+    error,
+    isLoading,
+    referenceDate,
+}: {
+    className?: string;
+    entries: WateringCalendarEntry[];
+    error?: boolean;
+    isLoading?: boolean;
+    referenceDate?: Date;
+}) {
+    const months = buildWateringCalendarMonths(entries, referenceDate);
+    const visibleMonths = [...months].reverse();
+
+    return (
+        <Stack
+            spacing={3}
+            className={cx(
+                'rounded-lg border bg-card/80 p-3 shadow-sm',
+                className,
+            )}
+            data-watering-calendar
+        >
+            <Row spacing={2} justifyContent="space-between">
+                <Row spacing={2}>
+                    <Droplets className="size-4 shrink-0 text-sky-600" />
+                    <Typography level="body1" semiBold>
+                        Kalendar zalijevanja
+                    </Typography>
+                </Row>
+                {entries.length > 0 ? (
+                    <Typography level="body3" className="text-sky-700">
+                        {entries.length}
+                    </Typography>
+                ) : null}
+            </Row>
+            {error ? (
+                <Alert color="danger">
+                    Kalendar zalijevanja nije dostupan.
+                </Alert>
+            ) : null}
+            {isLoading ? (
+                <Row spacing={2}>
+                    <Spinner loadingLabel="Učitavanje kalendara" />
+                    <Typography level="body2" secondary>
+                        Učitavanje...
+                    </Typography>
+                </Row>
+            ) : null}
+            {!error && !isLoading && months.length === 0 ? (
+                <Typography level="body2" secondary>
+                    Još nema zabilježenih zalijevanja.
+                </Typography>
+            ) : null}
+            {months.length > 0 ? (
+                <div className="max-h-72 space-y-4 overflow-y-auto pr-1">
+                    {visibleMonths.map((month) => (
+                        <WateringCalendarMonthView
+                            key={month.key}
+                            month={month}
+                        />
+                    ))}
+                </div>
+            ) : null}
+        </Stack>
+    );
+}

--- a/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
@@ -13,25 +13,33 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
 import { formatLocalDate } from '../RaisedBedPlantPicker';
+import { RaisedBedWateringCalendar } from '../RaisedBedWateringCalendar';
 
 export function OperationScheduleModal({
+    gardenId,
     operation,
     onConfirm,
+    raisedBedId,
     trigger,
 }: {
+    gardenId?: number;
     operation: OperationData;
     onConfirm: (date: Date) => Promise<void>;
+    raisedBedId?: number;
     trigger: React.ReactElement;
 }) {
     const [open, setOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [scheduledDateInput, setScheduledDateInput] = useState<string | null>(
+        null,
+    );
 
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
-        const date = formData.get('scheduledDate') as string;
-        if (date) {
+        const date = formData.get('scheduledDate');
+        if (typeof date === 'string' && date) {
             const scheduledDate = new Date(date);
             setErrorMessage(null);
             setIsLoading(true);
@@ -58,6 +66,8 @@ export function OperationScheduleModal({
         tomorrow.getDate(),
     );
     const operationDefaultDate = formatLocalDate(tomorrow);
+    const selectedDateInput = scheduledDateInput ?? operationDefaultDate;
+    const selectedDate = selectedDateInput ? new Date(selectedDateInput) : null;
     const min = formatLocalDate(tomorrow);
     const max = formatLocalDate(threeMonthsFromTomorrow);
     const isHarvestOperation =
@@ -79,6 +89,7 @@ export function OperationScheduleModal({
                 setOpen(nextOpen);
                 if (!nextOpen) {
                     setErrorMessage(null);
+                    setScheduledDateInput(null);
                 }
             }}
         >
@@ -134,11 +145,23 @@ export function OperationScheduleModal({
                         name="scheduledDate"
                         className="w-full bg-card"
                         disabled={isLoading}
-                        defaultValue={operationDefaultDate}
+                        value={selectedDateInput}
                         min={min}
                         max={max}
+                        onChange={(event) =>
+                            setScheduledDateInput(event.target.value)
+                        }
                         required
                     />
+                    {gardenId != null && raisedBedId != null ? (
+                        <RaisedBedWateringCalendar
+                            className="shadow-none"
+                            gardenId={gardenId}
+                            previewDate={selectedDate}
+                            previewOperation={operation}
+                            raisedBedId={raisedBedId}
+                        />
+                    ) : null}
                     <Row spacing={2}>
                         <Button
                             variant="plain"

--- a/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
@@ -122,10 +122,12 @@ export function OperationsListItem({
             <div className="flex flex-wrap gap-y-1 gap-x-2 pr-4 items-center justify-between">
                 <Row>
                     <OperationScheduleModal
+                        gardenId={gardenId}
                         operation={operation}
                         onConfirm={async (date) => {
                             await handleOperationPicked(operation, date);
                         }}
+                        raisedBedId={raisedBedId}
                         trigger={
                             <Button
                                 title="Zakaži radnju"

--- a/packages/game/src/hud/raisedBed/wateringCalendarModel.ts
+++ b/packages/game/src/hud/raisedBed/wateringCalendarModel.ts
@@ -1,0 +1,236 @@
+export type WateringCalendarEntrySource =
+    | 'completed'
+    | 'scheduled'
+    | 'cart'
+    | 'preview';
+
+export type WateringCalendarEntry = {
+    id: string;
+    date: Date | string;
+    label: string;
+    source: WateringCalendarEntrySource;
+    weight?: number | null;
+};
+
+export type WateringCalendarDayTone =
+    | 'none'
+    | 'completed'
+    | 'scheduled'
+    | 'cart'
+    | 'preview';
+
+export type WateringCalendarDay = {
+    key: string;
+    date: Date;
+    dayOfMonth: number;
+    entries: WateringCalendarEntry[];
+    markerSize: number;
+    tone: WateringCalendarDayTone;
+    totalWeight: number;
+};
+
+export type WateringCalendarMonth = {
+    key: string;
+    date: Date;
+    weeks: Array<Array<WateringCalendarDay | null>>;
+};
+
+const minimumMarkerSize = 16;
+const defaultMarkerSize = 22;
+const maximumMarkerSize = 30;
+const fallbackEntryWeight = 1;
+
+function parseEntryDate(value: Date | string) {
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function startOfLocalDay(date: Date) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function startOfLocalMonth(date: Date) {
+    return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function addMonths(date: Date, months: number) {
+    return new Date(date.getFullYear(), date.getMonth() + months, 1);
+}
+
+export function formatLocalDayKey(date: Date) {
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function formatMonthKey(date: Date) {
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    return `${date.getFullYear()}-${month}`;
+}
+
+function entryWeight(entry: WateringCalendarEntry) {
+    return typeof entry.weight === 'number' && entry.weight > 0
+        ? entry.weight
+        : fallbackEntryWeight;
+}
+
+function markerSize({
+    maximumWeight,
+    minimumWeight,
+    weight,
+}: {
+    maximumWeight: number;
+    minimumWeight: number;
+    weight: number;
+}) {
+    if (maximumWeight <= minimumWeight) {
+        return defaultMarkerSize;
+    }
+
+    const ratio = (weight - minimumWeight) / (maximumWeight - minimumWeight);
+    return Math.round(
+        minimumMarkerSize + ratio * (maximumMarkerSize - minimumMarkerSize),
+    );
+}
+
+function toneForDay(
+    entries: WateringCalendarEntry[],
+    date: Date,
+    referenceDate: Date,
+): WateringCalendarDayTone {
+    if (entries.some((entry) => entry.source === 'preview')) {
+        return 'preview';
+    }
+
+    if (entries.some((entry) => entry.source === 'cart')) {
+        return 'cart';
+    }
+
+    if (
+        entries.some((entry) => entry.source === 'scheduled') ||
+        startOfLocalDay(date).getTime() >
+            startOfLocalDay(referenceDate).getTime()
+    ) {
+        return 'scheduled';
+    }
+
+    return 'completed';
+}
+
+function monthRange(entries: WateringCalendarEntry[]) {
+    const dates = entries
+        .map((entry) => parseEntryDate(entry.date))
+        .filter((date): date is Date => date !== null)
+        .map(startOfLocalDay)
+        .sort((left, right) => left.getTime() - right.getTime());
+
+    if (dates.length === 0) {
+        return null;
+    }
+
+    return {
+        from: startOfLocalMonth(dates[0]),
+        to: startOfLocalMonth(dates[dates.length - 1]),
+    };
+}
+
+export function buildWateringCalendarMonths(
+    entries: WateringCalendarEntry[],
+    referenceDate = new Date(),
+): WateringCalendarMonth[] {
+    const range = monthRange(entries);
+    if (!range) {
+        return [];
+    }
+
+    const entriesByDay = new Map<string, WateringCalendarEntry[]>();
+    for (const entry of entries) {
+        const date = parseEntryDate(entry.date);
+        if (!date) {
+            continue;
+        }
+
+        const key = formatLocalDayKey(date);
+        entriesByDay.set(key, [...(entriesByDay.get(key) ?? []), entry]);
+    }
+
+    const dayWeights = Array.from(entriesByDay.values()).map((dayEntries) =>
+        dayEntries.reduce((sum, entry) => sum + entryWeight(entry), 0),
+    );
+    const minimumWeight = Math.min(...dayWeights);
+    const maximumWeight = Math.max(...dayWeights);
+    const months: WateringCalendarMonth[] = [];
+
+    for (
+        let cursor = range.from;
+        cursor.getTime() <= range.to.getTime();
+        cursor = addMonths(cursor, 1)
+    ) {
+        const firstDay = startOfLocalMonth(cursor);
+        const daysInMonth = new Date(
+            firstDay.getFullYear(),
+            firstDay.getMonth() + 1,
+            0,
+        ).getDate();
+        const mondayOffset = (firstDay.getDay() + 6) % 7;
+        const cells: Array<WateringCalendarDay | null> = Array.from({
+            length: mondayOffset,
+        }).map(() => null);
+
+        for (let day = 1; day <= daysInMonth; day += 1) {
+            const date = new Date(
+                firstDay.getFullYear(),
+                firstDay.getMonth(),
+                day,
+            );
+            const key = formatLocalDayKey(date);
+            const dayEntries = entriesByDay.get(key) ?? [];
+            if (dayEntries.length === 0) {
+                cells.push({
+                    key,
+                    date,
+                    dayOfMonth: day,
+                    entries: [],
+                    markerSize: 0,
+                    tone: 'none',
+                    totalWeight: 0,
+                });
+                continue;
+            }
+
+            const totalWeight = dayEntries.reduce(
+                (sum, entry) => sum + entryWeight(entry),
+                0,
+            );
+            cells.push({
+                key,
+                date,
+                dayOfMonth: day,
+                entries: dayEntries,
+                markerSize: markerSize({
+                    maximumWeight,
+                    minimumWeight,
+                    weight: totalWeight,
+                }),
+                tone: toneForDay(dayEntries, date, referenceDate),
+                totalWeight,
+            });
+        }
+
+        const trailingCells = (7 - (cells.length % 7)) % 7;
+        cells.push(...Array.from({ length: trailingCells }).map(() => null));
+
+        const weeks: WateringCalendarMonth['weeks'] = [];
+        for (let index = 0; index < cells.length; index += 7) {
+            weeks.push(cells.slice(index, index + 7));
+        }
+
+        months.push({
+            key: formatMonthKey(firstDay),
+            date: firstDay,
+            weeks,
+        });
+    }
+
+    return months;
+}

--- a/packages/game/src/hud/raisedBed/wateringCalendarModel.unit.ts
+++ b/packages/game/src/hud/raisedBed/wateringCalendarModel.unit.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    buildWateringCalendarMonths,
+    type WateringCalendarEntry,
+} from './wateringCalendarModel';
+
+function markedDays(entries: WateringCalendarEntry[]) {
+    return buildWateringCalendarMonths(
+        entries,
+        new Date('2026-06-18T12:00:00.000Z'),
+    ).flatMap((month) =>
+        month.weeks.flatMap((week) =>
+            week.filter((day) => day?.entries.length),
+        ),
+    );
+}
+
+test('watering calendar keeps empty dates visible between marked dates', () => {
+    const months = buildWateringCalendarMonths([
+        {
+            id: 'first',
+            date: '2026-05-03T08:00:00.000Z',
+            label: 'Lagano zalijevanje',
+            source: 'completed',
+            weight: 15,
+        },
+        {
+            id: 'second',
+            date: '2026-06-12T08:00:00.000Z',
+            label: 'Dubinsko zalijevanje',
+            source: 'scheduled',
+            weight: 60,
+        },
+    ]);
+
+    assert.deepEqual(
+        months.map((month) => month.key),
+        ['2026-05', '2026-06'],
+    );
+    const mayDays = months[0].weeks.flatMap((week) =>
+        week.filter((day) => day?.key.startsWith('2026-05')),
+    );
+    assert.equal(mayDays.length, 31);
+    assert.equal(mayDays[0]?.entries.length, 0);
+    assert.equal(
+        mayDays.find((day) => day?.key === '2026-05-03')?.entries.length,
+        1,
+    );
+});
+
+test('watering calendar scales marker size by total watering weight', () => {
+    const days = markedDays([
+        {
+            id: 'small',
+            date: '2026-06-01T08:00:00.000Z',
+            label: 'Kratko zalijevanje',
+            source: 'completed',
+            weight: 10,
+        },
+        {
+            id: 'large',
+            date: '2026-06-02T08:00:00.000Z',
+            label: 'Veliko zalijevanje',
+            source: 'completed',
+            weight: 90,
+        },
+    ]);
+
+    const small = days.find((day) => day?.key === '2026-06-01');
+    const large = days.find((day) => day?.key === '2026-06-02');
+
+    assert.ok(small);
+    assert.ok(large);
+    assert.ok(small.markerSize < large.markerSize);
+});
+
+test('watering calendar prioritizes preview and cart markers for shared dates', () => {
+    const days = markedDays([
+        {
+            id: 'completed',
+            date: '2026-06-10T08:00:00.000Z',
+            label: 'Gotovo zalijevanje',
+            source: 'completed',
+            weight: 30,
+        },
+        {
+            id: 'cart',
+            date: '2026-06-11T08:00:00.000Z',
+            label: 'Zalijevanje u košari',
+            source: 'cart',
+            weight: 30,
+        },
+        {
+            id: 'preview',
+            date: '2026-06-11T08:00:00.000Z',
+            label: 'Novi termin',
+            source: 'preview',
+            weight: 30,
+        },
+    ]);
+
+    assert.equal(
+        days.find((day) => day?.key === '2026-06-10')?.tone,
+        'completed',
+    );
+    assert.equal(
+        days.find((day) => day?.key === '2026-06-11')?.tone,
+        'preview',
+    );
+});


### PR DESCRIPTION
## Summary
- add a reusable raised-bed watering calendar with blue date markers scaled by watering size
- include completed history, scheduled operations, cart operations, and the currently previewed schedule date
- show one month at a time with previous/next month controls and hover/focus tooltips for watering details
- show the calendar in the watering panel, scheduling modal, cart reschedule popper, and Storybook

## Validation
- corepack pnpm --filter @gredice/game lint
- corepack pnpm --filter @gredice/game test
- corepack pnpm --filter @gredice/game typecheck
- corepack pnpm --filter storybook lint
- corepack pnpm --filter storybook typecheck
- corepack pnpm --filter storybook build
- corepack pnpm --filter garden typecheck
- git diff --check
- Storybook browser check: one visible month, previous/next month navigation, marked-day tooltip, no console errors

## Screenshot
- Local screenshot captured at /tmp/gredice-watering-calendar-month-tooltip.png