### PR TITLE
[codex] Order operation diaries by task date

### DIFF
--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -57,6 +57,7 @@ import {
 } from '../hooks/useShoppingCart';
 import { ScrollView } from '../shared-ui/ScrollView';
 import { useShoppingCartOpenParam } from '../useUrlState';
+import { sortOperationTasksNewestFirst } from './gardenOperationOrdering';
 import { RaisedBedDiaryCancelAction } from './raisedBed/RaisedBedDiaryCancelAction';
 import { RaisedBedDiaryRescheduleAction } from './raisedBed/RaisedBedDiaryRescheduleAction';
 
@@ -1629,36 +1630,8 @@ function HistoryModal({
     );
 }
 
-function getLatestOperationChangeTime(operation: GardenOperationHudItem) {
-    let latest = new Date(operation.createdAt).getTime();
-
-    for (const entry of operation.statusHistory) {
-        const changedAt = new Date(entry.changedAt).getTime();
-        if (Number.isFinite(changedAt) && changedAt > latest) {
-            latest = changedAt;
-        }
-    }
-
-    return latest;
-}
-
 export function sortNewestFirst(operations: GardenOperationHudItem[]) {
-    return [...operations].sort((a, b) => {
-        const dateDiff =
-            getLatestOperationChangeTime(b) - getLatestOperationChangeTime(a);
-
-        return dateDiff !== 0 ? dateDiff : b.id - a.id;
-    });
-}
-
-function sortScheduledSoonestFirst(operations: GardenOperationHudItem[]) {
-    return [...operations].sort((a, b) => {
-        const aDate = new Date(a.scheduledDate ?? a.createdAt).getTime();
-        const bDate = new Date(b.scheduledDate ?? b.createdAt).getTime();
-        const dateDiff = aDate - bDate;
-
-        return dateDiff !== 0 ? dateDiff : a.id - b.id;
-    });
+    return sortOperationTasksNewestFirst(operations);
 }
 
 export function GardenOperationsHud() {
@@ -1715,7 +1688,7 @@ export function GardenOperationsHud() {
 
     const pendingOperations = useMemo(
         () =>
-            sortScheduledSoonestFirst(
+            sortNewestFirst(
                 [
                     ...(pending.data?.pages.flatMap((page) => page.items) ??
                         []),
@@ -1798,10 +1771,10 @@ export function GardenOperationsHud() {
             })
             .sort((a, b) => {
                 const dateDiff =
-                    getTimestamp(a.scheduledDate) -
-                    getTimestamp(b.scheduledDate);
+                    getTimestamp(b.scheduledDate) -
+                    getTimestamp(a.scheduledDate);
 
-                return dateDiff !== 0 ? dateDiff : a.item.id - b.item.id;
+                return dateDiff !== 0 ? dateDiff : b.item.id - a.item.id;
             });
     }, [cart?.items, currentGarden, operationDataById]);
     const activeOperationCount =

--- a/packages/game/src/hud/gardenOperationOrdering.ts
+++ b/packages/game/src/hud/gardenOperationOrdering.ts
@@ -1,0 +1,51 @@
+type OperationOrderingItem = {
+    id: number;
+    createdAt: string;
+    scheduledDate: string | null;
+    completedAt: string | null;
+    verifiedAt: string | null;
+    canceledAt: string | null;
+    statusHistory: {
+        changedAt: string;
+    }[];
+};
+
+function getTimestamp(value: string | Date | null | undefined) {
+    const timestamp = value ? new Date(value).getTime() : 0;
+    return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function getLatestOperationChangeTime(operation: OperationOrderingItem) {
+    let latest = getTimestamp(operation.createdAt);
+
+    for (const entry of operation.statusHistory) {
+        const changedAt = getTimestamp(entry.changedAt);
+        if (changedAt > latest) {
+            latest = changedAt;
+        }
+    }
+
+    return latest;
+}
+
+export function getOperationOrderingTime(operation: OperationOrderingItem) {
+    return (
+        getTimestamp(operation.scheduledDate) ||
+        getTimestamp(operation.verifiedAt) ||
+        getTimestamp(operation.completedAt) ||
+        getTimestamp(operation.canceledAt) ||
+        getLatestOperationChangeTime(operation) ||
+        getTimestamp(operation.createdAt)
+    );
+}
+
+export function sortOperationTasksNewestFirst<
+    Operation extends OperationOrderingItem,
+>(operations: Operation[]) {
+    return [...operations].sort((a, b) => {
+        const dateDiff =
+            getOperationOrderingTime(b) - getOperationOrderingTime(a);
+
+        return dateDiff !== 0 ? dateDiff : b.id - a.id;
+    });
+}

--- a/packages/game/src/hud/gardenOperationOrdering.unit.ts
+++ b/packages/game/src/hud/gardenOperationOrdering.unit.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { sortOperationTasksNewestFirst } from './gardenOperationOrdering';
+
+function operation({
+    canceledAt = null,
+    completedAt = null,
+    createdAt,
+    id,
+    scheduledDate = null,
+    statusHistory = [],
+    verifiedAt = null,
+}: {
+    canceledAt?: string | null;
+    completedAt?: string | null;
+    createdAt: string;
+    id: number;
+    scheduledDate?: string | null;
+    statusHistory?: { changedAt: string }[];
+    verifiedAt?: string | null;
+}) {
+    return {
+        canceledAt,
+        completedAt,
+        createdAt,
+        id,
+        scheduledDate,
+        statusHistory,
+        verifiedAt,
+    };
+}
+
+test('sortOperationTasksNewestFirst prefers scheduled date over status changes', () => {
+    const sorted = sortOperationTasksNewestFirst([
+        operation({
+            id: 1,
+            createdAt: '2026-06-01T08:00:00.000Z',
+            completedAt: '2026-06-24T08:00:00.000Z',
+            scheduledDate: '2026-06-25T00:00:00.000Z',
+            statusHistory: [{ changedAt: '2026-06-24T08:00:00.000Z' }],
+        }),
+        operation({
+            id: 2,
+            createdAt: '2026-06-01T08:00:00.000Z',
+            completedAt: '2026-06-24T09:00:00.000Z',
+            scheduledDate: '2026-06-23T00:00:00.000Z',
+            statusHistory: [{ changedAt: '2026-06-24T09:00:00.000Z' }],
+        }),
+        operation({
+            id: 3,
+            createdAt: '2026-06-01T08:00:00.000Z',
+            scheduledDate: '2026-06-26T00:00:00.000Z',
+            statusHistory: [{ changedAt: '2026-06-20T08:00:00.000Z' }],
+        }),
+    ]);
+
+    assert.deepEqual(
+        sorted.map((item) => item.id),
+        [3, 1, 2],
+    );
+});
+
+test('sortOperationTasksNewestFirst falls back to operation event dates and ids', () => {
+    const sorted = sortOperationTasksNewestFirst([
+        operation({
+            id: 4,
+            createdAt: '2026-06-01T08:00:00.000Z',
+            statusHistory: [{ changedAt: '2026-06-03T08:00:00.000Z' }],
+        }),
+        operation({
+            id: 5,
+            createdAt: '2026-06-01T08:00:00.000Z',
+            completedAt: '2026-06-04T08:00:00.000Z',
+        }),
+        operation({
+            id: 6,
+            createdAt: '2026-06-01T08:00:00.000Z',
+            completedAt: '2026-06-04T08:00:00.000Z',
+        }),
+    ]);
+
+    assert.deepEqual(
+        sorted.map((item) => item.id),
+        [6, 5, 4],
+    );
+});

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -21,8 +21,8 @@ import {
     GardenOperationCard,
     GardenOperationScheduleAction,
     getGardenOperationCancelTarget,
-    sortNewestFirst,
 } from '../GardenOperationsHud';
+import { sortOperationTasksNewestFirst } from '../gardenOperationOrdering';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
 import {
     buildFieldPlantSortIdById,
@@ -128,7 +128,7 @@ export function RaisedBedOperationHistoryList({
     );
     const operations = useMemo(
         () =>
-            sortNewestFirst([
+            sortOperationTasksNewestFirst([
                 ...(history.data?.pages.flatMap((page) => page.items) ?? []),
                 ...sowingOperations,
             ]),

--- a/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
@@ -16,7 +16,7 @@ import { useGardenOperations } from '../../hooks/useGardenOperations';
 import { useOperations } from '../../hooks/useOperations';
 import { useRaisedBedAiHistory } from '../../hooks/useRaisedBedAiHistory';
 import { ButtonGreen } from '../../shared-ui/ButtonGreen';
-import { sortNewestFirst } from '../GardenOperationsHud';
+import { sortOperationTasksNewestFirst } from '../gardenOperationOrdering';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
 import {
     buildFieldPositionById,
@@ -107,7 +107,7 @@ export function RaisedBedPhotosModal({
     );
     const photoOperations = useMemo(
         () =>
-            sortNewestFirst(
+            sortOperationTasksNewestFirst(
                 history.data?.pages
                     .flatMap((page) => page.items)
                     .filter((operation) => operation.imageUrls.length > 0) ??

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -426,14 +426,8 @@ const appliedRaisedBedOperationStatuses: OperationStatus[] = [
     'pendingVerification',
 ];
 
-function getOperationTimelineSortExpression() {
-    const scheduledDateExpression = getOperationScheduledDateExpression();
-
-    return sql<Date>`coalesce(${scheduledDateExpression}, ${operations.createdAt})`;
-}
-
-function getOperationHistorySortExpression() {
-    return sql<Date>`coalesce((
+function getOperationLatestStatusChangeDateExpression() {
+    return sql<Date | null>`(
         select ${events.createdAt}
         from ${events}
         where ${events.aggregateId} = CAST(${operations.id} as text)
@@ -443,7 +437,15 @@ function getOperationHistorySortExpression() {
           )})
         order by ${events.createdAt} desc, ${events.id} desc
         limit 1
-    ), ${operations.createdAt})`;
+    )`;
+}
+
+function getOperationTaskSortExpression() {
+    const scheduledDateExpression = getOperationScheduledDateExpression();
+    const latestStatusChangeDateExpression =
+        getOperationLatestStatusChangeDateExpression();
+
+    return sql<Date>`coalesce(${scheduledDateExpression}, ${latestStatusChangeDateExpression}, ${operations.createdAt})`;
 }
 
 export async function getOperations(
@@ -472,14 +474,11 @@ export async function getOperationsPage(
     const offset = input.cursor ?? 0;
     const pageSize = input.limit ?? 20;
     const statusExpression = getOperationStatusExpression();
-    const timelineSortExpression = getOperationTimelineSortExpression();
-    const historySortExpression = getOperationHistorySortExpression();
+    const taskSortExpression = getOperationTaskSortExpression();
     const includeCompletedWhere = input.includeCompleted
         ? undefined
         : sql`${statusExpression} != 'completed'`;
-    const sortOrder = input.includeCompleted
-        ? [desc(historySortExpression), desc(operations.id)]
-        : [asc(timelineSortExpression), asc(operations.id)];
+    const sortOrder = [desc(taskSortExpression), desc(operations.id)];
 
     const [pageRows, totalResult] = await Promise.all([
         storage()

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -425,6 +425,11 @@ const appliedRaisedBedOperationStatuses: OperationStatus[] = [
     'completed',
     'pendingVerification',
 ];
+const terminalOperationStatuses: OperationStatus[] = [
+    'completed',
+    'failed',
+    'canceled',
+];
 
 function getOperationLatestStatusChangeDateExpression() {
     return sql<Date | null>`(
@@ -477,7 +482,10 @@ export async function getOperationsPage(
     const taskSortExpression = getOperationTaskSortExpression();
     const includeCompletedWhere = input.includeCompleted
         ? undefined
-        : sql`${statusExpression} != 'completed'`;
+        : sql`${statusExpression} not in (${sql.join(
+              terminalOperationStatuses.map((value) => sql`${value}`),
+              sql`, `,
+          )})`;
     const sortOrder = [desc(taskSortExpression), desc(operations.id)];
 
     const [pageRows, totalResult] = await Promise.all([

--- a/packages/storage/src/repositories/raisedBedDiaryRepo.ts
+++ b/packages/storage/src/repositories/raisedBedDiaryRepo.ts
@@ -95,7 +95,7 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
                 (opData) => opData.id === op.entityId,
             )?.information?.shortDescription,
             status: operationStatusToLabel(op.status),
-            timestamp: op.completedAt ?? op.scheduledDate ?? op.createdAt,
+            timestamp: operationDiaryTimestamp(op),
             imageUrls: op.imageUrls,
             rescheduleTarget: operationDiaryRescheduleTarget(op),
         }))
@@ -237,7 +237,7 @@ export async function getRaisedBedFieldDiaryEntries(
                 (opData) => opData.id === op.entityId,
             )?.information?.shortDescription,
             status: operationStatusToLabel(op.status),
-            timestamp: op.completedAt ?? op.scheduledDate ?? op.createdAt,
+            timestamp: operationDiaryTimestamp(op),
             imageUrls: op.imageUrls,
             rescheduleTarget: operationDiaryRescheduleTarget(op, positionIndex),
         }))
@@ -283,6 +283,16 @@ type RaisedBedFieldWithEvents = Awaited<
 >[number];
 
 const fieldPlantRescheduleStatuses = new Set(['new', 'planned']);
+
+function operationDiaryTimestamp(operation: DiaryOperation) {
+    return (
+        operation.scheduledDate ??
+        operation.verifiedAt ??
+        operation.completedAt ??
+        operation.canceledAt ??
+        operation.createdAt
+    );
+}
 
 function operationDiaryRescheduleTarget(
     operation: DiaryOperation,

--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -808,3 +808,50 @@ test('diary entries expose operation and field reschedule targets', async () => 
         scheduledDate: '2026-06-05T00:00:00.000Z',
     });
 });
+
+test('raised bed diary entries order operations by scheduled or completed dates', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const scheduledCompletedOperationId = await createScheduledOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        scheduledDate: '2030-06-25T00:00:00.000Z',
+    });
+    const completedOperationId = await createOperation({
+        accountId,
+        entityId: 1,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+
+    await createEvent(
+        knownEvents.operations.completedV1(
+            scheduledCompletedOperationId.toString(),
+            {
+                completedBy: 'test-user',
+            },
+        ),
+    );
+    await createEvent(
+        knownEvents.operations.completedV1(completedOperationId.toString(), {
+            completedBy: 'test-user',
+        }),
+    );
+
+    const raisedBedEntries = await getRaisedBedDiaryEntries(raisedBedId);
+    const operationEntryIds = raisedBedEntries
+        .map((entry) => entry.id)
+        .filter((entryId) =>
+            [scheduledCompletedOperationId, completedOperationId].includes(
+                entryId,
+            ),
+        );
+
+    assert.deepEqual(operationEntryIds, [
+        scheduledCompletedOperationId,
+        completedOperationId,
+    ]);
+});

--- a/packages/storage/tests/operationsRepo.node.spec.ts
+++ b/packages/storage/tests/operationsRepo.node.spec.ts
@@ -138,7 +138,7 @@ test('farm-targeted operations are visible and assignable for farm users', async
     );
 });
 
-test('getOperationsPage returns included history by newest status change first', async () => {
+test('getOperationsPage returns operations by newest scheduled or completed task date', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =
         await createOperationsPageTestContext();
@@ -167,6 +167,12 @@ test('getOperationsPage returns included history by newest status change first',
         raisedBedId,
         createdAt: new Date('2026-01-15T08:00:00.000Z'),
     });
+    const completedScheduledOperationId = await createDatedOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        createdAt: new Date('2026-01-20T08:00:00.000Z'),
+    });
 
     await createEvent(
         knownEvents.operations.completedV1(completedOperationId.toString(), {
@@ -176,7 +182,7 @@ test('getOperationsPage returns included history by newest status change first',
     await setOperationEventCreatedAt(
         completedOperationId,
         knownEventTypes.operations.complete,
-        new Date('2026-05-01T08:00:00.000Z'),
+        new Date('2026-05-08T08:00:00.000Z'),
     );
     await createEvent(
         knownEvents.operations.scheduledV1(scheduledOperationId.toString(), {
@@ -188,19 +194,49 @@ test('getOperationsPage returns included history by newest status change first',
         knownEventTypes.operations.schedule,
         new Date('2026-05-03T08:00:00.000Z'),
     );
+    await createEvent(
+        knownEvents.operations.scheduledV1(
+            completedScheduledOperationId.toString(),
+            {
+                scheduledDate: '2026-05-12T08:00:00.000Z',
+            },
+        ),
+    );
+    await setOperationEventCreatedAt(
+        completedScheduledOperationId,
+        knownEventTypes.operations.schedule,
+        new Date('2026-05-01T08:00:00.000Z'),
+    );
+    await createEvent(
+        knownEvents.operations.completedV1(
+            completedScheduledOperationId.toString(),
+            {
+                completedBy: 'test-user',
+            },
+        ),
+    );
+    await setOperationEventCreatedAt(
+        completedScheduledOperationId,
+        knownEventTypes.operations.complete,
+        new Date('2026-05-07T08:00:00.000Z'),
+    );
 
     const firstPage = await getOperationsPage({
         accountId,
         gardenId,
         includeCompleted: true,
-        limit: 2,
+        limit: 3,
     });
 
     assert.deepStrictEqual(
         firstPage.items.map((operation) => operation.id),
-        [scheduledOperationId, completedOperationId],
+        [
+            completedScheduledOperationId,
+            scheduledOperationId,
+            completedOperationId,
+        ],
     );
-    assert.strictEqual(firstPage.nextCursor, 2);
+    assert.strictEqual(firstPage.nextCursor, 3);
 
     const secondPage = await getOperationsPage({
         accountId,
@@ -215,6 +251,48 @@ test('getOperationsPage returns included history by newest status change first',
         [createdOperationId, oldOperationId],
     );
     assert.strictEqual(secondPage.nextCursor, null);
+});
+
+test('getOperationsPage returns active operations by newest scheduled date first', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createOperationsPageTestContext();
+
+    const soonerOperationId = await createDatedOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        createdAt: new Date('2026-06-01T08:00:00.000Z'),
+    });
+    const laterOperationId = await createDatedOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        createdAt: new Date('2026-06-02T08:00:00.000Z'),
+    });
+
+    await createEvent(
+        knownEvents.operations.scheduledV1(soonerOperationId.toString(), {
+            scheduledDate: '2026-06-10T08:00:00.000Z',
+        }),
+    );
+    await createEvent(
+        knownEvents.operations.scheduledV1(laterOperationId.toString(), {
+            scheduledDate: '2026-06-12T08:00:00.000Z',
+        }),
+    );
+
+    const page = await getOperationsPage({
+        accountId,
+        gardenId,
+        includeCompleted: false,
+        limit: 2,
+    });
+
+    assert.deepStrictEqual(
+        page.items.map((operation) => operation.id),
+        [laterOperationId, soonerOperationId],
+    );
 });
 
 test('completed operations expose completion notes and image URLs', async () => {

--- a/packages/storage/tests/operationsRepo.node.spec.ts
+++ b/packages/storage/tests/operationsRepo.node.spec.ts
@@ -270,6 +270,12 @@ test('getOperationsPage returns active operations by newest scheduled date first
         raisedBedId,
         createdAt: new Date('2026-06-02T08:00:00.000Z'),
     });
+    const canceledOperationId = await createDatedOperation({
+        accountId,
+        gardenId,
+        raisedBedId,
+        createdAt: new Date('2026-06-03T08:00:00.000Z'),
+    });
 
     await createEvent(
         knownEvents.operations.scheduledV1(soonerOperationId.toString(), {
@@ -279,6 +285,17 @@ test('getOperationsPage returns active operations by newest scheduled date first
     await createEvent(
         knownEvents.operations.scheduledV1(laterOperationId.toString(), {
             scheduledDate: '2026-06-12T08:00:00.000Z',
+        }),
+    );
+    await createEvent(
+        knownEvents.operations.scheduledV1(canceledOperationId.toString(), {
+            scheduledDate: '2026-06-30T08:00:00.000Z',
+        }),
+    );
+    await createEvent(
+        knownEvents.operations.canceledV1(canceledOperationId.toString(), {
+            canceledBy: 'test-user',
+            reason: 'test-cancel',
         }),
     );
 
@@ -293,6 +310,7 @@ test('getOperationsPage returns active operations by newest scheduled date first
         page.items.map((operation) => operation.id),
         [laterOperationId, soonerOperationId],
     );
+    assert.strictEqual(page.total, 2);
 });
 
 test('completed operations expose completion notes and image URLs', async () => {


### PR DESCRIPTION
## Summary

Updates operation and sowing task ordering so lists use the task date users scan on the cards: scheduled date first, then verified/completed/canceled/status-change dates, then creation time. This keeps future scheduled work at the top and older completed work lower in raised-bed diaries, plant diaries, the operations HUD, operation history, and photo operation lists.

## Root cause

The operation-card history sort used the latest status-history event, while the active HUD used soonest scheduled date and the simple diary repository preferred completed dates over scheduled dates. That let confirmed/completed operations and planned operations interleave inconsistently when scheduled dates and status dates differed.

## Validation

- `pnpm --filter @gredice/game exec tsx --test src/hud/gardenOperationOrdering.unit.ts`
- `pnpm --filter @gredice/storage test:node operationsRepo.node.spec.ts gardenDiaryRescheduleRepo.node.spec.ts`
- `pnpm typecheck --filter @gredice/game`
- `pnpm lint --filter @gredice/game`
- `pnpm lint --filter @gredice/storage`
- `pnpm --filter @gredice/game test`
- `git diff --check`