### PR TITLE
[codex] Tighten admin schedule mobile rows

### DIFF
--- a/apps/app/app/admin/schedule/AcceptOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptOperationModal.tsx
@@ -6,6 +6,7 @@ import { AcceptRequestModal } from './AcceptRequestModal';
 interface AcceptOperationModalProps {
     operationId: number;
     label: string;
+    raisedBedPhysicalId?: string;
     disabled?: boolean;
     onConfirm?: () => unknown | Promise<unknown>;
 }
@@ -13,6 +14,7 @@ interface AcceptOperationModalProps {
 export function AcceptOperationModal({
     operationId,
     label,
+    raisedBedPhysicalId,
     disabled = false,
     onConfirm,
 }: AcceptOperationModalProps) {
@@ -32,6 +34,7 @@ export function AcceptOperationModal({
             trigger={
                 <IconButton
                     variant="plain"
+                    size="xs"
                     title="Potvrdi operaciju"
                     disabled={disabled}
                 >
@@ -40,6 +43,7 @@ export function AcceptOperationModal({
             }
             title="Potvrda radnje"
             header="Potvrda radnje"
+            raisedBedPhysicalId={raisedBedPhysicalId}
         />
     );
 }

--- a/apps/app/app/admin/schedule/AcceptRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptRaisedBedFieldModal.tsx
@@ -9,6 +9,7 @@ interface AcceptRaisedBedFieldModalProps {
     raisedBedId: number;
     positionIndex: number;
     label: string;
+    raisedBedPhysicalId?: string;
     disabled?: boolean;
     onConfirm?: () => unknown | Promise<unknown>;
 }
@@ -17,6 +18,7 @@ export function AcceptRaisedBedFieldModal({
     raisedBedId,
     positionIndex,
     label,
+    raisedBedPhysicalId,
     disabled = false,
     onConfirm,
 }: AcceptRaisedBedFieldModalProps) {
@@ -36,6 +38,7 @@ export function AcceptRaisedBedFieldModal({
             trigger={
                 <IconButton
                     variant="plain"
+                    size="xs"
                     title="Potvrdi sijanje"
                     disabled={disabled}
                 >
@@ -44,6 +47,7 @@ export function AcceptRaisedBedFieldModal({
             }
             title="Potvrda sijanja"
             header="Potvrda sijanja"
+            raisedBedPhysicalId={raisedBedPhysicalId}
         />
     );
 }

--- a/apps/app/app/admin/schedule/AcceptRequestModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptRequestModal.tsx
@@ -5,6 +5,7 @@ import { IconButton } from '@gredice/ui/IconButton';
 import { Check } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
+import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
@@ -15,6 +16,7 @@ interface AcceptRequestModalProps {
     trigger?: React.ReactElement;
     title?: string;
     header?: string;
+    raisedBedPhysicalId?: string;
 }
 
 export function AcceptRequestModal({
@@ -23,6 +25,7 @@ export function AcceptRequestModal({
     trigger,
     title = 'Potvrda zadatka',
     header = 'Potvrda zadatka',
+    raisedBedPhysicalId,
 }: AcceptRequestModalProps) {
     const [open, setOpen] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -49,6 +52,7 @@ export function AcceptRequestModal({
                 trigger ?? (
                     <IconButton
                         variant="plain"
+                        size="xs"
                         title="Potvrdi"
                         loading={isSubmitting}
                     >
@@ -59,6 +63,12 @@ export function AcceptRequestModal({
         >
             <Stack spacing={4}>
                 <Typography level="h5">{header}</Typography>
+                {raisedBedPhysicalId && (
+                    <RaisedBedLabel
+                        physicalId={raisedBedPhysicalId}
+                        size="compact"
+                    />
+                )}
                 <Typography>
                     Jeste li sigurni da želite potvrditi zadatak:{' '}
                     <strong>{label}</strong>?

--- a/apps/app/app/admin/schedule/AssignOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AssignOperationModal.tsx
@@ -120,7 +120,7 @@ export function AssignOperationModal({
         (assignedUsers?.length ?? 0) > 0 ? (
             <button
                 type="button"
-                className="rounded-full transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex size-7 items-center justify-center rounded-full transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
                 title={`Dodijeljeno korisnika: ${assignedUsers?.length ?? 0}`}
                 aria-label={`Dodijeljeno korisnika: ${assignedUsers?.length ?? 0}`}
                 disabled={!canOpen}
@@ -134,7 +134,7 @@ export function AssignOperationModal({
                                 assignedUser.displayName ??
                                 assignedUser.userName
                             }
-                            className="size-7 ring-2 ring-background"
+                            className="size-6 ring-1 ring-background"
                         />
                     ))}
                     {(assignedUsers?.length ?? 0) > 2 && (
@@ -148,6 +148,7 @@ export function AssignOperationModal({
             <IconButton
                 variant="soft"
                 color="warning"
+                size="xs"
                 title={
                     canOpen
                         ? 'Dodijeli korisnika'

--- a/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
@@ -138,7 +138,7 @@ export function AssignRaisedBedFieldModal({
         selectedUsers.length > 0 ? (
             <button
                 type="button"
-                className="rounded-full transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex size-7 items-center justify-center rounded-full transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
                 title={`Dodijeljeno korisnika: ${selectedUsers.length}`}
                 aria-label={`Dodijeljeno korisnika: ${selectedUsers.length}`}
                 disabled={!canOpen}
@@ -152,7 +152,7 @@ export function AssignRaisedBedFieldModal({
                                 selectedUser.displayName ??
                                 selectedUser.userName
                             }
-                            className="size-7 ring-2 ring-background"
+                            className="size-6 ring-1 ring-background"
                         />
                     ))}
                     {selectedUsers.length > 2 && (
@@ -166,6 +166,7 @@ export function AssignRaisedBedFieldModal({
             <IconButton
                 variant="soft"
                 color="warning"
+                size="xs"
                 title={
                     canOpen
                         ? 'Dodijeli korisnika'

--- a/apps/app/app/admin/schedule/BulkApproveRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkApproveRaisedBedButton.tsx
@@ -75,6 +75,7 @@ export function BulkApproveRaisedBedButton({
             trigger={
                 <IconButton
                     variant="plain"
+                    size="xs"
                     title="Potvrdi sve zadatke gredice"
                     disabled={disabled}
                     aria-disabled={disabled}

--- a/apps/app/app/admin/schedule/BulkAssignRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkAssignRaisedBedButton.tsx
@@ -154,6 +154,7 @@ export function BulkAssignRaisedBedButton({
             trigger={
                 <IconButton
                     variant="plain"
+                    size="xs"
                     title="Dodijeli korisnika svim nepotvrđenim zadacima gredice"
                     disabled={disabled}
                     aria-disabled={disabled}

--- a/apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx
@@ -116,6 +116,7 @@ export function BulkRescheduleRaisedBedButton({
             trigger={
                 <IconButton
                     variant="plain"
+                    size="xs"
                     title="Zakaži sve nepotvrđene zadatke gredice"
                     disabled={disabled}
                     aria-disabled={disabled}

--- a/apps/app/app/admin/schedule/CompleteOperationModal.tsx
+++ b/apps/app/app/admin/schedule/CompleteOperationModal.tsx
@@ -4,6 +4,7 @@ import { Button } from '@gredice/ui/Button';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
+import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useCallback, useRef, useState } from 'react';
@@ -23,6 +24,7 @@ const MAX_COMPLETION_NOTES_LENGTH = 2000;
 type CompleteOperationModalProps = {
     operationId: number;
     label: string;
+    raisedBedPhysicalId?: string;
     conditions?: EntityStandardized['conditions'];
     onConfirm?: (
         imageUrls: string[] | undefined,
@@ -33,6 +35,7 @@ type CompleteOperationModalProps = {
 export function CompleteOperationModal({
     operationId,
     label,
+    raisedBedPhysicalId,
     conditions,
     onConfirm,
 }: CompleteOperationModalProps) {
@@ -177,7 +180,6 @@ export function CompleteOperationModal({
             onOpenChange={handleOpenChange}
             trigger={
                 <Checkbox
-                    className="size-5 mx-2"
                     checked={isOpen}
                     onCheckedChange={(checked: boolean) =>
                         handleOpenChange(checked)
@@ -186,6 +188,12 @@ export function CompleteOperationModal({
             }
         >
             <Stack spacing={4}>
+                {raisedBedPhysicalId && (
+                    <RaisedBedLabel
+                        physicalId={raisedBedPhysicalId}
+                        size="compact"
+                    />
+                )}
                 <Typography>
                     Jeste li sigurni da želite označiti operaciju kao završenu:{' '}
                     <strong>{label}</strong>?

--- a/apps/app/app/admin/schedule/CompletePlantingModal.tsx
+++ b/apps/app/app/admin/schedule/CompletePlantingModal.tsx
@@ -4,17 +4,20 @@ import { Button } from '@gredice/ui/Button';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
+import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
 
 interface CompletePlantingModalProps {
     label: string;
+    raisedBedPhysicalId?: string;
     onConfirm: () => Promise<void>;
 }
 
 export function CompletePlantingModal({
     label,
+    raisedBedPhysicalId,
     onConfirm,
 }: CompletePlantingModalProps) {
     const [open, setOpen] = useState(false);
@@ -51,7 +54,6 @@ export function CompletePlantingModal({
             onOpenChange={handleOpenChange}
             trigger={
                 <Checkbox
-                    className="size-5 mx-2"
                     checked={open}
                     onCheckedChange={(checked: boolean) =>
                         handleOpenChange(checked)
@@ -60,6 +62,12 @@ export function CompletePlantingModal({
             }
         >
             <Stack spacing={4}>
+                {raisedBedPhysicalId && (
+                    <RaisedBedLabel
+                        physicalId={raisedBedPhysicalId}
+                        size="compact"
+                    />
+                )}
                 <Typography>
                     Jeste li sigurni da želite označiti da je posijano:{' '}
                     <strong>{label}</strong>?

--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -135,7 +135,7 @@ export function FarmOperationsScheduleSection({
                     </Typography>
                 )}
             </Row>
-            <Stack spacing={2}>
+            <Stack spacing={0}>
                 {dayOperations.map((operation) => {
                     const operationData = operationDataById.get(
                         operation.entityId,
@@ -204,19 +204,18 @@ export function FarmOperationsScheduleSection({
                     return (
                         <Row
                             key={operation.id}
-                            spacing={2}
+                            spacing={1}
                             className={getScheduleTaskRowClassName({
                                 accepted: operationApproved,
                                 pendingAcceptance: operationPendingAcceptance,
                             })}
                         >
-                            <Row spacing={2} className="min-w-0 grow flex-wrap">
+                            <Row
+                                spacing={1}
+                                className="min-w-0 flex-1 flex-nowrap"
+                            >
                                 {isOperationCompleted(operation.status) ? (
-                                    <Checkbox
-                                        className="size-5 mx-2"
-                                        checked
-                                        disabled
-                                    />
+                                    <Checkbox checked disabled />
                                 ) : operationPendingVerification ? (
                                     <VerifyOperationModal
                                         operationId={operation.id}
@@ -243,10 +242,7 @@ export function FarmOperationsScheduleSection({
                                         }
                                     />
                                 ) : operationLocked ? (
-                                    <Checkbox
-                                        className="size-5 mx-2"
-                                        disabled
-                                    />
+                                    <Checkbox disabled />
                                 ) : operation.isAccepted ? (
                                     <CompleteOperationModal
                                         operationId={operation.id}
@@ -312,6 +308,7 @@ export function FarmOperationsScheduleSection({
                                     />
                                 )}
                                 <a
+                                    className="min-w-0 flex-1"
                                     href={
                                         operationData?.information?.label
                                             ? KnownPages.GrediceOperation(
@@ -324,10 +321,12 @@ export function FarmOperationsScheduleSection({
                                     rel="noopener noreferrer"
                                 >
                                     <Typography
+                                        level="body2"
+                                        noWrap
                                         className={
                                             operationTextInactive
                                                 ? 'line-through text-muted-foreground'
-                                                : undefined
+                                                : ''
                                         }
                                     >
                                         {operationLabel}
@@ -336,7 +335,7 @@ export function FarmOperationsScheduleSection({
                                 {operationStatusText && (
                                     <Typography
                                         level="body2"
-                                        className={`ml-1 italic ${operationStatusClassName}`}
+                                        className={`shrink-0 italic ${operationStatusClassName}`}
                                     >
                                         {operationStatusText}
                                     </Typography>
@@ -346,7 +345,7 @@ export function FarmOperationsScheduleSection({
                                     <Typography
                                         level="body2"
                                         component="div"
-                                        className="select-none"
+                                        className="shrink-0 select-none"
                                     >
                                         {showScheduledDate ? (
                                             <LocalDateTime time={false}>
@@ -364,7 +363,7 @@ export function FarmOperationsScheduleSection({
                                     </Typography>
                                 )}
                             </Row>
-                            <Row spacing={1} className="ml-auto shrink-0">
+                            <Row spacing={0} className="ml-auto shrink-0">
                                 {!isOperationCompleted(operation.status) &&
                                     !operationPendingVerification && (
                                         <OperationRequirementIcons
@@ -473,6 +472,7 @@ export function FarmOperationsScheduleSection({
                                     trigger={
                                         <IconButton
                                             variant="plain"
+                                            size="xs"
                                             title={
                                                 operation.scheduledDate
                                                     ? 'Prerasporedi radnju'
@@ -513,6 +513,7 @@ export function FarmOperationsScheduleSection({
                                     trigger={
                                         <IconButton
                                             variant="plain"
+                                            size="xs"
                                             title="Otkaži operaciju"
                                             disabled={operationLocked}
                                         >

--- a/apps/app/app/admin/schedule/OperationCompletionAttachments.tsx
+++ b/apps/app/app/admin/schedule/OperationCompletionAttachments.tsx
@@ -8,7 +8,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 
-const THUMBNAIL_SIZE = 36;
+const THUMBNAIL_SIZE = 32;
 
 type OperationCompletionAttachmentsProps = {
     operationId: number;
@@ -52,6 +52,7 @@ export function OperationCompletionAttachments({
                     trigger={
                         <IconButton
                             variant="plain"
+                            size="xs"
                             title="Prikaži napomenu završetka"
                         >
                             <FileText className="size-4 shrink-0" />
@@ -72,7 +73,7 @@ export function OperationCompletionAttachments({
                 </Modal>
             )}
             {images.length > 0 && (
-                <div className="h-9 w-9 shrink-0 overflow-visible">
+                <div className="size-8 shrink-0 overflow-visible">
                     <ImageGallery
                         images={images}
                         previewWidth={THUMBNAIL_SIZE}

--- a/apps/app/app/admin/schedule/OperationRequirementIcons.tsx
+++ b/apps/app/app/admin/schedule/OperationRequirementIcons.tsx
@@ -50,7 +50,7 @@ export function OperationRequirementIcons({
                     key={key}
                     title={title}
                     className={cx(
-                        'inline-flex size-7 items-center justify-center rounded-md',
+                        'inline-flex size-6 items-center justify-center rounded-md',
                         required
                             ? 'text-amber-700 dark:text-amber-300'
                             : 'text-muted-foreground',

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -230,10 +230,16 @@ export function RaisedBedOperationsScheduleSection({
                 >
                     {raisedBedDetailsLink ? (
                         <Link href={raisedBedDetailsLink}>
-                            <RaisedBedLabel physicalId={physicalId} />
+                            <RaisedBedLabel
+                                physicalId={physicalId}
+                                size="compact"
+                            />
                         </Link>
                     ) : (
-                        <RaisedBedLabel physicalId={physicalId} />
+                        <RaisedBedLabel
+                            physicalId={physicalId}
+                            size="compact"
+                        />
                     )}
                     <Typography level="body2" className="text-muted-foreground">
                         {formatMinutes(durations.completed, true)} /{' '}
@@ -362,7 +368,7 @@ export function RaisedBedOperationsScheduleSection({
                     />
                 </Row>
             </Row>
-            <Stack spacing={2}>
+            <Stack spacing={0}>
                 {!dayOperations.length && (
                     <Typography level="body2">
                         Trenutno nema radnji za ovu gredicu.
@@ -440,7 +446,7 @@ export function RaisedBedOperationsScheduleSection({
                     return (
                         <div key={operation.id}>
                             <Row
-                                spacing={2}
+                                spacing={1}
                                 className={getScheduleTaskRowClassName({
                                     accepted: operationApproved,
                                     pendingAcceptance:
@@ -448,15 +454,11 @@ export function RaisedBedOperationsScheduleSection({
                                 })}
                             >
                                 <Row
-                                    spacing={2}
-                                    className="min-w-0 grow flex-wrap"
+                                    spacing={1}
+                                    className="min-w-0 flex-1 flex-nowrap"
                                 >
                                     {isOperationCompleted(operation.status) ? (
-                                        <Checkbox
-                                            className="size-5 mx-2"
-                                            checked
-                                            disabled
-                                        />
+                                        <Checkbox checked disabled />
                                     ) : operationPendingVerification ? (
                                         <VerifyOperationModal
                                             operationId={operation.id}
@@ -483,14 +485,12 @@ export function RaisedBedOperationsScheduleSection({
                                             }
                                         />
                                     ) : operationLocked ? (
-                                        <Checkbox
-                                            className="size-5 mx-2"
-                                            disabled
-                                        />
+                                        <Checkbox disabled />
                                     ) : operation.isAccepted ? (
                                         <CompleteOperationModal
                                             operationId={operation.id}
                                             label={operationLabel}
+                                            raisedBedPhysicalId={physicalId}
                                             conditions={
                                                 operationData?.conditions
                                             }
@@ -530,6 +530,7 @@ export function RaisedBedOperationsScheduleSection({
                                         <AcceptOperationModal
                                             operationId={operation.id}
                                             label={operationLabel}
+                                            raisedBedPhysicalId={physicalId}
                                             disabled={!operation.assignedUserId}
                                             onConfirm={() =>
                                                 runOptimisticAction({
@@ -554,6 +555,7 @@ export function RaisedBedOperationsScheduleSection({
                                         />
                                     )}
                                     <a
+                                        className="min-w-0 flex-1"
                                         href={
                                             operationData?.information?.label
                                                 ? KnownPages.GrediceOperation(
@@ -566,10 +568,12 @@ export function RaisedBedOperationsScheduleSection({
                                         rel="noopener noreferrer"
                                     >
                                         <Typography
+                                            level="body2"
+                                            noWrap
                                             className={
                                                 operationTextInactive
                                                     ? 'line-through text-muted-foreground'
-                                                    : undefined
+                                                    : ''
                                             }
                                         >
                                             {operationLabel}
@@ -578,7 +582,7 @@ export function RaisedBedOperationsScheduleSection({
                                     {operationStatusText && (
                                         <Typography
                                             level="body2"
-                                            className={`ml-1 italic ${operationStatusClassName}`}
+                                            className={`shrink-0 italic ${operationStatusClassName}`}
                                         >
                                             {operationStatusText}
                                         </Typography>
@@ -588,7 +592,7 @@ export function RaisedBedOperationsScheduleSection({
                                         <Typography
                                             level="body2"
                                             component="div"
-                                            className="select-none"
+                                            className="shrink-0 select-none"
                                         >
                                             {showScheduledDate ? (
                                                 <LocalDateTime time={false}>
@@ -606,7 +610,7 @@ export function RaisedBedOperationsScheduleSection({
                                         </Typography>
                                     )}
                                 </Row>
-                                <Row spacing={1} className="ml-auto shrink-0">
+                                <Row spacing={0} className="ml-auto shrink-0">
                                     {!isOperationCompleted(operation.status) &&
                                         !operationPendingVerification && (
                                             <OperationRequirementIcons
@@ -719,6 +723,7 @@ export function RaisedBedOperationsScheduleSection({
                                         trigger={
                                             <IconButton
                                                 variant="plain"
+                                                size="xs"
                                                 title={
                                                     operation.scheduledDate
                                                         ? 'Prerasporedi radnju'
@@ -765,6 +770,7 @@ export function RaisedBedOperationsScheduleSection({
                                         trigger={
                                             <IconButton
                                                 variant="plain"
+                                                size="xs"
                                                 title="Otkaži operaciju"
                                                 disabled={operationLocked}
                                             >

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -225,10 +225,16 @@ export function RaisedBedPlantingScheduleSection({
                 >
                     {raisedBedDetailsLink ? (
                         <Link href={raisedBedDetailsLink}>
-                            <RaisedBedLabel physicalId={physicalId} />
+                            <RaisedBedLabel
+                                physicalId={physicalId}
+                                size="compact"
+                            />
                         </Link>
                     ) : (
-                        <RaisedBedLabel physicalId={physicalId} />
+                        <RaisedBedLabel
+                            physicalId={physicalId}
+                            size="compact"
+                        />
                     )}
                     <Typography level="body2" className="text-muted-foreground">
                         {formatMinutes(durations.completed, true)} /{' '}
@@ -344,7 +350,7 @@ export function RaisedBedPlantingScheduleSection({
                     />
                 </Row>
             </Row>
-            <Stack spacing={2}>
+            <Stack spacing={0}>
                 {!dayFields.length && (
                     <Typography level="body2">
                         Trenutno nema sijanja za ovu gredicu.
@@ -427,22 +433,18 @@ export function RaisedBedPlantingScheduleSection({
                     return (
                         <div key={field.id}>
                             <Row
-                                spacing={2}
+                                spacing={1}
                                 className={getScheduleTaskRowClassName({
                                     accepted: fieldApprovedActive,
                                     pendingAcceptance: fieldPendingAcceptance,
                                 })}
                             >
                                 <Row
-                                    spacing={2}
-                                    className="min-w-0 grow flex-wrap"
+                                    spacing={1}
+                                    className="min-w-0 flex-1 flex-nowrap"
                                 >
                                     {fieldCompleted ? (
-                                        <Checkbox
-                                            className="size-5 mx-2"
-                                            checked
-                                            disabled
-                                        />
+                                        <Checkbox checked disabled />
                                     ) : fieldPendingVerification ? (
                                         <VerifyPlantingModal
                                             raisedBedId={field.raisedBedId}
@@ -476,6 +478,7 @@ export function RaisedBedPlantingScheduleSection({
                                             raisedBedId={field.raisedBedId}
                                             positionIndex={field.positionIndex}
                                             label={fieldLabel}
+                                            raisedBedPhysicalId={physicalId}
                                             disabled={!field.assignedUserId}
                                             onConfirm={() =>
                                                 runOptimisticAction({
@@ -503,14 +506,17 @@ export function RaisedBedPlantingScheduleSection({
                                     ) : (
                                         <CompletePlantingModal
                                             label={fieldLabel}
+                                            raisedBedPhysicalId={physicalId}
                                             onConfirm={handlePlantConfirm}
                                         />
                                     )}
                                     <Typography
+                                        level="body2"
+                                        noWrap
                                         className={
                                             fieldCompleted
-                                                ? 'line-through text-muted-foreground'
-                                                : undefined
+                                                ? 'min-w-0 flex-1 line-through text-muted-foreground'
+                                                : 'min-w-0 flex-1'
                                         }
                                     >
                                         {fieldLabel}
@@ -518,7 +524,7 @@ export function RaisedBedPlantingScheduleSection({
                                     {fieldStatusText && (
                                         <Typography
                                             level="body2"
-                                            className={`ml-1 italic ${fieldStatusClassName}`}
+                                            className={`shrink-0 italic ${fieldStatusClassName}`}
                                         >
                                             {fieldStatusText}
                                         </Typography>
@@ -528,7 +534,7 @@ export function RaisedBedPlantingScheduleSection({
                                         <Typography
                                             level="body2"
                                             component="div"
-                                            className="select-none"
+                                            className="shrink-0 select-none"
                                         >
                                             {showScheduledDate ? (
                                                 <LocalDateTime time={false}>
@@ -556,7 +562,8 @@ export function RaisedBedPlantingScheduleSection({
                                                 ? 'success'
                                                 : 'neutral'
                                         }
-                                        size="sm"
+                                        size="xs"
+                                        className="shrink-0"
                                         title={
                                             greenhouseSowing
                                                 ? 'Označeno za sijanje u stakleniku'
@@ -598,7 +605,7 @@ export function RaisedBedPlantingScheduleSection({
                                             : 'Direktno'}
                                     </Button>
                                 </Row>
-                                <Row spacing={1} className="ml-auto shrink-0">
+                                <Row spacing={0} className="ml-auto shrink-0">
                                     <AssignRaisedBedFieldModal
                                         raisedBedFieldId={field.id}
                                         label={fieldLabel}
@@ -677,6 +684,7 @@ export function RaisedBedPlantingScheduleSection({
                                         trigger={
                                             <IconButton
                                                 variant="plain"
+                                                size="xs"
                                                 title={
                                                     field.plantScheduledDate
                                                         ? 'Prerasporedi sijanje'
@@ -717,6 +725,7 @@ export function RaisedBedPlantingScheduleSection({
                                         trigger={
                                             <IconButton
                                                 variant="plain"
+                                                size="xs"
                                                 title="Otkaži sijanje"
                                                 disabled={fieldLocked}
                                             >

--- a/apps/app/app/admin/schedule/VerifyOperationModal.tsx
+++ b/apps/app/app/admin/schedule/VerifyOperationModal.tsx
@@ -48,7 +48,7 @@ export function VerifyOperationModal({
         <Button
             variant="solid"
             color="success"
-            size="sm"
+            size="xs"
             title="Verificiraj radnju"
             loading={isSubmitting}
             onClick={onClick}

--- a/apps/app/app/admin/schedule/VerifyPlantingModal.tsx
+++ b/apps/app/app/admin/schedule/VerifyPlantingModal.tsx
@@ -50,7 +50,7 @@ export function VerifyPlantingModal({
                 <Button
                     variant="solid"
                     color="success"
-                    size="sm"
+                    size="xs"
                     title="Verificiraj sijanje"
                     loading={isSubmitting}
                 >

--- a/apps/app/app/admin/schedule/scheduleShared.ts
+++ b/apps/app/app/admin/schedule/scheduleShared.ts
@@ -129,10 +129,10 @@ export function getScheduleTaskRowClassName({
     pendingAcceptance: boolean;
 }) {
     if (pendingAcceptance) {
-        return 'rounded bg-amber-50/80 text-foreground ring-1 ring-inset ring-amber-200/70 hover:bg-amber-100/80 dark:bg-amber-950/40 dark:ring-amber-900/70 dark:hover:bg-amber-950/60';
+        return 'min-w-0 flex-nowrap rounded bg-amber-50/80 text-foreground ring-1 ring-inset ring-amber-200/70 hover:bg-amber-100/80 dark:bg-amber-950/40 dark:ring-amber-900/70 dark:hover:bg-amber-950/60';
     }
 
-    return 'rounded hover:bg-muted';
+    return 'min-w-0 flex-nowrap rounded hover:bg-muted';
 }
 
 export function isSameScheduleDay(


### PR DESCRIPTION
## Summary
- Keep schedule task labels on one line with ellipsis and smaller body text
- Reduce vertical spacing between task rows and shrink row/header action controls for mobile
- Add raised-bed identity to raised-bed task confirmation modals so the clicked bed is clear

## Validation
- corepack pnpm lint --filter app
- corepack pnpm build --filter app
- corepack pnpm typecheck --filter app
- git diff --check