### PR TITLE
[codex] Add plant pages to farmer documentation

### DIFF
--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.ts
@@ -16,11 +16,12 @@ import {
 import { and, desc, gte, inArray } from 'drizzle-orm';
 
 export type FarmerDocumentationChangeType = 'insert' | 'replace' | 'discard';
-export type FarmerDocumentationEntityTypeName = 'operation' | 'plantSort';
-export type FarmerDocumentationPackageContent =
-    | 'all'
-    | 'operations'
-    | 'plantSorts';
+export type FarmerDocumentationEntityTypeName =
+    | 'operation'
+    | 'plant'
+    | 'plantSort';
+export type FarmerDocumentationPageEntityTypeName = 'operation' | 'plant';
+export type FarmerDocumentationPackageContent = 'all' | 'operations' | 'plants';
 
 export type FarmerDocumentationAttribute = {
     label: string;
@@ -34,7 +35,7 @@ export type FarmerDocumentationSection = {
 
 export type FarmerDocumentationPage = {
     id: number;
-    entityTypeName: FarmerDocumentationEntityTypeName;
+    entityTypeName: FarmerDocumentationPageEntityTypeName;
     documentTypeLabel: string;
     code: string;
     label: string;
@@ -50,8 +51,8 @@ export type FarmerDocumentationOperation = FarmerDocumentationPage & {
     entityTypeName: 'operation';
 };
 
-export type FarmerDocumentationPlantSort = FarmerDocumentationPage & {
-    entityTypeName: 'plantSort';
+export type FarmerDocumentationPlant = FarmerDocumentationPage & {
+    entityTypeName: 'plant';
 };
 
 export type FarmerDocumentationDiscard = {
@@ -68,12 +69,14 @@ export type FarmerDocumentationPackage = {
     since: Date | null;
     generatedAt: Date;
     totalOperations: number;
+    totalPlants: number;
     totalPlantSorts: number;
     currentOperations: FarmerDocumentationOperation[];
-    currentPlantSorts: FarmerDocumentationPlantSort[];
+    currentPlants: FarmerDocumentationPlant[];
     includedOperations: FarmerDocumentationOperation[];
-    includedPlantSorts: FarmerDocumentationPlantSort[];
+    includedPlants: FarmerDocumentationPlant[];
     discardedOperations: FarmerDocumentationDiscard[];
+    discardedPlants: FarmerDocumentationDiscard[];
     discardedPlantSorts: FarmerDocumentationDiscard[];
 };
 
@@ -94,6 +97,7 @@ export type FarmerDocumentationRevision = Pick<
 
 const documentationEntityTypeNames: FarmerDocumentationEntityTypeName[] = [
     'operation',
+    'plant',
     'plantSort',
 ];
 
@@ -111,6 +115,12 @@ const documentationEntityConfig: Record<
         documentTypeLabel: 'Radnja',
         fallbackLabel: 'Radnja',
         noun: 'radnja',
+    },
+    plant: {
+        codePrefix: 'PL',
+        documentTypeLabel: 'Biljka',
+        fallbackLabel: 'Biljka',
+        noun: 'biljka',
     },
     plantSort: {
         codePrefix: 'PS',
@@ -253,9 +263,11 @@ export function parseDocumentationPackageContent(
     switch (value?.trim()) {
         case 'operations':
             return 'operations';
+        case 'plants':
+        case 'plants-sorts':
         case 'plant-sorts':
         case 'plantSorts':
-            return 'plantSorts';
+            return 'plants';
         default:
             return 'all';
     }
@@ -269,8 +281,8 @@ export function documentationPackageContentQueryValue(
             return 'all';
         case 'operations':
             return 'operations';
-        case 'plantSorts':
-            return 'plant-sorts';
+        case 'plants':
+            return 'plants';
     }
 }
 
@@ -281,7 +293,7 @@ export function includedDocumentationPages(
     return filterDocumentationPagesByContent(
         [
             ...documentationPackage.includedOperations,
-            ...documentationPackage.includedPlantSorts,
+            ...documentationPackage.includedPlants,
         ],
         content,
     ).sort(compareDocumentationPage);
@@ -294,7 +306,7 @@ export function currentDocumentationPages(
     return filterDocumentationPagesByContent(
         [
             ...documentationPackage.currentOperations,
-            ...documentationPackage.currentPlantSorts,
+            ...documentationPackage.currentPlants,
         ],
         content,
     ).sort(compareDocumentationPage);
@@ -307,6 +319,7 @@ export function discardedDocumentationPages(
     return filterDocumentationPagesByContent(
         [
             ...documentationPackage.discardedOperations,
+            ...documentationPackage.discardedPlants,
             ...documentationPackage.discardedPlantSorts,
         ],
         content,
@@ -320,12 +333,17 @@ export async function getFarmerDocumentationPackage({
 }): Promise<FarmerDocumentationPackage> {
     const [
         operations,
+        plants,
         plantSorts,
         revisions,
         operationAttributeDefinitions,
+        plantAttributeDefinitions,
         plantSortAttributeDefinitions,
     ] = await Promise.all([
         getEntitiesFormatted<EntityStandardized>('operation').catch(
+            (): EntityStandardized[] => [],
+        ),
+        getEntitiesFormatted<EntityStandardized>('plant').catch(
             (): EntityStandardized[] => [],
         ),
         getEntitiesFormatted<EntityStandardized>('plantSort').catch(
@@ -333,21 +351,26 @@ export async function getFarmerDocumentationPackage({
         ),
         getDocumentationRevisionsSince(since),
         getAttributeDefinitions('operation').catch(() => []),
+        getAttributeDefinitions('plant').catch(() => []),
         getAttributeDefinitions('plantSort').catch(() => []),
     ]);
 
     return buildFarmerDocumentationPackage({
         operations,
+        plants,
         plantSorts,
         revisions,
         labelAttributeDefinitionIds: {
             operation: labelAttributeDefinitionIds(
                 operationAttributeDefinitions,
             ),
+            plant: labelAttributeDefinitionIds(plantAttributeDefinitions),
             plantSort: labelAttributeDefinitionIds(
                 plantSortAttributeDefinitions,
             ),
         },
+        plantSortPlantAttributeDefinitionIds:
+            plantSortPlantAttributeDefinitionIds(plantSortAttributeDefinitions),
         generatedAt: new Date(),
         since,
     });
@@ -357,7 +380,9 @@ export function buildFarmerDocumentationPackage({
     generatedAt,
     labelAttributeDefinitionIds,
     operations,
+    plants,
     plantSorts,
+    plantSortPlantAttributeDefinitionIds,
     revisions,
     since,
 }: {
@@ -367,7 +392,9 @@ export function buildFarmerDocumentationPackage({
         ReadonlySet<number>
     >;
     operations: EntityStandardized[];
+    plants: EntityStandardized[];
     plantSorts: EntityStandardized[];
+    plantSortPlantAttributeDefinitionIds: ReadonlySet<number>;
     revisions: FarmerDocumentationRevision[];
     since: Date | null;
 }): FarmerDocumentationPackage {
@@ -379,7 +406,25 @@ export function buildFarmerDocumentationPackage({
             numeric: true,
         }),
     );
+    const sortedPlants = plantsWithReferencedSortPlants(
+        plants,
+        sortedPlantSorts,
+    ).sort((left, right) =>
+        getPlantLabel(left).localeCompare(getPlantLabel(right), 'hr', {
+            numeric: true,
+        }),
+    );
+    const plantSortsByPlantId = groupPlantSortsByPlantId(sortedPlantSorts);
+    const plantSortsById = new Map(
+        sortedPlantSorts.map((plantSort) => [plantSort.id, plantSort]),
+    );
     const revisionsByEntityKey = groupRevisionsByEntityKey(revisions);
+    const movedPlantSortsByPreviousPlantId =
+        groupMovedPlantSortsByPreviousPlantId({
+            plantSortsById,
+            plantSortPlantAttributeDefinitionIds,
+            revisions,
+        });
     const currentOperations = sortedOperations.map((operation) =>
         toDocumentationOperation(
             operation,
@@ -389,14 +434,22 @@ export function buildFarmerDocumentationPackage({
             since,
         ),
     );
-    const currentPlantSorts = sortedPlantSorts.map((plantSort) =>
-        toDocumentationPlantSort(
-            plantSort,
-            revisionsByEntityKey.get(
-                documentationEntityKey('plantSort', plantSort.id),
-            ) ?? [],
+    const currentPlants = sortedPlants.map((plant) =>
+        toDocumentationPlant({
+            plant,
+            plantSorts: plantSortsByPlantId.get(plant.id) ?? [],
+            plantRevisions:
+                revisionsByEntityKey.get(
+                    documentationEntityKey('plant', plant.id),
+                ) ?? [],
+            plantSortRevisions: plantSortRevisionsForPlant({
+                plantId: plant.id,
+                plantSorts: plantSortsByPlantId.get(plant.id) ?? [],
+                revisionsByEntityKey,
+                movedPlantSortsByPreviousPlantId,
+            }),
             since,
-        ),
+        }),
     );
     const includedOperations = currentOperations.filter((operation) =>
         shouldIncludeCurrentEntity(
@@ -406,12 +459,13 @@ export function buildFarmerDocumentationPackage({
             revisionsByEntityKey,
         ),
     );
-    const includedPlantSorts = currentPlantSorts.filter((plantSort) =>
-        shouldIncludeCurrentEntity(
-            plantSort,
-            'plantSort',
+    const includedPlants = currentPlants.filter((plant) =>
+        shouldIncludeCurrentPlant(
+            plant,
+            plantSortsByPlantId.get(plant.id) ?? [],
             since,
             revisionsByEntityKey,
+            movedPlantSortsByPreviousPlantId,
         ),
     );
 
@@ -419,15 +473,22 @@ export function buildFarmerDocumentationPackage({
         since,
         generatedAt,
         totalOperations: sortedOperations.length,
+        totalPlants: sortedPlants.length,
         totalPlantSorts: sortedPlantSorts.length,
         currentOperations,
-        currentPlantSorts,
+        currentPlants,
         includedOperations,
-        includedPlantSorts,
+        includedPlants,
         discardedOperations: discardedPagesForType({
             currentEntities: sortedOperations,
             entityTypeName: 'operation',
             labelAttributeDefinitionIds: labelAttributeDefinitionIds.operation,
+            revisionsByEntityKey,
+        }),
+        discardedPlants: discardedPagesForType({
+            currentEntities: sortedPlants,
+            entityTypeName: 'plant',
+            labelAttributeDefinitionIds: labelAttributeDefinitionIds.plant,
             revisionsByEntityKey,
         }),
         discardedPlantSorts: discardedPagesForType({
@@ -490,6 +551,24 @@ function labelAttributeDefinitionIds(
     );
 }
 
+function plantSortPlantAttributeDefinitionIds(
+    attributeDefinitions: Array<{
+        id: number;
+        category: string | null;
+        name: string;
+    }>,
+) {
+    return new Set(
+        attributeDefinitions
+            .filter(
+                (definition) =>
+                    definition.category === 'information' &&
+                    definition.name === 'plant',
+            )
+            .map((definition) => definition.id),
+    );
+}
+
 function groupRevisionsByEntityKey(revisions: FarmerDocumentationRevision[]) {
     const grouped = new Map<string, FarmerDocumentationRevision[]>();
 
@@ -513,7 +592,7 @@ function groupRevisionsByEntityKey(revisions: FarmerDocumentationRevision[]) {
 function normalizeDocumentationEntityTypeName(
     value: string,
 ): FarmerDocumentationEntityTypeName | null {
-    if (value === 'operation' || value === 'plantSort') {
+    if (value === 'operation' || value === 'plant' || value === 'plantSort') {
         return value;
     }
 
@@ -541,6 +620,29 @@ function shouldIncludeCurrentEntity(
     );
 }
 
+function shouldIncludeCurrentPlant(
+    plant: { id: number },
+    plantSorts: EntityStandardized[],
+    since: Date | null,
+    revisionsByEntityKey: ReadonlyMap<string, FarmerDocumentationRevision[]>,
+    movedPlantSortsByPreviousPlantId: ReadonlyMap<number, ReadonlySet<number>>,
+) {
+    return (
+        shouldIncludeCurrentEntity(
+            plant,
+            'plant',
+            since,
+            revisionsByEntityKey,
+        ) ||
+        movedPlantSortsByPreviousPlantId.has(plant.id) ||
+        plantSorts.some((plantSort) =>
+            revisionsByEntityKey.has(
+                documentationEntityKey('plantSort', plantSort.id),
+            ),
+        )
+    );
+}
+
 function filterDocumentationPagesByContent<
     T extends { entityTypeName: FarmerDocumentationEntityTypeName },
 >(pages: T[], content: FarmerDocumentationPackageContent) {
@@ -549,9 +651,146 @@ function filterDocumentationPagesByContent<
             return pages;
         case 'operations':
             return pages.filter((page) => page.entityTypeName === 'operation');
-        case 'plantSorts':
-            return pages.filter((page) => page.entityTypeName === 'plantSort');
+        case 'plants':
+            return pages.filter(
+                (page) =>
+                    page.entityTypeName === 'plant' ||
+                    page.entityTypeName === 'plantSort',
+            );
     }
+}
+
+function plantsWithReferencedSortPlants(
+    plants: EntityStandardized[],
+    plantSorts: EntityStandardized[],
+) {
+    const plantsById = new Map(plants.map((plant) => [plant.id, plant]));
+
+    for (const plantSort of plantSorts) {
+        const plant = getPlantSortPlant(plantSort);
+        if (plant && !plantsById.has(plant.id)) {
+            plantsById.set(plant.id, plant);
+        }
+    }
+
+    return Array.from(plantsById.values());
+}
+
+function groupPlantSortsByPlantId(plantSorts: EntityStandardized[]) {
+    const plantSortsByPlantId = new Map<number, EntityStandardized[]>();
+
+    for (const plantSort of plantSorts) {
+        const plant = getPlantSortPlant(plantSort);
+        if (!plant) {
+            continue;
+        }
+
+        const plantSortsForPlant = plantSortsByPlantId.get(plant.id) ?? [];
+        plantSortsForPlant.push(plantSort);
+        plantSortsByPlantId.set(plant.id, plantSortsForPlant);
+    }
+
+    return plantSortsByPlantId;
+}
+
+function groupMovedPlantSortsByPreviousPlantId({
+    plantSortsById,
+    plantSortPlantAttributeDefinitionIds,
+    revisions,
+}: {
+    plantSortsById: ReadonlyMap<number, EntityStandardized>;
+    plantSortPlantAttributeDefinitionIds: ReadonlySet<number>;
+    revisions: FarmerDocumentationRevision[];
+}) {
+    const movedPlantSortsByPreviousPlantId = new Map<number, Set<number>>();
+
+    for (const revision of revisions) {
+        if (
+            revision.entityTypeName !== 'plantSort' ||
+            !revision.attributeDefinitionId ||
+            !plantSortPlantAttributeDefinitionIds.has(
+                revision.attributeDefinitionId,
+            ) ||
+            !(
+                revision.action === 'attribute.updated' ||
+                revision.action === 'attribute.deleted'
+            )
+        ) {
+            continue;
+        }
+
+        const previousPlantId = revisionEntityRefId(revision.previousValue);
+        if (!previousPlantId) {
+            continue;
+        }
+
+        const currentPlantSort = plantSortsById.get(revision.entityId);
+        const currentPlantId =
+            currentPlantSort && getPlantSortPlant(currentPlantSort)?.id;
+        const nextPlantId =
+            currentPlantId ?? revisionEntityRefId(revision.nextValue);
+        if (nextPlantId === previousPlantId) {
+            continue;
+        }
+
+        const movedSortIds =
+            movedPlantSortsByPreviousPlantId.get(previousPlantId) ??
+            new Set<number>();
+        movedSortIds.add(revision.entityId);
+        movedPlantSortsByPreviousPlantId.set(previousPlantId, movedSortIds);
+    }
+
+    return movedPlantSortsByPreviousPlantId;
+}
+
+function revisionEntityRefId(value: string | null) {
+    const normalized = value?.trim();
+    if (!normalized || !/^\d+$/.test(normalized)) {
+        return null;
+    }
+
+    const parsed = Number.parseInt(normalized, 10);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function plantSortRevisionsForPlant({
+    plantId,
+    plantSorts,
+    revisionsByEntityKey,
+    movedPlantSortsByPreviousPlantId,
+}: {
+    plantId: number;
+    plantSorts: EntityStandardized[];
+    revisionsByEntityKey: ReadonlyMap<string, FarmerDocumentationRevision[]>;
+    movedPlantSortsByPreviousPlantId: ReadonlyMap<number, ReadonlySet<number>>;
+}) {
+    const revisions = [
+        ...plantSorts.flatMap(
+            (plantSort) =>
+                revisionsByEntityKey.get(
+                    documentationEntityKey('plantSort', plantSort.id),
+                ) ?? [],
+        ),
+        ...Array.from(
+            movedPlantSortsByPreviousPlantId.get(plantId) ?? [],
+        ).flatMap(
+            (plantSortId) =>
+                revisionsByEntityKey.get(
+                    documentationEntityKey('plantSort', plantSortId),
+                ) ?? [],
+        ),
+    ];
+
+    return uniqueRevisions(revisions);
+}
+
+function uniqueRevisions(revisions: FarmerDocumentationRevision[]) {
+    const unique = new Map<number, FarmerDocumentationRevision>();
+    for (const revision of revisions) {
+        unique.set(revision.id, revision);
+    }
+
+    return Array.from(unique.values());
 }
 
 function discardedPagesForType({
@@ -658,32 +897,41 @@ function toDocumentationOperation(
     };
 }
 
-function toDocumentationPlantSort(
-    plantSort: EntityStandardized,
-    revisions: FarmerDocumentationRevision[],
-    since: Date | null,
-): FarmerDocumentationPlantSort {
-    const plant = getPlantSortPlant(plantSort);
+function toDocumentationPlant({
+    plant,
+    plantRevisions,
+    plantSortRevisions,
+    plantSorts,
+    since,
+}: {
+    plant: EntityStandardized;
+    plantRevisions: FarmerDocumentationRevision[];
+    plantSortRevisions: FarmerDocumentationRevision[];
+    plantSorts: EntityStandardized[];
+    since: Date | null;
+}): FarmerDocumentationPlant {
     const plantInformation = recordProperty(plant, 'information');
     const latinName = textProperty(plantInformation, 'latinName');
+    const revisions = [...plantRevisions, ...plantSortRevisions];
     const plantLabel = getPlantLabel(plant);
     const changedAt =
         revisions.length > 0 ? latestRevisionDate(revisions) : null;
-    const changeType = isInsertPage(revisions, since) ? 'insert' : 'replace';
+    const changeType = isInsertPage(plantRevisions, since)
+        ? 'insert'
+        : 'replace';
 
     return {
-        id: plantSort.id,
-        entityTypeName: 'plantSort',
-        documentTypeLabel:
-            documentationEntityConfig.plantSort.documentTypeLabel,
-        code: getFarmerDocumentationCode('plantSort', plantSort.id),
-        label: getPlantSortLabel(plantSort),
-        appPath: `/plants/${plantSort.id}`,
+        id: plant.id,
+        entityTypeName: 'plant',
+        documentTypeLabel: documentationEntityConfig.plant.documentTypeLabel,
+        code: getFarmerDocumentationCode('plant', plant.id),
+        label: plantLabel,
+        appPath: '/plants',
         summaryRows: compactRows([
-            ['Kod', getFarmerDocumentationCode('plantSort', plantSort.id)],
-            ['Vrsta', documentationEntityConfig.plantSort.documentTypeLabel],
-            ['Biljka', plantLabel],
+            ['Kod', getFarmerDocumentationCode('plant', plant.id)],
+            ['Vrsta', documentationEntityConfig.plant.documentTypeLabel],
             ['Latinski naziv', latinName],
+            ['Dostupnih sorti', formatInteger(plantSorts.length)],
             [
                 'Promjena',
                 changedAt
@@ -691,10 +939,13 @@ function toDocumentationPlantSort(
                     : 'Cijeli priručnik',
             ],
         ]),
-        sections: plantSortSections(plantSort),
+        sections: plantSections(plant, plantSorts),
         changedAt,
         changeType,
-        revisionActions: revisionActionSummary(revisions, 'plantSort'),
+        revisionActions: uniqueStrings([
+            ...revisionActionSummary(plantRevisions, 'plant'),
+            ...revisionActionSummary(plantSortRevisions, 'plantSort'),
+        ]),
     };
 }
 
@@ -718,11 +969,11 @@ function getPlantSortPlant(plantSort: EntityStandardized) {
     return plantSort.information?.plant ?? null;
 }
 
-function getPlantLabel(plant: EntityStandardized | null) {
+function getPlantLabel(plant: EntityStandardized) {
     return (
         plant?.information?.label?.trim() ||
         plant?.information?.name?.trim() ||
-        null
+        `${documentationEntityConfig.plant.fallbackLabel} #${plant.id}`
     );
 }
 
@@ -787,52 +1038,78 @@ function operationAttributes(operation: EntityStandardized) {
         );
 }
 
-function plantSortSections(plantSort: EntityStandardized) {
-    const plant = getPlantSortPlant(plantSort);
-    const sortInformation = isRecord(plantSort.information)
-        ? plantSort.information
-        : null;
+function plantSections(
+    plant: EntityStandardized,
+    plantSorts: EntityStandardized[],
+) {
     const plantInformation = recordProperty(plant, 'information');
     const plantAttributes = recordProperty(plant, 'attributes');
     const plantCalendar = recordProperty(plant, 'calendar');
-    const sortAttributes = isRecord(plantSort.attributes)
-        ? plantSort.attributes
-        : null;
 
     return [
+        documentationSection(
+            'Dostupne sorte',
+            plantSorts.length > 0
+                ? plantSorts.map(plantSortListLine)
+                : ['Nema dostupnih sorti.'],
+        ),
         ...plantSortTextFields
             .map(({ key, title }) => {
-                const text =
-                    textProperty(sortInformation, key) ??
-                    textProperty(plantInformation, key);
+                const text = textProperty(plantInformation, key);
 
                 return documentationSection(title, text ? [text] : []);
             })
             .filter((section): section is FarmerDocumentationSection =>
                 Boolean(section),
             ),
-        detailSection('Sorta', buildSortRows(sortAttributes)),
         detailSection('Sjetva', buildSowingRows(plantAttributes)),
         detailSection('Rast', buildGrowthRows(plantAttributes)),
         detailSection('Zalijevanje', buildWateringRows(plantAttributes)),
         detailSection('Berba', buildHarvestRows(plantAttributes)),
         detailSection('Kalendar uzgoja', buildCalendarRows(plantCalendar)),
+        ...plantSorts.map((plantSort) =>
+            plantSortAdditionalSection(plantSort, plant),
+        ),
     ].filter((section): section is FarmerDocumentationSection =>
         Boolean(section),
     );
 }
 
-function buildSortRows(attributes: Record<string, unknown> | null) {
-    const reproductionType = stringProperty(attributes, 'reproductionType');
+function plantSortListLine(plantSort: EntityStandardized) {
+    const sortAttributes = isRecord(plantSort.attributes)
+        ? plantSort.attributes
+        : null;
+    const reproductionType = stringProperty(sortAttributes, 'reproductionType');
+    const reproductionTypeLabel = reproductionType
+        ? (reproductionTypeLabels[reproductionType] ?? reproductionType)
+        : null;
+    const detail = reproductionTypeLabel ? `, ${reproductionTypeLabel}` : '';
 
-    return compactRows([
-        [
-            'Vrsta reprodukcije',
-            reproductionType
-                ? (reproductionTypeLabels[reproductionType] ?? reproductionType)
-                : null,
-        ],
-    ]);
+    return `${getFarmerDocumentationCode('plantSort', plantSort.id)} - ${getPlantSortLabel(plantSort)}${detail}`;
+}
+
+function plantSortAdditionalSection(
+    plantSort: EntityStandardized,
+    plant: EntityStandardized,
+) {
+    const sortInformation = isRecord(plantSort.information)
+        ? plantSort.information
+        : null;
+    const plantInformation = recordProperty(plant, 'information');
+    const lines = plantSortTextFields
+        .map(({ key, title }) => {
+            const sortText = textProperty(sortInformation, key);
+            const plantText = textProperty(plantInformation, key);
+            return sortText && sortText !== plantText
+                ? `${title}: ${sortText}`
+                : null;
+        })
+        .filter((line): line is string => Boolean(line));
+
+    return documentationSection(
+        `Dodatne informacije sorte - ${getPlantSortLabel(plantSort)}`,
+        lines,
+    );
 }
 
 function buildSowingRows(attributes: Record<string, unknown> | null) {
@@ -1246,6 +1523,10 @@ function revisionActionSummary(
             }),
         ),
     );
+}
+
+function uniqueStrings(values: string[]) {
+    return Array.from(new Set(values));
 }
 
 function compareDocumentationPage(

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
@@ -19,8 +19,10 @@ test('builds insert, replace, and discard instructions from manual revisions', (
         since,
         labelAttributeDefinitionIds: {
             operation: new Set([10]),
+            plant: new Set([30]),
             plantSort: new Set([20]),
         },
+        plantSortPlantAttributeDefinitionIds: new Set([21]),
         operations: [
             operationFixture(
                 4,
@@ -40,6 +42,7 @@ test('builds insert, replace, and discard instructions from manual revisions', (
                 frequency: 'required',
             }),
         ],
+        plants: [plantFixture()],
         plantSorts: [
             plantSortFixture(14, 'Cherry rajčica', {
                 reproductionType: 'seed',
@@ -106,6 +109,7 @@ test('builds insert, replace, and discard instructions from manual revisions', (
     const pagesByHeader = includedDocumentationPages(documentationPackage);
 
     assert.equal(documentationPackage.totalOperations, 3);
+    assert.equal(documentationPackage.totalPlants, 1);
     assert.equal(documentationPackage.totalPlantSorts, 1);
     assert.deepEqual(
         currentDocumentationPages(documentationPackage).map((page) => [
@@ -113,9 +117,9 @@ test('builds insert, replace, and discard instructions from manual revisions', (
             page.label,
         ]),
         [
-            ['PS-0014', 'Cherry rajčica'],
             ['OP-0008', 'Čišćenje gredice'],
             ['OP-0006', 'Okopavanje'],
+            ['PL-1014', 'Rajčica'],
             ['OP-0004', 'Zalijevanje'],
         ],
     );
@@ -130,15 +134,24 @@ test('builds insert, replace, and discard instructions from manual revisions', (
         ],
     );
     assert.deepEqual(
-        documentationPackage.includedPlantSorts.map((plantSort) => [
-            plantSort.code,
-            plantSort.changeType,
+        documentationPackage.includedPlants.map((plant) => [
+            plant.code,
+            plant.changeType,
+            plant.appPath,
         ]),
-        [['PS-0014', 'insert']],
+        [['PL-1014', 'replace', '/plants']],
     );
+    assert.equal(
+        documentationPackage.includedPlants[0]?.sections[0]?.title,
+        'Dostupne sorte',
+    );
+    assert.deepEqual(documentationPackage.includedPlants[0]?.sections.at(-1), {
+        title: 'Dodatne informacije sorte - Cherry rajčica',
+        lines: ['Opis: Kratak opis sorte.'],
+    });
     assert.deepEqual(
         pagesByHeader.map((page) => page.code),
-        ['PS-0014', 'OP-0008', 'OP-0004'],
+        ['OP-0008', 'PL-1014', 'OP-0004'],
     );
     assert.deepEqual(
         includedDocumentationPages(documentationPackage, 'operations').map(
@@ -147,10 +160,10 @@ test('builds insert, replace, and discard instructions from manual revisions', (
         ['OP-0008', 'OP-0004'],
     );
     assert.deepEqual(
-        includedDocumentationPages(documentationPackage, 'plantSorts').map(
+        includedDocumentationPages(documentationPackage, 'plants').map(
             (page) => page.code,
         ),
-        ['PS-0014'],
+        ['PL-1014'],
     );
     assert.deepEqual(
         documentationPackage.includedOperations[0]?.summaryRows.find(
@@ -179,11 +192,88 @@ test('builds insert, replace, and discard instructions from manual revisions', (
         [['PS-0016', 'Stara sorta']],
     );
     assert.deepEqual(
-        discardedDocumentationPages(documentationPackage, 'plantSorts').map(
+        documentationPackage.discardedPlants.map((plant) => [
+            plant.code,
+            plant.label,
+        ]),
+        [],
+    );
+    assert.deepEqual(
+        discardedDocumentationPages(documentationPackage, 'plants').map(
             (plantSort) => [plantSort.code, plantSort.label],
         ),
         [['PS-0016', 'Stara sorta']],
     );
+});
+
+test('regenerates the previous plant page when a sort moves plants', () => {
+    const tomato = plantFixture();
+    const pepper = plantFixture({
+        id: 2020,
+        label: 'Paprika',
+        description: 'Opis paprike.',
+    });
+    const documentationPackage = buildFarmerDocumentationPackage({
+        generatedAt,
+        since,
+        labelAttributeDefinitionIds: {
+            operation: new Set(),
+            plant: new Set(),
+            plantSort: new Set(),
+        },
+        plantSortPlantAttributeDefinitionIds: new Set([21]),
+        operations: [],
+        plants: [tomato, pepper],
+        plantSorts: [
+            plantSortFixture(
+                18,
+                'Žuta paprika',
+                { reproductionType: 'seed' },
+                tomato,
+            ),
+        ],
+        revisions: [
+            revisionFixture({
+                id: 1,
+                entityId: 18,
+                entityTypeName: 'plantSort',
+                action: 'attribute.updated',
+                attributeDefinitionId: 21,
+                previousValue: '2020',
+                nextValue: '1014',
+                createdAt: new Date('2026-06-08T13:00:00.000Z'),
+            }),
+        ],
+    });
+
+    assert.deepEqual(
+        documentationPackage.includedPlants.map((plant) => [
+            plant.code,
+            plant.label,
+            plant.appPath,
+            plant.revisionActions,
+        ]),
+        [
+            ['PL-2020', 'Paprika', '/plants', ['promijenjeni podaci']],
+            ['PL-1014', 'Rajčica', '/plants', ['promijenjeni podaci']],
+        ],
+    );
+
+    const previousPlantPage = documentationPackage.includedPlants.find(
+        (plant) => plant.code === 'PL-2020',
+    );
+    assert.deepEqual(previousPlantPage?.sections[0], {
+        title: 'Dostupne sorte',
+        lines: ['Nema dostupnih sorti.'],
+    });
+
+    const currentPlantPage = documentationPackage.includedPlants.find(
+        (plant) => plant.code === 'PL-1014',
+    );
+    assert.deepEqual(currentPlantPage?.sections[0], {
+        title: 'Dostupne sorte',
+        lines: ['PS-0018 - Žuta paprika, Sjeme'],
+    });
 });
 
 test('generates a guide-first PDF without page numbering text', () => {
@@ -192,8 +282,10 @@ test('generates a guide-first PDF without page numbering text', () => {
         since,
         labelAttributeDefinitionIds: {
             operation: new Set(),
+            plant: new Set(),
             plantSort: new Set(),
         },
+        plantSortPlantAttributeDefinitionIds: new Set(),
         operations: [
             operationFixture(
                 4,
@@ -213,6 +305,7 @@ test('generates a guide-first PDF without page numbering text', () => {
                 application: 'raisedBed',
             }),
         ],
+        plants: [plantFixture()],
         plantSorts: [
             plantSortFixture(14, 'Cherry rajčica', {
                 reproductionType: 'seed',
@@ -248,14 +341,17 @@ test('generates a guide-first PDF without page numbering text', () => {
     assert.match(content, /ORG-GUIDE/);
     assert.match(content, /OP-0004/);
     assert.match(content, /OP-0008/);
+    assert.match(content, /PL-1014/);
     assert.match(content, /PS-0014/);
     assert.match(content, /Zalijevanje/);
-    assertPdfText(content, 'abecedno prije PS-0014 - Cherry rajčica');
+    assertPdfText(content, 'abecedno prije OP-0006 - Okopavanje');
     assertPdfText(
         content,
-        'abecedno između OP-0008 - Berba i OP-0006 - Okopavanje',
+        'abecedno između OP-0006 - Okopavanje i OP-0004 - Zalijevanje',
     );
-    assertPdfText(content, 'abecedno poslije OP-0006 - Okopavanje');
+    assertPdfText(content, 'abecedno poslije PL-1014 - Rajčica');
+    assertPdfText(content, 'DOSTUPNE SORTE');
+    assertPdfText(content, 'DODATNE INFORMACIJE SORTE - CHERRY RAJČICA');
     assertPdfText(content, 'Cherry rajčica');
     assertPdfText(content, 'Rajčica');
     assertPdfText(content, 'Vlažno tlo');
@@ -278,14 +374,17 @@ test('generates filtered PDF packages for updates', () => {
         since,
         labelAttributeDefinitionIds: {
             operation: new Set(),
+            plant: new Set(),
             plantSort: new Set(),
         },
+        plantSortPlantAttributeDefinitionIds: new Set(),
         operations: [
             operationFixture(4, 'Zalijevanje', {
                 duration: 25,
                 application: 'raisedBedFull',
             }),
         ],
+        plants: [plantFixture()],
         plantSorts: [
             plantSortFixture(14, 'Cherry rajčica', {
                 reproductionType: 'seed',
@@ -317,18 +416,21 @@ test('generates filtered PDF packages for updates', () => {
     assert.match(content, /Radnje/);
     assert.match(content, /OP-0004/);
     assert.match(content, /Kratak opis radnje/);
+    assert.doesNotMatch(content, /Opis biljke/);
     assert.doesNotMatch(content, /Kratak opis sorte/);
 
-    const plantSortsPdf = generateFarmerDocumentationPdf(documentationPackage, {
-        content: 'plantSorts',
+    const plantsPdf = generateFarmerDocumentationPdf(documentationPackage, {
+        content: 'plants',
     });
-    const plantSortsContent = new TextDecoder().decode(plantSortsPdf);
+    const plantsContent = new TextDecoder().decode(plantsPdf);
 
-    assert.match(plantSortsContent, /ORG-GUIDE/);
-    assert.match(plantSortsContent, /Biljke i sorte/);
-    assert.match(plantSortsContent, /PS-0014/);
-    assert.match(plantSortsContent, /Kratak opis sorte/);
-    assert.doesNotMatch(plantSortsContent, /Kratak opis radnje/);
+    assert.match(plantsContent, /ORG-GUIDE/);
+    assert.match(plantsContent, /Biljke i sorte/);
+    assert.match(plantsContent, /PL-1014/);
+    assert.match(plantsContent, /PS-0014/);
+    assert.match(plantsContent, /Opis biljke/);
+    assert.match(plantsContent, /Kratak opis sorte/);
+    assert.doesNotMatch(plantsContent, /Kratak opis radnje/);
 });
 
 const pdfTextGlyphCodes = new Map([
@@ -407,6 +509,7 @@ function plantSortFixture(
     id: number,
     label: string,
     attributes: EntityStandardized['attributes'],
+    plant: EntityStandardized = plantFixture(),
 ): EntityStandardized {
     return {
         id,
@@ -414,28 +517,40 @@ function plantSortFixture(
             label,
             name: label,
             description: 'Kratak opis sorte.',
-            plant: {
-                id: 1000 + id,
-                information: {
-                    label: 'Rajčica',
-                    name: 'Rajčica',
-                    description: 'Opis biljke.',
-                },
-                attributes: {
-                    seedingDistance: 30,
-                    germinationWindowMin: 7,
-                    germinationWindowMax: 10,
-                    growthWindowMin: 60,
-                    growthWindowMax: 80,
-                    water: 'Vlažno tlo',
-                    yieldMin: 100,
-                    yieldMax: 200,
-                    yieldType: 'perPlant',
-                    cleanHarvest: false,
-                },
-            },
+            plant,
         },
         attributes,
+    };
+}
+
+function plantFixture({
+    description = 'Opis biljke.',
+    id = 1014,
+    label = 'Rajčica',
+}: {
+    description?: string;
+    id?: number;
+    label?: string;
+} = {}): EntityStandardized {
+    return {
+        id,
+        information: {
+            label,
+            name: label,
+            description,
+        },
+        attributes: {
+            seedingDistance: 30,
+            germinationWindowMin: 7,
+            germinationWindowMax: 10,
+            growthWindowMin: 60,
+            growthWindowMax: 80,
+            water: 'Vlažno tlo',
+            yieldMin: 100,
+            yieldMax: 200,
+            yieldType: 'perPlant',
+            cleanHarvest: false,
+        },
     };
 }
 
@@ -455,7 +570,7 @@ function revisionFixture({
     attributeDefinitionId?: number | null;
     createdAt: Date;
     entityId: number;
-    entityTypeName?: 'operation' | 'plantSort';
+    entityTypeName?: 'operation' | 'plant' | 'plantSort';
     id: number;
     nextState?: string | null;
     nextValue?: string | null;

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
@@ -101,9 +101,10 @@ const latinExtendedGlyphs = [
     { character: 'ž', code: 0x89, glyph: 'zcaron', unicode: '017E' },
 ] as const;
 
-const latinExtendedGlyphByCharacter = new Map(
-    latinExtendedGlyphs.map((glyph) => [glyph.character, glyph]),
-);
+const latinExtendedGlyphByCharacter: ReadonlyMap<
+    string,
+    (typeof latinExtendedGlyphs)[number]
+> = new Map(latinExtendedGlyphs.map((glyph) => [glyph.character, glyph]));
 
 class PdfCanvas {
     private readonly operations: string[] = [];
@@ -360,7 +361,7 @@ function farmerDocumentationFilenameContentPart(
             return '';
         case 'operations':
             return '-radnje';
-        case 'plantSorts':
+        case 'plants':
             return '-biljke-sorte';
     }
 }
@@ -373,7 +374,7 @@ function organizationGuideContentSubtitle(
             return null;
         case 'operations':
             return 'Radnje';
-        case 'plantSorts':
+        case 'plants':
             return 'Biljke i sorte';
     }
 }
@@ -399,7 +400,7 @@ function organizationGuidePackageContentLabel(
             return 'sve priručnike';
         case 'operations':
             return 'priručnike radnji';
-        case 'plantSorts':
+        case 'plants':
             return 'priručnike biljaka i sorti';
     }
 }

--- a/apps/app/app/admin/farmers/documentation/page.tsx
+++ b/apps/app/app/admin/farmers/documentation/page.tsx
@@ -52,9 +52,9 @@ export default async function FarmerDocumentationPage({
         sinceInput,
         content: 'operations',
     });
-    const plantSortsChangesHref = printoutHref({
+    const plantsChangesHref = printoutHref({
         sinceInput,
-        content: 'plantSorts',
+        content: 'plants',
     });
     const invalidSince = Boolean(sinceInput) && !since;
     const menuAllLabel = since ? 'Sve promjene' : 'Cijeli paket';
@@ -87,7 +87,7 @@ export default async function FarmerDocumentationPage({
                                         Samo radnje
                                     </DropdownMenuItem>
                                     <DropdownMenuItem
-                                        href={plantSortsChangesHref}
+                                        href={plantsChangesHref}
                                         startDecorator={
                                             <Sprout className="size-4" />
                                         }
@@ -109,6 +109,16 @@ export default async function FarmerDocumentationPage({
                     </>
                 }
             />
+
+            <Stack spacing={1}>
+                <Typography level="h4" component="h1">
+                    Dokumentacija farmera
+                </Typography>
+                <Typography level="body2" className="text-muted-foreground">
+                    Ispis priručnika radnji, biljaka i sorti iz farmer
+                    aplikacije, organiziran po stabilnim OP, PL i PS kodovima.
+                </Typography>
+            </Stack>
 
             <Card>
                 <CardContent>
@@ -149,17 +159,21 @@ export default async function FarmerDocumentationPage({
                 </CardContent>
             </Card>
 
-            <div className="grid gap-3 md:grid-cols-6">
+            <div className="grid gap-3 md:grid-cols-7">
                 <DocumentationSummaryCard
                     label="Trenutnih priručnika"
                     value={
                         documentationPackage.totalOperations +
-                        documentationPackage.totalPlantSorts
+                        documentationPackage.totalPlants
                     }
                 />
                 <DocumentationSummaryCard
                     label="Radnji"
                     value={documentationPackage.totalOperations}
+                />
+                <DocumentationSummaryCard
+                    label="Biljaka"
+                    value={documentationPackage.totalPlants}
                 />
                 <DocumentationSummaryCard
                     label="Sorti"
@@ -169,13 +183,14 @@ export default async function FarmerDocumentationPage({
                     label="Stranica u paketu"
                     value={
                         documentationPackage.includedOperations.length +
-                        documentationPackage.includedPlantSorts.length
+                        documentationPackage.includedPlants.length
                     }
                 />
                 <DocumentationSummaryCard
                     label="Za uklanjanje"
                     value={
                         documentationPackage.discardedOperations.length +
+                        documentationPackage.discardedPlants.length +
                         documentationPackage.discardedPlantSorts.length
                     }
                 />


### PR DESCRIPTION
## Summary

Adds plant documents to the farmer documentation package at `/admin/farmers/documentation`.

- Builds `PL-####` plant pages alongside operation pages.
- Treats plant sorts as extensions of plants: each plant page lists available sorts first and appends sort-specific extra information at the end when present.
- Keeps plant sort revisions in change detection so sort changes regenerate the parent plant document, while deleted sort pages can still be listed for removal from older binders.
- Updates PDF package filtering/copy and the admin summary counts for operations, plants, and sorts.

## Validation

- `pnpm --filter app exec node --conditions=react-server --import tsx --test app/admin/farmers/documentation/farmerDocumentationData.unit.ts`
- `pnpm lint --filter app`
- `pnpm typecheck --filter app`
- `git diff --check`

Note: `pnpm --filter app exec tsc --noEmit --pretty false` was also tried as an extra sanity check, but it fails on existing unrelated app-wide type errors outside the farmer documentation files.