### PR TITLE
fix(storage): page event projection reads

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -29,9 +29,9 @@ import {
     GardenDiaryRescheduleError,
     getAccount,
     getAccountGardensMetadata,
+    getAllEvents,
     getAppliedRaisedBedOperationsForGarden,
     getEntitiesFormatted,
-    getEvents,
     getGarden,
     getGardenBlocks,
     getGardenStack,
@@ -963,7 +963,6 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const [garden, /*blockPlaceEventsRaw,*/ blocks, operations] =
                 await Promise.all([
                     getGarden(gardenIdNumber),
-                    // getEvents(knownEventTypes.gardens.blockPlace, gardenId, 0, 10000),
                     getGardenBlocks(gardenIdNumber),
                     getAppliedRaisedBedOperationsForGarden(
                         accountId,
@@ -988,11 +987,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 .map((raisedBed) => raisedBed.id.toString());
             const raisedBedAbandonEvents =
                 abandonedRaisedBedAggregateIds.length > 0
-                    ? await getEvents(
+                    ? await getAllEvents(
                           knownEventTypes.raisedBeds.abandon,
                           abandonedRaisedBedAggregateIds,
-                          0,
-                          10000,
                       )
                     : [];
             const abandonReasonByRaisedBedId = raisedBedAbandonEvents.reduce(
@@ -1141,12 +1138,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
             // TODO: Refactor to use a single function for public and non-public garden retrieval
             const [garden, blockPlaceEventsRaw, blocks] = await Promise.all([
                 getGarden(gardenIdNumber),
-                getEvents(
-                    knownEventTypes.gardens.blockPlace,
-                    [gardenId],
-                    0,
-                    10000,
-                ),
+                getAllEvents(knownEventTypes.gardens.blockPlace, [gardenId]),
                 getGardenBlocks(gardenIdNumber),
             ]);
             if (!garden) {

--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -4,6 +4,7 @@ import { asc, desc, eq } from 'drizzle-orm';
 import { accounts, accountUsers, ensureAccountAchievement, storage } from '..';
 import {
     createEvent,
+    getAllEvents,
     getEvents,
     knownEvents,
     knownEventTypes,
@@ -123,7 +124,7 @@ export async function updateAccountTimeZone(
 export async function getSunflowers(accountId: string) {
     // Calculate sunflowers based on events
     let currentSunflowers = 0;
-    const events = await getEvents(
+    const events = await getAllEvents(
         [
             knownEventTypes.accounts.earnSunflowers,
             knownEventTypes.accounts.earnSunflowerDrop,

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -40,7 +40,7 @@ import { getDeliveryAddress } from './deliveryAddressesRepo';
 import { getEntitiesFormatted, getEntityFormatted } from './entitiesRepo';
 import {
     createEvent,
-    getEvents,
+    getAllEvents,
     knownEvents,
     knownEventTypes,
 } from './eventsRepo';
@@ -50,7 +50,7 @@ import { getOperationById, getOperationsByIds } from './operationsRepo';
 import { getPickupLocation } from './pickupLocationsRepo';
 import { closeTimeSlot, getTimeSlot } from './timeSlotsRepo';
 
-type DbEvent = Awaited<ReturnType<typeof getEvents>>[number];
+type DbEvent = Awaited<ReturnType<typeof getAllEvents>>[number];
 type DeliveryTraceLink = Awaited<
     ReturnType<typeof getHarvestTraceLinksForOperationIds>
 >[number];
@@ -352,11 +352,9 @@ async function reconstructDeliveryRequestRows<
         return [];
     }
 
-    const requestEvents = await getEvents(
+    const requestEvents = await getAllEvents(
         deliveryRequestEventTypes,
         requests.map((request) => request.id),
-        0,
-        100000,
     );
     const eventsByAggregateId = groupEventsByAggregateId(requestEvents);
     const reconstructedRows = requests.map((request) => {
@@ -951,23 +949,7 @@ export async function getDeliveryRequest(
     if (!request) return undefined;
 
     // Get events for this request
-    const events = await getEvents(
-        [
-            knownEventTypes.delivery.requestCreated,
-            knownEventTypes.delivery.requestCancelled,
-            knownEventTypes.delivery.requestAddressChanged,
-            knownEventTypes.delivery.requestConfirmed,
-            knownEventTypes.delivery.requestPreparing,
-            knownEventTypes.delivery.requestReady,
-            knownEventTypes.delivery.requestFulfilled,
-            knownEventTypes.delivery.requestSurveySent,
-            knownEventTypes.delivery.requestSlotChanged,
-            knownEventTypes.delivery.userCancelled,
-        ],
-        [request.id],
-        0,
-        100000,
-    );
+    const events = await getAllEvents(deliveryRequestEventTypes, [request.id]);
 
     return reconstructDeliveryRequestFromEvents(request, events);
 }
@@ -1000,23 +982,7 @@ export async function getDeliveryRequestByOperation(
     if (!request) return undefined;
 
     // Get events and reconstruct state
-    const events = await getEvents(
-        [
-            knownEventTypes.delivery.requestCreated,
-            knownEventTypes.delivery.requestCancelled,
-            knownEventTypes.delivery.requestAddressChanged,
-            knownEventTypes.delivery.requestConfirmed,
-            knownEventTypes.delivery.requestPreparing,
-            knownEventTypes.delivery.requestReady,
-            knownEventTypes.delivery.requestFulfilled,
-            knownEventTypes.delivery.requestSurveySent,
-            knownEventTypes.delivery.requestSlotChanged,
-            knownEventTypes.delivery.userCancelled,
-        ],
-        [request.id],
-        0,
-        100000,
-    );
+    const events = await getAllEvents(deliveryRequestEventTypes, [request.id]);
 
     return reconstructDeliveryRequestFromEvents(request, events);
 }

--- a/packages/storage/src/repositories/inventoryRepo.ts
+++ b/packages/storage/src/repositories/inventoryRepo.ts
@@ -1,7 +1,12 @@
 import { and, eq, gte, sql } from 'drizzle-orm';
 import { events } from '../schema';
 import { storage } from '../storage';
-import { createEvent, getEvents, knownEvents, knownEventTypes } from './events';
+import {
+    createEvent,
+    getAllEvents,
+    knownEvents,
+    knownEventTypes,
+} from './events';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = Parameters<
@@ -139,12 +144,10 @@ async function getInventoryForAggregateIds(
         return [];
     }
 
-    const inventoryEvents = await getEvents(
+    const inventoryEvents = await getAllEvents(
         [knownEventTypes.inventory.add, knownEventTypes.inventory.consume],
         aggregateIds,
-        0,
-        5000,
-        db,
+        { db },
     );
 
     const totals = new Map<string, InventoryItem>();

--- a/packages/storage/src/repositories/raisedBedDiaryRepo.ts
+++ b/packages/storage/src/repositories/raisedBedDiaryRepo.ts
@@ -2,7 +2,7 @@ import 'server-only';
 import { plantFieldStatusLabel } from '@gredice/js/plants';
 import { getEntitiesFormatted, getOperations } from '..';
 import type { EntityStandardized } from '../@types/EntityStandardized';
-import { getEvents, knownEventTypes } from './eventsRepo';
+import { getAllEvents, knownEventTypes } from './eventsRepo';
 import type { getRaisedBedFieldsWithEvents } from './raisedBedFieldsRepo';
 import { getRaisedBed } from './raisedBedsRepo';
 
@@ -13,7 +13,7 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
     }
 
     const [events, operationsData, operations] = await Promise.all([
-        getEvents(
+        getAllEvents(
             [
                 knownEventTypes.raisedBeds.create,
                 knownEventTypes.raisedBeds.aiAnalysis,
@@ -21,8 +21,6 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
                 knownEventTypes.raisedBeds.abandon,
             ],
             [raisedBedId.toString()],
-            0,
-            10000,
         ),
         getEntitiesFormatted<EntityStandardized>('operation'),
         // TODO: Maybe retrieve operations from other accounts as well, but anonimized
@@ -128,7 +126,7 @@ export async function getRaisedBedFieldDiaryEntries(
         (f) => f.positionIndex === positionIndex,
     );
     const [events, operationsData, operations] = await Promise.all([
-        getEvents(
+        getAllEvents(
             [
                 knownEventTypes.raisedBedFields.create,
                 knownEventTypes.raisedBedFields.plantPlace,
@@ -139,8 +137,6 @@ export async function getRaisedBedFieldDiaryEntries(
                 knownEventTypes.raisedBedFields.delete,
             ],
             [`${raisedBedId.toString()}|${positionIndex.toString()}`],
-            0,
-            10000,
         ),
         getEntitiesFormatted<EntityStandardized>('operation'),
         // TODO: Maybe retrieve operations from other accounts as well, but anonimized
@@ -363,14 +359,12 @@ export async function getRaisedBedAiHistoryEntries(raisedBedId: number) {
         ),
     ];
 
-    const events = await getEvents(
+    const events = await getAllEvents(
         [
             knownEventTypes.raisedBeds.aiAnalysis,
             knownEventTypes.raisedBedFields.aiAnalysis,
         ],
         aggregateIds,
-        0,
-        10000,
     );
 
     return events

--- a/packages/storage/src/repositories/raisedBedFieldsRepo.ts
+++ b/packages/storage/src/repositories/raisedBedFieldsRepo.ts
@@ -19,7 +19,6 @@ import { normalizeAssignedUserIds } from './events/normalizeAssignedUserIds';
 import {
     createEvent,
     getAllEvents,
-    getEvents,
     knownEvents,
     knownEventTypes,
     type RaisedBedFieldSowingLocation,
@@ -1031,11 +1030,9 @@ export async function updateActiveRaisedBedFieldPlantStatusEventCreatedAt({
     createdAt: Date;
 }) {
     const aggregateId = `${raisedBedId.toString()}|${positionIndex.toString()}`;
-    const plantEvents = await getEvents(
+    const plantEvents = await getAllEvents(
         [...PLANT_CYCLE_EVENT_TYPES],
         [aggregateId],
-        0,
-        100000,
     );
     const activePlantCycleEvents = splitPlantCycleEvents(plantEvents).find(
         (plantCycleEvents) => {

--- a/packages/storage/src/repositories/raisedBedsRepo.ts
+++ b/packages/storage/src/repositories/raisedBedsRepo.ts
@@ -28,7 +28,7 @@ import {
 } from '../schema/gardenSchema';
 import {
     createEvent,
-    getEvents,
+    getAllEvents,
     knownEvents,
     knownEventTypes,
     type RaisedBedWeedStateLevel,
@@ -199,11 +199,9 @@ async function getRaisedBedWeedStatesByIds(raisedBedIds: number[]) {
         return weedStatesByRaisedBedId;
     }
 
-    const weedStateEvents = await getEvents(
+    const weedStateEvents = await getAllEvents(
         knownEventTypes.raisedBeds.weedStateSet,
         uniqueRaisedBedIds.map((raisedBedId) => raisedBedId.toString()),
-        0,
-        100000,
     );
 
     const eventsByRaisedBedId = new Map<

--- a/packages/storage/src/repositories/sunflowerDropsRepo.ts
+++ b/packages/storage/src/repositories/sunflowerDropsRepo.ts
@@ -2,7 +2,12 @@ import { randomUUID } from 'node:crypto';
 import { and, eq, sql } from 'drizzle-orm';
 import { events } from '../schema';
 import { storage } from '../storage';
-import { createEvent, getEvents, knownEvents, knownEventTypes } from './events';
+import {
+    createEvent,
+    getAllEvents,
+    knownEvents,
+    knownEventTypes,
+} from './events';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = Parameters<
@@ -117,15 +122,13 @@ async function lockSunflowerDrops(accountId: string, db: DatabaseClient) {
 }
 
 async function getSunflowerDropEvents(accountId: string, db: DatabaseClient) {
-    return getEvents(
+    return getAllEvents(
         [
             knownEventTypes.accounts.sunflowerDropSpawn,
             knownEventTypes.accounts.earnSunflowerDrop,
         ],
         [accountId],
-        0,
-        5000,
-        db,
+        { db },
     );
 }
 

--- a/packages/storage/src/repositories/tutorialChecklistRepo.ts
+++ b/packages/storage/src/repositories/tutorialChecklistRepo.ts
@@ -11,7 +11,12 @@ import {
 } from './accountsRepo';
 import { getAccountAchievements } from './achievementsRepo';
 import { getDeliveryAddresses } from './deliveryAddressesRepo';
-import { createEvent, getEvents, knownEventTypes } from './eventsRepo';
+import {
+    createEvent,
+    getAllEvents,
+    getEvents,
+    knownEventTypes,
+} from './eventsRepo';
 import { getAccountGardens } from './gardensRepo';
 import { getOperations } from './operationsRepo';
 import { getAccountReferralState } from './referralsRepo';
@@ -608,7 +613,7 @@ function getManualReadyTaskKey(value: unknown) {
 }
 
 async function getManualReadyTaskKeys(accountId: string) {
-    const readyEvents = await getEvents(
+    const readyEvents = await getAllEvents(
         knownEventTypes.tutorialChecklist.taskReady,
         [accountId],
     );


### PR DESCRIPTION
## Summary
- Replace fixed-limit event reads with `getAllEvents` for event-sourced projections that need complete history.
- Cover account sunflower balance, delivery request reconstruction, inventory totals, raised-bed diary/AI history, raised-bed field active-cycle updates, raised-bed weed states, sunflower drops, tutorial manual-ready tasks, and garden API event projections.
- Leave intentional pagination/existence reads on `getEvents`: sunflower history, operation page loop, and tutorial garden-renamed probe.

## Validation
- `pnpm --filter @gredice/storage test:node -- eventsRepo.node.spec.ts accountsRepo.node.spec.ts deliveryRequestsRepo.node.spec.ts inventoryRepo.node.spec.ts sunflowerDropsRepo.node.spec.ts tutorialChecklistRepo.node.spec.ts gardensRepo.node.spec.ts gardensRepo.raisedBedFields.node.spec.ts gardenDiaryRescheduleRepo.node.spec.ts`
- `pnpm lint --filter @gredice/storage`
- `pnpm lint --filter api`
- `git diff --check origin/main...HEAD`

## Notes
- `pnpm --filter @gredice/storage exec tsc --noEmit --pretty false` is blocked by pre-existing unrelated errors in storage scripts/tests.
- `pnpm --filter api exec tsc --noEmit --pretty false` is blocked by a pre-existing optional-parameter error in `lib/notifications/webPushSender.node.spec.ts`.
