### PR TITLE
Update calendar component usage

### DIFF
--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -119,6 +119,28 @@ function expectBaseSchedulingPayload(
     }
 }
 
+function formatDateInput(date: Date) {
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function defaultScheduleDateInput() {
+    const today = new Date();
+    return formatDateInput(
+        new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1),
+    );
+}
+
+async function expectCalendarDatePicker(scheduleDialog: Locator) {
+    await expect(scheduleDialog.locator('[data-event-calendar]')).toBeVisible();
+    await expect(scheduleDialog.getByLabel('Željeni datum radnje')).toHaveCount(
+        0,
+    );
+
+    return defaultScheduleDateInput();
+}
+
 async function expectNoHorizontalOverflow(locator: Locator) {
     const overflow = await locator.evaluate((element) => ({
         clientWidth: element.clientWidth,
@@ -269,9 +291,7 @@ test('saved AI operation links render as scheduling chips', async ({
         scheduleDialog.getByText('Malčiranje gredice', { exact: true }),
     ).toBeVisible();
 
-    const selectedDate = await scheduleDialog
-        .getByLabel('Željeni datum radnje')
-        .inputValue();
+    const selectedDate = await expectCalendarDatePicker(scheduleDialog);
     await scheduleDialog.getByRole('button', { name: 'Potvrdi' }).click();
 
     expectBaseSchedulingPayload(await scheduledPayload, {
@@ -299,9 +319,7 @@ test('saved AI plant operation chip schedules the targeted field', async ({
     const scheduleDialog = page.getByRole('dialog', {
         name: 'Zakaži radnju: Zalijevanje biljke',
     });
-    const selectedDate = await scheduleDialog
-        .getByLabel('Željeni datum radnje')
-        .inputValue();
+    const selectedDate = await expectCalendarDatePicker(scheduleDialog);
     await scheduleDialog.getByRole('button', { name: 'Potvrdi' }).click();
 
     expectBaseSchedulingPayload(await scheduledPayload, {
@@ -333,9 +351,7 @@ test('saved AI operation scheduling failures stay recoverable', async ({
     const scheduleDialog = page.getByRole('dialog', {
         name: 'Zakaži radnju: Malčiranje gredice',
     });
-    const selectedDate = await scheduleDialog
-        .getByLabel('Željeni datum radnje')
-        .inputValue();
+    const selectedDate = await expectCalendarDatePicker(scheduleDialog);
     await scheduleDialog.getByRole('button', { name: 'Potvrdi' }).click();
 
     expectBaseSchedulingPayload(await scheduledPayload, {

--- a/apps/garden/tests/watering-operations-calendar.spec.tsx
+++ b/apps/garden/tests/watering-operations-calendar.spec.tsx
@@ -33,16 +33,41 @@ test('watering calendar keeps the header quiet and highlights today with waterin
     await expect(page.locator('[data-watering-calendar]')).toBeVisible();
     await expect(page.getByText('Kalendar zalijevanja')).toHaveCount(0);
 
-    const calendarControls = page
-        .getByRole('button', { name: 'Prethodni mjesec' })
-        .locator('xpath=..');
-
     await expect
-        .poll(async () => (await calendarControls.textContent())?.trim())
-        .toBe('');
+        .poll(async () =>
+            (
+                await page
+                    .locator('[data-event-calendar-month="2026-06"]')
+                    .locator('div')
+                    .first()
+                    .textContent()
+            )?.trim(),
+        )
+        .toContain('lipanj 2026.');
     await expect(
         page.locator(
-            'button:has([data-watering-calendar-today-marker]):has([data-watering-calendar-marker])',
+            'button:has([data-event-calendar-today-marker]):has([data-event-calendar-marker])',
         ),
     ).toHaveCount(1);
+    await expect(
+        page.locator('[data-event-calendar-marker]').first(),
+    ).toHaveCSS('border-top-width', '0px');
+});
+
+test('watering calendar opens day details on mobile tap', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 390, height: 720 });
+    await mount(
+        <WateringOperationsCalendar
+            entries={wateringEntries}
+            referenceDate={new Date('2026-06-18T12:00:00.000Z')}
+        />,
+    );
+
+    await page.getByRole('button', { name: /Sljedeće zalijevanje/ }).click();
+
+    await expect(page.getByText('Sljedeće zalijevanje')).toBeVisible();
+    await expect(page.getByText('Zakazano · 18 min')).toBeVisible();
 });

--- a/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
@@ -49,6 +49,10 @@ import { Divider } from '@gredice/ui/Divider';
 import { DotIndicator } from '@gredice/ui/DotIndicator';
 import { EditableInput } from '@gredice/ui/EditableInput';
 import { ErrorFallback } from '@gredice/ui/ErrorFallback';
+import {
+    EventCalendar,
+    type EventCalendarEntry,
+} from '@gredice/ui/EventCalendar';
 import { ExpandableSearchInput } from '@gredice/ui/ExpandableSearchInput';
 import { FilterInput } from '@gredice/ui/FilterInput';
 import { Gallery } from '@gredice/ui/Gallery';
@@ -241,6 +245,33 @@ const operationRows = [
         status: 'Ceka sadnju',
         owner: 'Petra',
         dueAt: new Date('2026-05-23T08:00:00+02:00'),
+    },
+];
+
+const gardenCalendarEntries: EventCalendarEntry[] = [
+    {
+        id: 'garden-watering-completed',
+        date: '2026-06-18T08:00:00.000Z',
+        label: 'Površinsko zalijevanje',
+        meta: 'Obavljeno · 20 min',
+        tone: 'completed',
+        weight: 20,
+    },
+    {
+        id: 'garden-watering-scheduled',
+        date: '2026-06-20T08:00:00.000Z',
+        label: 'Zalijevanje gredice',
+        meta: 'Zakazano · 50 min',
+        tone: 'scheduled',
+        weight: 50,
+    },
+    {
+        id: 'garden-cart',
+        date: '2026-06-21T08:00:00.000Z',
+        label: 'Sustav navodnjavanja',
+        meta: 'U košari',
+        tone: 'cart',
+        weight: 90,
     },
 ];
 
@@ -1464,6 +1495,13 @@ function GardenWorkspaceShowcase() {
                                     </Row>
                                 </CardContent>
                             </Card>
+
+                            <EventCalendar
+                                entries={gardenCalendarEntries}
+                                referenceDate={
+                                    new Date('2026-06-18T12:00:00.000Z')
+                                }
+                            />
                         </Stack>
 
                         <div className="relative h-full overflow-hidden bg-emerald-50 p-6 dark:bg-emerald-950/20">

--- a/apps/storybook/stories/packages/ui/EventCalendar.stories.tsx
+++ b/apps/storybook/stories/packages/ui/EventCalendar.stories.tsx
@@ -1,0 +1,113 @@
+import {
+    EventCalendar,
+    type EventCalendarEntry,
+} from '@gredice/ui/EventCalendar';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { type ComponentProps, useState } from 'react';
+
+const referenceDate = new Date('2026-06-18T12:00:00.000Z');
+const selectableFrom = new Date('2026-06-19T00:00:00.000Z');
+const selectableTo = new Date('2026-09-19T00:00:00.000Z');
+
+const entries: EventCalendarEntry[] = [
+    {
+        id: 'completed-light',
+        date: '2026-06-08T08:00:00.000Z',
+        label: 'Lagano zalijevanje gredice',
+        meta: 'Obavljeno · 15 min',
+        tone: 'completed',
+        weight: 15,
+    },
+    {
+        id: 'completed-medium',
+        date: '2026-06-10T08:00:00.000Z',
+        label: 'Površinsko zalijevanje gredice',
+        meta: 'Obavljeno · 35 min',
+        tone: 'completed',
+        weight: 35,
+    },
+    {
+        id: 'scheduled',
+        date: '2026-07-08T08:00:00.000Z',
+        label: 'Zakazano zalijevanje',
+        meta: 'Zakazano · 45 min',
+        tone: 'scheduled',
+        weight: 45,
+    },
+    {
+        id: 'cart',
+        date: '2026-07-17T08:00:00.000Z',
+        label: 'Zalijevanje u košari',
+        meta: 'U košari · 30 min',
+        tone: 'cart',
+        weight: 30,
+    },
+    {
+        id: 'preview',
+        date: '2026-07-21T08:00:00.000Z',
+        label: 'Novi termin zalijevanja',
+        meta: 'Novi termin · 60 min',
+        tone: 'preview',
+        weight: 60,
+    },
+];
+
+function SelectableScheduleStory(args: ComponentProps<typeof EventCalendar>) {
+    const [selectedDate, setSelectedDate] = useState(
+        new Date('2026-06-20T00:00:00.000Z'),
+    );
+
+    return (
+        <div className="min-h-screen bg-[#c7be74] p-8">
+            <div className="w-[22rem] max-w-full">
+                <EventCalendar
+                    {...args}
+                    maxSelectableDate={selectableTo}
+                    minSelectableDate={selectableFrom}
+                    onDateSelect={setSelectedDate}
+                    selectedDate={selectedDate}
+                    visibleFrom={selectableFrom}
+                    visibleTo={selectableTo}
+                />
+            </div>
+        </div>
+    );
+}
+
+const meta = {
+    title: 'packages/ui/EventCalendar',
+    component: EventCalendar,
+    tags: ['autodocs'],
+    args: {
+        entries,
+        referenceDate,
+    },
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Shared calendar for compact operation and event timelines, including selectable scheduling dates and tap-friendly day details.',
+            },
+        },
+    },
+    render: (args) => (
+        <div className="min-h-screen bg-[#c7be74] p-8">
+            <div className="w-[22rem] max-w-full">
+                <EventCalendar {...args} />
+            </div>
+        </div>
+    ),
+} satisfies Meta<typeof EventCalendar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Timeline: Story = {
+    name: 'Timeline',
+};
+
+export const SelectableSchedule: Story = {
+    name: 'Selectable schedule',
+    render: SelectableScheduleStory,
+};

--- a/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
@@ -41,14 +41,12 @@ export function RaisedBedWatering({
             }
         >
             <Stack spacing={4}>
-                <Typography level="h5">Radnje zalijevanja</Typography>
-                <Typography>
+                <Typography level="body2" semiBold>
+                    Radnje zalijevanja
+                </Typography>
+                <Typography level="body2" secondary>
                     Odaberite radnju zalijevanja za ovu gredicu.
                 </Typography>
-                <RaisedBedWateringCalendar
-                    gardenId={gardenId}
-                    raisedBedId={raisedBedId}
-                />
                 <OperationsList
                     gardenId={gardenId}
                     raisedBedId={raisedBedId}
@@ -57,6 +55,10 @@ export function RaisedBedWatering({
                             'watering' &&
                         operation.attributes.application === 'raisedBedFull'
                     }
+                />
+                <RaisedBedWateringCalendar
+                    gardenId={gardenId}
+                    raisedBedId={raisedBedId}
                 />
             </Stack>
         </Modal>

--- a/packages/game/src/hud/raisedBed/RaisedBedWateringCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWateringCalendar.tsx
@@ -226,17 +226,29 @@ function buildPreviewEntry({
 export function RaisedBedWateringCalendar({
     className,
     gardenId,
+    maxSelectableDate,
+    minSelectableDate,
+    onDateSelect,
     operationId,
     previewDate,
     previewOperation,
     raisedBedId,
+    selectedDate,
+    visibleFrom,
+    visibleTo,
 }: {
     className?: string;
     gardenId: number;
+    maxSelectableDate?: Date;
+    minSelectableDate?: Date;
+    onDateSelect?: (date: Date) => void;
     operationId?: number;
     previewDate?: Date | null;
     previewOperation?: OperationData;
     raisedBedId: number;
+    selectedDate?: Date | null;
+    visibleFrom?: Date;
+    visibleTo?: Date;
 }) {
     const referenceDate = useLiveTime();
     const { data: operations, isError: isOperationsError } = useOperations();
@@ -323,7 +335,13 @@ export function RaisedBedWateringCalendar({
                 history.isFetchingNextPage ||
                 operations === undefined
             }
+            maxSelectableDate={maxSelectableDate}
+            minSelectableDate={minSelectableDate}
+            onDateSelect={onDateSelect}
             referenceDate={referenceDate}
+            selectedDate={selectedDate}
+            visibleFrom={visibleFrom}
+            visibleTo={visibleTo}
         />
     );
 }

--- a/packages/game/src/hud/raisedBed/WateringOperationsCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/WateringOperationsCalendar.tsx
@@ -1,64 +1,17 @@
 'use client';
 
-import { Alert } from '@gredice/ui/Alert';
-import { IconButton } from '@gredice/ui/IconButton';
-import { ArrowLeft, ArrowRight, Calendar } from '@gredice/ui/icons';
-import { Row } from '@gredice/ui/Row';
-import { Spinner } from '@gredice/ui/Spinner';
-import { Stack } from '@gredice/ui/Stack';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@gredice/ui/Tooltip';
-import { Typography } from '@gredice/ui/Typography';
-import { cx } from '@gredice/ui/utils';
-import { useEffect, useMemo, useState } from 'react';
 import {
-    buildWateringCalendarMonths,
-    formatLocalDayKey,
-    type WateringCalendarDay,
-    type WateringCalendarEntry,
-    type WateringCalendarMonth,
-} from './wateringCalendarModel';
+    EventCalendar,
+    type EventCalendarEntry,
+} from '@gredice/ui/EventCalendar';
+import type { WateringCalendarEntry } from './wateringCalendarModel';
 
-const weekDays = ['Pon', 'Uto', 'Sri', 'Čet', 'Pet', 'Sub', 'Ned'];
-const monthFormatter = new Intl.DateTimeFormat('hr-HR', {
-    month: 'long',
-    year: 'numeric',
-});
-const dayFormatter = new Intl.DateTimeFormat('hr-HR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-});
 const sourceLabels = {
     cart: 'U košari',
     completed: 'Obavljeno',
     preview: 'Novi termin',
     scheduled: 'Zakazano',
 } satisfies Record<WateringCalendarEntry['source'], string>;
-
-function markerClassName(day: WateringCalendarDay) {
-    if (day.tone === 'preview') {
-        return 'border-sky-600 bg-sky-100/70 border-dashed';
-    }
-
-    if (day.tone === 'cart') {
-        return 'border-sky-600 bg-sky-200/80 shadow-sm shadow-sky-300/50';
-    }
-
-    if (day.tone === 'scheduled') {
-        return 'border-sky-500 bg-sky-100/70';
-    }
-
-    return 'border-sky-500 bg-sky-500/20';
-}
-
-function dayTitle(day: WateringCalendarDay) {
-    if (day.entries.length === 0) {
-        return dayFormatter.format(day.date);
-    }
-
-    const labels = day.entries.map((entry) => entry.label).join(', ');
-    return `${dayFormatter.format(day.date)}: ${labels}`;
-}
 
 function entryMeta(entry: WateringCalendarEntry) {
     const roundedWeight =
@@ -74,132 +27,17 @@ function entryMeta(entry: WateringCalendarEntry) {
         .join(' · ');
 }
 
-function TodayMarker() {
-    return (
-        <span
-            aria-hidden
-            className="absolute size-9 rounded-full bg-white shadow-sm ring-2 ring-sky-600/40 dark:bg-neutral-950 dark:ring-sky-300/50"
-            data-watering-calendar-today-marker
-        />
-    );
-}
-
-function WateringCalendarDayView({
-    day,
-    todayKey,
-}: {
-    day: WateringCalendarDay;
-    todayKey: string;
-}) {
-    const isToday = day.key === todayKey;
-
-    if (day.entries.length === 0) {
-        return (
-            <div className="relative grid size-8 place-items-center text-xs tabular-nums">
-                {isToday ? <TodayMarker /> : null}
-                <span className="relative z-10">{day.dayOfMonth}</span>
-            </div>
-        );
-    }
-
-    const content = (
-        <button
-            type="button"
-            className={cx(
-                'relative grid size-8 place-items-center rounded-full text-xs tabular-nums',
-                'font-semibold text-slate-950 dark:text-white',
-            )}
-            aria-label={dayTitle(day)}
-        >
-            {isToday ? <TodayMarker /> : null}
-            <span
-                aria-hidden
-                className={cx(
-                    'absolute rounded-full border-2',
-                    markerClassName(day),
-                )}
-                data-watering-calendar-marker
-                data-watering-calendar-tone={day.tone}
-                style={{
-                    height: day.markerSize,
-                    width: day.markerSize,
-                }}
-            />
-            <span className="relative z-10">{day.dayOfMonth}</span>
-        </button>
-    );
-
-    return (
-        <Tooltip delayDuration={100}>
-            <TooltipTrigger asChild>{content}</TooltipTrigger>
-            <TooltipContent className="max-w-64 p-3">
-                <Stack spacing={2}>
-                    <Typography level="body3" semiBold>
-                        {dayFormatter.format(day.date)}
-                    </Typography>
-                    <Stack spacing={1}>
-                        {day.entries.map((entry) => (
-                            <Stack key={entry.id} spacing={0}>
-                                <Typography level="body3" semiBold>
-                                    {entry.label}
-                                </Typography>
-                                <Typography level="body3" secondary>
-                                    {entryMeta(entry)}
-                                </Typography>
-                            </Stack>
-                        ))}
-                    </Stack>
-                </Stack>
-            </TooltipContent>
-        </Tooltip>
-    );
-}
-
-function WateringCalendarMonthView({
-    month,
-    todayKey,
-}: {
-    month: WateringCalendarMonth;
-    todayKey: string;
-}) {
-    return (
-        <section className="space-y-2" data-watering-calendar-month={month.key}>
-            <Row spacing={2} className="text-slate-700 dark:text-slate-200">
-                <Calendar className="size-4 shrink-0 text-sky-600" />
-                <Typography level="body2" semiBold className="capitalize">
-                    {monthFormatter.format(month.date)}
-                </Typography>
-            </Row>
-            <div className="grid grid-cols-7 gap-1 text-center">
-                {weekDays.map((weekDay) => (
-                    <div
-                        key={weekDay}
-                        className="text-[0.65rem] font-semibold uppercase text-muted-foreground"
-                    >
-                        {weekDay}
-                    </div>
-                ))}
-                {month.weeks.flatMap((week, weekIndex) =>
-                    week.map((day, dayIndex) => (
-                        <div
-                            key={
-                                day?.key ??
-                                `${month.key}-${weekIndex}-${dayIndex}`
-                            }
-                            className="grid h-8 place-items-center"
-                        >
-                            {day ? (
-                                <WateringCalendarDayView
-                                    day={day}
-                                    todayKey={todayKey}
-                                />
-                            ) : null}
-                        </div>
-                    )),
-                )}
-            </div>
-        </section>
-    );
+function toEventCalendarEntry(
+    entry: WateringCalendarEntry,
+): EventCalendarEntry {
+    return {
+        id: entry.id,
+        date: entry.date,
+        label: entry.label,
+        meta: entryMeta(entry),
+        tone: entry.source,
+        weight: entry.weight,
+    };
 }
 
 export function WateringOperationsCalendar({
@@ -207,128 +45,42 @@ export function WateringOperationsCalendar({
     entries,
     error,
     isLoading,
+    maxSelectableDate,
+    minSelectableDate,
+    onDateSelect,
     referenceDate,
+    selectedDate,
+    visibleFrom,
+    visibleTo,
 }: {
     className?: string;
     entries: WateringCalendarEntry[];
     error?: boolean;
     isLoading?: boolean;
+    maxSelectableDate?: Date;
+    minSelectableDate?: Date;
+    onDateSelect?: (date: Date) => void;
     referenceDate?: Date;
+    selectedDate?: Date | null;
+    visibleFrom?: Date;
+    visibleTo?: Date;
 }) {
-    const months = useMemo(
-        () => buildWateringCalendarMonths(entries, referenceDate),
-        [entries, referenceDate],
-    );
-    const todayKey = formatLocalDayKey(referenceDate ?? new Date());
-    const [selectedMonthKey, setSelectedMonthKey] = useState<string | null>(
-        null,
-    );
-
-    useEffect(() => {
-        if (months.length === 0) {
-            setSelectedMonthKey(null);
-            return;
-        }
-
-        setSelectedMonthKey((currentKey) => {
-            if (
-                currentKey &&
-                months.some((month) => month.key === currentKey)
-            ) {
-                return currentKey;
-            }
-
-            return months[months.length - 1].key;
-        });
-    }, [months]);
-
-    const requestedMonthIndex = selectedMonthKey
-        ? months.findIndex((month) => month.key === selectedMonthKey)
-        : -1;
-    const selectedMonthIndex =
-        months.length === 0
-            ? -1
-            : requestedMonthIndex >= 0
-              ? requestedMonthIndex
-              : months.length - 1;
-    const selectedMonth =
-        selectedMonthIndex >= 0 ? months[selectedMonthIndex] : null;
-    const canGoBack = selectedMonthIndex > 0;
-    const canGoForward =
-        selectedMonthIndex >= 0 && selectedMonthIndex < months.length - 1;
-
     return (
-        <Stack
-            spacing={3}
-            className={cx(
-                'rounded-lg border bg-card/80 p-3 shadow-sm',
-                className,
-            )}
+        <EventCalendar
+            className={className}
             data-watering-calendar
-        >
-            {entries.length > 0 ? (
-                <Row spacing={1} justifyContent="end">
-                    <IconButton
-                        aria-label="Prethodni mjesec"
-                        disabled={!canGoBack}
-                        size="xs"
-                        title="Prethodni mjesec"
-                        type="button"
-                        variant="plain"
-                        onClick={() => {
-                            if (canGoBack) {
-                                setSelectedMonthKey(
-                                    months[selectedMonthIndex - 1].key,
-                                );
-                            }
-                        }}
-                    >
-                        <ArrowLeft className="size-3.5" />
-                    </IconButton>
-                    <IconButton
-                        aria-label="Sljedeći mjesec"
-                        disabled={!canGoForward}
-                        size="xs"
-                        title="Sljedeći mjesec"
-                        type="button"
-                        variant="plain"
-                        onClick={() => {
-                            if (canGoForward) {
-                                setSelectedMonthKey(
-                                    months[selectedMonthIndex + 1].key,
-                                );
-                            }
-                        }}
-                    >
-                        <ArrowRight className="size-3.5" />
-                    </IconButton>
-                </Row>
-            ) : null}
-            {error ? (
-                <Alert color="danger">
-                    Kalendar zalijevanja nije dostupan.
-                </Alert>
-            ) : null}
-            {isLoading ? (
-                <Row spacing={2}>
-                    <Spinner loadingLabel="Učitavanje kalendara" />
-                    <Typography level="body2" secondary>
-                        Učitavanje...
-                    </Typography>
-                </Row>
-            ) : null}
-            {!error && !isLoading && months.length === 0 ? (
-                <Typography level="body2" secondary>
-                    Još nema zabilježenih zalijevanja.
-                </Typography>
-            ) : null}
-            {selectedMonth ? (
-                <WateringCalendarMonthView
-                    key={selectedMonth.key}
-                    month={selectedMonth}
-                    todayKey={todayKey}
-                />
-            ) : null}
-        </Stack>
+            emptyLabel="Još nema zabilježenih zalijevanja."
+            entries={entries.map(toEventCalendarEntry)}
+            error={error}
+            errorLabel="Kalendar zalijevanja nije dostupan."
+            isLoading={isLoading}
+            maxSelectableDate={maxSelectableDate}
+            minSelectableDate={minSelectableDate}
+            onDateSelect={onDateSelect}
+            referenceDate={referenceDate}
+            selectedDate={selectedDate}
+            visibleFrom={visibleFrom}
+            visibleTo={visibleTo}
+        />
     );
 }

--- a/packages/game/src/hud/raisedBed/WateringOperationsCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/WateringOperationsCalendar.tsx
@@ -4,7 +4,10 @@ import {
     EventCalendar,
     type EventCalendarEntry,
 } from '@gredice/ui/EventCalendar';
-import type { WateringCalendarEntry } from './wateringCalendarModel';
+import {
+    toWateringEventCalendarEntry,
+    type WateringCalendarEntry,
+} from './wateringCalendarModel';
 
 const sourceLabels = {
     cart: 'U košari',
@@ -29,14 +32,13 @@ function entryMeta(entry: WateringCalendarEntry) {
 
 function toEventCalendarEntry(
     entry: WateringCalendarEntry,
+    referenceDate: Date,
 ): EventCalendarEntry {
+    const calendarEntry = toWateringEventCalendarEntry(entry, referenceDate);
+
     return {
-        id: entry.id,
-        date: entry.date,
-        label: entry.label,
+        ...calendarEntry,
         meta: entryMeta(entry),
-        tone: entry.source,
-        weight: entry.weight,
     };
 }
 
@@ -65,19 +67,23 @@ export function WateringOperationsCalendar({
     visibleFrom?: Date;
     visibleTo?: Date;
 }) {
+    const resolvedReferenceDate = referenceDate ?? new Date();
+
     return (
         <EventCalendar
             className={className}
             data-watering-calendar
             emptyLabel="Još nema zabilježenih zalijevanja."
-            entries={entries.map(toEventCalendarEntry)}
+            entries={entries.map((entry) =>
+                toEventCalendarEntry(entry, resolvedReferenceDate),
+            )}
             error={error}
             errorLabel="Kalendar zalijevanja nije dostupan."
             isLoading={isLoading}
             maxSelectableDate={maxSelectableDate}
             minSelectableDate={minSelectableDate}
             onDateSelect={onDateSelect}
-            referenceDate={referenceDate}
+            referenceDate={resolvedReferenceDate}
             selectedDate={selectedDate}
             visibleFrom={visibleFrom}
             visibleTo={visibleTo}

--- a/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
@@ -4,7 +4,7 @@ import { getHarvestOperationRemovalDisclaimer } from '@gredice/js/plants';
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
-import { Input } from '@gredice/ui/Input';
+import { EventCalendar } from '@gredice/ui/EventCalendar';
 import { Calendar } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { OperationImage } from '@gredice/ui/OperationImage';
@@ -13,7 +13,20 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
 import { formatLocalDate } from '../RaisedBedPlantPicker';
-import { RaisedBedWateringCalendar } from '../RaisedBedWateringCalendar';
+import {
+    isWateringOperation,
+    RaisedBedWateringCalendar,
+} from '../RaisedBedWateringCalendar';
+
+function parseLocalDateInput(value: string) {
+    const [year, month, day] = value.split('-').map(Number);
+    if (!year || !month || !day) {
+        return null;
+    }
+
+    const date = new Date(year, month - 1, day);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
 
 export function OperationScheduleModal({
     gardenId,
@@ -35,25 +48,6 @@ export function OperationScheduleModal({
         null,
     );
 
-    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        const formData = new FormData(event.currentTarget);
-        const date = formData.get('scheduledDate');
-        if (typeof date === 'string' && date) {
-            const scheduledDate = new Date(date);
-            setErrorMessage(null);
-            setIsLoading(true);
-            try {
-                await onConfirm(scheduledDate);
-                setOpen(false);
-            } catch {
-                setErrorMessage('Zakazivanje nije uspjelo. Pokušaj ponovno.');
-            } finally {
-                setIsLoading(false);
-            }
-        }
-    }
-
     const today = new Date();
     const tomorrow = new Date(
         today.getFullYear(),
@@ -67,9 +61,11 @@ export function OperationScheduleModal({
     );
     const operationDefaultDate = formatLocalDate(tomorrow);
     const selectedDateInput = scheduledDateInput ?? operationDefaultDate;
-    const selectedDate = selectedDateInput ? new Date(selectedDateInput) : null;
-    const min = formatLocalDate(tomorrow);
-    const max = formatLocalDate(threeMonthsFromTomorrow);
+    const selectedDate = parseLocalDateInput(selectedDateInput);
+    const showWateringCalendar =
+        gardenId != null &&
+        raisedBedId != null &&
+        isWateringOperation(operation);
     const isHarvestOperation =
         operation.attributes.stage.information?.name === 'harvest';
     const harvestPlantRemovalDescription = isHarvestOperation
@@ -78,6 +74,30 @@ export function OperationScheduleModal({
               true,
           )
         : null;
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const scheduledDate = new Date(selectedDateInput);
+        if (Number.isNaN(scheduledDate.getTime())) {
+            setErrorMessage('Odaberi datum radnje.');
+            return;
+        }
+
+        setErrorMessage(null);
+        setIsLoading(true);
+        try {
+            await onConfirm(scheduledDate);
+            setOpen(false);
+        } catch {
+            setErrorMessage('Zakazivanje nije uspjelo. Pokušaj ponovno.');
+        } finally {
+            setIsLoading(false);
+        }
+    }
+
+    const handleDateSelect = (date: Date) => {
+        setScheduledDateInput(formatLocalDate(date));
+    };
 
     return (
         <Modal
@@ -95,8 +115,10 @@ export function OperationScheduleModal({
         >
             <form onSubmit={handleSubmit}>
                 <Stack spacing={4}>
-                    <Typography level="h5">Zakazivanje radnje</Typography>
-                    <Typography>
+                    <Typography level="body2" semiBold>
+                        Zakazivanje radnje
+                    </Typography>
+                    <Typography level="body2" secondary>
                         Ova radnja će biti zakazana za odabrani datum.
                     </Typography>
                     <Card>
@@ -139,29 +161,33 @@ export function OperationScheduleModal({
                             </Typography>
                         </Alert>
                     ) : null}
-                    <Input
-                        type="date"
-                        label="Željeni datum radnje"
-                        name="scheduledDate"
-                        className="w-full bg-card"
-                        disabled={isLoading}
-                        value={selectedDateInput}
-                        min={min}
-                        max={max}
-                        onChange={(event) =>
-                            setScheduledDateInput(event.target.value)
-                        }
-                        required
-                    />
-                    {gardenId != null && raisedBedId != null ? (
+                    {showWateringCalendar ? (
                         <RaisedBedWateringCalendar
                             className="shadow-none"
                             gardenId={gardenId}
+                            maxSelectableDate={threeMonthsFromTomorrow}
+                            minSelectableDate={tomorrow}
+                            onDateSelect={handleDateSelect}
                             previewDate={selectedDate}
                             previewOperation={operation}
                             raisedBedId={raisedBedId}
+                            selectedDate={selectedDate}
+                            visibleFrom={tomorrow}
+                            visibleTo={threeMonthsFromTomorrow}
                         />
-                    ) : null}
+                    ) : (
+                        <EventCalendar
+                            className="shadow-none"
+                            emptyLabel={null}
+                            entries={[]}
+                            maxSelectableDate={threeMonthsFromTomorrow}
+                            minSelectableDate={tomorrow}
+                            onDateSelect={handleDateSelect}
+                            selectedDate={selectedDate}
+                            visibleFrom={tomorrow}
+                            visibleTo={threeMonthsFromTomorrow}
+                        />
+                    )}
                     <Row spacing={2}>
                         <Button
                             variant="plain"

--- a/packages/game/src/hud/raisedBed/wateringCalendarModel.ts
+++ b/packages/game/src/hud/raisedBed/wateringCalendarModel.ts
@@ -1,3 +1,13 @@
+import {
+    buildEventCalendarMonths,
+    type EventCalendarDay,
+    type EventCalendarDayTone,
+    type EventCalendarEntry,
+    type EventCalendarMonth,
+    formatEventCalendarDayKey,
+    startOfEventCalendarDay,
+} from '@gredice/ui/EventCalendar';
+
 export type WateringCalendarEntrySource =
     | 'completed'
     | 'scheduled'
@@ -12,225 +22,30 @@ export type WateringCalendarEntry = {
     weight?: number | null;
 };
 
-export type WateringCalendarDayTone =
-    | 'none'
-    | 'completed'
-    | 'scheduled'
-    | 'cart'
-    | 'preview';
+export type WateringCalendarDayTone = EventCalendarDayTone;
+export type WateringCalendarDay = EventCalendarDay;
+export type WateringCalendarMonth = EventCalendarMonth;
 
-export type WateringCalendarDay = {
-    key: string;
-    date: Date;
-    dayOfMonth: number;
-    entries: WateringCalendarEntry[];
-    markerSize: number;
-    tone: WateringCalendarDayTone;
-    totalWeight: number;
-};
+export const startOfLocalDay = startOfEventCalendarDay;
+export const formatLocalDayKey = formatEventCalendarDayKey;
 
-export type WateringCalendarMonth = {
-    key: string;
-    date: Date;
-    weeks: Array<Array<WateringCalendarDay | null>>;
-};
-
-const minimumMarkerSize = 16;
-const defaultMarkerSize = 22;
-const maximumMarkerSize = 30;
-const fallbackEntryWeight = 1;
-
-function parseEntryDate(value: Date | string) {
-    const date = value instanceof Date ? value : new Date(value);
-    return Number.isNaN(date.getTime()) ? null : date;
-}
-
-export function startOfLocalDay(date: Date) {
-    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
-}
-
-function startOfLocalMonth(date: Date) {
-    return new Date(date.getFullYear(), date.getMonth(), 1);
-}
-
-function addMonths(date: Date, months: number) {
-    return new Date(date.getFullYear(), date.getMonth() + months, 1);
-}
-
-export function formatLocalDayKey(date: Date) {
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${date.getFullYear()}-${month}-${day}`;
-}
-
-function formatMonthKey(date: Date) {
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    return `${date.getFullYear()}-${month}`;
-}
-
-function entryWeight(entry: WateringCalendarEntry) {
-    return typeof entry.weight === 'number' && entry.weight > 0
-        ? entry.weight
-        : fallbackEntryWeight;
-}
-
-function markerSize({
-    maximumWeight,
-    minimumWeight,
-    weight,
-}: {
-    maximumWeight: number;
-    minimumWeight: number;
-    weight: number;
-}) {
-    if (maximumWeight <= minimumWeight) {
-        return defaultMarkerSize;
-    }
-
-    const ratio = (weight - minimumWeight) / (maximumWeight - minimumWeight);
-    return Math.round(
-        minimumMarkerSize + ratio * (maximumMarkerSize - minimumMarkerSize),
-    );
-}
-
-function toneForDay(
-    entries: WateringCalendarEntry[],
-    date: Date,
-    referenceDate: Date,
-): WateringCalendarDayTone {
-    if (entries.some((entry) => entry.source === 'preview')) {
-        return 'preview';
-    }
-
-    if (entries.some((entry) => entry.source === 'cart')) {
-        return 'cart';
-    }
-
-    if (
-        entries.some((entry) => entry.source === 'scheduled') ||
-        startOfLocalDay(date).getTime() >
-            startOfLocalDay(referenceDate).getTime()
-    ) {
-        return 'scheduled';
-    }
-
-    return 'completed';
-}
-
-function monthRange(entries: WateringCalendarEntry[]) {
-    const dates = entries
-        .map((entry) => parseEntryDate(entry.date))
-        .filter((date): date is Date => date !== null)
-        .map(startOfLocalDay)
-        .sort((left, right) => left.getTime() - right.getTime());
-
-    if (dates.length === 0) {
-        return null;
-    }
-
+function toEventCalendarEntry(
+    entry: WateringCalendarEntry,
+): EventCalendarEntry {
     return {
-        from: startOfLocalMonth(dates[0]),
-        to: startOfLocalMonth(dates[dates.length - 1]),
+        id: entry.id,
+        date: entry.date,
+        label: entry.label,
+        tone: entry.source,
+        weight: entry.weight,
     };
 }
 
 export function buildWateringCalendarMonths(
     entries: WateringCalendarEntry[],
-    referenceDate = new Date(),
+    _referenceDate?: Date,
 ): WateringCalendarMonth[] {
-    const range = monthRange(entries);
-    if (!range) {
-        return [];
-    }
-
-    const entriesByDay = new Map<string, WateringCalendarEntry[]>();
-    for (const entry of entries) {
-        const date = parseEntryDate(entry.date);
-        if (!date) {
-            continue;
-        }
-
-        const key = formatLocalDayKey(date);
-        entriesByDay.set(key, [...(entriesByDay.get(key) ?? []), entry]);
-    }
-
-    const dayWeights = Array.from(entriesByDay.values()).map((dayEntries) =>
-        dayEntries.reduce((sum, entry) => sum + entryWeight(entry), 0),
-    );
-    const minimumWeight = Math.min(...dayWeights);
-    const maximumWeight = Math.max(...dayWeights);
-    const months: WateringCalendarMonth[] = [];
-
-    for (
-        let cursor = range.from;
-        cursor.getTime() <= range.to.getTime();
-        cursor = addMonths(cursor, 1)
-    ) {
-        const firstDay = startOfLocalMonth(cursor);
-        const daysInMonth = new Date(
-            firstDay.getFullYear(),
-            firstDay.getMonth() + 1,
-            0,
-        ).getDate();
-        const mondayOffset = (firstDay.getDay() + 6) % 7;
-        const cells: Array<WateringCalendarDay | null> = Array.from({
-            length: mondayOffset,
-        }).map(() => null);
-
-        for (let day = 1; day <= daysInMonth; day += 1) {
-            const date = new Date(
-                firstDay.getFullYear(),
-                firstDay.getMonth(),
-                day,
-            );
-            const key = formatLocalDayKey(date);
-            const dayEntries = entriesByDay.get(key) ?? [];
-            if (dayEntries.length === 0) {
-                cells.push({
-                    key,
-                    date,
-                    dayOfMonth: day,
-                    entries: [],
-                    markerSize: 0,
-                    tone: 'none',
-                    totalWeight: 0,
-                });
-                continue;
-            }
-
-            const totalWeight = dayEntries.reduce(
-                (sum, entry) => sum + entryWeight(entry),
-                0,
-            );
-            cells.push({
-                key,
-                date,
-                dayOfMonth: day,
-                entries: dayEntries,
-                markerSize: markerSize({
-                    maximumWeight,
-                    minimumWeight,
-                    weight: totalWeight,
-                }),
-                tone: toneForDay(dayEntries, date, referenceDate),
-                totalWeight,
-            });
-        }
-
-        const trailingCells = (7 - (cells.length % 7)) % 7;
-        cells.push(...Array.from({ length: trailingCells }).map(() => null));
-
-        const weeks: WateringCalendarMonth['weeks'] = [];
-        for (let index = 0; index < cells.length; index += 7) {
-            weeks.push(cells.slice(index, index + 7));
-        }
-
-        months.push({
-            key: formatMonthKey(firstDay),
-            date: firstDay,
-            weeks,
-        });
-    }
-
-    return months;
+    return buildEventCalendarMonths({
+        entries: entries.map(toEventCalendarEntry),
+    });
 }

--- a/packages/game/src/hud/raisedBed/wateringCalendarModel.ts
+++ b/packages/game/src/hud/raisedBed/wateringCalendarModel.ts
@@ -29,23 +29,50 @@ export type WateringCalendarMonth = EventCalendarMonth;
 export const startOfLocalDay = startOfEventCalendarDay;
 export const formatLocalDayKey = formatEventCalendarDayKey;
 
-function toEventCalendarEntry(
+function dateFromUnknown(value: Date | string) {
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function sourceForReferenceDate(
     entry: WateringCalendarEntry,
+    referenceDate: Date,
+): WateringCalendarEntrySource {
+    if (entry.source !== 'completed') {
+        return entry.source;
+    }
+
+    const entryDate = dateFromUnknown(entry.date);
+    if (!entryDate) {
+        return entry.source;
+    }
+
+    return startOfLocalDay(entryDate).getTime() >
+        startOfLocalDay(referenceDate).getTime()
+        ? 'scheduled'
+        : entry.source;
+}
+
+export function toWateringEventCalendarEntry(
+    entry: WateringCalendarEntry,
+    referenceDate = new Date(),
 ): EventCalendarEntry {
     return {
         id: entry.id,
         date: entry.date,
         label: entry.label,
-        tone: entry.source,
+        tone: sourceForReferenceDate(entry, referenceDate),
         weight: entry.weight,
     };
 }
 
 export function buildWateringCalendarMonths(
     entries: WateringCalendarEntry[],
-    _referenceDate?: Date,
+    referenceDate = new Date(),
 ): WateringCalendarMonth[] {
     return buildEventCalendarMonths({
-        entries: entries.map(toEventCalendarEntry),
+        entries: entries.map((entry) =>
+            toWateringEventCalendarEntry(entry, referenceDate),
+        ),
     });
 }

--- a/packages/game/src/hud/raisedBed/wateringCalendarModel.unit.ts
+++ b/packages/game/src/hud/raisedBed/wateringCalendarModel.unit.ts
@@ -109,3 +109,31 @@ test('watering calendar prioritizes preview and cart markers for shared dates', 
         'preview',
     );
 });
+
+test('watering calendar renders future completed entries as scheduled', () => {
+    const days = markedDays([
+        {
+            id: 'past-completed',
+            date: '2026-06-10T08:00:00.000Z',
+            label: 'Gotovo zalijevanje',
+            source: 'completed',
+            weight: 30,
+        },
+        {
+            id: 'future-confirmed',
+            date: '2026-06-22T08:00:00.000Z',
+            label: 'Potvrđeno buduće zalijevanje',
+            source: 'completed',
+            weight: 30,
+        },
+    ]);
+
+    assert.equal(
+        days.find((day) => day?.key === '2026-06-10')?.tone,
+        'completed',
+    );
+    assert.equal(
+        days.find((day) => day?.key === '2026-06-22')?.tone,
+        'scheduled',
+    );
+});

--- a/packages/ui/src/EventCalendar/EventCalendar.tsx
+++ b/packages/ui/src/EventCalendar/EventCalendar.tsx
@@ -1,0 +1,732 @@
+'use client';
+
+import type { HTMLAttributes, ReactNode } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Alert } from '../Alert';
+import { IconButton } from '../IconButton';
+import { ArrowLeft, ArrowRight, Calendar } from '../icons';
+import { Popper } from '../Popper';
+import { Row } from '../Row';
+import { Spinner } from '../Spinner';
+import { Stack } from '../Stack';
+import { Typography } from '../Typography';
+import { cx } from '../utils';
+
+export type EventCalendarEntryTone =
+    | 'neutral'
+    | 'info'
+    | 'success'
+    | 'warning'
+    | 'danger'
+    | 'completed'
+    | 'scheduled'
+    | 'cart'
+    | 'preview';
+
+export type EventCalendarEntry = {
+    id: string;
+    date: Date | string;
+    label: string;
+    meta?: ReactNode;
+    tone?: EventCalendarEntryTone;
+    weight?: number | null;
+};
+
+export type EventCalendarDayTone = EventCalendarEntryTone | 'none';
+
+export type EventCalendarDay = {
+    key: string;
+    date: Date;
+    dayOfMonth: number;
+    entries: EventCalendarEntry[];
+    markerSize: number;
+    tone: EventCalendarDayTone;
+    totalWeight: number;
+};
+
+export type EventCalendarMonth = {
+    key: string;
+    date: Date;
+    weeks: Array<Array<EventCalendarDay | null>>;
+};
+
+type EventCalendarProps = Omit<
+    HTMLAttributes<HTMLDivElement>,
+    'children' | 'onSelect'
+> & {
+    entries: EventCalendarEntry[];
+    emptyLabel?: ReactNode;
+    error?: boolean;
+    errorLabel?: ReactNode;
+    isDateDisabled?: (date: Date) => boolean;
+    isLoading?: boolean;
+    loadingLabel?: ReactNode;
+    maxSelectableDate?: Date;
+    minSelectableDate?: Date;
+    onDateSelect?: (date: Date) => void;
+    referenceDate?: Date;
+    selectedDate?: Date | null;
+    visibleFrom?: Date;
+    visibleTo?: Date;
+};
+
+const weekDays = ['Pon', 'Uto', 'Sri', 'Čet', 'Pet', 'Sub', 'Ned'];
+const minimumMarkerSize = 16;
+const defaultMarkerSize = 22;
+const maximumMarkerSize = 30;
+const fallbackEntryWeight = 1;
+
+const monthFormatter = new Intl.DateTimeFormat('hr-HR', {
+    month: 'long',
+    year: 'numeric',
+});
+const dayFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+});
+
+const tonePriority = [
+    'preview',
+    'cart',
+    'danger',
+    'warning',
+    'scheduled',
+    'info',
+    'success',
+    'completed',
+    'neutral',
+] satisfies EventCalendarEntryTone[];
+
+const markerClassNames = {
+    neutral:
+        'bg-muted-foreground text-background dark:bg-neutral-500 dark:text-white',
+    info: 'bg-sky-600 text-white shadow-sm shadow-sky-300/40',
+    success: 'bg-green-600 text-white shadow-sm shadow-green-300/40',
+    warning: 'bg-amber-400 text-amber-950 shadow-sm shadow-amber-200/50',
+    danger: 'bg-red-600 text-white shadow-sm shadow-red-300/40',
+    completed: 'bg-sky-600 text-white shadow-sm shadow-sky-300/40',
+    scheduled: 'bg-sky-500 text-white shadow-sm shadow-sky-300/40',
+    cart: 'bg-cyan-700 text-white shadow-sm shadow-cyan-300/40',
+    preview: 'bg-blue-700 text-white shadow-sm shadow-blue-300/40',
+} satisfies Record<EventCalendarEntryTone, string>;
+
+const markerTextClassNames = {
+    neutral: 'text-background dark:text-white',
+    info: 'text-white',
+    success: 'text-white',
+    warning: 'text-amber-950',
+    danger: 'text-white',
+    completed: 'text-white',
+    scheduled: 'text-white',
+    cart: 'text-white',
+    preview: 'text-white',
+} satisfies Record<EventCalendarEntryTone, string>;
+
+function parseEventDate(value: Date | string | undefined) {
+    if (value === undefined) {
+        return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function startOfEventCalendarDay(date: Date) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function startOfLocalMonth(date: Date) {
+    return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function addMonths(date: Date, months: number) {
+    return new Date(date.getFullYear(), date.getMonth() + months, 1);
+}
+
+export function formatEventCalendarDayKey(date: Date) {
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function formatMonthKey(date: Date) {
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    return `${date.getFullYear()}-${month}`;
+}
+
+function entryWeight(entry: EventCalendarEntry) {
+    return typeof entry.weight === 'number' && entry.weight > 0
+        ? entry.weight
+        : fallbackEntryWeight;
+}
+
+function markerSize({
+    maximumWeight,
+    minimumWeight,
+    weight,
+}: {
+    maximumWeight: number;
+    minimumWeight: number;
+    weight: number;
+}) {
+    if (maximumWeight <= minimumWeight) {
+        return defaultMarkerSize;
+    }
+
+    const ratio = (weight - minimumWeight) / (maximumWeight - minimumWeight);
+    return Math.round(
+        minimumMarkerSize + ratio * (maximumMarkerSize - minimumMarkerSize),
+    );
+}
+
+function toneForDay(entries: EventCalendarEntry[]): EventCalendarDayTone {
+    if (entries.length === 0) {
+        return 'none';
+    }
+
+    return (
+        tonePriority.find((tone) =>
+            entries.some((entry) => (entry.tone ?? 'info') === tone),
+        ) ?? 'info'
+    );
+}
+
+function monthRange({
+    entries,
+    visibleFrom,
+    visibleTo,
+}: {
+    entries: EventCalendarEntry[];
+    visibleFrom?: Date;
+    visibleTo?: Date;
+}) {
+    const dates = [
+        ...entries
+            .map((entry) => parseEventDate(entry.date))
+            .filter((date): date is Date => date !== null),
+        parseEventDate(visibleFrom),
+        parseEventDate(visibleTo),
+    ]
+        .filter((date): date is Date => date !== null)
+        .map(startOfEventCalendarDay)
+        .sort((left, right) => left.getTime() - right.getTime());
+
+    if (dates.length === 0) {
+        return null;
+    }
+
+    return {
+        from: startOfLocalMonth(dates[0]),
+        to: startOfLocalMonth(dates[dates.length - 1]),
+    };
+}
+
+export function buildEventCalendarMonths({
+    entries,
+    visibleFrom,
+    visibleTo,
+}: {
+    entries: EventCalendarEntry[];
+    visibleFrom?: Date;
+    visibleTo?: Date;
+}): EventCalendarMonth[] {
+    const range = monthRange({ entries, visibleFrom, visibleTo });
+    if (!range) {
+        return [];
+    }
+
+    const entriesByDay = new Map<string, EventCalendarEntry[]>();
+    for (const entry of entries) {
+        const date = parseEventDate(entry.date);
+        if (!date) {
+            continue;
+        }
+
+        const key = formatEventCalendarDayKey(date);
+        entriesByDay.set(key, [...(entriesByDay.get(key) ?? []), entry]);
+    }
+
+    const dayWeights = Array.from(entriesByDay.values()).map((dayEntries) =>
+        dayEntries.reduce((sum, entry) => sum + entryWeight(entry), 0),
+    );
+    const minimumWeight = dayWeights.length > 0 ? Math.min(...dayWeights) : 0;
+    const maximumWeight = dayWeights.length > 0 ? Math.max(...dayWeights) : 0;
+    const months: EventCalendarMonth[] = [];
+
+    for (
+        let cursor = range.from;
+        cursor.getTime() <= range.to.getTime();
+        cursor = addMonths(cursor, 1)
+    ) {
+        const firstDay = startOfLocalMonth(cursor);
+        const daysInMonth = new Date(
+            firstDay.getFullYear(),
+            firstDay.getMonth() + 1,
+            0,
+        ).getDate();
+        const mondayOffset = (firstDay.getDay() + 6) % 7;
+        const cells: Array<EventCalendarDay | null> = Array.from({
+            length: mondayOffset,
+        }).map(() => null);
+
+        for (let day = 1; day <= daysInMonth; day += 1) {
+            const date = new Date(
+                firstDay.getFullYear(),
+                firstDay.getMonth(),
+                day,
+            );
+            const key = formatEventCalendarDayKey(date);
+            const dayEntries = entriesByDay.get(key) ?? [];
+            if (dayEntries.length === 0) {
+                cells.push({
+                    key,
+                    date,
+                    dayOfMonth: day,
+                    entries: [],
+                    markerSize: 0,
+                    tone: 'none',
+                    totalWeight: 0,
+                });
+                continue;
+            }
+
+            const totalWeight = dayEntries.reduce(
+                (sum, entry) => sum + entryWeight(entry),
+                0,
+            );
+            cells.push({
+                key,
+                date,
+                dayOfMonth: day,
+                entries: dayEntries,
+                markerSize: markerSize({
+                    maximumWeight,
+                    minimumWeight,
+                    weight: totalWeight,
+                }),
+                tone: toneForDay(dayEntries),
+                totalWeight,
+            });
+        }
+
+        const trailingCells = (7 - (cells.length % 7)) % 7;
+        cells.push(...Array.from({ length: trailingCells }).map(() => null));
+
+        const weeks: EventCalendarMonth['weeks'] = [];
+        for (let index = 0; index < cells.length; index += 7) {
+            weeks.push(cells.slice(index, index + 7));
+        }
+
+        months.push({
+            key: formatMonthKey(firstDay),
+            date: firstDay,
+            weeks,
+        });
+    }
+
+    return months;
+}
+
+function isSameDay(left: Date, right: Date) {
+    return formatEventCalendarDayKey(left) === formatEventCalendarDayKey(right);
+}
+
+function isBeforeDay(left: Date, right: Date) {
+    return (
+        startOfEventCalendarDay(left).getTime() <
+        startOfEventCalendarDay(right).getTime()
+    );
+}
+
+function isAfterDay(left: Date, right: Date) {
+    return (
+        startOfEventCalendarDay(left).getTime() >
+        startOfEventCalendarDay(right).getTime()
+    );
+}
+
+function dayTitle(day: EventCalendarDay, isSelected: boolean) {
+    const dateLabel = dayFormatter.format(day.date);
+    const suffix = isSelected ? ', odabrano' : '';
+
+    if (day.entries.length === 0) {
+        return `${dateLabel}${suffix}`;
+    }
+
+    const labels = day.entries.map((entry) => entry.label).join(', ');
+    return `${dateLabel}${suffix}: ${labels}`;
+}
+
+function TodayMarker() {
+    return (
+        <span
+            aria-hidden
+            className="absolute size-9 rounded-full ring-2 ring-sky-600/40 dark:ring-sky-300/50"
+            data-event-calendar-today-marker
+        />
+    );
+}
+
+function EventCalendarDayDetails({ day }: { day: EventCalendarDay }) {
+    return (
+        <Stack spacing={2}>
+            <Typography level="body3" semiBold>
+                {dayFormatter.format(day.date)}
+            </Typography>
+            <Stack spacing={1}>
+                {day.entries.map((entry) => (
+                    <Stack key={entry.id} spacing={0}>
+                        <Typography level="body3" semiBold>
+                            {entry.label}
+                        </Typography>
+                        {entry.meta ? (
+                            <Typography level="body3" secondary>
+                                {entry.meta}
+                            </Typography>
+                        ) : null}
+                    </Stack>
+                ))}
+            </Stack>
+        </Stack>
+    );
+}
+
+function EventCalendarDayView({
+    day,
+    isDateDisabled,
+    maxSelectableDate,
+    minSelectableDate,
+    onDateSelect,
+    selectedDate,
+    todayKey,
+}: {
+    day: EventCalendarDay;
+    isDateDisabled?: (date: Date) => boolean;
+    maxSelectableDate?: Date;
+    minSelectableDate?: Date;
+    onDateSelect?: (date: Date) => void;
+    selectedDate?: Date | null;
+    todayKey: string;
+}) {
+    const isToday = day.key === todayKey;
+    const hasEntries = day.entries.length > 0;
+    const isSelected = selectedDate ? isSameDay(day.date, selectedDate) : false;
+    const dateIsOutsideRange =
+        (minSelectableDate && isBeforeDay(day.date, minSelectableDate)) ||
+        (maxSelectableDate && isAfterDay(day.date, maxSelectableDate)) ||
+        isDateDisabled?.(day.date) === true;
+    const isSelectable = Boolean(onDateSelect) && !dateIsOutsideRange;
+
+    if (!hasEntries && !onDateSelect) {
+        return (
+            <div className="relative grid size-8 place-items-center text-xs tabular-nums">
+                {isToday ? <TodayMarker /> : null}
+                <span className="relative z-10">{day.dayOfMonth}</span>
+            </div>
+        );
+    }
+
+    const tone = hasEntries && day.tone !== 'none' ? day.tone : null;
+    const content = (
+        <button
+            type="button"
+            className={cx(
+                'relative grid size-8 place-items-center rounded-full text-xs tabular-nums transition-colors',
+                'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                tone && 'font-semibold',
+                tone && markerTextClassNames[tone],
+                !tone &&
+                    isSelected &&
+                    'bg-primary font-semibold text-primary-foreground',
+                !tone &&
+                    !isSelected &&
+                    isSelectable &&
+                    'text-foreground hover:bg-muted',
+                !tone &&
+                    !isSelected &&
+                    !isSelectable &&
+                    'text-muted-foreground/40',
+                isSelected &&
+                    'ring-2 ring-primary ring-offset-2 ring-offset-card',
+            )}
+            aria-label={dayTitle(day, isSelected)}
+            aria-pressed={onDateSelect ? isSelected : undefined}
+            data-event-calendar-selected={isSelected ? true : undefined}
+            disabled={!hasEntries && !isSelectable}
+            onClick={() => {
+                if (isSelectable) {
+                    onDateSelect?.(day.date);
+                }
+            }}
+        >
+            {isToday ? <TodayMarker /> : null}
+            {tone ? (
+                <span
+                    aria-hidden
+                    className={cx(
+                        'absolute rounded-full',
+                        markerClassNames[tone],
+                    )}
+                    data-event-calendar-marker
+                    data-event-calendar-tone={tone}
+                    style={{
+                        height: day.markerSize,
+                        width: day.markerSize,
+                    }}
+                />
+            ) : null}
+            <span className="relative z-10">{day.dayOfMonth}</span>
+        </button>
+    );
+
+    if (!hasEntries) {
+        return content;
+    }
+
+    return (
+        <Popper
+            className="w-[min(calc(100vw-2rem),16rem)] p-3"
+            side="top"
+            sideOffset={6}
+            trigger={content}
+        >
+            <EventCalendarDayDetails day={day} />
+        </Popper>
+    );
+}
+
+function EventCalendarMonthView({
+    canGoBack,
+    canGoForward,
+    isDateDisabled,
+    maxSelectableDate,
+    minSelectableDate,
+    month,
+    onDateSelect,
+    onNextMonth,
+    onPreviousMonth,
+    selectedDate,
+    todayKey,
+}: {
+    canGoBack: boolean;
+    canGoForward: boolean;
+    isDateDisabled?: (date: Date) => boolean;
+    maxSelectableDate?: Date;
+    minSelectableDate?: Date;
+    month: EventCalendarMonth;
+    onDateSelect?: (date: Date) => void;
+    onNextMonth: () => void;
+    onPreviousMonth: () => void;
+    selectedDate?: Date | null;
+    todayKey: string;
+}) {
+    return (
+        <section className="space-y-2" data-event-calendar-month={month.key}>
+            <Row
+                spacing={2}
+                className="text-slate-700 dark:text-slate-200"
+                justifyContent="space-between"
+            >
+                <Row spacing={2} className="min-w-0">
+                    <Calendar className="size-4 shrink-0 text-sky-600" />
+                    <Typography
+                        level="body2"
+                        semiBold
+                        className="truncate capitalize"
+                    >
+                        {monthFormatter.format(month.date)}
+                    </Typography>
+                </Row>
+                <Row spacing={1} className="shrink-0">
+                    <IconButton
+                        aria-label="Prethodni mjesec"
+                        disabled={!canGoBack}
+                        size="xs"
+                        title="Prethodni mjesec"
+                        type="button"
+                        variant="plain"
+                        onClick={onPreviousMonth}
+                    >
+                        <ArrowLeft className="size-3.5" />
+                    </IconButton>
+                    <IconButton
+                        aria-label="Sljedeći mjesec"
+                        disabled={!canGoForward}
+                        size="xs"
+                        title="Sljedeći mjesec"
+                        type="button"
+                        variant="plain"
+                        onClick={onNextMonth}
+                    >
+                        <ArrowRight className="size-3.5" />
+                    </IconButton>
+                </Row>
+            </Row>
+            <div className="grid grid-cols-7 gap-1 text-center">
+                {weekDays.map((weekDay) => (
+                    <div
+                        key={weekDay}
+                        className="text-[0.65rem] font-semibold uppercase text-muted-foreground"
+                    >
+                        {weekDay}
+                    </div>
+                ))}
+                {month.weeks.flatMap((week, weekIndex) =>
+                    week.map((day, dayIndex) => (
+                        <div
+                            key={
+                                day?.key ??
+                                `${month.key}-${weekIndex}-${dayIndex}`
+                            }
+                            className="grid h-8 place-items-center"
+                        >
+                            {day ? (
+                                <EventCalendarDayView
+                                    day={day}
+                                    isDateDisabled={isDateDisabled}
+                                    maxSelectableDate={maxSelectableDate}
+                                    minSelectableDate={minSelectableDate}
+                                    onDateSelect={onDateSelect}
+                                    selectedDate={selectedDate}
+                                    todayKey={todayKey}
+                                />
+                            ) : null}
+                        </div>
+                    )),
+                )}
+            </div>
+        </section>
+    );
+}
+
+export function EventCalendar({
+    className,
+    emptyLabel = 'Nema zabilježenih događaja.',
+    entries,
+    error,
+    errorLabel = 'Kalendar nije dostupan.',
+    isDateDisabled,
+    isLoading,
+    loadingLabel = 'Učitavanje...',
+    maxSelectableDate,
+    minSelectableDate,
+    onDateSelect,
+    referenceDate,
+    selectedDate,
+    visibleFrom,
+    visibleTo,
+    ...rest
+}: EventCalendarProps) {
+    const months = useMemo(
+        () => buildEventCalendarMonths({ entries, visibleFrom, visibleTo }),
+        [entries, visibleFrom, visibleTo],
+    );
+    const todayKey = formatEventCalendarDayKey(referenceDate ?? new Date());
+    const selectedDateKey = selectedDate
+        ? formatMonthKey(startOfLocalMonth(selectedDate))
+        : null;
+    const [selectedMonthKey, setSelectedMonthKey] = useState<string | null>(
+        null,
+    );
+
+    useEffect(() => {
+        if (months.length === 0) {
+            setSelectedMonthKey(null);
+            return;
+        }
+
+        setSelectedMonthKey((currentKey) => {
+            if (
+                currentKey &&
+                months.some((month) => month.key === currentKey)
+            ) {
+                return currentKey;
+            }
+
+            if (
+                selectedDateKey &&
+                months.some((month) => month.key === selectedDateKey)
+            ) {
+                return selectedDateKey;
+            }
+
+            return months[months.length - 1].key;
+        });
+    }, [months, selectedDateKey]);
+
+    const fallbackMonthKey =
+        selectedDateKey && months.some((month) => month.key === selectedDateKey)
+            ? selectedDateKey
+            : (months[months.length - 1]?.key ?? null);
+    const requestedMonthKey = selectedMonthKey ?? fallbackMonthKey;
+    const requestedMonthIndex = requestedMonthKey
+        ? months.findIndex((month) => month.key === requestedMonthKey)
+        : -1;
+    const selectedMonthIndex =
+        months.length === 0
+            ? -1
+            : requestedMonthIndex >= 0
+              ? requestedMonthIndex
+              : months.length - 1;
+    const selectedMonth =
+        selectedMonthIndex >= 0 ? months[selectedMonthIndex] : null;
+    const canGoBack = selectedMonthIndex > 0;
+    const canGoForward =
+        selectedMonthIndex >= 0 && selectedMonthIndex < months.length - 1;
+
+    return (
+        <Stack
+            spacing={3}
+            className={cx(
+                'rounded-lg border bg-card/80 p-3 shadow-sm',
+                className,
+            )}
+            data-event-calendar
+            {...rest}
+        >
+            {error ? <Alert color="danger">{errorLabel}</Alert> : null}
+            {isLoading ? (
+                <Row spacing={2}>
+                    <Spinner loadingLabel="Učitavanje kalendara" />
+                    <Typography level="body2" secondary>
+                        {loadingLabel}
+                    </Typography>
+                </Row>
+            ) : null}
+            {!error && !isLoading && months.length === 0 && emptyLabel ? (
+                <Typography level="body2" secondary>
+                    {emptyLabel}
+                </Typography>
+            ) : null}
+            {selectedMonth ? (
+                <EventCalendarMonthView
+                    key={selectedMonth.key}
+                    canGoBack={canGoBack}
+                    canGoForward={canGoForward}
+                    isDateDisabled={isDateDisabled}
+                    maxSelectableDate={maxSelectableDate}
+                    minSelectableDate={minSelectableDate}
+                    month={selectedMonth}
+                    onDateSelect={onDateSelect}
+                    onNextMonth={() => {
+                        if (canGoForward) {
+                            setSelectedMonthKey(
+                                months[selectedMonthIndex + 1].key,
+                            );
+                        }
+                    }}
+                    onPreviousMonth={() => {
+                        if (canGoBack) {
+                            setSelectedMonthKey(
+                                months[selectedMonthIndex - 1].key,
+                            );
+                        }
+                    }}
+                    selectedDate={selectedDate}
+                    todayKey={todayKey}
+                />
+            ) : null}
+        </Stack>
+    );
+}

--- a/packages/ui/src/EventCalendar/index.ts
+++ b/packages/ui/src/EventCalendar/index.ts
@@ -1,0 +1,11 @@
+export {
+    buildEventCalendarMonths,
+    EventCalendar,
+    type EventCalendarDay,
+    type EventCalendarDayTone,
+    type EventCalendarEntry,
+    type EventCalendarEntryTone,
+    type EventCalendarMonth,
+    formatEventCalendarDayKey,
+    startOfEventCalendarDay,
+} from './EventCalendar';


### PR DESCRIPTION
## Summary
- Replace the raised-bed watering calendar with the shared `EventCalendar` implementation
- Update the scheduling modal to use calendar selection instead of the date input for watering actions
- Refresh garden and Storybook coverage to reflect the new calendar behavior and mobile interaction

## Testing
- UI tests updated for raised-bed diary and watering calendar flows
- Storybook coverage added for the shared event calendar
- Not run (not requested)