### PR TITLE
[codex] Allow admins to override operation status

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -524,6 +524,22 @@ export async function acceptOperationAction(operationId: number) {
     await revalidateOperationPaths(operation);
 }
 
+export async function unacceptOperationAction(operationId: number) {
+    await auth(['admin']);
+    const operation = await getOperationById(operationId);
+    if (!operation) {
+        throw new Error(`Operation with ID ${operationId} not found.`);
+    }
+    if (!operation.isAccepted) {
+        return { success: true };
+    }
+
+    await unacceptOperation(operationId);
+    await revalidateOperationPaths(operation);
+
+    return { success: true };
+}
+
 export async function assignOperationUserAction(
     operationId: number,
     assignedUserIds: string[],
@@ -829,16 +845,8 @@ export async function cancelOperationAction(formData: FormData) {
         throw new Error(`Operation with ID ${operationId} not found.`);
     }
 
-    // Only allow canceling new or planned operations
-    if (
-        operation.status === 'completed' ||
-        operation.status === 'pendingVerification' ||
-        operation.status === 'failed' ||
-        operation.status === 'canceled'
-    ) {
-        throw new Error(
-            `Cannot cancel operation with status ${operation.status}`,
-        );
+    if (operation.status === 'canceled') {
+        return { success: true };
     }
 
     // Get operation details for notification and refund calculation
@@ -921,4 +929,5 @@ export async function cancelOperationAction(formData: FormData) {
     ]);
 
     await revalidateOperationPaths(operation);
+    return { success: true };
 }

--- a/apps/app/app/admin/operations/[operationId]/page.tsx
+++ b/apps/app/app/admin/operations/[operationId]/page.tsx
@@ -40,9 +40,11 @@ import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navig
 import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { OperationCancelButton } from '../../../../components/operations/OperationCancelButton';
 import { OperationRescheduleButton } from '../../../../components/operations/OperationRescheduleButton';
+import { OperationUnacceptButton } from '../../../../components/operations/OperationUnacceptButton';
 import type { EntityStandardized } from '../../../../lib/@types/EntityStandardized';
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
+import { AcceptOperationModal } from '../../schedule/AcceptOperationModal';
 import { VerifyOperationModal } from '../../schedule/VerifyOperationModal';
 
 export const dynamic = 'force-dynamic';
@@ -540,6 +542,21 @@ export default async function OperationDetailsPage({
                                 <VerifyOperationModal
                                     operationId={operation.id}
                                     label={operationTitle}
+                                />
+                            )}
+                            {operation.isAccepted ? (
+                                <OperationUnacceptButton
+                                    operationId={operation.id}
+                                    operationLabel={operationTitle}
+                                />
+                            ) : (
+                                <AcceptOperationModal
+                                    operationId={operation.id}
+                                    label={operationTitle}
+                                    disabled={!operation.assignedUserId}
+                                    raisedBedPhysicalId={
+                                        raisedBed?.physicalId ?? undefined
+                                    }
                                 />
                             )}
                             <OperationRescheduleButton

--- a/apps/app/app/admin/schedule/AcceptOperationModal.tsx
+++ b/apps/app/app/admin/schedule/AcceptOperationModal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { IconButton } from '@gredice/ui/IconButton';
 import { Check } from '@gredice/ui/icons';
 import { acceptOperationAction } from '../../(actions)/operationActions';

