### PR TITLE
[codex] Add monthly farm inventory automation

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -139,6 +139,12 @@ MVP modules:
   threshold.
 - `action.log`: records a no-op step for diagnostics.
 
+The managed default `default.monthly-farm-inventory-operations` uses the shared
+monthly `trigger.schedule` on day 1 in `Europe/Zagreb` and creates the published
+internal farm inventory operation set (`inventoryRaisedBedBoards` through
+`inventoryPlasticDeliveryBags`, operation entity ids 554-565) for each active
+farm.
+
 When adding a module, define metadata, config validation, dry-run behavior, and
 the executor function in the registry. Prefer idempotent repository functions for
 actions that mutate operations, plant state, notifications, or customer-visible

--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -21,6 +21,8 @@ export const farmRaisedBedWeedingAutomationKey =
     'default.farm-raised-bed-weeding';
 export const greenhouseSeedlingWateringAutomationKey =
     'default.greenhouse-seedling-watering';
+export const monthlyFarmInventoryOperationsAutomationKey =
+    'default.monthly-farm-inventory-operations';
 
 const seedlingTransplantingOperationId = 593;
 const plantRemovalOperationId = 346;
@@ -28,6 +30,20 @@ export const FARM_RAISED_BED_WEEDING_OPERATION_ID = 654;
 export const farmRaisedBedWeedingOperationKey = 'cleanWeedsAroundRaisedBeds';
 export const farmRaisedBedWeedingBiweeklyAnchorDate = '2026-01-05';
 const greenhouseSeedlingWateringOperationId = 655;
+export const monthlyFarmInventoryOperationConfigs = [
+    { entityId: 554, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 555, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 556, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 557, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 558, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 559, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 560, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 561, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 562, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 563, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 564, entityTypeName: 'operation', scheduledInDays: 0 },
+    { entityId: 565, entityTypeName: 'operation', scheduledInDays: 0 },
+];
 
 export function seasonalSowedWateringAutomationGraph(): AutomationGraph {
     return {
@@ -344,6 +360,41 @@ export function greenhouseSeedlingWateringAutomationGraph(): AutomationGraph {
     };
 }
 
+export function monthlyFarmInventoryOperationsAutomationGraph(): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerSchedule,
+                position: { x: 0, y: 160 },
+                config: {
+                    frequency: 'monthly',
+                    dayOfMonth: 1,
+                    timeZone: 'Europe/Zagreb',
+                },
+            },
+            {
+                id: 'create-inventory-operations',
+                kind: 'action',
+                moduleKey:
+                    automationModuleKeys.actionCreateFarmInventoryOperations,
+                position: { x: 360, y: 160 },
+                config: {
+                    operations: monthlyFarmInventoryOperationConfigs,
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-create-inventory-operations',
+                source: 'trigger',
+                target: 'create-inventory-operations',
+            },
+        ],
+    };
+}
+
 export async function ensureDefaultAutomationDefinitions() {
     await initializeAutomationEventCursorToLatest();
 
@@ -454,6 +505,25 @@ export async function ensureDefaultAutomationDefinitions() {
         },
     });
 
+    const monthlyFarmInventoryOperations =
+        await upsertAutomationDefinitionByKey({
+            key: monthlyFarmInventoryOperationsAutomationKey,
+            name: 'Mjesečna inventura farme',
+            description:
+                'Svakog prvog dana u mjesecu kreiraj inventurne radnje za svaku aktivnu farmu.',
+            status: 'enabled',
+            graph: monthlyFarmInventoryOperationsAutomationGraph(),
+            metadata: {
+                managedBy: 'gredice',
+                defaultAutomation: true,
+                dayOfMonth: 1,
+                timeZone: 'Europe/Zagreb',
+                operationEntityIds: monthlyFarmInventoryOperationConfigs.map(
+                    (operation) => operation.entityId,
+                ),
+            },
+        });
+
     return {
         seasonalSowedWatering,
         operationImagePlantStatusReview,
@@ -462,5 +532,6 @@ export async function ensureDefaultAutomationDefinitions() {
         plantRemovalOperationStatus,
         farmRaisedBedWeeding,
         greenhouseSeedlingWatering,
+        monthlyFarmInventoryOperations,
     };
 }

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -1676,7 +1676,9 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
             );
         }
 
