### PR TITLE
Add completed-state dismissal for the tutorial checklist

### DIFF
--- a/apps/garden/tests/TutorialChecklistHudStory.tsx
+++ b/apps/garden/tests/TutorialChecklistHudStory.tsx
@@ -1,6 +1,6 @@
 import * as ReactQuery from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
 import {
     type TutorialChecklistGroup,
@@ -119,20 +119,119 @@ const checklistState: TutorialChecklistState = {
     },
 };
 
-function createTutorialChecklistQueryClient() {
+function settleTask(task: TutorialChecklistTask): TutorialChecklistTask {
+    return {
+        ...task,
+        claimable: false,
+        claimedAt: '2026-06-12T08:00:00.000Z',
+        completed: true,
+        status: task.rewardSunflowers > 0 ? 'claimed' : 'completed',
+    };
+}
+
+function settleGroup(group: TutorialChecklistGroup): TutorialChecklistGroup {
+    const tasks = group.tasks.map(settleTask);
+
+    return {
+        ...group,
+        claimableCount: 0,
+        completedCount: tasks.length,
+        tasks,
+        totalCount: tasks.length,
+    };
+}
+
+function getTotals(
+    groups: TutorialChecklistGroup[],
+): TutorialChecklistState['totals'] {
+    const tasks = groups.flatMap((group) => group.tasks);
+
+    return {
+        availableSunflowers: tasks
+            .filter((task) => task.claimable)
+            .reduce((total, task) => total + task.rewardSunflowers, 0),
+        claimableCount: tasks.filter((task) => task.claimable).length,
+        completedCount: tasks.filter((task) => task.completed).length,
+        earnedSunflowers: tasks
+            .filter((task) => task.completed)
+            .reduce((total, task) => total + task.rewardSunflowers, 0),
+        totalCount: tasks.length,
+    };
+}
+
+const completedGroups = checklistState.groups.map(settleGroup);
+
+const completedChecklistState: TutorialChecklistState = {
+    groups: completedGroups,
+    totals: getTotals(completedGroups),
+};
+
+const completedGroupsWithNewTask = completedChecklistState.groups.map(
+    (group) => {
+        if (group.id !== 'day-2') {
+            return group;
+        }
+
+        return settleGroup({
+            ...group,
+            tasks: [
+                ...group.tasks,
+                createTask({
+                    completed: true,
+                    groupId: 'day-2',
+                    index: 3,
+                    title: 'Novi zadatak',
+                }),
+            ],
+        });
+    },
+);
+
+const completedChecklistStateWithNewTask: TutorialChecklistState = {
+    groups: completedGroupsWithNewTask,
+    totals: getTotals(completedGroupsWithNewTask),
+};
+
+function createTutorialChecklistQueryClient(state: TutorialChecklistState) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
             queries: { retry: false, staleTime: Infinity },
         },
     });
 
-    queryClient.setQueryData(tutorialChecklistKeys, checklistState);
+    queryClient.setQueryData(tutorialChecklistKeys, state);
 
     return queryClient;
 }
 
