### PR TITLE
fix(game): count only backpack inventory in HUD

### DIFF
--- a/apps/garden/tests/InventoryHudStory.tsx
+++ b/apps/garden/tests/InventoryHudStory.tsx
@@ -7,7 +7,20 @@ import {
     GameStateContext,
 } from '../../../packages/game/src/useGameState';
 
-function createInventoryHudQueryClient() {
+type InventoryHudStoryOptions = {
+    backpackItemAmount?: number;
+    gardenBoxItemAmount?: number;
+};
+
+const mixedInventoryStoryOptions = {
+    backpackItemAmount: 3,
+    gardenBoxItemAmount: 29,
+};
+
+function createInventoryHudQueryClient({
+    backpackItemAmount = 0,
+    gardenBoxItemAmount = 2,
+}: InventoryHudStoryOptions = {}) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
             queries: { retry: false, staleTime: Infinity },
@@ -16,33 +29,54 @@ function createInventoryHudQueryClient() {
 
     queryClient.setQueryData(['currentUser'], { id: 'test-user' });
     queryClient.setQueryData(['inventory'], {
-        items: [],
+        items:
+            backpackItemAmount > 0
+                ? [
+                      {
+                          amount: backpackItemAmount,
+                          entityId: '2',
+                          entityTypeName: 'block',
+                          name: 'Seed bag',
+                      },
+                  ]
+                : [],
         gardenBoxes: [
             {
                 blockId: 'garden-box-1',
                 gardenId: 1,
                 gardenName: 'Test garden',
-                items: [
-                    {
-                        amount: 2,
-                        entityId: '1',
-                        entityTypeName: 'block',
-                        name: 'Bucket',
-                    },
-                ],
+                items:
+                    gardenBoxItemAmount > 0
+                        ? [
+                              {
+                                  amount: gardenBoxItemAmount,
+                                  entityId: '1',
+                                  entityTypeName: 'block',
+                                  name: 'Bucket',
+                              },
+                          ]
+                        : [],
             },
         ],
     });
     queryClient.setQueryData(['operations'], []);
+    queryClient.setQueryData(['blocks'], []);
 
     return queryClient;
 }
 
 function InventoryHudTestProviders({
     children,
+    inventoryOptions,
     searchParams,
-}: PropsWithChildren<{ searchParams?: string }>) {
-    const queryClient = useMemo(() => createInventoryHudQueryClient(), []);
+}: PropsWithChildren<{
+    inventoryOptions?: InventoryHudStoryOptions;
+    searchParams?: string;
+}>) {
+    const queryClient = useMemo(
+        () => createInventoryHudQueryClient(inventoryOptions),
+        [inventoryOptions],
+    );
     const gameStore = useMemo(
         () =>
             createGameState({
@@ -62,6 +96,18 @@ function InventoryHudTestProviders({
                 </GameStateContext.Provider>
             </ReactQuery.QueryClientProvider>
         </NuqsTestingAdapter>
+    );
+}
+
+export function InventoryHudClosedStory() {
+    return (
+        <InventoryHudTestProviders
+            inventoryOptions={mixedInventoryStoryOptions}
+        >
+            <div className="relative h-screen w-screen p-8">
+                <InventoryHud />
+            </div>
+        </InventoryHudTestProviders>
     );
 }
 

--- a/apps/garden/tests/inventory-hud.spec.tsx
+++ b/apps/garden/tests/inventory-hud.spec.tsx
@@ -1,5 +1,26 @@
 import { expect, test } from '@playwright/experimental-ct-react';
-import { InventoryHudGardenBoxesOpenStory } from './InventoryHudStory';
+import {
+    InventoryHudClosedStory,
+    InventoryHudGardenBoxesOpenStory,
+} from './InventoryHudStory';
+
+test('inventory HUD badge counts backpack items without garden box contents', async ({
+    mount,
+    page,
+}) => {
+    await mount(<InventoryHudClosedStory />);
+
+    const inventoryButton = page.locator('button[title="Inventar"]');
+
+    await expect(inventoryButton).toBeVisible();
+    await expect(inventoryButton.getByText('3', { exact: true })).toBeVisible();
+    await expect(inventoryButton.getByText('32', { exact: true })).toHaveCount(
+        0,
+    );
+    await expect(inventoryButton.getByText('29', { exact: true })).toHaveCount(
+        0,
+    );
+});
 
 test('inventory can open directly on garden boxes tab', async ({
     mount,

--- a/packages/game/src/hud/InventoryHud.tsx
+++ b/packages/game/src/hud/InventoryHud.tsx
@@ -649,14 +649,17 @@ export function InventoryHud() {
                     >
                         <div className="relative flex items-center justify-center">
                             <BackpackIcon className="size-6" />
-                            {totalItems > 0 && (
+                            {backpackItemsTotal > 0 && (
                                 <div
                                     className={cx(
                                         'absolute -top-4 -right-4 size-6 px-1.5 rounded-full bg-tertiary text-tertiary-foreground text-sm font-semibold leading-none flex items-center justify-center shadow-md border border-tertiary-foreground/30',
-                                        totalItems > 99 && 'text-[10px]',
+                                        backpackItemsTotal > 99 &&
+                                            'text-[10px]',
                                     )}
                                 >
-                                    {totalItems > 99 ? '99+' : totalItems}
+                                    {backpackItemsTotal > 99
+                                        ? '99+'
+                                        : backpackItemsTotal}
                                 </div>
                             )}
                         </div>


### PR DESCRIPTION
## What changed

- Updated the game inventory HUD trigger badge to count only backpack inventory items.
- Kept garden box contents available in the inventory modal without adding them to the HUD badge total.
- Added component coverage for a mixed inventory case where backpack items and garden box items differ.

## Why

The inventory HUD badge was using the combined inventory total, so items stored inside garden boxes inflated the visible backpack count in-game.

## Validation

- `corepack pnpm lint --filter @gredice/game --filter garden`
- `corepack pnpm typecheck --filter @gredice/game --filter garden`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm exec playwright test tests/inventory-hud.spec.tsx`
- `git diff --check`