### PR TITLE
[codex] Add biweekly farm weeding automation

### DIFF
--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -17,9 +17,14 @@ export const seedlingTransplantWateringAutomationKey =
     'default.seedling-transplant-watering';
 export const plantRemovalOperationStatusAutomationKey =
     'default.plant-removal-operation-status';
+export const farmRaisedBedWeedingAutomationKey =
+    'default.farm-raised-bed-weeding';
 
 const seedlingTransplantingOperationId = 593;
 const plantRemovalOperationId = 346;
+export const FARM_RAISED_BED_WEEDING_OPERATION_ID = 654;
+export const farmRaisedBedWeedingOperationKey = 'cleanWeedsAroundRaisedBeds';
+export const farmRaisedBedWeedingBiweeklyAnchorDate = '2026-01-05';
 
 export function seasonalSowedWateringAutomationGraph(): AutomationGraph {
     return {
@@ -258,6 +263,48 @@ export function plantRemovalOperationStatusAutomationGraph(): AutomationGraph {
     };
 }
 
+export function farmRaisedBedWeedingAutomationGraph(): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerSchedule,
+                position: { x: 0, y: 160 },
+                config: {
+                    frequency: 'biweekly',
+                    dayOfWeek: 'monday',
+                    anchorDate: farmRaisedBedWeedingBiweeklyAnchorDate,
+                    timeZone: 'Europe/Zagreb',
+                },
+            },
+            {
+                id: 'create-farm-weeding-operations',
+                kind: 'action',
+                moduleKey:
+                    automationModuleKeys.actionCreateFarmInventoryOperations,
+                position: { x: 360, y: 160 },
+                config: {
+                    operations: [
+                        {
+                            entityId: FARM_RAISED_BED_WEEDING_OPERATION_ID,
+                            entityTypeName: 'operation',
+                            scheduledInDays: 0,
+                        },
+                    ],
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-create-farm-weeding-operations',
+                source: 'trigger',
+                target: 'create-farm-weeding-operations',
+            },
+        ],
+    };
+}
+
 export async function ensureDefaultAutomationDefinitions() {
     await initializeAutomationEventCursorToLatest();
 
@@ -333,11 +380,30 @@ export async function ensureDefaultAutomationDefinitions() {
         },
     });
 
+    const farmRaisedBedWeeding = await upsertAutomationDefinitionByKey({
+        key: farmRaisedBedWeedingAutomationKey,
+        name: 'Dodaj čišćenje korova oko gredica za svaku farmu',
+        description:
+            'Svaki drugi ponedjeljak dodaj prihvaćenu radnju na razini farme Čišćenje korova oko gredica za svaku aktivnu farmu. Definicija je pripremljena za uključivanje nakon operativnog pregleda draft radnje.',
+        status: 'draft',
+        graph: farmRaisedBedWeedingAutomationGraph(),
+        preserveExistingStatus: true,
+        metadata: {
+            managedBy: 'gredice',
+            defaultAutomation: true,
+            operationEntityId: FARM_RAISED_BED_WEEDING_OPERATION_ID,
+            operationEntityKey: farmRaisedBedWeedingOperationKey,
+            biweeklyAnchorDate: farmRaisedBedWeedingBiweeklyAnchorDate,
+            resolvedFromIssue: 3700,
+        },
+    });
+
     return {
         seasonalSowedWatering,
         operationImagePlantStatusReview,
         seedlingTransplantDirectSowingLocation,
         seedlingTransplantWatering,
         plantRemovalOperationStatus,
+        farmRaisedBedWeeding,
     };
 }

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -1640,13 +1640,16 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
         }
 
         if (context.dryRun) {
+            const projectedCreateCount =
+                activeFarms.length * operationConfigs.length -
+                skippedExistingCount;
             return success({
                 dryRun: true,
                 farmCount: activeFarms.length,
                 operationCount: operationConfigs.length,
-                projectedCreateCount:
-                    activeFarms.length * operationConfigs.length -
-                    skippedExistingCount,
+                createdCount: projectedCreateCount,
+                projectedCreateCount,
+                skippedCount: skippedExistingCount,
                 skippedExistingCount,
             });
         }
@@ -1660,6 +1663,7 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
                 {
                     farmCount: activeFarms.length,
                     operationCount: operationConfigs.length,
+                    skippedCount: skippedExistingCount,
                     skippedExistingCount,
                 },
             );
@@ -1670,6 +1674,7 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
             createdCount: createdOperationIds.length,
             repairedScheduledOperationIds,
             repairedScheduledCount: repairedScheduledOperationIds.length,
+            skippedCount: skippedExistingCount,
             skippedExistingCount,
             farmCount: activeFarms.length,
             operationCount: operationConfigs.length,

--- a/packages/storage/src/repositories/automationsRepo.ts
+++ b/packages/storage/src/repositories/automationsRepo.ts
@@ -44,10 +44,14 @@ export type AutomationDefinitionInput = {
     metadata?: AutomationJsonObject;
     createdByUserId?: string | null;
     updatedByUserId?: string | null;
+    preserveExistingStatus?: boolean;
 };
 
 export type AutomationDefinitionUpdate = Partial<
