### PR TITLE
[codex] Add schedule bulk cancel and task visuals

### DIFF
--- a/apps/app/app/admin/schedule/BulkCancelRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkCancelRaisedBedButton.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { Checkbox } from '@gredice/ui/Checkbox';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Close } from '@gredice/ui/icons';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cancelOperationAction } from '../../(actions)/operationActions';
+import { cancelRaisedBedFieldAction } from '../../(actions)/raisedBedFieldsActions';
+import { CancelRequestModal } from './CancelRequestModal';
+
+export type FieldCancelTarget = {
+    id?: number;
+    raisedBedId: number;
+    positionIndex: number;
+    label: string;
+};
+
+export type OperationCancelTarget = {
+    id: number;
+    label: string;
+};
+
+interface BulkCancelRaisedBedButtonProps {
+    physicalId: string;
+    fields: FieldCancelTarget[];
+    operations: OperationCancelTarget[];
+    onSubmit?: (formData: FormData) => unknown | Promise<unknown>;
+}
+
+function copyCancelOptions(source: FormData, target: FormData) {
+    const reason = source.get('reason');
+    if (typeof reason === 'string') {
+        target.set('reason', reason);
+    }
+
+    for (const value of source.getAll('shouldRefund')) {
+        if (typeof value === 'string') {
+            target.append('shouldRefund', value);
+        }
+    }
+
+    for (const value of source.getAll('shouldNotify')) {
+        if (typeof value === 'string') {
+            target.append('shouldNotify', value);
+        }
+    }
+}
+
+export function buildFieldCancelFormData(
+    field: FieldCancelTarget,
+    source: FormData,
+) {
+    const formData = new FormData();
+    formData.set('raisedBedId', field.raisedBedId.toString());
+    formData.set('positionIndex', field.positionIndex.toString());
+    copyCancelOptions(source, formData);
+    return formData;
+}
+
+export function buildOperationCancelFormData(
+    operation: OperationCancelTarget,
+    source: FormData,
+) {
+    const formData = new FormData();
+    formData.set('operationId', operation.id.toString());
+    copyCancelOptions(source, formData);
+    return formData;
+}
+
+export function BulkCancelRaisedBedButton({
+    physicalId,
+    fields,
+    operations,
+    onSubmit,
+}: BulkCancelRaisedBedButtonProps) {
+    const totalItems = fields.length + operations.length;
+    const disabled = totalItems === 0;
+    const targetLabel =
+        physicalId === 'dan' ? 'za dan' : `za gredicu ${physicalId}`;
+
+    async function handleSubmit(formData: FormData) {
+        if (totalItems === 0) {
+            return;
+        }
+
+        if (onSubmit) {
+            await onSubmit(formData);
+            return;
+        }
+
+        await Promise.all([
+            ...fields.map((field) =>
+                cancelRaisedBedFieldAction(
+                    buildFieldCancelFormData(field, formData),
+                ),
+            ),
+            ...operations.map((operation) =>
+                cancelOperationAction(
+                    buildOperationCancelFormData(operation, formData),
+                ),
+            ),
+        ]);
+    }
+
+    return (
+        <CancelRequestModal
+            label={`sve zadatke (${totalItems}) ${targetLabel}`}
+            onSubmit={handleSubmit}
+            hiddenFields={null}
+            description={`Svi odabrani zadaci (${totalItems}) bit će otkazani.`}
+            confirmLabel="Otkaži zadatke"
+            additionalFields={
+                operations.length > 0 ? (
+                    <Stack spacing={2}>
+                        <input
+                            type="hidden"
+                            name="shouldRefund"
+                            value="false"
+                        />
+                        <Checkbox
+                            className="size-5"
+                            name="shouldRefund"
+                            value="true"
+                            defaultChecked
+                            label={
+                                <Typography level="body2">
+                                    Vrati suncokrete za radnje
+                                </Typography>
+                            }
+                        />
+                        <input
+                            type="hidden"
+                            name="shouldNotify"
+                            value="false"
+                        />
+                        <Checkbox
+                            className="size-5"
+                            name="shouldNotify"
+                            value="true"
+                            defaultChecked
+                            label={
+                                <Typography level="body2">
+                                    Pošalji obavijest korisniku za radnje
+                                </Typography>
+                            }
+                        />
+                    </Stack>
+                ) : null
+            }
+            trigger={
+                <IconButton
+                    variant="plain"
+                    size="xs"
+                    title="Otkaži sve zadatke"
+                    disabled={disabled}
+                    aria-disabled={disabled}
+                >
+                    <Close className="size-4 shrink-0" />
+                </IconButton>
+            }
+        />
+    );
+}
+
+export default BulkCancelRaisedBedButton;

