### PR TITLE
[codex] Add admin operation switch action

### DIFF
--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -19,12 +19,14 @@ import {
     getAssignableFarmUsersByFarmIds,
     getAssignableFarmUsersByGardenIds,
     getAssignableFarmUsersByOperationIds,
+    getEntitiesFormatted,
     getEntityFormatted,
     getFarmUserAcceptedOperationById,
     getOperationById,
     getRaisedBed,
     type InsertOperation,
     knownEvents,
+    switchOperationEntity,
     unacceptOperation,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
@@ -469,6 +471,83 @@ export async function bulkCreateOperationsAction(
                 error instanceof Error
                     ? error.message
                     : 'Došlo je do greške pri kreiranju radnji.',
+        };
+    }
+}
+
+export type SwitchOperationEntityActionState = {
+    success: boolean;
+    message: string;
+};
+
+function parseRequiredPositiveInteger(
+    formData: FormData,
+    name: string,
+    message: string,
+) {
+    const value = formData.get(name);
+    const parsed = typeof value === 'string' ? Number(value) : NaN;
+
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(message);
+    }
+
+    return parsed;
+}
+
+export async function switchOperationEntityAction(
+    _previousState: SwitchOperationEntityActionState | null,
+    formData: FormData,
+): Promise<SwitchOperationEntityActionState> {
+    try {
+        await auth(['admin']);
+
+        const operationId = parseRequiredPositiveInteger(
+            formData,
+            'operationId',
+            'Operation ID is required.',
+        );
+        const entityId = parseRequiredPositiveInteger(
+            formData,
+            'entityId',
+            'Odaberite novu radnju.',
+        );
+
+        const operation = await getOperationById(operationId);
+        const availableOperations =
+            await getEntitiesFormatted<EntityStandardized>('operation');
+        const replacementOperation = availableOperations.find(
+            (candidate) => candidate.id === entityId,
+        );
+
+        if (!replacementOperation) {
+            throw new Error('Odabrana radnja nije dostupna.');
+        }
+
+        if (
+            operation.entityId === entityId &&
+            operation.entityTypeName === 'operation'
+        ) {
+            return {
+                success: true,
+                message: 'Odabrana radnja je već postavljena.',
+            };
+        }
+
+        await switchOperationEntity(operationId, {
+            entityId,
+            entityTypeName: 'operation',
+        });
+        await revalidateOperationPaths(operation);
+
+        return { success: true, message: 'Radnja je promijenjena.' };
+    } catch (error) {
+        return {
+            success: false,
+            message:
+                error instanceof Error
+                    ? error.message
+                    : 'Došlo je do greške pri promjeni radnje.',
         };
     }
 }

--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -33,6 +33,7 @@ import { revalidatePath } from 'next/cache';
 import type { EntityStandardized } from '../../lib/@types/EntityStandardized';
 import { auth } from '../../lib/auth/auth';
 import { KnownPages } from '../../src/KnownPages';
+import { operationDefinitionMatchesTargetScope } from '../admin/operations/operationScope';
 
 const MAX_COMPLETION_NOTES_LENGTH = 2000;
 
@@ -514,6 +515,16 @@ export async function switchOperationEntityAction(
         );
 
         const operation = await getOperationById(operationId);