-        const referenceDate = getScheduleReferenceDate(context.run.input);
+        const referenceDate = getScheduleOccurrenceReferenceDate(
+            context.run.input,
+        );
         const scheduledDates = operationConfigs.map((operationConfig) =>
             addUtcDays(referenceDate, operationConfig.scheduledInDays),
         );

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -1696,6 +1696,7 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
         }
 
         let skippedExistingCount = 0;
+        let repairedScheduledCount = 0;
         const createdOperationIds: number[] = [];
         const repairedScheduledOperationIds: number[] = [];
 
@@ -1751,22 +1752,22 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
                     existingOperationKeys.has(operationKey)
                 ) {
                     skippedExistingCount += 1;
-                    if (
-                        existingOperation &&
-                        !existingOperation.scheduledDate &&
-                        !context.dryRun
-                    ) {
-                        await createEvent(
-                            knownEvents.operations.scheduledV1(
-                                existingOperation.id.toString(),
-                                {
-                                    scheduledDate: scheduledDate.toISOString(),
-                                },
-                            ),
-                        );
-                        repairedScheduledOperationIds.push(
-                            existingOperation.id,
-                        );
+                    if (existingOperation && !existingOperation.scheduledDate) {
+                        repairedScheduledCount += 1;
+                        if (!context.dryRun) {
+                            await createEvent(
+                                knownEvents.operations.scheduledV1(
+                                    existingOperation.id.toString(),
+                                    {
+                                        scheduledDate:
+                                            scheduledDate.toISOString(),
+                                    },
+                                ),
+                            );
+                            repairedScheduledOperationIds.push(
+                                existingOperation.id,
+                            );
+                        }
                     }
                     continue;
                 }
@@ -1804,6 +1805,8 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
                 projectedCreateCount,
                 skippedCount: skippedExistingCount,
                 skippedExistingCount,
+                skippedScheduledCount: skippedExistingCount,
+                repairedScheduledCount,
             });
         }
 
@@ -1816,8 +1819,11 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
                 {
                     farmCount: activeFarms.length,
                     operationCount: operationConfigs.length,
+                    createdCount: 0,
                     skippedCount: skippedExistingCount,
                     skippedExistingCount,
+                    skippedScheduledCount: skippedExistingCount,
+                    repairedScheduledCount: 0,
                 },
             );
         }
@@ -1829,6 +1835,7 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
             repairedScheduledCount: repairedScheduledOperationIds.length,
             skippedCount: skippedExistingCount,
             skippedExistingCount,
+            skippedScheduledCount: skippedExistingCount,
             farmCount: activeFarms.length,
             operationCount: operationConfigs.length,
         });

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -1329,7 +1329,7 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
         lockedBy: 'automations-test',
     });
     assert.strictEqual(processResult.succeeded, 1);