-    Omit<AutomationDefinitionInput, 'key' | 'createdByUserId'>
+    Omit<
+        AutomationDefinitionInput,
+        'key' | 'createdByUserId' | 'preserveExistingStatus'
+    >
 > & {
     key?: string;
 };
@@ -208,7 +212,9 @@ export async function upsertAutomationDefinitionByKey(
             set: {
                 name: values.name,
                 description: values.description,
-                status: values.status,
+                ...(input.preserveExistingStatus
+                    ? {}
+                    : { status: values.status }),
                 ...(input.maxConcurrentRuns !== undefined
                     ? { maxConcurrentRuns: values.maxConcurrentRuns }
                     : {}),

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -21,7 +21,11 @@ import {
     enqueueAutomationRunsFromSchedules,
     ensureDefaultAutomationDefinitions,
     executeAutomationRun,
+    FARM_RAISED_BED_WEEDING_OPERATION_ID,
     FREE_WATERING_OPERATION_ID,
+    farmRaisedBedWeedingAutomationKey,
+    farmRaisedBedWeedingBiweeklyAnchorDate,
+    farms,
     getAutomationDefinitionByKey,
     getAutomationEventCursor,
     getAutomationRunWithSteps,
@@ -53,6 +57,7 @@ import {
     upsertRaisedBedField,
     validateAutomationGraph,
 } from '@gredice/storage';
+import { eq } from 'drizzle-orm';
 import {
     createTestBlock,
     createTestGarden,
@@ -251,6 +256,31 @@ function monthlyScheduleRunInput(index: number) {
         occurrenceKey: `test.monthly-log:${index}`,
         period: '2026-06',
         occurrenceDate: '2026-06-01T08:00:00.000Z',
+    };
+}
+
+function biweeklyScheduleRunInput({
+    occurrenceDate,
+    occurrenceKey = `test.biweekly:${occurrenceDate}`,
+    weekOffset = 0,
+}: {
+    occurrenceDate: string;
+    occurrenceKey?: string;
+    weekOffset?: number;
+}) {
+    return {
+        scheduleType: 'biweekly',
+        frequency: 'biweekly',
+        triggerModuleKey: automationModuleKeys.triggerSchedule,
+        occurrenceKey,
+        occurrenceDate: occurrenceDate.slice(0, 10),
+        enqueuedAt: occurrenceDate,
+        timeZone: 'Europe/Zagreb',
+        intervalWeeks: 2,
+        anchorDate: farmRaisedBedWeedingBiweeklyAnchorDate,
+        weekOffset,
+        dayOfWeek: 'monday',
+        daysOfWeek: ['monday'],
     };
 }
 
@@ -1231,6 +1261,181 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
             ),
         );
         assert.strictEqual(inventoryOperations.length, operationConfigs.length);
+    }
+});
+
+test('default farm raised-bed weeding automation stays draft until enabled', async () => {
+    createTestDb();
+
+    await ensureDefaultAutomationDefinitions();
+    const draftDefinition = await getAutomationDefinitionByKey(
+        farmRaisedBedWeedingAutomationKey,
+    );
+    assert.ok(draftDefinition);
+    assert.strictEqual(draftDefinition.status, 'draft');
+    assert.strictEqual(
+        draftDefinition.triggerModuleKey,
+        automationModuleKeys.triggerSchedule,
+    );
+    assert.deepStrictEqual(
+        draftDefinition.metadata.operationEntityId,
+        FARM_RAISED_BED_WEEDING_OPERATION_ID,
+    );
+
+    const enabledDefinition = await updateAutomationDefinition(
+        draftDefinition.id,
+        { status: 'enabled' },
+    );
+    assert.ok(enabledDefinition);
+
+    await ensureDefaultAutomationDefinitions();
+    const preservedDefinition = await getAutomationDefinitionByKey(
+        farmRaisedBedWeedingAutomationKey,
+    );
+    assert.ok(preservedDefinition);
+    assert.strictEqual(preservedDefinition.status, 'enabled');
+});
+
+test('default farm raised-bed weeding automation filters farms and prevents duplicate occurrence operations', async () => {
+    createTestDb();
+    await createFarm({
+        name: 'Automation Weeding Farm A',
+        latitude: 45.7,
+        longitude: 16.1,
+    });
+    const deletedFarmId = await createFarm({
+        name: 'Automation Weeding Deleted Farm',
+        latitude: 45.6,
+        longitude: 16.0,
+    });
+    await storage()
+        .update(farms)
+        .set({ isDeleted: true })
+        .where(eq(farms.id, deletedFarmId));
+
+    const activeFarms = (await getFarms()).filter((farm) => !farm.isDeleted);
+    assert.ok(activeFarms.length > 0);
+
+    const { farmRaisedBedWeeding } = await ensureDefaultAutomationDefinitions();
+    const enabledDefinition = await updateAutomationDefinition(
+        farmRaisedBedWeeding.id,
+        { status: 'enabled' },
+    );
+    assert.ok(enabledDefinition);
+
+    const dryRun = await createAutomationRun({
+        automationDefinition: enabledDefinition,
+        source: 'test',
+        input: biweeklyScheduleRunInput({
+            occurrenceDate: '2026-01-05T08:00:00.000Z',
+        }),
+    });
+    assert.ok(dryRun);
+    const startedDryRun = await startAutomationRun(dryRun.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedDryRun);
+    const dryRunResult = await executeAutomationRun(startedDryRun);
+    assert.strictEqual(dryRunResult.status, 'succeeded');
+    const dryRunWithSteps = await getAutomationRunWithSteps(dryRun.id);
+    const dryRunActionStep = dryRunWithSteps?.steps.find(
+        (step) => step.nodeId === 'create-farm-weeding-operations',
+    );
+    assert.ok(dryRunActionStep);
+    assert.strictEqual(
+        dryRunActionStep.output.createdCount,
+        activeFarms.length,
+    );
+    assert.strictEqual(dryRunActionStep.output.skippedCount, 0);
+
+    const firstResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-01-05T08:00:00.000Z'),
+    });
+    const duplicateResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-01-05T09:00:00.000Z'),
+    });
+    const offWeekResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-01-12T08:00:00.000Z'),
+    });
+
+    assert.strictEqual(firstResult.enqueuedRuns, 1);
+    assert.strictEqual(duplicateResult.enqueuedRuns, 0);
+    assert.strictEqual(offWeekResult.enqueuedRuns, 0);
+
+    const processResult = await processDueAutomationRuns({
+        limit: 10,
+        lockedBy: 'automations-test',
+    });
+    assert.strictEqual(processResult.succeeded, 1);
+
+    const occurrenceStart = new Date('2026-01-05T08:00:00.000Z');
+    const occurrenceEnd = addUtcDays(occurrenceStart, 1);
+    for (const farm of activeFarms) {
+        const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
+            farmId: farm.id,
+            from: occurrenceStart,
+            to: occurrenceEnd,
+        });
+        const weedingOperations = farmOperations.filter(
+            (operation) =>
+                operation.entityId === FARM_RAISED_BED_WEEDING_OPERATION_ID,
+        );
+
+        assert.strictEqual(weedingOperations.length, 1);
+        assert.strictEqual(weedingOperations[0]?.farmId, farm.id);
+        assert.strictEqual(weedingOperations[0]?.gardenId, null);
+        assert.strictEqual(weedingOperations[0]?.raisedBedId, null);
+        assert.strictEqual(weedingOperations[0]?.raisedBedFieldId, null);
+    }
+
+    const deletedFarmOperations =
+        await getFarmAcceptedOperationsByScheduleRange({
+            farmId: deletedFarmId,
+            from: occurrenceStart,
+            to: occurrenceEnd,
+        });
+    assert.strictEqual(
+        deletedFarmOperations.filter(
+            (operation) =>
+                operation.entityId === FARM_RAISED_BED_WEEDING_OPERATION_ID,
+        ).length,
+        0,
+    );
+
+    const firstRun = (
+        await listAutomationRuns({
+            automationDefinitionId: enabledDefinition.id,
+        })
+    ).find((run) => run.source === 'schedule');
+    assert.ok(firstRun);
+    assert.strictEqual(firstRun.input.weekOffset, 0);
+
+    const replayRun = await createAutomationRun({
+        automationDefinition: enabledDefinition,
+        source: 'replay',
+        input: firstRun.input,
+    });
+    assert.ok(replayRun);
+    const startedReplay = await startAutomationRun(replayRun.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedReplay);
+    const replayResult = await executeAutomationRun(startedReplay);
+
+    assert.strictEqual(replayResult.status, 'skipped');
+    for (const farm of activeFarms) {
+        const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
+            farmId: farm.id,
+            from: occurrenceStart,
+            to: occurrenceEnd,
+        });
+        assert.strictEqual(
+            farmOperations.filter(
+                (operation) =>
+                    operation.entityId === FARM_RAISED_BED_WEEDING_OPERATION_ID,
+            ).length,
+            1,
+        );
     }
 });
 


### PR DESCRIPTION
## Summary

- Adds the default `default.farm-raised-bed-weeding` automation using `trigger.schedule` with a biweekly Monday cadence anchored at `2026-01-05`.
- Configures the automation to create farm-scoped `Čišćenje korova oko gredica` operations for active farms only via `action.createFarmInventoryOperations`.
- Keeps the new default automation in `draft` on first install, while preserving later admin status changes so it can be enabled from `/admin/automations` after review.
- Exposes explicit `createdCount` / `skippedCount` output for farm inventory dry-runs and scheduled runs.

## Operation definition

Resolved from #3700 live data/comments:

- entity id: `654`
- key: `cleanWeedsAroundRaisedBeds`
- label: `Čišćenje korova oko gredica`

The automation definition remains `draft` by default because the operation definition itself was created as a draft for review.

## Validation

- `pnpm lint --filter @gredice/storage`
- `pnpm --filter @gredice/storage test -- automationsRepo.node.spec.ts`
- `git diff --check`
- `pnpm typecheck --filter @gredice/storage` reported no configured tasks for `@gredice/storage`.

Closes #3703
