### PR TITLE
[codex] Rearrange admin farm navigation

### DIFF
--- a/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
@@ -5,6 +5,7 @@ import {
     Bank,
     Book,
     Calendar,
+    Cloud,
     Discount,
     Euro,
     Fence,
@@ -13,6 +14,7 @@ import {
     Home,
     Inbox,
     Lightning,
+    Link,
     Mail,
     Map as MapIcon,
     Megaphone,
@@ -104,10 +106,16 @@ const breadcrumbSections: {
         title: 'Administracija',
         pages: [
             { ...adminPages.Accounts, icon: <Bank className="size-4" /> },
+            { ...adminPages.Users, icon: <User className="size-4" /> },
             {
                 ...adminPages.Achievements,
                 icon: <Success className="size-4" />,
             },
+        ],
+    },
+    {
+        title: 'Financije',
+        pages: [
             {
                 ...adminPages.ShoppingCarts,
                 icon: <ShoppingCart className="size-4" />,
@@ -120,19 +128,38 @@ const breadcrumbSections: {
             { ...adminPages.Sunflowers, icon: <Success className="size-4" /> },
             { ...adminPages.Receipts, icon: <File className="size-4" /> },
             { ...adminPages.Outlet, icon: <Discount className="size-4" /> },
-            { ...adminPages.Users, icon: <User className="size-4" /> },
+        ],
+    },
+    {
+        title: 'Farme',
+        pages: [
             { ...adminPages.Farms, icon: <MapIcon className="size-4" /> },
+            { ...adminPages.Operations, icon: <Hammer className="size-4" /> },
+            {
+                ...adminPages.FarmerPrices,
+                icon: <Euro className="size-4" />,
+            },
+            {
+                ...adminPages.FarmerPayouts,
+                icon: <Euro className="size-4" />,
+            },
+            {
+                ...adminPages.FarmerDocumentation,
+                icon: <Book className="size-4" />,
+            },
+            { ...adminPages.HarvestTraces, icon: <Link className="size-4" /> },
+        ],
+    },
+    {
+        title: 'Vrtovi',
+        pages: [
+            { ...adminPages.Weather, icon: <Cloud className="size-4" /> },
             { ...adminPages.Gardens, icon: <Fence className="size-4" /> },
             {
                 ...adminPages.RaisedBeds,
                 icon: <RaisedBedIcon className="size-4" physicalId={null} />,
             },
             { ...adminPages.Greenhouse, icon: <Sprout className="size-4" /> },
-            { ...adminPages.Operations, icon: <Hammer className="size-4" /> },
-            {
-                ...adminPages.FarmerDocumentation,
-                icon: <Book className="size-4" />,
-            },
         ],
     },
     {

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -457,9 +457,6 @@ export function Nav({
                         adminPages.ShoppingCarts.href,
                         adminPages.Invoices.href,
                         adminPages.Transactions.href,
-                        adminPages.FarmerPayouts.href,
-                        adminPages.FarmerPrices.href,
-                        adminPages.FarmerDocumentation.href,
                         adminPages.Sunflowers.href,
                         adminPages.Receipts.href,
                         adminPages.Outlet.href,
@@ -491,30 +488,6 @@ export function Nav({
                         nested
                     />
                     <NavItem
-                        href={adminPages.FarmerPayouts.href}
-                        label={adminPages.FarmerPayouts.label}
-                        icon={<Euro className="size-5" />}
-                        onClick={onItemClick}
-                        compact={compact}
-                        nested
-                    />
-                    <NavItem
-                        href={adminPages.FarmerPrices.href}
-                        label={adminPages.FarmerPrices.label}
-                        icon={<Euro className="size-5" />}
-                        onClick={onItemClick}
-                        compact={compact}
-                        nested
-                    />
-                    <NavItem
-                        href={adminPages.FarmerDocumentation.href}
-                        label={adminPages.FarmerDocumentation.label}
-                        icon={<Book className="size-5" />}
-                        onClick={onItemClick}
-                        compact={compact}
-                        nested
-                    />
-                    <NavItem
                         href={adminPages.Sunflowers.href}
                         label={adminPages.Sunflowers.label}
                         icon={<Success className="size-5" />}
@@ -540,27 +513,78 @@ export function Nav({
                     />
                 </NavGroup>
                 <NavGroup
-                    label="Vrtovi"
+                    label="Farme"
                     icon={<MapIcon className="size-5" />}
                     forceOpen={includesSelectedPath(pathname, [
                         adminPages.Farms.href,
-                        adminPages.Weather.href,
-                        adminPages.Gardens.href,
-                        adminPages.RaisedBeds.href,
-                        adminPages.Greenhouse.href,
-                        adminPages.HarvestTraces.href,
                         adminPages.Operations.href,
+                        adminPages.FarmerPrices.href,
+                        adminPages.FarmerPayouts.href,
+                        adminPages.FarmerDocumentation.href,
+                        adminPages.HarvestTraces.href,
                     ])}
                     compact={compact}
                 >
                     <NavItem
                         href={adminPages.Farms.href}
-                        label={adminPages.Farms.label}
+                        label="Pregled farmi"
                         icon={<MapIcon className="size-5" />}
                         onClick={onItemClick}
                         compact={compact}
                         nested
                     />
+                    <NavItem
+                        href={adminPages.Operations.href}
+                        label={adminPages.Operations.label}
+                        icon={<Hammer className="size-5" />}
+                        onClick={onItemClick}
+                        compact={compact}
+                        nested
+                    />
+                    <NavItem
+                        href={adminPages.FarmerPrices.href}
+                        label={adminPages.FarmerPrices.label}
+                        icon={<Euro className="size-5" />}
+                        onClick={onItemClick}
+                        compact={compact}
+                        nested
+                    />
+                    <NavItem
+                        href={adminPages.FarmerPayouts.href}
+                        label={adminPages.FarmerPayouts.label}
+                        icon={<Euro className="size-5" />}
+                        onClick={onItemClick}
+                        compact={compact}
+                        nested
+                    />
+                    <NavItem
+                        href={adminPages.FarmerDocumentation.href}
+                        label={adminPages.FarmerDocumentation.label}
+                        icon={<Book className="size-5" />}
+                        onClick={onItemClick}
+                        compact={compact}
+                        nested
+                    />
+                    <NavItem
+                        href={adminPages.HarvestTraces.href}
+                        label={adminPages.HarvestTraces.label}
+                        icon={<Link className="size-5" />}
+                        onClick={onItemClick}
+                        compact={compact}
+                        nested
+                    />
+                </NavGroup>
+                <NavGroup
+                    label="Vrtovi"
+                    icon={<Fence className="size-5" />}
+                    forceOpen={includesSelectedPath(pathname, [
+                        adminPages.Weather.href,
+                        adminPages.Gardens.href,
+                        adminPages.RaisedBeds.href,
+                        adminPages.Greenhouse.href,
+                    ])}
+                    compact={compact}
+                >
                     <NavItem
                         href={adminPages.Weather.href}
                         label={adminPages.Weather.label}
@@ -594,22 +618,6 @@ export function Nav({
                         href={adminPages.Greenhouse.href}
                         label={adminPages.Greenhouse.label}
                         icon={<Sprout className="size-5" />}
-                        onClick={onItemClick}
-                        compact={compact}
-                        nested
-                    />
-                    <NavItem
-                        href={adminPages.Operations.href}
-                        label={adminPages.Operations.label}
-                        icon={<Hammer className="size-5" />}
-                        onClick={onItemClick}
-                        compact={compact}
-                        nested
-                    />
-                    <NavItem
-                        href={adminPages.HarvestTraces.href}
-                        label={adminPages.HarvestTraces.label}
-                        icon={<Link className="size-5" />}
                         onClick={onItemClick}
                         compact={compact}
                         nested


### PR DESCRIPTION
## Summary
- Add a dedicated **Farme** group to the admin sidebar.
- Move farm overview, operations, operation prices, farmer payouts, farmer documentation, and QR traces into that group.
- Keep account/commerce finance pages under **Financije** and reduce **Vrtovi** to weather, gardens, raised beds, and greenhouse.
- Align the breadcrumb page selector with the same finance/farm/garden grouping.

## Validation
- `pnpm lint --filter app`
- `pnpm build --filter app`
- `git diff --check`

## Notes
- `pnpm --filter app exec tsc --noEmit --pretty false` still fails on existing unrelated type errors outside the touched navigation files; the app build also reports that Next skips type validation.