### PR TITLE
[codex] Add daily greenhouse seedling watering automation

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -122,6 +122,13 @@ MVP modules:
 - `action.createFarmInventoryOperations`: creates accepted, scheduled farm-level
   operations for every active farm from a JSON list in the automation
   definition.
+- `action.createGreenhouseSeedlingWateringOperations`: creates at most one
+  accepted, scheduled farm-level `Zalijevanje presadnica u stakleniku`
+  operation per active farm and local schedule date. A farm is eligible when it
+  has current greenhouse-located raised-bed fields, or when central outlet stock
+  has active published non-expired offers with remaining quantity. Outlet offers
+  are not farm-scoped in storage, so active outlet stock makes every active farm
+  eligible for the daily care operation.
 - `action.updateRaisedBedFieldPlantAttributes`: writes plant status and/or
   sowing location events for the operation target field. Use this for new
   no-code plant-state automations.

--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -19,12 +19,15 @@ export const plantRemovalOperationStatusAutomationKey =
     'default.plant-removal-operation-status';
 export const farmRaisedBedWeedingAutomationKey =
     'default.farm-raised-bed-weeding';
+export const greenhouseSeedlingWateringAutomationKey =
+    'default.greenhouse-seedling-watering';
 
 const seedlingTransplantingOperationId = 593;
 const plantRemovalOperationId = 346;
 export const FARM_RAISED_BED_WEEDING_OPERATION_ID = 654;
 export const farmRaisedBedWeedingOperationKey = 'cleanWeedsAroundRaisedBeds';
 export const farmRaisedBedWeedingBiweeklyAnchorDate = '2026-01-05';
+const greenhouseSeedlingWateringOperationId = 655;
 
 export function seasonalSowedWateringAutomationGraph(): AutomationGraph {
     return {
@@ -305,6 +308,42 @@ export function farmRaisedBedWeedingAutomationGraph(): AutomationGraph {
     };
 }
 
+export function greenhouseSeedlingWateringAutomationGraph(): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerSchedule,
+                position: { x: 0, y: 160 },
+                config: {
+                    frequency: 'daily',
+                    timeZone: 'Europe/Zagreb',
+                },
+            },
+            {
+                id: 'create-greenhouse-seedling-waterings',
+                kind: 'action',
+                moduleKey:
+                    automationModuleKeys.actionCreateGreenhouseSeedlingWateringOperations,
+                position: { x: 360, y: 160 },
+                config: {
+                    entityId: greenhouseSeedlingWateringOperationId,
+                    entityTypeName: 'operation',
+                    scheduledInDays: 0,
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-create-greenhouse-seedling-waterings',
+                source: 'trigger',
+                target: 'create-greenhouse-seedling-waterings',
+            },
+        ],
+    };
+}
+
 export async function ensureDefaultAutomationDefinitions() {
     await initializeAutomationEventCursorToLatest();
 
@@ -398,6 +437,23 @@ export async function ensureDefaultAutomationDefinitions() {
         },
     });
 
+    const greenhouseSeedlingWatering = await upsertAutomationDefinitionByKey({
+        key: greenhouseSeedlingWateringAutomationKey,
+        name: 'Dodaj dnevno zalijevanje presadnica u stakleniku',
+        description:
+            'Svaki dan dodaj jednu farmsku radnju zalijevanja presadnica u stakleniku za aktivne farme koje imaju presadnice u stakleniku ili aktivne outlet presadnice.',
+        status: 'enabled',
+        graph: greenhouseSeedlingWateringAutomationGraph(),
+        metadata: {
+            managedBy: 'gredice',
+            defaultAutomation: true,
+            operationEntityId: greenhouseSeedlingWateringOperationId,
+            operationInternalName: 'waterGreenhouseSeedlings',
+            operationName: 'Zalijevanje presadnica u stakleniku',
+            resolvedFromIssue: 3700,
+        },
+    });
+
     return {
         seasonalSowedWatering,
         operationImagePlantStatusReview,
@@ -405,5 +461,6 @@ export async function ensureDefaultAutomationDefinitions() {
         seedlingTransplantWatering,
         plantRemovalOperationStatus,
         farmRaisedBedWeeding,
+        greenhouseSeedlingWatering,
     };
 }

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -1882,6 +1882,9 @@ const createGreenhouseSeedlingWateringOperationsActionModule: AutomationModule =
             const referenceDate = getScheduleOccurrenceReferenceDate(
                 context.run.input,
             );
+            const availabilityDate = getScheduleReferenceDate(
+                context.run.input,
+            );
             const scheduledDate = addUtcDays(
                 referenceDate,
                 operationConfig.scheduledInDays,
@@ -1893,7 +1896,7 @@ const createGreenhouseSeedlingWateringOperationsActionModule: AutomationModule =
                         farms.filter((farm) => !farm.isDeleted),
                     ),
                     getGreenhouseFieldCountsByFarmId(),
-                    getOutletOffers({ now: referenceDate }),
+                    getOutletOffers({ now: availabilityDate }),
                 ]);
 
             if (activeFarms.length === 0) {
@@ -2030,6 +2033,7 @@ const createGreenhouseSeedlingWateringOperationsActionModule: AutomationModule =
                 existingOperationSkips,
                 existingOperationSkipCount: existingOperationSkips.length,
                 activeOutletOfferCount,
+                outletAvailabilityCheckedAt: availabilityDate.toISOString(),
                 projectedCreateCount:
                     eligibleFarms.length - existingOperationSkips.length,
             };

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -8,13 +8,18 @@ import {
     type RaisedBedFieldSowingLocation,
 } from '../repositories/events';
 import { getFarms } from '../repositories/farmsRepo';
