### PR TITLE
Update raised bed photo thumbnails

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1413,8 +1413,29 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         const photoButton = page.getByRole('button', {
             name: /Fotografije gredice Raised Bed 1/u,
         });
+        const detailsButton = page.locator('[data-raised-bed-details-trigger]');
         await expect(photoButton).toBeVisible();
+        await expect(detailsButton).toBeVisible();
         await expect(photoButton.locator('img')).toBeVisible();
+        await expect(
+            photoButton.locator('[data-raised-bed-photo-count]'),
+        ).toHaveCount(0);
+
+        await expect
+            .poll(async () => {
+                const photoBox = await photoButton.boundingBox();
+                const detailsBox = await detailsButton.boundingBox();
+
+                if (!photoBox || !detailsBox) {
+                    return false;
+                }
+
+                return (
+                    photoBox.x < detailsBox.x &&
+                    Math.abs(photoBox.height - detailsBox.height) <= 1
+                );
+            })
+            .toBe(true);
 
         await photoButton.click();
 
@@ -2090,6 +2111,10 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
         const tabList = dialog.getByRole('tablist');
         await expect(moreButton).toBeVisible();
         await expect(photoButton).toBeVisible();
+        await expect(photoButton.locator('img')).toBeVisible();
+        await expect(
+            photoButton.locator('[data-raised-bed-photo-count]'),
+        ).toHaveCount(0);
         await expect(tabList).toBeVisible();
 
         await expect
@@ -2109,6 +2134,25 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
         await expect(
             dialog.getByRole('button', { name: 'Napusti gredicu' }),
         ).toBeVisible();
+    });
+
+    test('raised bed info modal falls back to the block image without photos', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<RaisedBedInfoModalStory scenario={emptyScenario()} />);
+
+        const dialog = page.getByRole('dialog');
+        const photoButton = dialog.getByRole('button', {
+            name: /Fotografije gredice Raised Bed 1/u,
+        });
+        await expect(photoButton).toBeVisible();
+        await expect(
+            photoButton.getByRole('img', { name: 'Raised_Bed' }),
+        ).toBeVisible();
+        await expect(
+            photoButton.locator('[data-raised-bed-photo-count]'),
+        ).toHaveCount(0);
     });
 
     test('mobile drawer dismisses via swipe down on the drag handle', async ({

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -2136,6 +2136,85 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
         ).toBeVisible();
     });
 
