### PR TITLE
[codex] Add raised-bed photo automation

### DIFF
--- a/apps/app/app/admin/automations/presentation.ts
+++ b/apps/app/app/admin/automations/presentation.ts
@@ -22,6 +22,7 @@ export const automationModuleKeys = {
     actionCreateOperation: 'action.createOperation',
     actionCreatePlantStatusRequestsFromImageAnalysis:
         'action.createPlantStatusRequestsFromImageAnalysis',
+    actionCreateRaisedBedOperations: 'action.createRaisedBedOperations',
     actionLog: 'action.log',
     actionQueuePostTransplantWateringOperations:
         'action.queuePostTransplantWateringOperations',
@@ -204,6 +205,19 @@ const automationModulePresentations: Record<
                 description:
                     'JSON niz: [{"entityId": 123, "entityTypeName": "operation", "scheduledInDays": 0}]',
             },
+        },
+    },
+    [automationModuleKeys.actionCreateRaisedBedOperations]: {
+        title: 'Radnje aktivnih gredica',
+        description: 'Kreira konfiguriranu radnju za svaku aktivnu gredicu.',
+        inputDescription: 'Pojava rasporeda.',
+        outputDescription:
+            'ID-jevi kreiranih radnji, broj primatelja i broj preskočenih postojećih radnji.',
+        fields: {
+            entityId: { label: 'ID entiteta radnje' },
+            entityTypeName: { label: 'Tip entiteta' },
+            scheduledInDays: { label: 'Zakaži nakon dana' },
+            acceptOnCreate: { label: 'Potvrdi pri kreiranju' },
         },
     },
     [automationModuleKeys.actionUpdateRaisedBedFieldPlantAttributes]: {

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -15,7 +15,10 @@ watering scheduled on those days. Verifying the `Uklanjanje biljke` operation
 marks the targeted raised-bed field plant status as `removed`, which closes the
 plant cycle and frees the field for future planting. Plant field changes are
 available as configurable action modules so new operation-driven plant-state
-automations can be created from the admin graph editor without adding code.
+automations can be created from the admin graph editor without adding code. A
+managed weekly schedule also creates `Fotografiranje gredice` operations every
+Tuesday and Friday for active raised beds, reusing the existing operation
+completion image flow and `photographyUpdate` visual reward handling.
 
 ## Ownership
 
@@ -129,6 +132,11 @@ MVP modules:
   has active published non-expired offers with remaining quantity. Outlet offers
   are not farm-scoped in storage, so active outlet stock makes every active farm
   eligible for the daily care operation.
+- `action.createRaisedBedOperations`: creates accepted, scheduled raised-bed
+  operations for every active, non-deleted raised bed from a single operation
+  entity config. It targets `raisedBedId` without `raisedBedFieldId`, skips
+  inactive, deleted, and abandoned raised beds, and reports `recipientCount`,
+  `projectedCreateCount`, and `skippedExistingCount` during dry runs.
 - `action.updateRaisedBedFieldPlantAttributes`: writes plant status and/or
   sowing location events for the operation target field. Use this for new
   no-code plant-state automations.
@@ -155,6 +163,14 @@ trigger can flow into one `condition.operationMatches` node and then fan out to
 separate plant-attribute, watering, notification, or operation-creation actions.
 The executor records those sibling actions as separate steps; actions should
 remain idempotent because replays and retries can run the same graph again.
+
+The managed raised-bed photo automation uses `trigger.schedule` with
+`daysOfWeek: ["tuesday", "friday"]` in the `Europe/Zagreb` time zone and
+`action.createRaisedBedOperations` with operation entity `301`
+(`raisedBedFullPhoto`, label `Fotografiranje gredice`). Duplicate prevention is
+scoped to the raised bed, operation entity, and weekday occurrence date; existing
+non-canceled/non-failed operations for the same day are counted as existing
+skips.
 
 ## Graph Validation
 

--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -23,6 +23,8 @@ export const greenhouseSeedlingWateringAutomationKey =
     'default.greenhouse-seedling-watering';
 export const monthlyFarmInventoryOperationsAutomationKey =
     'default.monthly-farm-inventory-operations';
+export const raisedBedPhotoOperationsAutomationKey =
+    'default.raised-bed-photo-operations';
 
 const seedlingTransplantingOperationId = 593;
 const plantRemovalOperationId = 346;
@@ -44,6 +46,8 @@ export const monthlyFarmInventoryOperationConfigs = [
     { entityId: 564, entityTypeName: 'operation', scheduledInDays: 0 },
     { entityId: 565, entityTypeName: 'operation', scheduledInDays: 0 },
 ];
+export const RAISED_BED_PHOTO_OPERATION_ID = 301;
+export const RAISED_BED_PHOTO_OPERATION_NAME = 'raisedBedFullPhoto';
 
 export function seasonalSowedWateringAutomationGraph(): AutomationGraph {
     return {
@@ -395,6 +399,43 @@ export function monthlyFarmInventoryOperationsAutomationGraph(): AutomationGraph
     };
 }
 
+export function raisedBedPhotoOperationsAutomationGraph(): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerSchedule,
+                position: { x: 0, y: 160 },
+                config: {
+                    frequency: 'weekly',
+                    daysOfWeek: ['tuesday', 'friday'],
+                    timeZone: 'Europe/Zagreb',
+                },
+            },
+            {
+                id: 'create-photo-operations',
+                kind: 'action',
+                moduleKey: automationModuleKeys.actionCreateRaisedBedOperations,
+                position: { x: 360, y: 160 },
+                config: {
+                    entityId: RAISED_BED_PHOTO_OPERATION_ID,
+                    entityTypeName: 'operation',
+                    scheduledInDays: 0,
+                    acceptOnCreate: true,
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-create-photo-operations',
+                source: 'trigger',
+                target: 'create-photo-operations',
+            },
+        ],
+    };
+}
+
 export async function ensureDefaultAutomationDefinitions() {
     await initializeAutomationEventCursorToLatest();
 
@@ -524,6 +565,23 @@ export async function ensureDefaultAutomationDefinitions() {
             },
         });
 
