### PR TITLE
[codex] Fix Suncokret trial and cart guards

### DIFF
--- a/apps/api/app/api/mcp/commerce/tools/call/execute.ts
+++ b/apps/api/app/api/mcp/commerce/tools/call/execute.ts
@@ -1,9 +1,16 @@
 import {
+    isRaisedBedAbandoned,
+    RAISED_BED_ABANDONED_ACTIONS_DISABLED_MESSAGE,
+    RAISED_BED_ABANDONED_DUE_TO_INACTIVITY_MESSAGE,
+} from '@gredice/js/raisedBeds';
+import {
     type EntityStandardized,
     getEntitiesFormatted,
     getEntityFormatted,
     getEntityRaw,
+    getGarden,
     getOrCreateShoppingCart,
+    getRaisedBed,
     upsertOrRemoveCartItem,
 } from '@gredice/storage';
 import { z } from 'zod';
@@ -131,6 +138,73 @@ function formatCart(
     };
 }
 
+async function validateCartLocation({
+    accountId,
+    gardenId,
+    positionIndex,
+    raisedBedId,
+}: {
+    accountId: string;
+    gardenId?: number | null;
+    positionIndex?: number | null;
+    raisedBedId?: number | null;
+}) {
+    if (gardenId) {
+        const garden = await getGarden(gardenId);
+        if (!garden || garden.accountId !== accountId) {
+            throw new Error('Garden not found for authenticated account');
+        }
+    }
+
+    if (!raisedBedId) {
+        return {
+            gardenId: gardenId ?? undefined,
+            raisedBedId: undefined,
+            positionIndex: positionIndex ?? undefined,
+        };
+    }
+
+    const raisedBed = await getRaisedBed(raisedBedId);
+    if (!raisedBed || raisedBed.accountId !== accountId) {
+        throw new Error('Raised bed not found for authenticated account');
+    }
+
+    const finalGardenId = raisedBed.gardenId;
+    if (!finalGardenId) {
+        throw new Error('Raised bed is not assigned to a garden');
+    }
+
+    if (gardenId && finalGardenId !== gardenId) {
+        throw new Error('Raised bed does not belong to the provided garden');
+    }
+
+    if (!gardenId) {
+        const garden = await getGarden(finalGardenId);
+        if (!garden || garden.accountId !== accountId) {
+            throw new Error('Garden not found for authenticated account');
+        }
+    }
+
+    if (isRaisedBedAbandoned(raisedBed.status)) {
+        throw new Error(
+            `${RAISED_BED_ABANDONED_DUE_TO_INACTIVITY_MESSAGE} ${RAISED_BED_ABANDONED_ACTIONS_DISABLED_MESSAGE}`,
+        );
+    }
+
+    if (
+        typeof positionIndex === 'number' &&
+        !raisedBed.fields.some((field) => field.positionIndex === positionIndex)
+    ) {
+        throw new Error('Raised bed field not found');
+    }
+
+    return {
+        gardenId: finalGardenId,
+        raisedBedId: raisedBed.id,
+        positionIndex: positionIndex ?? undefined,
+    };
+}
+
 export async function executeCommerceTool(
     name: string,
     args: unknown,
@@ -184,6 +258,12 @@ export async function executeCommerceTool(
             if (!cart) {
                 throw new Error('Cart could not be created');
             }
+            const location = await validateCartLocation({
+                accountId: auth.accountId,
+                gardenId: input.gardenId,
+                raisedBedId: input.raisedBedId,
+                positionIndex: input.positionIndex,
+            });
             const additionalData = input.scheduledDate
                 ? JSON.stringify({ scheduledDate: input.scheduledDate })
                 : null;
@@ -193,9 +273,9 @@ export async function executeCommerceTool(
                 entityId.toString(),
                 'plantSort',
                 input.quantity,
-                input.gardenId,
-                input.raisedBedId,
-                input.positionIndex,
+                location.gardenId,
+                location.raisedBedId,
+                location.positionIndex,
                 additionalData,
             );
             const refreshedCart = await getOrCreateShoppingCart(auth.accountId);
@@ -220,15 +300,28 @@ export async function executeCommerceTool(
             if (!item) {
                 throw new Error('Cart item not found');
             }
+            const location =
+                input.quantity > 0
+                    ? await validateCartLocation({
+                          accountId: auth.accountId,
+                          gardenId: item.gardenId,
+                          raisedBedId: item.raisedBedId,
+                          positionIndex: item.positionIndex,
+                      })
+                    : {
+                          gardenId: item.gardenId ?? undefined,
+                          raisedBedId: item.raisedBedId ?? undefined,
+                          positionIndex: item.positionIndex ?? undefined,
+                      };
             const cartItemId = await upsertOrRemoveCartItem(
                 item.id,
                 cart.id,
                 item.entityId,
                 item.entityTypeName,
                 input.quantity,
-                item.gardenId ?? undefined,
-                item.raisedBedId ?? undefined,
-                item.positionIndex ?? undefined,
+                location.gardenId,
+                location.raisedBedId,
+                location.positionIndex,
                 item.additionalData,
             );
             const refreshedCart = await getOrCreateShoppingCart(auth.accountId);

--- a/packages/storage/src/repositories/aiChatRepo.ts
+++ b/packages/storage/src/repositories/aiChatRepo.ts
@@ -329,11 +329,15 @@ export async function getAiChatAccountLimitState(
                 : sum,
         0,
     );
-    const trialChatDaysUsed = new Set(
+    const finalizedUsageDates = new Set(
         ledgerRows
             .filter((row) => statusCountsAsFinalized(row.status))
             .map((row) => row.usageDate),
-    ).size;
+    );
+    const trialChatDaysUsed = finalizedUsageDates.size;
+    const priorTrialChatDaysUsed = Array.from(finalizedUsageDates).filter(
+        (dateKey) => dateKey < usageDate,
+    ).length;
     const trialChatDaysLimit =
         override?.trialChatDays ?? SUNCOKRET_TRIAL_CHAT_DAYS;
     const tier: AiChatLimitTier = activeRaisedBed
@@ -350,7 +354,7 @@ export async function getAiChatAccountLimitState(
     const disabled = Boolean(override?.disabled);
     const blockedReason = disabled
         ? 'disabled'
-        : !activeRaisedBed && trialChatDaysUsed >= trialChatDaysLimit
+        : !activeRaisedBed && priorTrialChatDaysUsed >= trialChatDaysLimit
           ? 'trial_days_exhausted'
           : null;
 

--- a/packages/storage/tests/aiChatRepo.node.spec.ts
+++ b/packages/storage/tests/aiChatRepo.node.spec.ts
@@ -105,6 +105,43 @@ test('getAiChatAccountLimitState blocks trial accounts after five used chat days
     assert.strictEqual(state.blockedReason, 'trial_days_exhausted');
 });
 
+test('getAiChatAccountLimitState allows trial users to finish their final trial day', async () => {
+    createTestDb();
+    const { accountId, userId } = await createAiChatTestUser();
+    const usageDates = [
+        '2026-06-01',
+        '2026-06-02',
+        '2026-06-03',
+        '2026-06-04',
+        '2026-06-05',
+    ];
+
+    await storage()
+        .insert(aiUsageLedger)
+        .values(
+            usageDates.map((usageDate) => ({
+                id: randomUUID(),
+                accountId,
+                userId,
+                requestId: randomUUID(),
+                feature: SUNCOKRET_AI_FEATURE,
+                model: 'openai/gpt-5.5',
+                usageDate,
+                status: 'finalized',
+                totalMicroUsd: 1,
+            })),
+        );
+
+    const state = await getAiChatAccountLimitState(
+        accountId,
+        new Date('2026-06-05T10:00:00Z'),
+    );
+
+    assert.strictEqual(state.trialChatDaysUsed, SUNCOKRET_TRIAL_CHAT_DAYS);
+    assert.strictEqual(state.blockedReason, null);
+    assert.ok(state.remainingMicroUsd > 0);
+});
+
 test('reserveAiChatUsage serializes concurrent reservations for the daily cap', async () => {
     createTestDb();
     const { accountId, userId } = await createAiChatTestUser();


### PR DESCRIPTION
## Summary

- Adds the authenticated, feature-flagged Suncokret in-game AI chat flow.
- Adds AI chat storage, usage ledger, daily budget enforcement, model registry, and admin analytics visibility.
- Extends MCP garden/commerce tools and requires approval for sensitive cart/checkout-style actions.
- Fixes review issues for MCP cart location validation and final trial-day access.

## Fixes included

- Validates MCP cart `gardenId`/`raisedBedId` before inserting or positively updating cart items.
- Rejects abandoned or cross-account raised-bed targets and normalizes cart rows to the raised bed's actual garden.
- Allows no-active-bed trial users to continue using remaining budget during their fifth counted trial day.

## Validation

- `pnpm --filter @gredice/storage test aiChatRepo.node.spec.ts`
- `pnpm typecheck --filter @gredice/game`
- `pnpm --filter garden exec tsc --noEmit --pretty false`
- `pnpm test --filter @gredice/game`
- `pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/mcp/catalog.node.spec.ts`
- `POSTGRES_URL=postgres://user:pass@localhost:5432/gredice pnpm --filter @gredice/storage db-generate`
- `git diff --check`

Known unrelated blockers:

- `pnpm --filter api exec tsc --noEmit --pretty false` still fails on existing `lib/notifications/webPushSender.node.spec.ts` type errors.
- `pnpm --filter @gredice/storage exec tsc --noEmit --pretty false` still fails on existing storage scripts/tests type errors.