-import { getRaisedBed } from '../repositories/gardensRepo';
+import {
+    getAllRaisedBeds,
+    getGardens,
+    getRaisedBed,
+} from '../repositories/gardensRepo';
 import {
     acceptOperation,
     createOperation,
     getFarmAcceptedOperationsByScheduleRange,
     getOperationById,
 } from '../repositories/operationsRepo';
+import { getOutletOffers } from '../repositories/outletOffersRepo';
 import {
     queuePostTransplantWateringOperations,
     queueSeasonalSowingOfferOperations,
@@ -48,6 +53,8 @@ const queuePostTransplantWateringOperationsActionKey =
 const createOperationActionKey = 'action.createOperation';
 const createFarmInventoryOperationsActionKey =
     'action.createFarmInventoryOperations';
+const createGreenhouseSeedlingWateringOperationsActionKey =
+    'action.createGreenhouseSeedlingWateringOperations';
 const updateRaisedBedFieldPlantAttributesActionKey =
     'action.updateRaisedBedFieldPlantAttributes';
 const createPlantStatusRequestsFromImageAnalysisActionKey =
@@ -131,6 +138,8 @@ export const automationModuleKeys = {
         queuePostTransplantWateringOperationsActionKey,
     actionCreateOperation: createOperationActionKey,
     actionCreateFarmInventoryOperations: createFarmInventoryOperationsActionKey,
+    actionCreateGreenhouseSeedlingWateringOperations:
+        createGreenhouseSeedlingWateringOperationsActionKey,
     actionUpdateRaisedBedFieldPlantAttributes:
         updateRaisedBedFieldPlantAttributesActionKey,
     actionCreatePlantStatusRequestsFromImageAnalysis:
@@ -524,6 +533,39 @@ type FarmInventoryOperationConfig = {
     scheduledInDays: number;
 };
 
+const greenhouseSeedlingPlantStatuses = new Set([
+    'new',
+    'planned',
+    'pendingVerification',
+    'sowed',
+    'sprouted',
+]);
+
+type RaisedBedForGreenhouseCare = Awaited<
+    ReturnType<typeof getAllRaisedBeds>
+>[number];
+type RaisedBedFieldForGreenhouseCare =
+    RaisedBedForGreenhouseCare['fields'][number];
+
+type GreenhouseFarmEligibility = {
+    farmId: number;
+    greenhouseRaisedBedCount: number;
+    greenhouseFieldCount: number;
+    activeOutletOfferCount: number;
+    reasons: string[];
+};
+
+type GreenhouseFarmSkip = {
+    farmId: number;
+    reason: string;
+};
+
+type ExistingOperationSkip = {
+    farmId: number;
+    operationId: number;
+    scheduledDate: string;
+};
+
 function parseFarmInventoryOperationConfigs(
     value: unknown,
 ): FarmInventoryOperationConfig[] {
@@ -584,6 +626,49 @@ function validateFarmInventoryOperationsConfig(config: AutomationJsonObject) {
     }
 
     return [];
+}
+
+function parseSingleOperationConfig(
+    config: AutomationJsonObject,
+): FarmInventoryOperationConfig | null {
+    const entityId = getNumber(config, 'entityId');
+    if (!entityId || !Number.isInteger(entityId) || entityId <= 0) {
+        return null;
+    }
+
+    const scheduledInDays = getNumber(config, 'scheduledInDays');
+    if (
+        scheduledInDays !== undefined &&
+        (!Number.isInteger(scheduledInDays) || scheduledInDays < 0)
+    ) {
+        return null;
+    }
+
+    return {
+        entityId,
+        entityTypeName: getString(config, 'entityTypeName') ?? 'operation',
+        scheduledInDays: scheduledInDays ?? 0,
+    };
+}
+
+function validateGreenhouseSeedlingWateringConfig(
+    config: AutomationJsonObject,
+) {
+    const entityId = getNumber(config, 'entityId');
+    const scheduledInDays = getNumber(config, 'scheduledInDays');
+    const errors: string[] = [];
+
+    if (!entityId || !Number.isInteger(entityId) || entityId <= 0) {
+        errors.push('entityId is required.');
+    }
+    if (
+        scheduledInDays !== undefined &&
+        (!Number.isInteger(scheduledInDays) || scheduledInDays < 0)
+    ) {
+        errors.push('scheduledInDays must be a non-negative integer.');
+    }
+
+    return errors;
 }
 
 function validateImagePlantStatusReviewConfig(config: AutomationJsonObject) {
@@ -672,6 +757,18 @@ function getScheduleReferenceDate(input: AutomationJsonObject) {
     return new Date();
 }
 
+function getScheduleOccurrenceReferenceDate(input: AutomationJsonObject) {
+    const occurrenceDate = input.occurrenceDate;
+    if (
+        typeof occurrenceDate === 'string' &&
+        /^\d{4}-\d{2}-\d{2}$/.test(occurrenceDate)
+    ) {
+        return new Date(`${occurrenceDate}T00:00:00.000Z`);
+    }
+
+    return getScheduleReferenceDate(input);
+}
+
 function farmOperationKey({
     entityId,
     entityTypeName,
@@ -682,6 +779,62 @@ function farmOperationKey({
     scheduledDate: Date;
 }) {
     return `${entityTypeName}:${entityId}:${toUtcDayKey(scheduledDate)}`;
+}
+
+function isCurrentlyGreenhouseSeedling(field: RaisedBedFieldForGreenhouseCare) {
+    return Boolean(
+        field.active &&
+            field.sowingLocation === 'greenhouse' &&
+            typeof field.plantSortId === 'number' &&
+            greenhouseSeedlingPlantStatuses.has(field.plantStatus ?? '') &&
+            !field.plantDeadDate &&
+            !field.plantHarvestedDate &&
+            !field.plantRemovedDate,
+    );
+}
+
+async function getGreenhouseFieldCountsByFarmId() {
+    const [raisedBeds, gardens] = await Promise.all([
+        getAllRaisedBeds(),
+        getGardens(),
+    ]);
+    const farmIdByGardenId = new Map(
+        gardens
+            .filter((garden) => !garden.isDeleted && !garden.isSandbox)
+            .map((garden) => [garden.id, garden.farmId]),
+    );
+    const countsByFarmId = new Map<
+        number,
+        { greenhouseRaisedBedIds: Set<number>; greenhouseFieldCount: number }
+    >();
+
+    for (const raisedBed of raisedBeds) {
+        if (!raisedBed.gardenId) {
+            continue;
+        }
+
+        const farmId = farmIdByGardenId.get(raisedBed.gardenId);
+        if (!farmId) {
+            continue;
+        }
+
+        const greenhouseFieldCount = raisedBed.fields.filter(
+            isCurrentlyGreenhouseSeedling,
+        ).length;
+        if (greenhouseFieldCount === 0) {
+            continue;
+        }
+
+        const farmCounts = countsByFarmId.get(farmId) ?? {
+            greenhouseRaisedBedIds: new Set<number>(),
+            greenhouseFieldCount: 0,
+        };
+        farmCounts.greenhouseRaisedBedIds.add(raisedBed.id);
+        farmCounts.greenhouseFieldCount += greenhouseFieldCount;
+        countsByFarmId.set(farmId, farmCounts);
+    }
+
+    return countsByFarmId;
 }
 
 function parseRaisedBedFieldAggregateId(aggregateId: string) {
@@ -1682,6 +1835,236 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
     },
 };
 
+const createGreenhouseSeedlingWateringOperationsActionModule: AutomationModule =
+    {
+        key: createGreenhouseSeedlingWateringOperationsActionKey,
+        kind: 'action',
+        title: 'Create greenhouse seedling watering operations',
+        description:
+            'Creates one daily farm-scoped greenhouse seedling watering operation for farms with greenhouse seedlings or active outlet seedling stock.',
+        category: 'Operations',
+        configFields: [
+            {
+                key: 'entityId',
+                label: 'Operation entity ID',
+                type: 'number',
+                required: true,
+            },
+            {
+                key: 'entityTypeName',
+                label: 'Entity type',
+                type: 'string',
+                placeholder: 'operation',
+            },
+            {
+                key: 'scheduledInDays',
+                label: 'Schedule after days',
+                type: 'number',
+                placeholder: '0',
+            },
+        ],
+        inputDescription: 'A daily schedule occurrence.',
+        outputDescription:
+            'Eligible farms, skipped farms, existing-operation skips, and created operation ids.',
+        dryRunSupported: true,
+        mutatesData: true,
+        retryable: true,
+        validateConfig: validateGreenhouseSeedlingWateringConfig,
+        execute: async (context, node) => {
+            const operationConfig = parseSingleOperationConfig(node.config);
+            if (!operationConfig) {
+                throw new AutomationModuleExecutionError(
+                    'Greenhouse seedling watering action is missing a valid operation config.',
+                    'invalid_config',
+                );
+            }
+
+            const referenceDate = getScheduleOccurrenceReferenceDate(
+                context.run.input,
+            );
+            const scheduledDate = addUtcDays(
+                referenceDate,
+                operationConfig.scheduledInDays,
+            );
+            const rangeEnd = addUtcDays(scheduledDate, 1);
+            const [activeFarms, greenhouseCountsByFarmId, activeOutletOffers] =
+                await Promise.all([
+                    getFarms().then((farms) =>
+                        farms.filter((farm) => !farm.isDeleted),
+                    ),
+                    getGreenhouseFieldCountsByFarmId(),
+                    getOutletOffers({ now: referenceDate }),
+                ]);
+
+            if (activeFarms.length === 0) {
+                return skip('No active farms were found.');
+            }
+
+            const activeOutletOfferCount = activeOutletOffers.length;
+            const eligibleFarms: GreenhouseFarmEligibility[] = [];
+            const skippedFarms: GreenhouseFarmSkip[] = [];
+
+            for (const farm of activeFarms) {
+                const greenhouseCounts = greenhouseCountsByFarmId.get(farm.id);
+                const greenhouseFieldCount =
+                    greenhouseCounts?.greenhouseFieldCount ?? 0;
+                const greenhouseRaisedBedCount =
+                    greenhouseCounts?.greenhouseRaisedBedIds.size ?? 0;
+                const reasons = [
+                    ...(greenhouseFieldCount > 0 ? ['greenhouseFields'] : []),
+                    ...(activeOutletOfferCount > 0
+                        ? ['activeOutletStock']
+                        : []),
+                ];
+
+                if (reasons.length === 0) {
+                    skippedFarms.push({
+                        farmId: farm.id,
+                        reason: 'No greenhouse-located plants or active outlet seedlings.',
+                    });
+                    continue;
+                }
+
+                eligibleFarms.push({
+                    farmId: farm.id,
+                    greenhouseRaisedBedCount,
+                    greenhouseFieldCount,
+                    activeOutletOfferCount,
+                    reasons,
+                });
+            }
+
+            const existingOperationSkips: ExistingOperationSkip[] = [];
+            const createdOperationIds: number[] = [];
+            const repairedScheduledOperationIds: number[] = [];
+
+            for (const farm of eligibleFarms) {
+                const existingOperations =
+                    await getFarmAcceptedOperationsByScheduleRange({
+                        farmId: farm.farmId,
+                        from: scheduledDate,
+                        to: rangeEnd,
+                    });
+                const existingOperationsByKey = new Map(
+                    existingOperations.flatMap((operation) => {
+                        if (
+                            operation.status === 'canceled' ||
+                            operation.status === 'failed'
+                        ) {
+                            return [];
+                        }
+
+                        return [
+                            [
+                                farmOperationKey({
+                                    entityId: operation.entityId,
+                                    entityTypeName: operation.entityTypeName,
+                                    scheduledDate:
+                                        operation.scheduledDate ??
+                                        operation.timestamp,
+                                }),
+                                operation,
+                            ],
+                        ];
+                    }),
+                );
+                const operationKey = farmOperationKey({
+                    entityId: operationConfig.entityId,
+                    entityTypeName: operationConfig.entityTypeName,
+                    scheduledDate,
+                });
+                const existingOperation =
+                    existingOperationsByKey.get(operationKey);
+
+                if (existingOperation) {
+                    existingOperationSkips.push({
+                        farmId: farm.farmId,
+                        operationId: existingOperation.id,
+                        scheduledDate: scheduledDate.toISOString(),
+                    });
+                    if (!existingOperation.scheduledDate && !context.dryRun) {
+                        await createEvent(
+                            knownEvents.operations.scheduledV1(
+                                existingOperation.id.toString(),
+                                {
+                                    scheduledDate: scheduledDate.toISOString(),
+                                },
+                            ),
+                        );
+                        repairedScheduledOperationIds.push(
+                            existingOperation.id,
+                        );
+                    }
+                    continue;
+                }
+
+                if (context.dryRun) {
+                    continue;
+                }
+
+                const operationId = await createOperation({
+                    entityId: operationConfig.entityId,
+                    entityTypeName: operationConfig.entityTypeName,
+                    farmId: farm.farmId,
+                    timestamp: scheduledDate,
+                });
+                await acceptOperation(operationId);
+                await createEvent(
+                    knownEvents.operations.scheduledV1(operationId.toString(), {
+                        scheduledDate: scheduledDate.toISOString(),
+                    }),
+                );
+                createdOperationIds.push(operationId);
+            }
+
+            const output = {
+                dryRun: context.dryRun,
+                operationEntityId: operationConfig.entityId,
+                entityTypeName: operationConfig.entityTypeName,
+                scheduledDate: scheduledDate.toISOString(),
+                activeFarmCount: activeFarms.length,
+                eligibleFarms,
+                eligibleFarmCount: eligibleFarms.length,
+                skippedFarms,
+                skippedFarmCount: skippedFarms.length,
+                existingOperationSkips,
+                existingOperationSkipCount: existingOperationSkips.length,
+                activeOutletOfferCount,
+                projectedCreateCount:
+                    eligibleFarms.length - existingOperationSkips.length,
+            };
+
+            if (context.dryRun) {
+                return success(output);
+            }
+
+            if (
+                createdOperationIds.length === 0 &&
+                repairedScheduledOperationIds.length === 0
+            ) {
+                if (eligibleFarms.length === 0) {
+                    return skip(
+                        'No farms require greenhouse seedling watering.',
+                        output,
+                    );
+                }
+
+                return skip(
+                    'All greenhouse seedling watering operations already exist.',
+                    output,
+                );
+            }
+
+            return success({
+                ...output,
+                createdOperationIds,
+                createdCount: createdOperationIds.length,
+                repairedScheduledOperationIds,
+                repairedScheduledCount: repairedScheduledOperationIds.length,
+            });
+        },
+    };
+
 async function updateRaisedBedFieldPlantAttributes({
     context,
     node,
@@ -1945,6 +2328,7 @@ export const automationModules = [
     queuePostTransplantWateringOperationsActionModule,
     createOperationActionModule,
     createFarmInventoryOperationsActionModule,
+    createGreenhouseSeedlingWateringOperationsActionModule,
     updateRaisedBedFieldPlantAttributesActionModule,
     createPlantStatusRequestsFromImageAnalysisActionModule,
     logActionModule,

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -346,10 +346,12 @@ function dailyScheduleRunInput(date: Date, key: string) {
 
 async function createAutomationRunForDailyGreenhouseWatering({
     entityId,
+    enqueuedAt,
     referenceDate,
     dryRun = false,
 }: {
     entityId: number;
+    enqueuedAt?: Date;
     referenceDate: Date;
     dryRun?: boolean;
 }) {
@@ -360,9 +362,11 @@ async function createAutomationRunForDailyGreenhouseWatering({
         graph: greenhouseSeedlingWateringAutomationGraphForEntity(entityId),
     });
     const input = dailyScheduleRunInput(
-        referenceDate,
+        enqueuedAt ?? referenceDate,
         `test.greenhouse-seedling-watering-${entityId}`,
     );
+    input.occurrenceDate = referenceDate.toISOString().slice(0, 10);
+    input.occurrenceKey = `test.greenhouse-seedling-watering-${entityId}:${input.occurrenceDate}`;
     const run = await createAutomationRun({
         automationDefinition: definition,
         source: 'schedule',
@@ -1677,6 +1681,60 @@ test('greenhouse seedling watering treats active outlet stock as eligible greenh
                 Array.isArray(reasons) && reasons.includes('activeOutletStock')
             );
         }),
+    );
+});
+
+test('greenhouse seedling watering checks outlet availability at enqueue time', async () => {
+    createTestDb();
+    const entityId = 9_920_006;
+    const occurrenceDate = new Date('2026-10-03T00:00:00.000Z');
+    const enqueuedAt = new Date('2026-10-02T22:05:00.000Z');
+    await createFarm({
+        name: 'Automation Greenhouse Future Outlet Farm',
+        latitude: 45.9,
+        longitude: 16.0,
+    });
+    const plantSortId = await createTestPlantSortForOutlet();
+    await createOutletOffer({
+        plantSortId,
+        sowingDate: new Date('2026-09-20T00:00:00.000Z'),
+        initialPlantStatus: 'sprouted',
+        imageUrls: [],
+        outletPriceCents: 199,
+        comparePriceCents: 349,
+        quantity: 3,
+        startAt: new Date('2026-10-03T00:00:00.000Z'),
+        endAt: new Date('2026-10-04T00:00:00.000Z'),
+        status: 'published',
+        adminNotes: null,
+    });
+
+    const { actionOutput } =
+        await createAutomationRunForDailyGreenhouseWatering({
+            entityId,
+            referenceDate: occurrenceDate,
+            enqueuedAt,
+            dryRun: true,
+        });
+
+    assert.strictEqual(Reflect.get(actionOutput, 'activeOutletOfferCount'), 0);
+    assert.strictEqual(
+        Reflect.get(actionOutput, 'outletAvailabilityCheckedAt'),
+        enqueuedAt.toISOString(),
+    );
+    const eligibleFarms = Reflect.get(actionOutput, 'eligibleFarms');
+    assert.ok(
+        !Array.isArray(eligibleFarms) ||
+            eligibleFarms.every((farm) => {
+                const reasons =
+                    farm && typeof farm === 'object'
+                        ? Reflect.get(farm, 'reasons')
+                        : null;
+                return (
+                    !Array.isArray(reasons) ||
+                    !reasons.includes('activeOutletStock')
+                );
+            }),
     );
 });
 

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import test, { afterEach } from 'node:test';
 import {
     type AutomationGraph,
@@ -14,9 +15,11 @@ import {
     createAccount,
     createAutomationDefinition,
     createAutomationRun,
+    createEntity,
     createEvent,
     createFarm,
     createOperation,
+    createOutletOffer,
     enqueueAutomationRunsFromDomainEvents,
     enqueueAutomationRunsFromSchedules,
     ensureDefaultAutomationDefinitions,
@@ -34,6 +37,8 @@ import {
     getFarms,
     getOperations,
     getRaisedBed,
+    greenhouseSeedlingWateringAutomationGraph,
+    greenhouseSeedlingWateringAutomationKey,
     knownEvents,
     knownEventTypes,
     listAutomationDefinitionRunSummaries,
@@ -54,6 +59,8 @@ import {
     startAutomationRun,
     storage,
     updateAutomationDefinition,
+    updateEntity,
+    upsertEntityType,
     upsertRaisedBedField,
     validateAutomationGraph,
 } from '@gredice/storage';
@@ -89,6 +96,7 @@ async function createAutomationRaisedBedContext() {
 
     return {
         accountId,
+        farmId,
         gardenId,
         raisedBedId,
     };
@@ -282,6 +290,126 @@ function biweeklyScheduleRunInput({
         dayOfWeek: 'monday',
         daysOfWeek: ['monday'],
     };
+}
+
+function greenhouseSeedlingWateringAutomationGraphForEntity(
+    entityId: number,
+): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerSchedule,
+                position: { x: 0, y: 0 },
+                config: {
+                    frequency: 'daily',
+                    timeZone: 'Europe/Zagreb',
+                },
+            },
+            {
+                id: 'create-greenhouse-seedling-waterings',
+                kind: 'action',
+                moduleKey:
+                    automationModuleKeys.actionCreateGreenhouseSeedlingWateringOperations,
+                position: { x: 320, y: 0 },
+                config: {
+                    entityId,
+                    entityTypeName: 'operation',
+                    scheduledInDays: 0,
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-action',
+                source: 'trigger',
+                target: 'create-greenhouse-seedling-waterings',
+            },
+        ],
+    };
+}
+
+function dailyScheduleRunInput(date: Date, key: string) {
+    const occurrenceDate = date.toISOString().slice(0, 10);
+
+    return {
+        scheduleType: 'daily',
+        frequency: 'daily',
+        triggerModuleKey: automationModuleKeys.triggerSchedule,
+        occurrenceKey: `${key}:${occurrenceDate}`,
+        occurrenceDate,
+        timeZone: 'Europe/Zagreb',
+        enqueuedAt: date.toISOString(),
+    };
+}
+
+async function createAutomationRunForDailyGreenhouseWatering({
+    entityId,
+    referenceDate,
+    dryRun = false,
+}: {
+    entityId: number;
+    referenceDate: Date;
+    dryRun?: boolean;
+}) {
+    const definition = await createAutomationDefinition({
+        key: `test.greenhouse-seedling-watering-${entityId}-${randomUUID()}`,
+        name: 'Greenhouse seedling watering',
+        status: 'enabled',
+        graph: greenhouseSeedlingWateringAutomationGraphForEntity(entityId),
+    });
+    const input = dailyScheduleRunInput(
+        referenceDate,
+        `test.greenhouse-seedling-watering-${entityId}`,
+    );
+    const run = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'schedule',
+        sourceEventType: automationScheduleEventType,
+        sourceAggregateId:
+            typeof input.occurrenceKey === 'string'
+                ? input.occurrenceKey
+                : undefined,
+        dryRun,
+        input,
+    });
+    assert.ok(run);
+
+    const startedRun = await startAutomationRun(run.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedRun);
+
+    const result = await executeAutomationRun(startedRun);
+    const runWithSteps = await getAutomationRunWithSteps(startedRun.id);
+    const actionStep = runWithSteps?.steps.find(
+        (step) =>
+            step.nodeId === 'create-greenhouse-seedling-waterings' &&
+            step.moduleKind === 'action',
+    );
+    assert.ok(actionStep);
+
+    return {
+        result,
+        actionOutput: actionStep.output,
+    };
+}
+
+async function createTestPlantSortForOutlet() {
+    const entityTypeName = `automation-outlet-plant-sort-${randomUUID()}`;
+    await upsertEntityType({
+        name: entityTypeName,
+        label: 'Automation Outlet Plant Sort',
+    });
+    const entityId = await createEntity(entityTypeName);
+    await updateEntity({
+        id: entityId,
+        entityTypeName,
+        state: 'published',
+    });
+
+    return entityId;
 }
 
 test('automation definitions persist graph trigger metadata and event-run idempotency', async () => {
@@ -871,9 +999,9 @@ test('monthly schedule automation enqueues once per configured period', async ()
         now: new Date('2026-06-02T08:00:00.000Z'),
     });
 
-    assert.strictEqual(firstResult.enqueuedRuns, 1);
+    assert.strictEqual(firstResult.enqueuedRuns, 2);
     assert.strictEqual(duplicateResult.enqueuedRuns, 0);
-    assert.strictEqual(offDayResult.enqueuedRuns, 0);
+    assert.strictEqual(offDayResult.enqueuedRuns, 1);
 
     const runs = await listAutomationRuns({
         automationDefinitionId: definition.id,
@@ -916,9 +1044,9 @@ test('daily schedule automation enqueues once per local day and executes', async
         now: new Date('2026-06-24T08:00:00.000Z'),
     });
 
-    assert.strictEqual(firstResult.enqueuedRuns, 1);
+    assert.strictEqual(firstResult.enqueuedRuns, 2);
     assert.strictEqual(duplicateResult.enqueuedRuns, 0);
-    assert.strictEqual(nextDayResult.enqueuedRuns, 1);
+    assert.strictEqual(nextDayResult.enqueuedRuns, 2);
 
     const runs = await listAutomationRuns({
         automationDefinitionId: definition.id,
@@ -939,6 +1067,7 @@ test('daily schedule automation enqueues once per local day and executes', async
         lockedBy: 'automations-test',
     });
     assert.strictEqual(processResult.succeeded, 2);
+    assert.strictEqual(processResult.skipped, 2);
 });
 
 test('weekly schedule automation supports selected weekdays', async () => {
@@ -967,10 +1096,10 @@ test('weekly schedule automation supports selected weekdays', async () => {
         now: new Date('2026-06-26T08:00:00.000Z'),
     });
 
-    assert.strictEqual(offDayResult.enqueuedRuns, 0);
-    assert.strictEqual(tuesdayResult.enqueuedRuns, 1);
+    assert.strictEqual(offDayResult.enqueuedRuns, 1);
+    assert.strictEqual(tuesdayResult.enqueuedRuns, 2);
     assert.strictEqual(duplicateTuesdayResult.enqueuedRuns, 0);
-    assert.strictEqual(fridayResult.enqueuedRuns, 1);
+    assert.strictEqual(fridayResult.enqueuedRuns, 2);
 
     const runs = await listAutomationRuns({
         automationDefinitionId: definition.id,
@@ -1013,9 +1142,9 @@ test('biweekly schedule automation respects anchor week', async () => {
             now: new Date('2026-06-16T09:00:00.000Z'),
         });
 
-    assert.strictEqual(firstWeekResult.enqueuedRuns, 1);
-    assert.strictEqual(skippedWeekResult.enqueuedRuns, 0);
-    assert.strictEqual(secondOccurrenceResult.enqueuedRuns, 1);
+    assert.strictEqual(firstWeekResult.enqueuedRuns, 2);
+    assert.strictEqual(skippedWeekResult.enqueuedRuns, 1);
+    assert.strictEqual(secondOccurrenceResult.enqueuedRuns, 2);
     assert.strictEqual(duplicateSecondOccurrenceResult.enqueuedRuns, 0);
 
     const runs = await listAutomationRuns({
@@ -1166,13 +1295,14 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
     const enqueueResult = await enqueueAutomationRunsFromSchedules({
         now: referenceDate,
     });
-    assert.strictEqual(enqueueResult.enqueuedRuns, 1);
+    assert.strictEqual(enqueueResult.enqueuedRuns, 2);
 
     const processResult = await processDueAutomationRuns({
         limit: 10,
         lockedBy: 'automations-test',
     });
     assert.strictEqual(processResult.succeeded, 1);
+    assert.strictEqual(processResult.skipped, 1);
 
     const expectedScheduledDates = operationConfigs.map((operationConfig) =>
         addUtcDays(
@@ -1358,15 +1488,16 @@ test('default farm raised-bed weeding automation filters farms and prevents dupl
         now: new Date('2026-01-12T08:00:00.000Z'),
     });
 
-    assert.strictEqual(firstResult.enqueuedRuns, 1);
+    assert.strictEqual(firstResult.enqueuedRuns, 2);
     assert.strictEqual(duplicateResult.enqueuedRuns, 0);
-    assert.strictEqual(offWeekResult.enqueuedRuns, 0);
+    assert.strictEqual(offWeekResult.enqueuedRuns, 1);
 
     const processResult = await processDueAutomationRuns({
         limit: 10,
         lockedBy: 'automations-test',
     });
     assert.strictEqual(processResult.succeeded, 1);
+    assert.strictEqual(processResult.skipped, 2);
 
     const occurrenceStart = new Date('2026-01-05T08:00:00.000Z');
     const occurrenceEnd = addUtcDays(occurrenceStart, 1);
@@ -1437,6 +1568,245 @@ test('default farm raised-bed weeding automation filters farms and prevents dupl
             1,
         );
     }
+});
+
+test('default greenhouse seedling watering automation is enabled daily', async () => {
+    createTestDb();
+    await ensureDefaultAutomationDefinitions();
+
+    const definition = await getAutomationDefinitionByKey(
+        greenhouseSeedlingWateringAutomationKey,
+    );
+
+    assert.ok(definition);
+    assert.strictEqual(definition.status, 'enabled');
+    assert.strictEqual(
+        definition.triggerModuleKey,
+        automationModuleKeys.triggerSchedule,
+    );
+    assert.deepStrictEqual(
+        definition.graph,
+        greenhouseSeedlingWateringAutomationGraph(),
+    );
+    assert.deepStrictEqual(definition.metadata, {
+        managedBy: 'gredice',
+        defaultAutomation: true,
+        operationEntityId: 655,
+        operationInternalName: 'waterGreenhouseSeedlings',
+        operationName: 'Zalijevanje presadnica u stakleniku',
+        resolvedFromIssue: 3700,
+    });
+});
+
+test('greenhouse seedling watering dry run reports no-op farms', async () => {
+    createTestDb();
+    const entityId = 9_920_001;
+    await createFarm({
+        name: 'Automation Greenhouse No-op Farm',
+        latitude: 45.8,
+        longitude: 15.9,
+    });
+    const { result, actionOutput } =
+        await createAutomationRunForDailyGreenhouseWatering({
+            entityId,
+            referenceDate: new Date('2026-08-01T08:00:00.000Z'),
+            dryRun: true,
+        });
+
+    assert.strictEqual(result.status, 'succeeded');
+    assert.strictEqual(Reflect.get(actionOutput, 'dryRun'), true);
+    assert.strictEqual(Reflect.get(actionOutput, 'eligibleFarmCount'), 0);
+    assert.strictEqual(Reflect.get(actionOutput, 'projectedCreateCount'), 0);
+    assert.strictEqual(
+        Reflect.get(actionOutput, 'skippedFarmCount'),
+        Reflect.get(actionOutput, 'activeFarmCount'),
+    );
+    assert.strictEqual(
+        Reflect.get(actionOutput, 'existingOperationSkipCount'),
+        0,
+    );
+});
+
+test('greenhouse seedling watering treats active outlet stock as eligible greenhouse care', async () => {
+    createTestDb();
+    const entityId = 9_920_002;
+    const referenceDate = new Date('2026-08-03T08:00:00.000Z');
+    await createFarm({
+        name: 'Automation Greenhouse Outlet Farm',
+        latitude: 45.9,
+        longitude: 16.0,
+    });
+    const plantSortId = await createTestPlantSortForOutlet();
+    await createOutletOffer({
+        plantSortId,
+        sowingDate: new Date('2026-07-20T00:00:00.000Z'),
+        initialPlantStatus: 'sprouted',
+        imageUrls: [],
+        outletPriceCents: 199,
+        comparePriceCents: 349,
+        quantity: 3,
+        startAt: new Date('2026-08-03T00:00:00.000Z'),
+        endAt: new Date('2026-08-04T00:00:00.000Z'),
+        status: 'published',
+        adminNotes: null,
+    });
+
+    const { result, actionOutput } =
+        await createAutomationRunForDailyGreenhouseWatering({
+            entityId,
+            referenceDate,
+            dryRun: true,
+        });
+
+    assert.strictEqual(result.status, 'succeeded');
+    assert.strictEqual(Reflect.get(actionOutput, 'activeOutletOfferCount'), 1);
+    assert.strictEqual(
+        Reflect.get(actionOutput, 'eligibleFarmCount'),
+        Reflect.get(actionOutput, 'activeFarmCount'),
+    );
+    assert.strictEqual(Reflect.get(actionOutput, 'skippedFarmCount'), 0);
+    const eligibleFarms = Reflect.get(actionOutput, 'eligibleFarms');
+    assert.ok(Array.isArray(eligibleFarms));
+    assert.ok(
+        eligibleFarms.every((farm) => {
+            const reasons =
+                farm && typeof farm === 'object'
+                    ? Reflect.get(farm, 'reasons')
+                    : null;
+            return (
+                Array.isArray(reasons) && reasons.includes('activeOutletStock')
+            );
+        }),
+    );
+});
+
+test('greenhouse seedling watering creates one operation for farms with greenhouse fields', async () => {
+    createTestDb();
+    const entityId = 9_920_003;
+    const referenceDate = new Date('2026-08-10T08:00:00.000Z');
+    const { farmId, raisedBedId } = await createAutomationRaisedBedContext();
+    const fieldAggregateId = `${raisedBedId}|0`;
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(fieldAggregateId, {
+            plantSortId: '101',
+            scheduledDate: '2026-08-01T08:00:00.000Z',
+            sowingLocation: 'greenhouse',
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(fieldAggregateId, {
+            status: 'sprouted',
+        }),
+    );
+
+    const { result, actionOutput } =
+        await createAutomationRunForDailyGreenhouseWatering({
+            entityId,
+            referenceDate,
+        });
+
+    assert.strictEqual(result.status, 'succeeded');
+    assert.strictEqual(Reflect.get(actionOutput, 'dryRun'), false);
+    const eligibleFarms = Reflect.get(actionOutput, 'eligibleFarms');
+    assert.ok(Array.isArray(eligibleFarms));
+    assert.ok(
+        eligibleFarms.some((farm) => {
+            if (!farm || typeof farm !== 'object') {
+                return false;
+            }
+
+            return (
+                Reflect.get(farm, 'farmId') === farmId &&
+                Reflect.get(farm, 'greenhouseFieldCount') === 1
+            );
+        }),
+    );
+
+    const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
+        farmId,
+        from: new Date('2026-08-10T00:00:00.000Z'),
+        to: new Date('2026-08-11T00:00:00.000Z'),
+    });
+    const wateringOperations = farmOperations.filter(
+        (operation) => operation.entityId === entityId,
+    );
+    assert.strictEqual(wateringOperations.length, 1);
+    assert.strictEqual(wateringOperations[0]?.farmId, farmId);
+    assert.strictEqual(
+        wateringOperations[0]?.scheduledDate?.toISOString(),
+        '2026-08-10T00:00:00.000Z',
+    );
+});
+
+test('greenhouse seedling watering skips duplicate farm-date operations', async () => {
+    createTestDb();
+    const entityId = 9_920_004;
+    const referenceDate = new Date('2026-08-11T08:00:00.000Z');
+    const { farmId, raisedBedId } = await createAutomationRaisedBedContext();
+    const fieldAggregateId = `${raisedBedId}|0`;
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(fieldAggregateId, {
+            plantSortId: '101',
+            scheduledDate: '2026-08-01T08:00:00.000Z',
+            sowingLocation: 'greenhouse',
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(fieldAggregateId, {
+            status: 'sowed',
+        }),
+    );
+    const existingOperationId = await createOperation({
+        entityId,
+        entityTypeName: 'operation',
+        farmId,
+        timestamp: new Date('2026-08-11T00:00:00.000Z'),
+    });
+    await acceptOperation(existingOperationId);
+    await createEvent(
+        knownEvents.operations.scheduledV1(existingOperationId.toString(), {
+            scheduledDate: '2026-08-11T00:00:00.000Z',
+        }),
+    );
+
+    const { actionOutput } =
+        await createAutomationRunForDailyGreenhouseWatering({
+            entityId,
+            referenceDate,
+        });
+
+    const existingOperationSkips = Reflect.get(
+        actionOutput,
+        'existingOperationSkips',
+    );
+    assert.ok(Array.isArray(existingOperationSkips));
+    assert.ok(
+        existingOperationSkips.some((skip) => {
+            if (!skip || typeof skip !== 'object') {
+                return false;
+            }
+
+            return (
+                Reflect.get(skip, 'farmId') === farmId &&
+                Reflect.get(skip, 'operationId') === existingOperationId
+            );
+        }),
+    );
+
+    const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
+        farmId,
+        from: new Date('2026-08-11T00:00:00.000Z'),
+        to: new Date('2026-08-12T00:00:00.000Z'),
+    });
+    const wateringOperations = farmOperations.filter(
+        (operation) => operation.entityId === entityId,
+    );
+    assert.deepStrictEqual(
+        wateringOperations.map((operation) => operation.id),
+        [existingOperationId],
+    );
 });
 
 test('default sowed automation queues seasonal watering operations through executor', async () => {


### PR DESCRIPTION
## Summary

Closes #3705.

Adds the daily greenhouse seedling watering automation for farm operations:

- registers `action.createGreenhouseSeedlingWateringOperations`
- adds the managed daily default automation using operation entity `655` / `waterGreenhouseSeedlings` from #3700
- creates at most one accepted farm-scoped `Zalijevanje presadnica u stakleniku` operation per eligible farm and local schedule date
- reports eligible farms, skipped farms, and existing-operation skips in dry-run/action output
- documents the outlet scoping rule: outlet offers are central, not farm-scoped, so active published non-expired outlet stock with remaining quantity makes every active farm eligible

## Eligibility and idempotency

Greenhouse field eligibility follows the existing greenhouse screen predicate: active field, `sowingLocation = greenhouse`, known pre-transplant status, plant sort present, and no dead/harvested/removed date.

Outlet eligibility uses `getOutletOffers({ now })`, which applies published/start/end/remaining-stock rules.

Duplicate prevention uses the same accepted farm operation schedule-range lookup as existing farm inventory automation, keyed by farm, operation entity/type, and schedule date.

## Validation

- `pnpm --filter @gredice/storage lint`
- `pnpm --filter @gredice/storage test -- automationsRepo.node.spec.ts`
- `git diff --check`