### PR TITLE
[codex] Fix collapsed water stack height

### DIFF
--- a/packages/game/src/controls/PickupPlacementResolver.ts
+++ b/packages/game/src/controls/PickupPlacementResolver.ts
@@ -10,7 +10,11 @@ import {
 } from '../dragPreviewIdentity';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
-import { getBlockDataByName, getStackHeight } from '../utils/stackHeightCore';
+import {
+    getBlockDataByName,
+    getStackBlockHeight,
+    getStackHeight,
+} from '../utils/stackHeightCore';
 import { isRecyclerPlacementTarget } from './recyclerPlacement';
 
 export type MovingSegment = {
@@ -83,7 +87,12 @@ function createOccupiedCells({
         let stackHeight = 0;
         stack.blocks.forEach((block, blockIndex) => {
             const blockEntity = getBlockDataByName(blockData, block.name);
-            const blockHeight = blockEntity?.attributes?.height ?? 0;
+            const blockHeight = getStackBlockHeight(
+                blockData,
+                stack,
+                block,
+                blockIndex,
+            );
 
             if (!movingBlockIds.has(block.id)) {
                 for (const offset of getGardenBlockFootprintOffsets(

--- a/packages/game/src/entities/waterBlockHeight.ts
+++ b/packages/game/src/entities/waterBlockHeight.ts
@@ -1,7 +1,11 @@
 import type { BlockData } from '@gredice/client';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
-import { getBlockDataByName, getStackHeight } from '../utils/stackHeightCore';
+import {
+    getBlockDataByName,
+    getStackHeight,
+    isEdgeOrCornerTerrainBlockName,
+} from '../utils/stackHeightCore';
 import {
     defaultWaterBlockVisualHeight,
     waterBlockBottomOverlap,
@@ -14,13 +18,6 @@ export type WaterBlockVerticalRange = {
     min: number;
 };
 
-function isEdgeOrCornerTerrainBlock(blockName: string) {
-    return (
-        blockName.startsWith('Block_') &&
-        (blockName.endsWith('_Angle') || blockName.endsWith('_Corner'))
-    );
-}
-
 function getWaterBlockIndex(stack: Stack, block: Block) {
     return stack.blocks.indexOf(block);
 }
@@ -32,7 +29,9 @@ function getWaterSupportBlock(stack: Stack, block: Block) {
 
 function isWaterFillSupportBlock(stack: Stack, block: Block) {
     const supportBlock = getWaterSupportBlock(stack, block);
-    return supportBlock ? isEdgeOrCornerTerrainBlock(supportBlock.name) : false;
+    return supportBlock
+        ? isEdgeOrCornerTerrainBlockName(supportBlock.name)
+        : false;
 }
 
 export function getWaterBlockVisualHeight({
@@ -46,7 +45,7 @@ export function getWaterBlockVisualHeight({
 }) {
     const supportBlock = getWaterSupportBlock(stack, block);
 
-    if (!supportBlock || !isEdgeOrCornerTerrainBlock(supportBlock.name)) {
+    if (!supportBlock || !isEdgeOrCornerTerrainBlockName(supportBlock.name)) {
         return defaultWaterBlockVisualHeight;
     }
 

--- a/packages/game/src/entities/waterBlockHeight.unit.ts
+++ b/packages/game/src/entities/waterBlockHeight.unit.ts
@@ -128,4 +128,27 @@ describe('getWaterBlockVisualHeight', () => {
 
         assert.deepEqual(range, { min: 0.34, max: 0.74 });
     });
+
+    it('stacks water above collapsed shaped terrain water', () => {
+        const lowerWater = block('water-lower', 'Block_Water');
+        const upperWater = block('water-upper', 'Block_Water');
+        const currentStack = stack([
+            block('angle-a', 'Block_Sand_Angle'),
+            lowerWater,
+            upperWater,
+        ]);
+        const lowerRange = getWaterBlockVerticalRange({
+            block: lowerWater,
+            blockData: getLocalSandboxBlockData(),
+            stack: currentStack,
+        });
+        const upperRange = getWaterBlockVerticalRange({
+            block: upperWater,
+            blockData: getLocalSandboxBlockData(),
+            stack: currentStack,
+        });
+
+        assert.deepEqual(lowerRange, { min: 0, max: 0.34 });
+        assert.deepEqual(upperRange, { min: 0.34, max: 0.74 });
+    });
 });

--- a/packages/game/src/utils/stackHeightCore.ts
+++ b/packages/game/src/utils/stackHeightCore.ts
@@ -2,6 +2,15 @@ import type { BlockData } from '@gredice/client';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
 
+const waterBlockName = 'Block_Water';
+
+export function isEdgeOrCornerTerrainBlockName(blockName: string) {
+    return (
+        blockName.startsWith('Block_') &&
+        (blockName.endsWith('_Angle') || blockName.endsWith('_Corner'))
+    );
+}
+
 export function getBlockDataByName(
     blockData: BlockData[] | null | undefined,
     name: string,
@@ -11,6 +20,34 @@ export function getBlockDataByName(
         console.error(`Block data not found for block with name: ${name}`);
     }
     return block;
+}
+
+function isWaterBlockCollapsedIntoSupport(
+    stack: Stack,
+    block: Block,
+    blockIndex: number,
+) {
+    if (block.name !== waterBlockName) {
+        return false;
+    }
+
+    const supportBlock = stack.blocks[blockIndex - 1];
+    return supportBlock
+        ? isEdgeOrCornerTerrainBlockName(supportBlock.name)
+        : false;
+}
+
+export function getStackBlockHeight(
+    blockData: BlockData[] | null | undefined,
+    stack: Stack,
+    block: Block,
+    blockIndex = stack.blocks.indexOf(block),
+) {
+    if (isWaterBlockCollapsedIntoSupport(stack, block, blockIndex)) {
+        return 0;
+    }
+
+    return getBlockDataByName(blockData, block.name)?.attributes.height ?? 0;
 }
 
 export function getStackHeight(
@@ -23,12 +60,11 @@ export function getStackHeight(
     }
 
     let height = 0;
-    for (const block of stack.blocks) {
+    for (const [blockIndex, block] of stack.blocks.entries()) {
         if (block === stopBlock) {
             return height;
         }
-        height +=
-            getBlockDataByName(blockData, block.name)?.attributes.height ?? 0;
+        height += getStackBlockHeight(blockData, stack, block, blockIndex);
     }
     return height;
 }

--- a/packages/game/src/utils/stackHeightCore.unit.ts
+++ b/packages/game/src/utils/stackHeightCore.unit.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import { getLocalSandboxBlockData } from '../localSandboxBlockData';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { getStackBlockHeight, getStackHeight } from './stackHeightCore';
+
+function block(id: string, name: string): Block {
+    return { id, name, rotation: 0 };
+}
+
+function stack(blocks: Block[]): Stack {
+    return {
+        blocks,
+        position: new Vector3(0, 0, 0),
+    };
+}
+
+describe('getStackHeight', () => {
+    const localBlockHeight = 0.4;
+
+    it('collapses water directly above shaped terrain into the support height', () => {
+        const sandEdge = block('sand-edge', 'Block_Sand_Angle');
+        const bottomWater = block('water-bottom', 'Block_Water');
+        const topWater = block('water-top', 'Block_Water');
+        const currentStack = stack([sandEdge, bottomWater, topWater]);
+        const blockData = getLocalSandboxBlockData();
+
+        assert.equal(
+            getStackBlockHeight(blockData, currentStack, bottomWater),
+            0,
+        );
+        assert.equal(
+            getStackHeight(blockData, currentStack, bottomWater),
+            localBlockHeight,
+        );
+        assert.equal(
+            getStackHeight(blockData, currentStack, topWater),
+            localBlockHeight,
+        );
+        assert.equal(
+            getStackHeight(blockData, currentStack),
+            localBlockHeight * 2,
+        );
+    });
+
+    it('keeps normal water height above a flat terrain block', () => {
+        const sand = block('sand', 'Block_Sand');
+        const bottomWater = block('water-bottom', 'Block_Water');
+        const topWater = block('water-top', 'Block_Water');
+        const currentStack = stack([sand, bottomWater, topWater]);
+        const blockData = getLocalSandboxBlockData();
+
+        assert.equal(
+            getStackBlockHeight(blockData, currentStack, bottomWater),
+            localBlockHeight,
+        );
+        assert.equal(
+            getStackHeight(blockData, currentStack, topWater),
+            localBlockHeight * 2,
+        );
+        assert.equal(
+            getStackHeight(blockData, currentStack),
+            localBlockHeight * 3,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Treat water directly stacked on angled/corner terrain as zero added stack height, so a stack like sand edge + water + water totals as sand edge + water.
- Reuse the effective stack-height rule in pickup placement occupancy so render placement and interaction math agree.
- Add regression coverage for collapsed water stack height and the second water block vertical range.

## Root Cause

Shaped-terrain water already rendered as a collapsed fill inside the edge/corner block, but the shared stack-height accumulator still counted that lower water block at its full catalog height. Blocks above it were therefore placed one water-height too high.

## Validation

- `pnpm --filter @gredice/game exec tsx --test src/utils/stackHeightCore.unit.ts src/entities/waterBlockHeight.unit.ts`
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `git diff --check`