### PR TITLE
[codex] Make spendSunflowers concurrency-safe

### DIFF
--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { randomUUID } from 'node:crypto';
-import { asc, desc, eq } from 'drizzle-orm';
+import { asc, desc, eq, sql } from 'drizzle-orm';
 import { accounts, accountUsers, ensureAccountAchievement, storage } from '..';
 import {
     createEvent,
@@ -198,13 +198,22 @@ export async function spendSunflowers(
     reason: string,
     db: ReturnType<typeof storage> = storage(),
 ) {
-    const currentSunflowers = await getSunflowers(accountId);
-    if (currentSunflowers < amount) {
-        throw new Error('Insufficient sunflowers');
-    }
+    await db.transaction(async (tx) => {
+        await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtext(${`account-sunflowers:${accountId}`}));`,
+        );
 
-    await createEvent(
-        knownEvents.accounts.sunflowersSpentV1(accountId, { amount, reason }),
-        db,
-    );
+        const currentSunflowers = await getSunflowers(accountId);
+        if (currentSunflowers < amount) {
+            throw new Error('Insufficient sunflowers');
+        }
+
+        await createEvent(
+            knownEvents.accounts.sunflowersSpentV1(accountId, {
+                amount,
+                reason,
+            }),
+            tx,
+        );
+    });
 }

--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -121,7 +121,10 @@ export async function updateAccountTimeZone(
     return result[0];
 }
 
-export async function getSunflowers(accountId: string) {
+export async function getSunflowers(
+    accountId: string,
+    db: ReturnType<typeof storage> = storage(),
+) {
     // Calculate sunflowers based on events
     let currentSunflowers = 0;
     const events = await getAllEvents(
@@ -131,6 +134,7 @@ export async function getSunflowers(accountId: string) {
             knownEventTypes.accounts.spendSunflowers,
         ],
         [accountId],
+        { db },
     );
     for (const event of events) {
         const { amount } = parseSunflowerEventData(event.data);
@@ -203,7 +207,7 @@ export async function spendSunflowers(
             sql`select pg_advisory_xact_lock(hashtext(${`account-sunflowers:${accountId}`}));`,
         );
 
-        const currentSunflowers = await getSunflowers(accountId);
+        const currentSunflowers = await getSunflowers(accountId, tx);
         if (currentSunflowers < amount) {
             throw new Error('Insufficient sunflowers');
         }

--- a/packages/storage/tests/accountsRepo.node.spec.ts
+++ b/packages/storage/tests/accountsRepo.node.spec.ts
@@ -13,6 +13,108 @@ import {
 import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
+function createInsertBarrierDb(
+    db: ReturnType<typeof createTestDb>,
+    releaseAfter: number,
+) {
+    let waitingInserts = 0;
+    let releaseBarrier = () => {};
+    const barrier = new Promise<void>((resolve) => {
+        releaseBarrier = resolve;
+    });
+
+    return new Proxy(db, {
+        get(target, property, receiver) {
+            if (property !== 'insert') {
+                const value = Reflect.get(target, property, receiver);
+                return typeof value === 'function' ? value.bind(target) : value;
+            }
+
+            return (...insertArgs: unknown[]) => {
+                const insertBuilder = Reflect.apply(
+                    target.insert,
+                    target,
+                    insertArgs,
+                );
+
+                return new Proxy(insertBuilder, {
+                    get(insertTarget, insertProperty, insertReceiver) {
+                        if (insertProperty !== 'values') {
+                            const value = Reflect.get(
+                                insertTarget,
+                                insertProperty,
+                                insertReceiver,
+                            );
+                            return typeof value === 'function'
+                                ? value.bind(insertTarget)
+                                : value;
+                        }
+
+                        return (...valuesArgs: unknown[]) => {
+                            const valuesBuilder = Reflect.apply(
+                                Reflect.get(
+                                    insertTarget,
+                                    insertProperty,
+                                    insertReceiver,
+                                ),
+                                insertTarget,
+                                valuesArgs,
+                            );
+                            if (
+                                !valuesBuilder ||
+                                typeof valuesBuilder !== 'object'
+                            ) {
+                                throw new Error(
+                                    'Expected insert values builder.',
+                                );
+                            }
+
+                            return new Proxy(valuesBuilder, {
+                                get(
+                                    valuesTarget,
+                                    valuesProperty,
+                                    valuesReceiver,
+                                ) {
+                                    if (valuesProperty !== 'returning') {
+                                        const value = Reflect.get(
+                                            valuesTarget,
+                                            valuesProperty,
+                                            valuesReceiver,
+                                        );
+                                        return typeof value === 'function'
+                                            ? value.bind(valuesTarget)
+                                            : value;
+                                    }
+
+                                    return async (
+                                        ...returningArgs: unknown[]
+                                    ) => {
+                                        waitingInserts += 1;
+                                        if (waitingInserts === releaseAfter) {
+                                            releaseBarrier();
+                                        }
+                                        await barrier;
+
+                                        return Reflect.apply(
+                                            Reflect.get(
+                                                valuesTarget,
+                                                valuesProperty,
+                                                valuesReceiver,
+                                            ),
+                                            valuesTarget,
+                                            returningArgs,
+                                        );
+                                    };
+                                },
+                            });
+                        };
+                    },
+                });
+            };
+        },
+    });
+}
+
 test('createAccount creates a new account', async () => {
     createTestDb();
     const accountId = await createTestAccount();
@@ -83,6 +185,36 @@ test('spendSunflowers throws if insufficient sunflowers', async () => {
         () => spendSunflowers(accountId, 2000, 'fail'),
         /Insufficient sunflowers/,
     );
+});
+
+test('spendSunflowers rejects one concurrent overspend', async () => {
+    const db = createInsertBarrierDb(createTestDb(), 2);
+    const accountId = await createTestAccount();
+    const results = await Promise.allSettled([
+        spendSunflowers(accountId, 700, 'concurrent-a', db),
+        spendSunflowers(accountId, 700, 'concurrent-b', db),
+    ]);
+
+    assert.strictEqual(
+        results.filter((result) => result.status === 'fulfilled').length,
+        1,
+    );
+    const rejected = results.filter((result) => result.status === 'rejected');
+    assert.strictEqual(rejected.length, 1);
+    assert.ok(rejected[0].reason instanceof Error);
+    assert.strictEqual(rejected[0].reason.message, 'Insufficient sunflowers');
+
+    const sunflowers = await getSunflowers(accountId);
+    assert.strictEqual(sunflowers, 300);
+});
+
+test('spendSunflowers allows sequential spends', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    await spendSunflowers(accountId, 200, 'first-spend');
+    await spendSunflowers(accountId, 300, 'second-spend');
+    const sunflowers = await getSunflowers(accountId);
+    assert.strictEqual(sunflowers, 500);
 });
 
 test('getSunflowersHistory returns correct history', async () => {


### PR DESCRIPTION
## Summary

- Wrap `spendSunflowers` in a Postgres transaction-scoped advisory lock keyed by account.
- Keep the balance check and spend event write inside the serialized lock path, with the event written through the transaction handle.
- Add a deterministic concurrent overspend regression test plus a sequential-spend guard.

## Root cause

`spendSunflowers` read the event-sourced balance and then wrote the spend event without serialization, so concurrent spenders could both pass the same pre-spend balance check.

## Validation

- `pnpm install`
- Baseline regression proof: `pnpm --filter @gredice/storage run test:node accountsRepo.node.spec.ts` failed on the unmodified function with both concurrent spend calls fulfilled (`2 !== 1`).
- `pnpm lint --filter @gredice/storage`
- `pnpm test --filter @gredice/storage` (369 passing)
- `pnpm typecheck --filter @gredice/storage` (exit 0; Turbo reports no tasks for this package)
- `pnpm typecheck --filter api` (exit 0; API package has no own typecheck task, so Turbo only ran dependency typechecks)

Fixes #3410