### PR TITLE
[codex] Hide operations for not sprouted plants

### DIFF
--- a/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
@@ -16,7 +16,10 @@ import {
     findRaisedBedOccupiedField,
     type RaisedBedFieldPlantHistoryEntry,
 } from '../../utils/raisedBedFields';
-import type { PlantFieldStatus } from './featuredOperations';
+import {
+    isPlantFieldStatus,
+    shouldShowPlantOperationRecommendations,
+} from './featuredOperations';
 import { plantFieldStatusEmoji } from './PlantFieldStatusEmoji';
 import {
     getPlantLifecycleProgressData,
@@ -111,6 +114,11 @@ export function RaisedBedFieldLifecycleTab({
             plantSort.information.name,
         plantSort.information.name,
     );
+    const plantStatus = isPlantFieldStatus(field.plantStatus)
+        ? field.plantStatus
+        : undefined;
+    const showPlantOperationRecommendations =
+        shouldShowPlantOperationRecommendations(plantStatus);
     const statusContent = (
         <>
             <span className="text-2xl leading-none" aria-hidden="true">
@@ -163,16 +171,18 @@ export function RaisedBedFieldLifecycleTab({
                 }
             />
 
-            {field.active && typeof field.plantSortId === 'number' && (
-                <RecommendationsCard
-                    onShowOperations={onShowOperations}
-                    gardenId={garden.id}
-                    raisedBedId={raisedBedId}
-                    positionIndex={positionIndex}
-                    plantStatus={field.plantStatus as PlantFieldStatus}
-                    plantSortId={field.plantSortId}
-                />
-            )}
+            {field.active &&
+                typeof field.plantSortId === 'number' &&
+                showPlantOperationRecommendations && (
+                    <RecommendationsCard
+                        onShowOperations={onShowOperations}
+                        gardenId={garden.id}
+                        raisedBedId={raisedBedId}
+                        positionIndex={positionIndex}
+                        plantStatus={plantStatus}
+                        plantSortId={field.plantSortId}
+                    />
+                )}
 
             {field.active && field.toBeRemoved && (
                 <Row>

--- a/packages/game/src/hud/raisedBed/RecommendationsCard.tsx
+++ b/packages/game/src/hud/raisedBed/RecommendationsCard.tsx
@@ -16,9 +16,10 @@ import { usePlants } from '../../hooks/usePlants';
 import {
     DEFAULT_FEATURED_OPERATION_LIMIT,
     FEATURED_OPERATIONS_BY_STAGE,
-    PLANT_STATUS_STAGE_SEQUENCE,
+    getPlantOperationRecommendationStages,
     type PlantFieldStatus,
     type PlantStageName,
+    shouldShowPlantOperationRecommendations,
 } from './featuredOperations';
 import { OperationsListItem } from './shared/OperationsListItem';
 
@@ -66,9 +67,10 @@ export function RecommendationsCard({
         return operationNames.length ? new Set(operationNames) : null;
     }, [plantSort]);
 
-    const stageSequence: PlantStageName[] | undefined = plantStatus
-        ? PLANT_STATUS_STAGE_SEQUENCE[plantStatus as PlantFieldStatus]
-        : undefined;
+    const showPlantOperationRecommendations =
+        shouldShowPlantOperationRecommendations(plantStatus);
+    const stageSequence: PlantStageName[] | undefined =
+        getPlantOperationRecommendationStages(plantStatus);
 
     const { selectedStage, stageOperations } = useMemo<{
         selectedStage: PlantStageName | undefined;
@@ -172,12 +174,16 @@ export function RecommendationsCard({
     }, [favoriteOperationIds, selectedStage, stageOperations]);
 
     const plantHealthIssues = useMemo(() => {
+        if (!showPlantOperationRecommendations) {
+            return [];
+        }
+
         const plantHealth = plant?.health;
         return [
             ...(plantHealth?.diseases ?? []),
             ...(plantHealth?.pests ?? []),
         ];
-    }, [plant]);
+    }, [plant, showPlantOperationRecommendations]);
 
     const healthOperationIds = useMemo(() => {
         const operationIds = new Set<number>();

--- a/packages/game/src/hud/raisedBed/featuredOperations.ts
+++ b/packages/game/src/hud/raisedBed/featuredOperations.ts
@@ -140,6 +140,28 @@ export const PLANT_STATUS_STAGE_SEQUENCE: Record<
     removed: ['maintenance', 'maintenance'],
 } as const;
 
+export function isPlantFieldStatus(
+    status: string | null | undefined,
+): status is PlantFieldStatus {
+    return typeof status === 'string' && status in PLANT_STATUS_STAGE_SEQUENCE;
+}
+
+export function shouldShowPlantOperationRecommendations(
+    plantStatus: PlantFieldStatus | undefined,
+) {
+    return plantStatus !== 'notSprouted';
+}
+
+export function getPlantOperationRecommendationStages(
+    plantStatus: PlantFieldStatus | undefined,
+) {
+    if (!plantStatus || !shouldShowPlantOperationRecommendations(plantStatus)) {
+        return undefined;
+    }
+
+    return PLANT_STATUS_STAGE_SEQUENCE[plantStatus];
+}
+
 export const FEATURED_OPERATIONS_BY_STAGE: Partial<
     Record<PlantStageName, string[]>
 > = {

--- a/packages/game/src/hud/raisedBed/featuredOperations.unit.ts
+++ b/packages/game/src/hud/raisedBed/featuredOperations.unit.ts
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
     FEATURED_OPERATIONS_BY_STAGE,
+    getPlantOperationRecommendationStages,
     PLANT_STATUS_STAGE_SEQUENCE,
+    shouldShowPlantOperationRecommendations,
 } from './featuredOperations';
 
 describe('featured operations', () => {
@@ -15,6 +17,17 @@ describe('featured operations', () => {
         assert.deepStrictEqual(
             FEATURED_OPERATIONS_BY_STAGE[PLANT_STATUS_STAGE_SEQUENCE.died[0]],
             ['plantRemoval'],
+        );
+    });
+
+    it('does not recommend operations when a plant has not sprouted', () => {
+        assert.equal(
+            shouldShowPlantOperationRecommendations('notSprouted'),
+            false,
+        );
+        assert.equal(
+            getPlantOperationRecommendationStages('notSprouted'),
+            undefined,
         );
     });
 });


### PR DESCRIPTION
## Summary

- Hide the plant operation recommendation card when a raised-bed field is in `notSprouted` status.
- Guard `RecommendationsCard` so stage recommendations and plant-health/protection operations are suppressed for `notSprouted` even if another caller renders it directly.
- Add a regression test for the `notSprouted` recommendation guard.

## Root cause

`notSprouted` still had a lifecycle stage sequence (`sowing`, `maintenance`), so the drawer could surface recommended plant operations and health/protection operations even though the plant no longer exists in that state.

## Validation

- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `git diff --check`