+        if (
+            operation.entityId === entityId &&
+            operation.entityTypeName === 'operation'
+        ) {
+            return {
+                success: true,
+                message: 'Odabrana radnja je već postavljena.',
+            };
+        }
+
         const availableOperations =
             await getEntitiesFormatted<EntityStandardized>('operation');
         const replacementOperation = availableOperations.find(
@@ -525,13 +536,14 @@ export async function switchOperationEntityAction(
         }
 
         if (
-            operation.entityId === entityId &&
-            operation.entityTypeName === 'operation'
+            !operationDefinitionMatchesTargetScope(
+                operation,
+                replacementOperation,
+            )
         ) {
-            return {
-                success: true,
-                message: 'Odabrana radnja je već postavljena.',
-            };
+            throw new Error(
+                'Odabrana radnja nije kompatibilna s lokacijom postojeće radnje.',
+            );
         }
 
         await switchOperationEntity(operationId, {

--- a/apps/app/app/admin/operations/[operationId]/page.tsx
+++ b/apps/app/app/admin/operations/[operationId]/page.tsx
@@ -47,6 +47,7 @@ import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
 import { AcceptOperationModal } from '../../schedule/AcceptOperationModal';
 import { VerifyOperationModal } from '../../schedule/VerifyOperationModal';
+import { operationDefinitionMatchesTargetScope } from '../operationScope';
 
 export const dynamic = 'force-dynamic';
 
@@ -181,13 +182,17 @@ export default async function OperationDetailsPage({
         (op) => op.id === operation.entityId,
     );
     const publishedOperationOptions =
-        operationsData?.map((op) => ({
-            id: op.id,
-            label:
-                op.information?.label ??
-                op.information?.name ??
-                `Radnja ${op.id}`,
-        })) ?? [];
+        operationsData
+            ?.filter((op) =>
+                operationDefinitionMatchesTargetScope(operation, op),
+            )
+            .map((op) => ({
+                id: op.id,
+                label:
+                    op.information?.label ??
+                    op.information?.name ??
+                    `Radnja ${op.id}`,
+            })) ?? [];
     const accountUsers = account?.accountUsers
         .map((au) => au.user.displayName ?? au.user.userName)
         .join(', ');

--- a/apps/app/app/admin/operations/[operationId]/page.tsx
+++ b/apps/app/app/admin/operations/[operationId]/page.tsx
@@ -40,6 +40,7 @@ import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navig
 import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { OperationCancelButton } from '../../../../components/operations/OperationCancelButton';
 import { OperationRescheduleButton } from '../../../../components/operations/OperationRescheduleButton';
+import { OperationSwitchButton } from '../../../../components/operations/OperationSwitchButton';
 import { OperationUnacceptButton } from '../../../../components/operations/OperationUnacceptButton';
 import type { EntityStandardized } from '../../../../lib/@types/EntityStandardized';
 import { auth } from '../../../../lib/auth/auth';
@@ -179,6 +180,14 @@ export default async function OperationDetailsPage({
     const operationDetails = operationsData?.find(
         (op) => op.id === operation.entityId,
     );
+    const publishedOperationOptions =
+        operationsData?.map((op) => ({
+            id: op.id,
+            label:
+                op.information?.label ??
+                op.information?.name ??
+                `Radnja ${op.id}`,
+        })) ?? [];
     const accountUsers = account?.accountUsers
         .map((au) => au.user.displayName ?? au.user.userName)
         .join(', ');
@@ -196,6 +205,17 @@ export default async function OperationDetailsPage({
     const publicOperationHref = operationDetails?.information?.label
         ? KnownPages.GrediceOperation(operationDetails.information.label)
         : KnownPages.GrediceOperations;
+    const operationSwitchOptions = publishedOperationOptions.some(
+        (option) => option.id === operation.entityId,
+    )
+        ? publishedOperationOptions
+        : [
+              {
+                  id: operation.entityId,
+                  label: operationTitle,
+              },
+              ...publishedOperationOptions,
+          ];
     const assignedUsers =
         operation.assignedUsers && operation.assignedUsers.length > 0 ? (
             <Stack spacing={1}>
@@ -559,6 +579,12 @@ export default async function OperationDetailsPage({
                                     }
                                 />
                             )}
+                            <OperationSwitchButton
+                                operationId={operation.id}
+                                currentEntityId={operation.entityId}
+                                operationLabel={operationTitle}
+                                operationOptions={operationSwitchOptions}
+                            />
                             <OperationRescheduleButton
                                 operation={operationAction}
                                 operationLabel={operationTitle}

--- a/apps/app/app/admin/operations/operationScope.ts
+++ b/apps/app/app/admin/operations/operationScope.ts
@@ -1,0 +1,74 @@
+export type OperationTargetScope = 'farm' | 'garden' | 'raisedBed' | 'plant';
+
+type OperationLocation = {
+    farmId?: number | null;
+    gardenId?: number | null;
+    raisedBedId?: number | null;
+    raisedBedFieldId?: number | null;
+};
+
+type OperationDefinition = {
+    attributes?: {
+        application?: string | null;
+    };
+};
+
+export function operationTargetScope(
+    operation: OperationLocation,
+): OperationTargetScope | undefined {
+    if (operation.raisedBedFieldId) {
+        return 'plant';
+    }
+
+    if (operation.raisedBedId) {
+        return 'raisedBed';
+    }
+
+    if (operation.gardenId) {
+        return 'garden';
+    }
+
+    if (operation.farmId) {
+        return 'farm';
+    }
+
+    return undefined;
+}
+
+export function operationApplicationScope(
+    application: string | null | undefined,
+): OperationTargetScope | undefined {
+    if (application === 'farm') {
+        return 'farm';
+    }
+
+    if (application === 'garden') {
+        return 'garden';
+    }
+
+    if (application === 'plant') {
+        return 'plant';
+    }
+
+    if (application) {
+        return 'raisedBed';
+    }
+
+    return undefined;
+}
+
+export function operationDefinitionMatchesTargetScope(
+    operation: OperationLocation,
+    operationDefinition: OperationDefinition,
+) {
+    const targetScope = operationTargetScope(operation);
+    if (!targetScope) {
+        return true;
+    }
+
+    return (
+        operationApplicationScope(
+            operationDefinition.attributes?.application,
+        ) === targetScope
+    );
+}

--- a/apps/app/app/admin/operations/operationScope.unit.ts
+++ b/apps/app/app/admin/operations/operationScope.unit.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    operationApplicationScope,
+    operationDefinitionMatchesTargetScope,
+    operationTargetScope,
+} from './operationScope';
+
+test('operationTargetScope infers target from the stored operation location', () => {
+    assert.strictEqual(operationTargetScope({ farmId: 1 }), 'farm');
+    assert.strictEqual(
+        operationTargetScope({ farmId: 1, gardenId: 2 }),
+        'garden',
+    );
+    assert.strictEqual(
+        operationTargetScope({ gardenId: 2, raisedBedId: 3 }),
+        'raisedBed',
+    );
+    assert.strictEqual(
+        operationTargetScope({
+            gardenId: 2,
+            raisedBedId: 3,
+            raisedBedFieldId: 4,
+        }),
+        'plant',
+    );
+});
+
+test('operationApplicationScope follows create modal target selection modes', () => {
+    assert.strictEqual(operationApplicationScope('farm'), 'farm');
+    assert.strictEqual(operationApplicationScope('garden'), 'garden');
+    assert.strictEqual(operationApplicationScope('plant'), 'plant');
+    assert.strictEqual(operationApplicationScope('raisedBedFull'), 'raisedBed');
+    assert.strictEqual(operationApplicationScope('raisedBed1m'), 'raisedBed');
+    assert.strictEqual(operationApplicationScope(undefined), undefined);
+});
+
+test('operationDefinitionMatchesTargetScope blocks cross-scope switches', () => {
+    const raisedBedOperation = { gardenId: 2, raisedBedId: 3 };
+    assert.equal(
+        operationDefinitionMatchesTargetScope(raisedBedOperation, {
+            attributes: { application: 'raisedBedFull' },
+        }),
+        true,
+    );
+    assert.equal(
+        operationDefinitionMatchesTargetScope(raisedBedOperation, {
+            attributes: { application: 'plant' },
+        }),
+        false,
+    );
+    assert.equal(
+        operationDefinitionMatchesTargetScope(raisedBedOperation, {
+            attributes: { application: 'farm' },
+        }),
+        false,
+    );
+
+    const fieldOperation = {
+        gardenId: 2,
+        raisedBedId: 3,
+        raisedBedFieldId: 4,
+    };
+    assert.equal(
+        operationDefinitionMatchesTargetScope(fieldOperation, {
+            attributes: { application: 'plant' },
+        }),
+        true,
+    );
+    assert.equal(
+        operationDefinitionMatchesTargetScope(fieldOperation, {
+            attributes: { application: 'raisedBed1m' },
+        }),
+        false,
+    );
+});

--- a/apps/app/components/operations/OperationSwitchButton.tsx
+++ b/apps/app/components/operations/OperationSwitchButton.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Replace } from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { Row } from '@gredice/ui/Row';
+import { SelectItems } from '@gredice/ui/SelectItems';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useActionState, useEffect, useMemo, useState } from 'react';
+import {
+    type SwitchOperationEntityActionState,
+    switchOperationEntityAction,
+} from '../../app/(actions)/operationActions';
+
+export type OperationSwitchOption = {
+    id: number;
+    label: string;
+};
+
+interface OperationSwitchButtonProps {
+    operationId: number;
+    currentEntityId: number;
+    operationLabel: string;
+    operationOptions: OperationSwitchOption[];
+}
+
+export function OperationSwitchButton({
+    operationId,
+    currentEntityId,
+    operationLabel,
+    operationOptions,
+}: OperationSwitchButtonProps) {
+    const [open, setOpen] = useState(false);
+    const [selectedEntityId, setSelectedEntityId] = useState(
+        currentEntityId.toString(),
+    );
+    const [state, formAction, isPending] = useActionState<
+        SwitchOperationEntityActionState | null,
+        FormData
+    >(switchOperationEntityAction, null);
+
+    const currentEntityValue = currentEntityId.toString();
+    const hasReplacementOptions = operationOptions.some(
+        (operationOption) => operationOption.id !== currentEntityId,
+    );
+    const items = useMemo(
+        () =>
+            operationOptions.map((operationOption) => {
+                const isCurrent = operationOption.id === currentEntityId;
+
+                return {
+                    value: operationOption.id.toString(),
+                    label: isCurrent
+                        ? `${operationOption.label} (trenutno)`
+                        : operationOption.label,
+                    disabled: isCurrent,
+                };
+            }),
+        [currentEntityId, operationOptions],
+    );
+
+    useEffect(() => {
+        if (state?.success) {
+            setOpen(false);
+        }
+    }, [state?.success]);
+
+    function handleOpenChange(nextOpen: boolean) {
+        setOpen(nextOpen);
+        if (nextOpen) {
+            setSelectedEntityId(currentEntityValue);
+        }
+    }
+
+    if (!hasReplacementOptions) {
+        return null;
+    }
+
+    return (
+        <Modal
+            title="Promijeni radnju"
+            open={open}
+            onOpenChange={handleOpenChange}
+            trigger={
+                <IconButton
+                    variant="plain"
+                    title="Promijeni radnju"
+                    loading={isPending}
+                >
+                    <Replace className="size-4 shrink-0" />
+                </IconButton>
+            }
+        >
+            <form action={formAction}>
+                <Stack spacing={4}>
+                    <Typography level="h5">Promijeni radnju</Typography>
+                    <Typography>
+                        <strong>{operationLabel}</strong>
+                    </Typography>
+                    <input
+                        type="hidden"
+                        name="operationId"
+                        value={operationId}
+                    />
+                    <input
+                        type="hidden"
+                        name="entityId"
+                        value={selectedEntityId}
+                    />
+                    <SelectItems
+                        items={items}
+                        value={selectedEntityId}
+                        onValueChange={setSelectedEntityId}
+                        label="Nova radnja"
+                        searchable
+                        searchPlaceholder="Pretraži radnje..."
+                    />
+                    {state?.message && !state.success ? (
+                        <Typography level="body2" className="text-red-600">
+                            {state.message}
+                        </Typography>
+                    ) : null}
+                    <Row spacing={2} justifyContent="end">
+                        <Button
+                            type="button"
+                            variant="outlined"
+                            onClick={() => setOpen(false)}
+                            disabled={isPending}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            type="submit"
+                            loading={isPending}
+                            disabled={
+                                isPending ||
+                                selectedEntityId === currentEntityValue
+                            }
+                        >
+                            Promijeni
+                        </Button>
+                    </Row>
+                </Stack>
+            </form>
+        </Modal>
+    );
+}

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -12,7 +12,7 @@
         "start": "node ../../scripts/run-app-command.mjs start",
         "test": "pnpm run test:run",
         "test:prepare": "turbo build --filter=app",
-        "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test src/ai/aiAnalyticsCost.unit.ts src/social/providers/reddit/redditAdapter.unit.ts src/social/providers/directAdapters.unit.ts lib/auth/cookieSecurity.unit.ts app/admin/schedule/scheduleDayFilters.unit.ts app/admin/greenhouse/operationMatching.unit.ts 'app/admin/inventory/[inventoryId]/inventoryStatus.unit.ts' app/admin/inventory/inventoryPrintoutPdf.unit.ts app/admin/farmers/documentation/farmerDocumentationData.unit.ts 'app/(actions)/socialPublishActions.unit.ts' 'app/(actions)/socialAccountActions.unit.ts'",
+        "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test src/ai/aiAnalyticsCost.unit.ts src/social/providers/reddit/redditAdapter.unit.ts src/social/providers/directAdapters.unit.ts lib/auth/cookieSecurity.unit.ts app/admin/schedule/scheduleDayFilters.unit.ts app/admin/greenhouse/operationMatching.unit.ts app/admin/operations/operationScope.unit.ts 'app/admin/inventory/[inventoryId]/inventoryStatus.unit.ts' app/admin/inventory/inventoryPrintoutPdf.unit.ts app/admin/farmers/documentation/farmerDocumentationData.unit.ts 'app/(actions)/socialPublishActions.unit.ts' 'app/(actions)/socialAccountActions.unit.ts'",
         "test:run": "pnpm run test:unit && playwright test",
         "test-ui": "pnpm run test:prepare && playwright test --ui",
         "test:local": "pnpm run test:prepare && pnpm run test:run"

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -992,6 +992,26 @@ export async function createOperation({
     return result.id;
 }
 
+export async function switchOperationEntity(
+    id: number,
+    entity: Pick<InsertOperation, 'entityId' | 'entityTypeName'>,
+) {
+    const [result] = await storage()
+        .update(operations)
+        .set({
+            entityId: entity.entityId,
+            entityTypeName: entity.entityTypeName,
+        })
+        .where(and(eq(operations.id, id), eq(operations.isDeleted, false)))
+        .returning({ id: operations.id });
+
+    if (!result) {
+        throw new Error(`Operation with id ${id} not found`);
+    }
+
+    await bustScheduleCache();
+}
+
 export async function acceptOperation(id: number) {
     await storage()
         .update(operations)

--- a/packages/storage/tests/operationsRepo.node.spec.ts
+++ b/packages/storage/tests/operationsRepo.node.spec.ts
@@ -20,6 +20,7 @@ import {
     knownEventTypes,
     operations,
     storage,
+    switchOperationEntity,
     users,
 } from '@gredice/storage';
 import { and, eq } from 'drizzle-orm';
@@ -243,6 +244,54 @@ test('completed operations expose completion notes and image URLs', async () => 
         'https://cdn.gredice.com/operation-complete.jpg',
     ]);
     assert.strictEqual(operation.completionNotes, 'Zaliveno nakon berbe.');
+});
+
+test('switchOperationEntity changes only the selected operation entity', async () => {
+    createTestDb();
+
+    const accountId = randomUUID();
+    const assignedUserId = randomUUID();
+    const scheduledDate = '2030-01-05T08:00:00.000Z';
+    const operationId = await createOperation({
+        entityId: 1,
+        entityTypeName: 'operation',
+        accountId,
+        timestamp: new Date('2030-01-02T08:00:00.000Z'),
+    });
+    await acceptOperation(operationId);
+    await createEvent(
+        knownEvents.operations.scheduledV1(operationId.toString(), {
+            scheduledDate,
+        }),
+    );
+    await createEvent(
+        knownEvents.operations.assignedV1(operationId.toString(), {
+            assignedUserId,
+            assignedBy: randomUUID(),
+        }),
+    );
+
+    const originalOperation = await getOperationById(operationId);
+    await switchOperationEntity(operationId, {
+        entityId: 2,
+        entityTypeName: 'operation',
+    });
+
+    const switchedOperation = await getOperationById(operationId);
+    assert.strictEqual(switchedOperation.entityId, 2);
+    assert.strictEqual(switchedOperation.entityTypeName, 'operation');
+    assert.strictEqual(switchedOperation.accountId, accountId);
+    assert.strictEqual(
+        switchedOperation.timestamp.getTime(),
+        originalOperation.timestamp.getTime(),
+    );
+    assert.strictEqual(switchedOperation.isAccepted, true);
+    assert.strictEqual(switchedOperation.status, 'planned');
+    assert.strictEqual(
+        switchedOperation.scheduledDate?.toISOString(),
+        scheduledDate,
+    );
+    assert.strictEqual(switchedOperation.assignedUserId, assignedUserId);
 });
 
 test('all operations can be filtered by event-derived status', async () => {


### PR DESCRIPTION
## Summary
- add an admin operation detail action to switch an operation row to another published operation definition
- update only the operation entity reference while keeping schedule, assignment, status, location, and history intact
- add storage coverage for preserving operation data during the switch

## Validation
- corepack pnpm --filter app lint
- corepack pnpm --filter @gredice/storage lint
- corepack pnpm --filter @gredice/storage exec bash ./tests/runNodeTests.sh operationsRepo.node.spec.ts
- corepack pnpm --filter app build
- git diff --check
- local dev smoke check: http://localhost:3123/admin/operations/2663 returned 401 at the admin auth boundary

## Notes
- app and storage full tsc checks still fail on pre-existing unrelated errors; no compiler errors matched the files changed in this PR during filtered output checks.