### PR TITLE
[codex] Gate weather alerts behind opt-in

### DIFF
--- a/apps/api/lib/weather/alertNotifications.node.spec.ts
+++ b/apps/api/lib/weather/alertNotifications.node.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
     filterWeatherAlertsForNotifications,
+    resolveWeatherAlertOptInRecipients,
     weatherAlertNotificationCollapseKey,
     weatherAlertNotificationLookupCollapseKeys,
 } from './alertNotifications';
@@ -120,5 +121,75 @@ describe('weather alert notification collapse keys', () => {
                 `weather-risk:43:${yellowAlert.deduplicationKey}`,
             ],
         );
+    });
+});
+
+describe('resolveWeatherAlertOptInRecipients', () => {
+    it('defaults weather alert recipients off until a user opts in', () => {
+        const recipients = resolveWeatherAlertOptInRecipients(
+            [
+                { accountId: 'account-1', userId: 'enabled-user' },
+                { accountId: 'account-1', userId: 'missing-user' },
+                { accountId: 'account-2', userId: 'disabled-user' },
+            ],
+            [
+                {
+                    accountId: null,
+                    enabled: true,
+                    scope: 'global',
+                    userId: 'enabled-user',
+                },
+                {
+                    accountId: null,
+                    enabled: false,
+                    scope: 'global',
+                    userId: 'disabled-user',
+                },
+            ],
+        );
+
+        assert.deepEqual(Array.from(recipients.entries()), [
+            ['account-1', ['enabled-user']],
+        ]);
+    });
+
+    it('lets account-level preferences override global weather alert opt-ins', () => {
+        const recipients = resolveWeatherAlertOptInRecipients(
+            [
+                { accountId: 'account-1', userId: 'globally-enabled' },
+                { accountId: 'account-1', userId: 'account-enabled' },
+                { accountId: 'account-2', userId: 'account-enabled' },
+            ],
+            [
+                {
+                    accountId: null,
+                    enabled: true,
+                    scope: 'global',
+                    userId: 'globally-enabled',
+                },
+                {
+                    accountId: 'account-1',
+                    enabled: false,
+                    scope: 'account',
+                    userId: 'globally-enabled',
+                },
+                {
+                    accountId: null,
+                    enabled: false,
+                    scope: 'global',
+                    userId: 'account-enabled',
+                },
+                {
+                    accountId: 'account-2',
+                    enabled: true,
+                    scope: 'account',
+                    userId: 'account-enabled',
+                },
+            ],
+        );
+
+        assert.deepEqual(Array.from(recipients.entries()), [
+            ['account-2', ['account-enabled']],
+        ]);
     });
 });

