### PR TITLE
[codex] Polish recommendation sections

### DIFF
--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -185,7 +185,15 @@ function RaisedBedHudTestProviders({
         <NuqsTestingAdapter>
             <ReactQuery.QueryClientProvider client={queryClient}>
                 <GameStateContext.Provider value={gameStore}>
-                    <GameAnalyticsProvider capture={() => undefined}>
+                    <GameAnalyticsProvider
+                        capture={(eventName, properties) => {
+                            window.dispatchEvent(
+                                new CustomEvent('gredice:game-analytics', {
+                                    detail: { eventName, properties },
+                                }),
+                            );
+                        }}
+                    >
                         {children}
                     </GameAnalyticsProvider>
                 </GameStateContext.Provider>

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -21,6 +21,19 @@ import {
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
 const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
 const favoriteTimestamp = '2026-06-01T00:00:00.000Z';
+const healthRecommendationsViewedEvent =
+    'game_plant_health_recommendations_viewed';
+
+type AnalyticsEvent = {
+    eventName: string;
+    properties?: Record<string, unknown>;
+};
+
+declare global {
+    interface Window {
+        recordGameAnalyticsEvent?: (event: unknown) => void;
+    }
+}
 
 function favoriteItem({
     entityId,
@@ -113,6 +126,41 @@ async function mockFavoriteRequests(
             status: 200,
         });
     });
+}
+
+async function captureGameAnalyticsEvents(page: Page) {
+    const analyticsEvents: AnalyticsEvent[] = [];
+
+    await page.exposeFunction('recordGameAnalyticsEvent', (event: unknown) => {
+        if (!isRecord(event) || typeof event.eventName !== 'string') {
+            return;
+        }
+
+        analyticsEvents.push({
+            eventName: event.eventName,
+            properties: isRecord(event.properties)
+                ? event.properties
+                : undefined,
+        });
+    });
+
+    await page.evaluate(() => {
+        window.addEventListener('gredice:game-analytics', (event) => {
+            if (event instanceof CustomEvent) {
+                window.recordGameAnalyticsEvent?.(event.detail);
+            }
+        });
+    });
+
+    return analyticsEvents;
+}
+
+function countAnalyticsEvents(
+    analyticsEvents: AnalyticsEvent[],
+    eventName: string,
+) {
+    return analyticsEvents.filter((event) => event.eventName === eventName)
+        .length;
 }
 
 function emptyScenario(): RaisedBedScenario {
@@ -973,6 +1021,8 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         mount,
         page,
     }) => {
+        const analyticsEvents = await captureGameAnalyticsEvents(page);
+
         await mount(
             <RaisedBedFieldHudStory
                 scenario={plantedGrowingWithHealthRecommendedOperationsScenario()}
@@ -1000,6 +1050,14 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
             '[data-plant-health-operation-list]',
         );
         await expect(healthList).toHaveCount(0);
+        await expect
+            .poll(() =>
+                countAnalyticsEvents(
+                    analyticsEvents,
+                    healthRecommendationsViewedEvent,
+                ),
+            )
+            .toBe(0);
 
         const healthHeader = healthSection.getByRole('button', {
             name: /Zdravlje biljke/,
@@ -1009,10 +1067,27 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(healthSection.getByText('Lisne uši')).toBeVisible();
         await expect(healthList).toBeVisible();
         await expect(healthList).toContainText('Ispiranje biljke od štetnika');
+        await expect
+            .poll(() =>
+                countAnalyticsEvents(
+                    analyticsEvents,
+                    healthRecommendationsViewedEvent,
+                ),
+            )
+            .toBe(1);
 
         await healthHeader.click();
         await expect(healthSection.getByTitle('1 preporuka')).toBeVisible();
         await expect(healthList).toHaveCount(0);
+        await healthHeader.click();
+        await expect
+            .poll(() =>
+                countAnalyticsEvents(
+                    analyticsEvents,
+                    healthRecommendationsViewedEvent,
+                ),
+            )
+            .toBe(1);
     });
 
     test('favorite operations are ranked first in recommendations and operation choices', async ({

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -705,6 +705,10 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(
             dialog.getByRole('tab', { name: /Dnevnik/ }),
         ).toBeVisible();
+        await dialog
+            .locator('[data-recommendation-section="operations"]')
+            .getByRole('button', { name: /Radnje/ })
+            .click();
         await expect(
             dialog.getByRole('button', { name: /Kontrola sadnice/ }),
         ).toBeVisible();
@@ -914,17 +918,28 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(
             operationsSection.locator('svg.lucide-hammer'),
         ).toBeVisible();
+        await expect(
+            operationsSection.locator('[data-recommendation-section-icon]'),
+        ).not.toHaveClass(/green/);
+        await expect(
+            operationsSection.locator('[data-recommendation-section-count]'),
+        ).toHaveClass(/size-5/);
+        await expect(operationsSection.getByTitle('2 preporuka')).toBeVisible();
 
         const recommendationsList = dialog.locator(
             '[data-recommended-operation-list]',
         );
-        await expect(recommendationsList).toBeVisible();
-        await expect(recommendationsList).toContainText('Okopavanje');
-        await expect(recommendationsList).toContainText('Uklanjanje korova');
+        await expect(recommendationsList).toHaveCount(0);
 
         const operationsHeader = operationsSection.getByRole('button', {
             name: /Radnje/,
         });
+        await operationsHeader.click();
+
+        await expect(recommendationsList).toBeVisible();
+        await expect(recommendationsList).toContainText('Okopavanje');
+        await expect(recommendationsList).toContainText('Uklanjanje korova');
+
         await operationsHeader.click();
         await expect(operationsSection.getByTitle('2 preporuka')).toBeVisible();
         await expect(recommendationsList).toHaveCount(0);
@@ -973,19 +988,29 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         );
         await expect(healthSection).toBeVisible();
         await expect(healthSection.locator('svg.lucide-plus')).toBeVisible();
-        await expect(healthSection.getByText('Lisne uši')).toBeVisible();
+        await expect(
+            healthSection.locator('[data-recommendation-section-icon]'),
+        ).not.toHaveClass(/green/);
+        await expect(
+            healthSection.locator('[data-recommendation-section-count]'),
+        ).toHaveClass(/size-5/);
+        await expect(healthSection.getByTitle('1 preporuka')).toBeVisible();
 
         const healthList = healthSection.locator(
             '[data-plant-health-operation-list]',
         );
-        await expect(healthList).toBeVisible();
-        await expect(healthList).toContainText('Ispiranje biljke od štetnika');
+        await expect(healthList).toHaveCount(0);
 
         const healthHeader = healthSection.getByRole('button', {
             name: /Zdravlje biljke/,
         });
         await healthHeader.click();
 
+        await expect(healthSection.getByText('Lisne uši')).toBeVisible();
+        await expect(healthList).toBeVisible();
+        await expect(healthList).toContainText('Ispiranje biljke od štetnika');
+
+        await healthHeader.click();
         await expect(healthSection.getByTitle('1 preporuka')).toBeVisible();
         await expect(healthList).toHaveCount(0);
     });
@@ -1010,6 +1035,10 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await page.getByRole('button').first().click();
 
         const dialog = page.getByRole('dialog');
+        await dialog
+            .locator('[data-recommendation-section="operations"]')
+            .getByRole('button', { name: /Radnje/ })
+            .click();
         const recommendationsList = dialog.locator(
             '[data-recommended-operation-list]',
         );

--- a/packages/game/src/hud/raisedBed/RecommendationSection.tsx
+++ b/packages/game/src/hud/raisedBed/RecommendationSection.tsx
@@ -33,7 +33,10 @@ export function RecommendationSection({
             >
                 <Row spacing={2} justifyContent="space-between">
                     <Row spacing={2} alignItems="center" className="min-w-0">
-                        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-200">
+                        <span
+                            className="flex size-5 shrink-0 items-center justify-center text-muted-foreground"
+                            data-recommendation-section-icon
+                        >
                             {icon}
                         </span>
                         <Typography level="body2" semiBold noWrap>
@@ -41,7 +44,8 @@ export function RecommendationSection({
                         </Typography>
                         {!open && (
                             <span
-                                className="inline-flex min-w-6 items-center justify-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold leading-none text-green-700 dark:bg-green-900/50 dark:text-green-200"
+                                className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-green-100 text-[11px] font-semibold leading-none text-green-700 dark:bg-green-900/50 dark:text-green-200"
+                                data-recommendation-section-count
                                 title={`${count} preporuka`}
                             >
                                 {count}

--- a/packages/game/src/hud/raisedBed/RecommendationsCard.tsx
+++ b/packages/game/src/hud/raisedBed/RecommendationsCard.tsx
@@ -47,8 +47,8 @@ export function RecommendationsCard({
     plantSortId?: number;
 }) {
     const { track } = useGameAnalytics();
-    const [operationsOpen, setOperationsOpen] = useState(true);
-    const [healthOpen, setHealthOpen] = useState(true);
+    const [operationsOpen, setOperationsOpen] = useState(false);
+    const [healthOpen, setHealthOpen] = useState(false);
     const favoriteOperationIds = useFavoriteIds('operation');
     // Fetch and prepare data for recommendations
     const {

--- a/packages/game/src/hud/raisedBed/RecommendationsCard.tsx
+++ b/packages/game/src/hud/raisedBed/RecommendationsCard.tsx
@@ -237,6 +237,7 @@ export function RecommendationsCard({
 
     useEffect(() => {
         if (
+            !healthOpen ||
             !healthRecommendationViewKey ||
             lastTrackedHealthRecommendationViewKey.current ===
                 healthRecommendationViewKey
@@ -256,6 +257,7 @@ export function RecommendationsCard({
         });
     }, [
         gardenId,
+        healthOpen,
         healthRecommendationViewKey,
         healthRecommendedOperations.length,
         plantHealthIssues.length,


### PR DESCRIPTION
## Summary
- collapse both recommendation sections by default
- make leading section icons visually neutral so count badges stay prominent
- render collapsed recommendation counts as fully round green badges

## Validation
- pnpm lint --filter @gredice/game --filter garden
- pnpm typecheck --filter @gredice/game --filter garden
- pnpm --filter garden test:prepare
- pnpm --filter garden test:run -- tests/raised-bed-field-hud.spec.tsx