### PR TITLE
[codex] Show scheduled operation indicators

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -201,6 +201,39 @@ function plantedGrowingWithRecommendedOperationsScenario(): RaisedBedScenario {
         ...plantedGrowingScenario(),
         operations,
         sorts: [tomatoSortWithOperations],
+        operationHistoryItems: [
+            {
+                id: 801,
+                entityId: 201,
+                entityTypeName: 'operation',
+                raisedBedId: 1,
+                raisedBedFieldId: 1,
+                status: 'completed',
+                createdAt: '2026-05-09T00:00:00.000Z',
+                scheduledDate: '2026-05-10T00:00:00.000Z',
+                scheduledAt: '2026-05-09T00:00:00.000Z',
+                completedAt: '2026-05-10T08:00:00.000Z',
+                verifiedAt: '2026-05-10T09:00:00.000Z',
+                canceledAt: null,
+                imageUrls: [],
+                completionNotes: null,
+                targetLabel: 'Raised Bed 1 › Polje 1',
+                statusHistory: [
+                    {
+                        status: 'new',
+                        changedAt: '2026-05-09T00:00:00.000Z',
+                    },
+                    {
+                        status: 'planned',
+                        changedAt: '2026-05-09T00:00:00.000Z',
+                    },
+                    {
+                        status: 'completed',
+                        changedAt: '2026-05-10T09:00:00.000Z',
+                    },
+                ],
+            },
+        ],
     };
 }
 
@@ -845,6 +878,12 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(recommendationsList).toBeVisible();
         await expect(recommendationsList).toContainText('Okopavanje');
         await expect(recommendationsList).toContainText('Uklanjanje korova');
+        await expect(
+            recommendationsList.locator('[data-operation-id="201"]'),
+        ).toContainText('Zakazano');
+        await expect(
+            recommendationsList.locator('[data-operation-id="202"]'),
+        ).not.toContainText('Zakazano');
 
         const listItems = recommendationsList.locator(':scope > *');
         await expect(listItems).toHaveCount(3);
@@ -867,6 +906,11 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
                 .locator('[role="tabpanel"]:not([hidden])')
                 .locator('[data-scroll-view]'),
         ).toBeVisible();