+    test('raised bed info modal cover searches older history pages', async ({
+        mount,
+        page,
+    }) => {
+        const scenario = plantedGrowingWithOperationHistoryScenario();
+        const baseOperation = scenario.operationHistoryItems?.[0];
+
+        if (!baseOperation) {
+            throw new Error('Expected operation history item.');
+        }
+
+        const firstPageWithoutPhotos = Array.from({ length: 20 }).map(
+            (_, index) => ({
+                ...baseOperation,
+                id: 1000 + index,
+                imageUrls: [],
+                completionNotes: null,
+                statusHistory: [
+                    {
+                        status: 'completed' as const,
+                        changedAt: `2026-05-${String(12 - Math.floor(index / 2)).padStart(2, '0')}T09:00:00.000Z`,
+                    },
+                ],
+            }),
+        );
+        const olderOperationWithPhoto = {
+            ...baseOperation,
+            id: 1099,
+            completedAt: '2026-04-20T08:00:00.000Z',
+            imageUrls: ['https://example.com/older-watering.jpg'],
+            completionNotes: 'Starija fotografija nakon pregleda tla.',
+            statusHistory: [
+                {
+                    status: 'completed' as const,
+                    changedAt: '2026-04-20T09:00:00.000Z',
+                },
+            ],
+        };
+
+        await page.route(
+            '**/api/gredice/api/gardens/*/operations**',
+            async (route) => {
+                const url = new URL(route.request().url());
+                const cursor = url.searchParams.get('cursor');
+
+                await route.fulfill({
+                    body: JSON.stringify({
+                        items: cursor === '20' ? [olderOperationWithPhoto] : [],
+                        nextCursor: null,
+                        total: 21,
+                    }),
+                    contentType: 'application/json',
+                    status: 200,
+                });
+            },
+        );
+
+        await mount(
+            <RaisedBedInfoModalStory
+                scenario={{
+                    ...scenario,
+                    operationHistoryItems: firstPageWithoutPhotos,
+                    operationHistoryNextCursor: 20,
+                }}
+            />,
+        );
+
+        const dialog = page.getByRole('dialog');
+        const photoButton = dialog.getByRole('button', {
+            name: /Fotografije gredice Raised Bed 1/u,
+        });
+        await expect(photoButton).toBeVisible();
+        await expect(
+            photoButton.locator(
+                'img[src="https://example.com/older-watering.jpg"]',
+            ),
+        ).toBeVisible();
+    });
+
     test('raised bed info modal falls back to the block image without photos', async ({
         mount,
         page,

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -88,7 +88,18 @@ export function RaisedBedFieldHud() {
         >
             {currentGarden && raisedBed && (
                 <div className="absolute z-40 top-[var(--raised-bed-ui-top)] left-[var(--raised-bed-title-left)]">
-                    <Row spacing={2} className="items-center">
+                    <div className="relative flex items-center">
+                        {!isSandbox && (
+                            <div className="absolute right-full top-1/2 mr-2 -translate-y-1/2">
+                                <RaisedBedPhotosModal
+                                    gardenId={currentGarden.id}
+                                    raisedBedId={raisedBed.id}
+                                    subjectName={raisedBed.name}
+                                    triggerPlacement="hud"
+                                    hideWhenEmpty
+                                />
+                            </div>
+                        )}
                         <Modal
                             open={isInfoOpen}
                             onOpenChange={(open) => {
@@ -107,6 +118,7 @@ export function RaisedBedFieldHud() {
                             trigger={
                                 <ButtonGreen
                                     className="max-w-64 md:max-w-[312px]"
+                                    data-raised-bed-details-trigger
                                     endDecorator={
                                         <Navigate className="size-4 shrink-0" />
                                     }
@@ -128,16 +140,7 @@ export function RaisedBedFieldHud() {
                                 raisedBed={raisedBed}
                             />
                         </Modal>
-                        {!isSandbox && (
-                            <RaisedBedPhotosModal
-                                gardenId={currentGarden.id}
-                                raisedBedId={raisedBed.id}
-                                subjectName={raisedBed.name}
-                                triggerPlacement="hud"
-                                hideWhenEmpty
-                            />
-                        )}
-                    </Row>
+                    </div>
                 </div>
             )}
             <div className="absolute z-0 top-[calc(50%-1px)] left-1/2 -translate-x-1/2 -translate-y-1/2 w-[var(--raised-bed-grid-size)] h-[var(--raised-bed-grid-height)]">

--- a/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
@@ -1,5 +1,4 @@
 import { Alert } from '@gredice/ui/Alert';
-import { BlockImage } from '@gredice/ui/BlockImage';
 import { Button } from '@gredice/ui/Button';
 import { EditableInput } from '@gredice/ui/EditableInput';
 import { Book, Hammer, Info, MoreHorizontal, Warning } from '@gredice/ui/icons';
@@ -71,11 +70,11 @@ export function RaisedBedInfo({
         <Stack spacing={4} className="min-w-0 max-w-full">
             <div className="grid min-w-0 max-w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 pr-8">
                 <Row spacing={4} className="min-w-0 flex-1 items-start">
-                    <BlockImage
-                        blockName="Raised_Bed"
-                        width={80}
-                        height={80}
-                        className="size-20 shrink-0"
+                    <RaisedBedPhotosModal
+                        gardenId={gardenId}
+                        raisedBedId={raisedBed.id}
+                        subjectName={raisedBed.name}
+                        triggerPlacement="cover"
                     />
                     <Stack className="min-w-0 flex-1">
                         <Typography level="body2">Naziv gredice</Typography>
@@ -87,11 +86,6 @@ export function RaisedBedInfo({
                     </Stack>
                 </Row>
                 <Row spacing={2} className="items-start">
-                    <RaisedBedPhotosModal
-                        gardenId={gardenId}
-                        raisedBedId={raisedBed.id}
-                        subjectName={raisedBed.name}
-                    />
                     <Button
                         type="button"
                         variant="plain"

--- a/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
@@ -1,4 +1,5 @@
 import { Alert } from '@gredice/ui/Alert';
+import { BlockImage } from '@gredice/ui/BlockImage';
 import { Button } from '@gredice/ui/Button';
 import { Chip } from '@gredice/ui/Chip';
 import { ImageGallery } from '@gredice/ui/ImageGallery';
@@ -10,12 +11,11 @@ import { Spinner } from '@gredice/ui/Spinner';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { useEffect, useMemo } from 'react';
+import { type ReactNode, useEffect, useMemo } from 'react';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useGardenOperations } from '../../hooks/useGardenOperations';
 import { useOperations } from '../../hooks/useOperations';
 import { useRaisedBedAiHistory } from '../../hooks/useRaisedBedAiHistory';
-import { ButtonGreen } from '../../shared-ui/ButtonGreen';
 import { sortOperationTasksNewestFirst } from '../gardenOperationOrdering';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
 import {
@@ -31,7 +31,7 @@ type RaisedBedPhotosModalProps = {
     raisedBedId: number;
     subjectName: string;
     positionIndex?: number;
-    triggerPlacement?: 'hud' | 'header';
+    triggerPlacement?: 'hud' | 'header' | 'cover';
     hideWhenEmpty?: boolean;
     className?: string;
 };
@@ -67,6 +67,34 @@ function getPhotoCountLabel(photoCount: number) {
 
 function isGenericPhotoOperationName(name: string) {
     return /^fotografiranje\b/iu.test(name.trim());
+}
+
+function RaisedBedPhotoThumbnail({
+    fallback,
+    imageUrl,
+}: {
+    fallback?: ReactNode;
+    imageUrl: string | undefined;
+}) {
+    return (
+        <span className="relative flex size-full items-center justify-center overflow-hidden rounded-[inherit]">
+            {imageUrl ? (
+                <>
+                    {/** biome-ignore lint/performance/noImgElement: Operation photos come from runtime data and can use external blob hosts. */}
+                    <img
+                        src={imageUrl}
+                        alt=""
+                        className="size-full object-cover"
+                        loading="lazy"
+                    />
+                </>
+            ) : (
+                (fallback ?? (
+                    <Camera className="size-5 text-muted-foreground" />
+                ))
+            )}
+        </span>
+    );
 }
 
 export function RaisedBedPhotosModal({
@@ -122,6 +150,7 @@ export function RaisedBedPhotosModal({
     const latestImageUrls = Array.from(
         new Set(photoOperations.flatMap((operation) => operation.imageUrls)),
     ).slice(0, 3);
+    const latestImageUrl = latestImageUrls[0];
     const isFieldScoped = typeof positionIndex === 'number';
     const triggerLabel = isFieldScoped
         ? `Fotografije biljke ${subjectName}`
@@ -149,7 +178,7 @@ export function RaisedBedPhotosModal({
         return null;
     }
 
-    const thumbnail = (
+    const stackedThumbnail = (
         <span className="relative flex size-full items-center justify-center overflow-hidden rounded-[inherit] bg-card">
             {latestImageUrls.length > 0 ? (
                 latestImageUrls.map((imageUrl, index) => (
@@ -180,28 +209,46 @@ export function RaisedBedPhotosModal({
         </span>
     );
 
-    const photoCountBadge =
-        photoCount > 0 ? (
-            <span className="absolute -bottom-1 -right-1 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold leading-none text-primary-foreground shadow-sm">
-                {photoCount}
-            </span>
-        ) : null;
     const trigger =
-        triggerPlacement === 'hud' ? (
-            <ButtonGreen
-                variant="plain"
+        triggerPlacement === 'cover' ? (
+            <button
+                type="button"
                 className={cx(
-                    'size-10 rounded-xl p-1 shadow-lg ring-1 ring-black/10',
+                    'relative inline-flex size-20 shrink-0 items-center justify-center rounded-xl p-0 transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700 focus-visible:ring-offset-2',
+                    latestImageUrl
+                        ? 'overflow-hidden shadow-sm ring-1 ring-black/10'
+                        : 'overflow-visible',
                     className,
                 )}
                 aria-label={triggerLabel}
+                data-raised-bed-photo-trigger={triggerPlacement}
                 title={triggerLabel}
             >
-                <span className="relative block size-full rounded-[inherit]">
-                    {thumbnail}
-                    {photoCountBadge}
-                </span>
-            </ButtonGreen>
+                <RaisedBedPhotoThumbnail
+                    imageUrl={latestImageUrl}
+                    fallback={
+                        <BlockImage
+                            blockName="Raised_Bed"
+                            width={80}
+                            height={80}
+                            className="size-full"
+                        />
+                    }
+                />
+            </button>
+        ) : triggerPlacement === 'hud' ? (
+            <button
+                type="button"
+                className={cx(
+                    'relative inline-flex size-10 min-h-10 shrink-0 items-center justify-center overflow-hidden rounded-xl p-0 shadow-sm ring-1 ring-black/10 transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700 focus-visible:ring-offset-2',
+                    className,
+                )}
+                aria-label={triggerLabel}
+                data-raised-bed-photo-trigger={triggerPlacement}
+                title={triggerLabel}
+            >
+                <RaisedBedPhotoThumbnail imageUrl={latestImageUrl} />
+            </button>
         ) : (
             <button
                 type="button"
@@ -210,10 +257,18 @@ export function RaisedBedPhotosModal({
                     className,
                 )}
                 aria-label={triggerLabel}
+                data-raised-bed-photo-trigger={triggerPlacement}
                 title={triggerLabel}
             >
-                {thumbnail}
-                {photoCountBadge}
+                {stackedThumbnail}
+                {photoCount > 0 && (
+                    <span
+                        className="absolute -bottom-1 -right-1 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold leading-none text-primary-foreground shadow-sm"
+                        data-raised-bed-photo-count
+                    >
+                        {photoCount}
+                    </span>
+                )}
             </button>
         );
 

--- a/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
@@ -158,8 +158,10 @@ export function RaisedBedPhotosModal({
     const modalTitle = isFieldScoped
         ? 'Fotografije biljke'
         : 'Fotografije gredice';
+    const shouldSearchOlderPhotos =
+        hideWhenEmpty || triggerPlacement === 'cover';
     const shouldFetchOlderPhotos =
-        hideWhenEmpty &&
+        shouldSearchOlderPhotos &&
         photoCount === 0 &&
         !history.isLoading &&
         !history.isError &&


### PR DESCRIPTION
## Summary
- move the raised bed HUD photo thumbnail to the left of the details button and render it as a plain single image without a count badge
- use the latest raised bed photo as the details modal cover image, falling back to the existing raised bed block image when no photos exist
- add component test coverage for HUD positioning, hidden count badges, and the modal fallback image

## Validation
- pnpm lint --filter @gredice/game --filter garden
- pnpm typecheck --filter @gredice/game --filter garden
- pnpm --filter garden test:prepare
- pnpm --filter garden exec playwright test tests/raised-bed-field-hud.spec.tsx -g "closeup HUD photo shortcut opens|raised bed more action sits|raised bed info modal falls back"