+    const raisedBedPhotoOperations = await upsertAutomationDefinitionByKey({
+        key: raisedBedPhotoOperationsAutomationKey,
+        name: 'Dodaj fotografiranje aktivnih gredica',
+        description:
+            'Svakog utorka i petka dodaj radnju fotografiranja za svaku aktivnu gredicu ako ta gredica već nema fotografiranje za tu pojavu rasporeda.',
+        status: 'enabled',
+        graph: raisedBedPhotoOperationsAutomationGraph(),
+        metadata: {
+            managedBy: 'gredice',
+            defaultAutomation: true,
+            operationEntityId: RAISED_BED_PHOTO_OPERATION_ID,
+            operationEntityName: RAISED_BED_PHOTO_OPERATION_NAME,
+            operationEntityLabel: 'Fotografiranje gredice',
+            operationEntitySource: 'live-admin-data',
+        },
+    });
+
     return {
         seasonalSowedWatering,
         operationImagePlantStatusReview,
@@ -533,5 +591,6 @@ export async function ensureDefaultAutomationDefinitions() {
         farmRaisedBedWeeding,
         greenhouseSeedlingWatering,
         monthlyFarmInventoryOperations,
+        raisedBedPhotoOperations,
     };
 }

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -2185,7 +2185,7 @@ const createRaisedBedOperationsActionModule: AutomationModule = {
             from,
             to,
         });
