### PR TITLE
Show dogs resting inside doghouses at night

### DIFF
--- a/packages/game/src/entities/dogs/Dogs.tsx
+++ b/packages/game/src/entities/dogs/Dogs.tsx
@@ -136,6 +136,7 @@ const clearDogWeather = {
 const dogScale = 0.46;
 const dogGroundLift = 0.02;
 const dogHouseDoorOffset = 0.46;
+const dogHouseNightRestInset = 0.42;
 const dogGroundSurfaceHalfSize = 0.5;
 const dogGroundSurfaceEpsilon = 0.001;
 const dogWalkSpeedBlocksPerSecond = 0.9;
@@ -243,6 +244,33 @@ function getDogWalkYAt(
 
 function getTargetWalkPosition(target: DogTarget) {
     return (target.walkPosition ?? target.position).clone();
+}
+
+function copyDogSettledPosition(
+    result: Vector3,
+    target: DogTarget,
+    timeOfDay: number,
+) {
+    result.copy(target.position);
+
+    if (
+        target.behavior === 'doghouse' &&
+        isDogNight(timeOfDay) &&
+        target.facingYaw !== undefined
+    ) {
+        result.x -= Math.sin(target.facingYaw) * dogHouseNightRestInset;
+        result.z -= Math.cos(target.facingYaw) * dogHouseNightRestInset;
+    }
+
+    return result;
+}
+
+function isDogSettledAtTarget(runtime: DogRuntimeState, target: DogTarget) {
+    return (
+        runtime.phase === 'settled' &&
+        runtime.target.id === target.id &&
+        runtime.target.behavior === target.behavior
+    );
 }
 
 function candidatesInRange<T extends { position: Vector3 }>(
@@ -1603,7 +1631,10 @@ function Dog({
             weather,
         });
 
-        if (group.position.distanceTo(target.position) < 0.08) {
+        if (
+            isDogSettledAtTarget(runtime, target) ||
+            group.position.distanceTo(target.position) < 0.08
+        ) {
             runtimeRef.current = makeSettledState({
                 now,
                 random,
@@ -1692,6 +1723,7 @@ function Dog({
 
                 if (target) {
                     runtime =
+                        isDogSettledAtTarget(runtime, target) ||
                         group.position.distanceTo(target.position) < 0.08
                             ? makeSettledState({
                                   now,
@@ -1772,7 +1804,7 @@ function Dog({
             rig: dogModel.rig,
             walkDistance: 0,
         });
-        group.position.copy(runtime.target.position);
+        copyDogSettledPosition(group.position, runtime.target, timeOfDay);
         if (
             runtime.target.behavior === 'doghouse' ||
             runtime.target.behavior === 'cover'
@@ -1809,7 +1841,10 @@ function Dog({
             timeOfDay,
             weather,
         });
-        if (group.position.distanceTo(target.position) < 0.08) {
+        if (
+            isDogSettledAtTarget(runtime, target) ||
+            group.position.distanceTo(target.position) < 0.08
+        ) {
             runtimeRef.current = makeSettledState({
                 now,
                 random,

--- a/packages/game/src/entities/dogs/Dogs.tsx
+++ b/packages/game/src/entities/dogs/Dogs.tsx
@@ -265,11 +265,17 @@ function copyDogSettledPosition(
     return result;
 }
 
-function isDogSettledAtTarget(runtime: DogRuntimeState, target: DogTarget) {
+function isDogSettledAtNightDogHouse(
+    runtime: DogRuntimeState,
+    target: DogTarget,
+    timeOfDay: number,
+) {
     return (
         runtime.phase === 'settled' &&
+        isDogNight(timeOfDay) &&
         runtime.target.id === target.id &&
-        runtime.target.behavior === target.behavior
+        runtime.target.behavior === 'doghouse' &&
+        target.behavior === 'doghouse'
     );
 }
 
@@ -1632,7 +1638,7 @@ function Dog({
         });
 
         if (
-            isDogSettledAtTarget(runtime, target) ||
+            isDogSettledAtNightDogHouse(runtime, target, timeOfDay) ||
             group.position.distanceTo(target.position) < 0.08
         ) {
             runtimeRef.current = makeSettledState({
@@ -1723,8 +1729,11 @@ function Dog({
 
                 if (target) {
                     runtime =
-                        isDogSettledAtTarget(runtime, target) ||
-                        group.position.distanceTo(target.position) < 0.08
+                        isDogSettledAtNightDogHouse(
+                            runtime,
+                            target,
+                            timeOfDay,
+                        ) || group.position.distanceTo(target.position) < 0.08
                             ? makeSettledState({
                                   now,
                                   random,
@@ -1842,7 +1851,7 @@ function Dog({
             weather,
         });
         if (
-            isDogSettledAtTarget(runtime, target) ||
+            isDogSettledAtNightDogHouse(runtime, target, timeOfDay) ||
             group.position.distanceTo(target.position) < 0.08
         ) {
             runtimeRef.current = makeSettledState({


### PR DESCRIPTION
## Summary
- Offset settled doghouse dogs inward at night so they appear inside the house instead of on the doorway edge
- Treat already-settled dogs as settled even if the target position shifts slightly

## Testing
- Not run (not requested)