### PR TITLE
[codex] Fix confirmed operation schedule status

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -338,6 +338,53 @@ function plantedGrowingWithOperationHistoryScenario(): RaisedBedScenario {
     };
 }
 
+function plantedGrowingWithPendingOperationHistoryScenario(): RaisedBedScenario {
+    const scenario = plantedGrowingWithOperationHistoryScenario();
+    const operation = scenario.operations?.[0];
+
+    if (!operation) {
+        return scenario;
+    }
+
+    return {
+        ...scenario,
+        operationHistoryItems: [
+            ...(scenario.operationHistoryItems ?? []),
+            {
+                id: 903,
+                entityId: operation.id,
+                entityTypeName: 'operation',
+                raisedBedId: 1,
+                raisedBedFieldId: 1,
+                status: 'confirmed',
+                createdAt: '2026-06-23T00:00:00.000Z',
+                scheduledDate: '2026-06-24T00:00:00.000Z',
+                scheduledAt: '2026-06-23T00:00:00.000Z',
+                completedAt: null,
+                verifiedAt: null,
+                canceledAt: null,
+                imageUrls: [],
+                completionNotes: null,
+                targetLabel: 'Raised Bed 1 › Polje 1',
+                statusHistory: [
+                    {
+                        status: 'planned',
+                        changedAt: '2026-06-23T00:00:00.000Z',
+                    },
+                    {
+                        status: 'assigned',
+                        changedAt: '2026-06-23T08:00:00.000Z',
+                    },
+                    {
+                        status: 'confirmed',
+                        changedAt: '2026-06-23T09:00:00.000Z',
+                    },
+                ],
+            },
+        ],
+    };
+}
+
 function raisedBedScrollableOperationHistoryScenario(): RaisedBedScenario {
     const scenario = plantedGrowingWithOperationHistoryScenario();
     const baseOperationHistoryItem = scenario.operationHistoryItems?.[0];
@@ -980,7 +1027,7 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
     }) => {
         await mount(
             <RaisedBedFieldHudStory
-                scenario={plantedGrowingWithOperationHistoryScenario()}
+                scenario={plantedGrowingWithPendingOperationHistoryScenario()}
                 positionIndex={0}
             />,
         );
@@ -1033,6 +1080,22 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
             page.getByText('Obavljeno · Raised Bed 1 › Polje 1'),
         ).toBeVisible();
         await expect(page.getByText(/30 min/)).toHaveCount(0);
+
+        await page.keyboard.press('Escape');
+        await scheduleDialog
+            .getByRole('button', { name: 'Sljedeći mjesec' })
+            .click();
+        await expect(
+            scheduleDialog.locator('[data-event-calendar-month="2026-06"]'),
+        ).toBeVisible();
+        await scheduleDialog
+            .getByRole('button', {
+                name: /24\. 06\. 2026.*Površinsko zalijevanje/u,
+            })
+            .click();
+        await expect(
+            page.getByText('Zakazano · Raised Bed 1 › Polje 1'),
+        ).toBeVisible();
     });
 
     test('diary tab shows filtered operation history with photos and notes', async ({

--- a/packages/game/src/hud/raisedBed/RaisedBedWateringCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWateringCalendar.tsx
@@ -78,10 +78,13 @@ function operationDate(operation: GardenOperationItem) {
         return null;
     }
 
+    const completionDate =
+        dateFromUnknown(operation.verifiedAt) ??
+        dateFromUnknown(operation.completedAt);
+
     if (operation.status === 'completed') {
         return (
-            dateFromUnknown(operation.verifiedAt) ??
-            dateFromUnknown(operation.completedAt) ??
+            completionDate ??
             dateFromUnknown(operation.scheduledDate) ??
             dateFromUnknown(operation.createdAt)
         );
@@ -89,8 +92,9 @@ function operationDate(operation: GardenOperationItem) {
 
     if (operation.status === 'confirmed') {
         return (
-            dateFromUnknown(operation.completedAt) ??
+            completionDate ??
             dateFromUnknown(operation.scheduledDate) ??
+            dateFromUnknown(operation.scheduledAt) ??
             dateFromUnknown(operation.createdAt)
         );
     }
@@ -104,9 +108,19 @@ function operationDate(operation: GardenOperationItem) {
 function operationSource(
     operation: GardenOperationItem,
 ): WateringCalendarEntrySource {
-    return operation.status === 'completed' || operation.status === 'confirmed'
-        ? 'completed'
-        : 'scheduled';
+    if (operation.status === 'completed') {
+        return 'completed';
+    }
+
+    if (
+        operation.status === 'confirmed' &&
+        (dateFromUnknown(operation.verifiedAt) ??
+            dateFromUnknown(operation.completedAt))
+    ) {
+        return 'completed';
+    }
+
+    return 'scheduled';
 }
 
 function cartItemMatchesRaisedBed({

--- a/packages/game/src/hud/raisedBed/shared/OperationScheduleCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationScheduleCalendar.tsx
@@ -68,10 +68,13 @@ function operationDate(operation: GardenOperationItem) {
         return null;
     }
 
+    const completionDate =
+        dateFromUnknown(operation.verifiedAt) ??
+        dateFromUnknown(operation.completedAt);
+
     if (operation.status === 'completed') {
         return (
-            dateFromUnknown(operation.verifiedAt) ??
-            dateFromUnknown(operation.completedAt) ??
+            completionDate ??
             dateFromUnknown(operation.scheduledDate) ??
             dateFromUnknown(operation.createdAt)
         );
@@ -79,8 +82,9 @@ function operationDate(operation: GardenOperationItem) {
 
     if (operation.status === 'confirmed') {
         return (
-            dateFromUnknown(operation.completedAt) ??
+            completionDate ??
             dateFromUnknown(operation.scheduledDate) ??
+            dateFromUnknown(operation.scheduledAt) ??
             dateFromUnknown(operation.createdAt)
         );
     }
@@ -94,9 +98,19 @@ function operationDate(operation: GardenOperationItem) {
 function operationSource(
     operation: GardenOperationItem,
 ): OperationScheduleEntrySource {
-    return operation.status === 'completed' || operation.status === 'confirmed'
-        ? 'completed'
-        : 'scheduled';
+    if (operation.status === 'completed') {
+        return 'completed';
+    }
+
+    if (
+        operation.status === 'confirmed' &&
+        (dateFromUnknown(operation.verifiedAt) ??
+            dateFromUnknown(operation.completedAt))
+    ) {
+        return 'completed';
+    }
+
+    return 'scheduled';
 }
 
 function entryMeta({


### PR DESCRIPTION
## Summary

- Treat `confirmed` operation history as completed only when it has a completion or verification timestamp.
- Keep pending confirmed operation history labeled as scheduled in both standard and watering scheduling calendars.
- Add a regression assertion for a future confirmed operation without completion timestamps.

## Follow-up

Addresses the Codex review thread from #3710.

## Validation

- `git diff --check`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm --filter garden test:run tests/raised-bed-field-hud.spec.tsx -g "operation scheduling calendar shows previous history"`
- `corepack pnpm --filter garden test:run tests/watering-operations-calendar.spec.tsx`