-        const existingOperationKeys = new Set(
+        const existingOperationsByKey = new Map(
             existingOperations.flatMap((operation) => {
                 if (
                     !operation.raisedBedId ||
@@ -2196,17 +2196,23 @@ const createRaisedBedOperationsActionModule: AutomationModule = {
                 }
 
                 return [
-                    raisedBedOperationKey({
-                        entityId: operation.entityId,
-                        entityTypeName: operation.entityTypeName,
-                        raisedBedId: operation.raisedBedId,
-                        scheduledDate:
-                            operation.scheduledDate ?? operation.timestamp,
-                    }),
+                    [
+                        raisedBedOperationKey({
+                            entityId: operation.entityId,
+                            entityTypeName: operation.entityTypeName,
+                            raisedBedId: operation.raisedBedId,
+                            scheduledDate:
+                                operation.scheduledDate ?? operation.timestamp,
+                        }),
+                        operation,
+                    ],
                 ];
             }),
         );
+        const existingOperationKeys = new Set(existingOperationsByKey.keys());
         const createdOperationIds: number[] = [];
+        const repairedAcceptedOperationIds: number[] = [];
+        const repairedScheduledOperationIds: number[] = [];
         let skippedExistingCount = 0;
 
         for (const raisedBed of activeRaisedBeds) {
@@ -2217,8 +2223,28 @@ const createRaisedBedOperationsActionModule: AutomationModule = {
                 scheduledDate,
             });
 
-            if (existingOperationKeys.has(operationKey)) {
+            const existingOperation = existingOperationsByKey.get(operationKey);
+            if (existingOperation || existingOperationKeys.has(operationKey)) {
                 skippedExistingCount += 1;
+                if (existingOperation && !context.dryRun) {
+                    if (acceptOnCreate && !existingOperation.isAccepted) {
+                        await acceptOperation(existingOperation.id);
+                        repairedAcceptedOperationIds.push(existingOperation.id);
+                    }
+                    if (!existingOperation.scheduledDate) {
+                        await createEvent(
+                            knownEvents.operations.scheduledV1(
+                                existingOperation.id.toString(),
+                                {
+                                    scheduledDate: scheduledDate.toISOString(),
+                                },
+                            ),
+                        );
+                        repairedScheduledOperationIds.push(
+                            existingOperation.id,
+                        );
+                    }
+                }
                 continue;
             }
 
@@ -2261,7 +2287,11 @@ const createRaisedBedOperationsActionModule: AutomationModule = {
             });
         }
 
-        if (createdOperationIds.length === 0) {
+        if (
+            createdOperationIds.length === 0 &&
+            repairedAcceptedOperationIds.length === 0 &&
+            repairedScheduledOperationIds.length === 0
+        ) {
             return skip('All raised-bed operations already exist.', {
                 entityId,
                 entityTypeName,
@@ -2274,6 +2304,10 @@ const createRaisedBedOperationsActionModule: AutomationModule = {
         return success({
             createdOperationIds,
             createdCount: createdOperationIds.length,
+            repairedAcceptedOperationIds,
+            repairedAcceptedCount: repairedAcceptedOperationIds.length,
+            repairedScheduledOperationIds,
+            repairedScheduledCount: repairedScheduledOperationIds.length,
             entityId,
             entityTypeName,
             scheduledDate: scheduledDate.toISOString(),

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -12,12 +12,14 @@ import {
     getAllRaisedBeds,
     getGardens,
     getRaisedBed,
+    listActiveRaisedBedOperationTargets,
 } from '../repositories/gardensRepo';
 import {
     acceptOperation,
     createOperation,
     getFarmAcceptedOperationsByScheduleRange,
     getOperationById,
+    getRaisedBedOperationsByScheduleRange,
 } from '../repositories/operationsRepo';
 import { getOutletOffers } from '../repositories/outletOffersRepo';
 import {
@@ -55,6 +57,7 @@ const createFarmInventoryOperationsActionKey =
     'action.createFarmInventoryOperations';
 const createGreenhouseSeedlingWateringOperationsActionKey =
     'action.createGreenhouseSeedlingWateringOperations';
+const createRaisedBedOperationsActionKey = 'action.createRaisedBedOperations';
 const updateRaisedBedFieldPlantAttributesActionKey =
     'action.updateRaisedBedFieldPlantAttributes';
 const createPlantStatusRequestsFromImageAnalysisActionKey =
@@ -140,6 +143,7 @@ export const automationModuleKeys = {
     actionCreateFarmInventoryOperations: createFarmInventoryOperationsActionKey,
     actionCreateGreenhouseSeedlingWateringOperations:
         createGreenhouseSeedlingWateringOperationsActionKey,
+    actionCreateRaisedBedOperations: createRaisedBedOperationsActionKey,
     actionUpdateRaisedBedFieldPlantAttributes:
         updateRaisedBedFieldPlantAttributesActionKey,
     actionCreatePlantStatusRequestsFromImageAnalysis:
@@ -671,6 +675,22 @@ function validateGreenhouseSeedlingWateringConfig(
     return errors;
 }
 
+function validateRaisedBedOperationsConfig(config: AutomationJsonObject) {
+    const entityId = getNumber(config, 'entityId');
+    const scheduledInDays = getNumber(config, 'scheduledInDays') ?? 0;
+    const errors: string[] = [];
+
+    if (!entityId || !Number.isInteger(entityId) || entityId <= 0) {
+        errors.push('entityId must be a positive integer.');
+    }
+
+    if (!Number.isInteger(scheduledInDays)) {
+        errors.push('scheduledInDays must be an integer.');
+    }
+
+    return errors;
+}
+
 function validateImagePlantStatusReviewConfig(config: AutomationJsonObject) {
     const minConfidence =
         getNumber(config, 'minConfidence') ??
@@ -779,6 +799,22 @@ function farmOperationKey({
     scheduledDate: Date;
 }) {
     return `${entityTypeName}:${entityId}:${toUtcDayKey(scheduledDate)}`;
+}
+
+function raisedBedOperationKey({
+    entityId,
+    entityTypeName,
+    raisedBedId,
+    scheduledDate,
+}: {
+    entityId: number;
+    entityTypeName: string;
+    raisedBedId: number;
+    scheduledDate: Date;
+}) {
+    return `${raisedBedId}:${entityTypeName}:${entityId}:${toUtcDayKey(
+        scheduledDate,
+    )}`;
 }
 
 function isCurrentlyGreenhouseSeedling(field: RaisedBedFieldForGreenhouseCare) {
@@ -2078,6 +2114,176 @@ const createGreenhouseSeedlingWateringOperationsActionModule: AutomationModule =
         },
     };
 
+const createRaisedBedOperationsActionModule: AutomationModule = {
+    key: createRaisedBedOperationsActionKey,
+    kind: 'action',
+    title: 'Create raised-bed operations',
+    description:
+        'Creates a configured raised-bed-scoped operation for every active raised bed.',
+    category: 'Operations',
+    configFields: [
+        {
+            key: 'entityId',
+            label: 'Operation entity ID',
+            type: 'number',
+            required: true,
+        },
+        {
+            key: 'entityTypeName',
+            label: 'Entity type',
+            type: 'string',
+            placeholder: 'operation',
+        },
+        {
+            key: 'scheduledInDays',
+            label: 'Schedule after days',
+            type: 'number',
+        },
+        {
+            key: 'acceptOnCreate',
+            label: 'Accept on create',
+            type: 'boolean',
+        },
+    ],
+    inputDescription: 'A schedule occurrence.',
+    outputDescription:
+        'Created operation ids, recipient count, and skipped existing count.',
+    dryRunSupported: true,
+    mutatesData: true,
+    retryable: true,
+    validateConfig: validateRaisedBedOperationsConfig,
+    execute: async (context, node) => {
+        const entityId = getNumber(node.config, 'entityId');
+        if (!entityId) {
+            throw new AutomationModuleExecutionError(
+                'Raised-bed operation action is missing entityId.',
+                'invalid_config',
+            );
+        }
+
+        const entityTypeName =
+            getString(node.config, 'entityTypeName') ?? 'operation';
+        const scheduledInDays = getNumber(node.config, 'scheduledInDays') ?? 0;
+        const acceptOnCreate = node.config.acceptOnCreate !== false;
+        const referenceDate = getScheduleOccurrenceReferenceDate(
+            context.run.input,
+        );
+        const scheduledDate = addUtcDays(referenceDate, scheduledInDays);
+        const from = new Date(`${toUtcDayKey(scheduledDate)}T00:00:00.000Z`);
+        const to = addUtcDays(from, 1);
+        const activeRaisedBeds = await listActiveRaisedBedOperationTargets();
+
+        if (activeRaisedBeds.length === 0) {
+            return skip('No active raised beds were found.', {
+                recipientCount: 0,
+                skippedExistingCount: 0,
+            });
+        }
+
+        const existingOperations = await getRaisedBedOperationsByScheduleRange({
+            raisedBedIds: activeRaisedBeds.map((raisedBed) => raisedBed.id),
+            from,
+            to,
+        });
+        const existingOperationKeys = new Set(
+            existingOperations.flatMap((operation) => {
+                if (
+                    !operation.raisedBedId ||
+                    operation.status === 'canceled' ||
+                    operation.status === 'failed'
+                ) {
+                    return [];
+                }
+
+                return [
+                    raisedBedOperationKey({
+                        entityId: operation.entityId,
+                        entityTypeName: operation.entityTypeName,
+                        raisedBedId: operation.raisedBedId,
+                        scheduledDate:
+                            operation.scheduledDate ?? operation.timestamp,
+                    }),
+                ];
+            }),
+        );
+        const createdOperationIds: number[] = [];
+        let skippedExistingCount = 0;
+
+        for (const raisedBed of activeRaisedBeds) {
+            const operationKey = raisedBedOperationKey({
+                entityId,
+                entityTypeName,
+                raisedBedId: raisedBed.id,
+                scheduledDate,
+            });
+
+            if (existingOperationKeys.has(operationKey)) {
+                skippedExistingCount += 1;
+                continue;
+            }
+
+            if (context.dryRun) {
+                continue;
+            }
+
+            const operationId = await createOperation({
+                entityId,
+                entityTypeName,
+                accountId: raisedBed.accountId,
+                gardenId: raisedBed.gardenId,
+                raisedBedId: raisedBed.id,
+                timestamp: scheduledDate,
+            });
+            if (acceptOnCreate) {
+                await acceptOperation(operationId);
+            }
+            await createEvent(
+                knownEvents.operations.scheduledV1(operationId.toString(), {
+                    scheduledDate: scheduledDate.toISOString(),
+                }),
+            );
+            createdOperationIds.push(operationId);
+            existingOperationKeys.add(operationKey);
+        }
+
+        const recipientCount = activeRaisedBeds.length;
+        const projectedCreateCount = recipientCount - skippedExistingCount;
+
+        if (context.dryRun) {
+            return success({
+                dryRun: true,
+                entityId,
+                entityTypeName,
+                scheduledDate: scheduledDate.toISOString(),
+                recipientCount,
+                projectedCreateCount,
+                skippedExistingCount,
+            });
+        }
+
+        if (createdOperationIds.length === 0) {
+            return skip('All raised-bed operations already exist.', {
+                entityId,
+                entityTypeName,
+                scheduledDate: scheduledDate.toISOString(),
+                recipientCount,
+                skippedExistingCount,
+            });
+        }
+
+        return success({
+            createdOperationIds,
+            createdCount: createdOperationIds.length,
+            entityId,
+            entityTypeName,
+            scheduledDate: scheduledDate.toISOString(),
+            recipientCount,
+            skippedExistingCount,
+            acceptedCount: acceptOnCreate ? createdOperationIds.length : 0,
+        });
+    },
+};
+
 async function updateRaisedBedFieldPlantAttributes({
     context,
     node,
@@ -2342,6 +2548,7 @@ export const automationModules = [
     createOperationActionModule,
     createFarmInventoryOperationsActionModule,
     createGreenhouseSeedlingWateringOperationsActionModule,
+    createRaisedBedOperationsActionModule,
     updateRaisedBedFieldPlantAttributesActionModule,
     createPlantStatusRequestsFromImageAnalysisActionModule,
     logActionModule,

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -868,6 +868,66 @@ export async function getFarmAcceptedOperationsByScheduleRange({
     return getOperationsByIds(operationIds);
 }
 
+export async function getRaisedBedOperationsByScheduleRange({
+    raisedBedIds,
+    from,
+    to,
+}: {
+    raisedBedIds: number[];
+    from: Date;
+    to: Date;
+}) {
+    const uniqueRaisedBedIds = Array.from(new Set(raisedBedIds));
+    if (uniqueRaisedBedIds.length === 0) {
+        return [];
+    }
+
+    const scheduledDateExpression = sql<string>`${events.data} ->> 'scheduledDate'`;
+    const scheduledRows = await storage()
+        .selectDistinct({ id: operations.id })
+        .from(operations)
+        .leftJoin(raisedBeds, eq(operations.raisedBedId, raisedBeds.id))
+        .leftJoin(gardens, eq(gardens.id, operationGardenIdExpression()))
+        .innerJoin(
+            events,
+            and(
+                sql`${events.aggregateId} = cast(${operations.id} as text)`,
+                eq(events.type, knownEventTypes.operations.schedule),
+            ),
+        )
+        .where(
+            and(
+                inArray(operations.raisedBedId, uniqueRaisedBedIds),
+                eq(operations.isDeleted, false),
+                operationLocationIntegrityWhere(),
+                gte(scheduledDateExpression, from.toISOString()),
+                lte(scheduledDateExpression, to.toISOString()),
+            ),
+        );
+    const timestampRows = await storage()
+        .selectDistinct({ id: operations.id })
+        .from(operations)
+        .leftJoin(raisedBeds, eq(operations.raisedBedId, raisedBeds.id))
+        .leftJoin(gardens, eq(gardens.id, operationGardenIdExpression()))
+        .where(
+            and(
+                inArray(operations.raisedBedId, uniqueRaisedBedIds),
+                eq(operations.isDeleted, false),
+                operationLocationIntegrityWhere(),
+                gte(operations.timestamp, from),
+                lte(operations.timestamp, to),
+            ),
+        );
+    const operationIds = Array.from(
+        new Set([
+            ...scheduledRows.map((row) => row.id),
+            ...timestampRows.map((row) => row.id),
+        ]),
+    );
+
+    return getOperationsByIds(operationIds);
+}
+
 export async function getFarmUserAcceptedOperationById(
     userId: string,
     id: number,

--- a/packages/storage/src/repositories/raisedBedsRepo.ts
+++ b/packages/storage/src/repositories/raisedBedsRepo.ts
@@ -1,5 +1,14 @@
 import 'server-only';
-import { and, asc, count, eq, inArray, isNull, or } from 'drizzle-orm';
+import {
+    and,
+    asc,
+    count,
+    eq,
+    inArray,
+    isNotNull,
+    isNull,
+    or,
+} from 'drizzle-orm';
 import { storage } from '..';
 import {
     bustScheduleCache,
@@ -190,6 +199,39 @@ export async function getRaisedBedMetadataByIds(raisedBedIds: number[]) {
             ),
         )
         .orderBy(asc(raisedBeds.id));
+}
+
+export async function listActiveRaisedBedOperationTargets() {
+    const rows = await storage()
+        .select({
+            id: raisedBeds.id,
+            accountId: raisedBeds.accountId,
+            gardenId: raisedBeds.gardenId,
+        })
+        .from(raisedBeds)
+        .innerJoin(gardens, eq(gardens.id, raisedBeds.gardenId))
+        .where(
+            and(
+                eq(raisedBeds.status, 'active'),
+                eq(raisedBeds.isDeleted, false),
+                eq(gardens.isDeleted, false),
+                isNotNull(raisedBeds.accountId),
+                isNotNull(raisedBeds.gardenId),
+            ),
+        )
+        .orderBy(asc(raisedBeds.id));
+
+    return rows.flatMap((row) =>
+        row.accountId && row.gardenId
+            ? [
+                  {
+                      id: row.id,
+                      accountId: row.accountId,
+                      gardenId: row.gardenId,
+                  },
+              ]
+            : [],
+    );
 }
 
 async function getRaisedBedWeedStatesByIds(raisedBedIds: number[]) {

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -37,10 +37,12 @@ import {
     getFarms,
     getOperations,
     getRaisedBed,
+    getRaisedBedOperationsByScheduleRange,
     greenhouseSeedlingWateringAutomationGraph,
     greenhouseSeedlingWateringAutomationKey,
     knownEvents,
     knownEventTypes,
+    listActiveRaisedBedOperationTargets,
     listAutomationDefinitionRunSummaries,
     listAutomationDefinitions,
     listAutomationRuns,
@@ -52,6 +54,7 @@ import {
     plantRemovalOperationStatusAutomationKey,
     processDueAutomationRuns,
     RAISED_BED_WATERING_50L_OPERATION_ID,
+    raisedBedPhotoOperationsAutomationKey,
     recordAutomationRunStep,
     retryFailedAutomationRun,
     seasonalSowedWateringAutomationGraph,
@@ -62,6 +65,7 @@ import {
     storage,
     updateAutomationDefinition,
     updateEntity,
+    updateRaisedBed,
     upsertEntityType,
     upsertRaisedBedField,
     validateAutomationGraph,
@@ -253,10 +257,93 @@ function scheduleLogAutomationGraph(
     };
 }
 
+function raisedBedOperationsAutomationGraph({
+    entityId,
+    acceptOnCreate = true,
+}: {
+    entityId: number;
+    acceptOnCreate?: boolean;
+}): AutomationGraph {
+    return {
+        nodes: [
+            {
+                id: 'trigger',
+                kind: 'trigger',
+                moduleKey: automationModuleKeys.triggerSchedule,
+                position: { x: 0, y: 0 },
+                config: {
+                    frequency: 'weekly',
+                    daysOfWeek: ['tuesday', 'friday'],
+                    timeZone: 'Europe/Zagreb',
+                },
+            },
+            {
+                id: 'create-raised-bed-operations',
+                kind: 'action',
+                moduleKey: automationModuleKeys.actionCreateRaisedBedOperations,
+                position: { x: 320, y: 0 },
+                config: {
+                    entityId,
+                    entityTypeName: 'operation',
+                    scheduledInDays: 0,
+                    acceptOnCreate,
+                },
+            },
+        ],
+        edges: [
+            {
+                id: 'trigger-to-create-raised-bed-operations',
+                source: 'trigger',
+                target: 'create-raised-bed-operations',
+            },
+        ],
+    };
+}
+
 function addUtcDays(date: Date, days: number) {
     const nextDate = new Date(date);
     nextDate.setUTCDate(nextDate.getUTCDate() + days);
     return nextDate;
+}
+
+function weeklyScheduleInput(dateKey: string, dayOfWeek = 'tuesday') {
+    return {
+        scheduleType: 'weekly',
+        frequency: 'weekly',
+        triggerModuleKey: automationModuleKeys.triggerSchedule,
+        occurrenceKey: `${automationModuleKeys.triggerSchedule}:Europe/Zagreb:weekly:${dateKey}:${dayOfWeek}`,
+        occurrenceDate: dateKey,
+        dayOfWeek,
+        daysOfWeek: ['tuesday', 'friday'],
+        intervalWeeks: 1,
+        timeZone: 'Europe/Zagreb',
+        enqueuedAt: `${dateKey}T08:00:00.000Z`,
+    };
+}
+
+async function executeManualAutomationRun(
+    automationDefinition: Awaited<
+        ReturnType<typeof createAutomationDefinition>
+    >,
+    input: Record<string, unknown>,
+    options: { dryRun?: boolean } = {},
+) {
+    const run = await createAutomationRun({
+        automationDefinition,
+        source: 'manual',
+        dryRun: options.dryRun,
+        input,
+    });
+    assert.ok(run);
+    const startedRun = await startAutomationRun(run.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedRun);
+    const result = await executeAutomationRun(startedRun);
+    const runWithSteps = await getAutomationRunWithSteps(startedRun.id);
+    assert.ok(runWithSteps);
+
+    return { result, run: runWithSteps };
 }
 
 function monthlyScheduleRunInput(index: number) {
@@ -1623,6 +1710,299 @@ test('default farm raised-bed weeding automation filters farms and prevents dupl
             1,
         );
     }
+});
+
+test('default raised-bed photo automation enqueues only Tuesday and Friday occurrences', async () => {
+    createTestDb();
+    await ensureDefaultAutomationDefinitions();
+    const definition = await getAutomationDefinitionByKey(
+        raisedBedPhotoOperationsAutomationKey,
+    );
+    assert.ok(definition);
+    assert.strictEqual(definition.status, 'enabled');
+    const validation = validateAutomationGraph(definition.graph);
+    assert.strictEqual(validation.ok, true);
+
+    const definitions = await listAutomationDefinitions({ limit: 100 });
+    for (const candidate of definitions) {
+        if (candidate.id !== definition.id) {
+            await updateAutomationDefinition(candidate.id, {
+                status: 'disabled',
+            });
+        }
+    }
+
+    const wednesdayResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-06-24T08:00:00.000Z'),
+    });
+    assert.strictEqual(wednesdayResult.enqueuedRuns, 0);
+
+    const tuesdayResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-06-23T08:00:00.000Z'),
+    });
+    assert.strictEqual(tuesdayResult.enqueuedRuns, 1);
+
+    const duplicateTuesdayResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-06-23T09:00:00.000Z'),
+    });
+    assert.strictEqual(duplicateTuesdayResult.enqueuedRuns, 0);
+
+    const fridayResult = await enqueueAutomationRunsFromSchedules({
+        now: new Date('2026-06-26T08:00:00.000Z'),
+    });
+    assert.strictEqual(fridayResult.enqueuedRuns, 1);
+});
+
+test('raised-bed operation automation filters inactive deleted and abandoned raised beds', async (t) => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({
+        accountId,
+        farmId,
+        name: `Raised-bed photo filtering ${accountId}`,
+    });
+    const blockId = await createTestBlock(
+        gardenId,
+        `raised-bed-photo-filtering-${accountId}`,
+    );
+    const activeRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockId,
+    );
+    const secondActiveRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockId,
+    );
+    const inactiveRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockId,
+    );
+    const abandonedRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockId,
+    );
+    const deletedRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockId,
+    );
+    const createdRaisedBedIds = [
+        activeRaisedBedId,
+        secondActiveRaisedBedId,
+        inactiveRaisedBedId,
+        abandonedRaisedBedId,
+        deletedRaisedBedId,
+    ];
+    t.after(async () => {
+        for (const raisedBedId of createdRaisedBedIds) {
+            await updateRaisedBed({ id: raisedBedId, status: 'new' }).catch(
+                () => undefined,
+            );
+        }
+    });
+    await updateRaisedBed({ id: activeRaisedBedId, status: 'active' });
+    await updateRaisedBed({ id: secondActiveRaisedBedId, status: 'active' });
+    await updateRaisedBed({ id: inactiveRaisedBedId, status: 'new' });
+    await updateRaisedBed({ id: abandonedRaisedBedId, status: 'abandoned' });
+    await updateRaisedBed({ id: deletedRaisedBedId, status: 'active' });
+    await storage()
+        .update(raisedBeds)
+        .set({ isDeleted: true })
+        .where(eq(raisedBeds.id, deletedRaisedBedId));
+    const expectedRecipientCount = (await listActiveRaisedBedOperationTargets())
+        .length;
+
+    const entityId = 9_920_001;
+    const definition = await createAutomationDefinition({
+        key: 'test.raised-bed-photo-filtering',
+        name: 'Raised-bed photo filtering',
+        status: 'enabled',
+        graph: raisedBedOperationsAutomationGraph({ entityId }),
+    });
+
+    const { result, run } = await executeManualAutomationRun(
+        definition,
+        weeklyScheduleInput('2026-06-23'),
+    );
+
+    assert.strictEqual(result.status, 'succeeded');
+    const operations = await getRaisedBedOperationsByScheduleRange({
+        raisedBedIds: createdRaisedBedIds,
+        from: new Date('2026-06-23T00:00:00.000Z'),
+        to: new Date('2026-06-24T00:00:00.000Z'),
+    });
+    const photoOperations = operations
+        .filter((operation) => operation.entityId === entityId)
+        .sort(
+            (left, right) => (left.raisedBedId ?? 0) - (right.raisedBedId ?? 0),
+        );
+
+    assert.deepStrictEqual(
+        photoOperations.map((operation) => operation.raisedBedId),
+        [activeRaisedBedId, secondActiveRaisedBedId].sort(
+            (left, right) => left - right,
+        ),
+    );
+    assert.ok(photoOperations.every((operation) => operation.isAccepted));
+    assert.ok(
+        photoOperations.every(
+            (operation) => operation.raisedBedFieldId === null,
+        ),
+    );
+    assert.deepStrictEqual(
+        photoOperations.map((operation) =>
+            operation.scheduledDate?.toISOString(),
+        ),
+        ['2026-06-23T00:00:00.000Z', '2026-06-23T00:00:00.000Z'],
+    );
+
+    const actionStep = run.steps.find(
+        (step) =>
+            step.moduleKey ===
+            automationModuleKeys.actionCreateRaisedBedOperations,
+    );
+    assert.ok(actionStep);
+    assert.strictEqual(
+        Reflect.get(actionStep.output, 'recipientCount'),
+        expectedRecipientCount,
+    );
+    assert.strictEqual(
+        Reflect.get(actionStep.output, 'skippedExistingCount'),
+        0,
+    );
+});
+
+test('raised-bed operation automation reports existing skips and prevents duplicates', async (t) => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({
+        accountId,
+        farmId,
+        name: `Raised-bed photo duplicates ${accountId}`,
+    });
+    const blockId = await createTestBlock(
+        gardenId,
+        `raised-bed-photo-duplicates-${accountId}`,
+    );
+    const firstRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockId,
+    );
+    const secondRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockId,
+    );
+    t.after(async () => {
+        await updateRaisedBed({ id: firstRaisedBedId, status: 'new' }).catch(
+            () => undefined,
+        );
+        await updateRaisedBed({ id: secondRaisedBedId, status: 'new' }).catch(
+            () => undefined,
+        );
+    });
+    await updateRaisedBed({ id: firstRaisedBedId, status: 'active' });
+    await updateRaisedBed({ id: secondRaisedBedId, status: 'active' });
+    const expectedRecipientCount = (await listActiveRaisedBedOperationTargets())
+        .length;
+
+    const entityId = 9_920_002;
+    const scheduledDate = new Date('2026-06-23T00:00:00.000Z');
+    const preexistingOperationId = await createOperation({
+        entityId,
+        entityTypeName: 'operation',
+        accountId,
+        gardenId,
+        raisedBedId: firstRaisedBedId,
+        timestamp: scheduledDate,
+    });
+    await createEvent(
+        knownEvents.operations.scheduledV1(preexistingOperationId.toString(), {
+            scheduledDate: scheduledDate.toISOString(),
+        }),
+    );
+    const definition = await createAutomationDefinition({
+        key: 'test.raised-bed-photo-duplicates',
+        name: 'Raised-bed photo duplicates',
+        status: 'enabled',
+        graph: raisedBedOperationsAutomationGraph({ entityId }),
+    });
+
+    const dryRun = await executeManualAutomationRun(
+        definition,
+        weeklyScheduleInput('2026-06-23'),
+        { dryRun: true },
+    );
+    assert.strictEqual(dryRun.result.status, 'succeeded');
+    const dryRunActionStep = dryRun.run.steps.find(
+        (step) =>
+            step.moduleKey ===
+            automationModuleKeys.actionCreateRaisedBedOperations,
+    );
+    assert.ok(dryRunActionStep);
+    assert.strictEqual(
+        Reflect.get(dryRunActionStep.output, 'recipientCount'),
+        expectedRecipientCount,
+    );
+    assert.strictEqual(
+        Reflect.get(dryRunActionStep.output, 'skippedExistingCount'),
+        1,
+    );
+    assert.strictEqual(
+        Reflect.get(dryRunActionStep.output, 'projectedCreateCount'),
+        expectedRecipientCount - 1,
+    );
+
+    const firstRun = await executeManualAutomationRun(
+        definition,
+        weeklyScheduleInput('2026-06-23'),
+    );
+    assert.strictEqual(firstRun.result.status, 'succeeded');
+
+    const replayRun = await executeManualAutomationRun(
+        definition,
+        weeklyScheduleInput('2026-06-23'),
+    );
+    assert.strictEqual(replayRun.result.status, 'skipped');
+    const replayActionStep = replayRun.run.steps.find(
+        (step) =>
+            step.moduleKey ===
+            automationModuleKeys.actionCreateRaisedBedOperations,
+    );
+    assert.ok(replayActionStep);
+    assert.strictEqual(
+        Reflect.get(replayActionStep.output, 'recipientCount'),
+        expectedRecipientCount,
+    );
+    assert.strictEqual(
+        Reflect.get(replayActionStep.output, 'skippedExistingCount'),
+        expectedRecipientCount,
+    );
+
+    const operations = await getRaisedBedOperationsByScheduleRange({
+        raisedBedIds: [firstRaisedBedId, secondRaisedBedId],
+        from: new Date('2026-06-23T00:00:00.000Z'),
+        to: new Date('2026-06-24T00:00:00.000Z'),
+    });
+    const photoOperations = operations.filter(
+        (operation) => operation.entityId === entityId,
+    );
+    assert.strictEqual(photoOperations.length, 2);
+    assert.deepStrictEqual(
+        photoOperations
+            .map((operation) => operation.raisedBedId)
+            .sort((left, right) => (left ?? 0) - (right ?? 0)),
+        [firstRaisedBedId, secondRaisedBedId].sort(
+            (left, right) => left - right,
+        ),
+    );
 });
 
 test('default greenhouse seedling watering automation is enabled daily', async () => {

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -55,6 +55,7 @@ import {
     processDueAutomationRuns,
     RAISED_BED_WATERING_50L_OPERATION_ID,
     raisedBedPhotoOperationsAutomationKey,
+    raisedBeds,
     recordAutomationRunStep,
     retryFailedAutomationRun,
     seasonalSowedWateringAutomationGraph,
@@ -1094,7 +1095,7 @@ test('monthly schedule automation enqueues once per configured period', async ()
 
     assert.strictEqual(firstResult.enqueuedRuns, 2);
     assert.strictEqual(duplicateResult.enqueuedRuns, 0);
-    assert.strictEqual(offDayResult.enqueuedRuns, 1);
+    assert.strictEqual(offDayResult.enqueuedRuns, 2);
 
     const runs = await listAutomationRuns({
         automationDefinitionId: definition.id,
@@ -1137,7 +1138,7 @@ test('daily schedule automation enqueues once per local day and executes', async
         now: new Date('2026-06-24T08:00:00.000Z'),
     });
 
-    assert.strictEqual(firstResult.enqueuedRuns, 2);
+    assert.strictEqual(firstResult.enqueuedRuns, 3);
     assert.strictEqual(duplicateResult.enqueuedRuns, 0);
     assert.strictEqual(nextDayResult.enqueuedRuns, 2);
 
@@ -1155,12 +1156,17 @@ test('daily schedule automation enqueues once per local day and executes', async
         'daily',
     ]);
 
-    const processResult = await processDueAutomationRuns({
+    await processDueAutomationRuns({
         limit: 10,
         lockedBy: 'automations-test',
     });
-    assert.strictEqual(processResult.succeeded, 2);
-    assert.strictEqual(processResult.skipped, 2);
+    const processedRuns = await listAutomationRuns({
+        automationDefinitionId: definition.id,
+    });
+    assert.deepStrictEqual(processedRuns.map((run) => run.status).sort(), [
+        'succeeded',
+        'succeeded',
+    ]);
 });
 
 test('weekly schedule automation supports selected weekdays', async () => {
@@ -1190,9 +1196,9 @@ test('weekly schedule automation supports selected weekdays', async () => {
     });
 
     assert.strictEqual(offDayResult.enqueuedRuns, 1);
-    assert.strictEqual(tuesdayResult.enqueuedRuns, 2);
+    assert.strictEqual(tuesdayResult.enqueuedRuns, 3);
     assert.strictEqual(duplicateTuesdayResult.enqueuedRuns, 0);
-    assert.strictEqual(fridayResult.enqueuedRuns, 2);
+    assert.strictEqual(fridayResult.enqueuedRuns, 3);
 
     const runs = await listAutomationRuns({
         automationDefinitionId: definition.id,
@@ -1235,9 +1241,9 @@ test('biweekly schedule automation respects anchor week', async () => {
             now: new Date('2026-06-16T09:00:00.000Z'),
         });
 
-    assert.strictEqual(firstWeekResult.enqueuedRuns, 2);
-    assert.strictEqual(skippedWeekResult.enqueuedRuns, 1);
-    assert.strictEqual(secondOccurrenceResult.enqueuedRuns, 2);
+    assert.strictEqual(firstWeekResult.enqueuedRuns, 3);
+    assert.strictEqual(skippedWeekResult.enqueuedRuns, 2);
+    assert.strictEqual(secondOccurrenceResult.enqueuedRuns, 3);
     assert.strictEqual(duplicateSecondOccurrenceResult.enqueuedRuns, 0);
 
     const runs = await listAutomationRuns({
@@ -1731,26 +1737,32 @@ test('default raised-bed photo automation enqueues only Tuesday and Friday occur
             });
         }
     }
+    const getPhotoRunCount = async () =>
+        (
+            await listAutomationRuns({
+                automationDefinitionId: definition.id,
+            })
+        ).length;
 
-    const wednesdayResult = await enqueueAutomationRunsFromSchedules({
+    await enqueueAutomationRunsFromSchedules({
         now: new Date('2026-06-24T08:00:00.000Z'),
     });
-    assert.strictEqual(wednesdayResult.enqueuedRuns, 0);
+    assert.strictEqual(await getPhotoRunCount(), 0);
 
-    const tuesdayResult = await enqueueAutomationRunsFromSchedules({
+    await enqueueAutomationRunsFromSchedules({
         now: new Date('2026-06-23T08:00:00.000Z'),
     });
-    assert.strictEqual(tuesdayResult.enqueuedRuns, 1);
+    assert.strictEqual(await getPhotoRunCount(), 1);
 
-    const duplicateTuesdayResult = await enqueueAutomationRunsFromSchedules({
+    await enqueueAutomationRunsFromSchedules({
         now: new Date('2026-06-23T09:00:00.000Z'),
     });
-    assert.strictEqual(duplicateTuesdayResult.enqueuedRuns, 0);
+    assert.strictEqual(await getPhotoRunCount(), 1);
 
-    const fridayResult = await enqueueAutomationRunsFromSchedules({
+    await enqueueAutomationRunsFromSchedules({
         now: new Date('2026-06-26T08:00:00.000Z'),
     });
-    assert.strictEqual(fridayResult.enqueuedRuns, 1);
+    assert.strictEqual(await getPhotoRunCount(), 2);
 });
 
 test('raised-bed operation automation filters inactive deleted and abandoned raised beds', async (t) => {
@@ -2002,6 +2014,113 @@ test('raised-bed operation automation reports existing skips and prevents duplic
         [firstRaisedBedId, secondRaisedBedId].sort(
             (left, right) => left - right,
         ),
+    );
+});
+
+test('raised-bed operation automation repairs partial existing operations on retry', async (t) => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({
+        accountId,
+        farmId,
+        name: `Raised-bed photo repair ${accountId}`,
+    });
+    const blockId = await createTestBlock(
+        gardenId,
+        `raised-bed-photo-repair-${accountId}`,
+    );
+    const firstRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockId,
+    );
+    const secondRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        blockId,
+    );
+    t.after(async () => {
+        await updateRaisedBed({ id: firstRaisedBedId, status: 'new' }).catch(
+            () => undefined,
+        );
+        await updateRaisedBed({ id: secondRaisedBedId, status: 'new' }).catch(
+            () => undefined,
+        );
+    });
+    await updateRaisedBed({ id: firstRaisedBedId, status: 'active' });
+    await updateRaisedBed({ id: secondRaisedBedId, status: 'active' });
+    const expectedRecipientCount = (await listActiveRaisedBedOperationTargets())
+        .length;
+
+    const entityId = 9_920_003;
+    const scheduledDate = new Date('2026-06-23T00:00:00.000Z');
+    const partialOperationId = await createOperation({
+        entityId,
+        entityTypeName: 'operation',
+        accountId,
+        gardenId,
+        raisedBedId: firstRaisedBedId,
+        timestamp: scheduledDate,
+    });
+    const definition = await createAutomationDefinition({
+        key: 'test.raised-bed-photo-repair',
+        name: 'Raised-bed photo repair',
+        status: 'enabled',
+        graph: raisedBedOperationsAutomationGraph({ entityId }),
+    });
+
+    const { result, run } = await executeManualAutomationRun(
+        definition,
+        weeklyScheduleInput('2026-06-23'),
+    );
+
+    assert.strictEqual(result.status, 'succeeded');
+    const actionStep = run.steps.find(
+        (step) =>
+            step.moduleKey ===
+            automationModuleKeys.actionCreateRaisedBedOperations,
+    );
+    assert.ok(actionStep);
+    assert.strictEqual(
+        Reflect.get(actionStep.output, 'recipientCount'),
+        expectedRecipientCount,
+    );
+    assert.strictEqual(
+        Reflect.get(actionStep.output, 'skippedExistingCount'),
+        1,
+    );
+    assert.strictEqual(
+        Reflect.get(actionStep.output, 'createdCount'),
+        expectedRecipientCount - 1,
+    );
+    assert.deepStrictEqual(
+        Reflect.get(actionStep.output, 'repairedAcceptedOperationIds'),
+        [partialOperationId],
+    );
+    assert.deepStrictEqual(
+        Reflect.get(actionStep.output, 'repairedScheduledOperationIds'),
+        [partialOperationId],
+    );
+
+    const operations = await getRaisedBedOperationsByScheduleRange({
+        raisedBedIds: [firstRaisedBedId, secondRaisedBedId],
+        from: new Date('2026-06-23T00:00:00.000Z'),
+        to: new Date('2026-06-24T00:00:00.000Z'),
+    });
+    const photoOperations = operations.filter(
+        (operation) => operation.entityId === entityId,
+    );
+    assert.strictEqual(photoOperations.length, 2);
+
+    const repairedOperation = photoOperations.find(
+        (operation) => operation.id === partialOperationId,
+    );
+    assert.ok(repairedOperation);
+    assert.strictEqual(repairedOperation.isAccepted, true);
+    assert.strictEqual(
+        repairedOperation.scheduledDate?.toISOString(),
+        scheduledDate.toISOString(),
     );
 });
 


### PR DESCRIPTION
## Summary
- Add a reusable `action.createRaisedBedOperations` automation module that creates accepted raised-bed-scoped operations for active raised beds only.
- Add the managed Tuesday/Friday raised-bed photo automation using `trigger.schedule` with `daysOfWeek: ["tuesday", "friday"]`.
- Keep duplicate prevention scoped to raised bed, operation entity, and occurrence day, and expose `recipientCount`, `projectedCreateCount`, and `skippedExistingCount` in dry-run output.
- Document the new module/default and add admin presentation labels.

## Live operation resolution
- Queried live/admin operation directory data after pulling Vercel development env.
- Resolved the current raised-bed photo operation as entity `301`, name `raisedBedFullPhoto`, label `Fotografiranje gredice`, with `completionAttachImages=true`, `completionAttachImagesRequired=true`, and `visualReward=photographyUpdate`.

## Validation
- `pnpm --filter @gredice/storage test -- automationsRepo.node.spec.ts`
- `pnpm --filter @gredice/storage lint`
- `pnpm --filter app lint`
- `pnpm typecheck --filter @gredice/storage` (no configured storage typecheck task)
- `pnpm typecheck --filter app`
- `pnpm build --filter app`
- `pnpm build --filter api`
- `git diff --check`

Closes #3706
