### PR TITLE
Filter inactive raised beds from operation targets

### DIFF
--- a/apps/app/app/admin/operations/page.tsx
+++ b/apps/app/app/admin/operations/page.tsx
@@ -1,5 +1,5 @@
 import {
-    getAllRaisedBeds,
+    getAllRaisedBedsFiltered,
     getFarms,
     getGardens,
     getUniqueAssignableFarmUsersByFarmIds,
@@ -26,7 +26,7 @@ export default async function OperationsPage({
     const [farms, gardens, raisedBeds] = await Promise.all([
         getFarms(),
         getGardens(),
-        getAllRaisedBeds(),
+        getAllRaisedBedsFiltered({ status: 'active' }),
     ]);
     const activeFarms = farms
         .filter((farm) => !farm.isDeleted)


### PR DESCRIPTION
## Summary
- Load only active raised beds for the admin operations create modals.
- Keeps abandoned and other non-active beds out of the shared single/bulk target picker before submit.

## Testing
- Not run locally; command execution failed before shell startup in this Codex environment.
