### PR TITLE
Add raised bed photo shortcuts

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -982,7 +982,7 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
             name: /Fotografije gredice Raised Bed 1/u,
         });
         await expect(photoButton).toBeVisible();
-        await expect(photoButton).toContainText('Foto');
+        await expect(photoButton.locator('img')).toBeVisible();
 
         await photoButton.click();
 
@@ -1074,7 +1074,7 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
             name: /Fotografije gredice Raised Bed 1/u,
         });
         await expect(photoButton).toBeVisible();
-        await expect(photoButton).toContainText('1');
+        await expect(photoButton.locator('img')).toBeVisible();
 
         await photoButton.click();
 

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -87,57 +87,57 @@ export function RaisedBedFieldHud() {
             style={hudStyles}
         >
             {currentGarden && raisedBed && (
-                <div className="absolute z-40 max-w-64 md:max-w-[312px] top-[var(--raised-bed-ui-top)] left-[var(--raised-bed-title-left)]">
-                    <Modal
-                        open={isInfoOpen}
-                        onOpenChange={(open) => {
-                            if (open) {
-                                track('game_raised_bed_info_opened', {
-                                    garden_id: currentGarden.id,
-                                    raised_bed_id: raisedBed.id,
-                                    raised_bed_name: raisedBed.name,
-                                });
-                            }
-                            setIsInfoOpen(open);
-                        }}
-                        title="Informacije o gredici"
-                        modal={false}
-                        className="overflow-x-hidden md:border-tertiary md:border-b-4"
-                        trigger={
-                            <ButtonGreen
-                                fullWidth
-                                endDecorator={
-                                    <Navigate className="size-4 shrink-0" />
+                <div className="absolute z-40 top-[var(--raised-bed-ui-top)] left-[var(--raised-bed-title-left)]">
+                    <Row spacing={2} className="items-center">
+                        <Modal
+                            open={isInfoOpen}
+                            onOpenChange={(open) => {
+                                if (open) {
+                                    track('game_raised_bed_info_opened', {
+                                        garden_id: currentGarden.id,
+                                        raised_bed_id: raisedBed.id,
+                                        raised_bed_name: raisedBed.name,
+                                    });
                                 }
-                            >
-                                <Row spacing={2}>
-                                    <RaisedBedIcon
-                                        physicalId={raisedBed.physicalId}
-                                        className="size-6"
-                                    />
-                                    <Typography semiBold noWrap>
-                                        {raisedBed?.name}
-                                    </Typography>
-                                </Row>
-                            </ButtonGreen>
-                        }
-                    >
-                        <RaisedBedInfo
-                            gardenId={currentGarden.id}
-                            raisedBed={raisedBed}
-                        />
-                    </Modal>
-                </div>
-            )}
-            {currentGarden && raisedBed && !isSandbox && (
-                <div className="absolute z-40 top-[calc(var(--raised-bed-ui-top)+48px)] left-[var(--raised-bed-title-left)]">
-                    <RaisedBedPhotosModal
-                        gardenId={currentGarden.id}
-                        raisedBedId={raisedBed.id}
-                        subjectName={raisedBed.name}
-                        triggerPlacement="hud"
-                        hideWhenEmpty
-                    />
+                                setIsInfoOpen(open);
+                            }}
+                            title="Informacije o gredici"
+                            modal={false}
+                            className="overflow-x-hidden md:border-tertiary md:border-b-4"
+                            trigger={
+                                <ButtonGreen
+                                    className="max-w-64 md:max-w-[312px]"
+                                    endDecorator={
+                                        <Navigate className="size-4 shrink-0" />
+                                    }
+                                >
+                                    <Row spacing={2} className="min-w-0">
+                                        <RaisedBedIcon
+                                            physicalId={raisedBed.physicalId}
+                                            className="size-6 shrink-0"
+                                        />
+                                        <Typography semiBold noWrap>
+                                            {raisedBed?.name}
+                                        </Typography>
+                                    </Row>
+                                </ButtonGreen>
+                            }
+                        >
+                            <RaisedBedInfo
+                                gardenId={currentGarden.id}
+                                raisedBed={raisedBed}
+                            />
+                        </Modal>
+                        {!isSandbox && (
+                            <RaisedBedPhotosModal
+                                gardenId={currentGarden.id}
+                                raisedBedId={raisedBed.id}
+                                subjectName={raisedBed.name}
+                                triggerPlacement="hud"
+                                hideWhenEmpty
+                            />
+                        )}
+                    </Row>
                 </div>
             )}
             <div className="absolute z-0 top-[calc(50%-1px)] left-1/2 -translate-x-1/2 -translate-y-1/2 w-[var(--raised-bed-grid-size)] h-[var(--raised-bed-grid-height)]">

--- a/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
@@ -65,6 +65,10 @@ function getPhotoCountLabel(photoCount: number) {
     return `${photoCount} fotografija`;
 }
 
+function isGenericPhotoOperationName(name: string) {
+    return /^fotografiranje\b/iu.test(name.trim());
+}
+
 export function RaisedBedPhotosModal({
     gardenId,
     raisedBedId,
@@ -187,25 +191,15 @@ export function RaisedBedPhotosModal({
             <ButtonGreen
                 variant="plain"
                 className={cx(
-                    'h-12 w-24 rounded-2xl p-1 shadow-lg ring-1 ring-black/10',
+                    'size-10 rounded-xl p-1 shadow-lg ring-1 ring-black/10',
                     className,
                 )}
                 aria-label={triggerLabel}
                 title={triggerLabel}
             >
-                <span className="relative flex h-full w-full items-center justify-start">
-                    <span className="relative size-10 shrink-0 rounded-xl">
-                        {thumbnail}
-                        {photoCountBadge}
-                    </span>
-                    <span className="ml-2 flex min-w-0 flex-col items-start">
-                        <span className="text-xs font-semibold leading-tight">
-                            Foto
-                        </span>
-                        <span className="text-[11px] leading-tight text-primary/70">
-                            {photoCount > 0 ? photoCount : '...'}
-                        </span>
-                    </span>
+                <span className="relative block size-full rounded-[inherit]">
+                    {thumbnail}
+                    {photoCountBadge}
                 </span>
             </ButtonGreen>
         ) : (
@@ -269,104 +263,130 @@ export function RaisedBedPhotosModal({
                         Nema zabilježenih fotografija.
                     </NoDataPlaceholder>
                 )}
-                {photoOperations.map((operation) => {
-                    const operationData =
-                        operation.entityTypeName === 'operation'
-                            ? operationDataById.get(operation.entityId)
-                            : undefined;
-                    const entryName =
-                        operationData?.information.label ??
-                        operation.targetLabel;
-                    const operationPositionIndex =
-                        positionIndex ??
-                        (operation.raisedBedFieldId
-                            ? fieldPositionById.get(operation.raisedBedFieldId)
-                            : undefined);
-                    const operationDateLabel = getDateLabel(
-                        getOperationReferenceDate(operation),
-                    );
-                    const completionNotes = operation.completionNotes?.trim();
+                {photoOperations.length > 0 && (
+                    <div className="grid gap-3 md:grid-cols-2">
+                        {photoOperations.map((operation) => {
+                            const operationData =
+                                operation.entityTypeName === 'operation'
+                                    ? operationDataById.get(operation.entityId)
+                                    : undefined;
+                            const entryName =
+                                operationData?.information.label ??
+                                operation.targetLabel;
+                            const showEntryName =
+                                !isGenericPhotoOperationName(entryName);
+                            const operationPositionIndex =
+                                positionIndex ??
+                                (operation.raisedBedFieldId
+                                    ? fieldPositionById.get(
+                                          operation.raisedBedFieldId,
+                                      )
+                                    : undefined);
+                            const referenceDate =
+                                getOperationReferenceDate(operation);
+                            const operationDateLabel =
+                                getDateLabel(referenceDate);
+                            const completionNotes =
+                                operation.completionNotes?.trim();
+                            const imageAltBase = showEntryName
+                                ? entryName
+                                : `${modalTitle} ${subjectName}`;
 
-                    return (
-                        <div
-                            key={`${operation.entityTypeName}-${operation.id}`}
-                            className="rounded-xl border bg-card p-3 shadow-xs"
-                            data-raised-bed-photo-entry
-                        >
-                            <Stack spacing={3}>
-                                <Row
-                                    spacing={2}
-                                    className="min-w-0 flex-wrap items-start justify-between gap-y-2"
+                            return (
+                                <div
+                                    key={`${operation.entityTypeName}-${operation.id}`}
+                                    className="rounded-xl border bg-card p-3 shadow-xs"
+                                    data-raised-bed-photo-entry
                                 >
-                                    <Stack spacing={0.5} className="min-w-0">
-                                        <Typography
-                                            level="body1"
-                                            semiBold
-                                            className="break-words"
+                                    <Stack spacing={3}>
+                                        <Row
+                                            spacing={2}
+                                            className="min-w-0 flex-wrap items-start justify-between gap-y-2"
                                         >
-                                            {entryName}
-                                        </Typography>
-                                        <Typography level="body3" secondary>
-                                            {operationDateLabel ??
-                                                operation.targetLabel}
-                                        </Typography>
+                                            <Stack
+                                                spacing={0.5}
+                                                className="min-w-0"
+                                            >
+                                                {showEntryName && (
+                                                    <Typography
+                                                        level="body1"
+                                                        semiBold
+                                                        className="break-words"
+                                                    >
+                                                        {entryName}
+                                                    </Typography>
+                                                )}
+                                                <Typography
+                                                    level={
+                                                        showEntryName
+                                                            ? 'body3'
+                                                            : 'body1'
+                                                    }
+                                                    semiBold={!showEntryName}
+                                                    secondary={showEntryName}
+                                                >
+                                                    {operationDateLabel ??
+                                                        'Fotografija'}
+                                                </Typography>
+                                            </Stack>
+                                            {operation.imageUrls.length > 1 && (
+                                                <Chip variant="soft">
+                                                    {getPhotoCountLabel(
+                                                        operation.imageUrls
+                                                            .length,
+                                                    )}
+                                                </Chip>
+                                            )}
+                                        </Row>
+                                        <ImageGallery
+                                            images={operation.imageUrls.map(
+                                                (imageUrl, imageIndex) => ({
+                                                    src: imageUrl,
+                                                    alt: `${imageAltBase} ${imageIndex + 1}`,
+                                                }),
+                                            )}
+                                            previewAs="div"
+                                            previewVariant="grid"
+                                            previewWidth={220}
+                                            previewLimitBeforeStack={5}
+                                        />
+                                        {completionNotes && (
+                                            <Typography
+                                                level="body2"
+                                                className="break-words"
+                                            >
+                                                {completionNotes}
+                                            </Typography>
+                                        )}
+                                        <Row
+                                            spacing={2}
+                                            className="items-center justify-end gap-y-2"
+                                        >
+                                            <RaisedBedDiaryAiAction
+                                                gardenId={gardenId}
+                                                raisedBedId={raisedBedId}
+                                                positionIndex={
+                                                    operationPositionIndex
+                                                }
+                                                entryName={entryName}
+                                                imageUrls={operation.imageUrls}
+                                                referenceDate={referenceDate}
+                                                historyEntries={getAiHistoryForOperation(
+                                                    {
+                                                        imageUrls:
+                                                            operation.imageUrls,
+                                                        entries:
+                                                            aiHistoryEntries,
+                                                    },
+                                                )}
+                                            />
+                                        </Row>
                                     </Stack>
-                                    <Chip variant="soft">
-                                        {getPhotoCountLabel(
-                                            operation.imageUrls.length,
-                                        )}
-                                    </Chip>
-                                </Row>
-                                <ImageGallery
-                                    images={operation.imageUrls.map(
-                                        (imageUrl, imageIndex) => ({
-                                            src: imageUrl,
-                                            alt: `${entryName} ${imageIndex + 1}`,
-                                            dateLabel:
-                                                operationDateLabel ?? undefined,
-                                        }),
-                                    )}
-                                    previewAs="div"
-                                    previewVariant="grid"
-                                    previewWidth={240}
-                                    previewLimitBeforeStack={5}
-                                />
-                                {completionNotes && (
-                                    <Typography
-                                        level="body2"
-                                        className="break-words"
-                                    >
-                                        {completionNotes}
-                                    </Typography>
-                                )}
-                                <Row
-                                    spacing={2}
-                                    className="items-center justify-between gap-y-2"
-                                >
-                                    <Typography level="body3" secondary>
-                                        {operation.targetLabel}
-                                    </Typography>
-                                    <RaisedBedDiaryAiAction
-                                        gardenId={gardenId}
-                                        raisedBedId={raisedBedId}
-                                        positionIndex={operationPositionIndex}
-                                        entryName={entryName}
-                                        imageUrls={operation.imageUrls}
-                                        referenceDate={getOperationReferenceDate(
-                                            operation,
-                                        )}
-                                        historyEntries={getAiHistoryForOperation(
-                                            {
-                                                imageUrls: operation.imageUrls,
-                                                entries: aiHistoryEntries,
-                                            },
-                                        )}
-                                    />
-                                </Row>
-                            </Stack>
-                        </div>
-                    );
-                })}
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
                 {history.hasNextPage && (
                     <Button
                         variant="plain"


### PR DESCRIPTION
## Summary
- add raised-bed and plant photo shortcuts with photo history modal access
- keep the closeup HUD shortcut inline with the raised-bed button and thumbnail-only
- simplify photo modal cards with responsive desktop columns, no duplicate photo-action/date labels, and AI suggestion access

## Validation
- pnpm --filter @gredice/game exec biome check --write src/hud/RaisedBedFieldHud.tsx src/hud/raisedBed/RaisedBedPhotosModal.tsx
- pnpm --filter garden exec biome check --write tests/raised-bed-field-hud.spec.tsx
- pnpm --filter @gredice/game typecheck
- pnpm --filter garden test:prepare
- pnpm --filter garden exec playwright test tests/raised-bed-field-hud.spec.tsx --grep "photo|raised bed more action"
- git diff --check