-export function TutorialChecklistHudStory() {
-    const queryClient = useMemo(() => createTutorialChecklistQueryClient(), []);
+type TutorialChecklistHudStoryVariant =
+    | 'completed'
+    | 'completed-with-new-task'
+    | 'default';
+
+function stateForVariant(
+    variant: TutorialChecklistHudStoryVariant,
+): TutorialChecklistState {
+    if (variant === 'completed') {
+        return completedChecklistState;
+    }
+
+    if (variant === 'completed-with-new-task') {
+        return completedChecklistStateWithNewTask;
+    }
+
+    return checklistState;
+}
+
+export function TutorialChecklistHudStory({
+    variant = 'default',
+}: {
+    variant?: TutorialChecklistHudStoryVariant;
+}) {
+    const state = stateForVariant(variant);
+    const [queryClient] = useState(() =>
+        createTutorialChecklistQueryClient(state),
+    );
     const gameStore = useMemo(
         () =>
             createGameState({
@@ -143,6 +242,10 @@ export function TutorialChecklistHudStory() {
             }),
         [],
     );
+
+    useEffect(() => {
+        queryClient.setQueryData(tutorialChecklistKeys, state);
+    }, [queryClient, state]);
 
     return (
         <NuqsTestingAdapter>

--- a/apps/garden/tests/tutorial-checklist-hud.spec.tsx
+++ b/apps/garden/tests/tutorial-checklist-hud.spec.tsx
@@ -160,7 +160,7 @@ test('tutorial checklist modal uses claimable checklist cards and collapses comp
     expect(activeGroupHeaderBox).not.toBeNull();
     expect(
         Math.abs((activeGroupHeaderBox?.x ?? 0) - (activeGroupBox?.x ?? 0)),
-    ).toBeLessThanOrEqual(1);
+    ).toBeLessThanOrEqual(2);
     expect(
         Math.abs(
             (activeGroupHeaderBox?.width ?? 0) - (activeGroupBox?.width ?? 0),
@@ -291,4 +291,86 @@ test('tutorial checklist modal uses readable dark mode surfaces', async ({
     expect(claimableBackground).toBe(tokenColors.background);
     expect(openButtonBackground).toBe(tokenColors.background);
     expect(titleColor).toBe(tokenColors.foreground);
+});
+
+test('tutorial checklist completed state shows a green checkmark and can be hidden', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await mount(<TutorialChecklistHudStory variant="completed" />);
+
+    const trigger = page.locator('[data-tutorial-checklist-trigger="true"]');
+    await expect(trigger).toBeVisible();
+    await expect(trigger).toHaveAttribute(
+        'data-tutorial-checklist-complete',
+        'true',
+    );
+    await expect(
+        trigger.locator('[data-tutorial-checklist-complete-icon="true"]'),
+    ).toBeVisible();
+    await expect(
+        page.locator('[data-tutorial-checklist-progress="true"]'),
+    ).toHaveCount(0);
+    await expect(
+        page.locator('[data-tutorial-checklist-claim-dot="true"]'),
+    ).toHaveCount(0);
+
+    await trigger.click();
+
+    const dialog = page.getByRole('dialog', { name: 'Zadaci za novi vrt' });
+    await expect(dialog).toBeVisible();
+
+    const completeBanner = dialog.locator(
+        '[data-tutorial-checklist-complete-banner="true"]',
+    );
+    await expect(completeBanner).toBeVisible();
+    await expect(
+        completeBanner.locator(
+            '[data-tutorial-checklist-complete-text="true"]',
+        ),
+    ).toHaveText('Svi zadaci su dovršeni.');
+    const completeBannerClassName = await completeBanner.evaluate(
+        (node) => node.className,
+    );
+    expect(completeBannerClassName).toContain('bg-green-600');
+
+    await completeBanner.getByRole('button', { name: 'Sakrij popis' }).click();
+
+    await expect(
+        page.locator('[data-tutorial-checklist-trigger="true"]'),
+    ).toHaveCount(0);
+});
+
+test('tutorial checklist completed dismissal returns when the task set changes', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    const component = await mount(
+        <TutorialChecklistHudStory variant="completed" />,
+    );
+
+    await page.locator('[data-tutorial-checklist-trigger="true"]').click();
+    await page
+        .getByRole('dialog', { name: 'Zadaci za novi vrt' })
+        .getByRole('button', { name: 'Sakrij popis' })
+        .click();
+    await expect(
+        page.locator('[data-tutorial-checklist-trigger="true"]'),
+    ).toHaveCount(0);
+
+    await component.update(
+        <TutorialChecklistHudStory variant="completed-with-new-task" />,
+    );
+
+    const trigger = page.locator('[data-tutorial-checklist-trigger="true"]');
+    await expect(trigger).toBeVisible();
+    await expect(trigger).toHaveAttribute(
+        'data-tutorial-checklist-complete',
+        'true',
+    );
+    await expect(
+        trigger.locator('[data-tutorial-checklist-complete-icon="true"]'),
+    ).toBeVisible();
 });

--- a/packages/game/src/hooks/useThemeManager.ts
+++ b/packages/game/src/hooks/useThemeManager.ts
@@ -1,6 +1,6 @@
 import { useTheme } from 'next-themes';
 import { useEffect } from 'react';
-import { getTimes } from 'suncalc';
+import SunCalc from 'suncalc';
 import {
     DAY_NIGHT_CYCLE_DISABLED_CHANGE_EVENT,
     isDayNightCycleDisabled,
@@ -11,7 +11,7 @@ import { resolveDayNightTheme } from './dayNightTheme';
 const defaultLocation = { lat: 45.739, lon: 16.572 };
 
 function isDaytime(now: Date): boolean {
-    const { sunrise, sunset } = getTimes(
+    const { sunrise, sunset } = SunCalc.getTimes(
         now,
         defaultLocation.lat,
         defaultLocation.lon,

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -13,7 +13,7 @@ import { cx } from '@gredice/ui/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { parseAsString, useQueryState } from 'nuqs';
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import {
@@ -36,6 +36,8 @@ import { RAISED_BED_ONBOARDING_OPEN_EVENT } from './RaisedBedOnboardingModal';
 import styles from './TutorialChecklistHud.module.css';
 
 const tutorialTaskListIconSrc = '/assets/hud/tutorial-task-list.png';
+const completedChecklistDismissedStorageKey =
+    'game:tutorial-checklist:completed-dismissed-v1';
 
 type CurrentGardenData = NonNullable<
     ReturnType<typeof useCurrentGarden>['data']
@@ -80,6 +82,105 @@ function isGroupComplete(group: TutorialChecklistGroup) {
         group.completedCount >= group.totalCount &&
         group.claimableCount === 0
     );
+}
+
+function isChecklistComplete(
+    checklist: TutorialChecklistState | null | undefined,
+) {
+    return Boolean(
+        checklist &&
+            checklist.totals.totalCount > 0 &&
+            checklist.totals.completedCount >= checklist.totals.totalCount &&
+            checklist.totals.claimableCount === 0,
+    );
+}
+
+function getChecklistTaskFingerprint(checklist: TutorialChecklistState) {
+    return checklist.groups
+        .flatMap((group) =>
+            group.tasks.map((task) => `${group.id}:${task.key}`),
+        )
+        .sort()
+        .join('|');
+}
+
+function readCompletedChecklistDismissedFingerprint() {
+    if (typeof window === 'undefined') {
+        return null;
+    }
+
+    try {
+        return window.localStorage.getItem(
+            completedChecklistDismissedStorageKey,
+        );
+    } catch {
+        return null;
+    }
+}
+
+function writeCompletedChecklistDismissedFingerprint(fingerprint: string) {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(
+            completedChecklistDismissedStorageKey,
+            fingerprint,
+        );
+    } catch {
+        // Ignore storage failures; the current session state still dismisses it.
+    }
+}
+
+function useCompletedChecklistDismissal(
+    checklist: TutorialChecklistState | null | undefined,
+) {
+    const allTasksFinished = isChecklistComplete(checklist);
+    const taskFingerprint = useMemo(
+        () => (checklist ? getChecklistTaskFingerprint(checklist) : null),
+        [checklist],
+    );
+    const [dismissedFingerprint, setDismissedFingerprint] = useState<
+        string | null
+    >(null);
+    const [readyFingerprint, setReadyFingerprint] = useState<string | null>(
+        null,
+    );
+
+    useEffect(() => {
+        if (!taskFingerprint) {
+            setDismissedFingerprint(null);
+            setReadyFingerprint(null);
+            return;
+        }
+
+        setDismissedFingerprint(readCompletedChecklistDismissedFingerprint());
+        setReadyFingerprint(taskFingerprint);
+    }, [taskFingerprint]);
+
+    const dismissalReady =
+        taskFingerprint !== null && readyFingerprint === taskFingerprint;
+    const isDismissed =
+        allTasksFinished &&
+        dismissalReady &&
+        dismissedFingerprint === taskFingerprint;
+    const dismiss = useCallback(() => {
+        if (!allTasksFinished || !taskFingerprint) {
+            return;
+        }
+
+        writeCompletedChecklistDismissedFingerprint(taskFingerprint);
+        setDismissedFingerprint(taskFingerprint);
+        setReadyFingerprint(taskFingerprint);
+    }, [allTasksFinished, taskFingerprint]);
+
+    return {
+        allTasksFinished,
+        dismissalReady,
+        dismiss,
+        isDismissed,
+    };
 }
 
 function ClaimButtonContent({ task }: { task: TutorialChecklistTask }) {
@@ -538,8 +639,12 @@ function TutorialChecklistTaskRow({
 }
 
 function TutorialChecklistContent({
+    allTasksFinished,
+    onDismissCompleted,
     onOpenChange,
 }: {
+    allTasksFinished: boolean;
+    onDismissCompleted: () => void;
     onOpenChange: (open: boolean) => void;
 }) {
     const checklistQuery = useTutorialChecklist();
@@ -615,22 +720,44 @@ function TutorialChecklistContent({
             <Stack
                 alignItems="center"
                 spacing={2}
-                className="mt-4 rounded-md border bg-card px-5 py-5 text-center text-card-foreground shadow-sm sm:mx-8"
+                className={cx(
+                    'mt-4 rounded-md border px-5 py-5 text-center shadow-sm sm:mx-8',
+                    allTasksFinished
+                        ? 'border-green-700 bg-green-600 text-white dark:border-green-500/70 dark:bg-green-700'
+                        : 'bg-card text-card-foreground',
+                )}
+                data-tutorial-checklist-complete-banner={
+                    allTasksFinished ? 'true' : 'false'
+                }
             >
-                <span className="grid size-12 place-items-center rounded-full border bg-background text-foreground shadow-sm">
-                    <Image
-                        alt=""
-                        aria-hidden="true"
-                        className="size-11 object-contain drop-shadow-[0_2px_4px_rgb(15_23_42_/_0.25)]"
-                        height={48}
-                        loading="eager"
-                        src={tutorialTaskListIconSrc}
-                        unoptimized
-                        width={48}
-                    />
+                <span
+                    className={cx(
+                        'grid size-12 place-items-center rounded-full border shadow-sm',
+                        allTasksFinished
+                            ? 'border-white/30 bg-white/15 text-white'
+                            : 'bg-background text-foreground',
+                    )}
+                >
+                    {allTasksFinished ? (
+                        <Check className="size-7" />
+                    ) : (
+                        <Image
+                            alt=""
+                            aria-hidden="true"
+                            className="size-11 object-contain drop-shadow-[0_2px_4px_rgb(15_23_42_/_0.25)]"
+                            height={48}
+                            loading="eager"
+                            src={tutorialTaskListIconSrc}
+                            unoptimized
+                            width={48}
+                        />
+                    )}
                 </span>
                 <Typography
-                    className="text-2xl leading-tight font-semibold tracking-tight text-foreground"
+                    className={cx(
+                        'text-2xl leading-tight font-semibold tracking-tight',
+                        allTasksFinished ? 'text-white' : 'text-foreground',
+                    )}
                     component="h2"
                     data-tutorial-checklist-modal-title="true"
                     level="h3"
@@ -640,6 +767,28 @@ function TutorialChecklistContent({
                 >
                     Zadaci za novi vrt
                 </Typography>
+                {allTasksFinished ? (
+                    <>
+                        <Typography
+                            className="max-w-lg text-green-50"
+                            data-tutorial-checklist-complete-text="true"
+                            level="body2"
+                        >
+                            Svi zadaci su dovršeni.
+                        </Typography>
+                        <Button
+                            className="bg-white px-4 font-bold text-green-800 hover:bg-green-50 dark:bg-white dark:text-green-900 dark:hover:bg-green-50"
+                            color="success"
+                            data-tutorial-checklist-hide-completed="true"
+                            onClick={onDismissCompleted}
+                            size="sm"
+                            type="button"
+                            variant="solid"
+                        >
+                            Sakrij popis
+                        </Button>
+                    </>
+                ) : null}
             </Stack>
             <Stack spacing={4}>
                 {sortedGroups.map((group, groupIndex) => {
@@ -760,14 +909,32 @@ export function TutorialChecklistHud() {
     const { data } = useTutorialChecklist();
     const { track } = useGameAnalytics();
     const claimableCount = data?.totals.claimableCount ?? 0;
+    const {
+        allTasksFinished,
+        dismissalReady,
+        dismiss: dismissCompletedChecklist,
+        isDismissed,
+    } = useCompletedChecklistDismissal(data);
     const progressLabel = useMemo(() => {
-        if (!data) return null;
+        if (!data || allTasksFinished) return null;
         const firstActiveGroup = data.groups.find(
             (group) => !isGroupComplete(group),
         );
         if (!firstActiveGroup) return null;
         return `${firstActiveGroup.completedCount}/${firstActiveGroup.totalCount}`;
-    }, [data]);
+    }, [allTasksFinished, data]);
+
+    const handleDismissCompleted = useCallback(() => {
+        dismissCompletedChecklist();
+        setIsOpen(false);
+        track('game_tutorial_checklist_completed_dismissed', {
+            total_count: data?.totals.totalCount ?? 0,
+        });
+    }, [data?.totals.totalCount, dismissCompletedChecklist, track]);
+
+    if ((allTasksFinished && !dismissalReady) || isDismissed) {
+        return null;
+    }
 
     function handleOpenChange(open: boolean) {
         if (open) {
@@ -806,37 +973,62 @@ export function TutorialChecklistHud() {
                 trigger={
                     <IconButton
                         aria-label={
-                            progressLabel ? `Zadaci ${progressLabel}` : 'Zadaci'
+                            allTasksFinished
+                                ? 'Svi zadaci su dovršeni'
+                                : progressLabel
+                                  ? `Zadaci ${progressLabel}`
+                                  : 'Zadaci'
                         }
-                        className="relative rounded-full w-10 h-10"
+                        className={cx(
+                            'relative rounded-full w-10 h-10',
+                            allTasksFinished &&
+                                'bg-green-600 text-white hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-600',
+                        )}
+                        data-tutorial-checklist-complete={
+                            allTasksFinished ? 'true' : 'false'
+                        }
                         data-tutorial-checklist-trigger="true"
                         title="Zadaci"
                         variant="plain"
                     >
-                        <Image
-                            alt=""
-                            aria-hidden="true"
-                            className="pointer-events-none absolute left-1/2 top-0 size-9 shrink-0 -translate-x-1/2 -translate-y-3.5 object-contain drop-shadow-[0_2px_3px_rgb(15_23_42_/_0.35)]"
-                            data-tutorial-checklist-trigger-icon="true"
-                            height={36}
-                            loading="eager"
-                            src={tutorialTaskListIconSrc}
-                            unoptimized
-                            width={36}
-                        />
-                        <Typography
-                            aria-hidden="true"
-                            bold
-                            className="pointer-events-none text-foreground mt-5"
-                            data-tutorial-checklist-progress="true"
-                            level="body3"
-                        >
-                            {progressLabel ?? '0/0'}
-                        </Typography>
+                        {allTasksFinished ? (
+                            <Check
+                                aria-hidden="true"
+                                className="pointer-events-none size-6"
+                                data-tutorial-checklist-complete-icon="true"
+                            />
+                        ) : (
+                            <>
+                                <Image
+                                    alt=""
+                                    aria-hidden="true"
+                                    className="pointer-events-none absolute left-1/2 top-0 size-9 shrink-0 -translate-x-1/2 -translate-y-3.5 object-contain drop-shadow-[0_2px_3px_rgb(15_23_42_/_0.35)]"
+                                    data-tutorial-checklist-trigger-icon="true"
+                                    height={36}
+                                    loading="eager"
+                                    src={tutorialTaskListIconSrc}
+                                    unoptimized
+                                    width={36}
+                                />
+                                <Typography
+                                    aria-hidden="true"
+                                    bold
+                                    className="pointer-events-none text-foreground mt-5"
+                                    data-tutorial-checklist-progress="true"
+                                    level="body3"
+                                >
+                                    {progressLabel ?? '0/0'}
+                                </Typography>
+                            </>
+                        )}
                     </IconButton>
                 }
             >
-                <TutorialChecklistContent onOpenChange={handleOpenChange} />
+                <TutorialChecklistContent
+                    allTasksFinished={allTasksFinished}
+                    onDismissCompleted={handleDismissCompleted}
+                    onOpenChange={handleOpenChange}
+                />
             </Modal>
         </HudCard>
     );

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -3,7 +3,7 @@
 import { useFrame, useThree } from '@react-three/fiber';
 import chroma from 'chroma-js';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { getPosition } from 'suncalc';
+import SunCalc from 'suncalc';
 import { Color, Quaternion, Vector3 } from 'three';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useSnapshotTime } from '../hooks/useSnapshotTime';
@@ -313,7 +313,7 @@ function getSunPosition(
     timeOfDay: number,
 ) {
     const date = timeOfDayToDate(currentTime, timeOfDay);
-    const { altitude, azimuth } = getPosition(date, lat, lon);
+    const { altitude, azimuth } = SunCalc.getPosition(date, lat, lon);
     return altAzToScenePosition(altitude, azimuth);
 }
 

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -3,7 +3,7 @@
 import { useThree } from '@react-three/fiber';
 import chroma from 'chroma-js';
 import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
-import { getMoonIllumination, getMoonPosition, getPosition } from 'suncalc';
+import SunCalc from 'suncalc';
 import {
     AdditiveBlending,
     Color,
@@ -284,9 +284,9 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
         moonMesh.current.scale.setScalar(screenScale);
 
         const date = timeOfDayToDate(currentTime, timeOfDay);
-        const sun = getPosition(date, location.lat, location.lon);
-        const moon = getMoonPosition(date, location.lat, location.lon);
-        const illumination = getMoonIllumination(date);
+        const sun = SunCalc.getPosition(date, location.lat, location.lon);
+        const moon = SunCalc.getMoonPosition(date, location.lat, location.lon);
+        const illumination = SunCalc.getMoonIllumination(date);
 
         const sunOpacity =
             smoothstep(HORIZON_FADE_START, HORIZON_FADE_END, sun.altitude) *

--- a/packages/game/src/utils/timeOfDay.ts
+++ b/packages/game/src/utils/timeOfDay.ts
@@ -1,4 +1,4 @@
-import { getTimes } from 'suncalc';
+import SunCalc from 'suncalc';
 import { ALWAYS_DAY_TIME } from './dayNightCycle';
 
 const sunriseValue = 0.2;
@@ -24,7 +24,7 @@ export function getGameSunriseSunset(
     { lat, lon }: GameLocation,
     currentTime: Date,
 ) {
-    const { sunrise, sunset } = getTimes(currentTime, lat, lon);
+    const { sunrise, sunset } = SunCalc.getTimes(currentTime, lat, lon);
     return { sunrise, sunset };
 }
 


### PR DESCRIPTION
## Summary
- Show a completed-state tutorial checklist trigger and banner when all tasks are done
- Persist completed checklist dismissal by task fingerprint, and restore it when the task set changes
- Update the checklist story and UI tests to cover completed and re-appearing states
- Switch game time/sun calculations to the `SunCalc` default export

## Testing
- UI tests added for the completed checklist trigger, hide action, and task-set reset behavior
- Existing tutorial checklist UI coverage updated for the completed-state layout