+        await expect(
+            dialog
+                .getByRole('tabpanel', { name: 'Radnje' })
+                .locator('[data-operation-id="201"]'),
+        ).toContainText('Zakazano');
     });
 
     test('favorite operations are ranked first in recommendations and operation choices', async ({

--- a/packages/game/src/hud/raisedBed/GreenhouseSeedlingTransplantAction.tsx
+++ b/packages/game/src/hud/raisedBed/GreenhouseSeedlingTransplantAction.tsx
@@ -5,9 +5,9 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useMemo } from 'react';
 import { useOperations } from '../../hooks/useOperations';
-import { useShoppingCart } from '../../hooks/useShoppingCart';
 import { isSeedlingTransplantingOperation } from './greenhouseSeedlings';
 import { OperationsListItem } from './shared/OperationsListItem';
+import { useOperationContextIndicators } from './shared/useOperationContextIndicators';
 
 export function GreenhouseSeedlingTransplantAction({
     gardenId,
@@ -19,22 +19,23 @@ export function GreenhouseSeedlingTransplantAction({
     positionIndex: number;
 }) {
     const { data: operations, isError, isLoading } = useOperations();
-    const { data: cart } = useShoppingCart();
+    const { shoppingCartOperationIds, scheduledOperationIds } =
+        useOperationContextIndicators({
+            gardenId,
+            raisedBedId,
+            positionIndex,
+        });
     const transplantOperation = useMemo(
         () => operations?.find(isSeedlingTransplantingOperation),
         [operations],
     );
     const inShoppingCart = Boolean(
         transplantOperation &&
-            cart?.items.some(
-                (item) =>
-                    item.entityTypeName === 'operation' &&
-                    item.status === 'new' &&
-                    item.gardenId === gardenId &&
-                    item.raisedBedId === raisedBedId &&
-                    item.positionIndex === positionIndex &&
-                    Number(item.entityId) === transplantOperation.id,
-            ),
+            shoppingCartOperationIds.has(transplantOperation.id),
+    );
+    const isScheduled = Boolean(
+        transplantOperation &&
+            scheduledOperationIds.has(transplantOperation.id),
     );
 
     if (isLoading) {
@@ -81,6 +82,7 @@ export function GreenhouseSeedlingTransplantAction({
                         raisedBedId={raisedBedId}
                         positionIndex={positionIndex}
                         inShoppingCart={inShoppingCart}
+                        isScheduled={isScheduled}
                     />
                 </CardOverflow>
             </Card>

--- a/packages/game/src/hud/raisedBed/RecommendationsCard.tsx
+++ b/packages/game/src/hud/raisedBed/RecommendationsCard.tsx
@@ -22,6 +22,7 @@ import {
     shouldShowPlantOperationRecommendations,
 } from './featuredOperations';
 import { OperationsListItem } from './shared/OperationsListItem';
+import { useOperationContextIndicators } from './shared/useOperationContextIndicators';
 
 type PlantHealthIssueSummary = NonNullable<
     NonNullable<PlantData['health']>['diseases']
@@ -55,6 +56,12 @@ export function RecommendationsCard({
     } = useOperations();
     const { data: plantSort } = usePlantSort(plantSortId);
     const { data: plants } = usePlants();
+    const { shoppingCartOperationIds, scheduledOperationIds } =
+        useOperationContextIndicators({
+            gardenId,
+            raisedBedId,
+            positionIndex,
+        });
     const plant = plants?.find(
         (candidate) => candidate.id === plantSort?.information.plant.id,
     );
@@ -324,6 +331,12 @@ export function RecommendationsCard({
                                             gardenId={gardenId}
                                             raisedBedId={raisedBedId}
                                             positionIndex={positionIndex}
+                                            inShoppingCart={shoppingCartOperationIds.has(
+                                                operation.id,
+                                            )}
+                                            isScheduled={scheduledOperationIds.has(
+                                                operation.id,
+                                            )}
                                         />
                                     ))}
                                     {onShowOperations && (
@@ -383,6 +396,12 @@ export function RecommendationsCard({
                                                 gardenId={gardenId}
                                                 raisedBedId={raisedBedId}
                                                 positionIndex={positionIndex}
+                                                inShoppingCart={shoppingCartOperationIds.has(
+                                                    operation.id,
+                                                )}
+                                                isScheduled={scheduledOperationIds.has(
+                                                    operation.id,
+                                                )}
                                                 onOperationPicked={() => {
                                                     track(
                                                         'game_plant_health_recommendation_selected',

--- a/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsList.tsx
@@ -7,50 +7,20 @@ import { List } from '@gredice/ui/List';
 import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
-import { memo, useMemo, useState } from 'react';
+import { memo, useState } from 'react';
 import {
     sortFavoritesFirst,
     useFavoriteIds,
 } from '../../../hooks/useFavorites';
 import { useOperations } from '../../../hooks/useOperations';
 import { usePlantSort } from '../../../hooks/usePlantSorts';
-import {
-    type ShoppingCartItemData,
-    useShoppingCart,
-} from '../../../hooks/useShoppingCart';
 import { ScrollView } from '../../../shared-ui/ScrollView';
 import { useShoppingCartOpenParam } from '../../../useUrlState';
 import { OperationListItemSkeleton } from '../OperationListItemSkeleton';
 import { OperationsListItem } from './OperationsListItem';
+import { useOperationContextIndicators } from './useOperationContextIndicators';
 
 const MemoizedOperationsListItem = memo(OperationsListItem);
-
-function isOperationInCurrentContext(
-    {
-        entityTypeName,
-        status,
-        gardenId: itemGardenId,
-        raisedBedId: itemRaisedBedId,
-        positionIndex: itemPositionIndex,
-    }: ShoppingCartItemData,
-    {
-        gardenId,
-        raisedBedId,
-        positionIndex,
-    }: {
-        gardenId: number;
-        raisedBedId?: number;
-        positionIndex?: number;
-    },
-) {
-    return (
-        entityTypeName === 'operation' &&
-        status === 'new' &&
-        itemGardenId === gardenId &&
-        (itemRaisedBedId ?? undefined) === raisedBedId &&
-        (itemPositionIndex ?? undefined) === positionIndex
-    );
-}
 
 const OperationsListContent = memo(function OperationsListContent({
     operations,
@@ -60,6 +30,7 @@ const OperationsListContent = memo(function OperationsListContent({
     raisedBedId,
     positionIndex,
     shoppingCartOperationIds,
+    scheduledOperationIds,
 }: {
     operations: OperationData[] | undefined;
     isLoading: boolean;
@@ -68,6 +39,7 @@ const OperationsListContent = memo(function OperationsListContent({
     raisedBedId?: number;
     positionIndex?: number;
     shoppingCartOperationIds: Set<number>;
+    scheduledOperationIds: Set<number>;
 }) {
     return (
         <ScrollView
@@ -94,6 +66,7 @@ const OperationsListContent = memo(function OperationsListContent({
                         inShoppingCart={shoppingCartOperationIds.has(
                             operation.id,
                         )}
+                        isScheduled={scheduledOperationIds.has(operation.id)}
                         key={operation.id}
                         operation={operation}
                         gardenId={gardenId}
@@ -126,28 +99,18 @@ export function OperationsList({
     } = useOperations();
     const { data: plantSort, isLoading: isPlantSortLoading } =
         usePlantSort(plantSortId);
-    const { data: cart } = useShoppingCart();
     const favoriteOperationIds = useFavoriteIds('operation');
     const [, setShoppingCartOpen] = useShoppingCartOpenParam();
     const isLoading =
         isLoadingOperations || (Boolean(plantSortId) && isPlantSortLoading);
     const [search, setSearch] = useState('');
 
-    const shoppingCartOperationIds = useMemo(
-        () =>
-            new Set(
-                (cart?.items ?? [])
-                    .filter((item) =>
-                        isOperationInCurrentContext(item, {
-                            gardenId,
-                            raisedBedId,
-                            positionIndex,
-                        }),
-                    )
-                    .map((item) => Number(item.entityId)),
-            ),
-        [cart?.items, gardenId, raisedBedId, positionIndex],
-    );
+    const { shoppingCartOperationIds, scheduledOperationIds } =
+        useOperationContextIndicators({
+            gardenId,
+            raisedBedId,
+            positionIndex,
+        });
 
     const filteredOperations = operations
         ?.filter(filterFunc)
@@ -234,6 +197,7 @@ export function OperationsList({
                 raisedBedId={raisedBedId}
                 positionIndex={positionIndex}
                 shoppingCartOperationIds={shoppingCartOperationIds}
+                scheduledOperationIds={scheduledOperationIds}
             />
         </Stack>
     );

--- a/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
@@ -3,7 +3,7 @@ import { formatPrice } from '@gredice/js/currency';
 import { getHarvestOperationRemovalDisclaimer } from '@gredice/js/plants';
 import { BackpackIcon } from '@gredice/ui/BackpackIcon';
 import { Button } from '@gredice/ui/Button';
-import { Calendar } from '@gredice/ui/icons';
+import { Calendar, ShoppingCart } from '@gredice/ui/icons';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -24,6 +24,7 @@ export function OperationsListItem({
     raisedBedId,
     positionIndex,
     inShoppingCart,
+    isScheduled,
     onOperationPicked,
 }: {
     gardenId: number;
@@ -31,6 +32,7 @@ export function OperationsListItem({
     positionIndex?: number;
     operation: OperationData;
     inShoppingCart?: boolean;
+    isScheduled?: boolean;
     onOperationPicked?: (operation: OperationData) => void;
 }) {
     const setShoppingCartItem = useSetShoppingCartItem();
@@ -86,15 +88,50 @@ export function OperationsListItem({
                 <OperationImage operation={operation} size={32} />
             </AnimateFlyToItem>
             <Stack className="w-full">
-                <div className="grid grid-cols-[1fr_auto] gap-2 items-center">
-                    <Typography level="body1" semiBold noWrap>
-                        {operation.information.label}
-                    </Typography>
-                    {inShoppingCart && (
-                        <Typography level="body3" className="text-amber-600">
-                            U košari (nije kupljeno)
+                <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2 items-start">
+                    <Stack spacing={0.5} className="min-w-0">
+                        <Typography level="body1" semiBold noWrap>
+                            {operation.information.label}
                         </Typography>
-                    )}
+                        {(inShoppingCart || isScheduled) && (
+                            <Row spacing={1.5} className="flex-wrap min-w-0">
+                                {inShoppingCart && (
+                                    <Row
+                                        spacing={0.75}
+                                        className="min-w-0 text-amber-600"
+                                        title="Radnja je u košari i još nije kupljena"
+                                    >
+                                        <ShoppingCart className="size-3.5 shrink-0" />
+                                        <Typography
+                                            level="body3"
+                                            semiBold
+                                            noWrap
+                                            className="min-w-0"
+                                        >
+                                            U košari (nije kupljeno)
+                                        </Typography>
+                                    </Row>
+                                )}
+                                {isScheduled && (
+                                    <Row
+                                        spacing={0.75}
+                                        className="min-w-0 text-indigo-600"
+                                        title="Radnja je zakazana"
+                                    >
+                                        <Calendar className="size-3.5 shrink-0" />
+                                        <Typography
+                                            level="body3"
+                                            semiBold
+                                            noWrap
+                                            className="min-w-0"
+                                        >
+                                            Zakazano
+                                        </Typography>
+                                    </Row>
+                                )}
+                            </Row>
+                        )}
+                    </Stack>
                     <Typography level="body1" semiBold>
                         {price}
                     </Typography>

--- a/packages/game/src/hud/raisedBed/shared/useOperationContextIndicators.ts
+++ b/packages/game/src/hud/raisedBed/shared/useOperationContextIndicators.ts
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+import { useGardenOperations } from '../../../hooks/useGardenOperations';
+import {
+    type ShoppingCartItemData,
+    useShoppingCart,
+} from '../../../hooks/useShoppingCart';
+
+type OperationContextTarget = {
+    gardenId: number;
+    raisedBedId?: number;
+    positionIndex?: number;
+};
+
+function isOperationInCurrentContext(
+    {
+        entityTypeName,
+        status,
+        gardenId: itemGardenId,
+        raisedBedId: itemRaisedBedId,
+        positionIndex: itemPositionIndex,
+    }: ShoppingCartItemData,
+    { gardenId, raisedBedId, positionIndex }: OperationContextTarget,
+) {
+    return (
+        entityTypeName === 'operation' &&
+        status === 'new' &&
+        itemGardenId === gardenId &&
+        (itemRaisedBedId ?? undefined) === raisedBedId &&
+        (itemPositionIndex ?? undefined) === positionIndex
+    );
+}
+
+export function useOperationContextIndicators({
+    gardenId,
+    raisedBedId,
+    positionIndex,
+}: OperationContextTarget) {
+    const { data: cart } = useShoppingCart();
+    const scheduledOperations = useGardenOperations({
+        includeCompleted: true,
+        pageSize: 20,
+        raisedBedId,
+        positionIndex,
+    });
+    const scheduledOperationPages = scheduledOperations.data?.pages;
+
+    const shoppingCartOperationIds = useMemo(
+        () =>
+            new Set(
+                (cart?.items ?? [])
+                    .filter((item) =>
+                        isOperationInCurrentContext(item, {
+                            gardenId,
+                            raisedBedId,
+                            positionIndex,
+                        }),
+                    )
+                    .map((item) => Number(item.entityId)),
+            ),
+        [cart?.items, gardenId, raisedBedId, positionIndex],
+    );
+
+    const scheduledOperationIds = useMemo(
+        () =>
+            new Set(
+                (scheduledOperationPages ?? []).flatMap((page) =>
+                    page.items.flatMap((operation) =>
+                        operation.entityTypeName === 'operation'
+                            ? [operation.entityId]
+                            : [],
+                    ),
+                ),
+            ),
+        [scheduledOperationPages],
+    );
+
+    return {
+        shoppingCartOperationIds,
+        scheduledOperationIds,
+    };
+}

--- a/packages/game/src/hud/raisedBed/shared/useOperationContextIndicators.ts
+++ b/packages/game/src/hud/raisedBed/shared/useOperationContextIndicators.ts
@@ -38,7 +38,6 @@ export function useOperationContextIndicators({
     const { data: cart } = useShoppingCart();
     const scheduledOperations = useGardenOperations({
         includeCompleted: true,
-        pageSize: 50,
         raisedBedId,
         positionIndex,
     });


### PR DESCRIPTION
## Summary

Adds scheduled-operation indicators to the garden operation rows alongside the existing shopping-cart indicator. The badge is driven from garden operation records for the current garden/raised-bed/field target, with completed and other operation states included via the existing garden operations history query.

The shared indicator lookup is reused by the full operations list, recommended operation cards, and the greenhouse transplant card so the modal surfaces stay consistent.

## Validation

- `pnpm lint --filter @gredice/game --filter garden`
- `pnpm typecheck --filter @gredice/game --filter garden`
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden test:run -- tests/raised-bed-field-hud.spec.tsx`