### PR TITLE
[codex] Group operation recommendations

### DIFF
--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -80,7 +80,7 @@ function createScenarioQueryClient(
     });
     queryClient.setQueryData(['inventory'], { items: [] });
     queryClient.setQueryData(favoritesQueryKey, favorites);
-    queryClient.setQueryData(['plants'], allPlants);
+    queryClient.setQueryData(['plants'], scenario.plants ?? allPlants);
     queryClient.setQueryData(['sorts'], scenario.sorts ?? allSorts);
     queryClient.setQueryData(['operations'], scenario.operations ?? []);
     const operationHistoryItems = scenario.operationHistoryItems ?? [];

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1,4 +1,8 @@
-import type { FavoriteEntityType, FavoriteItem } from '@gredice/client';
+import type {
+    FavoriteEntityType,
+    FavoriteItem,
+    PlantData,
+} from '@gredice/client';
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Page } from '@playwright/test';
 import {
@@ -201,6 +205,51 @@ function plantedGrowingWithRecommendedOperationsScenario(): RaisedBedScenario {
         ...plantedGrowingScenario(),
         operations,
         sorts: [tomatoSortWithOperations],
+    };
+}
+
+function plantedGrowingWithHealthRecommendedOperationsScenario(): RaisedBedScenario {
+    const scenario = plantedGrowingWithRecommendedOperationsScenario();
+    const healthOperation = buildOperation({
+        id: 203,
+        name: 'mock-pest-rinse',
+        label: 'Ispiranje biljke od štetnika',
+        stageName: 'maintenance',
+        stageLabel: 'Održavanje',
+        relativeDays: 3,
+    });
+    const tomatoPlantWithHealth = {
+        ...testSorts.tomato.information.plant,
+        health: {
+            pests: [
+                {
+                    id: 501,
+                    slug: 'mock-aphids',
+                    name: 'Lisne uši',
+                    kind: 'pest',
+                    operations: {
+                        reduction: [
+                            {
+                                id: healthOperation.id,
+                                slug: healthOperation.slug,
+                                name: healthOperation.information.name,
+                                label: healthOperation.information.label,
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    } satisfies PlantData;
+
+    return {
+        ...scenario,
+        operations: [...(scenario.operations ?? []), healthOperation],
+        plants: [
+            tomatoPlantWithHealth,
+            testSorts.basil.information.plant,
+            testSorts.lettuce.information.plant,
+        ],
     };
 }
 
@@ -839,12 +888,34 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await page.getByRole('button').first().click();
 
         const dialog = page.getByRole('dialog');
+        await expect(
+            dialog.getByRole('heading', { name: 'Preporuke' }),
+        ).toBeVisible();
+        await expect(dialog.getByText('Preporučene radnje')).toHaveCount(0);
+
+        const operationsSection = dialog.locator(
+            '[data-recommendation-section="operations"]',
+        );
+        await expect(operationsSection).toBeVisible();
+        await expect(
+            operationsSection.locator('svg.lucide-hammer'),
+        ).toBeVisible();
+
         const recommendationsList = dialog.locator(
             '[data-recommended-operation-list]',
         );
         await expect(recommendationsList).toBeVisible();
         await expect(recommendationsList).toContainText('Okopavanje');
         await expect(recommendationsList).toContainText('Uklanjanje korova');
+
+        const operationsHeader = operationsSection.getByRole('button', {
+            name: /Radnje/,
+        });
+        await operationsHeader.click();
+        await expect(operationsSection.getByTitle('2 preporuka')).toBeVisible();
+        await expect(recommendationsList).toHaveCount(0);
+        await operationsHeader.click();
+        await expect(recommendationsList).toBeVisible();
 
         const listItems = recommendationsList.locator(':scope > *');
         await expect(listItems).toHaveCount(3);
@@ -867,6 +938,42 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
                 .locator('[role="tabpanel"]:not([hidden])')
                 .locator('[data-scroll-view]'),
         ).toBeVisible();
+    });
+
+    test('recommendations group plant health operations with collapsed counts', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingWithHealthRecommendedOperationsScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        const healthSection = dialog.locator(
+            '[data-recommendation-section="health"]',
+        );
+        await expect(healthSection).toBeVisible();
+        await expect(healthSection.locator('svg.lucide-plus')).toBeVisible();
+        await expect(healthSection.getByText('Lisne uši')).toBeVisible();
+
+        const healthList = healthSection.locator(
+            '[data-plant-health-operation-list]',
+        );
+        await expect(healthList).toBeVisible();
+        await expect(healthList).toContainText('Ispiranje biljke od štetnika');
+
+        const healthHeader = healthSection.getByRole('button', {
+            name: /Zdravlje biljke/,
+        });
+        await healthHeader.click();
+
+        await expect(healthSection.getByTitle('1 preporuka')).toBeVisible();
+        await expect(healthList).toHaveCount(0);
     });
 
     test('favorite operations are ranked first in recommendations and operation choices', async ({

--- a/apps/garden/tests/raisedBedFieldHudScenarios.ts
+++ b/apps/garden/tests/raisedBedFieldHudScenarios.ts
@@ -151,6 +151,7 @@ export type FieldConfig = {
 export type RaisedBedScenario = {
     fields: FieldConfig[];
     cartItems?: ShoppingCartItemData[];
+    plants?: PlantData[];
     sorts?: PlantSortData[];
     operations?: OperationData[];
     operationHistoryItems?: GardenOperationItem[];

--- a/packages/game/src/hud/raisedBed/RecommendationSection.tsx
+++ b/packages/game/src/hud/raisedBed/RecommendationSection.tsx
@@ -1,0 +1,63 @@
+import { ExpandDown } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import type { ReactNode } from 'react';
+
+type RecommendationSectionKind = 'operations' | 'health';
+
+export function RecommendationSection({
+    children,
+    count,
+    icon,
+    kind,
+    onOpenChange,
+    open,
+    title,
+}: {
+    children: ReactNode;
+    count: number;
+    icon: ReactNode;
+    kind: RecommendationSectionKind;
+    onOpenChange: (open: boolean) => void;
+    open: boolean;
+    title: string;
+}) {
+    return (
+        <div data-recommendation-section={kind}>
+            <button
+                aria-expanded={open}
+                className="w-full px-2 py-4 text-left"
+                onClick={() => onOpenChange(!open)}
+                type="button"
+            >
+                <Row spacing={2} justifyContent="space-between">
+                    <Row spacing={2} alignItems="center" className="min-w-0">
+                        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-200">
+                            {icon}
+                        </span>
+                        <Typography level="body2" semiBold noWrap>
+                            {title}
+                        </Typography>
+                        {!open && (
+                            <span
+                                className="inline-flex min-w-6 items-center justify-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold leading-none text-green-700 dark:bg-green-900/50 dark:text-green-200"
+                                title={`${count} preporuka`}
+                            >
+                                {count}
+                            </span>
+                        )}
+                    </Row>
+                    <ExpandDown
+                        aria-hidden
+                        className={cx(
+                            'size-5 shrink-0 transition-transform',
+                            open && '-scale-y-100',
+                        )}
+                    />
+                </Row>
+            </button>
+            {open && <div className="px-2 pt-2 pb-4">{children}</div>}
+        </div>
+    );
+}

--- a/packages/game/src/hud/raisedBed/RecommendationsCard.tsx
+++ b/packages/game/src/hud/raisedBed/RecommendationsCard.tsx
@@ -2,12 +2,12 @@ import type { OperationData, PlantData } from '@gredice/client';
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardOverflow } from '@gredice/ui/Card';
-import { Navigate } from '@gredice/ui/icons';
+import { Add as Cross, Hammer, Navigate } from '@gredice/ui/icons';
 import { List } from '@gredice/ui/List';
 import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { sortFavoritesFirst, useFavoriteIds } from '../../hooks/useFavorites';
 import { useOperations } from '../../hooks/useOperations';
@@ -21,6 +21,7 @@ import {
     type PlantStageName,
     shouldShowPlantOperationRecommendations,
 } from './featuredOperations';
+import { RecommendationSection } from './RecommendationSection';
 import { OperationsListItem } from './shared/OperationsListItem';
 
 type PlantHealthIssueSummary = NonNullable<
@@ -46,6 +47,8 @@ export function RecommendationsCard({
     plantSortId?: number;
 }) {
     const { track } = useGameAnalytics();
+    const [operationsOpen, setOperationsOpen] = useState(true);
+    const [healthOpen, setHealthOpen] = useState(true);
     const favoriteOperationIds = useFavoriteIds('operation');
     // Fetch and prepare data for recommendations
     const {
@@ -266,10 +269,12 @@ export function RecommendationsCard({
     const hasStageRecommendations = Boolean(stageSequence?.length);
     const hasHealthIssueRecommendations = plantHealthIssues.length > 0;
     const isLoadingHealthOperations =
-        !hasStageRecommendations &&
         isLoadingOperations &&
         hasHealthIssueRecommendations &&
         healthRecommendedOperations.length === 0;
+    const showHealthSection =
+        hasHealthIssueRecommendations &&
+        (isLoadingHealthOperations || healthRecommendedOperations.length > 0);
     const skeletonKeys = useMemo(
         () =>
             Array.from(
@@ -291,123 +296,140 @@ export function RecommendationsCard({
                 className="leading-tight font-semibold uppercase"
                 component="h2"
             >
-                Preporučene radnje
+                Preporuke
             </Typography>
             <Card>
-                <CardOverflow>
-                    <Stack>
+                <CardOverflow className="overflow-hidden">
+                    <Stack className="divide-y">
                         {isOperationsError && (
-                            <Alert color="danger">
+                            <Alert color="danger" className="m-2">
                                 Greška prilikom učitavanja radnji
                             </Alert>
                         )}
                         {hasStageRecommendations ? (
-                            isLoadingFeaturedOperations ? (
-                                <Stack spacing={2}>
-                                    {skeletonKeys.map((skeletonKey) => (
-                                        <Skeleton
-                                            key={skeletonKey}
-                                            className="h-16 w-full rounded-md"
-                                        />
-                                    ))}
-                                </Stack>
-                            ) : featuredOperations.length ? (
-                                <List
-                                    variant="outlined"
-                                    data-recommended-operation-list
-                                    className="border-b-0 border-l-0 border-r-0 rounded-none max-h-[25dvh] overflow-y-auto"
-                                >
-                                    {featuredOperations.map((operation) => (
-                                        <OperationsListItem
-                                            key={operation.id}
-                                            operation={operation}
-                                            gardenId={gardenId}
-                                            raisedBedId={raisedBedId}
-                                            positionIndex={positionIndex}
-                                        />
-                                    ))}
-                                    {onShowOperations && (
-                                        <ShowAllOperationsListItem
-                                            onShowOperations={onShowOperations}
-                                        />
-                                    )}
-                                </List>
-                            ) : (
-                                <Typography
-                                    level="body2"
-                                    secondary
-                                    className="p-4 border-t"
-                                >
-                                    Trenutno nema dostupnih radnji za ovu fazu.
-                                </Typography>
-                            )
-                        ) : null}
-                        {isLoadingHealthOperations && (
-                            <Stack spacing={2}>
-                                {skeletonKeys.map((skeletonKey) => (
-                                    <Skeleton
-                                        key={`health-${skeletonKey}`}
-                                        className="h-16 w-full rounded-md"
-                                    />
-                                ))}
-                            </Stack>
-                        )}
-                        {healthRecommendedOperations.length > 0 && (
-                            <Stack spacing={2} className="border-t p-3">
-                                <Stack spacing={1}>
-                                    <Typography
-                                        level="body3"
-                                        className="leading-tight font-semibold uppercase"
+                            <RecommendationSection
+                                count={featuredOperations.length}
+                                icon={<Hammer className="size-4" />}
+                                kind="operations"
+                                onOpenChange={setOperationsOpen}
+                                open={operationsOpen}
+                                title="Radnje"
+                            >
+                                {isLoadingFeaturedOperations ? (
+                                    <Stack spacing={2}>
+                                        {skeletonKeys.map((skeletonKey) => (
+                                            <Skeleton
+                                                key={skeletonKey}
+                                                className="h-16 w-full rounded-md"
+                                            />
+                                        ))}
+                                    </Stack>
+                                ) : featuredOperations.length ? (
+                                    <List
+                                        variant="outlined"
+                                        data-recommended-operation-list
+                                        className="max-h-[25dvh] overflow-y-auto rounded-md"
                                     >
-                                        Zdravlje biljke
-                                    </Typography>
-                                    <Typography level="body3" secondary>
-                                        {healthIssueLabels
-                                            .slice(0, 3)
-                                            .join(', ')}
-                                        {healthIssueLabels.length > 3
-                                            ? ` +${healthIssueLabels.length - 3}`
-                                            : ''}
-                                    </Typography>
-                                </Stack>
-                                <List
-                                    variant="outlined"
-                                    data-plant-health-operation-list
-                                    className="border rounded-md"
-                                >
-                                    {healthRecommendedOperations.map(
-                                        (operation) => (
+                                        {featuredOperations.map((operation) => (
                                             <OperationsListItem
                                                 key={operation.id}
                                                 operation={operation}
                                                 gardenId={gardenId}
                                                 raisedBedId={raisedBedId}
                                                 positionIndex={positionIndex}
-                                                onOperationPicked={() => {
-                                                    track(
-                                                        'game_plant_health_recommendation_selected',
-                                                        {
-                                                            garden_id: gardenId,
-                                                            raised_bed_id:
-                                                                raisedBedId,
-                                                            position_index:
-                                                                positionIndex,
-                                                            plant_sort_id:
-                                                                plantSortId,
-                                                            operation_id:
-                                                                operation.id,
-                                                            operation_name:
-                                                                operation
-                                                                    .information
-                                                                    .name,
-                                                        },
-                                                    );
-                                                }}
                                             />
-                                        ),
+                                        ))}
+                                        {onShowOperations && (
+                                            <ShowAllOperationsListItem
+                                                onShowOperations={
+                                                    onShowOperations
+                                                }
+                                            />
+                                        )}
+                                    </List>
+                                ) : (
+                                    <Typography level="body2" secondary>
+                                        Trenutno nema dostupnih radnji za ovu
+                                        fazu.
+                                    </Typography>
+                                )}
+                            </RecommendationSection>
+                        ) : null}
+                        {showHealthSection && (
+                            <RecommendationSection
+                                count={healthRecommendedOperations.length}
+                                icon={<Cross className="size-4" />}
+                                kind="health"
+                                onOpenChange={setHealthOpen}
+                                open={healthOpen}
+                                title="Zdravlje biljke"
+                            >
+                                <Stack spacing={2}>
+                                    {healthIssueLabels.length > 0 && (
+                                        <Typography level="body3" secondary>
+                                            {healthIssueLabels
+                                                .slice(0, 3)
+                                                .join(', ')}
+                                            {healthIssueLabels.length > 3
+                                                ? ` +${healthIssueLabels.length - 3}`
+                                                : ''}
+                                        </Typography>
                                     )}
-                                </List>
-                            </Stack>
+                                    {isLoadingHealthOperations ? (
+                                        <Stack spacing={2}>
+                                            {skeletonKeys.map((skeletonKey) => (
+                                                <Skeleton
+                                                    key={`health-${skeletonKey}`}
+                                                    className="h-16 w-full rounded-md"
+                                                />
+                                            ))}
+                                        </Stack>
+                                    ) : (
+                                        <List
+                                            variant="outlined"
+                                            data-plant-health-operation-list
+                                            className="max-h-[25dvh] overflow-y-auto rounded-md"
+                                        >
+                                            {healthRecommendedOperations.map(
+                                                (operation) => (
+                                                    <OperationsListItem
+                                                        key={operation.id}
+                                                        operation={operation}
+                                                        gardenId={gardenId}
+                                                        raisedBedId={
+                                                            raisedBedId
+                                                        }
+                                                        positionIndex={
+                                                            positionIndex
+                                                        }
+                                                        onOperationPicked={() => {
+                                                            track(
+                                                                'game_plant_health_recommendation_selected',
+                                                                {
+                                                                    garden_id:
+                                                                        gardenId,
+                                                                    raised_bed_id:
+                                                                        raisedBedId,
+                                                                    position_index:
+                                                                        positionIndex,
+                                                                    plant_sort_id:
+                                                                        plantSortId,
+                                                                    operation_id:
+                                                                        operation.id,
+                                                                    operation_name:
+                                                                        operation
+                                                                            .information
+                                                                            .name,
+                                                                },
+                                                            );
+                                                        }}
+                                                    />
+                                                ),
+                                            )}
+                                        </List>
+                                    )}
+                                </Stack>
+                            </RecommendationSection>
                         )}
                     </Stack>
                 </CardOverflow>


### PR DESCRIPTION
## Summary

Updates the plant recommendation card to present one `Preporuke` area with two matching collapsible groups: `Radnje` and `Zdravlje biljke`.

Each group has its own icon, and collapsed groups show a green count chip with the number of suggested operations. Plant-health recommendations now use the same section treatment as standard operation recommendations instead of reading as a separate secondary list.

## Validation

- `pnpm lint --filter @gredice/game --filter garden`
- `pnpm typecheck --filter @gredice/game --filter garden`
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden test:run -- tests/raised-bed-field-hud.spec.tsx`