--- a/apps/app/app/admin/schedule/CancelOperationModal.tsx
+++ b/apps/app/app/admin/schedule/CancelOperationModal.tsx
@@ -22,6 +22,10 @@ export function CancelOperationModal({
     trigger,
     onSubmit,
 }: CancelOperationModalProps) {
+    const hasCompletionState =
+        operation.status === 'completed' ||
+        operation.status === 'pendingVerification';
+
     return (
         <CancelRequestModal
             label={operationLabel}
@@ -33,6 +37,10 @@ export function CancelOperationModal({
             description={`Operacija će biti otkazana. Koristi opcije ispod za povrat suncokreta i slanje obavijesti korisniku.${
                 operation.status === 'planned'
                     ? ' Ako je operacija plaćena suncokretima, preporučujemo da ih vratiš.'
+                    : ''
+            }${
+                hasCompletionState
+                    ? ' Radnja ima zapis završetka; otkazivanje će postaviti najnoviji status na otkazano, ali neće obrisati povijest završetka.'
                     : ''
             }`}
             additionalFields={

--- a/apps/app/components/operations/OperationCancelButton.tsx
+++ b/apps/app/components/operations/OperationCancelButton.tsx
@@ -18,13 +18,7 @@ export function OperationCancelButton({
     operation,
     operationLabel,
 }: OperationCancelButtonProps) {
-    // Only show cancel button for new and planned operations
-    if (
-        operation.status === 'completed' ||
-        operation.status === 'pendingVerification' ||
-        operation.status === 'failed' ||
-        operation.status === 'canceled'
-    ) {
+    if (operation.status === 'canceled' || operation.status === 'cancelled') {
         return null;
     }
 

--- a/apps/app/components/operations/OperationRescheduleButton.tsx
+++ b/apps/app/components/operations/OperationRescheduleButton.tsx
@@ -18,16 +18,6 @@ export function OperationRescheduleButton({
     operation,
     operationLabel,
 }: OperationRescheduleButtonProps) {
-    // Only show reschedule button for new and planned operations
-    if (
-        operation.status === 'completed' ||
-        operation.status === 'pendingVerification' ||
-        operation.status === 'failed' ||
-        operation.status === 'canceled'
-    ) {
-        return null;
-    }
-
     return (
         <RescheduleOperationModal
             operation={operation}
@@ -37,8 +27,8 @@ export function OperationRescheduleButton({
                     variant="plain"
                     title={
                         operation.scheduledDate
-                            ? 'Prerasporedi operaciju'
-                            : 'Zakaži operaciju'
+                            ? 'Prerasporedi radnju'
+                            : 'Zakaži radnju'
                     }
                 >
                     <Calendar className="size-4 shrink-0" />

--- a/apps/app/components/operations/OperationUnacceptButton.tsx
+++ b/apps/app/components/operations/OperationUnacceptButton.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Undo } from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useState } from 'react';
+import { unacceptOperationAction } from '../../app/(actions)/operationActions';
+
+interface OperationUnacceptButtonProps {
+    operationId: number;
+    operationLabel: string;
+}
+
+export function OperationUnacceptButton({
+    operationId,
+    operationLabel,
+}: OperationUnacceptButtonProps) {
+    const [open, setOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    async function handleConfirm() {
+        try {
+            setIsSubmitting(true);
+            await unacceptOperationAction(operationId);
+            setOpen(false);
+        } catch (error) {
+            console.error('Error unaccepting operation:', error);
+            alert(
+                'Poništavanje potvrde radnje nije uspjelo. Pokušajte ponovno.',
+            );
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    return (
+        <Modal
+            title="Poništavanje potvrde radnje"
+            open={open}
+            onOpenChange={setOpen}
+            trigger={
+                <IconButton
+                    variant="plain"
+                    title="Poništi potvrdu radnje"
+                    loading={isSubmitting}
+                >
+                    <Undo className="size-4 shrink-0" />
+                </IconButton>
+            }
+        >
+            <Stack spacing={4}>
+                <Typography level="h5">Poništavanje potvrde radnje</Typography>
+                <Typography>
+                    Jeste li sigurni da želite poništiti potvrdu radnje:{' '}
+                    <strong>{operationLabel}</strong>?
+                </Typography>
+                <Row spacing={2} justifyContent="end">
+                    <Button
+                        variant="outlined"
+                        onClick={() => setOpen(false)}
+                        disabled={isSubmitting}
+                    >
+                        Odustani
+                    </Button>
+                    <Button
+                        variant="solid"
+                        onClick={handleConfirm}
+                        loading={isSubmitting}
+                        disabled={isSubmitting}
+                    >
+                        Poništi potvrdu
+                    </Button>
+                </Row>
+            </Stack>
+        </Modal>
+    );
+}


### PR DESCRIPTION
## Summary
- Exposes approve/un-approve, reschedule, and cancel controls on the admin operation detail page.
- Allows reschedule to override completed, pending-verification, failed, or canceled operation states by appending a later schedule event.
- Allows cancel to override completed, pending-verification, and failed operation states while making already-canceled submissions a no-op to avoid duplicate refund side effects.

## Impact
Administrators can correct operation lifecycle mistakes from the detail page, including changing the date, clearing approval, or canceling an operation even after completion was marked.

## Validation
- `pnpm lint --filter app`
- `pnpm --filter app exec biome check 'app/(actions)/operationActions.ts' 'app/admin/operations/[operationId]/page.tsx' app/admin/schedule/CancelOperationModal.tsx components/operations/OperationCancelButton.tsx components/operations/OperationRescheduleButton.tsx components/operations/OperationUnacceptButton.tsx`
- `git diff --check`

Note: `pnpm --filter app exec tsc --noEmit --pretty false` was attempted, but the app currently has unrelated pre-existing TypeScript errors outside this change set, including missing generated `PageProps` references, notification composer type mismatches, and generated fiscalization re-export errors.