### PR TITLE
[codex] Polish admin schedule task status colors

### DIFF
--- a/apps/app/app/admin/schedule/AssignOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AssignOperationModal.tsx
@@ -146,7 +146,8 @@ export function AssignOperationModal({
             </button>
         ) : (
             <IconButton
-                variant="plain"
+                variant="soft"
+                color="warning"
                 title={
                     canOpen
                         ? 'Dodijeli korisnika'

--- a/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
@@ -164,7 +164,8 @@ export function AssignRaisedBedFieldModal({
             </button>
         ) : (
             <IconButton
-                variant="plain"
+                variant="soft"
+                color="warning"
                 title={
                     canOpen
                         ? 'Dodijeli korisnika'

--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { OperationAssignableFarmUser } from '@gredice/storage';
-import { Button } from '@gredice/ui/Button';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
@@ -35,6 +34,7 @@ import {
 import {
     formatMinutes,
     getOperationDurationMinutes,
+    getScheduleTaskRowClassName,
     isOperationCancelled,
     isOperationCompleted,
     isOperationPendingVerification,
@@ -149,6 +149,10 @@ export function FarmOperationsScheduleSection({
                     const operationTextInactive =
                         isOperationCancelled(operation.status) ||
                         isOperationCompleted(operation.status);
+                    const operationApproved =
+                        operation.isAccepted && !operationLocked;
+                    const operationPendingAcceptance =
+                        !operation.isAccepted && !operationLocked;
                     const attachImages = Boolean(
                         operationData?.conditions?.completionAttachImages ||
                             operationData?.conditions
@@ -207,11 +211,10 @@ export function FarmOperationsScheduleSection({
                         <Row
                             key={operation.id}
                             spacing={2}
-                            className={
-                                operation.isAccepted && !operationLocked
-                                    ? 'rounded bg-muted/60 text-foreground hover:bg-muted/80'
-                                    : 'rounded hover:bg-muted'
-                            }
+                            className={getScheduleTaskRowClassName({
+                                accepted: operationApproved,
+                                pendingAcceptance: operationPendingAcceptance,
+                            })}
                         >
                             <Row spacing={2} className="grow">
                                 {isOperationCompleted(operation.status) ? (
@@ -244,27 +247,6 @@ export function FarmOperationsScheduleSection({
                                                     'Verifikacija radnje nije uspjela. Promjena je vraćena.',
                                             })
                                         }
-                                        renderTrigger={({
-                                            isSubmitting,
-                                            openModal,
-                                            defaultTrigger,
-                                        }) => (
-                                            <Row
-                                                spacing={1}
-                                                className="items-center"
-                                            >
-                                                {defaultTrigger}
-                                                <Button
-                                                    variant="solid"
-                                                    size="sm"
-                                                    className="bg-green-600 hover:bg-green-700 text-white"
-                                                    onClick={openModal}
-                                                    disabled={isSubmitting}
-                                                >
-                                                    Potvrdi
-                                                </Button>
-                                            </Row>
-                                        )}
                                     />
                                 ) : operationLocked ? (
                                     <Checkbox

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { OperationAssignableFarmUser } from '@gredice/storage';
-import { Button } from '@gredice/ui/Button';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
@@ -40,6 +39,7 @@ import {
 import {
     formatMinutes,
     getOperationDurationMinutes,
+    getScheduleTaskRowClassName,
     isOperationCancelled,
     isOperationCompleted,
     isOperationPendingVerification,
@@ -386,6 +386,8 @@ export function RaisedBedOperationsScheduleSection({
                         operation.isAccepted &&
                         !operationLocked &&
                         !operationTextInactive;
+                    const operationPendingAcceptance =
+                        !operation.isAccepted && !operationLocked;
 
                     const operationStatusText = isOperationCancelled(
                         operation.status,
@@ -444,11 +446,11 @@ export function RaisedBedOperationsScheduleSection({
                         <div key={operation.id}>
                             <Row
                                 spacing={2}
-                                className={
-                                    operationApproved
-                                        ? 'rounded bg-muted/60 text-foreground hover:bg-muted/80'
-                                        : 'rounded hover:bg-muted'
-                                }
+                                className={getScheduleTaskRowClassName({
+                                    accepted: operationApproved,
+                                    pendingAcceptance:
+                                        operationPendingAcceptance,
+                                })}
                             >
                                 <Row spacing={2} className="grow">
                                     {isOperationCompleted(operation.status) ? (
@@ -481,27 +483,6 @@ export function RaisedBedOperationsScheduleSection({
                                                         'Verifikacija radnje nije uspjela. Promjena je vraćena.',
                                                 })
                                             }
-                                            renderTrigger={({
-                                                isSubmitting,
-                                                openModal,
-                                                defaultTrigger,
-                                            }) => (
-                                                <Row
-                                                    spacing={1}
-                                                    className="items-center"
-                                                >
-                                                    {defaultTrigger}
-                                                    <Button
-                                                        variant="solid"
-                                                        size="sm"
-                                                        className="bg-green-600 hover:bg-green-700 text-white"
-                                                        onClick={openModal}
-                                                        disabled={isSubmitting}
-                                                    >
-                                                        Potvrdi
-                                                    </Button>
-                                                </Row>
-                                            )}
                                         />
                                     ) : operationLocked ? (
                                         <Checkbox

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -36,6 +36,7 @@ import { RescheduleRaisedBedFieldModal } from './RescheduleRaisedBedFieldModal';
 import { parseScheduledDateInput } from './scheduleOptimisticHelpers';
 import {
     formatMinutes,
+    getScheduleTaskRowClassName,
     isFieldApproved,
     isFieldCompleted,
     isFieldPendingVerification,
@@ -414,16 +415,17 @@ export function RaisedBedPlantingScheduleSection({
                     const fieldLocked =
                         fieldCompleted || fieldPendingVerification;
                     const fieldApprovedActive = fieldApproved && !fieldLocked;
+                    const fieldPendingAcceptance =
+                        !fieldApproved && !fieldLocked;
 
                     return (
                         <div key={field.id}>
                             <Row
                                 spacing={2}
-                                className={
-                                    fieldApprovedActive
-                                        ? 'rounded bg-muted/60 text-foreground hover:bg-muted/80'
-                                        : 'rounded hover:bg-muted'
-                                }
+                                className={getScheduleTaskRowClassName({
+                                    accepted: fieldApprovedActive,
+                                    pendingAcceptance: fieldPendingAcceptance,
+                                })}
                             >
                                 <Row spacing={2} className="grow">
                                     {fieldCompleted ? (

--- a/apps/app/app/admin/schedule/VerifyOperationModal.tsx
+++ b/apps/app/app/admin/schedule/VerifyOperationModal.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { Button } from '@gredice/ui/Button';
-import { IconButton } from '@gredice/ui/IconButton';
-import { Check } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -47,14 +45,16 @@ export function VerifyOperationModal({
     const [isSubmitting, setIsSubmitting] = useState(false);
     const openModal = () => setOpen(true);
     const defaultTrigger = (
-        <IconButton
-            variant="plain"
+        <Button
+            variant="solid"
+            color="success"
+            size="sm"
             title="Verificiraj radnju"
             loading={isSubmitting}
             onClick={openModal}
         >
-            <Check className="size-4 shrink-0" />
-        </IconButton>
+            Potvrdi
+        </Button>
     );
 
     const handleConfirm = async () => {

--- a/apps/app/app/admin/schedule/VerifyPlantingModal.tsx
+++ b/apps/app/app/admin/schedule/VerifyPlantingModal.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { Button } from '@gredice/ui/Button';
-import { IconButton } from '@gredice/ui/IconButton';
-import { Check } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -49,13 +47,15 @@ export function VerifyPlantingModal({
             open={open}
             onOpenChange={setOpen}
             trigger={
-                <IconButton
-                    variant="plain"
+                <Button
+                    variant="solid"
+                    color="success"
+                    size="sm"
                     title="Verificiraj sijanje"
                     loading={isSubmitting}
                 >
-                    <Check className="size-4 shrink-0" />
-                </IconButton>
+                    Potvrdi
+                </Button>
             }
         >
             <Stack spacing={4}>

--- a/apps/app/app/admin/schedule/scheduleShared.ts
+++ b/apps/app/app/admin/schedule/scheduleShared.ts
@@ -122,6 +122,24 @@ export function formatMinutes(minutes: number, hideUnit = false) {
     return hideUnit ? `${rounded}` : `${rounded} min`;
 }
 
+export function getScheduleTaskRowClassName({
+    accepted,
+    pendingAcceptance,
+}: {
+    accepted: boolean;
+    pendingAcceptance: boolean;
+}) {
+    if (accepted) {
+        return 'rounded bg-muted/60 text-foreground hover:bg-muted/80';
+    }
+
+    if (pendingAcceptance) {
+        return 'rounded bg-amber-50/80 text-foreground ring-1 ring-inset ring-amber-200/70 hover:bg-amber-100/80 dark:bg-amber-950/40 dark:ring-amber-900/70 dark:hover:bg-amber-950/60';
+    }
+
+    return 'rounded hover:bg-muted';
+}
+
 export function isTaskDateBeforeToday(date: Date | undefined) {
     if (!date) {
         return false;


### PR DESCRIPTION
## Summary
- Add a warning background for schedule rows that are not yet accepted/confirmed.
- Tint unassigned task assignee buttons with the warning color.
- Use green verification buttons for completed-but-not-confirmed planting and operation tasks.

## Validation
- `corepack pnpm lint --filter app`
- `corepack pnpm build --filter app`
- `git diff --check`
- Attempted `corepack pnpm --filter app exec tsc --noEmit --pretty false`; it fails on existing app-wide type issues outside the touched schedule files.