### PR TITLE
[codex] Improve operation scheduling calendar

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -245,10 +245,24 @@ function plantedGrowingWithOperationHistoryScenario(): RaisedBedScenario {
         stageName: 'maintenance',
         stageLabel: 'Održavanje',
     });
+    const tomatoSortWithOperation = {
+        ...testSorts.tomato,
+        information: {
+            ...testSorts.tomato.information,
+            plant: {
+                ...testSorts.tomato.information.plant,
+                information: {
+                    ...testSorts.tomato.information.plant.information,
+                    operations: [wateringOperation],
+                },
+            },
+        },
+    };
 
     return {
         ...plantedGrowingScenario(),
         operations: [wateringOperation],
+        sorts: [tomatoSortWithOperation],
         operationDiaryEntries: [
             {
                 id: 991,
@@ -919,6 +933,106 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
                 name: 'Ukloni radnju iz omiljenih',
             }),
         ).toBeVisible();
+    });
+
+    test('operation item click opens scheduling without a separate schedule action', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingWithRecommendedOperationsScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await dialog.getByRole('tab', { name: /Radnje/ }).click();
+
+        const operationsPanel = dialog.getByRole('tabpanel', {
+            name: 'Radnje',
+        });
+        await expect(
+            operationsPanel.getByRole('button', { name: 'Zakaži' }),
+        ).toHaveCount(0);
+
+        const operationRow = operationsPanel.locator(
+            '[data-operation-id="201"]',
+        );
+        await operationRow.getByRole('button', { name: /Okopavanje/ }).click();
+
+        const scheduleDialog = page.getByRole('dialog', {
+            name: 'Zakaži radnju: Okopavanje',
+        });
+        await expect(
+            scheduleDialog.locator('[data-event-calendar]'),
+        ).toBeVisible();
+        await expect(
+            scheduleDialog.getByText('Zakazivanje radnje'),
+        ).toBeVisible();
+    });
+
+    test('operation scheduling calendar shows previous history with icon details', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingWithOperationHistoryScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await dialog.getByRole('tab', { name: /Radnje/ }).click();
+
+        const operationRow = dialog.locator('[data-operation-id="301"]');
+        await operationRow
+            .getByRole('button', {
+                name: /Površinsko zalijevanje gredice/,
+            })
+            .click();
+
+        const scheduleDialog = page.getByRole('dialog', {
+            name: 'Zakaži radnju: Površinsko zalijevanje gredice (20L)',
+        });
+        await expect(
+            scheduleDialog.locator('[data-event-calendar]'),
+        ).toBeVisible();
+
+        await expect(
+            scheduleDialog.getByRole('button', {
+                name: 'Prethodni mjesec',
+            }),
+        ).toBeEnabled();
+        await scheduleDialog
+            .getByRole('button', { name: 'Prethodni mjesec' })
+            .click();
+
+        await expect(
+            scheduleDialog.locator('[data-event-calendar-month="2026-05"]'),
+        ).toBeVisible();
+        await expect(
+            scheduleDialog.locator('[data-event-calendar-tone="completed"]'),
+        ).toHaveClass(/bg-primary/);
+
+        await scheduleDialog
+            .getByRole('button', {
+                name: /10\. 05\. 2026.*Površinsko zalijevanje/u,
+            })
+            .click();
+
+        await expect(
+            page.locator('[data-event-calendar-entry-visual]'),
+        ).toBeVisible();
+        await expect(
+            page.getByText('Obavljeno · Raised Bed 1 › Polje 1'),
+        ).toBeVisible();
+        await expect(page.getByText(/30 min/)).toHaveCount(0);
     });
 
     test('diary tab shows filtered operation history with photos and notes', async ({

--- a/apps/garden/tests/watering-operations-calendar.spec.tsx
+++ b/apps/garden/tests/watering-operations-calendar.spec.tsx
@@ -17,6 +17,13 @@ const wateringEntries: WateringCalendarEntry[] = [
         source: 'scheduled',
         weight: 18,
     },
+    {
+        id: 'preview',
+        date: '2026-06-23T08:00:00.000Z',
+        label: 'Novi termin zalijevanja',
+        source: 'preview',
+        weight: 24,
+    },
 ];
 
 test('watering calendar keeps the header quiet and highlights today with watering', async ({
@@ -50,8 +57,22 @@ test('watering calendar keeps the header quiet and highlights today with waterin
         ),
     ).toHaveCount(1);
     await expect(
+        page.locator('[data-event-calendar-today-marker]'),
+    ).toHaveClass(/bg-muted/);
+    await expect(
         page.locator('[data-event-calendar-marker]').first(),
-    ).toHaveCSS('border-top-width', '0px');
+    ).toHaveClass(/bg-sky-600/);
+
+    const scheduledMarker = page.locator(
+        '[data-event-calendar-tone="scheduled"]',
+    );
+    await expect(scheduledMarker).toHaveClass(/bg-sky-600/);
+    await expect(scheduledMarker).toHaveCSS('height', '6px');
+    await expect(scheduledMarker).toHaveCSS('width', '6px');
+
+    await expect(
+        page.locator('[data-event-calendar-tone="preview"]'),
+    ).toHaveClass(/bg-sky-600/);
 });
 
 test('watering calendar opens day details on mobile tap', async ({
@@ -69,5 +90,6 @@ test('watering calendar opens day details on mobile tap', async ({
     await page.getByRole('button', { name: /Sljedeće zalijevanje/ }).click();
 
     await expect(page.getByText('Sljedeće zalijevanje')).toBeVisible();
-    await expect(page.getByText('Zakazano · 18 min')).toBeVisible();
+    await expect(page.getByText('Zakazano', { exact: true })).toBeVisible();
+    await expect(page.getByText(/18 min/)).toHaveCount(0);
 });

--- a/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
@@ -168,6 +168,7 @@ function RaisedBedAiOperationChip({
 
     return (
         <OperationScheduleModal
+            gardenId={gardenId}
             operation={operation}
             onConfirm={async (scheduledDate) => {
                 await setShoppingCartItem.mutateAsync({
@@ -183,6 +184,9 @@ function RaisedBedAiOperationChip({
                     currency: 'eur',
                 });
             }}
+            positionIndex={targetPositionIndex}
+            raisedBedId={target.raisedBedId}
+            showHistory={false}
             trigger={
                 <Chip
                     color={

--- a/packages/game/src/hud/raisedBed/WateringOperationsCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/WateringOperationsCalendar.tsx
@@ -4,6 +4,7 @@ import {
     EventCalendar,
     type EventCalendarEntry,
 } from '@gredice/ui/EventCalendar';
+import { OperationCategoryIcon } from '@gredice/ui/OperationImage';
 import {
     toWateringEventCalendarEntry,
     type WateringCalendarEntry,
@@ -17,17 +18,7 @@ const sourceLabels = {
 } satisfies Record<WateringCalendarEntry['source'], string>;
 
 function entryMeta(entry: WateringCalendarEntry) {
-    const roundedWeight =
-        typeof entry.weight === 'number' && entry.weight > 0
-            ? Math.round(entry.weight)
-            : null;
-
-    return [
-        sourceLabels[entry.source],
-        roundedWeight == null ? null : `${roundedWeight} min`,
-    ]
-        .filter(Boolean)
-        .join(' · ');
+    return sourceLabels[entry.source];
 }
 
 function toEventCalendarEntry(
@@ -39,6 +30,12 @@ function toEventCalendarEntry(
     return {
         ...calendarEntry,
         meta: entryMeta(entry),
+        visual: (
+            <OperationCategoryIcon
+                categoryName="watering"
+                className="size-4 shrink-0"
+            />
+        ),
     };
 }
 
@@ -71,6 +68,7 @@ export function WateringOperationsCalendar({
 
     return (
         <EventCalendar
+            accent="blue"
             className={className}
             data-watering-calendar
             emptyLabel="Još nema zabilježenih zalijevanja."

--- a/packages/game/src/hud/raisedBed/shared/OperationScheduleCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationScheduleCalendar.tsx
@@ -1,0 +1,313 @@
+import type { OperationData } from '@gredice/client';
+import {
+    EventCalendar,
+    type EventCalendarEntry,
+} from '@gredice/ui/EventCalendar';
+import { OperationImage } from '@gredice/ui/OperationImage';
+import { useEffect, useMemo } from 'react';
+import {
+    type GardenOperationItem,
+    useGardenOperations,
+} from '../../../hooks/useGardenOperations';
+import {
+    type ShoppingCartItemData,
+    useShoppingCart,
+} from '../../../hooks/useShoppingCart';
+
+type OperationScheduleEntrySource =
+    | 'cart'
+    | 'completed'
+    | 'preview'
+    | 'scheduled';
+
+const operationCalendarPageSize = 20;
+
+const sourceLabels = {
+    cart: 'U košari',
+    completed: 'Obavljeno',
+    preview: 'Novi termin',
+    scheduled: 'Zakazano',
+} satisfies Record<OperationScheduleEntrySource, string>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseAdditionalData(additionalData?: string | null) {
+    if (!additionalData) {
+        return {};
+    }
+
+    try {
+        const parsed = JSON.parse(additionalData);
+        return isRecord(parsed) ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
+function dateFromUnknown(value: unknown) {
+    if (typeof value !== 'string' && !(value instanceof Date)) {
+        return null;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getTomorrowDate(referenceDate: Date) {
+    return new Date(
+        referenceDate.getFullYear(),
+        referenceDate.getMonth(),
+        referenceDate.getDate() + 1,
+    );
+}
+
+function operationDate(operation: GardenOperationItem) {
+    if (operation.status === 'canceled' || operation.status === 'failed') {
+        return null;
+    }
+
+    if (operation.status === 'completed') {
+        return (
+            dateFromUnknown(operation.verifiedAt) ??
+            dateFromUnknown(operation.completedAt) ??
+            dateFromUnknown(operation.scheduledDate) ??
+            dateFromUnknown(operation.createdAt)
+        );
+    }
+
+    if (operation.status === 'confirmed') {
+        return (
+            dateFromUnknown(operation.completedAt) ??
+            dateFromUnknown(operation.scheduledDate) ??
+            dateFromUnknown(operation.createdAt)
+        );
+    }
+
+    return (
+        dateFromUnknown(operation.scheduledDate) ??
+        dateFromUnknown(operation.scheduledAt)
+    );
+}
+
+function operationSource(
+    operation: GardenOperationItem,
+): OperationScheduleEntrySource {
+    return operation.status === 'completed' || operation.status === 'confirmed'
+        ? 'completed'
+        : 'scheduled';
+}
+
+function entryMeta({
+    source,
+    targetLabel,
+}: {
+    source: OperationScheduleEntrySource;
+    targetLabel?: string | null;
+}) {
+    return [sourceLabels[source], targetLabel].filter(Boolean).join(' · ');
+}
+
+function cartItemMatchesOperation({
+    gardenId,
+    item,
+    operation,
+    positionIndex,
+    raisedBedId,
+}: {
+    gardenId: number;
+    item: ShoppingCartItemData;
+    operation: OperationData;
+    positionIndex?: number;
+    raisedBedId?: number;
+}) {
+    return (
+        item.entityTypeName === operation.entityType.name &&
+        item.status === 'new' &&
+        item.gardenId === gardenId &&
+        Number(item.entityId) === operation.id &&
+        (raisedBedId === undefined
+            ? true
+            : (item.raisedBedId ?? undefined) === raisedBedId) &&
+        (positionIndex === undefined
+            ? true
+            : (item.positionIndex ?? undefined) === positionIndex)
+    );
+}
+
+function cartItemDate(item: ShoppingCartItemData, referenceDate: Date) {
+    const additionalData = parseAdditionalData(item.additionalData);
+    return (
+        dateFromUnknown(additionalData.scheduledDate) ??
+        getTomorrowDate(referenceDate)
+    );
+}
+
+function operationVisual(operation: OperationData) {
+    return <OperationImage operation={operation} size={20} />;
+}
+
+function toCalendarEntry({
+    date,
+    id,
+    operation,
+    source,
+    targetLabel,
+}: {
+    date: Date;
+    id: string;
+    operation: OperationData;
+    source: OperationScheduleEntrySource;
+    targetLabel?: string | null;
+}): EventCalendarEntry {
+    return {
+        id,
+        date,
+        label: operation.information.label,
+        meta: entryMeta({ source, targetLabel }),
+        tone: source,
+        visual: operationVisual(operation),
+    };
+}
+
+export function OperationScheduleCalendar({
+    className,
+    gardenId,
+    maxSelectableDate,
+    minSelectableDate,
+    onDateSelect,
+    operation,
+    positionIndex,
+    previewDate,
+    raisedBedId,
+    referenceDate = new Date(),
+    selectedDate,
+    visibleFrom,
+    visibleTo,
+}: {
+    className?: string;
+    gardenId: number;
+    maxSelectableDate?: Date;
+    minSelectableDate?: Date;
+    onDateSelect?: (date: Date) => void;
+    operation: OperationData;
+    positionIndex?: number;
+    previewDate?: Date | null;
+    raisedBedId?: number;
+    referenceDate?: Date;
+    selectedDate?: Date | null;
+    visibleFrom?: Date;
+    visibleTo?: Date;
+}) {
+    const { data: cart } = useShoppingCart();
+    const history = useGardenOperations({
+        includeCompleted: true,
+        pageSize: operationCalendarPageSize,
+        raisedBedId,
+        positionIndex,
+    });
+
+    const hasNextHistoryPage = history.hasNextPage;
+    const isFetchingNextHistoryPage = history.isFetchingNextPage;
+    const fetchNextHistoryPage = history.fetchNextPage;
+
+    useEffect(() => {
+        if (hasNextHistoryPage && !isFetchingNextHistoryPage) {
+            void fetchNextHistoryPage();
+        }
+    }, [fetchNextHistoryPage, hasNextHistoryPage, isFetchingNextHistoryPage]);
+
+    const entries = useMemo(() => {
+        const historyEntries =
+            history.data?.pages.flatMap((page) =>
+                page.items.flatMap((item): EventCalendarEntry[] => {
+                    if (
+                        item.entityTypeName !== operation.entityType.name ||
+                        item.entityId !== operation.id
+                    ) {
+                        return [];
+                    }
+
+                    const date = operationDate(item);
+                    if (!date) {
+                        return [];
+                    }
+
+                    return [
+                        toCalendarEntry({
+                            date,
+                            id: `operation-${item.id}`,
+                            operation,
+                            source: operationSource(item),
+                            targetLabel: item.targetLabel,
+                        }),
+                    ];
+                }),
+            ) ?? [];
+
+        const cartEntries =
+            cart?.items.flatMap((item): EventCalendarEntry[] => {
+                if (
+                    !cartItemMatchesOperation({
+                        gardenId,
+                        item,
+                        operation,
+                        positionIndex,
+                        raisedBedId,
+                    })
+                ) {
+                    return [];
+                }
+
+                return [
+                    toCalendarEntry({
+                        date: cartItemDate(item, referenceDate),
+                        id: `cart-${item.id}`,
+                        operation,
+                        source: 'cart',
+                    }),
+                ];
+            }) ?? [];
+
+        const previewEntry = previewDate
+            ? [
+                  toCalendarEntry({
+                      date: previewDate,
+                      id: `preview-${operation.id}`,
+                      operation,
+                      source: 'preview',
+                  }),
+              ]
+            : [];
+
+        return [...historyEntries, ...cartEntries, ...previewEntry];
+    }, [
+        cart?.items,
+        gardenId,
+        history.data?.pages,
+        operation,
+        positionIndex,
+        previewDate,
+        raisedBedId,
+        referenceDate,
+    ]);
+
+    return (
+        <EventCalendar
+            className={className}
+            emptyLabel={null}
+            entries={entries}
+            error={history.isError}
+            errorLabel="Kalendar radnji nije dostupan."
+            isLoading={history.isLoading || history.isFetchingNextPage}
+            maxSelectableDate={maxSelectableDate}
+            minSelectableDate={minSelectableDate}
+            onDateSelect={onDateSelect}
+            referenceDate={referenceDate}
+            selectedDate={selectedDate}
+            visibleFrom={visibleFrom}
+            visibleTo={visibleTo}
+        />
+    );
+}

--- a/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
@@ -17,6 +17,7 @@ import {
     isWateringOperation,
     RaisedBedWateringCalendar,
 } from '../RaisedBedWateringCalendar';
+import { OperationScheduleCalendar } from './OperationScheduleCalendar';
 
 function parseLocalDateInput(value: string) {
     const [year, month, day] = value.split('-').map(Number);
@@ -32,13 +33,17 @@ export function OperationScheduleModal({
     gardenId,
     operation,
     onConfirm,
+    positionIndex,
     raisedBedId,
+    showHistory = true,
     trigger,
 }: {
-    gardenId?: number;
+    gardenId: number;
     operation: OperationData;
     onConfirm: (date: Date) => Promise<void>;
+    positionIndex?: number;
     raisedBedId?: number;
+    showHistory?: boolean;
     trigger: React.ReactElement;
 }) {
     const [open, setOpen] = useState(false);
@@ -63,9 +68,7 @@ export function OperationScheduleModal({
     const selectedDateInput = scheduledDateInput ?? operationDefaultDate;
     const selectedDate = parseLocalDateInput(selectedDateInput);
     const showWateringCalendar =
-        gardenId != null &&
-        raisedBedId != null &&
-        isWateringOperation(operation);
+        raisedBedId != null && isWateringOperation(operation);
     const isHarvestOperation =
         operation.attributes.stage.information?.name === 'harvest';
     const harvestPlantRemovalDescription = isHarvestOperation
@@ -161,7 +164,7 @@ export function OperationScheduleModal({
                             </Typography>
                         </Alert>
                     ) : null}
-                    {showWateringCalendar ? (
+                    {open && showWateringCalendar ? (
                         <RaisedBedWateringCalendar
                             className="shadow-none"
                             gardenId={gardenId}
@@ -175,7 +178,24 @@ export function OperationScheduleModal({
                             visibleFrom={tomorrow}
                             visibleTo={threeMonthsFromTomorrow}
                         />
-                    ) : (
+                    ) : null}
+                    {open && !showWateringCalendar && showHistory ? (
+                        <OperationScheduleCalendar
+                            className="shadow-none"
+                            gardenId={gardenId}
+                            maxSelectableDate={threeMonthsFromTomorrow}
+                            minSelectableDate={tomorrow}
+                            onDateSelect={handleDateSelect}
+                            operation={operation}
+                            positionIndex={positionIndex}
+                            previewDate={selectedDate}
+                            raisedBedId={raisedBedId}
+                            selectedDate={selectedDate}
+                            visibleFrom={tomorrow}
+                            visibleTo={threeMonthsFromTomorrow}
+                        />
+                    ) : null}
+                    {open && !showWateringCalendar && !showHistory ? (
                         <EventCalendar
                             className="shadow-none"
                             emptyLabel={null}
@@ -187,7 +207,7 @@ export function OperationScheduleModal({
                             visibleFrom={tomorrow}
                             visibleTo={threeMonthsFromTomorrow}
                         />
-                    )}
+                    ) : null}
                     <Row spacing={2}>
                         <Button
                             variant="plain"

--- a/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationsListItem.tsx
@@ -3,7 +3,6 @@ import { formatPrice } from '@gredice/js/currency';
 import { getHarvestOperationRemovalDisclaimer } from '@gredice/js/plants';
 import { BackpackIcon } from '@gredice/ui/BackpackIcon';
 import { Button } from '@gredice/ui/Button';
-import { Calendar } from '@gredice/ui/icons';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -80,7 +79,7 @@ export function OperationsListItem({
         <Button
             variant="plain"
             className="justify-start text-start p-0 h-auto py-1 gap-3 px-4 rounded-none font-normal"
-            onClick={() => handleOperationPicked(operation)}
+            disabled={setShoppingCartItem.isPending}
         >
             <AnimateFlyToItem {...animateFlyToShoppingCart.props}>
                 <OperationImage operation={operation} size={32} />
@@ -118,43 +117,56 @@ export function OperationsListItem({
 
     return (
         <Stack key={operation.id} data-operation-id={operation.id}>
-            {operationButton}
+            <OperationScheduleModal
+                gardenId={gardenId}
+                operation={operation}
+                onConfirm={async (date) => {
+                    await handleOperationPicked(operation, date);
+                }}
+                positionIndex={positionIndex}
+                raisedBedId={raisedBedId}
+                trigger={operationButton}
+            />
             <div className="flex flex-wrap gap-y-1 gap-x-2 pr-4 items-center justify-between">
                 <Row>
-                    <OperationScheduleModal
-                        gardenId={gardenId}
-                        operation={operation}
-                        onConfirm={async (date) => {
-                            await handleOperationPicked(operation, date);
-                        }}
-                        raisedBedId={raisedBedId}
-                        trigger={
-                            <Button
-                                title="Zakaži radnju"
-                                variant="plain"
-                                size="sm"
-                                startDecorator={
-                                    <Calendar className="size-4 shrink-0" />
-                                }
-                                disabled={setShoppingCartItem.isPending}
-                            >
-                                Zakaži
-                            </Button>
-                        }
-                    />
-                    <Button
-                        variant="plain"
-                        size="sm"
-                        disabled={!availableFromInventory}
-                        startDecorator={
-                            <BackpackIcon className="size-5 shrink-0" />
-                        }
-                        onClick={() =>
-                            handleOperationPicked(operation, undefined, true)
-                        }
-                    >
-                        {`U ruksaku (${availableFromInventory ?? 0})`}
-                    </Button>
+                    {availableFromInventory ? (
+                        <OperationScheduleModal
+                            gardenId={gardenId}
+                            operation={operation}
+                            onConfirm={async (date) => {
+                                await handleOperationPicked(
+                                    operation,
+                                    date,
+                                    true,
+                                );
+                            }}
+                            positionIndex={positionIndex}
+                            raisedBedId={raisedBedId}
+                            trigger={
+                                <Button
+                                    variant="plain"
+                                    size="sm"
+                                    disabled={setShoppingCartItem.isPending}
+                                    startDecorator={
+                                        <BackpackIcon className="size-5 shrink-0" />
+                                    }
+                                >
+                                    {`U ruksaku (${availableFromInventory})`}
+                                </Button>
+                            }
+                        />
+                    ) : (
+                        <Button
+                            variant="plain"
+                            size="sm"
+                            disabled
+                            startDecorator={
+                                <BackpackIcon className="size-5 shrink-0" />
+                            }
+                        >
+                            {`U ruksaku (${availableFromInventory ?? 0})`}
+                        </Button>
+                    )}
                 </Row>
                 <Row>
                     <Button

--- a/packages/ui/src/EventCalendar/EventCalendar.tsx
+++ b/packages/ui/src/EventCalendar/EventCalendar.tsx
@@ -29,6 +29,7 @@ export type EventCalendarEntry = {
     label: string;
     meta?: ReactNode;
     tone?: EventCalendarEntryTone;
+    visual?: ReactNode;
     weight?: number | null;
 };
 
@@ -54,6 +55,7 @@ type EventCalendarProps = Omit<
     HTMLAttributes<HTMLDivElement>,
     'children' | 'onSelect'
 > & {
+    accent?: 'default' | 'blue';
     entries: EventCalendarEntry[];
     emptyLabel?: ReactNode;
     error?: boolean;
@@ -71,7 +73,7 @@ type EventCalendarProps = Omit<
 };
 
 const weekDays = ['Pon', 'Uto', 'Sri', 'Čet', 'Pet', 'Sub', 'Ned'];
-const minimumMarkerSize = 16;
+const minimumMarkerSize = 18;
 const defaultMarkerSize = 22;
 const maximumMarkerSize = 30;
 const fallbackEntryWeight = 1;
@@ -106,22 +108,48 @@ const markerClassNames = {
     warning: 'bg-amber-400 text-amber-950 shadow-sm shadow-amber-200/50',
     danger: 'bg-red-600 text-white shadow-sm shadow-red-300/40',
     completed: 'bg-sky-600 text-white shadow-sm shadow-sky-300/40',
-    scheduled: 'bg-sky-500 text-white shadow-sm shadow-sky-300/40',
+    scheduled: 'bg-sky-600 text-white shadow-sm shadow-sky-300/40',
     cart: 'bg-cyan-700 text-white shadow-sm shadow-cyan-300/40',
-    preview: 'bg-blue-700 text-white shadow-sm shadow-blue-300/40',
+    preview: 'bg-sky-600 text-white shadow-sm shadow-sky-300/40',
 } satisfies Record<EventCalendarEntryTone, string>;
 
-const markerTextClassNames = {
-    neutral: 'text-background dark:text-white',
-    info: 'text-white',
-    success: 'text-white',
-    warning: 'text-amber-950',
-    danger: 'text-white',
-    completed: 'text-white',
-    scheduled: 'text-white',
-    cart: 'text-white',
-    preview: 'text-white',
-} satisfies Record<EventCalendarEntryTone, string>;
+const accentClassNames = {
+    default: {
+        icon: 'text-primary',
+        marker: 'bg-primary',
+        selected:
+            'bg-primary text-primary-foreground ring-primary ring-offset-card',
+    },
+    blue: {
+        icon: 'text-sky-600',
+        marker: 'bg-sky-600',
+        selected:
+            'bg-sky-600 text-white ring-sky-600 ring-offset-card dark:ring-sky-300',
+    },
+} satisfies Record<
+    NonNullable<EventCalendarProps['accent']>,
+    {
+        icon: string;
+        marker: string;
+        selected: string;
+    }
+>;
+
+const accentedTones = new Set<EventCalendarEntryTone>([
+    'completed',
+    'info',
+    'preview',
+    'scheduled',
+]);
+
+function markerClassName(
+    tone: EventCalendarEntryTone,
+    accent: NonNullable<EventCalendarProps['accent']>,
+) {
+    return accentedTones.has(tone)
+        ? accentClassNames[accent].marker
+        : markerClassNames[tone];
+}
 
 function parseEventDate(value: Date | string | undefined) {
     if (value === undefined) {
@@ -358,16 +386,6 @@ function dayTitle(day: EventCalendarDay, isSelected: boolean) {
     return `${dateLabel}${suffix}: ${labels}`;
 }
 
-function TodayMarker() {
-    return (
-        <span
-            aria-hidden
-            className="absolute size-9 rounded-full ring-2 ring-sky-600/40 dark:ring-sky-300/50"
-            data-event-calendar-today-marker
-        />
-    );
-}
-
 function EventCalendarDayDetails({ day }: { day: EventCalendarDay }) {
     return (
         <Stack spacing={2}>
@@ -376,16 +394,30 @@ function EventCalendarDayDetails({ day }: { day: EventCalendarDay }) {
             </Typography>
             <Stack spacing={1}>
                 {day.entries.map((entry) => (
-                    <Stack key={entry.id} spacing={0}>
-                        <Typography level="body3" semiBold>
-                            {entry.label}
-                        </Typography>
-                        {entry.meta ? (
-                            <Typography level="body3" secondary>
-                                {entry.meta}
-                            </Typography>
+                    <Row key={entry.id} spacing={2} alignItems="start">
+                        {entry.visual ? (
+                            <span
+                                className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+                                data-event-calendar-entry-visual
+                            >
+                                {entry.visual}
+                            </span>
                         ) : null}
-                    </Stack>
+                        <Stack spacing={0} className="min-w-0">
+                            <Typography
+                                level="body3"
+                                semiBold
+                                className="min-w-0"
+                            >
+                                {entry.label}
+                            </Typography>
+                            {entry.meta ? (
+                                <Typography level="body3" secondary>
+                                    {entry.meta}
+                                </Typography>
+                            ) : null}
+                        </Stack>
+                    </Row>
                 ))}
             </Stack>
         </Stack>
@@ -400,7 +432,9 @@ function EventCalendarDayView({
     onDateSelect,
     selectedDate,
     todayKey,
+    accent,
 }: {
+    accent: NonNullable<EventCalendarProps['accent']>;
     day: EventCalendarDay;
     isDateDisabled?: (date: Date) => boolean;
     maxSelectableDate?: Date;
@@ -421,34 +455,31 @@ function EventCalendarDayView({
     if (!hasEntries && !onDateSelect) {
         return (
             <div className="relative grid size-8 place-items-center text-xs tabular-nums">
-                {isToday ? <TodayMarker /> : null}
-                <span className="relative z-10">{day.dayOfMonth}</span>
+                <span
+                    className={cx(
+                        'relative grid size-6 place-items-center rounded-full',
+                        isToday && 'bg-muted',
+                    )}
+                    data-event-calendar-today-marker={
+                        isToday ? true : undefined
+                    }
+                >
+                    {day.dayOfMonth}
+                </span>
             </div>
         );
     }
 
-    const tone = hasEntries && day.tone !== 'none' ? day.tone : null;
+    const visibleEntries = day.entries.slice(0, 3);
     const content = (
         <button
             type="button"
             className={cx(
                 'relative grid size-8 place-items-center rounded-full text-xs tabular-nums transition-colors',
                 'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                tone && 'font-semibold',
-                tone && markerTextClassNames[tone],
-                !tone &&
-                    isSelected &&
-                    'bg-primary font-semibold text-primary-foreground',
-                !tone &&
-                    !isSelected &&
-                    isSelectable &&
-                    'text-foreground hover:bg-muted',
-                !tone &&
-                    !isSelected &&
-                    !isSelectable &&
-                    'text-muted-foreground/40',
-                isSelected &&
-                    'ring-2 ring-primary ring-offset-2 ring-offset-card',
+                isSelected && 'font-semibold',
+                !isSelected && isSelectable && 'text-foreground hover:bg-muted',
+                !isSelected && !isSelectable && 'text-muted-foreground/60',
             )}
             aria-label={dayTitle(day, isSelected)}
             aria-pressed={onDateSelect ? isSelected : undefined}
@@ -460,23 +491,41 @@ function EventCalendarDayView({
                 }
             }}
         >
-            {isToday ? <TodayMarker /> : null}
-            {tone ? (
+            {visibleEntries.length > 0 ? (
                 <span
                     aria-hidden
-                    className={cx(
-                        'absolute rounded-full',
-                        markerClassNames[tone],
-                    )}
-                    data-event-calendar-marker
-                    data-event-calendar-tone={tone}
-                    style={{
-                        height: day.markerSize,
-                        width: day.markerSize,
-                    }}
-                />
+                    className="absolute top-0.5 left-1/2 flex -translate-x-1/2 gap-0.5"
+                    data-event-calendar-markers
+                >
+                    {visibleEntries.map((entry) => {
+                        const entryTone = entry.tone ?? 'info';
+                        return (
+                            <span
+                                key={entry.id}
+                                className={cx(
+                                    'size-1.5 rounded-full',
+                                    markerClassName(entryTone, accent),
+                                )}
+                                data-event-calendar-marker
+                                data-event-calendar-tone={entryTone}
+                            />
+                        );
+                    })}
+                </span>
             ) : null}
-            <span className="relative z-10">{day.dayOfMonth}</span>
+            <span
+                className={cx(
+                    'relative z-10 grid size-6 place-items-center rounded-full',
+                    isToday && !isSelected && 'bg-muted',
+                    isSelected && [
+                        'ring-2 ring-offset-2',
+                        accentClassNames[accent].selected,
+                    ],
+                )}
+                data-event-calendar-today-marker={isToday ? true : undefined}
+            >
+                {day.dayOfMonth}
+            </span>
         </button>
     );
 
@@ -497,6 +546,7 @@ function EventCalendarDayView({
 }
 
 function EventCalendarMonthView({
+    accent,
     canGoBack,
     canGoForward,
     isDateDisabled,
@@ -509,6 +559,7 @@ function EventCalendarMonthView({
     selectedDate,
     todayKey,
 }: {
+    accent: NonNullable<EventCalendarProps['accent']>;
     canGoBack: boolean;
     canGoForward: boolean;
     isDateDisabled?: (date: Date) => boolean;
@@ -529,7 +580,12 @@ function EventCalendarMonthView({
                 justifyContent="space-between"
             >
                 <Row spacing={2} className="min-w-0">
-                    <Calendar className="size-4 shrink-0 text-sky-600" />
+                    <Calendar
+                        className={cx(
+                            'size-4 shrink-0',
+                            accentClassNames[accent].icon,
+                        )}
+                    />
                     <Typography
                         level="body2"
                         semiBold
@@ -583,6 +639,7 @@ function EventCalendarMonthView({
                         >
                             {day ? (
                                 <EventCalendarDayView
+                                    accent={accent}
                                     day={day}
                                     isDateDisabled={isDateDisabled}
                                     maxSelectableDate={maxSelectableDate}
@@ -601,6 +658,7 @@ function EventCalendarMonthView({
 }
 
 export function EventCalendar({
+    accent = 'default',
     className,
     emptyLabel = 'Nema zabilježenih događaja.',
     entries,
@@ -702,6 +760,7 @@ export function EventCalendar({
             {selectedMonth ? (
                 <EventCalendarMonthView
                     key={selectedMonth.key}
+                    accent={accent}
                     canGoBack={canGoBack}
                     canGoForward={canGoForward}
                     isDateDisabled={isDateDisabled}


### PR DESCRIPTION
## Summary

- Route standard operation item clicks directly into scheduling, removing the extra bottom schedule action.
- Add a shared operation scheduling calendar with history/cart/preview entries, dots above dates, icon-rich popovers, and no duration text.
- Keep watering calendars on blue accents while standard operation calendars use the primary accent and show today with a muted background.

## Validation

- `git diff --check`
- `corepack pnpm typecheck --filter @gredice/ui`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm --filter garden test:run tests/watering-operations-calendar.spec.tsx`
- `corepack pnpm --filter garden test:run tests/raised-bed-diary.spec.tsx`
- `corepack pnpm --filter garden test:run tests/raised-bed-field-hud.spec.tsx`