### PR TITLE
[codex] Polish Suncokret chat responses

### DIFF
--- a/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
+++ b/apps/api/app/api/[...route]/aiSuncokretRoutes.ts
@@ -156,6 +156,8 @@ function systemPrompt(input: {
         'Ti si Suncokret, Gredice AI pomoćnik u vrtu.',
         'Piši isključivo na hrvatskom jeziku, kratko, konkretno i prijateljski.',
         'Koristi alate za podatke o vrtu, gredicama, biljkama, radnjama i košarici. Ne pogađaj stanje vrta ako ga možeš dohvatiti alatom.',
+        'Ne zovi isti alat s istim argumentima više puta u jednom odgovoru. Nakon dohvaćanja podataka nastavi korisniku završnim odgovorom; ne završavaj razgovor samo na rezultatu alata.',
+        'Kada korisnik pita što treba napraviti ovaj tjedan, odgovori s naslovom "Plan za ovaj tjedan" i 3-6 prioriteta. Za svaki prioritet navedi zašto je važan, kada ga napraviti ako podaci imaju termin i koju Gredice radnju naručiti kada postoji odgovarajuća radnja.',
         'Korisnik nema nužno fizički pristup gredici. Kada preporuka traži rad na gredici, predloži naručivanje odgovarajuće radnje ili sijanja kroz dostupne alate.',
         'Ne tvrdi da je radnja, sijanje, izmjena košarice ili checkout izvršen dok alat ne potvrdi rezultat.',
         'Za kupnju, checkout, promjene košarice, sijanje, zakazivanje, otkazivanje i druge promjene prvo sažmi što želiš napraviti i koristi alat koji traži odobrenje korisnika.',
@@ -170,6 +172,13 @@ function systemPrompt(input: {
             ? `Trenutno polje u fokusu: ${(input.positionIndex + 1).toString()}.`
             : 'Trenutno polje nije zadano u sučelju.',
     ].join('\n');
+}
+
+function finalAnswerSystemPrompt(baseSystem: string) {
+    return [
+        baseSystem,
+        'Sada više ne koristi alate. Napiši završni odgovor korisniku iz već dohvaćenih podataka. Ako neki podatak nedostaje, reci to kratko i svejedno daj najbolji praktični plan iz dostupnog konteksta.',
+    ].join('\n\n');
 }
 
 async function mcpToken(userId: string, accountId: string) {
@@ -656,7 +665,17 @@ const app = new Hono<{ Variables: ChatVariables }>()
                         token,
                         userId: auth.userId,
                     }),
-                    stopWhen: stepCountIs(6),
+                    stopWhen: stepCountIs(8),
+                    prepareStep: ({ stepNumber }) => {
+                        if (stepNumber < 4) {
+                            return undefined;
+                        }
+
+                        return {
+                            system: finalAnswerSystemPrompt(promptInput.system),
+                            toolChoice: 'none',
+                        };
+                    },
                     maxOutputTokens,
                     providerOptions: {
                         gateway: {

--- a/apps/api/lib/ai/suncokretModels.node.spec.ts
+++ b/apps/api/lib/ai/suncokretModels.node.spec.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getSuncokretModel } from './suncokretModels';
+
+function setEnvValue(name: string, value: string | undefined) {
+    if (typeof value === 'string') {
+        process.env[name] = value;
+        return;
+    }
+
+    delete process.env[name];
+}
+
+function withModelEnv(
+    env: {
+        defaultModel?: string;
+        allowlist?: string;
+    },
+    callback: () => void,
+) {
+    const previousDefault = process.env.SUNCOKRET_AI_DEFAULT_MODEL;
+    const previousAllowlist = process.env.SUNCOKRET_AI_MODEL_ALLOWLIST;
+
+    setEnvValue('SUNCOKRET_AI_DEFAULT_MODEL', env.defaultModel);
+    setEnvValue('SUNCOKRET_AI_MODEL_ALLOWLIST', env.allowlist);
+
+    try {
+        callback();
+    } finally {
+        setEnvValue('SUNCOKRET_AI_DEFAULT_MODEL', previousDefault);
+        setEnvValue('SUNCOKRET_AI_MODEL_ALLOWLIST', previousAllowlist);
+    }
+}
+
+test('getSuncokretModel defaults to DeepSeek V4 Flash', () => {
+    withModelEnv({}, () => {
+        assert.equal(getSuncokretModel()?.id, 'deepseek/deepseek-v4-flash');
+    });
+});
+
+test('getSuncokretModel falls back to the first enabled model for automatic selection', () => {
+    withModelEnv(
+        {
+            allowlist: 'openai/gpt-5.5',
+        },
+        () => {
+            assert.equal(getSuncokretModel()?.id, 'openai/gpt-5.5');
+        },
+    );
+});
+
+test('getSuncokretModel keeps explicit unavailable model requests invalid', () => {
+    withModelEnv(
+        {
+            allowlist: 'openai/gpt-5.5',
+        },
+        () => {
+            assert.equal(getSuncokretModel('deepseek/deepseek-v4-flash'), null);
+        },
+    );
+});

--- a/apps/api/lib/ai/suncokretModels.ts
+++ b/apps/api/lib/ai/suncokretModels.ts
@@ -9,7 +9,7 @@ export type SuncokretModelConfig = AiChatPricing & {
     enabled: boolean;
 };
 
-const DEFAULT_MODEL_ID = 'openai/gpt-5.5';
+const DEFAULT_MODEL_ID = 'deepseek/deepseek-v4-flash';
 
 const MODEL_REGISTRY: SuncokretModelConfig[] = [
     {
@@ -49,14 +49,25 @@ export function getSuncokretModelRegistry() {
 }
 
 export function getSuncokretModel(modelId?: string | null) {
-    const requestedModelId =
-        modelId?.trim() ||
-        process.env.SUNCOKRET_AI_DEFAULT_MODEL ||
-        DEFAULT_MODEL_ID;
+    const requestedModelId = modelId?.trim();
+    const registry = getSuncokretModelRegistry();
+
+    if (requestedModelId) {
+        return (
+            registry.find(
+                (model) => model.id === requestedModelId && model.enabled,
+            ) ?? null
+        );
+    }
+
+    const defaultModelId =
+        process.env.SUNCOKRET_AI_DEFAULT_MODEL || DEFAULT_MODEL_ID;
     return (
-        getSuncokretModelRegistry().find(
-            (model) => model.id === requestedModelId && model.enabled,
-        ) ?? null
+        registry.find(
+            (model) => model.id === defaultModelId && model.enabled,
+        ) ??
+        registry.find((model) => model.enabled) ??
+        null
     );
 }
 

--- a/packages/game/src/hud/SuncokretChatHud.tsx
+++ b/packages/game/src/hud/SuncokretChatHud.tsx
@@ -4,7 +4,15 @@ import { useChat } from '@ai-sdk/react';
 import { getBrowserGrediceAppOrigin } from '@gredice/client';
 import { Button } from '@gredice/ui/Button';
 import { IconButton } from '@gredice/ui/IconButton';
-import { AI, Check, Close, LoaderSpinner, Send, Sun } from '@gredice/ui/icons';
+import {
+    AI,
+    Check,
+    Close,
+    LoaderSpinner,
+    Send,
+    Sun,
+    Warning,
+} from '@gredice/ui/icons';
 import { Markdown } from '@gredice/ui/Markdown';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -84,6 +92,37 @@ function toolName(part: Record<string, unknown>) {
     return type.replace(/^tool-/, '');
 }
 
+function toolActivityLabel(name: string) {
+    switch (name) {
+        case 'listGardens':
+            return 'Provjeravam vrtove';
+        case 'listRaisedBeds':
+            return 'Provjeravam gredice';
+        case 'getRaisedBedFields':
+            return 'Provjeravam polja u gredici';
+        case 'listGardenOperations':
+            return 'Provjeravam radnje';
+        case 'getRaisedBedAiHistory':
+            return 'Provjeravam ranije savjete';
+        case 'searchDirectory':
+        case 'getOperationsDirectory':
+            return 'Pretražujem Gredice katalog';
+        case 'searchProducts':
+            return 'Provjeravam ponudu';
+        case 'getCart':
+            return 'Provjeravam košaricu';
+        case 'addProductToCart':
+        case 'updateCartItem':
+            return 'Pripremam košaricu';
+        case 'analyzeRaisedBedImages':
+            return 'Analiziram fotografije';
+        case 'prepareCheckout':
+            return 'Pripremam checkout';
+        default:
+            return 'Provjeravam podatke';
+    }
+}
+
 function approval(part: Record<string, unknown>) {
     return isRecord(part.approval) ? part.approval : null;
 }
@@ -99,6 +138,28 @@ function toolState(part: Record<string, unknown>) {
         return approvalData.state;
     }
     return typeof part.state === 'string' ? part.state : 'unknown';
+}
+
+function isToolApprovalRequested(part: Record<string, unknown>) {
+    return (
+        toolState(part) === 'approval-requested' && Boolean(approvalId(part))
+    );
+}
+
+function isToolCompleteState(state: string) {
+    return state === 'output-available' || state === 'result';
+}
+
+function isToolErrorState(state: string) {
+    return state === 'output-error' || state === 'error';
+}
+
+function isToolRunningState(state: string) {
+    return (
+        !isToolCompleteState(state) &&
+        !isToolErrorState(state) &&
+        state !== 'approval-requested'
+    );
 }
 
 function debugJson(value: unknown) {
@@ -149,18 +210,33 @@ function ToolPart({
     part: Record<string, unknown>;
 }) {
     const state = toolState(part);
-    const requestedApproval = state === 'approval-requested';
+    const requestedApproval = isToolApprovalRequested(part);
     const id = approvalId(part);
+    const name = toolName(part);
 
     return (
         <div className="rounded-md border bg-muted/30 p-2 text-xs">
             <Row justifyContent="space-between" className="gap-2">
-                <Typography level="body3" semiBold>
-                    {toolName(part)}
-                </Typography>
-                <span className="rounded-sm bg-background px-1.5 py-0.5 text-[10px] uppercase tracking-normal text-muted-foreground">
-                    {state}
-                </span>
+                <Stack spacing={0} className="min-w-0">
+                    <Typography level="body3" semiBold>
+                        {requestedApproval
+                            ? 'Suncokret treba potvrdu'
+                            : toolActivityLabel(name)}
+                    </Typography>
+                    {requestedApproval && (
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Prije promjene u vrtu ili košarici potvrdi nastavak.
+                        </Typography>
+                    )}
+                </Stack>
+                {debug && (
+                    <span className="rounded-sm bg-background px-1.5 py-0.5 text-[10px] uppercase tracking-normal text-muted-foreground">
+                        {name} · {state}
+                    </span>
+                )}
             </Row>
             {requestedApproval && id && (
                 <Row spacing={1} className="mt-2">
@@ -207,19 +283,126 @@ function ToolPart({
     );
 }
 
+function formatActivityScopes(scopes: string[]) {
+    if (scopes.length === 0) {
+        return 'podatke';
+    }
+
+    if (scopes.length === 1) {
+        return scopes[0];
+    }
+
+    if (scopes.length === 2) {
+        return `${scopes[0]} i ${scopes[1]}`;
+    }
+
+    return `${scopes.slice(0, -1).join(', ')} i ${scopes[scopes.length - 1]}`;
+}
+
+function toolActivityScope(parts: Record<string, unknown>[]) {
+    const names = parts.map(toolName);
+    const scopes = [
+        names.some((name) => name === 'analyzeRaisedBedImages')
+            ? 'fotografije'
+            : null,
+        names.some((name) =>
+            [
+                'listGardens',
+                'listRaisedBeds',
+                'getRaisedBedFields',
+                'listGardenOperations',
+                'getRaisedBedAiHistory',
+            ].includes(name),
+        )
+            ? 'vrt'
+            : null,
+        names.some((name) =>
+            [
+                'searchDirectory',
+                'getOperationsDirectory',
+                'searchProducts',
+            ].includes(name),
+        )
+            ? 'katalog'
+            : null,
+        names.some((name) =>
+            [
+                'getCart',
+                'addProductToCart',
+                'updateCartItem',
+                'prepareCheckout',
+            ].includes(name),
+        )
+            ? 'košaricu'
+            : null,
+    ].filter((scope) => typeof scope === 'string');
+
+    return formatActivityScopes(scopes);
+}
+
+function toolActivitySummary({
+    isStreaming,
+    parts,
+}: {
+    isStreaming: boolean;
+    parts: Record<string, unknown>[];
+}) {
+    const errorPart = parts.find((part) => isToolErrorState(toolState(part)));
+    if (errorPart) {
+        return 'Dio podataka nije dostupan. Suncokret nastavlja s onim što ima.';
+    }
+
+    const runningPart = parts.find((part) =>
+        isToolRunningState(toolState(part)),
+    );
+    if (runningPart) {
+        return `${toolActivityLabel(toolName(runningPart))}...`;
+    }
+
+    if (isStreaming) {
+        return 'Suncokret slaže odgovor...';
+    }
+
+    return `Suncokret je provjerio ${toolActivityScope(parts)}.`;
+}
+
 function ChatMessage({
     addToolApprovalResponse,
     debug,
+    isStreaming,
     message,
 }: {
     addToolApprovalResponse: ReturnType<
         typeof useChat
     >['addToolApprovalResponse'];
     debug: boolean;
+    isStreaming: boolean;
     message: UIMessage;
 }) {
     const isUser = message.role === 'user';
     const partKeyCounts = new Map<string, number>();
+    const toolParts = message.parts
+        .map(toolPart)
+        .filter((part): part is Record<string, unknown> => Boolean(part));
+    const hasText = message.parts.some((part) => Boolean(textPart(part)));
+    const passiveToolParts = toolParts.filter(
+        (part) => !isToolApprovalRequested(part),
+    );
+    const showToolActivity =
+        !debug &&
+        passiveToolParts.length > 0 &&
+        (!hasText ||
+            isStreaming ||
+            passiveToolParts.some((part) => {
+                const state = toolState(part);
+                return isToolRunningState(state) || isToolErrorState(state);
+            }));
+    const hasToolError = passiveToolParts.some((part) =>
+        isToolErrorState(toolState(part)),
+    );
+    const hasRunningTool = passiveToolParts.some((part) =>
+        isToolRunningState(toolState(part)),
+    );
 
     return (
         <div
@@ -252,6 +435,10 @@ function ChatMessage({
 
                     const toolData = toolPart(part);
                     if (toolData) {
+                        if (!debug && !isToolApprovalRequested(toolData)) {
+                            return null;
+                        }
+
                         return (
                             <ToolPart
                                 key={key}
@@ -273,6 +460,31 @@ function ChatMessage({
                         </pre>
                     ) : null;
                 })}
+                {showToolActivity && (
+                    <Row
+                        spacing={2}
+                        className={cx(
+                            'rounded-md border border-dashed px-2 py-1.5 text-muted-foreground',
+                            hasToolError
+                                ? 'border-amber-300 bg-amber-50 text-amber-900'
+                                : 'bg-muted/30',
+                        )}
+                    >
+                        {hasToolError ? (
+                            <Warning className="size-3.5 shrink-0" />
+                        ) : hasRunningTool || isStreaming ? (
+                            <LoaderSpinner className="size-3.5 shrink-0 animate-spin" />
+                        ) : (
+                            <AI className="size-3.5 shrink-0" />
+                        )}
+                        <Typography level="body3">
+                            {toolActivitySummary({
+                                isStreaming,
+                                parts: passiveToolParts,
+                            })}
+                        </Typography>
+                    </Row>
+                )}
                 {debug && Boolean(message.metadata) && (
                     <details>
                         <summary className="cursor-pointer text-xs text-muted-foreground">
@@ -541,6 +753,12 @@ export function SuncokretChatHud() {
                                         addToolApprovalResponse
                                     }
                                     debug={debug}
+                                    isStreaming={
+                                        loading &&
+                                        message.role === 'assistant' &&
+                                        message.id ===
+                                            messages[messages.length - 1]?.id
+                                    }
                                     message={message}
                                 />
                             ))}
@@ -551,7 +769,7 @@ export function SuncokretChatHud() {
                                 >
                                     <LoaderSpinner className="size-4 animate-spin" />
                                     <Typography level="body3">
-                                        Suncokret piše...
+                                        Suncokret razmišlja...
                                     </Typography>
                                 </Row>
                             )}

--- a/packages/game/src/hud/SuncokretChatHud.tsx
+++ b/packages/game/src/hud/SuncokretChatHud.tsx
@@ -147,11 +147,24 @@ function isToolApprovalRequested(part: Record<string, unknown>) {
 }
 
 function isToolCompleteState(state: string) {
-    return state === 'output-available' || state === 'result';
+    return (
+        state === 'output-available' ||
+        state === 'result' ||
+        state === 'approval-responded' ||
+        state === 'output-denied'
+    );
 }
 
 function isToolErrorState(state: string) {
     return state === 'output-error' || state === 'error';
+}
+
+function isToolDeniedState(state: string) {
+    return state === 'output-denied';
+}
+
+function isToolApprovalRespondedState(state: string) {
+    return state === 'approval-responded';
 }
 
 function isToolRunningState(state: string) {
@@ -352,6 +365,18 @@ function toolActivitySummary({
         return 'Dio podataka nije dostupan. Suncokret nastavlja s onim što ima.';
     }
 
+    const deniedPart = parts.find((part) => isToolDeniedState(toolState(part)));
+    if (deniedPart) {
+        return 'Radnja je otkazana.';
+    }
+
+    const approvalRespondedPart = parts.find((part) =>
+        isToolApprovalRespondedState(toolState(part)),
+    );
+    if (approvalRespondedPart) {
+        return 'Potvrda je zabilježena.';
+    }
+
     const runningPart = parts.find((part) =>
         isToolRunningState(toolState(part)),
     );
@@ -402,6 +427,12 @@ function ChatMessage({
     );
     const hasRunningTool = passiveToolParts.some((part) =>
         isToolRunningState(toolState(part)),
+    );
+    const hasDeniedTool = passiveToolParts.some((part) =>
+        isToolDeniedState(toolState(part)),
+    );
+    const hasApprovalRespondedTool = passiveToolParts.some((part) =>
+        isToolApprovalRespondedState(toolState(part)),
     );
 
     return (
@@ -472,7 +503,10 @@ function ChatMessage({
                     >
                         {hasToolError ? (
                             <Warning className="size-3.5 shrink-0" />
-                        ) : hasRunningTool || isStreaming ? (
+                        ) : hasDeniedTool ? (
+                            <Close className="size-3.5 shrink-0" />
+                        ) : hasRunningTool ||
+                          (isStreaming && !hasApprovalRespondedTool) ? (
                             <LoaderSpinner className="size-3.5 shrink-0 animate-spin" />
                         ) : (
                             <AI className="size-3.5 shrink-0" />


### PR DESCRIPTION
## What changed

- Make Suncokret produce a final user-facing answer after tool lookup rounds instead of ending on raw tool output.
- Render normal Suncokret tool calls as a compact thinking/activity state while keeping approval-required actions explicit.
- Switch the built-in Suncokret default model to DeepSeek V4 Flash and add fallback behavior when the default is disabled by allowlist.
- Add focused coverage for Suncokret model default selection.

## Why

The weekly-plan prompt could end with visible tool-call output and no useful suggestions. The chat should feel like Suncokret is checking garden context, then answer with concrete next steps.

## Validation

- `pnpm --filter @gredice/game lint`
- `pnpm --filter api lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `pnpm --filter api exec node --conditions=react-server --import tsx --test lib/ai/suncokretModels.node.spec.ts`
- `git diff --check`

Direct `pnpm --filter api exec tsc --noEmit --pretty false` is currently blocked by unrelated existing errors in `apps/api/lib/notifications/webPushSender.node.spec.ts:211`.