--- a/apps/api/lib/weather/alertNotifications.ts
+++ b/apps/api/lib/weather/alertNotifications.ts
@@ -1,12 +1,14 @@
 import {
+    accountUsers,
     createNotification,
     gardens,
     grediceCached,
     grediceCacheKeys,
     notifications,
+    notificationUserChannelPreferences,
     storage,
 } from '@gredice/storage';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
 import {
     type DhmzWeatherAlert,
     filterWeatherAlertsForFarm,
@@ -20,6 +22,20 @@ export type WeatherAlertNotificationResult = {
     alertsMatched: number;
     notificationsCreated: number;
     duplicatesSkipped: number;
+    optInRecipientsMatched: number;
+    optInSkipped: number;
+};
+
+type WeatherAlertAccountMembership = {
+    accountId: string;
+    userId: string;
+};
+
+type WeatherAlertPreference = {
+    accountId: string | null;
+    enabled: boolean;
+    scope: 'account' | 'global';
+    userId: string;
 };
 
 function formatAlertWindow(alert: DhmzWeatherAlert) {
@@ -92,10 +108,107 @@ export function filterWeatherAlertsForNotifications({
     );
 }
 
-async function notificationExists(accountId: string, collapseKeys: string[]) {
+export function resolveWeatherAlertOptInRecipients(
+    memberships: WeatherAlertAccountMembership[],
+    preferences: WeatherAlertPreference[],
+) {
+    const globalPreferences = new Map<string, boolean>();
+    const accountPreferences = new Map<string, boolean>();
+
+    for (const preference of preferences) {
+        if (preference.scope === 'account' && preference.accountId) {
+            accountPreferences.set(
+                `${preference.accountId}:${preference.userId}`,
+                preference.enabled,
+            );
+            continue;
+        }
+
+        if (preference.scope === 'global') {
+            globalPreferences.set(preference.userId, preference.enabled);
+        }
+    }
+
+    const recipientsByAccount = new Map<string, string[]>();
+    const seenRecipients = new Set<string>();
+
+    for (const membership of memberships) {
+        const recipientKey = `${membership.accountId}:${membership.userId}`;
+        if (seenRecipients.has(recipientKey)) continue;
+        seenRecipients.add(recipientKey);
+
+        const enabled =
+            accountPreferences.get(recipientKey) ??
+            globalPreferences.get(membership.userId) ??
+            false;
+        if (!enabled) continue;
+
+        const accountRecipients =
+            recipientsByAccount.get(membership.accountId) ?? [];
+        accountRecipients.push(membership.userId);
+        recipientsByAccount.set(membership.accountId, accountRecipients);
+    }
+
+    return recipientsByAccount;
+}
+
+async function loadWeatherAlertOptInRecipients(accountIds: string[]) {
+    if (accountIds.length === 0) return new Map<string, string[]>();
+
+    const memberships = await storage()
+        .select({
+            accountId: accountUsers.accountId,
+            userId: accountUsers.userId,
+        })
+        .from(accountUsers)
+        .where(inArray(accountUsers.accountId, accountIds));
+    const userIds = Array.from(
+        new Set(memberships.map((membership) => membership.userId)),
+    );
+    if (userIds.length === 0) return new Map<string, string[]>();
+
+    const preferences = await storage()
+        .select({
+            accountId: notificationUserChannelPreferences.accountId,
+            enabled: notificationUserChannelPreferences.enabled,
+            scope: notificationUserChannelPreferences.scope,
+            userId: notificationUserChannelPreferences.userId,
+        })
+        .from(notificationUserChannelPreferences)
+        .where(
+            and(
+                inArray(notificationUserChannelPreferences.userId, userIds),
+                eq(
+                    notificationUserChannelPreferences.category,
+                    'weather_alerts',
+                ),
+                eq(notificationUserChannelPreferences.channel, 'push'),
+                or(
+                    eq(notificationUserChannelPreferences.scope, 'global'),
+                    inArray(
+                        notificationUserChannelPreferences.accountId,
+                        accountIds,
+                    ),
+                ),
+            ),
+        );
+
+    return resolveWeatherAlertOptInRecipients(memberships, preferences);
+}
+
+async function notificationExists({
+    accountId,
+    collapseKeys,
+    userId,
+}: {
+    accountId: string;
+    collapseKeys: string[];
+    userId: string;
+}) {
     const existing = await storage().query.notifications.findFirst({
         where: and(
             eq(notifications.accountId, accountId),
+            or(eq(notifications.userId, userId), isNull(notifications.userId)),
             inArray(notifications.collapseKey, collapseKeys),
         ),
     });
@@ -130,6 +243,11 @@ export async function notifyWeatherRiskAlerts({
         gardenIds.push(garden.id);
         accountGardenIds.set(garden.accountId, gardenIds);
     }
+    const optInRecipientsByAccount = await loadWeatherAlertOptInRecipients(
+        Array.from(accountGardenIds.keys()),
+    );
+    let optInRecipientsMatched = 0;
+    let optInSkipped = 0;
 
     for (const garden of gardenRows) {
         const alerts = filterWeatherAlertsForNotifications({
@@ -138,52 +256,67 @@ export async function notifyWeatherRiskAlerts({
             sourceAlerts,
         });
         alertsMatched += alerts.length;
+        const optInUserIds =
+            optInRecipientsByAccount.get(garden.accountId) ?? [];
 
         for (const alert of alerts) {
             const collapseKey = weatherAlertNotificationCollapseKey(alert);
-            const accountNotificationKey = `${garden.accountId}:${collapseKey}`;
-            if (processedNotificationKeys.has(accountNotificationKey)) {
-                duplicatesSkipped += 1;
-                continue;
-            }
-            processedNotificationKeys.add(accountNotificationKey);
-
-            if (
-                await notificationExists(
-                    garden.accountId,
-                    weatherAlertNotificationLookupCollapseKeys(
-                        accountGardenIds.get(garden.accountId) ?? [garden.id],
-                        alert,
-                    ),
-                )
-            ) {
-                duplicatesSkipped += 1;
+            if (optInUserIds.length === 0) {
+                optInSkipped += 1;
                 continue;
             }
 
-            await createNotification({
-                accountId: garden.accountId,
-                gardenId: garden.id,
-                header: alert.event,
-                content: weatherAlertContent(alert),
-                category: 'weather_alerts',
-                type: 'weather_risk_alert',
-                primaryChannel: 'push',
-                priority: 'high',
-                collapseKey,
-                threadKey: `weather-risk:${garden.id}`,
-                metadata: {
-                    alertId: alert.id,
-                    awarenessLevel: alert.awarenessLevel?.id ?? null,
-                    awarenessType: alert.awarenessType?.id ?? null,
-                    expires: alert.expires,
-                    onset: alert.onset,
-                    regionCode: alert.area.regionCode,
-                    source: alert.source,
-                },
-                timestamp: now,
-            });
-            notificationsCreated += 1;
+            for (const userId of optInUserIds) {
+                const userNotificationKey = `${garden.accountId}:${userId}:${collapseKey}`;
+                if (processedNotificationKeys.has(userNotificationKey)) {
+                    duplicatesSkipped += 1;
+                    continue;
+                }
+                processedNotificationKeys.add(userNotificationKey);
+
+                if (
+                    await notificationExists({
+                        accountId: garden.accountId,
+                        collapseKeys:
+                            weatherAlertNotificationLookupCollapseKeys(
+                                accountGardenIds.get(garden.accountId) ?? [
+                                    garden.id,
+                                ],
+                                alert,
+                            ),
+                        userId,
+                    })
+                ) {
+                    duplicatesSkipped += 1;
+                    continue;
+                }
+
+                await createNotification({
+                    accountId: garden.accountId,
+                    userId,
+                    gardenId: garden.id,
+                    header: alert.event,
+                    content: weatherAlertContent(alert),
+                    category: 'weather_alerts',
+                    type: 'weather_risk_alert',
+                    primaryChannel: 'push',
+                    priority: 'high',
+                    collapseKey,
+                    threadKey: `weather-risk:${garden.id}`,
+                    metadata: {
+                        alertId: alert.id,
+                        awarenessLevel: alert.awarenessLevel?.id ?? null,
+                        awarenessType: alert.awarenessType?.id ?? null,
+                        expires: alert.expires,
+                        onset: alert.onset,
+                        regionCode: alert.area.regionCode,
+                        source: alert.source,
+                    },
+                    timestamp: now,
+                });
+                optInRecipientsMatched += 1;
+                notificationsCreated += 1;
+            }
         }
     }
 
@@ -192,5 +325,7 @@ export async function notifyWeatherRiskAlerts({
         alertsMatched,
         notificationsCreated,
         duplicatesSkipped,
+        optInRecipientsMatched,
+        optInSkipped,
     };
 }

--- a/docs/notification-preference-matrix.md
+++ b/docs/notification-preference-matrix.md
@@ -52,7 +52,7 @@ Per eventType, each channel gets one of:
 | `billing_order_delivery` | `order_confirmation` | high | ✅ | ❌ | ❌ | ❌ | required | required | default_on | never | never |
 | `garden` | `operation_scheduled`, `operation_rescheduled`, `operation_completed`, `operation_canceled` | high | ❌ | ✅ | ✅ | ✅ | default_on | default_on | default_on | default_on | never |
 | `garden` | `garden_health_alert` | high | ❌ | ✅ | ❌ | ❌ | default_on | default_on | default_on | never | never |
-| `weather_alerts` | `weather_risk_alert` | high | ❌ | ✅ | ❌ | ❌ | default_on | default_on | default_on | never | never |
+| `weather_alerts` | `weather_risk_alert` | high | ❌ | ✅ | ❌ | ❌ | default_off | default_off | default_off | never | never |
 | `garden` | `harvest_ready`, `harvest_window_ending` | normal | ❌ | ✅ | ✅ | ✅ | default_on | default_on | default_on | default_on | never |
 | `reminders` | `task_reminder`, `cart_abandonment_reminder`, `subscription_renewal_reminder` | normal | ❌ | ✅ | ✅ | ✅ | default_on | default_on | default_off | default_on | never |
 | `digests` | `daily_digest`, `weekly_digest`, `monthly_digest` | low | ❌ | ✅ | ❌ | ✅ | default_on | default_on | never | required | never |
@@ -87,6 +87,12 @@ shown as always-on explanatory rows instead of toggles. Event-level controls for
 mixed domains, such as delivery-status updates versus required billing/order
 messages, should be added only after the storage/API contract supports
 event-level overrides.
+
+Weather risk alerts are opt-in before notification creation. The weather alert
+producer must create user-scoped notification rows only for users with an enabled
+`weather_alerts` + `push` preference. Missing preferences default to off, and an
+account-scoped preference overrides the user's global weather-alert preference
+for that account.
 
 ## 5) Separation of required/security vs promotional
 


### PR DESCRIPTION
## Summary
- Gate weather alert notification creation by effective user opt-in instead of creating account-wide rows for every matching garden warning.
- Create weather alert notifications as user-scoped rows for opted-in users so notification-center visibility is also opt-in.
- Update the notification preference matrix to mark weather risk alerts as default-off and document account override behavior.

## Validation
- pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/weather/alertNotifications.node.spec.ts
- pnpm --filter api exec biome check lib/weather/alertNotifications.ts lib/weather/alertNotifications.node.spec.ts ../../docs/notification-preference-matrix.md
- git diff --check

## Notes
- API-wide TypeScript check was attempted with pnpm --filter api exec tsc --project tsconfig.json --noEmit --pretty false and currently fails on existing lib/notifications/webPushSender.node.spec.ts optional-parameter errors unrelated to this diff.