### PR TITLE
[codex] Fix game toolbar button order

### DIFF
--- a/packages/game/src/hud/AccountHud.tsx
+++ b/packages/game/src/hud/AccountHud.tsx
@@ -270,9 +270,6 @@ export function AccountHud() {
                     </DropdownMenuTrigger>
                     <ProfileCard />
                 </DropdownMenu>
-                <div className="md:order-3">
-                    <GardenOperationsHud />
-                </div>
                 <div className="hidden md:block md:order-1">
                     {isLoading ? (
                         <Skeleton className="w-32 h-7" />
@@ -334,6 +331,9 @@ export function AccountHud() {
                             }
                         />
                     </Popper>
+                </div>
+                <div className="md:order-3">
+                    <GardenOperationsHud />
                 </div>
             </Row>
         </HudCard>


### PR DESCRIPTION
## Summary
- Move the game operations HUD trigger after the notifications trigger in the account HUD row.
- Keep desktop and mobile button order consistent: notifications first, operations second.

## Root cause
The mobile layout followed the JSX source order, where operations rendered before notifications. Desktop overrode that with breakpoint-specific flex order classes, so the two layouts diverged.

## Validation
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `git diff --check`