### PR TITLE
[codex] Polish farmer documentation PDF printing

### DIFF
--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.ts
@@ -198,6 +198,10 @@ const plantSortTextFields = [
     { key: 'origin', title: 'Podrijetlo' },
 ];
 
+const plantTextFields = plantSortTextFields.filter(
+    ({ key }) => key !== 'origin',
+);
+
 const calendarDetails = [
     { key: 'propagating', title: 'Sjetva u zatvorenom' },
     { key: 'sowing', title: 'Sjetva na otvorenom' },
@@ -923,6 +927,7 @@ function toDocumentationPlant({
 }): FarmerDocumentationPlant {
     const plantInformation = recordProperty(plant, 'information');
     const latinName = textProperty(plantInformation, 'latinName');
+    const origin = textProperty(plantInformation, 'origin');
     const revisions = [...plantRevisions, ...plantSortRevisions];
     const plantLabel = getPlantLabel(plant);
     const changedAt =
@@ -943,6 +948,7 @@ function toDocumentationPlant({
             ['Kod', getFarmerDocumentationCode('plant', plant.id)],
             ['Vrsta', documentationEntityConfig.plant.documentTypeLabel],
             ['Latinski naziv', latinName],
+            ['Podrijetlo', origin],
             ['Dostupnih sorti', formatInteger(plantSorts.length)],
             [
                 'Promjena',
@@ -1109,7 +1115,7 @@ function plantSections(
                 ? plantSorts.map(plantSortListLine)
                 : ['Nema dostupnih sorti.'],
         ),
-        ...plantSortTextFields
+        ...plantTextFields
             .map(({ key, title }) => {
                 const text = textProperty(plantInformation, key);
 

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
@@ -165,6 +165,18 @@ test('builds insert, replace, and discard instructions from manual revisions', (
         ],
     );
     assert.deepEqual(
+        documentationPackage.includedPlants[0]?.summaryRows.find(
+            (row) => row.label === 'Podrijetlo',
+        ),
+        { label: 'Podrijetlo', value: 'Južna Amerika' },
+    );
+    assert.equal(
+        documentationPackage.includedPlants[0]?.sections.some(
+            (section) => section.title === 'Podrijetlo',
+        ),
+        false,
+    );
+    assert.deepEqual(
         pagesByHeader.map((page) => page.code),
         ['OP-0008', 'PL-1014', 'OP-0004'],
     );
@@ -403,6 +415,8 @@ test('renders compact plant attributes and markdown content in PDFs', async () =
         operations: [],
         plants: [
             plantFixture({
+                description:
+                    'Artičoke su “teški potrošači” hranjivih tvari i podnose 7–10°C skladištenje…',
                 storage: [
                     '1. **Kratkoročno skladištenje**',
                     '   - Hladnjak:',
@@ -436,6 +450,11 @@ test('renders compact plant attributes and markdown content in PDFs', async () =
 
     assert.equal(sowingPosition.y, growthPosition.y);
     assert.ok(growthPosition.x > sowingPosition.x + 200);
+    assertPdfText(
+        content,
+        'Artičoke su "teški potrošači" hranjivih tvari i podnose 7-10 C skladištenje...',
+    );
+    assert.doesNotMatch(content, /\?te/);
     assertPdfText(content, 'Kratkoročno skladištenje');
     assertPdfText(content, 'Papriku čuvajte u ladici za povrće');
     assertPdfText(content, 'Sušenje');
@@ -445,6 +464,39 @@ test('renders compact plant attributes and markdown content in PDFs', async () =
     assertPdfText(content, 'https://example.test/upute');
     assertPdfTextWithFont(content, 'F2', 'Sušenje');
     assert.doesNotMatch(content, /\(\* Papriku/);
+});
+
+test('inserts blank pages between documentation entries for duplex printing', async () => {
+    const documentationPackage = buildFarmerDocumentationPackage({
+        generatedAt,
+        since: null,
+        labelAttributeDefinitionIds: {
+            operation: new Set(),
+            plant: new Set(),
+            plantSort: new Set(),
+        },
+        plantSortPlantAttributeDefinitionIds: new Set(),
+        operations: [],
+        plants: [
+            plantFixture(),
+            plantFixture({
+                id: 2020,
+                label: 'Paprika',
+                origin: 'Srednja Amerika',
+            }),
+        ],
+        plantSorts: [],
+        revisions: [],
+    });
+
+    const pdf = await generateFarmerDocumentationPdf(documentationPackage, {
+        content: 'plants',
+    });
+    const content = decodePdfForAssertions(pdf);
+
+    assert.equal(pdfPageCount(content), 5);
+    assertPdfText(content, 'PL-1014');
+    assertPdfText(content, 'PL-2020');
 });
 
 test('generates filtered PDF packages for updates', async () => {
@@ -561,6 +613,15 @@ function pdfTextPosition(content: string, value: string) {
         x: Number.parseFloat(match[1]),
         y: Number.parseFloat(match[2]),
     };
+}
+
+function pdfPageCount(content: string) {
+    const match = /\/Type \/Pages \/Kids \[[^\]]+\] \/Count (\d+)/.exec(
+        content,
+    );
+
+    assert.ok(match?.[1]);
+    return Number.parseInt(match[1], 10);
 }
 
 function decodePdfForAssertions(pdf: ArrayBuffer) {
@@ -697,11 +758,13 @@ function plantFixture({
     description = 'Opis biljke.',
     id = 1014,
     label = 'Rajčica',
+    origin = 'Južna Amerika',
     storage,
 }: {
     description?: string;
     id?: number;
     label?: string;
+    origin?: string;
     storage?: string;
 } = {}): EntityStandardized {
     return {
@@ -710,6 +773,7 @@ function plantFixture({
             label,
             name: label,
             description,
+            origin,
             ...(storage ? { storage } : {}),
         },
         image: { cover: { url: plantImageDataUrl } },

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
@@ -129,6 +129,9 @@ const bodyFontSize = 9.4;
 const bodyLineHeight = 13.2;
 const smallFontSize = 7.8;
 const titleFontSize = 17;
+const summaryLabelFontSize = 6.7;
+const summaryValueFontSize = 8.7;
+const summaryRowHeight = 16;
 const markdownBlockSpacing = 5;
 const markdownListIndent = 13;
 const markdownListMarkerWidth = 15;
@@ -355,9 +358,19 @@ export async function generateFarmerDocumentationPdf(
     );
     const pages: PdfCanvas[] = [];
 
+    const guideStartIndex = pages.length;
     drawOrganizationGuide({ content, data, farmOrigin, pages, version });
+    if (documentationPages.length > 0) {
+        appendDuplexBlankPageIfNeeded(pages, guideStartIndex);
+    }
 
-    for (const page of documentationPages) {
+    for (let index = 0; index < documentationPages.length; index += 1) {
+        const page = documentationPages[index];
+        if (!page) {
+            continue;
+        }
+
+        const pageStartIndex = pages.length;
         drawDocumentationPage({
             data,
             farmOrigin,
@@ -366,12 +379,34 @@ export async function generateFarmerDocumentationPdf(
             version,
             page,
         });
+        if (index < documentationPages.length - 1) {
+            appendDuplexBlankPageIfNeeded(pages, pageStartIndex);
+        }
     }
 
     return writePdf(
         pages.map((page) => page.toString()),
         imageAssets,
     );
+}
+
+function appendDuplexBlankPageIfNeeded(
+    pages: PdfCanvas[],
+    documentStartIndex: number,
+) {
+    if ((pages.length - documentStartIndex) % 2 === 0) {
+        return;
+    }
+
+    const page = new PdfCanvas();
+    page.fillRect({
+        x: 0,
+        y: 0,
+        width: pageWidth,
+        height: pageHeight,
+        color: colors.white,
+    });
+    pages.push(page);
 }
 
 async function loadDocumentationImageAssets(pages: FarmerDocumentationPage[]) {
@@ -790,7 +825,7 @@ function drawDocumentationPage({
 
 function drawPageSummary(context: FlowContext, page: FarmerDocumentationPage) {
     const rows = page.summaryRows;
-    const boxHeight = rows.length * 21 + 18;
+    const boxHeight = rows.length * summaryRowHeight + 16;
     context = ensureSpace(context, boxHeight);
     context.page.fillRect({
         x: margin,
@@ -800,28 +835,32 @@ function drawPageSummary(context: FlowContext, page: FarmerDocumentationPage) {
         color: colors.softGray,
     });
 
-    let y = context.y - 25;
+    let y = context.y - 22;
     for (const row of rows) {
         context.page.text({
             x: margin + 12,
             y,
             value: row.label.toUpperCase(),
-            size: 6.9,
+            size: summaryLabelFontSize,
             font: 'F2',
             color: colors.muted,
         });
         context.page.text({
             x: margin + 142,
             y,
-            value: row.value,
-            size: 9,
+            value: fitSingleLine(
+                row.value,
+                contentWidth - 154,
+                summaryValueFontSize,
+            ),
+            size: summaryValueFontSize,
             font: 'F2',
             color: colors.text,
         });
-        y -= 21;
+        y -= summaryRowHeight;
     }
 
-    context.y -= boxHeight + 16;
+    context.y -= boxHeight + 12;
     return context;
 }
 
@@ -2392,8 +2431,21 @@ function sanitizePdfText(value: string) {
 
     for (const character of value
         .normalize('NFC')
-        .replace(/[–—]/g, '-')
-        .replace(/→/g, '->')) {
+        .replace(/[\u00a0\u202f]/g, ' ')
+        .replace(/[\u00ad\u200b]/g, '')
+        .replace(/[‐‑‒–—―]/g, '-')
+        .replace(/[“”„‟]/g, '"')
+        .replace(/[‘’‚‛]/g, "'")
+        .replace(/[•·]/g, '-')
+        .replace(/…/g, '...')
+        .replace(/→/g, '->')
+        .replace(/←/g, '<-')
+        .replace(/×/g, 'x')
+        .replace(/≤/g, '<=')
+        .replace(/≥/g, '>=')
+        .replace(/±/g, '+/-')
+        .replace(/°\s*C/giu, ' C')
+        .replace(/°/g, '')) {
         if (/^[\x20-\x7e]$/.test(character)) {
             sanitized += character;
             continue;


### PR DESCRIPTION
## Summary
- Move plant `Podrijetlo` into the PDF header summary and remove the duplicate body section.
- Tighten summary row spacing so the added header metadata stays compact.
- Normalize more Unicode punctuation before PDF encoding, including smart quotes, dash variants, degree symbols, ellipses, arrows, and comparison signs.
- Insert blank pages between guide/documentation entries so duplex printing starts each new entry on a front side.

## Validation
- `pnpm --filter app exec biome check --write app/admin/farmers/documentation/farmerDocumentationData.ts app/admin/farmers/documentation/farmerDocumentationPdf.ts app/admin/farmers/documentation/farmerDocumentationData.unit.ts`
- `pnpm --filter app test:unit`
- `pnpm typecheck --filter app`
- `git diff --check`