### PR TITLE
Stream compressed farmer documentation PDFs

### DIFF
--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { inflateSync } from 'node:zlib';
 import type { EntityStandardized } from '@gredice/storage';
 import {
     buildFarmerDocumentationPackage,
@@ -335,9 +336,10 @@ test('generates a guide-first PDF without page numbering text', () => {
     });
 
     const pdf = generateFarmerDocumentationPdf(documentationPackage);
-    const content = new TextDecoder().decode(pdf);
+    const content = decodePdfForAssertions(pdf);
 
     assert.match(content, /^%PDF-1\.4/);
+    assert.match(content, /\/Filter \/FlateDecode/);
     assert.match(content, /ORG-GUIDE/);
     assert.match(content, /OP-0004/);
     assert.match(content, /OP-0008/);
@@ -410,7 +412,7 @@ test('generates filtered PDF packages for updates', () => {
     const pdf = generateFarmerDocumentationPdf(documentationPackage, {
         content: 'operations',
     });
-    const content = new TextDecoder().decode(pdf);
+    const content = decodePdfForAssertions(pdf);
 
     assert.match(content, /ORG-GUIDE/);
     assert.match(content, /Radnje/);
@@ -422,7 +424,7 @@ test('generates filtered PDF packages for updates', () => {
     const plantsPdf = generateFarmerDocumentationPdf(documentationPackage, {
         content: 'plants',
     });
-    const plantsContent = new TextDecoder().decode(plantsPdf);
+    const plantsContent = decodePdfForAssertions(plantsPdf);
 
     assert.match(plantsContent, /ORG-GUIDE/);
     assert.match(plantsContent, /Biljke i sorte/);
@@ -448,6 +450,60 @@ const pdfTextGlyphCodes = new Map([
 
 function assertPdfText(content: string, value: string) {
     assert.match(content, new RegExp(escapeRegExp(encodedPdfText(value))));
+}
+
+function decodePdfForAssertions(pdf: ArrayBuffer) {
+    const bytes = new Uint8Array(pdf);
+    const textDecoder = new TextDecoder();
+    const contentParts = [textDecoder.decode(bytes)];
+    const streamStart = new TextEncoder().encode('stream\n');
+    const streamEnd = new TextEncoder().encode('\nendstream');
+    let offset = 0;
+
+    while (offset < bytes.byteLength) {
+        const start = indexOfBytes(bytes, streamStart, offset);
+        if (start === -1) break;
+
+        const contentStart = start + streamStart.byteLength;
+        const end = indexOfBytes(bytes, streamEnd, contentStart);
+        if (end === -1) break;
+
+        const streamContent = bytes.subarray(contentStart, end);
+        const streamDictionary = textDecoder.decode(
+            bytes.subarray(Math.max(0, start - 128), start),
+        );
+        contentParts.push(
+            streamDictionary.includes('/Filter /FlateDecode')
+                ? textDecoder.decode(inflateSync(streamContent))
+                : textDecoder.decode(streamContent),
+        );
+        offset = end + streamEnd.byteLength;
+    }
+
+    return contentParts.join('\n');
+}
+
+function indexOfBytes(
+    bytes: Uint8Array,
+    needle: Uint8Array,
+    fromIndex: number,
+) {
+    for (
+        let index = fromIndex;
+        index <= bytes.byteLength - needle.byteLength;
+        index += 1
+    ) {
+        let matches = true;
+        for (let offset = 0; offset < needle.byteLength; offset += 1) {
+            if (bytes[index + offset] !== needle[offset]) {
+                matches = false;
+                break;
+            }
+        }
+        if (matches) return index;
+    }
+
+    return -1;
 }
 
 function encodedPdfText(value: string) {

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
@@ -1,3 +1,4 @@
+import { deflateSync } from 'node:zlib';
 import { create as createQrCode } from 'qrcode';
 import {
     currentDocumentationPages,
@@ -930,69 +931,118 @@ function formatColor(color: PdfColor) {
 }
 
 function writePdf(pageContentStreams: string[]) {
-    const objects: string[] = [];
+    const objects: Uint8Array[] = [];
     const fontId = 3;
     const boldFontId = 4;
     const fontEncodingId = 5;
     const fontToUnicodeMapId = 6;
     const firstPageObjectId = 7;
+    const encoder = new TextEncoder();
     const kids = pageContentStreams
         .map((_, index) => `${firstPageObjectId + index * 2} 0 R`)
         .join(' ');
 
-    objects.push('<< /Type /Catalog /Pages 2 0 R >>');
+    objects.push(encodePdfObject('<< /Type /Catalog /Pages 2 0 R >>'));
     objects.push(
-        `<< /Type /Pages /Kids [${kids}] /Count ${pageContentStreams.length} >>`,
+        encodePdfObject(
+            `<< /Type /Pages /Kids [${kids}] /Count ${pageContentStreams.length} >>`,
+        ),
     );
     objects.push(
-        `<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding ${fontEncodingId} 0 R /ToUnicode ${fontToUnicodeMapId} 0 R >>`,
+        encodePdfObject(
+            `<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding ${fontEncodingId} 0 R /ToUnicode ${fontToUnicodeMapId} 0 R >>`,
+        ),
     );
     objects.push(
-        `<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding ${fontEncodingId} 0 R /ToUnicode ${fontToUnicodeMapId} 0 R >>`,
+        encodePdfObject(
+            `<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding ${fontEncodingId} 0 R /ToUnicode ${fontToUnicodeMapId} 0 R >>`,
+        ),
     );
-    objects.push(pdfLatinExtendedEncodingObject());
-    objects.push(pdfLatinExtendedToUnicodeMapObject());
+    objects.push(encodePdfObject(pdfLatinExtendedEncodingObject()));
+    objects.push(encodePdfObject(pdfLatinExtendedToUnicodeMapObject()));
 
     pageContentStreams.forEach((content, index) => {
         const pageObjectId = firstPageObjectId + index * 2;
         const contentObjectId = pageObjectId + 1;
         objects.push(
-            [
-                '<< /Type /Page',
-                '/Parent 2 0 R',
-                `/MediaBox [0 0 ${formatNumber(pageWidth)} ${formatNumber(pageHeight)}]`,
-                `/Resources << /Font << /F1 ${fontId} 0 R /F2 ${boldFontId} 0 R >> >>`,
-                `/Contents ${contentObjectId} 0 R`,
-                '>>',
-            ].join(' '),
+            encodePdfObject(
+                [
+                    '<< /Type /Page',
+                    '/Parent 2 0 R',
+                    `/MediaBox [0 0 ${formatNumber(pageWidth)} ${formatNumber(pageHeight)}]`,
+                    `/Resources << /Font << /F1 ${fontId} 0 R /F2 ${boldFontId} 0 R >> >>`,
+                    `/Contents ${contentObjectId} 0 R`,
+                    '>>',
+                ].join(' '),
+            ),
         );
-        objects.push(
-            `<< /Length ${content.length} >>\nstream\n${content}\nendstream`,
-        );
+        objects.push(pdfStreamObject(deflateSync(encoder.encode(content))));
     });
 
-    let pdf = '%PDF-1.4\n';
+    const chunks: Uint8Array[] = [encoder.encode('%PDF-1.4\n')];
+    let pdfByteLength = chunks[0]?.byteLength ?? 0;
     const offsets = [0];
 
     objects.forEach((object, index) => {
-        offsets.push(pdf.length);
-        pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+        offsets.push(pdfByteLength);
+        const objectHeader = encoder.encode(`${index + 1} 0 obj\n`);
+        const objectFooter = encoder.encode('\nendobj\n');
+        chunks.push(objectHeader, object, objectFooter);
+        pdfByteLength +=
+            objectHeader.byteLength +
+            object.byteLength +
+            objectFooter.byteLength;
     });
 
-    const xrefOffset = pdf.length;
-    pdf += `xref\n0 ${objects.length + 1}\n`;
-    pdf += '0000000000 65535 f \n';
+    const xrefOffset = pdfByteLength;
+    let xref = `xref\n0 ${objects.length + 1}\n`;
+    xref += '0000000000 65535 f \n';
     offsets.slice(1).forEach((offset) => {
-        pdf += `${offset.toString().padStart(10, '0')} 00000 n \n`;
+        xref += `${offset.toString().padStart(10, '0')} 00000 n \n`;
     });
-    pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
-    pdf += `startxref\n${xrefOffset}\n%%EOF\n`;
+    xref += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
+    xref += `startxref\n${xrefOffset}\n%%EOF\n`;
+    chunks.push(encoder.encode(xref));
 
-    const bytes = new TextEncoder().encode(pdf);
-    const buffer = new ArrayBuffer(bytes.byteLength);
-    new Uint8Array(buffer).set(bytes);
+    const buffer = new ArrayBuffer(
+        chunks.reduce((total, chunk) => total + chunk.byteLength, 0),
+    );
+    const bytes = new Uint8Array(buffer);
+    let offset = 0;
+    for (const chunk of chunks) {
+        bytes.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
 
     return buffer;
+}
+
+function encodePdfObject(value: string) {
+    return new TextEncoder().encode(value);
+}
+
+function pdfStreamObject(content: Uint8Array) {
+    const encoder = new TextEncoder();
+    return concatBytes([
+        encoder.encode(
+            `<< /Length ${content.byteLength} /Filter /FlateDecode >>\nstream\n`,
+        ),
+        content,
+        encoder.encode('\nendstream'),
+    ]);
+}
+
+function concatBytes(chunks: Uint8Array[]) {
+    const result = new Uint8Array(
+        chunks.reduce((total, chunk) => total + chunk.byteLength, 0),
+    );
+    let offset = 0;
+    for (const chunk of chunks) {
+        result.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+
+    return result;
 }
 
 function pdfLatinExtendedEncodingObject() {

--- a/apps/app/app/admin/farmers/documentation/printout/route.ts
+++ b/apps/app/app/admin/farmers/documentation/printout/route.ts
@@ -10,6 +10,7 @@ import {
 } from '../farmerDocumentationPdf';
 
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 export async function GET(request: Request) {
     await auth(['admin']);
@@ -30,7 +31,7 @@ export async function GET(request: Request) {
         content,
     });
 
-    return new Response(pdf, {
+    return new Response(arrayBufferToReadableStream(pdf), {
         headers: {
             'Cache-Control': 'no-store',
             'Content-Disposition': `attachment; filename="${farmerDocumentationFilename(
@@ -39,6 +40,28 @@ export async function GET(request: Request) {
             )}"`,
             'Content-Length': String(pdf.byteLength),
             'Content-Type': 'application/pdf',
+        },
+    });
+}
+
+function arrayBufferToReadableStream(buffer: ArrayBuffer) {
+    const bytes = new Uint8Array(buffer);
+    let offset = 0;
+    const chunkSize = 64 * 1024;
+
+    return new ReadableStream<Uint8Array>({
+        pull(controller) {
+            if (offset >= bytes.byteLength) {
+                controller.close();
+                return;
+            }
+
+            const chunk = bytes.subarray(
+                offset,
+                Math.min(offset + chunkSize, bytes.byteLength),
+            );
+            offset += chunk.byteLength;
+            controller.enqueue(chunk);
         },
     });
 }


### PR DESCRIPTION
## Summary
- Compress generated farmer documentation PDF streams with FlateDecode to reduce payload size
- Return the printout route response as a streamed `ReadableStream` in the Node runtime
- Update PDF tests to decode compressed streams before asserting on content

## Testing
- Unit tests updated to validate compressed PDF output and preserved text content
- Not run (not requested)