### PR TITLE
[codex] Fix schedule avatar trigger width

### DIFF
--- a/apps/app/app/admin/schedule/AssignOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AssignOperationModal.tsx
@@ -120,7 +120,7 @@ export function AssignOperationModal({
         (assignedUsers?.length ?? 0) > 0 ? (
             <button
                 type="button"
-                className="inline-flex size-7 items-center justify-center rounded-full transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex h-7 min-w-7 items-center justify-center rounded-full transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
                 title={`Dodijeljeno korisnika: ${assignedUsers?.length ?? 0}`}
                 aria-label={`Dodijeljeno korisnika: ${assignedUsers?.length ?? 0}`}
                 disabled={!canOpen}

--- a/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
+++ b/apps/app/app/admin/schedule/AssignRaisedBedFieldModal.tsx
@@ -138,7 +138,7 @@ export function AssignRaisedBedFieldModal({
         selectedUsers.length > 0 ? (
             <button
                 type="button"
-                className="inline-flex size-7 items-center justify-center rounded-full transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex h-7 min-w-7 items-center justify-center rounded-full transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
                 title={`Dodijeljeno korisnika: ${selectedUsers.length}`}
                 aria-label={`Dodijeljeno korisnika: ${selectedUsers.length}`}
                 disabled={!canOpen}


### PR DESCRIPTION
## Summary
- keep assigned-user avatar triggers compact vertically while allowing content-sized width
- fixes multi-user avatar stacks overlapping neighboring schedule actions

## Validation
- corepack pnpm lint --filter app
- git diff --check

Follow-up for review feedback on #3712.