### PR TITLE
[codex] Move operation card actions inline

### DIFF
--- a/apps/garden/tests/GardenOperationsHudStory.tsx
+++ b/apps/garden/tests/GardenOperationsHudStory.tsx
@@ -200,10 +200,7 @@ function buildHudOperationItem({
         createdAt: `2026-05-${day}T00:00:00.000Z`,
         scheduledDate: `2026-05-${day}T00:00:00.000Z`,
         scheduledAt: `2026-05-${day}T00:00:00.000Z`,
-        completedAt:
-            status === 'confirmed' || status === 'completed'
-                ? terminalChangedAt
-                : null,
+        completedAt: status === 'completed' ? terminalChangedAt : null,
         verifiedAt:
             status === 'completed' ? `2026-05-${day}T09:00:00.000Z` : null,
         canceledAt: status === 'canceled' ? terminalChangedAt : null,
@@ -289,7 +286,12 @@ function createQueryClient({
                           : undefined,
               }),
           )
-        : [];
+        : [
+              buildHudOperationItem({
+                  id: 610,
+                  status: 'confirmed',
+              }),
+          ];
     const pendingOperationPage = {
         pages: [
             {

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -102,10 +102,28 @@ test.describe('Garden operations HUD', () => {
         const dialog = page
             .getByRole('dialog')
             .filter({ hasText: 'Povijest radnji' });
-        await expect(dialog.getByText('Sadnja: Cherry rajčica')).toBeVisible();
-        await expect(dialog.getByLabel('Raised Bed 1 › Polje 3')).toBeVisible();
-        await expect(dialog.getByText('Završeno')).toBeVisible();
-        await expect(dialog.getByLabel('Tijek radnje').first()).toBeVisible();
+        const reschedulableHistoryCard = dialog
+            .locator('[data-garden-operation-card]')
+            .filter({ hasText: 'Zalijevanje u košari' });
+        await expect(
+            reschedulableHistoryCard.getByRole('button', {
+                name: '20. svibnja 2026.',
+            }),
+        ).toBeVisible();
+        await expect(
+            reschedulableHistoryCard.getByRole('button', { name: 'Otkaži' }),
+        ).toBeVisible();
+        const completedSowingCard = dialog
+            .locator('[data-garden-operation-card]')
+            .filter({ hasText: 'Sadnja: Cherry rajčica' });
+        await expect(completedSowingCard).toBeVisible();
+        await expect(
+            completedSowingCard.getByLabel('Raised Bed 1 › Polje 3'),
+        ).toBeVisible();
+        await expect(completedSowingCard.getByText('Završeno')).toBeVisible();
+        await expect(
+            completedSowingCard.getByLabel('Tijek radnje'),
+        ).toBeVisible();
         const canceledSowingCard = dialog
             .locator('[data-garden-operation-card]')
             .filter({ hasText: 'Sadnja: Maslac salata' });

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1216,7 +1216,7 @@ function OperationStatusSummary({
                             ? `Status radnje: ${config.label}. Razlog otkazivanja`
                             : `Status radnje: ${config.label}`
                     }
-                    className="flex max-w-[48%] shrink-0 flex-col items-end rounded-md px-1 py-0.5 text-right transition hover:bg-muted/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    className="flex max-w-full shrink-0 flex-col items-end rounded-md px-1 py-0.5 text-right transition hover:bg-muted/50 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                     onBlur={clearTooltipIntent}
                     onClick={(event) => {
                         event.preventDefault();
@@ -1320,11 +1320,14 @@ function OperationSchedule({
 }) {
     const scheduledDate = formatDate(operation.scheduledDate);
     const scheduleContent = scheduleAction ? (
-        <div className="w-fit max-w-full">{scheduleAction}</div>
+        <div className="min-w-0 max-w-full">{scheduleAction}</div>
     ) : scheduledDate ? (
-        <Row spacing={1} className="w-fit max-w-full text-muted-foreground">
+        <Row
+            spacing={1}
+            className="min-w-0 max-w-full justify-end text-muted-foreground"
+        >
             <Calendar aria-hidden className="size-3.5 shrink-0" />
-            <Typography level="body3" secondary noWrap>
+            <Typography level="body3" secondary noWrap className="min-w-0">
                 {scheduledDate}
             </Typography>
         </Row>
@@ -1335,7 +1338,10 @@ function OperationSchedule({
     }
 
     return (
-        <Row spacing={1} className="w-fit max-w-full items-center">
+        <Row
+            spacing={0.5}
+            className="min-w-0 max-w-full flex-wrap items-center justify-end gap-y-0.5"
+        >
             {scheduleContent}
             {cancelAction}
         </Row>
@@ -1581,36 +1587,39 @@ export function GardenOperationCard({
                     spacing={1.5}
                     className="min-w-0 max-w-full flex-1 overflow-hidden"
                 >
-                    <Stack spacing={0.75}>
-                        <Row
-                            spacing={1}
-                            alignItems="start"
-                            className="min-w-0 max-w-full gap-y-1"
+                    <Row
+                        spacing={1}
+                        alignItems="start"
+                        className="min-w-0 max-w-full gap-y-1"
+                    >
+                        <Stack spacing={0.5} className="min-w-0 flex-1">
+                            <Typography
+                                level="body2"
+                                semiBold
+                                noWrap
+                                className="min-w-0"
+                            >
+                                {resolvedOperationName}
+                            </Typography>
+                            <OperationTargetLabel
+                                targetDetails={targetDetails}
+                            />
+                        </Stack>
+                        <Stack
+                            spacing={0.25}
+                            className="max-w-[52%] shrink-0 items-end"
                         >
-                            <Stack spacing={0.5} className="min-w-0 flex-1">
-                                <Typography
-                                    level="body2"
-                                    semiBold
-                                    noWrap
-                                    className="min-w-0"
-                                >
-                                    {resolvedOperationName}
-                                </Typography>
-                                <OperationTargetLabel
-                                    targetDetails={targetDetails}
-                                />
-                            </Stack>
                             <OperationStatusSummary
                                 operation={operation}
                                 status={displayStatus}
                             />
-                        </Row>
-                    </Stack>
-                    <OperationSchedule
-                        operation={operation}
-                        cancelAction={cancelAction}
-                        scheduleAction={scheduleAction}
-                    />
+                            <OperationSchedule
+                                operation={operation}
+                                cancelAction={cancelAction}
+                                scheduleAction={scheduleAction}
+                            />
+                        </Stack>
+                    </Row>
                     <OperationEvidence operation={operation} />
                     {action && <div className="flex justify-end">{action}</div>}
                 </Stack>
@@ -1766,49 +1775,74 @@ function HistoryModal({
                                 Nema radnji.
                             </Typography>
                         ) : (
-                            operations.map((operation) => (
-                                <GardenOperationCard
-                                    key={`${operation.entityTypeName}-${operation.id}`}
-                                    operation={operation}
-                                    operationName={
-                                        operation.entityTypeName ===
-                                        cartOperationEntityType
-                                            ? operationDataById.get(
-                                                  operation.entityId,
-                                              )?.information.label
-                                            : undefined
-                                    }
-                                    operationData={
-                                        operation.entityTypeName ===
-                                        cartOperationEntityType
-                                            ? operationDataById.get(
-                                                  operation.entityId,
-                                              )
-                                            : undefined
-                                    }
-                                    plantSortData={
-                                        operation.entityTypeName ===
-                                        cartPlantSortEntityType
-                                            ? plantSortById.get(
-                                                  operation.entityId,
-                                              )
-                                            : undefined
-                                    }
-                                    targetPlantSortData={
-                                        operation.entityTypeName ===
-                                        cartOperationEntityType
-                                            ? (plantSortById.get(
-                                                  getOperationFieldPlantSortId(
-                                                      operation,
-                                                      currentGarden,
-                                                  ) ?? 0,
-                                              ) ?? undefined)
-                                            : undefined
-                                    }
-                                    currentGarden={currentGarden}
-                                    referenceDate={referenceDate}
-                                />
-                            ))
+                            operations.map((operation) => {
+                                const operationData =
+                                    operation.entityTypeName ===
+                                    cartOperationEntityType
+                                        ? operationDataById.get(
+                                              operation.entityId,
+                                          )
+                                        : undefined;
+                                const plantSortData =
+                                    operation.entityTypeName ===
+                                    cartPlantSortEntityType
+                                        ? plantSortById.get(operation.entityId)
+                                        : undefined;
+                                const operationName =
+                                    operationData?.information.label;
+                                const entryName = getActiveOperationName({
+                                    operation,
+                                    operationName,
+                                    plantSortName:
+                                        plantSortData?.information.name,
+                                });
+                                const scheduleAction = (
+                                    <GardenOperationScheduleAction
+                                        entryName={entryName}
+                                        garden={currentGarden}
+                                        operation={operation}
+                                        referenceDate={referenceDate}
+                                    />
+                                );
+                                const cancelTarget =
+                                    getGardenOperationCancelTarget(
+                                        operation,
+                                        currentGarden,
+                                    );
+                                const cancelAction = cancelTarget ? (
+                                    <GardenOperationCancelAction
+                                        entryName={entryName}
+                                        garden={currentGarden}
+                                        operation={operation}
+                                        referenceDate={referenceDate}
+                                    />
+                                ) : undefined;
+
+                                return (
+                                    <GardenOperationCard
+                                        key={`${operation.entityTypeName}-${operation.id}`}
+                                        operation={operation}
+                                        operationName={operationName}
+                                        operationData={operationData}
+                                        plantSortData={plantSortData}
+                                        targetPlantSortData={
+                                            operation.entityTypeName ===
+                                            cartOperationEntityType
+                                                ? (plantSortById.get(
+                                                      getOperationFieldPlantSortId(
+                                                          operation,
+                                                          currentGarden,
+                                                      ) ?? 0,
+                                                  ) ?? undefined)
+                                                : undefined
+                                        }
+                                        currentGarden={currentGarden}
+                                        referenceDate={referenceDate}
+                                        scheduleAction={scheduleAction}
+                                        cancelAction={cancelAction}
+                                    />
+                                );
+                            })
                         )}
                         <div ref={listRef} className="h-1" />
                     </Stack>

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
@@ -44,7 +44,7 @@ export function RaisedBedDiaryRescheduleAction({
         <Button
             type="button"
             size="xs"
-            variant="soft"
+            variant="plain"
             disabled={Boolean(disabledReason)}
             startDecorator={<Calendar className="size-3.5 shrink-0" />}
         >


### PR DESCRIPTION
## Summary
- moves operation schedule and cancel controls into the right status column to reduce card height
- makes the reschedule/date trigger use the plain button style
- enables reschedule/cancel actions from the operation history modal, matching active operations and diary operation lists

## Validation
- `pnpm --filter garden exec playwright test tests/garden-operations-hud.spec.tsx`
- `pnpm --filter garden typecheck`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden lint`
- `pnpm --filter @gredice/game lint`
- `git diff --check origin/main...HEAD`