### PR TITLE
[codex] Tune admin schedule row density

### DIFF
--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -210,10 +210,7 @@ export function FarmOperationsScheduleSection({
                                 pendingAcceptance: operationPendingAcceptance,
                             })}
                         >
-                            <Row
-                                spacing={1}
-                                className="min-w-0 flex-1 flex-nowrap"
-                            >
+                            <Row className="min-w-0 flex-1 flex-nowrap gap-1 md:gap-2">
                                 {isOperationCompleted(operation.status) ? (
                                     <Checkbox checked disabled />
                                 ) : operationPendingVerification ? (
@@ -321,7 +318,7 @@ export function FarmOperationsScheduleSection({
                                     rel="noopener noreferrer"
                                 >
                                     <Typography
-                                        level="body2"
+                                        level="body1"
                                         noWrap
                                         className={
                                             operationTextInactive

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -453,10 +453,7 @@ export function RaisedBedOperationsScheduleSection({
                                         operationPendingAcceptance,
                                 })}
                             >
-                                <Row
-                                    spacing={1}
-                                    className="min-w-0 flex-1 flex-nowrap"
-                                >
+                                <Row className="min-w-0 flex-1 flex-nowrap gap-1 md:gap-2">
                                     {isOperationCompleted(operation.status) ? (
                                         <Checkbox checked disabled />
                                     ) : operationPendingVerification ? (
@@ -568,7 +565,7 @@ export function RaisedBedOperationsScheduleSection({
                                         rel="noopener noreferrer"
                                     >
                                         <Typography
-                                            level="body2"
+                                            level="body1"
                                             noWrap
                                             className={
                                                 operationTextInactive

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -439,10 +439,7 @@ export function RaisedBedPlantingScheduleSection({
                                     pendingAcceptance: fieldPendingAcceptance,
                                 })}
                             >
-                                <Row
-                                    spacing={1}
-                                    className="min-w-0 flex-1 flex-nowrap"
-                                >
+                                <Row className="min-w-0 flex-1 flex-nowrap gap-1 md:gap-2">
                                     {fieldCompleted ? (
                                         <Checkbox checked disabled />
                                     ) : fieldPendingVerification ? (
@@ -511,7 +508,7 @@ export function RaisedBedPlantingScheduleSection({
                                         />
                                     )}
                                     <Typography
-                                        level="body2"
+                                        level="body1"
                                         noWrap
                                         className={
                                             fieldCompleted

--- a/apps/app/app/admin/schedule/scheduleShared.ts
+++ b/apps/app/app/admin/schedule/scheduleShared.ts
@@ -129,10 +129,10 @@ export function getScheduleTaskRowClassName({
     pendingAcceptance: boolean;
 }) {
     if (pendingAcceptance) {
-        return 'min-w-0 flex-nowrap rounded bg-amber-50/80 text-foreground ring-1 ring-inset ring-amber-200/70 hover:bg-amber-100/80 dark:bg-amber-950/40 dark:ring-amber-900/70 dark:hover:bg-amber-950/60';
+        return 'min-w-0 flex-nowrap rounded bg-amber-50/80 text-foreground ring-1 ring-inset ring-amber-200/70 hover:bg-amber-100/80 md:px-2 md:py-1 dark:bg-amber-950/40 dark:ring-amber-900/70 dark:hover:bg-amber-950/60';
     }
 
-    return 'min-w-0 flex-nowrap rounded hover:bg-muted';
+    return 'min-w-0 flex-nowrap rounded hover:bg-muted md:px-2 md:py-1';
 }
 
 export function isSameScheduleDay(


### PR DESCRIPTION
## Summary
- restore schedule task labels to body1 sizing for readability
- keep mobile rows compact while adding desktop row padding
- increase desktop gap between task controls and labels without changing the mobile gap

## Validation
- corepack pnpm lint --filter app
- corepack pnpm build --filter app
- git diff --check