### PR TITLE
[codex] Fix operation status tooltip focus

### DIFF
--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -131,6 +131,16 @@ test.describe('Garden operations HUD', () => {
             .getByRole('tooltip')
             .filter({ hasText: 'Statusi radnje' });
         await expect(statusTooltip).toHaveCount(0);
+        const firstStatusTrigger = cards.first().getByRole('button', {
+            name: /Status radnje:/,
+        });
+        await firstStatusTrigger.click();
+        await expect(statusTooltip).toHaveCount(1);
+        await expect(
+            statusTooltip.getByText(/\d{1,2}:\d{2}:\d{2}/),
+        ).toHaveCount(0);
+        await page.mouse.move(0, 0);
+        await expect(statusTooltip).toHaveCount(0);
         await expect(cards.first().getByLabel('Tijek radnje')).toBeVisible();
         await expect(cards.nth(5).getByLabel('Tijek radnje')).toBeVisible();
         await cards.first().getByLabel('Tijek radnje').hover();

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -14,6 +14,9 @@ test.describe('Garden operations HUD', () => {
         await page.getByTitle('Status radnji').click();
 
         await expect(page.getByText('Radnje u košari')).toBeVisible();
+        await expect(
+            page.getByRole('tooltip').filter({ hasText: 'Statusi radnje' }),
+        ).toHaveCount(0);
         await expect(page.getByText('Zalijevanje u košari')).toHaveCount(2);
         await expect(page.getByText('Sadnja: Maslac salata')).toBeVisible();
         await expect(
@@ -124,8 +127,17 @@ test.describe('Garden operations HUD', () => {
         const cards = page.locator('[data-garden-operation-card]');
         await expect(cards.nth(10)).toBeVisible();
         expect(await cards.count()).toBeGreaterThan(10);
+        const statusTooltip = page
+            .getByRole('tooltip')
+            .filter({ hasText: 'Statusi radnje' });
+        await expect(statusTooltip).toHaveCount(0);
         await expect(cards.first().getByLabel('Tijek radnje')).toBeVisible();
         await expect(cards.nth(5).getByLabel('Tijek radnje')).toBeVisible();
+        await cards.first().getByLabel('Tijek radnje').hover();
+        await expect(statusTooltip).toHaveCount(1);
+        await expect(
+            statusTooltip.getByText(/\d{1,2}:\d{2}:\d{2}/),
+        ).toHaveCount(0);
 
         const firstCardBox = await cards.first().boundingBox();
         const sixthCardBox = await cards.nth(5).boundingBox();

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1170,7 +1170,8 @@ function OperationStatusSummary({
                     aria-label={`Status radnje: ${config.label}`}
                     className="flex max-w-[48%] shrink-0 flex-col items-end rounded-md px-1 py-0.5 text-right transition hover:bg-muted/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                     onBlur={clearTooltipIntent}
-                    onClick={() => {
+                    onClick={(event) => {
+                        event.preventDefault();
                         tooltipIntentRef.current = true;
                         setTooltipOpen(true);
                     }}

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -31,6 +31,7 @@ import {
     useCallback,
     useMemo,
     useRef,
+    useState,
 } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import {
@@ -217,11 +218,6 @@ function formatDate(value?: string | null) {
         month: 'long',
         year: 'numeric',
     });
-}
-
-function formatDateTime(value?: string | null) {
-    if (!value) return null;
-    return new Date(value).toLocaleString('hr-HR');
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -1086,7 +1082,7 @@ function OperationStatusTooltipContent({
                 {steps.map((step) => {
                     const config = getDisplayStatusConfig(step.status);
                     const Icon = config.icon;
-                    const dateLabel = formatDateTime(step.date);
+                    const dateLabel = formatDate(step.date);
                     const fallbackLabel = step.current
                         ? 'Trenutno'
                         : step.skipped
@@ -1145,14 +1141,60 @@ function OperationStatusSummary({
         [operation, status],
     );
     const progressLabel = status === 'scheduled' ? undefined : 'Tijek radnje';
+    const tooltipIntentRef = useRef(false);
+    const [tooltipOpen, setTooltipOpen] = useState(false);
+    const handleTooltipOpenChange = useCallback((nextOpen: boolean) => {
+        if (!nextOpen) {
+            setTooltipOpen(false);
+            return;
+        }
+
+        if (tooltipIntentRef.current) {
+            setTooltipOpen(true);
+        }
+    }, []);
+    const clearTooltipIntent = useCallback(() => {
+        tooltipIntentRef.current = false;
+        setTooltipOpen(false);
+    }, []);
 
     return (
-        <Tooltip delayDuration={100}>
+        <Tooltip
+            delayDuration={100}
+            onOpenChange={handleTooltipOpenChange}
+            open={tooltipOpen}
+        >
             <TooltipTrigger asChild>
                 <button
                     type="button"
                     aria-label={`Status radnje: ${config.label}`}
                     className="flex max-w-[48%] shrink-0 flex-col items-end rounded-md px-1 py-0.5 text-right transition hover:bg-muted/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    onBlur={clearTooltipIntent}
+                    onClick={() => {
+                        tooltipIntentRef.current = true;
+                        setTooltipOpen(true);
+                    }}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Escape') {
+                            clearTooltipIntent();
+                            return;
+                        }
+
+                        if (event.key !== 'Enter' && event.key !== ' ') {
+                            return;
+                        }
+
+                        event.preventDefault();
+                        tooltipIntentRef.current = true;
+                        setTooltipOpen((currentOpen) => !currentOpen);
+                    }}
+                    onPointerDown={() => {
+                        tooltipIntentRef.current = true;
+                    }}
+                    onPointerEnter={() => {
+                        tooltipIntentRef.current = true;
+                    }}
+                    onPointerLeave={clearTooltipIntent}
                 >
                     <span className="flex min-w-0 max-w-full items-center justify-end gap-1.5">
                         <StatusBadge status={status} className="justify-end" />


### PR DESCRIPTION
## What changed

- Prevented operation status tooltips from opening only because the operations popover moved focus into a status trigger.
- Kept explicit tooltip access through hover, tap/click, and Enter/Space.
- Changed status tooltip dates to date-only formatting, removing the time portion.
- Added garden operations HUD component-test coverage for the tooltip staying closed on popover open, opening on hover, and not rendering time strings.

## Why

After the compact operation status indicator shipped, the tooltip could open immediately when the operations popover opened. That was caused by focus alone being enough to open the Radix tooltip. The tooltip is now controlled so it requires explicit user intent.

## Validation

- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden lint`
- `pnpm --filter garden exec playwright test tests/garden-operations-hud.spec.tsx`
- `pnpm --filter @gredice/game typecheck`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `pnpm --filter garden test:prepare`
- `git diff --check`