### PR TITLE
Add raised bed photo hover affordance

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -4,7 +4,7 @@ import type {
     PlantData,
 } from '@gredice/client';
 import { expect, test } from '@playwright/experimental-ct-react';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import {
     RaisedBedCloseupHudStory,
     RaisedBedFieldDndDialogStory,
@@ -162,6 +162,36 @@ function countAnalyticsEvents(
 ) {
     return analyticsEvents.filter((event) => event.eventName === eventName)
         .length;
+}
+
+async function expectPhotoButtonHoverAffordance(photoButton: Locator) {
+    const overlay = photoButton.locator(
+        '[data-raised-bed-photo-hover-overlay]',
+    );
+    const media = photoButton.locator('[data-raised-bed-photo-media]');
+
+    await photoButton.hover();
+    await expect
+        .poll(async () =>
+            Number(
+                await overlay.evaluate(
+                    (element) => getComputedStyle(element).opacity,
+                ),
+            ),
+        )
+        .toBeGreaterThan(0.9);
+    await expect
+        .poll(async () =>
+            media.evaluate((element) => {
+                const scale = getComputedStyle(element).scale;
+                if (!scale || scale === 'none') {
+                    return 1;
+                }
+
+                return Number(scale.split(' ')[0]);
+            }),
+        )
+        .toBeGreaterThan(1.01);
 }
 
 function emptyScenario(): RaisedBedScenario {
@@ -1437,6 +1467,8 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
             })
             .toBe(true);
 
+        await expectPhotoButtonHoverAffordance(photoButton);
+
         await photoButton.click();
 
         const photosModal = page.locator('[data-raised-bed-photos-modal]');
@@ -1783,6 +1815,12 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         );
 
         const dialog = page.getByRole('dialog');
+        const photoButton = dialog.getByRole('button', {
+            name: /Fotografije gredice Raised Bed 1/u,
+        });
+        await expect(photoButton).toBeVisible();
+        await expect(photoButton.locator('img')).toBeVisible();
+        await expectPhotoButtonHoverAffordance(photoButton);
         await expect(
             dialog.getByText('Površinsko zalijevanje gredice (20L)').first(),
         ).toBeVisible();

--- a/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
@@ -84,15 +84,25 @@ function RaisedBedPhotoThumbnail({
                     <img
                         src={imageUrl}
                         alt=""
-                        className="size-full object-cover"
+                        className="size-full object-cover transition-transform duration-300 group-hover:scale-105 group-focus-visible:scale-105"
+                        data-raised-bed-photo-media
                         loading="lazy"
                     />
                 </>
             ) : (
-                (fallback ?? (
-                    <Camera className="size-5 text-muted-foreground" />
-                ))
+                <span
+                    className="flex size-full items-center justify-center transition-transform duration-300 group-hover:scale-105 group-focus-visible:scale-105"
+                    data-raised-bed-photo-media
+                >
+                    {fallback ?? (
+                        <Camera className="size-5 text-muted-foreground" />
+                    )}
+                </span>
             )}
+            <span
+                className="pointer-events-none absolute inset-0 bg-white/30 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
+                data-raised-bed-photo-hover-overlay
+            />
         </span>
     );
 }
@@ -181,7 +191,10 @@ export function RaisedBedPhotosModal({
     }
 
     const stackedThumbnail = (
-        <span className="relative flex size-full items-center justify-center overflow-hidden rounded-[inherit] bg-card">
+        <span
+            className="relative flex size-full items-center justify-center overflow-hidden rounded-[inherit] bg-card transition-transform duration-300 group-hover:scale-105 group-focus-visible:scale-105"
+            data-raised-bed-photo-media
+        >
             {latestImageUrls.length > 0 ? (
                 latestImageUrls.map((imageUrl, index) => (
                     <span
@@ -216,9 +229,9 @@ export function RaisedBedPhotosModal({
             <button
                 type="button"
                 className={cx(
-                    'relative inline-flex size-20 shrink-0 items-center justify-center rounded-xl p-0 transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700 focus-visible:ring-offset-2',
+                    'group relative inline-flex size-20 shrink-0 items-center justify-center rounded-xl p-0 transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700 focus-visible:ring-offset-2 hover:cursor-zoom-in',
                     latestImageUrl
-                        ? 'overflow-hidden shadow-sm ring-1 ring-black/10'
+                        ? 'overflow-hidden shadow-sm ring-1 ring-black/10 hover:shadow-md'
                         : 'overflow-visible',
                     className,
                 )}
@@ -242,7 +255,7 @@ export function RaisedBedPhotosModal({
             <button
                 type="button"
                 className={cx(
-                    'relative inline-flex size-10 min-h-10 shrink-0 items-center justify-center overflow-hidden rounded-xl p-0 shadow-sm ring-1 ring-black/10 transition focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700 focus-visible:ring-offset-2',
+                    'group relative inline-flex size-10 min-h-10 shrink-0 items-center justify-center overflow-hidden rounded-xl p-0 shadow-sm ring-1 ring-black/10 transition hover:cursor-zoom-in hover:shadow-md focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700 focus-visible:ring-offset-2',
                     className,
                 )}
                 aria-label={triggerLabel}
@@ -255,7 +268,7 @@ export function RaisedBedPhotosModal({
             <button
                 type="button"
                 className={cx(
-                    'relative inline-flex size-14 shrink-0 items-center justify-center rounded-2xl border bg-card p-1 shadow-xs transition hover:bg-accent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700 focus-visible:ring-offset-2',
+                    'group relative inline-flex size-14 shrink-0 items-center justify-center rounded-2xl border bg-card p-1 shadow-xs transition hover:cursor-zoom-in hover:bg-accent hover:shadow-md focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700 focus-visible:ring-offset-2',
                     className,
                 )}
                 aria-label={triggerLabel}
@@ -263,6 +276,10 @@ export function RaisedBedPhotosModal({
                 title={triggerLabel}
             >
                 {stackedThumbnail}
+                <span
+                    className="pointer-events-none absolute inset-1 rounded-[inherit] bg-white/30 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
+                    data-raised-bed-photo-hover-overlay
+                />
                 {photoCount > 0 && (
                     <span
                         className="absolute -bottom-1 -right-1 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold leading-none text-primary-foreground shadow-sm"


### PR DESCRIPTION
## Summary
- add gallery-like hover affordance to raised bed photo triggers with image scale, light overlay, zoom cursor, and stronger shadow
- apply the affordance to the HUD thumbnail, details-modal cover, and stacked header photo trigger
- cover the hover overlay/scale behavior in raised-bed component tests

## Validation
- pnpm lint --filter @gredice/game --filter garden
- pnpm typecheck --filter @gredice/game --filter garden
- pnpm --filter garden exec playwright test tests/raised-bed-field-hud.spec.tsx -g "closeup HUD photo shortcut opens|raised bed diary operation history does not overflow|raised bed more action sits|raised bed info modal cover searches|raised bed info modal falls back"