### PR TITLE
feat(garden): add greenhouse sowing toggles

### DIFF
--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -24,6 +24,23 @@ function callsNamed(calls: RecordedCall[], name: string) {
     return calls.filter((call) => call.name === name);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isRecordedEvent(value: unknown): value is {
+    type: string;
+    aggregateId: string;
+    data: unknown;
+} {
+    return (
+        isRecord(value) &&
+        typeof value.type === 'string' &&
+        typeof value.aggregateId === 'string' &&
+        'data' in value
+    );
+}
+
 function makeDependencies(
     calls: RecordedCall[],
     overrides: Partial<
@@ -493,6 +510,52 @@ describe('processItem', () => {
             callsNamed(calls, 'earnSunflowersForPayment')[0]?.args,
             ['account-1', 25],
         );
+    });
+
+    it('places planned greenhouse sowing when requested in additional data', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getRaisedBed: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBed', args);
+                return { status: 'active' };
+            },
+        });
+
+        await processItem(
+            {
+                accountId: 'account-1',
+                amount_total: 2500,
+                additionalData: {
+                    scheduledDate: '2026-07-01',
+                    sowingLocation: 'greenhouse',
+                },
+                cartId: 100,
+                cartItemId: 1,
+                currency: 'eur',
+                entityId: '101',
+                entityTypeName: 'plantSort',
+                gardenId: 200,
+                positionIndex: 2,
+                raisedBedId: 300,
+            },
+            dependencies,
+        );
+
+        const plantPlaceEvents = callsNamed(calls, 'createEvent')
+            .map((call) => call.args[0])
+            .filter(isRecordedEvent)
+            .filter((event) => event.type === 'raisedBedFields.plantPlace');
+
+        assert.equal(plantPlaceEvents.length, 1);
+        assert.deepStrictEqual(plantPlaceEvents[0], {
+            type: 'raisedBedFields.plantPlace',
+            aggregateId: '300|2',
+            data: {
+                plantSortId: '101',
+                scheduledDate: '2026-07-01',
+                sowingLocation: 'greenhouse',
+            },
+        });
     });
 });
 

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -779,6 +779,16 @@ function scheduledDateFromAdditionalData(additionalData: unknown) {
         : scheduledDate;
 }
 
+function greenhouseSowingLocationFromAdditionalData(additionalData: unknown) {
+    const parsedAdditionalData = parseAdditionalDataValue(additionalData);
+    return typeof parsedAdditionalData === 'object' &&
+        parsedAdditionalData != null &&
+        'sowingLocation' in parsedAdditionalData &&
+        parsedAdditionalData.sowingLocation === 'greenhouse'
+        ? 'greenhouse'
+        : undefined;
+}
+
 function checkoutScheduledDateFromAdditionalData(
     additionalData: unknown,
     dependencies: ProcessCheckoutSessionDependencies = realDependencies,
@@ -1060,7 +1070,11 @@ export async function processItem(
                           itemData.additionalData,
                           dependencies,
                       ),
-                sowingLocation: outletReservation ? 'greenhouse' : undefined,
+                sowingLocation: outletReservation
+                    ? 'greenhouse'
+                    : greenhouseSowingLocationFromAdditionalData(
+                          itemData.additionalData,
+                      ),
             }),
         );
         if (outletReservation) {

--- a/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
+++ b/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
@@ -78,6 +78,52 @@ function createPaidCartItem() {
     } as unknown as ShoppingCartItemData;
 }
 