-    assert.strictEqual(processResult.skipped, 1);
+    assert.strictEqual(processResult.skipped, 2);
 
     const expectedScheduledDates = operationConfigs.map((operationConfig) =>
         addUtcDays(

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -45,6 +45,8 @@ import {
     listAutomationDefinitions,
     listAutomationRuns,
     listEnabledAutomationDefinitionsForEventType,
+    monthlyFarmInventoryOperationConfigs,
+    monthlyFarmInventoryOperationsAutomationKey,
     operationImagePlantStatusReviewAutomationGraph,
     plantRemovalOperationStatusAutomationGraph,
     plantRemovalOperationStatusAutomationKey,
@@ -964,7 +966,7 @@ test('monthly schedule automation enqueues once per configured period', async ()
                 kind: 'trigger' as const,
                 position: { x: 0, y: 0 },
                 config: {
-                    dayOfMonth: 1,
+                    dayOfMonth: 15,
                     timeZone: 'Europe/Zagreb',
                 },
             },
@@ -994,13 +996,13 @@ test('monthly schedule automation enqueues once per configured period', async ()
     });
 
     const firstResult = await enqueueAutomationRunsFromSchedules({
-        now: new Date('2026-06-01T08:00:00.000Z'),
+        now: new Date('2026-06-15T08:00:00.000Z'),
     });
     const duplicateResult = await enqueueAutomationRunsFromSchedules({
-        now: new Date('2026-06-01T09:00:00.000Z'),
+        now: new Date('2026-06-15T09:00:00.000Z'),
     });
     const offDayResult = await enqueueAutomationRunsFromSchedules({
-        now: new Date('2026-06-02T08:00:00.000Z'),
+        now: new Date('2026-06-16T08:00:00.000Z'),
     });
 
     assert.strictEqual(firstResult.enqueuedRuns, 2);
@@ -1014,7 +1016,7 @@ test('monthly schedule automation enqueues once per configured period', async ()
     assert.strictEqual(runs[0]?.source, 'schedule');
     assert.strictEqual(
         runs[0]?.sourceAggregateId,
-        'trigger.scheduleMonthly:Europe/Zagreb:2026-06:day-1',
+        'trigger.scheduleMonthly:Europe/Zagreb:2026-06:day-15',
     );
     for (const run of runs) {
         await completeAutomationRun({
@@ -1230,76 +1232,97 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
         latitude: 46.1,
         longitude: 16.2,
     });
+    const deletedFarmId = await createFarm({
+        name: 'Automation Inventory Deleted Farm',
+        latitude: 44.5,
+        longitude: 15.1,
+    });
+    await storage()
+        .update(farms)
+        .set({ isDeleted: true })
+        .where(eq(farms.id, deletedFarmId));
     const activeFarms = (await getFarms()).filter((farm) => !farm.isDeleted);
-    const referenceDate = new Date('2026-07-01T08:00:00.000Z');
-    const operationConfigs = [
-        {
-            entityId: 9_910_001,
-            entityTypeName: 'operation',
-            scheduledInDays: 0,
-        },
-        {
-            entityId: 9_910_002,
-            entityTypeName: 'operation',
-            scheduledInDays: 2,
-        },
-    ];
+    const occurrenceDate = new Date('2026-07-01T00:00:00.000Z');
+    const enqueuedAt = new Date('2026-07-01T08:00:00.000Z');
+    const operationConfigs = monthlyFarmInventoryOperationConfigs;
     const preexistingFarm = activeFarms[0];
     assert.ok(preexistingFarm);
     const preexistingOperationId = await createOperation({
         entityId: operationConfigs[0].entityId,
         entityTypeName: operationConfigs[0].entityTypeName,
         farmId: preexistingFarm.id,
-        timestamp: new Date('2026-05-01T08:00:00.000Z'),
+        timestamp: occurrenceDate,
     });
     await acceptOperation(preexistingOperationId);
-    await createEvent(
-        knownEvents.operations.scheduledV1(preexistingOperationId.toString(), {
-            scheduledDate: referenceDate.toISOString(),
-        }),
+    await ensureDefaultAutomationDefinitions();
+    const definition = await getAutomationDefinitionByKey(
+        monthlyFarmInventoryOperationsAutomationKey,
     );
-    const graph = {
-        nodes: [
-            {
-                id: 'trigger',
-                moduleKey: automationModuleKeys.triggerScheduleMonthly,
-                kind: 'trigger' as const,
-                position: { x: 0, y: 0 },
-                config: {
-                    dayOfMonth: 1,
-                    timeZone: 'Europe/Zagreb',
-                },
-            },
-            {
-                id: 'create-inventory-operations',
-                moduleKey:
-                    automationModuleKeys.actionCreateFarmInventoryOperations,
-                kind: 'action' as const,
-                position: { x: 300, y: 0 },
-                config: {
-                    operations: operationConfigs,
-                },
-            },
-        ],
-        edges: [
-            {
-                id: 'trigger-to-create-inventory-operations',
-                source: 'trigger',
-                target: 'create-inventory-operations',
-            },
-        ],
-    };
-    const definition = await createAutomationDefinition({
-        key: 'test.monthly-farm-inventory',
-        name: 'Monthly farm inventory',
-        status: 'enabled',
-        graph,
+    assert.ok(definition);
+    const triggerNode = definition.graph.nodes.find(
+        (node) => node.kind === 'trigger',
+    );
+    const actionNode = definition.graph.nodes.find(
+        (node) =>
+            node.moduleKey ===
+            automationModuleKeys.actionCreateFarmInventoryOperations,
+    );
+    assert.strictEqual(
+        triggerNode?.moduleKey,
+        automationModuleKeys.triggerSchedule,
+    );
+    assert.deepStrictEqual(triggerNode?.config, {
+        frequency: 'monthly',
+        dayOfMonth: 1,
+        timeZone: 'Europe/Zagreb',
     });
+    assert.deepStrictEqual(actionNode?.config.operations, operationConfigs);
 
     const enqueueResult = await enqueueAutomationRunsFromSchedules({
-        now: referenceDate,
+        now: enqueuedAt,
+    });
+    const duplicateResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-07-01T09:00:00.000Z'),
+    });
+    const offDayResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-07-02T08:00:00.000Z'),
     });
     assert.strictEqual(enqueueResult.enqueuedRuns, 2);
+    assert.strictEqual(duplicateResult.enqueuedRuns, 0);
+    assert.strictEqual(offDayResult.enqueuedRuns, 1);
+
+    const [scheduledRun] = await listAutomationRuns({
+        automationDefinitionId: definition.id,
+    });
+    assert.ok(scheduledRun);
+    assert.strictEqual(
+        scheduledRun.sourceAggregateId,
+        'trigger.schedule:Europe/Zagreb:monthly:2026-07:day-1',
+    );
+
+    const dryRun = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'test',
+        input: scheduledRun.input,
+    });
+    assert.ok(dryRun);
+    const startedDryRun = await startAutomationRun(dryRun.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedDryRun);
+    const dryRunResult = await executeAutomationRun(startedDryRun);
+    assert.strictEqual(dryRunResult.status, 'succeeded');
+    const dryRunWithSteps = await getAutomationRunWithSteps(dryRun.id);
+    const dryRunActionStep = dryRunWithSteps?.steps.find(
+        (step) => step.nodeId === 'create-inventory-operations',
+    );
+    assert.ok(dryRunActionStep);
+    assert.strictEqual(
+        dryRunActionStep.output.createdCount,
+        activeFarms.length * operationConfigs.length - 1,
+    );
+    assert.strictEqual(dryRunActionStep.output.skippedScheduledCount, 1);
+    assert.strictEqual(dryRunActionStep.output.repairedScheduledCount, 1);
 
     const processResult = await processDueAutomationRuns({
         limit: 10,
@@ -1310,15 +1333,17 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
 
     const expectedScheduledDates = operationConfigs.map((operationConfig) =>
         addUtcDays(
-            referenceDate,
+            occurrenceDate,
             operationConfig.scheduledInDays,
         ).toISOString(),
     );
+    const expectedCreatedCount =
+        activeFarms.length * operationConfigs.length - 1;
     for (const farm of activeFarms) {
         const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
             farmId: farm.id,
-            from: referenceDate,
-            to: addUtcDays(referenceDate, 3),
+            from: occurrenceDate,
+            to: addUtcDays(occurrenceDate, 1),
         });
         const inventoryOperations = farmOperations
             .filter((operation) =>
@@ -1364,14 +1389,29 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
         }
     }
 
-    const [firstRun] = await listAutomationRuns({
-        automationDefinitionId: definition.id,
-    });
-    assert.ok(firstRun);
+    const deletedFarmOperations =
+        await getFarmAcceptedOperationsByScheduleRange({
+            farmId: deletedFarmId,
+            from: occurrenceDate,
+            to: addUtcDays(occurrenceDate, 1),
+        });
+    assert.strictEqual(deletedFarmOperations.length, 0);
+
+    const scheduledRunWithSteps = await getAutomationRunWithSteps(
+        scheduledRun.id,
+    );
+    const actionStep = scheduledRunWithSteps?.steps.find(
+        (step) => step.nodeId === 'create-inventory-operations',
+    );
+    assert.ok(actionStep);
+    assert.strictEqual(actionStep.output.createdCount, expectedCreatedCount);
+    assert.strictEqual(actionStep.output.skippedScheduledCount, 1);
+    assert.strictEqual(actionStep.output.repairedScheduledCount, 1);
+
     const replayRun = await createAutomationRun({
         automationDefinition: definition,
         source: 'replay',
-        input: firstRun.input,
+        input: scheduledRun.input,
     });
     assert.ok(replayRun);
     const startedReplay = await startAutomationRun(replayRun.id, {
@@ -1385,8 +1425,8 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
     for (const farm of activeFarms) {
         const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
             farmId: farm.id,
-            from: referenceDate,
-            to: addUtcDays(referenceDate, 3),
+            from: occurrenceDate,
+            to: addUtcDays(occurrenceDate, 1),
         });
         const inventoryOperations = farmOperations.filter((operation) =>
             operationConfigs.some(
@@ -1396,6 +1436,17 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
         );
         assert.strictEqual(inventoryOperations.length, operationConfigs.length);
     }
+    const replayRunWithSteps = await getAutomationRunWithSteps(replayRun.id);
+    const replayActionStep = replayRunWithSteps?.steps.find(
+        (step) => step.nodeId === 'create-inventory-operations',
+    );
+    assert.ok(replayActionStep);
+    assert.strictEqual(replayActionStep.output.createdCount, 0);
+    assert.strictEqual(
+        replayActionStep.output.skippedScheduledCount,
+        activeFarms.length * operationConfigs.length,
+    );
+    assert.strictEqual(replayActionStep.output.repairedScheduledCount, 0);
 });
 
 test('default farm raised-bed weeding automation stays draft until enabled', async () => {
@@ -1503,7 +1554,7 @@ test('default farm raised-bed weeding automation filters farms and prevents dupl
     assert.strictEqual(processResult.succeeded, 1);
     assert.strictEqual(processResult.skipped, 2);
 
-    const occurrenceStart = new Date('2026-01-05T08:00:00.000Z');
+    const occurrenceStart = new Date('2026-01-05T00:00:00.000Z');
     const occurrenceEnd = addUtcDays(occurrenceStart, 1);
     for (const farm of activeFarms) {
         const farmOperations = await getFarmAcceptedOperationsByScheduleRange({


### PR DESCRIPTION
## Summary

- Adds the managed default `default.monthly-farm-inventory-operations` using shared `trigger.schedule` with monthly day 1 in `Europe/Zagreb`.
- Configures `action.createFarmInventoryOperations` with the confirmed published internal farm inventory operation set: entity ids `554`-`565` (`inventoryRaisedBedBoards` through `inventoryPlasticDeliveryBags`).
- Extends farm inventory action output with explicit created/skipped/repaired scheduled operation counters for dry-run, success, and all-existing skip paths.
- Updates focused automation storage coverage for recurrence, configured operation list, active-farm filtering, schedule repair, and duplicate prevention.

Closes #3704.

## Validation

- `pnpm --filter @gredice/storage test -- automationsRepo.node.spec.ts`
- `pnpm lint --filter @gredice/storage`
- `git diff --check`
- `pnpm typecheck --filter @gredice/storage` (no Turbo typecheck task exists for `@gredice/storage`; command completed with no tasks executed)

## Notes

- Ran `pnpm bootstrap` to pull development env and confirm live published inventory operation entities before configuring the default list.