### PR TITLE
Add raised bed photo modal shortcuts

### DIFF
--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -2,7 +2,7 @@ import type { FavoriteItem } from '@gredice/client';
 import { Modal } from '@gredice/ui/Modal';
 import * as ReactQuery from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
-import { type PropsWithChildren, useMemo, useState } from 'react';
+import { type PropsWithChildren, useEffect, useMemo, useState } from 'react';
 import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../../../packages/game/src/hooks/useCurrentGarden';
 import { favoritesQueryKey } from '../../../packages/game/src/hooks/useFavorites';
@@ -10,6 +10,7 @@ import { gardenOperationsQueryKey } from '../../../packages/game/src/hooks/useGa
 import { queryKeys as raisedBedAiHistoryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedAiHistory';
 import { queryKeys as raisedBedDiaryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedDiaryEntries';
 import { queryKeys as raisedBedFieldDiaryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedFieldDiaryEntries';
+import { RaisedBedFieldHud } from '../../../packages/game/src/hud/RaisedBedFieldHud';
 import { RaisedBedField } from '../../../packages/game/src/hud/raisedBed/RaisedBedField';
 import { RaisedBedFieldItem } from '../../../packages/game/src/hud/raisedBed/RaisedBedFieldItem';
 import { RaisedBedFieldSuggestions } from '../../../packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions';
@@ -17,6 +18,7 @@ import { RaisedBedInfo } from '../../../packages/game/src/hud/raisedBed/RaisedBe
 import {
     createGameState,
     GameStateContext,
+    useGameState,
 } from '../../../packages/game/src/useGameState';
 import {
     allPlants,
@@ -241,6 +243,39 @@ export function RaisedBedInfoModalStory({
         <RaisedBedHudTestProviders scenario={scenario}>
             <RaisedBedInfoModalStoryContent />
         </RaisedBedHudTestProviders>
+    );
+}
+
+export function RaisedBedCloseupHudStory({
+    scenario,
+}: {
+    scenario: RaisedBedScenario;
+}) {
+    return (
+        <RaisedBedHudTestProviders scenario={scenario}>
+            <RaisedBedCloseupHudStoryContent />
+        </RaisedBedHudTestProviders>
+    );
+}
+
+function RaisedBedCloseupHudStoryContent() {
+    const setView = useGameState((state) => state.setView);
+
+    useEffect(() => {
+        setView({
+            view: 'closeup',
+            block: {
+                id: 'raised-bed-1',
+                name: 'Raised_Bed',
+                rotation: 0,
+            },
+        });
+    }, [setView]);
+
+    return (
+        <div className="relative h-[620px] w-[720px]">
+            <RaisedBedFieldHud />
+        </div>
     );
 }
 

--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -108,7 +108,7 @@ function createScenarioQueryClient(
             pages: [
                 {
                     items: operationHistoryItems,
-                    nextCursor: null,
+                    nextCursor: scenario.operationHistoryNextCursor ?? null,
                     total: operationHistoryItems.length,
                 },
             ],

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -2,6 +2,7 @@ import type { FavoriteEntityType, FavoriteItem } from '@gredice/client';
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Page } from '@playwright/test';
 import {
+    RaisedBedCloseupHudStory,
     RaisedBedFieldDndDialogStory,
     RaisedBedFieldHudStory,
     RaisedBedFieldSuggestionsStory,
@@ -967,6 +968,80 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         ).toBeLessThanOrEqual(1);
     });
 
+    test('closeup HUD photo shortcut opens the raised bed photos modal', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedCloseupHudStory
+                scenario={plantedGrowingWithOperationHistoryScenario()}
+            />,
+        );
+
+        const photoButton = page.getByRole('button', {
+            name: /Fotografije gredice Raised Bed 1/u,
+        });
+        await expect(photoButton).toBeVisible();
+        await expect(photoButton).toContainText('Foto');
+
+        await photoButton.click();
+
+        const photosModal = page.locator('[data-raised-bed-photos-modal]');
+        await expect(
+            photosModal.getByRole('heading', { name: 'Fotografije gredice' }),
+        ).toBeVisible();
+        await expect(
+            photosModal.getByText('Površinsko zalijevanje gredice (20L)'),
+        ).toBeVisible();
+        await expect(
+            photosModal.locator('[data-raised-bed-photo-entry]'),
+        ).toHaveCount(1);
+        await expect(
+            photosModal.getByRole('button', {
+                name: /Pregledaj savjete suncokreta/u,
+            }),
+        ).toBeVisible();
+    });
+
+    test('plant modal header opens field-scoped photos with AI actions', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingWithOperationHistoryScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const plantDialog = page.getByRole('dialog');
+        const photoButton = plantDialog.getByRole('button', {
+            name: /Fotografije biljke Cherry rajčica/u,
+        });
+        await expect(photoButton).toBeVisible();
+
+        await photoButton.click();
+
+        const photosModal = page.locator('[data-raised-bed-photos-modal]');
+        await expect(
+            photosModal.getByRole('heading', { name: 'Fotografije biljke' }),
+        ).toBeVisible();
+        await expect(photosModal.getByText('Cherry rajčica')).toBeVisible();
+        await expect(
+            photosModal.getByText('Površinsko zalijevanje gredice (20L)'),
+        ).toBeVisible();
+        await expect(
+            photosModal.getByRole('button', {
+                name: /Pregledaj savjete suncokreta/u,
+            }),
+        ).toBeVisible();
+        await expect(
+            photosModal.getByText('Ovo je zapis za drugo polje.'),
+        ).toHaveCount(0);
+    });
+
     test('diary tab allows rescheduling future active operation cards', async ({
         mount,
         page,
@@ -1493,8 +1568,12 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
         const moreButton = dialog.getByRole('button', {
             name: 'Prikaži dodatne opcije gredice',
         });
+        const photoButton = dialog.getByRole('button', {
+            name: /Fotografije gredice Raised Bed 1/u,
+        });
         const tabList = dialog.getByRole('tablist');
         await expect(moreButton).toBeVisible();
+        await expect(photoButton).toBeVisible();
         await expect(tabList).toBeVisible();
 
         await expect

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1003,6 +1003,90 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         ).toBeVisible();
     });
 