+function createPlantSortCartItem() {
+    return {
+        ...cartItem,
+        entityId: '101',
+        entityTypeName: 'plantSort',
+        gardenId: 1,
+        raisedBedId: 1,
+        positionIndex: 0,
+        additionalData: JSON.stringify({
+            scheduledDate: '2040-01-05T00:00:00.000Z',
+        }),
+        shopData: {
+            ...cartItem.shopData,
+            name: 'Cherry rajčica',
+            description: 'Mock plant sort.',
+        },
+        entityData: {
+            id: 101,
+            entityType: {
+                id: 11,
+                name: 'plantSort',
+                label: 'Sorta biljke',
+            },
+            slug: 'mock-cherry-tomato',
+            information: {
+                name: 'Cherry rajčica',
+                plant: {
+                    information: {
+                        name: 'Rajčica',
+                    },
+                    image: {
+                        cover: {
+                            url: '',
+                        },
+                    },
+                },
+            },
+            image: {
+                cover: {
+                    url: '',
+                },
+            },
+        },
+    } as unknown as ShoppingCartItemData;
+}
+
 function createOptimisticToggleQueryClient(item = cartItem) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
@@ -100,7 +146,13 @@ function createOptimisticToggleQueryClient(item = cartItem) {
         name: 'Test garden',
         stacks: [],
         location: { lat: 45.739, lon: 16.572 },
-        raisedBeds: [],
+        raisedBeds: [
+            {
+                id: 1,
+                name: 'Mock gredica',
+                physicalId: '1',
+            },
+        ],
     });
     queryClient.setQueryData(['inventory'], { items: [] });
     queryClient.setQueryData(['shopping-cart'], {
@@ -189,6 +241,16 @@ export function ShoppingCartOutletCountdownStory() {
 
 export function ShoppingCartPaidItemStory() {
     const item = useMemo(() => createPaidCartItem(), []);
+
+    return (
+        <ShoppingCartOptimisticToggleProviders item={item}>
+            <ShoppingCartOptimisticTogglePanel />
+        </ShoppingCartOptimisticToggleProviders>
+    );
+}
+
+export function ShoppingCartPlantSortStory() {
+    const item = useMemo(() => createPlantSortCartItem(), []);
 
     return (
         <ShoppingCartOptimisticToggleProviders item={item}>

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -215,6 +215,9 @@ test('outlet sorts keep planned sowing selected by default', async ({
     await expect(
         page.getByRole('textbox', { name: 'Datum sijanja' }),
     ).toBeVisible();
+    await expect(
+        page.getByRole('switch', { name: 'Staklenik' }),
+    ).toHaveAttribute('aria-checked', 'false');
 
     await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
 
@@ -226,6 +229,43 @@ test('outlet sorts keep planned sowing selected by default', async ({
     }
     expect(post.outletOfferId).toBeUndefined();
     expect(post.entityId).toBe('101');
+});
+
+test('planned greenhouse sowing sends greenhouse location', async ({
+    mount,
+    page,
+}) => {
+    const posts = await mockShoppingCartPosts(page);
+
+    await mount(<PlantPickerTestStory />);
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+    await page.getByRole('button', { name: /Rajčica/ }).click();
+    await page.getByRole('button', { name: /Cherry rajčica/ }).click();
+
+    const greenhouseSwitch = page.getByRole('switch', { name: 'Staklenik' });
+    await expect(greenhouseSwitch).toHaveAttribute('aria-checked', 'false');
+    await greenhouseSwitch.click();
+    await expect(greenhouseSwitch).toHaveAttribute('aria-checked', 'true');
+
+    await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
+
+    await expect.poll(() => posts.length).toBe(1);
+    const post = posts[0];
+    expect(isRecord(post)).toBe(true);
+    if (!isRecord(post)) {
+        return;
+    }
+    expect(typeof post.additionalData).toBe('string');
+    if (typeof post.additionalData !== 'string') {
+        return;
+    }
+    const additionalData: unknown = JSON.parse(post.additionalData);
+    expect(isRecord(additionalData)).toBe(true);
+    if (!isRecord(additionalData)) {
+        return;
+    }
+    expect(additionalData.sowingLocation).toBe('greenhouse');
 });
 
 test('outlet sowing sends the selected outlet offer', async ({

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -3,7 +3,12 @@ import {
     ShoppingCartOptimisticToggleStory,
     ShoppingCartOutletCountdownStory,
     ShoppingCartPaidItemStory,
+    ShoppingCartPlantSortStory,
 } from './ShoppingCartOptimisticToggleStory';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
 
 function addDays(date: Date, days: number) {
     return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
@@ -137,6 +142,52 @@ test('shopping cart date chip updates scheduled date metadata', async ({
     expect(additionalData?.scheduledDate).toBe(
         scheduledDateIsoFromDateInput(selectedDate),
     );
+});
+
+test('shopping cart greenhouse toggle updates sowing location metadata', async ({
+    mount,
+    page,
+}) => {
+    let resolvePayload:
+        | ((payload: Record<string, unknown>) => void)
+        | undefined;
+    const postedPayload = new Promise<Record<string, unknown>>((resolve) => {
+        resolvePayload = resolve;
+    });
+
+    await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+        if (route.request().method() !== 'POST') {
+            await route.fallback();
+            return;
+        }
+
+        const payload: unknown = route.request().postDataJSON();
+        if (isRecord(payload)) {
+            resolvePayload?.(payload);
+        }
+        await route.fulfill({
+            body: JSON.stringify({ success: true }),
+            contentType: 'application/json',
+            status: 200,
+        });
+    });
+
+    await mount(<ShoppingCartPlantSortStory />);
+
+    const greenhouseSwitch = page.getByRole('switch', { name: 'Staklenik' });
+    await expect(greenhouseSwitch).toHaveAttribute('aria-checked', 'false');
+
+    await greenhouseSwitch.click();
+    await expect(greenhouseSwitch).toHaveAttribute('aria-checked', 'true');
+
+    const payload = await postedPayload;
+    const additionalData =
+        typeof payload.additionalData === 'string'
+            ? JSON.parse(payload.additionalData)
+            : null;
+
+    expect(additionalData?.scheduledDate).toBe('2040-01-05T00:00:00.000Z');
+    expect(additionalData?.sowingLocation).toBe('greenhouse');
 });
 
 test('paid shopping cart item date is not editable', async ({

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -8,6 +8,7 @@ import {
     Euro,
     Hammer,
     Navigate,
+    Sprout,
     Timer,
 } from '@gredice/ui/icons';
 import { ModalConfirm } from '@gredice/ui/ModalConfirm';
@@ -16,6 +17,7 @@ import { PlantOrSortImage } from '@gredice/ui/plants';
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
+import { Switch } from '@gredice/ui/Switch';
 import { Typography } from '@gredice/ui/Typography';
 import { useQueryClient } from '@tanstack/react-query';
 import { type CSSProperties, useEffect, useState } from 'react';
@@ -129,6 +131,22 @@ function getCartItemScheduledDateInfo(
     };
 }
 
+function greenhouseAdditionalData(
+    additionalData: Record<string, unknown>,
+    enabled: boolean,
+) {
+    if (enabled) {
+        return {
+            ...additionalData,
+            sowingLocation: 'greenhouse',
+        };
+    }
+
+    const nextAdditionalData = { ...additionalData };
+    delete nextAdditionalData.sowingLocation;
+    return nextAdditionalData;
+}
+
 export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     const { data: garden } = useCurrentGarden();
     const { data: account } = useCurrentAccount();
@@ -147,6 +165,7 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     const raisedBed = hasRaisedBed
         ? garden?.raisedBeds.find((rb) => rb.id === item.raisedBedId)
         : null;
+    const additionalData = parseAdditionalData(item.additionalData);
     const scheduledDateInfo = getCartItemScheduledDateInfo(item);
     const scheduledDate = scheduledDateInfo.date;
     const scheduledDateLabel = formatCartDate(scheduledDate);
@@ -156,6 +175,10 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     const hasOutletReservation = Boolean(item.outlet);
     const outletReservationExpiredFromApi = item.outlet?.expired ?? false;
     const outletHoldExpiresAtMs = outletHoldExpiresAt?.getTime() ?? null;
+    const isGreenhouseSowing =
+        item.entityTypeName === 'plantSort' &&
+        (hasOutletReservation ||
+            additionalData.sowingLocation === 'greenhouse');
     const outletReservationRemainingMs =
         outletHoldExpiresAtMs != null
             ? outletHoldExpiresAtMs - countdownNowMs
@@ -189,7 +212,12 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     const changeCurrencyShoppingCartItem = useSetShoppingCartItem();
     const removeShoppingCartItem = useSetShoppingCartItem();
     const changeScheduledDateShoppingCartItem = useSetShoppingCartItem();
+    const changeGreenhouseSowingShoppingCartItem = useSetShoppingCartItem();
     const canChangeScheduledDate = !isProcessed && !hasOutletReservation;
+    const canChangeGreenhouseSowing =
+        item.entityTypeName === 'plantSort' &&
+        !isProcessed &&
+        !hasOutletReservation;
     const parsedOperationId = Number(item.entityId);
     const operationId =
         Number.isInteger(parsedOperationId) && parsedOperationId > 0
@@ -301,6 +329,31 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
             entityTypeName: item.entityTypeName,
             currency: usesInventory ? 'eur' : 'inventory',
             additionalData: item.additionalData,
+            positionIndex: item.positionIndex ?? undefined,
+            gardenId: item.gardenId ?? undefined,
+            raisedBedId: item.raisedBedId ?? undefined,
+        });
+    }
+
+    async function handleToggleGreenhouseSowing(checked: boolean) {
+        const nextAdditionalData = greenhouseAdditionalData(
+            parseAdditionalData(item.additionalData),
+            checked,
+        );
+
+        track('game_cart_greenhouse_sowing_toggled', {
+            entity_id: item.entityId,
+            entity_type: item.entityTypeName,
+            item_id: item.id,
+            sow_in_greenhouse: checked,
+        });
+        await changeGreenhouseSowingShoppingCartItem.mutateAsync({
+            id: item.id,
+            amount: item.amount,
+            entityId: item.entityId,
+            entityTypeName: item.entityTypeName,
+            currency: item.currency,
+            additionalData: JSON.stringify(nextAdditionalData),
             positionIndex: item.positionIndex ?? undefined,
             gardenId: item.gardenId ?? undefined,
             raisedBedId: item.raisedBedId ?? undefined,
@@ -458,23 +511,61 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                             </Row>
                         </Row>
                     )}
-                {item.outlet && (
-                    <Row className="flex-wrap" spacing={1}>
-                        <Chip className="bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-100">
-                            <Typography level="body3">
-                                Outlet sadnica
-                            </Typography>
-                        </Chip>
-                        <Chip
-                            className={outletReservationChipClassName}
-                            title={outletReservationTitle}
-                        >
-                            <Typography level="body3">
-                                {outletReservationText}
-                            </Typography>
-                        </Chip>
-                    </Row>
-                )}
+                {(item.outlet || isGreenhouseSowing) &&
+                    !canChangeGreenhouseSowing && (
+                        <Row className="flex-wrap" spacing={1}>
+                            {item.outlet ? (
+                                <>
+                                    <Chip className="bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-100">
+                                        <Typography level="body3">
+                                            Outlet sadnica
+                                        </Typography>
+                                    </Chip>
+                                    <Chip
+                                        className={
+                                            outletReservationChipClassName
+                                        }
+                                        title={outletReservationTitle}
+                                    >
+                                        <Typography level="body3">
+                                            {outletReservationText}
+                                        </Typography>
+                                    </Chip>
+                                </>
+                            ) : null}
+                            {isGreenhouseSowing ? (
+                                <Chip
+                                    className="bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-100"
+                                    startDecorator={<Sprout />}
+                                >
+                                    <Typography level="body3">
+                                        Staklenik
+                                    </Typography>
+                                </Chip>
+                            ) : null}
+                        </Row>
+                    )}
+                {canChangeGreenhouseSowing ? (
+                    <div className="rounded-lg border border-input bg-card px-3 py-2">
+                        <Switch
+                            checked={isGreenhouseSowing}
+                            disabled={
+                                changeGreenhouseSowingShoppingCartItem.isPending
+                            }
+                            onCheckedChange={(checked) => {
+                                void handleToggleGreenhouseSowing(checked);
+                            }}
+                            size="sm"
+                            label={
+                                <span className="inline-flex items-center gap-1">
+                                    <Sprout className="size-4 shrink-0" />
+                                    <span>Staklenik</span>
+                                </span>
+                            }
+                            description="Sijanje počinje u stakleniku."
+                        />
+                    </div>
+                ) : null}
                 <Row justifyContent="space-between">
                     <Stack spacing={1}>
                         <Row spacing={2}>

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -3,11 +3,19 @@ import { BackpackIcon } from '@gredice/ui/BackpackIcon';
 import { Button } from '@gredice/ui/Button';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Input } from '@gredice/ui/Input';
-import { Check, Close, Left, Search, ShoppingCart } from '@gredice/ui/icons';
+import {
+    Check,
+    Close,
+    Left,
+    Search,
+    ShoppingCart,
+    Sprout,
+} from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
 import { PlantingSeedIcon } from '@gredice/ui/PlantingSeedIcon';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
+import { Switch } from '@gredice/ui/Switch';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import {
@@ -115,6 +123,27 @@ function groupOutletOffersBySortId(outletOffers: OutletOfferData[] = []) {
     return offersBySortId;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseAdditionalData(additionalData?: string | null) {
+    if (!additionalData) {
+        return {};
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(additionalData);
+        return isRecord(parsed) ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
+function isGreenhouseSowing(additionalData?: string | null) {
+    return parseAdditionalData(additionalData).sowingLocation === 'greenhouse';
+}
+
 type PlantPickerProps = {
     positionIndex: number;
     gardenId: number;
@@ -179,6 +208,7 @@ export function PlantPicker({
     const [flyToShoppingCart, setFlyToShoppingCart] = useState(false);
     const [useInventoryItem, setUseInventoryItem] = useState(false);
     const [useOutletOffer, setUseOutletOffer] = useState(false);
+    const [sowInGreenhouse, setSowInGreenhouse] = useState(false);
     const [selectedOutletOfferId, setSelectedOutletOfferId] = useState<
         number | null
     >(null);
@@ -275,6 +305,7 @@ export function PlantPicker({
         setPlantOptions(null);
         setUseInventoryItem(false);
         setUseOutletOffer(false);
+        setSowInGreenhouse(false);
         setSelectedOutletOfferId(null);
         resetSearch();
         await removeFromCart();
@@ -312,6 +343,7 @@ export function PlantPicker({
                 setSelectedPlantId(null);
                 setSelectedSortId(null);
                 setUseOutletOffer(false);
+                setSowInGreenhouse(false);
                 setSelectedOutletOfferId(null);
                 resetSearch();
             }
@@ -343,6 +375,11 @@ export function PlantPicker({
             position_index: positionIndex,
             raised_bed_id: raisedBedId,
             scheduled_date: plantOptions?.scheduledDate?.toISOString(),
+            sowing_location: selectedOutletOffer
+                ? 'greenhouse'
+                : sowInGreenhouse
+                  ? 'greenhouse'
+                  : 'direct',
             sort_id: selectedSortId,
             use_inventory: useInventoryItem,
             outlet_offer_id: selectedOutletOffer?.id,
@@ -365,6 +402,9 @@ export function PlantPicker({
                         : {
                               scheduledDate:
                                   plantOptions?.scheduledDate?.toISOString(),
+                              ...(sowInGreenhouse
+                                  ? { sowingLocation: 'greenhouse' }
+                                  : {}),
                           }),
                 }),
                 currency: useInventoryItem ? 'inventory' : 'eur',
@@ -404,7 +444,19 @@ export function PlantPicker({
         );
         setUseInventoryItem(existingItem?.currency === 'inventory');
         setUseOutletOffer(Boolean(existingItem?.outlet));
+        setSowInGreenhouse(isGreenhouseSowing(existingItem?.additionalData));
         setSelectedOutletOfferId(existingItem?.outlet?.offerId ?? null);
+    }
+
+    function handleGreenhouseSowingChange(checked: boolean) {
+        track('game_greenhouse_sowing_toggled', {
+            garden_id: gardenId,
+            position_index: positionIndex,
+            raised_bed_id: raisedBedId,
+            sort_id: selectedSortId,
+            sow_in_greenhouse: checked,
+        });
+        setSowInGreenhouse(checked);
     }
 
     // Plant options
@@ -856,20 +908,47 @@ export function PlantPicker({
                                             kratko nakon dodavanja u košaru.
                                         </div>
                                     ) : selectedOutletOfferUnavailable ? null : (
-                                        <Input
-                                            type="date"
-                                            label="Datum sijanja"
-                                            name="plantDate"
-                                            className="w-full bg-card"
-                                            value={plantDate}
-                                            onChange={(e) =>
-                                                handlePlantDateChange(
-                                                    e.target.value,
-                                                )
-                                            }
-                                            min={min}
-                                            max={max}
-                                        />
+                                        <>
+                                            <div
+                                                className={cx(
+                                                    'rounded-lg border p-3 transition-colors',
+                                                    sowInGreenhouse
+                                                        ? 'border-green-500 bg-green-50 text-green-950 dark:border-green-700 dark:bg-green-950/40 dark:text-green-100'
+                                                        : 'border-input bg-card',
+                                                )}
+                                            >
+                                                <Switch
+                                                    checked={sowInGreenhouse}
+                                                    onCheckedChange={
+                                                        handleGreenhouseSowingChange
+                                                    }
+                                                    size="sm"
+                                                    label={
+                                                        <span className="inline-flex items-center gap-1">
+                                                            <Sprout className="size-4 shrink-0" />
+                                                            <span>
+                                                                Staklenik
+                                                            </span>
+                                                        </span>
+                                                    }
+                                                    description="Sadnica počinje u stakleniku i kasnije se presađuje u gredicu."
+                                                />
+                                            </div>
+                                            <Input
+                                                type="date"
+                                                label="Datum sijanja"
+                                                name="plantDate"
+                                                className="w-full bg-card"
+                                                value={plantDate}
+                                                onChange={(e) =>
+                                                    handlePlantDateChange(
+                                                        e.target.value,
+                                                    )
+                                                }
+                                                min={min}
+                                                max={max}
+                                            />
+                                        </>
                                     )}
                                 </>
                             )}


### PR DESCRIPTION
## Summary
- add a greenhouse sowing switch to the garden plant picker
- persist planned greenhouse sowing in shopping cart metadata and restore it in the picker/cart
- carry greenhouse sowing metadata into the raised-bed plant placement event at checkout

## Validation
- `corepack pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/stripe/processCheckoutSession.node.spec.ts`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm --filter @gredice/game exec biome check --write src/hud/raisedBed/RaisedBedPlantPicker.tsx src/hud/components/shopping-cart/ShoppingCartItem.tsx`
- `corepack pnpm --filter garden exec biome check --write tests/raised-bed-plant-picker.spec.tsx tests/ShoppingCartOptimisticToggleStory.tsx tests/shopping-cart-optimistic-toggle.spec.tsx`
- `corepack pnpm --filter api exec biome check --write lib/stripe/processCheckoutSession.ts lib/stripe/processCheckoutSession.node.spec.ts`
- `corepack pnpm build --filter garden`
- `corepack pnpm --filter garden exec playwright test --config playwright.config.ts tests/raised-bed-plant-picker.spec.tsx`
- `corepack pnpm --filter garden exec playwright test --config playwright.config.ts tests/shopping-cart-optimistic-toggle.spec.tsx`
- `git diff --check`