### PR TITLE
[codex] Hide terminal status progress dots

### DIFF
--- a/apps/garden/tests/GardenOperationsHudStory.tsx
+++ b/apps/garden/tests/GardenOperationsHudStory.tsx
@@ -189,6 +189,10 @@ function buildHudOperationItem({
 }): GardenOperationItem {
     const day = String(Math.max(1, 30 - (id % 20))).padStart(2, '0');
     const terminalChangedAt = `2026-05-${day}T08:00:00.000Z`;
+    const terminalHistoryStatus =
+        status === 'completed' || status === 'failed' || status === 'canceled'
+            ? status
+            : 'confirmed';
 
     return {
         id,
@@ -216,15 +220,19 @@ function buildHudOperationItem({
             { status: 'planned', changedAt: `2026-05-${day}T01:00:00.000Z` },
             { status: 'assigned', changedAt: `2026-05-${day}T02:00:00.000Z` },
             {
-                status:
-                    status === 'completed' || status === 'canceled'
-                        ? status
-                        : 'confirmed',
+                status: terminalHistoryStatus,
                 changedAt: terminalChangedAt,
             },
         ],
     };
 }
+
+const denseHistoryStatuses: GardenOperationItem['status'][] = [
+    'completed',
+    'confirmed',
+    'failed',
+    'canceled',
+];
 
 function createQueryClient({
     denseOperations = false,
@@ -271,21 +279,15 @@ function createQueryClient({
               } satisfies GardenOperationItem,
           ];
     const historyOperationItems = denseOperations
-        ? Array.from({ length: 18 }, (_, index) =>
-              buildHudOperationItem({
+        ? Array.from({ length: 20 }, (_, index) => {
+              return buildHudOperationItem({
                   id: 800 + index,
                   status:
-                      index % 5 === 4
-                          ? 'canceled'
-                          : index % 3 === 0
-                            ? 'completed'
-                            : 'confirmed',
-                  cancellationReason:
-                      index % 5 === 4
-                          ? 'Korisnik je otkazao radnju.'
-                          : undefined,
-              }),
-          )
+                      denseHistoryStatuses[
+                          index % denseHistoryStatuses.length
+                      ] ?? 'completed',
+              });
+          })
         : [
               buildHudOperationItem({
                   id: 610,

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -123,7 +123,10 @@ test.describe('Garden operations HUD', () => {
         await expect(completedSowingCard.getByText('Završeno')).toBeVisible();
         await expect(
             completedSowingCard.getByLabel('Tijek radnje'),
-        ).toBeVisible();
+        ).toHaveCount(0);
+        await expect(
+            completedSowingCard.locator('[data-operation-status-progress]'),
+        ).toHaveCount(0);
         const canceledSowingCard = dialog
             .locator('[data-garden-operation-card]')
             .filter({ hasText: 'Sadnja: Maslac salata' });
@@ -178,9 +181,15 @@ test.describe('Garden operations HUD', () => {
         ).toHaveCount(0);
         await page.mouse.move(0, 0);
         await expect(statusTooltip).toHaveCount(0);
-        await expect(cards.first().getByLabel('Tijek radnje')).toBeVisible();
+        await expect(cards.first().getByLabel('Tijek radnje')).toHaveCount(0);
+        await expect(
+            cards.first().locator('[data-operation-status-progress]'),
+        ).toHaveCount(0);
         await expect(cards.nth(5).getByLabel('Tijek radnje')).toBeVisible();
-        await cards.first().getByLabel('Tijek radnje').hover();
+        await expect(
+            cards.nth(5).locator('[data-operation-status-progress]'),
+        ).toHaveCount(1);
+        await cards.nth(5).getByLabel('Tijek radnje').hover();
         await expect(statusTooltip).toHaveCount(1);
         await expect(
             statusTooltip.getByText(/\d{1,2}:\d{2}:\d{2}/),
@@ -240,7 +249,16 @@ test.describe('Garden operations HUD', () => {
         const cards = dialog.locator('[data-garden-operation-card]');
         await expect(cards.nth(10)).toBeVisible();
         expect(await cards.count()).toBeGreaterThan(10);
-        await expect(cards.first().getByLabel('Tijek radnje')).toBeVisible();
+        const completedCard = cards.filter({ hasText: 'Završeno' }).first();
+        const confirmedCard = cards.filter({ hasText: 'Potvrđeno' }).first();
+        await expect(completedCard).toBeVisible();
+        await expect(confirmedCard).toBeVisible();
+        await expect(
+            completedCard.locator('[data-operation-status-progress]'),
+        ).toHaveCount(0);
+        await expect(
+            confirmedCard.locator('[data-operation-status-progress]'),
+        ).toHaveCount(0);
         await expect(cards.nth(8)).toBeVisible();
 
         const firstCardBox = await cards.first().boundingBox();

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -251,13 +251,23 @@ test.describe('Garden operations HUD', () => {
         expect(await cards.count()).toBeGreaterThan(10);
         const completedCard = cards.filter({ hasText: 'Završeno' }).first();
         const confirmedCard = cards.filter({ hasText: 'Potvrđeno' }).first();
+        const failedCard = cards.filter({ hasText: 'Neuspjelo' }).first();
+        const canceledCard = cards.filter({ hasText: 'Otkazano' }).first();
         await expect(completedCard).toBeVisible();
         await expect(confirmedCard).toBeVisible();
+        await expect(failedCard).toBeVisible();
+        await expect(canceledCard).toBeVisible();
         await expect(
             completedCard.locator('[data-operation-status-progress]'),
         ).toHaveCount(0);
         await expect(
             confirmedCard.locator('[data-operation-status-progress]'),
+        ).toHaveCount(0);
+        await expect(
+            failedCard.locator('[data-operation-status-progress]'),
+        ).toHaveCount(0);
+        await expect(
+            canceledCard.locator('[data-operation-status-progress]'),
         ).toHaveCount(0);
         await expect(cards.nth(8)).toBeVisible();
 

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1181,10 +1181,13 @@ function OperationStatusSummary({
             ? operation.cancellationReason?.trim()
             : undefined;
     const hasCancellationReason = Boolean(cancellationReason);
+    const isTerminalFailureStatus =
+        status !== 'scheduled' && terminalFailureStatuses.has(status);
     const showProgressIndicator =
         !hasCancellationReason &&
         status !== 'confirmed' &&
-        status !== 'completed';
+        status !== 'completed' &&
+        !isTerminalFailureStatus;
     const progressLabel =
         showProgressIndicator && status !== 'scheduled'
             ? 'Tijek radnje'

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1181,10 +1181,14 @@ function OperationStatusSummary({
             ? operation.cancellationReason?.trim()
             : undefined;
     const hasCancellationReason = Boolean(cancellationReason);
+    const showProgressIndicator =
+        !hasCancellationReason &&
+        status !== 'confirmed' &&
+        status !== 'completed';
     const progressLabel =
-        hasCancellationReason || status === 'scheduled'
-            ? undefined
-            : 'Tijek radnje';
+        showProgressIndicator && status !== 'scheduled'
+            ? 'Tijek radnje'
+            : undefined;
     const tooltipIntentRef = useRef(false);
     const [tooltipOpen, setTooltipOpen] = useState(false);
     const handleTooltipOpenChange = useCallback((nextOpen: boolean) => {
@@ -1253,12 +1257,12 @@ function OperationStatusSummary({
                                 className="size-3.5 shrink-0 text-red-600"
                                 data-operation-cancellation-reason
                             />
-                        ) : (
+                        ) : showProgressIndicator ? (
                             <OperationStatusProgressIndicator
                                 label={progressLabel}
                                 steps={steps}
                             />
-                        )}
+                        ) : null}
                     </span>
                 </button>
             </TooltipTrigger>


### PR DESCRIPTION
## Summary
- Hide compact operation progress dots when the displayed status is confirmed or completed.
- Keep the status label/icon and tooltip trigger available for status dates.
- Update garden HUD component tests for terminal-status cards and retained progress on active in-progress cards.

## Validation
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden lint`
- `pnpm --filter garden exec playwright test tests/garden-operations-hud.spec.tsx`
- `pnpm --filter @gredice/game typecheck`
- `pnpm typecheck --filter garden`
- `git diff --check`