### PR TITLE
[codex] Add filtered farmer documentation packages

### DIFF
--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.ts
@@ -17,6 +17,10 @@ import { and, desc, gte, inArray } from 'drizzle-orm';
 
 export type FarmerDocumentationChangeType = 'insert' | 'replace' | 'discard';
 export type FarmerDocumentationEntityTypeName = 'operation' | 'plantSort';
+export type FarmerDocumentationPackageContent =
+    | 'all'
+    | 'operations'
+    | 'plantSorts';
 
 export type FarmerDocumentationAttribute = {
     label: string;
@@ -243,31 +247,70 @@ export function documentationChangeLabel(type: FarmerDocumentationChangeType) {
     }
 }
 
+export function parseDocumentationPackageContent(
+    value: string | null | undefined,
+): FarmerDocumentationPackageContent {
+    switch (value?.trim()) {
+        case 'operations':
+            return 'operations';
+        case 'plant-sorts':
+        case 'plantSorts':
+            return 'plantSorts';
+        default:
+            return 'all';
+    }
+}
+
+export function documentationPackageContentQueryValue(
+    content: FarmerDocumentationPackageContent,
+) {
+    switch (content) {
+        case 'all':
+            return 'all';
+        case 'operations':
+            return 'operations';
+        case 'plantSorts':
+            return 'plant-sorts';
+    }
+}
+
 export function includedDocumentationPages(
     documentationPackage: FarmerDocumentationPackage,
+    content: FarmerDocumentationPackageContent = 'all',
 ) {
-    return [
-        ...documentationPackage.includedOperations,
-        ...documentationPackage.includedPlantSorts,
-    ].sort(compareDocumentationPage);
+    return filterDocumentationPagesByContent(
+        [
+            ...documentationPackage.includedOperations,
+            ...documentationPackage.includedPlantSorts,
+        ],
+        content,
+    ).sort(compareDocumentationPage);
 }
 
 export function currentDocumentationPages(
     documentationPackage: FarmerDocumentationPackage,
+    content: FarmerDocumentationPackageContent = 'all',
 ) {
-    return [
-        ...documentationPackage.currentOperations,
-        ...documentationPackage.currentPlantSorts,
-    ].sort(compareDocumentationPage);
+    return filterDocumentationPagesByContent(
+        [
+            ...documentationPackage.currentOperations,
+            ...documentationPackage.currentPlantSorts,
+        ],
+        content,
+    ).sort(compareDocumentationPage);
 }
 
 export function discardedDocumentationPages(
     documentationPackage: FarmerDocumentationPackage,
+    content: FarmerDocumentationPackageContent = 'all',
 ) {
-    return [
-        ...documentationPackage.discardedOperations,
-        ...documentationPackage.discardedPlantSorts,
-    ].sort(compareDocumentationPage);
+    return filterDocumentationPagesByContent(
+        [
+            ...documentationPackage.discardedOperations,
+            ...documentationPackage.discardedPlantSorts,
+        ],
+        content,
+    ).sort(compareDocumentationPage);
 }
 
 export async function getFarmerDocumentationPackage({
@@ -496,6 +539,19 @@ function shouldIncludeCurrentEntity(
             documentationEntityKey(entityTypeName, entity.id),
         )
     );
+}
+
+function filterDocumentationPagesByContent<
+    T extends { entityTypeName: FarmerDocumentationEntityTypeName },
+>(pages: T[], content: FarmerDocumentationPackageContent) {
+    switch (content) {
+        case 'all':
+            return pages;
+        case 'operations':
+            return pages.filter((page) => page.entityTypeName === 'operation');
+        case 'plantSorts':
+            return pages.filter((page) => page.entityTypeName === 'plantSort');
+    }
 }
 
 function discardedPagesForType({

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
@@ -4,6 +4,7 @@ import type { EntityStandardized } from '@gredice/storage';
 import {
     buildFarmerDocumentationPackage,
     currentDocumentationPages,
+    discardedDocumentationPages,
     type FarmerDocumentationRevision,
     includedDocumentationPages,
 } from './farmerDocumentationData';
@@ -140,6 +141,18 @@ test('builds insert, replace, and discard instructions from manual revisions', (
         ['PS-0014', 'OP-0008', 'OP-0004'],
     );
     assert.deepEqual(
+        includedDocumentationPages(documentationPackage, 'operations').map(
+            (page) => page.code,
+        ),
+        ['OP-0008', 'OP-0004'],
+    );
+    assert.deepEqual(
+        includedDocumentationPages(documentationPackage, 'plantSorts').map(
+            (page) => page.code,
+        ),
+        ['PS-0014'],
+    );
+    assert.deepEqual(
         documentationPackage.includedOperations[0]?.summaryRows.find(
             (row) => row.label === 'Cijena',
         ),
@@ -153,10 +166,22 @@ test('builds insert, replace, and discard instructions from manual revisions', (
         [['OP-0011', 'Stara radnja']],
     );
     assert.deepEqual(
+        discardedDocumentationPages(documentationPackage, 'operations').map(
+            (operation) => [operation.code, operation.label],
+        ),
+        [['OP-0011', 'Stara radnja']],
+    );
+    assert.deepEqual(
         documentationPackage.discardedPlantSorts.map((plantSort) => [
             plantSort.code,
             plantSort.label,
         ]),
+        [['PS-0016', 'Stara sorta']],
+    );
+    assert.deepEqual(
+        discardedDocumentationPages(documentationPackage, 'plantSorts').map(
+            (plantSort) => [plantSort.code, plantSort.label],
+        ),
         [['PS-0016', 'Stara sorta']],
     );
 });
@@ -236,6 +261,65 @@ test('generates a guide-first PDF without page numbering text', () => {
     assert.match(content, /2,50 EUR/);
     assert.match(content, /2 Tr \(Gredice\)/);
     assert.doesNotMatch(content, /Stranica \d/);
+});
+
+test('generates filtered PDF packages for updates', () => {
+    const documentationPackage = buildFarmerDocumentationPackage({
+        generatedAt,
+        since,
+        labelAttributeDefinitionIds: {
+            operation: new Set(),
+            plantSort: new Set(),
+        },
+        operations: [
+            operationFixture(4, 'Zalijevanje', {
+                duration: 25,
+                application: 'raisedBedFull',
+            }),
+        ],
+        plantSorts: [
+            plantSortFixture(14, 'Cherry rajčica', {
+                reproductionType: 'seed',
+            }),
+        ],
+        revisions: [
+            revisionFixture({
+                id: 1,
+                entityId: 4,
+                action: 'attribute.updated',
+                createdAt: new Date('2026-06-08T12:00:00.000Z'),
+            }),
+            revisionFixture({
+                id: 2,
+                entityId: 14,
+                entityTypeName: 'plantSort',
+                action: 'attribute.updated',
+                createdAt: new Date('2026-06-08T13:00:00.000Z'),
+            }),
+        ],
+    });
+
+    const pdf = generateFarmerDocumentationPdf(documentationPackage, {
+        content: 'operations',
+    });
+    const content = new TextDecoder().decode(pdf);
+
+    assert.match(content, /ORG-GUIDE/);
+    assert.match(content, /Radnje/);
+    assert.match(content, /OP-0004/);
+    assert.match(content, /Kratak opis radnje/);
+    assert.doesNotMatch(content, /Kratak opis sorte/);
+
+    const plantSortsPdf = generateFarmerDocumentationPdf(documentationPackage, {
+        content: 'plantSorts',
+    });
+    const plantSortsContent = new TextDecoder().decode(plantSortsPdf);
+
+    assert.match(plantSortsContent, /ORG-GUIDE/);
+    assert.match(plantSortsContent, /Biljke i sorte/);
+    assert.match(plantSortsContent, /PS-0014/);
+    assert.match(plantSortsContent, /Kratak opis sorte/);
+    assert.doesNotMatch(plantSortsContent, /Kratak opis radnje/);
 });
 
 function operationFixture(

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
@@ -4,6 +4,7 @@ import {
     discardedDocumentationPages,
     documentationChangeLabel,
     type FarmerDocumentationPackage,
+    type FarmerDocumentationPackageContent,
     type FarmerDocumentationPage,
     formatDocumentationDateTime,
     getFarmerAppOrigin,
@@ -231,21 +232,29 @@ class PdfCanvas {
 
 export function generateFarmerDocumentationPdf(
     data: FarmerDocumentationPackage,
+    {
+        content = 'all',
+    }: {
+        content?: FarmerDocumentationPackageContent;
+    } = {},
 ): ArrayBuffer {
     const farmOrigin = getFarmerAppOrigin();
     const version = farmerDocumentationVersion(data.generatedAt);
     const pages: PdfCanvas[] = [];
 
-    drawOrganizationGuide({ data, farmOrigin, pages, version });
+    drawOrganizationGuide({ content, data, farmOrigin, pages, version });
 
-    for (const page of includedDocumentationPages(data)) {
+    for (const page of includedDocumentationPages(data, content)) {
         drawDocumentationPage({ data, farmOrigin, pages, version, page });
     }
 
     return writePdf(pages.map((page) => page.toString()));
 }
 
-export function farmerDocumentationFilename(data: FarmerDocumentationPackage) {
+export function farmerDocumentationFilename(
+    data: FarmerDocumentationPackage,
+    content: FarmerDocumentationPackageContent = 'all',
+) {
     const datePart = new Intl.DateTimeFormat('en-CA', {
         timeZone: 'Europe/Zagreb',
         year: 'numeric',
@@ -253,8 +262,9 @@ export function farmerDocumentationFilename(data: FarmerDocumentationPackage) {
         day: '2-digit',
     }).format(data.generatedAt);
     const scopePart = data.since ? 'promjene' : 'sve-stranice';
+    const contentPart = farmerDocumentationFilenameContentPart(content);
 
-    return `farmeri-dokumentacija-${scopePart}-${datePart}.pdf`;
+    return `farmeri-dokumentacija-${scopePart}${contentPart}-${datePart}.pdf`;
 }
 
 export function farmerDocumentationVersion(date: Date) {
@@ -277,32 +287,36 @@ export function farmerDocumentationVersion(date: Date) {
 }
 
 function drawOrganizationGuide({
+    content,
     data,
     farmOrigin,
     pages,
     version,
 }: {
+    content: FarmerDocumentationPackageContent;
     data: FarmerDocumentationPackage;
     farmOrigin: string;
     pages: PdfCanvas[];
     version: string;
 }) {
+    const subtitleScope = data.since
+        ? `Promjene od ${formatDocumentationDateTime(data.since)}`
+        : 'Cijeli prirucnik';
+    const subtitleContent = organizationGuideContentSubtitle(content);
     let context = startPage(pages, {
         code: 'ORG-GUIDE',
         title: 'Vodic za organizaciju',
-        subtitle: data.since
-            ? `Promjene od ${formatDocumentationDateTime(data.since)}`
-            : 'Cijeli prirucnik',
+        subtitle: subtitleContent
+            ? `${subtitleScope} - ${subtitleContent}`
+            : subtitleScope,
         qrUrl: farmOrigin,
         version,
         generatedAt: data.generatedAt,
     });
-    const packageType = data.since
-        ? 'Paket sadrzi organizacijski vodic i sve prirucnike promijenjene od zadnjeg ispisa.'
-        : 'Paket sadrzi organizacijski vodic i sve trenutno objavljene prirucnike.';
-    const includedPages = includedDocumentationPages(data);
+    const packageType = organizationGuidePackageDescription(data, content);
+    const includedPages = includedDocumentationPages(data, content);
     const allCurrentPages = currentDocumentationPages(data);
-    const discardedPages = discardedDocumentationPages(data);
+    const discardedPages = discardedDocumentationPages(data, content);
 
     context = drawSection(context, 'Svrha paketa', [
         packageType,
@@ -332,6 +346,58 @@ function drawOrganizationGuide({
     ]);
 
     drawFooter(context.page);
+}
+
+function farmerDocumentationFilenameContentPart(
+    content: FarmerDocumentationPackageContent,
+) {
+    switch (content) {
+        case 'all':
+            return '';
+        case 'operations':
+            return '-radnje';
+        case 'plantSorts':
+            return '-biljke-sorte';
+    }
+}
+
+function organizationGuideContentSubtitle(
+    content: FarmerDocumentationPackageContent,
+) {
+    switch (content) {
+        case 'all':
+            return null;
+        case 'operations':
+            return 'Radnje';
+        case 'plantSorts':
+            return 'Biljke i sorte';
+    }
+}
+
+function organizationGuidePackageDescription(
+    data: FarmerDocumentationPackage,
+    content: FarmerDocumentationPackageContent,
+) {
+    const contentLabel = organizationGuidePackageContentLabel(content);
+
+    if (data.since) {
+        return `Paket sadrzi organizacijski vodic i ${contentLabel} promijenjene od zadnjeg ispisa.`;
+    }
+
+    return `Paket sadrzi organizacijski vodic i ${contentLabel} trenutno objavljene u farmer aplikaciji.`;
+}
+
+function organizationGuidePackageContentLabel(
+    content: FarmerDocumentationPackageContent,
+) {
+    switch (content) {
+        case 'all':
+            return 'sve prirucnike';
+        case 'operations':
+            return 'prirucnike radnji';
+        case 'plantSorts':
+            return 'prirucnike biljaka i sorti';
+    }
 }
 
 function drawActionList(

--- a/apps/app/app/admin/farmers/documentation/page.tsx
+++ b/apps/app/app/admin/farmers/documentation/page.tsx
@@ -1,6 +1,8 @@
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
-import { Book, Printer } from '@gredice/ui/icons';
+import { Book, Hammer, Printer, Sprout } from '@gredice/ui/icons';
+import { DropdownMenuItem } from '@gredice/ui/Menu';
+import { SplitButton } from '@gredice/ui/SplitButton';
 import { Stack } from '@gredice/ui/Stack';
 import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
@@ -11,7 +13,9 @@ import { DocumentationChangeTypeBadge } from './DocumentationChangeTypeBadge';
 import { DocumentationSummaryCard } from './DocumentationSummaryCard';
 import {
     discardedDocumentationPages,
+    documentationPackageContentQueryValue,
     type FarmerDocumentationChangeType,
+    type FarmerDocumentationPackageContent,
     formatDocumentationDateTime,
     getFarmerDocumentationPackage,
     includedDocumentationPages,
@@ -43,20 +47,58 @@ export default async function FarmerDocumentationPage({
         since,
     });
     const packageRows = packageTableRows(documentationPackage);
-    const changesHref = printoutHref(sinceInput);
+    const changesHref = printoutHref({ sinceInput });
+    const operationsChangesHref = printoutHref({
+        sinceInput,
+        content: 'operations',
+    });
+    const plantSortsChangesHref = printoutHref({
+        sinceInput,
+        content: 'plantSorts',
+    });
     const invalidSince = Boolean(sinceInput) && !since;
+    const menuAllLabel = since ? 'Sve promjene' : 'Cijeli paket';
 
     return (
         <Stack spacing={4}>
             <AdminPageHeader
                 actions={
                     <>
-                        <Button
+                        <SplitButton
                             href={changesHref}
                             startDecorator={<Printer className="size-4" />}
+                            dropdownLabel="Odaberi sadržaj paketa"
+                            menuContent={
+                                <>
+                                    <DropdownMenuItem
+                                        href={changesHref}
+                                        startDecorator={
+                                            <Printer className="size-4" />
+                                        }
+                                    >
+                                        {menuAllLabel}
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        href={operationsChangesHref}
+                                        startDecorator={
+                                            <Hammer className="size-4" />
+                                        }
+                                    >
+                                        Samo radnje
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        href={plantSortsChangesHref}
+                                        startDecorator={
+                                            <Sprout className="size-4" />
+                                        }
+                                    >
+                                        Samo biljke/sorte
+                                    </DropdownMenuItem>
+                                </>
+                            }
                         >
                             Preuzmi paket
-                        </Button>
+                        </SplitButton>
                         <Button
                             href={`${KnownPages.FarmerDocumentationPrintout}?scope=all`}
                             variant="outlined"
@@ -226,10 +268,19 @@ function singleSearchParam(value: string | string[] | undefined) {
     return Array.isArray(value) ? value[0] : value;
 }
 
-function printoutHref(sinceInput: string | undefined) {
+function printoutHref({
+    content = 'all',
+    sinceInput,
+}: {
+    content?: FarmerDocumentationPackageContent;
+    sinceInput: string | undefined;
+}) {
     const params = new URLSearchParams();
     if (sinceInput) {
         params.set('since', sinceInput);
+    }
+    if (content !== 'all') {
+        params.set('content', documentationPackageContentQueryValue(content));
     }
 
     const query = params.toString();

--- a/apps/app/app/admin/farmers/documentation/printout/route.ts
+++ b/apps/app/app/admin/farmers/documentation/printout/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '../../../../../lib/auth/auth';
 import {
     getFarmerDocumentationPackage,
+    parseDocumentationPackageContent,
     parseDocumentationSince,
 } from '../farmerDocumentationData';
 import {
@@ -15,6 +16,9 @@ export async function GET(request: Request) {
 
     const url = new URL(request.url);
     const scope = url.searchParams.get('scope');
+    const content = parseDocumentationPackageContent(
+        url.searchParams.get('content'),
+    );
     const since =
         scope === 'all'
             ? null
@@ -22,13 +26,16 @@ export async function GET(request: Request) {
     const documentationPackage = await getFarmerDocumentationPackage({
         since,
     });
-    const pdf = generateFarmerDocumentationPdf(documentationPackage);
+    const pdf = generateFarmerDocumentationPdf(documentationPackage, {
+        content,
+    });
 
     return new Response(pdf, {
         headers: {
             'Cache-Control': 'no-store',
             'Content-Disposition': `attachment; filename="${farmerDocumentationFilename(
                 documentationPackage,
+                content,
             )}"`,
             'Content-Length': String(pdf.byteLength),
             'Content-Type': 'application/pdf',


### PR DESCRIPTION
## Summary

Adds filtered farmer documentation package downloads for admin farmers documentation.

- Adds operations-only and plants/sorts-only package choices to the admin documentation download control.
- Passes a content filter through the printout route and PDF generator.
- Keeps the organization guide, discard instructions, and filenames aligned with the selected package content.
- Extends unit coverage for filtered documentation helpers and both filtered PDF variants.

## Validation

- `pnpm --dir apps/app exec biome check --write app/admin/farmers/documentation/page.tsx app/admin/farmers/documentation/printout/route.ts app/admin/farmers/documentation/farmerDocumentationData.ts app/admin/farmers/documentation/farmerDocumentationPdf.ts app/admin/farmers/documentation/farmerDocumentationData.unit.ts`
- `NODE_OPTIONS="--conditions=react-server" pnpm --dir apps/app exec node --import tsx --test app/admin/farmers/documentation/farmerDocumentationData.unit.ts`
- `pnpm --dir apps/app exec next typegen`
- `git diff --check`

Direct `pnpm --dir apps/app exec tsc --noEmit --pretty false` is currently blocked by existing unrelated app/package type errors outside these farmer documentation files.