### PR TITLE
[codex] Use Suncokret feature flags for API gate

### DIFF
--- a/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
+++ b/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
@@ -42,6 +42,11 @@ const MAX_IMAGE_URLS_PER_ANALYSIS = 6;
 
 type ChatVariables = AuthVariables;
 
+const FeatureFlagsSchema = z.object({
+    enableSuncokretChatFlag: z.boolean().optional().default(false),
+    enableSuncokretDebugFlag: z.boolean().optional().default(false),
+});
+
 const ChatBodySchema = z.object({
     id: z.string().optional(),
     conversationId: z.string().optional(),
@@ -51,22 +56,27 @@ const ChatBodySchema = z.object({
     positionIndex: z.number().int().min(0).optional().nullable(),
     modelId: z.string().trim().min(1).optional().nullable(),
     debug: z.boolean().optional(),
+    featureFlags: FeatureFlagsSchema.optional().default({
+        enableSuncokretChatFlag: false,
+        enableSuncokretDebugFlag: false,
+    }),
 });
 
 const StatusQuerySchema = z.object({
     modelId: z.string().optional(),
+    enableSuncokretChatFlag: z.string().optional(),
+    enableSuncokretDebugFlag: z.string().optional(),
 });
 
-function booleanEnv(value: string | undefined) {
+function booleanFlag(value: string | undefined) {
     return ['1', 'true', 'yes', 'on'].includes(value?.toLowerCase() ?? '');
 }
 
-function suncokretChatEnabled() {
-    return booleanEnv(process.env.SUNCOKRET_CHAT_ENABLED);
-}
-
-function suncokretDebugEnabled() {
-    return booleanEnv(process.env.SUNCOKRET_CHAT_DEBUG_ENABLED);
+function queryFeatureFlags(query: z.infer<typeof StatusQuerySchema>) {
+    return {
+        enableSuncokretChatFlag: booleanFlag(query.enableSuncokretChatFlag),
+        enableSuncokretDebugFlag: booleanFlag(query.enableSuncokretDebugFlag),
+    };
 }
 
 function microUsdToUsd(value: number) {
@@ -89,8 +99,8 @@ function jsonError(
     };
 }
 
-function enabledOrResponse() {
-    if (suncokretChatEnabled()) {
+function enabledOrResponse(flags: z.infer<typeof FeatureFlagsSchema>) {
+    if (flags.enableSuncokretChatFlag) {
         return null;
     }
 
@@ -457,13 +467,16 @@ const app = new Hono<{ Variables: ChatVariables }>()
         zValidator('query', StatusQuerySchema),
         authValidator(['user', 'admin']),
         async (context) => {
-            const disabled = enabledOrResponse();
+            const query = context.req.valid('query');
+            const featureFlags = queryFeatureFlags(query);
+            const disabled = enabledOrResponse(featureFlags);
             const { accountId } = context.get('authContext');
-            const model = getSuncokretModel(context.req.valid('query').modelId);
+            const model = getSuncokretModel(query.modelId);
             const limitState = await getAiChatAccountLimitState(accountId);
 
             return context.json({
                 enabled: !disabled,
+                debugEnabled: featureFlags.enableSuncokretDebugFlag,
                 model: model
                     ? {
                           id: model.id,
@@ -486,9 +499,11 @@ const app = new Hono<{ Variables: ChatVariables }>()
             description: 'List enabled Suncokret AI Gateway models',
             security: authSecurity,
         }),
+        zValidator('query', StatusQuerySchema),
         authValidator(['user', 'admin']),
         async (context) => {
-            const disabled = enabledOrResponse();
+            const featureFlags = queryFeatureFlags(context.req.valid('query'));
+            const disabled = enabledOrResponse(featureFlags);
             if (disabled) {
                 return context.json(disabled.body, disabled.status);
             }
@@ -512,13 +527,15 @@ const app = new Hono<{ Variables: ChatVariables }>()
         zValidator('json', ChatBodySchema),
         authValidator(['user', 'admin']),
         async (context) => {
-            const disabled = enabledOrResponse();
+            const body = context.req.valid('json');
+            const disabled = enabledOrResponse(body.featureFlags);
             if (disabled) {
                 return context.json(disabled.body, disabled.status);
             }
 
-            const body = context.req.valid('json');
-            const debugAllowed = Boolean(body.debug && suncokretDebugEnabled());
+            const debugAllowed = Boolean(
+                body.debug && body.featureFlags.enableSuncokretDebugFlag,
+            );
             const auth = context.get('authContext');
             const model = getSuncokretModel(body.modelId);
             if (!model) {

--- a/packages/game/src/hud/SuncokretChatHud.tsx
+++ b/packages/game/src/hud/SuncokretChatHud.tsx
@@ -29,6 +29,7 @@ type SuncokretLimit = {
 
 type SuncokretStatus = {
     enabled: boolean;
+    debugEnabled?: boolean;
     model: { id: string; label: string } | null;
     limit: SuncokretLimit;
 };
@@ -127,6 +128,20 @@ function formatRetryAt(value: string | null | undefined) {
         dateStyle: 'medium',
         timeStyle: 'short',
     }).format(date);
+}
+
+function suncokretFlagParams({
+    debug,
+    enabled,
+}: {
+    debug: boolean;
+    enabled: boolean;
+}) {
+    const params = new URLSearchParams({
+        enableSuncokretChatFlag: enabled ? 'true' : 'false',
+        enableSuncokretDebugFlag: debug ? 'true' : 'false',
+    });
+    return params.toString();
 }
 
 function MessageText({ children }: { children: string }) {
@@ -300,6 +315,17 @@ export function SuncokretChatHud() {
     const chatId = useMemo(randomChatId, []);
     const scrollRef = useRef<HTMLDivElement>(null);
     const apiOrigin = getBrowserGrediceAppOrigin('api');
+    const featureFlags = useMemo(
+        () => ({
+            enableSuncokretChatFlag: enabled,
+            enableSuncokretDebugFlag: debug,
+        }),
+        [debug, enabled],
+    );
+    const featureFlagQuery = useMemo(
+        () => suncokretFlagParams({ debug, enabled }),
+        [debug, enabled],
+    );
     const { data: currentGarden } = useCurrentGarden();
     const closeupBlock = useGameState((state) => state.closeupBlock);
     const raisedBed = closeupBlock
@@ -322,11 +348,12 @@ export function SuncokretChatHud() {
                         raisedBedId,
                         modelId,
                         debug,
+                        featureFlags,
                     },
                     credentials: 'include',
                 }),
             }),
-        [apiOrigin, debug, gardenId, modelId, raisedBedId],
+        [apiOrigin, debug, featureFlags, gardenId, modelId, raisedBedId],
     );
 
     const { addToolApprovalResponse, error, messages, sendMessage, status } =
@@ -345,10 +372,10 @@ export function SuncokretChatHud() {
 
         let cancelled = false;
         void Promise.all([
-            fetch(`${apiOrigin}/api/ai/suncokret/status`, {
+            fetch(`${apiOrigin}/api/ai/suncokret/status?${featureFlagQuery}`, {
                 credentials: 'include',
             }).then((response) => response.json() as Promise<SuncokretStatus>),
-            fetch(`${apiOrigin}/api/ai/suncokret/models`, {
+            fetch(`${apiOrigin}/api/ai/suncokret/models?${featureFlagQuery}`, {
                 credentials: 'include',
             }).then(
                 (response) =>
@@ -374,7 +401,7 @@ export function SuncokretChatHud() {
         return () => {
             cancelled = true;
         };
-    }, [apiOrigin, enabled, open]);
+    }, [apiOrigin, enabled, featureFlagQuery, open]);
 
     useEffect(() => {
         scrollRef.current?.scrollTo({


### PR DESCRIPTION
## Summary

- Removes the Suncokret chat/debug API gates that read `SUNCOKRET_CHAT_ENABLED` and `SUNCOKRET_CHAT_DEBUG_ENABLED`.
- Passes the Garden-evaluated Suncokret feature flags from the game HUD to the Suncokret API.
- Uses the shared chat flag for `/status`, `/models`, and `/chat`, and uses the shared debug flag for streamed debug metadata.

## Validation

- `pnpm --filter api exec biome check --write 'app/api/[...route]/aiSuncokretRoutes.ts'`
- `pnpm --filter @gredice/game exec biome check --write src/hud/SuncokretChatHud.tsx`
- `pnpm typecheck --filter @gredice/game`
- `pnpm --filter garden exec tsc --noEmit --pretty false`
- `pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/mcp/catalog.node.spec.ts`
- `git diff --check origin/main...HEAD`

Known unrelated blocker:

- `pnpm --filter api exec tsc --noEmit --pretty false` still fails on existing `lib/notifications/webPushSender.node.spec.ts` type errors.