### PR TITLE
[codex] Fix news root redirect

### DIFF
--- a/apps/news/next.config.ts
+++ b/apps/news/next.config.ts
@@ -7,22 +7,59 @@ import {
 
 const app = getAppByName('news');
 const wwwApp = getAppByName('www');
+const newsBasePath = '/novosti';
+
+function isDevelopmentEnv() {
+    return (
+        process.env.NODE_ENV === 'development' ||
+        process.env.NEXT_PUBLIC_VERCEL_ENV === 'development'
+    );
+}
+
+function isProductionDeployment() {
+    return (
+        process.env.VERCEL_ENV === 'production' ||
+        process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
+    );
+}
+
+function trimTrailingSlash(value: string) {
+    return value.replace(/\/+$/u, '');
+}
+
+function newsRootRedirectDestination() {
+    if (!isProductionDeployment()) {
+        return newsBasePath;
+    }
+
+    const wwwOrigin = process.env.NEXT_PUBLIC_GREDICE_WWW_ORIGIN?.trim();
+    return `${wwwOrigin ? trimTrailingSlash(wwwOrigin) : 'https://www.gredice.com'}${newsBasePath}`;
+}
 
 const nextConfig: NextConfig = {
-    basePath: '/novosti',
+    basePath: newsBasePath,
     reactStrictMode: true,
     typedRoutes: true,
     reactCompiler: true,
     logging: {
         browserToTerminal: true,
     },
+    async redirects() {
+        return [
+            {
+                source: '/',
+                destination: newsRootRedirectDestination(),
+                permanent: true,
+                basePath: false,
+            },
+        ];
+    },
     async rewrites() {
-        const isDev =
-            process.env.NODE_ENV === 'development' ||
-            process.env.NEXT_PUBLIC_VERCEL_ENV === 'development';
         const apiHost =
             process.env.GREDICE_API_HOST ??
-            (isDev ? 'http://localhost:3005' : 'https://api.gredice.com');
+            (isDevelopmentEnv()
+                ? 'http://localhost:3005'
+                : 'https://api.gredice.com');
 
         return [
             {


### PR DESCRIPTION
## Summary

- Add a News app root redirect for the bare `/` path, bypassing the `/novosti` base path match with `basePath: false`.
- Redirect production News host roots to the canonical `https://www.gredice.com/novosti` URL.
- Keep local and non-production builds redirecting to the app base path `/novosti`.

## Root Cause

The News app is mounted with `basePath: '/novosti'`, so `https://novosti.gredice.com/novosti` serves the app but `https://novosti.gredice.com/` did not match any Next.js route and returned Vercel's 404.

## Validation

- `curl -I -L --max-redirs 2 https://novosti.gredice.com/` confirmed the current live root returns 404 before this change.
- `pnpm lint --filter news`
- `pnpm typecheck --filter news`
- `pnpm build --filter news`
- `VERCEL_ENV=production NEXT_PUBLIC_VERCEL_ENV=production pnpm --filter news build`
- Built-server check: local `/` returns `308 Location: /novosti` for non-production builds.
- Production-env built-server check: local `/` returns `308 Location: https://www.gredice.com/novosti`.