--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -28,6 +28,7 @@ import { CompleteOperationModal } from './CompleteOperationModal';
 import { OperationCompletionAttachments } from './OperationCompletionAttachments';
 import { OperationRequirementIcons } from './OperationRequirementIcons';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
+import { ScheduleOperationVisual } from './ScheduleTaskVisual';
 import {
     createOperationAssignedUsers,
     parseScheduledDateInput,
@@ -182,7 +183,7 @@ export function FarmOperationsScheduleSection({
                         : operationPendingVerification
                           ? 'Čeka verifikaciju'
                           : isOperationCompleted(operation.status)
-                            ? 'Završeno'
+                            ? null
                             : operation.isAccepted
                               ? null
                               : 'Nije potvrđeno';
@@ -304,6 +305,10 @@ export function FarmOperationsScheduleSection({
                                         }
                                     />
                                 )}
+                                <ScheduleOperationVisual
+                                    operation={operationData}
+                                    label={operationLabel}
+                                />
                                 <a
                                     className="min-w-0 flex-1"
                                     href={

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -6,8 +6,8 @@ import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Calendar, Close } from '@gredice/ui/icons';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Row } from '@gredice/ui/Row';
-import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
@@ -26,6 +26,10 @@ import { AcceptOperationModal } from './AcceptOperationModal';
 import { AssignOperationModal } from './AssignOperationModal';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
 import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
+import {
+    BulkCancelRaisedBedButton,
+    buildOperationCancelFormData,
+} from './BulkCancelRaisedBedButton';
 import { BulkRescheduleRaisedBedButton } from './BulkRescheduleRaisedBedButton';
 import { CancelOperationModal } from './CancelOperationModal';
 import { CompleteOperationModal } from './CompleteOperationModal';
@@ -33,6 +37,7 @@ import { CopyTasksButton } from './CopyTasksButton';
 import { OperationCompletionAttachments } from './OperationCompletionAttachments';
 import { OperationRequirementIcons } from './OperationRequirementIcons';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
+import { ScheduleOperationVisual } from './ScheduleTaskVisual';
 import {
     createOperationAssignedUsers,
     parseScheduledDateInput,
@@ -198,6 +203,25 @@ export function RaisedBedOperationsScheduleSection({
             id: operation.id,
             farmUsers: assignableFarmUsersByOperationId[operation.id] ?? [],
         }));
+    const operationsToCancel = dayOperations
+        .filter(
+            (operation) =>
+                !isOperationCompleted(operation.status) &&
+                !isOperationPendingVerification(operation.status) &&
+                !isOperationCancelled(operation.status) &&
+                operation.status !== 'failed',
+        )
+        .map((operation) => {
+            const operationData = operationDataById.get(operation.entityId);
+            const label =
+                operationData?.information?.label ??
+                operation.entityId.toString();
+
+            return {
+                id: operation.id,
+                label,
+            };
+        });
 
     const durations = dayOperations.reduce(
         (acc, operation) => {
@@ -229,16 +253,21 @@ export function RaisedBedOperationsScheduleSection({
                     className="min-w-0 grow items-center flex-wrap gap-y-1"
                 >
                     {raisedBedDetailsLink ? (
-                        <Link href={raisedBedDetailsLink}>
-                            <RaisedBedLabel
+                        <Link
+                            href={raisedBedDetailsLink}
+                            aria-label={`Gredica ${physicalId}`}
+                        >
+                            <RaisedBedIcon
                                 physicalId={physicalId}
-                                size="compact"
+                                className="size-5"
+                                containerClassName="h-5"
                             />
                         </Link>
                     ) : (
-                        <RaisedBedLabel
+                        <RaisedBedIcon
                             physicalId={physicalId}
-                            size="compact"
+                            className="size-5"
+                            containerClassName="h-5"
                         />
                     )}
                     <Typography level="body2" className="text-muted-foreground">
@@ -366,6 +395,36 @@ export function RaisedBedOperationsScheduleSection({
                             })
                         }
                     />
+                    <BulkCancelRaisedBedButton
+                        physicalId={physicalId.toString()}
+                        fields={[]}
+                        operations={operationsToCancel}
+                        onSubmit={(formData) =>
+                            runOptimisticAction({
+                                operationPatches: operationsToCancel.map(
+                                    (operation) => ({
+                                        id: operation.id,
+                                        patch: { status: 'canceled' },
+                                    }),
+                                ),
+                                action: () =>
+                                    Promise.all(
+                                        operationsToCancel.map((operation) =>
+                                            cancelOperationAction(
+                                                buildOperationCancelFormData(
+                                                    operation,
+                                                    formData,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                errorLogMessage:
+                                    'Failed to cancel all raised bed operation items:',
+                                errorAlertMessage:
+                                    'Skupno otkazivanje radnji nije uspjelo. Promjena je vraćena.',
+                            })
+                        }
+                    />
                 </Row>
             </Row>
             <Stack spacing={0}>
@@ -406,7 +465,7 @@ export function RaisedBedOperationsScheduleSection({
                         : operationPendingVerification
                           ? 'Čeka verifikaciju'
                           : isOperationCompleted(operation.status)
-                            ? 'Završeno'
+                            ? null
                             : operation.isAccepted
                               ? null
                               : 'Nije potvrđeno';
@@ -551,6 +610,10 @@ export function RaisedBedOperationsScheduleSection({
                                             }
                                         />
                                     )}
+                                    <ScheduleOperationVisual
+                                        operation={operationData}
+                                        label={operationLabel}
+                                    />
                                     <a
                                         className="min-w-0 flex-1"
                                         href={

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -8,8 +8,8 @@ import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Calendar, Close, ToggleLeft, ToggleRight } from '@gredice/ui/icons';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Row } from '@gredice/ui/Row';
-import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
@@ -28,11 +28,16 @@ import { AcceptRaisedBedFieldModal } from './AcceptRaisedBedFieldModal';
 import { AssignRaisedBedFieldModal } from './AssignRaisedBedFieldModal';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
 import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
+import {
+    BulkCancelRaisedBedButton,
+    buildFieldCancelFormData,
+} from './BulkCancelRaisedBedButton';
 import { BulkRescheduleRaisedBedButton } from './BulkRescheduleRaisedBedButton';
 import { CancelRaisedBedFieldModal } from './CancelRaisedBedFieldModal';
 import { CompletePlantingModal } from './CompletePlantingModal';
 import { CopyTasksButton } from './CopyTasksButton';
 import { RescheduleRaisedBedFieldModal } from './RescheduleRaisedBedFieldModal';
+import { SchedulePlantVisual } from './ScheduleTaskVisual';
 import { parseScheduledDateInput } from './scheduleOptimisticHelpers';
 import {
     formatMinutes,
@@ -201,6 +206,18 @@ export function RaisedBedPlantingScheduleSection({
             id: field.id,
             farmUsers: assignableFarmUsersByRaisedBedFieldId[field.id] ?? [],
         }));
+    const fieldsToCancel = dayFields
+        .filter(
+            (field) =>
+                !isFieldCompleted(field.plantStatus) &&
+                !isFieldPendingVerification(field.plantStatus),
+        )
+        .map((field) => ({
+            id: field.id,
+            raisedBedId: field.raisedBedId,
+            positionIndex: field.positionIndex,
+            label: `${field.positionIndex + 1}`,
+        }));
 
     const durations = dayFields.reduce(
         (acc, field) => {
@@ -224,16 +241,21 @@ export function RaisedBedPlantingScheduleSection({
                     className="min-w-0 grow items-center flex-wrap gap-y-1"
                 >
                     {raisedBedDetailsLink ? (
-                        <Link href={raisedBedDetailsLink}>
-                            <RaisedBedLabel
+                        <Link
+                            href={raisedBedDetailsLink}
+                            aria-label={`Gredica ${physicalId}`}
+                        >
+                            <RaisedBedIcon
                                 physicalId={physicalId}
-                                size="compact"
+                                className="size-5"
+                                containerClassName="h-5"
                             />
                         </Link>
                     ) : (
-                        <RaisedBedLabel
+                        <RaisedBedIcon
                             physicalId={physicalId}
-                            size="compact"
+                            className="size-5"
+                            containerClassName="h-5"
                         />
                     )}
                     <Typography level="body2" className="text-muted-foreground">
@@ -348,6 +370,34 @@ export function RaisedBedPlantingScheduleSection({
                             })
                         }
                     />
+                    <BulkCancelRaisedBedButton
+                        physicalId={physicalId.toString()}
+                        fields={fieldsToCancel}
+                        operations={[]}
+                        onSubmit={(formData) =>
+                            runOptimisticAction({
+                                fieldPatches: fieldsToCancel.map((field) => ({
+                                    id: field.id,
+                                    patch: { isDeleted: true },
+                                })),
+                                action: () =>
+                                    Promise.all(
+                                        fieldsToCancel.map((field) =>
+                                            cancelRaisedBedFieldAction(
+                                                buildFieldCancelFormData(
+                                                    field,
+                                                    formData,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                errorLogMessage:
+                                    'Failed to cancel all raised bed planting items:',
+                                errorAlertMessage:
+                                    'Skupno otkazivanje sijanja nije uspjelo. Promjena je vraćena.',
+                            })
+                        }
+                    />
                 </Row>
             </Row>
             <Stack spacing={0}>
@@ -407,13 +457,11 @@ export function RaisedBedPlantingScheduleSection({
                     const nextSowingLocation = greenhouseSowing
                         ? 'direct'
                         : 'greenhouse';
-                    const fieldStatusText = fieldCompleted
-                        ? 'Završeno'
-                        : fieldPendingVerification
-                          ? 'Čeka verifikaciju'
-                          : fieldApproved
-                            ? null
-                            : 'Nije potvrđeno';
+                    const fieldStatusText = fieldPendingVerification
+                        ? 'Čeka verifikaciju'
+                        : fieldApproved || fieldCompleted
+                          ? null
+                          : 'Nije potvrđeno';
                     const fieldStatusClassName = fieldCompleted
                         ? 'text-green-600'
                         : fieldPendingVerification
@@ -507,6 +555,10 @@ export function RaisedBedPlantingScheduleSection({
                                             onConfirm={handlePlantConfirm}
                                         />
                                     )}
+                                    <SchedulePlantVisual
+                                        plantSort={sortData}
+                                        label={fieldLabel}
+                                    />
                                     <Typography
                                         level="body1"
                                         noWrap

--- a/apps/app/app/admin/schedule/ScheduleDayOperationsBulkActions.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayOperationsBulkActions.tsx
@@ -4,13 +4,19 @@ import type { OperationAssignableFarmUser } from '@gredice/storage';
 import {
     acceptOperationAction,
     assignOperationUserAction,
+    cancelOperationAction,
 } from '../../(actions)/operationActions';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
 import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
 import {
+    BulkCancelRaisedBedButton,
+    buildOperationCancelFormData,
+} from './BulkCancelRaisedBedButton';
+import {
     createOperationAssignedUsers,
     isDayBulkOperationApprovalTargetVisible,
     isDayBulkOperationAssignmentTargetVisible,
+    isDayBulkOperationCancelTargetVisible,
 } from './scheduleOptimisticHelpers';
 import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
 
@@ -24,14 +30,21 @@ type OperationAssignmentTarget = {
     farmUsers: OperationAssignableFarmUser[];
 };
 
+type OperationCancelTarget = {
+    id: number;
+    label: string;
+};
+
 interface ScheduleDayOperationsBulkActionsProps {
     operationsToApprove: OperationApprovalTarget[];
     operationsToAssign: OperationAssignmentTarget[];
+    operationsToCancel: OperationCancelTarget[];
 }
 
 export function ScheduleDayOperationsBulkActions({
     operationsToApprove,
     operationsToAssign,
+    operationsToCancel,
 }: ScheduleDayOperationsBulkActionsProps) {
     const { getOperationPatch, runOptimisticAction } =
         useOptimisticScheduleActions();
@@ -44,6 +57,9 @@ export function ScheduleDayOperationsBulkActions({
         isDayBulkOperationAssignmentTargetVisible(
             getOperationPatch(operation.id),
         ),
+    );
+    const visibleOperationsToCancel = operationsToCancel.filter((operation) =>
+        isDayBulkOperationCancelTargetVisible(getOperationPatch(operation.id)),
     );
 
     return (
@@ -113,6 +129,36 @@ export function ScheduleDayOperationsBulkActions({
                             'Failed to assign users for all day operation items:',
                         errorAlertMessage:
                             'Skupna dodjela radnji nije uspjela. Promjena je vraćena.',
+                    })
+                }
+            />
+            <BulkCancelRaisedBedButton
+                physicalId="dan"
+                fields={[]}
+                operations={visibleOperationsToCancel}
+                onSubmit={(formData) =>
+                    runOptimisticAction({
+                        operationPatches: visibleOperationsToCancel.map(
+                            (operation) => ({
+                                id: operation.id,
+                                patch: { status: 'canceled' },
+                            }),
+                        ),
+                        action: () =>
+                            Promise.all(
+                                visibleOperationsToCancel.map((operation) =>
+                                    cancelOperationAction(
+                                        buildOperationCancelFormData(
+                                            operation,
+                                            formData,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        errorLogMessage:
+                            'Failed to cancel all day operation items:',
+                        errorAlertMessage:
+                            'Skupno otkazivanje radnji nije uspjelo. Promjena je vraćena.',
                     })
                 }
             />

--- a/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
@@ -97,6 +97,18 @@ export async function ScheduleDayOperationsSection({
             id: operation.id,
             farmUsers: assignableFarmUsersByOperationId[operation.id] ?? [],
         }));
+    const dayOperationsToCancel = scheduledOperations
+        .filter(
+            (operation) =>
+                !isOperationCompleted(operation.status) &&
+                !isOperationPendingVerification(operation.status) &&
+                !isOperationCancelled(operation.status) &&
+                operation.status !== 'failed',
+        )
+        .map((operation) => ({
+            id: operation.id,
+            label: operation.entityId.toString(),
+        }));
 
     return (
         <OptimisticScheduleActionsProvider>
@@ -109,6 +121,7 @@ export async function ScheduleDayOperationsSection({
                         <ScheduleDayOperationsBulkActions
                             operationsToApprove={dayOperationsToApprove}
                             operationsToAssign={dayOperationsToAssign}
+                            operationsToCancel={dayOperationsToCancel}
                         />
                     </Row>
                 </Row>

--- a/apps/app/app/admin/schedule/ScheduleDayPlantingsBulkActions.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayPlantingsBulkActions.tsx
@@ -4,12 +4,18 @@ import type { RaisedBedFieldAssignableFarmUser } from '@gredice/storage';
 import {
     acceptRaisedBedFieldAction,
     assignRaisedBedFieldUserAction,
+    cancelRaisedBedFieldAction,
 } from '../../(actions)/raisedBedFieldsActions';
 import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
 import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
 import {
+    BulkCancelRaisedBedButton,
+    buildFieldCancelFormData,
+} from './BulkCancelRaisedBedButton';
+import {
     isDayBulkFieldApprovalTargetVisible,
     isDayBulkFieldAssignmentTargetVisible,
+    isDayBulkFieldCancelTargetVisible,
 } from './scheduleOptimisticHelpers';
 import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
 
@@ -25,14 +31,23 @@ type FieldAssignmentTarget = {
     farmUsers: RaisedBedFieldAssignableFarmUser[];
 };
 
+type FieldCancelTarget = {
+    id: number;
+    raisedBedId: number;
+    positionIndex: number;
+    label: string;
+};
+
 interface ScheduleDayPlantingsBulkActionsProps {
     fieldsToApprove: FieldApprovalTarget[];
     fieldsToAssign: FieldAssignmentTarget[];
+    fieldsToCancel: FieldCancelTarget[];
 }
 
 export function ScheduleDayPlantingsBulkActions({
     fieldsToApprove,
     fieldsToAssign,
+    fieldsToCancel,
 }: ScheduleDayPlantingsBulkActionsProps) {
     const { getFieldPatch, runOptimisticAction } =
         useOptimisticScheduleActions();
@@ -41,6 +56,9 @@ export function ScheduleDayPlantingsBulkActions({
     );
     const visibleFieldsToAssign = fieldsToAssign.filter((field) =>
         isDayBulkFieldAssignmentTargetVisible(getFieldPatch(field.id)),
+    );
+    const visibleFieldsToCancel = fieldsToCancel.filter((field) =>
+        isDayBulkFieldCancelTargetVisible(getFieldPatch(field.id)),
     );
 
     return (
@@ -97,6 +115,34 @@ export function ScheduleDayPlantingsBulkActions({
                             'Failed to assign users for all day planting items:',
                         errorAlertMessage:
                             'Skupna dodjela sijanja nije uspjela. Promjena je vraćena.',
+                    })
+                }
+            />
+            <BulkCancelRaisedBedButton
+                physicalId="dan"
+                fields={visibleFieldsToCancel}
+                operations={[]}
+                onSubmit={(formData) =>
+                    runOptimisticAction({
+                        fieldPatches: visibleFieldsToCancel.map((field) => ({
+                            id: field.id,
+                            patch: { isDeleted: true },
+                        })),
+                        action: () =>
+                            Promise.all(
+                                visibleFieldsToCancel.map((field) =>
+                                    cancelRaisedBedFieldAction(
+                                        buildFieldCancelFormData(
+                                            field,
+                                            formData,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        errorLogMessage:
+                            'Failed to cancel all day planting items:',
+                        errorAlertMessage:
+                            'Skupno otkazivanje sijanja nije uspjelo. Promjena je vraćena.',
                     })
                 }
             />

--- a/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
@@ -68,6 +68,18 @@ export async function ScheduleDayPlantingsSection({
             id: field.id,
             farmUsers: assignableFarmUsersByRaisedBedFieldId[field.id] ?? [],
         }));
+    const dayFieldsToCancel = scheduledFields
+        .filter(
+            (field) =>
+                !isFieldCompleted(field.plantStatus) &&
+                !isFieldPendingVerification(field.plantStatus),
+        )
+        .map((field) => ({
+            id: field.id,
+            raisedBedId: field.raisedBedId,
+            positionIndex: field.positionIndex,
+            label: `${field.positionIndex + 1}`,
+        }));
 
     return (
         <OptimisticScheduleActionsProvider>
@@ -80,6 +92,7 @@ export async function ScheduleDayPlantingsSection({
                         <ScheduleDayPlantingsBulkActions
                             fieldsToApprove={dayFieldsToApprove}
                             fieldsToAssign={dayFieldsToAssign}
+                            fieldsToCancel={dayFieldsToCancel}
                         />
                     </Row>
                 </Row>

--- a/apps/app/app/admin/schedule/ScheduleTaskVisual.tsx
+++ b/apps/app/app/admin/schedule/ScheduleTaskVisual.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { OperationImage } from '@gredice/ui/OperationImage';
+import { PlantingSeedIcon } from '@gredice/ui/PlantingSeedIcon';
+import { cx } from '@gredice/ui/utils';
+import Image from 'next/image';
+import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
+
+function getCoverUrl(entity: EntityStandardized | null | undefined) {
+    return entity?.image?.cover?.url ?? entity?.images?.cover?.url ?? null;
+}
+
+function getPlantSortCoverUrl(
+    plantSort: EntityStandardized | null | undefined,
+) {
+    return (
+        getCoverUrl(plantSort) ??
+        getCoverUrl(plantSort?.information?.plant) ??
+        null
+    );
+}
+
+function isHostedImageUrl(url: string | null | undefined) {
+    return !!url && /^https?:\/\//u.test(url);
+}
+
+export function SchedulePlantVisual({
+    plantSort,
+    label,
+}: {
+    plantSort: EntityStandardized | null | undefined;
+    label: string;
+}) {
+    const coverUrl = getPlantSortCoverUrl(plantSort);
+
+    return (
+        <span className="flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-primary/10 text-primary">
+            {isHostedImageUrl(coverUrl) ? (
+                <Image
+                    src={coverUrl}
+                    alt={label}
+                    width={20}
+                    height={20}
+                    className="size-full object-cover"
+                />
+            ) : (
+                <PlantingSeedIcon
+                    aria-hidden="true"
+                    className="size-3.5 shrink-0"
+                />
+            )}
+        </span>
+    );
+}
+
+export function ScheduleOperationVisual({
+    operation,
+    label,
+}: {
+    operation: EntityStandardized | null | undefined;
+    label: string;
+}) {
+    return (
+        <span
+            className={cx(
+                'flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-muted text-muted-foreground',
+                getCoverUrl(operation) && 'bg-transparent',
+            )}
+        >
+            <OperationImage
+                operation={{
+                    image: operation?.image ?? operation?.images,
+                    information: { label },
+                }}
+                size={20}
+                className="size-5"
+            />
+        </span>
+    );
+}

--- a/apps/app/app/admin/schedule/scheduleOptimisticHelpers.ts
+++ b/apps/app/app/admin/schedule/scheduleOptimisticHelpers.ts
@@ -104,6 +104,17 @@ export function isDayBulkOperationAssignmentTargetVisible(
     );
 }
 
+export function isDayBulkOperationCancelTargetVisible(
+    patch: DayBulkOperationPatch | undefined,
+) {
+    return (
+        !isOperationCompleted(patch?.status) &&
+        !isOperationPendingVerification(patch?.status) &&
+        !isOperationCancelled(patch?.status) &&
+        patch?.status !== 'failed'
+    );
+}
+
 export function isDayBulkFieldApprovalTargetVisible(
     patch: DayBulkFieldPatch | undefined,
 ) {
@@ -111,6 +122,16 @@ export function isDayBulkFieldApprovalTargetVisible(
         !patch?.isDeleted &&
         !hasOptimisticUnassignment(patch) &&
         !isFieldApproved(patch?.plantStatus) &&
+        !isFieldPendingVerification(patch?.plantStatus) &&
+        !isFieldCompleted(patch?.plantStatus)
+    );
+}
+
+export function isDayBulkFieldCancelTargetVisible(
+    patch: DayBulkFieldPatch | undefined,
+) {
+    return (
+        !patch?.isDeleted &&
         !isFieldPendingVerification(patch?.plantStatus) &&
         !isFieldCompleted(patch?.plantStatus)
     );


### PR DESCRIPTION
## Summary
- add bulk cancel controls for schedule planting and operation tasks at day and raised-bed levels
- show compact plant and operation visuals next to task names
- remove completed "Završeno" row indicators and hide duplicate raised-bed "Gr N" header text

## Validation
- corepack pnpm lint --filter app
- corepack pnpm build --filter app
- git diff --check