+    test('closeup HUD photo shortcut searches older history pages before hiding', async ({
+        mount,
+        page,
+    }) => {
+        const scenario = plantedGrowingWithOperationHistoryScenario();
+        const baseOperation = scenario.operationHistoryItems?.[0];
+
+        if (!baseOperation) {
+            throw new Error('Expected operation history item.');
+        }
+
+        const firstPageWithoutPhotos = Array.from({ length: 20 }).map(
+            (_, index) => ({
+                ...baseOperation,
+                id: 800 + index,
+                imageUrls: [],
+                completionNotes: null,
+                statusHistory: [
+                    {
+                        status: 'completed' as const,
+                        changedAt: `2026-05-${String(12 - Math.floor(index / 2)).padStart(2, '0')}T09:00:00.000Z`,
+                    },
+                ],
+            }),
+        );
+        const olderOperationWithPhoto = {
+            ...baseOperation,
+            id: 999,
+            completedAt: '2026-04-20T08:00:00.000Z',
+            imageUrls: ['https://example.com/older-watering.jpg'],
+            completionNotes: 'Starija fotografija nakon pregleda tla.',
+            statusHistory: [
+                {
+                    status: 'completed' as const,
+                    changedAt: '2026-04-20T09:00:00.000Z',
+                },
+            ],
+        };
+
+        await page.route(
+            '**/api/gredice/api/gardens/*/operations**',
+            async (route) => {
+                const url = new URL(route.request().url());
+                const cursor = url.searchParams.get('cursor');
+
+                await route.fulfill({
+                    body: JSON.stringify({
+                        items: cursor === '20' ? [olderOperationWithPhoto] : [],
+                        nextCursor: null,
+                        total: 21,
+                    }),
+                    contentType: 'application/json',
+                    status: 200,
+                });
+            },
+        );
+
+        await mount(
+            <RaisedBedCloseupHudStory
+                scenario={{
+                    ...scenario,
+                    operationHistoryItems: firstPageWithoutPhotos,
+                    operationHistoryNextCursor: 20,
+                }}
+            />,
+        );
+
+        const photoButton = page.getByRole('button', {
+            name: /Fotografije gredice Raised Bed 1/u,
+        });
+        await expect(photoButton).toBeVisible();
+        await expect(photoButton).toContainText('1');
+
+        await photoButton.click();
+
+        const photosModal = page.locator('[data-raised-bed-photos-modal]');
+        await expect(
+            photosModal.getByText('Starija fotografija nakon pregleda tla.'),
+        ).toBeVisible();
+        await expect(
+            photosModal.locator('[data-raised-bed-photo-entry]'),
+        ).toHaveCount(1);
+    });
+
     test('plant modal header opens field-scoped photos with AI actions', async ({
         mount,
         page,

--- a/apps/garden/tests/raisedBedFieldHudScenarios.ts
+++ b/apps/garden/tests/raisedBedFieldHudScenarios.ts
@@ -154,6 +154,7 @@ export type RaisedBedScenario = {
     sorts?: PlantSortData[];
     operations?: OperationData[];
     operationHistoryItems?: GardenOperationItem[];
+    operationHistoryNextCursor?: number | null;
     raisedBedOperationDiaryEntries?: Array<{
         id: number;
         name: string;

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -23,6 +23,7 @@ import { RaisedBedField } from './raisedBed/RaisedBedField';
 import { RaisedBedFieldSuggestions } from './raisedBed/RaisedBedFieldSuggestions';
 import { RaisedBedGreenhouseSuggestion } from './raisedBed/RaisedBedGreenhouseSuggestion';
 import { RaisedBedInfo } from './raisedBed/RaisedBedInfo';
+import { RaisedBedPhotosModal } from './raisedBed/RaisedBedPhotosModal';
 import { RaisedBedSensorInfo } from './raisedBed/RaisedBedSensorInfo';
 import { RaisedBedWatering } from './raisedBed/RaisedBedWatering';
 
@@ -126,6 +127,17 @@ export function RaisedBedFieldHud() {
                             raisedBed={raisedBed}
                         />
                     </Modal>
+                </div>
+            )}
+            {currentGarden && raisedBed && !isSandbox && (
+                <div className="absolute z-40 top-[calc(var(--raised-bed-ui-top)+48px)] left-[var(--raised-bed-title-left)]">
+                    <RaisedBedPhotosModal
+                        gardenId={currentGarden.id}
+                        raisedBedId={raisedBed.id}
+                        subjectName={raisedBed.name}
+                        triggerPlacement="hud"
+                        hideWhenEmpty
+                    />
                 </div>
             )}
             <div className="absolute z-0 top-[calc(50%-1px)] left-1/2 -translate-x-1/2 -translate-y-1/2 w-[var(--raised-bed-grid-size)] h-[var(--raised-bed-grid-height)]">

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -50,6 +50,7 @@ import { RaisedBedFieldOperationsTab } from './RaisedBedFieldOperationsTab';
 import { RaisedBedFieldPlantHistoryModal } from './RaisedBedFieldPlantHistoryModal';
 import { RaisedBedFieldStatusChange } from './RaisedBedFieldStatusChange';
 import { RaisedBedOperationHistoryList } from './RaisedBedOperationHistoryList';
+import { RaisedBedPhotosModal } from './RaisedBedPhotosModal';
 import { RecommendationsCard } from './RecommendationsCard';
 import {
     parseScheduledSowingDateValue,
@@ -450,7 +451,7 @@ export function RaisedBedFieldItemPlanted({
             trigger={trigger ?? undefined}
         >
             <Stack spacing={4} className="min-w-0 max-w-full">
-                <Row spacing={4}>
+                <Row spacing={4} className="items-start pr-8">
                     {isGreenhouseSeedling ? (
                         <GreenhouseSeedlingPlantVisual
                             plantSort={plantSort}
@@ -489,6 +490,14 @@ export function RaisedBedFieldItemPlanted({
                             <span>Detalji</span>
                         </Link>
                     </Stack>
+                    {garden && !isHistorical && (
+                        <RaisedBedPhotosModal
+                            gardenId={garden.id}
+                            raisedBedId={raisedBedId}
+                            subjectName={plantSort.information.name}
+                            positionIndex={positionIndex}
+                        />
+                    )}
                 </Row>
                 <Tabs
                     value={activeTab}

--- a/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
@@ -22,6 +22,7 @@ import { useGameState } from '../../useGameState';
 import { RaisedBedInfoTab } from './RaisedBedInfoTab';
 import { RaisedBedOperationHistoryList } from './RaisedBedOperationHistoryList';
 import { RaisedBedOperationsTab } from './RaisedBedOperationsTab';
+import { RaisedBedPhotosModal } from './RaisedBedPhotosModal';
 
 type RaisedBedTab = 'diary' | 'operations' | 'info' | 'more';
 
@@ -68,7 +69,7 @@ export function RaisedBedInfo({
 
     return (
         <Stack spacing={4} className="min-w-0 max-w-full">
-            <div className="grid min-w-0 max-w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
+            <div className="grid min-w-0 max-w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 pr-8">
                 <Row spacing={4} className="min-w-0 flex-1 items-start">
                     <BlockImage
                         blockName="Raised_Bed"
@@ -85,21 +86,28 @@ export function RaisedBedInfo({
                         />
                     </Stack>
                 </Row>
-                <Button
-                    type="button"
-                    variant="plain"
-                    size="sm"
-                    aria-label="Prikaži dodatne opcije gredice"
-                    className={cx(
-                        'size-8 min-w-8 shrink-0 rounded-full p-0',
-                        activeTab === 'more'
-                            ? 'bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-300'
-                            : undefined,
-                    )}
-                    onClick={() => setActiveTab('more')}
-                >
-                    <MoreHorizontal className="size-4" />
-                </Button>
+                <Row spacing={2} className="items-start">
+                    <RaisedBedPhotosModal
+                        gardenId={gardenId}
+                        raisedBedId={raisedBed.id}
+                        subjectName={raisedBed.name}
+                    />
+                    <Button
+                        type="button"
+                        variant="plain"
+                        size="sm"
+                        aria-label="Prikaži dodatne opcije gredice"
+                        className={cx(
+                            'size-8 min-w-8 shrink-0 rounded-full p-0',
+                            activeTab === 'more'
+                                ? 'bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-300'
+                                : undefined,
+                        )}
+                        onClick={() => setActiveTab('more')}
+                    >
+                        <MoreHorizontal className="size-4" />
+                    </Button>
+                </Row>
             </div>
             <Tabs
                 value={activeTab}

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -24,40 +24,12 @@ import {
     sortNewestFirst,
 } from '../GardenOperationsHud';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
-
-type AiHistoryEntry = {
-    id: number;
-    description: string | undefined;
-    timestamp: Date;
-    imageUrls?: string[] | null;
-    isMarkdown?: boolean;
-};
-
-function buildFieldPositionById(
-    garden: ReturnType<typeof useCurrentGarden>['data'],
-) {
-    return new Map(
-        (garden?.raisedBeds ?? []).flatMap((raisedBed) =>
-            raisedBed.fields.map(
-                (field) => [field.id, field.positionIndex] as const,
-            ),
-        ),
-    );
-}
-
-function buildFieldPlantSortIdById(
-    garden: ReturnType<typeof useCurrentGarden>['data'],
-) {
-    return new Map(
-        (garden?.raisedBeds ?? []).flatMap((raisedBed) =>
-            raisedBed.fields.flatMap((field) =>
-                typeof field.plantSortId === 'number'
-                    ? [[field.id, field.plantSortId] as const]
-                    : [],
-            ),
-        ),
-    );
-}
+import {
+    buildFieldPlantSortIdById,
+    buildFieldPositionById,
+    getAiHistoryForOperation,
+    getOperationReferenceDate,
+} from './raisedBedOperationHistory';
 
 function filterOperationsByTarget({
     operations,
@@ -100,45 +72,6 @@ function filterOperationsByTarget({
 
         return true;
     });
-}
-
-function getAiHistoryForOperation({
-    imageUrls,
-    entries,
-}: {
-    imageUrls: string[];
-    entries: AiHistoryEntry[] | undefined;
-}) {
-    if (!imageUrls.length || !entries?.length) {
-        return undefined;
-    }
-
-    const relatedEntries = entries.filter((entry) => {
-        if (!entry.isMarkdown || !entry.imageUrls?.length) {
-            return false;
-        }
-
-        return imageUrls.some((imageUrl) =>
-            entry.imageUrls?.includes(imageUrl),
-        );
-    });
-
-    return relatedEntries.length
-        ? relatedEntries.sort(
-              (a, b) => b.timestamp.getTime() - a.timestamp.getTime(),
-          )
-        : undefined;
-}
-
-function getOperationReferenceDate(operation: GardenOperationItem) {
-    return (
-        operation.completedAt ??
-        operation.verifiedAt ??
-        operation.canceledAt ??
-        operation.scheduledAt ??
-        operation.scheduledDate ??
-        operation.createdAt
-    );
 }
 
 export function RaisedBedOperationHistoryList({

--- a/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
@@ -10,7 +10,7 @@ import { Spinner } from '@gredice/ui/Spinner';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useGardenOperations } from '../../hooks/useGardenOperations';
 import { useOperations } from '../../hooks/useOperations';
@@ -125,6 +125,21 @@ export function RaisedBedPhotosModal({
     const modalTitle = isFieldScoped
         ? 'Fotografije biljke'
         : 'Fotografije gredice';
+    const shouldFetchOlderPhotos =
+        hideWhenEmpty &&
+        photoCount === 0 &&
+        !history.isLoading &&
+        !history.isError &&
+        !history.isFetchingNextPage &&
+        Boolean(history.hasNextPage);
+
+    useEffect(() => {
+        if (!shouldFetchOlderPhotos) {
+            return;
+        }
+
+        void history.fetchNextPage();
+    }, [history.fetchNextPage, shouldFetchOlderPhotos]);
 
     if (hideWhenEmpty && (history.isError || photoCount === 0)) {
         return null;
@@ -270,6 +285,7 @@ export function RaisedBedPhotosModal({
                     const operationDateLabel = getDateLabel(
                         getOperationReferenceDate(operation),
                     );
+                    const completionNotes = operation.completionNotes?.trim();
 
                     return (
                         <div
@@ -315,6 +331,14 @@ export function RaisedBedPhotosModal({
                                     previewWidth={240}
                                     previewLimitBeforeStack={5}
                                 />
+                                {completionNotes && (
+                                    <Typography
+                                        level="body2"
+                                        className="break-words"
+                                    >
+                                        {completionNotes}
+                                    </Typography>
+                                )}
                                 <Row
                                     spacing={2}
                                     className="items-center justify-between gap-y-2"

--- a/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
@@ -1,0 +1,360 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
+import { ImageGallery } from '@gredice/ui/ImageGallery';
+import { Camera, Navigate } from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
+import { Row } from '@gredice/ui/Row';
+import { Spinner } from '@gredice/ui/Spinner';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import { useMemo } from 'react';
+import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { useGardenOperations } from '../../hooks/useGardenOperations';
+import { useOperations } from '../../hooks/useOperations';
+import { useRaisedBedAiHistory } from '../../hooks/useRaisedBedAiHistory';
+import { ButtonGreen } from '../../shared-ui/ButtonGreen';
+import { sortNewestFirst } from '../GardenOperationsHud';
+import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
+import {
+    buildFieldPositionById,
+    getAiHistoryForOperation,
+    getOperationReferenceDate,
+} from './raisedBedOperationHistory';
+
+const PHOTO_PAGE_SIZE = 20;
+
+type RaisedBedPhotosModalProps = {
+    gardenId: number;
+    raisedBedId: number;
+    subjectName: string;
+    positionIndex?: number;
+    triggerPlacement?: 'hud' | 'header';
+    hideWhenEmpty?: boolean;
+    className?: string;
+};
+
+function getDateLabel(value: string | Date | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    return date.toLocaleDateString('hr-HR', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+    });
+}
+
+function getPhotoCountLabel(photoCount: number) {
+    if (photoCount === 1) {
+        return '1 fotografija';
+    }
+
+    if (photoCount > 1 && photoCount < 5) {
+        return `${photoCount} fotografije`;
+    }
+
+    return `${photoCount} fotografija`;
+}
+
+export function RaisedBedPhotosModal({
+    gardenId,
+    raisedBedId,
+    subjectName,
+    positionIndex,
+    triggerPlacement = 'header',
+    hideWhenEmpty = false,
+    className,
+}: RaisedBedPhotosModalProps) {
+    const { data: currentGarden } = useCurrentGarden();
+    const { data: operationsData } = useOperations();
+    const history = useGardenOperations({
+        includeCompleted: true,
+        pageSize: PHOTO_PAGE_SIZE,
+        raisedBedId,
+        positionIndex,
+    });
+    const { data: aiHistoryEntries } = useRaisedBedAiHistory(
+        gardenId,
+        raisedBedId,
+        { enabled: Boolean(gardenId && raisedBedId) },
+    );
+    const fieldPositionById = useMemo(
+        () => buildFieldPositionById(currentGarden),
+        [currentGarden],
+    );
+    const operationDataById = useMemo(
+        () =>
+            new Map(
+                (operationsData ?? []).map((operation) => [
+                    operation.id,
+                    operation,
+                ]),
+            ),
+        [operationsData],
+    );
+    const photoOperations = useMemo(
+        () =>
+            sortNewestFirst(
+                history.data?.pages
+                    .flatMap((page) => page.items)
+                    .filter((operation) => operation.imageUrls.length > 0) ??
+                    [],
+            ),
+        [history.data?.pages],
+    );
+    const photoCount = photoOperations.reduce(
+        (count, operation) => count + operation.imageUrls.length,
+        0,
+    );
+    const latestImageUrls = Array.from(
+        new Set(photoOperations.flatMap((operation) => operation.imageUrls)),
+    ).slice(0, 3);
+    const isFieldScoped = typeof positionIndex === 'number';
+    const triggerLabel = isFieldScoped
+        ? `Fotografije biljke ${subjectName}`
+        : `Fotografije gredice ${subjectName}`;
+    const modalTitle = isFieldScoped
+        ? 'Fotografije biljke'
+        : 'Fotografije gredice';
+
+    if (hideWhenEmpty && (history.isError || photoCount === 0)) {
+        return null;
+    }
+
+    const thumbnail = (
+        <span className="relative flex size-full items-center justify-center overflow-hidden rounded-[inherit] bg-card">
+            {latestImageUrls.length > 0 ? (
+                latestImageUrls.map((imageUrl, index) => (
+                    <span
+                        key={imageUrl}
+                        className="absolute overflow-hidden rounded-[inherit] border border-white/80 bg-muted shadow-sm"
+                        style={{
+                            inset: index === 0 ? 0 : `${index * 4}px`,
+                            zIndex: latestImageUrls.length - index,
+                            transform:
+                                index === 0
+                                    ? undefined
+                                    : `translate(${index * 4}px, ${index * -3}px) rotate(${index * 4}deg)`,
+                        }}
+                    >
+                        {/** biome-ignore lint/performance/noImgElement: Operation photos come from runtime data and can use external blob hosts. */}
+                        <img
+                            src={imageUrl}
+                            alt=""
+                            className="size-full object-cover"
+                            loading="lazy"
+                        />
+                    </span>
+                ))
+            ) : (
+                <Camera className="size-5 text-muted-foreground" />
+            )}
+        </span>
+    );
+
+    const photoCountBadge =
+        photoCount > 0 ? (
+            <span className="absolute -bottom-1 -right-1 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold leading-none text-primary-foreground shadow-sm">
+                {photoCount}
+            </span>
+        ) : null;
+    const trigger =
+        triggerPlacement === 'hud' ? (
+            <ButtonGreen
+                variant="plain"
+                className={cx(
+                    'h-12 w-24 rounded-2xl p-1 shadow-lg ring-1 ring-black/10',
+                    className,
+                )}
+                aria-label={triggerLabel}
+                title={triggerLabel}
+            >
+                <span className="relative flex h-full w-full items-center justify-start">
+                    <span className="relative size-10 shrink-0 rounded-xl">
+                        {thumbnail}
+                        {photoCountBadge}
+                    </span>
+                    <span className="ml-2 flex min-w-0 flex-col items-start">
+                        <span className="text-xs font-semibold leading-tight">
+                            Foto
+                        </span>
+                        <span className="text-[11px] leading-tight text-primary/70">
+                            {photoCount > 0 ? photoCount : '...'}
+                        </span>
+                    </span>
+                </span>
+            </ButtonGreen>
+        ) : (
+            <button
+                type="button"
+                className={cx(
+                    'relative inline-flex size-14 shrink-0 items-center justify-center rounded-2xl border bg-card p-1 shadow-xs transition hover:bg-accent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700 focus-visible:ring-offset-2',
+                    className,
+                )}
+                aria-label={triggerLabel}
+                title={triggerLabel}
+            >
+                {thumbnail}
+                {photoCountBadge}
+            </button>
+        );
+
+    return (
+        <Modal
+            title={modalTitle}
+            className="overflow-x-hidden md:max-w-5xl md:border-tertiary md:border-b-4"
+            trigger={trigger}
+        >
+            <Stack
+                spacing={4}
+                className="min-w-0 max-w-full"
+                data-raised-bed-photos-modal
+            >
+                <Row
+                    spacing={4}
+                    className="min-w-0 flex-wrap items-start justify-between gap-y-2"
+                >
+                    <Stack spacing={1} className="min-w-0">
+                        <Typography level="h4" component="h1">
+                            {modalTitle}
+                        </Typography>
+                        <Typography level="body2" secondary>
+                            {subjectName}
+                        </Typography>
+                    </Stack>
+                    {photoCount > 0 && (
+                        <Chip variant="soft">
+                            {getPhotoCountLabel(photoCount)}
+                        </Chip>
+                    )}
+                </Row>
+                {history.isError && (
+                    <Alert color="danger">
+                        Došlo je do pogreške prilikom učitavanja fotografija.
+                    </Alert>
+                )}
+                {history.isLoading && (
+                    <Spinner
+                        loading
+                        loadingLabel="Učitavanje fotografija..."
+                        className="mx-auto my-8 flex items-center justify-center"
+                    />
+                )}
+                {!history.isLoading && !history.isError && photoCount === 0 && (
+                    <NoDataPlaceholder className="p-4">
+                        Nema zabilježenih fotografija.
+                    </NoDataPlaceholder>
+                )}
+                {photoOperations.map((operation) => {
+                    const operationData =
+                        operation.entityTypeName === 'operation'
+                            ? operationDataById.get(operation.entityId)
+                            : undefined;
+                    const entryName =
+                        operationData?.information.label ??
+                        operation.targetLabel;
+                    const operationPositionIndex =
+                        positionIndex ??
+                        (operation.raisedBedFieldId
+                            ? fieldPositionById.get(operation.raisedBedFieldId)
+                            : undefined);
+                    const operationDateLabel = getDateLabel(
+                        getOperationReferenceDate(operation),
+                    );
+
+                    return (
+                        <div
+                            key={`${operation.entityTypeName}-${operation.id}`}
+                            className="rounded-xl border bg-card p-3 shadow-xs"
+                            data-raised-bed-photo-entry
+                        >
+                            <Stack spacing={3}>
+                                <Row
+                                    spacing={2}
+                                    className="min-w-0 flex-wrap items-start justify-between gap-y-2"
+                                >
+                                    <Stack spacing={0.5} className="min-w-0">
+                                        <Typography
+                                            level="body1"
+                                            semiBold
+                                            className="break-words"
+                                        >
+                                            {entryName}
+                                        </Typography>
+                                        <Typography level="body3" secondary>
+                                            {operationDateLabel ??
+                                                operation.targetLabel}
+                                        </Typography>
+                                    </Stack>
+                                    <Chip variant="soft">
+                                        {getPhotoCountLabel(
+                                            operation.imageUrls.length,
+                                        )}
+                                    </Chip>
+                                </Row>
+                                <ImageGallery
+                                    images={operation.imageUrls.map(
+                                        (imageUrl, imageIndex) => ({
+                                            src: imageUrl,
+                                            alt: `${entryName} ${imageIndex + 1}`,
+                                            dateLabel:
+                                                operationDateLabel ?? undefined,
+                                        }),
+                                    )}
+                                    previewAs="div"
+                                    previewVariant="grid"
+                                    previewWidth={240}
+                                    previewLimitBeforeStack={5}
+                                />
+                                <Row
+                                    spacing={2}
+                                    className="items-center justify-between gap-y-2"
+                                >
+                                    <Typography level="body3" secondary>
+                                        {operation.targetLabel}
+                                    </Typography>
+                                    <RaisedBedDiaryAiAction
+                                        gardenId={gardenId}
+                                        raisedBedId={raisedBedId}
+                                        positionIndex={operationPositionIndex}
+                                        entryName={entryName}
+                                        imageUrls={operation.imageUrls}
+                                        referenceDate={getOperationReferenceDate(
+                                            operation,
+                                        )}
+                                        historyEntries={getAiHistoryForOperation(
+                                            {
+                                                imageUrls: operation.imageUrls,
+                                                entries: aiHistoryEntries,
+                                            },
+                                        )}
+                                    />
+                                </Row>
+                            </Stack>
+                        </div>
+                    );
+                })}
+                {history.hasNextPage && (
+                    <Button
+                        variant="plain"
+                        size="sm"
+                        loading={history.isFetchingNextPage}
+                        onClick={() => history.fetchNextPage()}
+                        endDecorator={<Navigate className="size-4" />}
+                    >
+                        Prikaži više
+                    </Button>
+                )}
+            </Stack>
+        </Modal>
+    );
+}

--- a/packages/game/src/hud/raisedBed/raisedBedOperationHistory.ts
+++ b/packages/game/src/hud/raisedBed/raisedBedOperationHistory.ts
@@ -1,0 +1,75 @@
+import type { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import type { GardenOperationItem } from '../../hooks/useGardenOperations';
+
+export type RaisedBedAiHistoryEntry = {
+    id: number;
+    description: string | undefined;
+    timestamp: Date;
+    imageUrls?: string[] | null;
+    isMarkdown?: boolean;
+};
+
+export function buildFieldPositionById(
+    garden: ReturnType<typeof useCurrentGarden>['data'],
+) {
+    return new Map(
+        (garden?.raisedBeds ?? []).flatMap((raisedBed) =>
+            raisedBed.fields.map(
+                (field) => [field.id, field.positionIndex] as const,
+            ),
+        ),
+    );
+}
+
+export function buildFieldPlantSortIdById(
+    garden: ReturnType<typeof useCurrentGarden>['data'],
+) {
+    return new Map(
+        (garden?.raisedBeds ?? []).flatMap((raisedBed) =>
+            raisedBed.fields.flatMap((field) =>
+                typeof field.plantSortId === 'number'
+                    ? [[field.id, field.plantSortId] as const]
+                    : [],
+            ),
+        ),
+    );
+}
+
+export function getAiHistoryForOperation({
+    imageUrls,
+    entries,
+}: {
+    imageUrls: string[];
+    entries: RaisedBedAiHistoryEntry[] | undefined;
+}) {
+    if (!imageUrls.length || !entries?.length) {
+        return undefined;
+    }
+
+    const relatedEntries = entries.filter((entry) => {
+        if (!entry.isMarkdown || !entry.imageUrls?.length) {
+            return false;
+        }
+
+        return imageUrls.some((imageUrl) =>
+            entry.imageUrls?.includes(imageUrl),
+        );
+    });
+
+    return relatedEntries.length
+        ? relatedEntries.sort(
+              (a, b) => b.timestamp.getTime() - a.timestamp.getTime(),
+          )
+        : undefined;
+}
+
+export function getOperationReferenceDate(operation: GardenOperationItem) {
+    return (
+        operation.completedAt ??
+        operation.verifiedAt ??
+        operation.canceledAt ??
+        operation.scheduledAt ??
+        operation.scheduledDate ??
+        operation.createdAt
+    );
+}


### PR DESCRIPTION
## Summary
- Add a raised bed photos modal trigger to the closeup HUD, plant header, and raised bed info header
- Surface photo-specific actions and history in the new modal for both bed-scoped and plant-scoped views
- Add Playwright component coverage for closeup, plant, and mobile HUD entry points

## Testing
- Not run (not requested)