### PR TITLE
feat(storage): Gate greenhouse plant inventory automation

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -127,7 +127,12 @@ MVP modules:
 - `action.createOperation`: creates an operation for the event context.
 - `action.createFarmInventoryOperations`: creates accepted, scheduled farm-level
   operations for every active farm from a JSON list in the automation
-  definition.
+  definition. Individual entries can set
+  `requiresGreenhouseOrOutletPlants: true` to create that operation only for
+  farms with current greenhouse-located raised-bed fields, or when central
+  outlet stock has active published non-expired offers with remaining quantity.
+  Because outlet offers are not farm-scoped in storage, active outlet stock makes
+  every active farm eligible for that conditional inventory operation.
 - `action.createGreenhouseSeedlingWateringOperations`: creates at most one
   accepted, scheduled farm-level `Zalijevanje presadnica u stakleniku`
   operation per active farm and local schedule date. A farm is eligible when it

--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -34,6 +34,7 @@ export const FARM_RAISED_BED_WEEDING_OPERATION_ID = 654;
 export const farmRaisedBedWeedingOperationKey = 'cleanWeedsAroundRaisedBeds';
 export const farmRaisedBedWeedingBiweeklyAnchorDate = '2026-01-05';
 const greenhouseSeedlingWateringOperationId = 655;
+export const FARM_GREENHOUSE_PLANT_INVENTORY_OPERATION_ID = 661;
 export const monthlyFarmInventoryOperationConfigs = [
     { entityId: 554, entityTypeName: 'operation', scheduledInDays: 0 },
     { entityId: 555, entityTypeName: 'operation', scheduledInDays: 0 },
@@ -47,6 +48,12 @@ export const monthlyFarmInventoryOperationConfigs = [
     { entityId: 563, entityTypeName: 'operation', scheduledInDays: 0 },
     { entityId: 564, entityTypeName: 'operation', scheduledInDays: 0 },
     { entityId: 565, entityTypeName: 'operation', scheduledInDays: 0 },
+    {
+        entityId: FARM_GREENHOUSE_PLANT_INVENTORY_OPERATION_ID,
+        entityTypeName: 'operation',
+        scheduledInDays: 0,
+        requiresGreenhouseOrOutletPlants: true,
+    },
 ];
 export const RAISED_BED_PHOTO_OPERATION_ID = 301;
 export const RAISED_BED_PHOTO_OPERATION_NAME = 'raisedBedFullPhoto';
@@ -593,7 +600,7 @@ export async function ensureDefaultAutomationDefinitions() {
             key: monthlyFarmInventoryOperationsAutomationKey,
             name: 'Mjesečna inventura farme',
             description:
-                'Dan prije prvog dana u mjesecu kreiraj inventurne radnje za svaku aktivnu farmu.',
+                'Dan prije prvog dana u mjesecu kreiraj inventurne radnje za svaku aktivnu farmu. Inventura biljaka u plasteniku kreira se samo kada farma ima biljke u plasteniku ili postoji aktivna outlet ponuda.',
             status: 'enabled',
             graph: monthlyFarmInventoryOperationsAutomationGraph(),
             metadata: {

--- a/packages/storage/src/automations/modules.ts
+++ b/packages/storage/src/automations/modules.ts
@@ -571,6 +571,7 @@ type FarmInventoryOperationConfig = {
     entityId: number;
     entityTypeName: string;
     scheduledInDays: number;
+    requiresGreenhouseOrOutletPlants: boolean;
 };
 
 const greenhouseSeedlingPlantStatuses = new Set([
@@ -606,6 +607,25 @@ type ExistingOperationSkip = {
     scheduledDate: string;
 };
 
+type GreenhouseFieldCountsByFarmId = Map<
+    number,
+    { greenhouseRaisedBedIds: Set<number>; greenhouseFieldCount: number }
+>;
+
+type GreenhouseOrOutletPlantEligibilitySnapshot = {
+    greenhouseCountsByFarmId: GreenhouseFieldCountsByFarmId;
+    activeOutletOfferCount: number;
+    availabilityDate: Date;
+};
+
+type IneligibleFarmInventoryOperationSkip = {
+    farmId: number;
+    entityId: number;
+    entityTypeName: string;
+    scheduledDate: string;
+    reason: string;
+};
+
 function parseFarmInventoryOperationConfigs(
     value: unknown,
 ): FarmInventoryOperationConfig[] {
@@ -622,6 +642,14 @@ function parseFarmInventoryOperationConfigs(
         const entityTypeName = Reflect.get(item, 'entityTypeName');
         const scheduledInDays = Reflect.get(item, 'scheduledInDays');
         const hasScheduledInDays = Reflect.has(item, 'scheduledInDays');
+        const requiresGreenhouseOrOutletPlants = Reflect.get(
+            item,
+            'requiresGreenhouseOrOutletPlants',
+        );
+        const hasGreenhouseOrOutletRequirement = Reflect.has(
+            item,
+            'requiresGreenhouseOrOutletPlants',
+        );
         if (
             typeof entityId !== 'number' ||
             !Number.isInteger(entityId) ||
@@ -636,6 +664,12 @@ function parseFarmInventoryOperationConfigs(
         ) {
             return [];
         }
+        if (
+            hasGreenhouseOrOutletRequirement &&
+            typeof requiresGreenhouseOrOutletPlants !== 'boolean'
+        ) {
+            return [];
+        }
 
         return [
             {
@@ -647,6 +681,10 @@ function parseFarmInventoryOperationConfigs(
                         : 'operation',
                 scheduledInDays:
                     typeof scheduledInDays === 'number' ? scheduledInDays : 0,
+                requiresGreenhouseOrOutletPlants:
+                    typeof requiresGreenhouseOrOutletPlants === 'boolean'
+                        ? requiresGreenhouseOrOutletPlants
+                        : false,
             },
         ];
     });
@@ -661,7 +699,7 @@ function validateFarmInventoryOperationsConfig(config: AutomationJsonObject) {
     const validOperations = parseFarmInventoryOperationConfigs(operations);
     if (validOperations.length !== operations.length) {
         return [
-            'Each operation must include a positive integer entityId. Optional fields: entityTypeName, integer scheduledInDays.',
+            'Each operation must include a positive integer entityId. Optional fields: entityTypeName, integer scheduledInDays, boolean requiresGreenhouseOrOutletPlants.',
         ];
     }
 
@@ -688,6 +726,7 @@ function parseSingleOperationConfig(
         entityId,
         entityTypeName: getString(config, 'entityTypeName') ?? 'operation',
         scheduledInDays: scheduledInDays ?? 0,
+        requiresGreenhouseOrOutletPlants: false,
     };
 }
 
@@ -865,7 +904,7 @@ function isCurrentlyGreenhouseSeedling(field: RaisedBedFieldForGreenhouseCare) {
     );
 }
 
-async function getGreenhouseFieldCountsByFarmId() {
+async function getGreenhouseFieldCountsByFarmId(): Promise<GreenhouseFieldCountsByFarmId> {
     const [raisedBeds, gardens] = await Promise.all([
         getAllRaisedBeds(),
         getGardens(),
@@ -907,6 +946,46 @@ async function getGreenhouseFieldCountsByFarmId() {
     }
 
     return countsByFarmId;
+}
+
+async function getGreenhouseOrOutletPlantEligibilitySnapshot(
+    availabilityDate: Date,
+): Promise<GreenhouseOrOutletPlantEligibilitySnapshot> {
+    const [greenhouseCountsByFarmId, activeOutletOffers] = await Promise.all([
+        getGreenhouseFieldCountsByFarmId(),
+        getOutletOffers({ now: availabilityDate }),
+    ]);
+
+    return {
+        greenhouseCountsByFarmId,
+        activeOutletOfferCount: activeOutletOffers.length,
+        availabilityDate,
+    };
+}
+
+function getGreenhouseOrOutletPlantEligibilityForFarm({
+    farmId,
+    snapshot,
+}: {
+    farmId: number;
+    snapshot: GreenhouseOrOutletPlantEligibilitySnapshot;
+}): GreenhouseFarmEligibility {
+    const greenhouseCounts = snapshot.greenhouseCountsByFarmId.get(farmId);
+    const greenhouseFieldCount = greenhouseCounts?.greenhouseFieldCount ?? 0;
+    const greenhouseRaisedBedCount =
+        greenhouseCounts?.greenhouseRaisedBedIds.size ?? 0;
+    const reasons = [
+        ...(greenhouseFieldCount > 0 ? ['greenhouseFields'] : []),
+        ...(snapshot.activeOutletOfferCount > 0 ? ['activeOutletStock'] : []),
+    ];
+
+    return {
+        farmId,
+        greenhouseRaisedBedCount,
+        greenhouseFieldCount,
+        activeOutletOfferCount: snapshot.activeOutletOfferCount,
+        reasons,
+    };
 }
 
 function parseRaisedBedFieldAggregateId(aggregateId: string) {
@@ -1720,7 +1799,7 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
     kind: 'action',
     title: 'Create farm inventory operations',
     description:
-        'Creates configured inventory task operations for every active farm.',
+        'Creates configured inventory task operations for every active farm, with optional greenhouse/outlet plant eligibility per operation.',
     category: 'Operations',
     configFields: [
         {
@@ -1729,7 +1808,7 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
             type: 'json',
             required: true,
             description:
-                'JSON array: [{"entityId": 123, "entityTypeName": "operation", "scheduledInDays": 0}]',
+                'JSON array: [{"entityId": 123, "entityTypeName": "operation", "scheduledInDays": 0, "requiresGreenhouseOrOutletPlants": false}]',
         },
     ],
     inputDescription: 'A monthly schedule occurrence.',
@@ -1765,15 +1844,29 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
         const activeFarms = (await getFarms()).filter(
             (farm) => !farm.isDeleted,
         );
+        const requiresGreenhouseOrOutletEligibility = operationConfigs.some(
+            (operationConfig) =>
+                operationConfig.requiresGreenhouseOrOutletPlants,
+        );
+        const greenhouseOrOutletEligibilitySnapshot =
+            requiresGreenhouseOrOutletEligibility
+                ? await getGreenhouseOrOutletPlantEligibilitySnapshot(
+                      getScheduleReferenceDate(context.run.input),
+                  )
+                : null;
 
         if (activeFarms.length === 0) {
             return skip('No active farms were found.');
         }
 
         let skippedExistingCount = 0;
+        let skippedIneligibleCount = 0;
+        let eligibleOperationTargetCount = 0;
         let repairedScheduledCount = 0;
         const createdOperationIds: number[] = [];
         const repairedScheduledOperationIds: number[] = [];
+        const skippedIneligibleOperations: IneligibleFarmInventoryOperationSkip[] =
+            [];
 
         for (const farm of activeFarms) {
             const existingOperations =
@@ -1814,6 +1907,29 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
                     referenceDate,
                     operationConfig.scheduledInDays,
                 );
+                if (
+                    operationConfig.requiresGreenhouseOrOutletPlants &&
+                    greenhouseOrOutletEligibilitySnapshot
+                ) {
+                    const eligibility =
+                        getGreenhouseOrOutletPlantEligibilityForFarm({
+                            farmId: farm.id,
+                            snapshot: greenhouseOrOutletEligibilitySnapshot,
+                        });
+                    if (eligibility.reasons.length === 0) {
+                        skippedIneligibleCount += 1;
+                        skippedIneligibleOperations.push({
+                            farmId: farm.id,
+                            entityId: operationConfig.entityId,
+                            entityTypeName: operationConfig.entityTypeName,
+                            scheduledDate: scheduledDate.toISOString(),
+                            reason: 'No greenhouse-located plants or active outlet seedlings.',
+                        });
+                        continue;
+                    }
+                }
+
+                eligibleOperationTargetCount += 1;
                 const operationKey = farmOperationKey({
                     entityId: operationConfig.entityId,
                     entityTypeName: operationConfig.entityTypeName,
@@ -1870,18 +1986,26 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
 
         if (context.dryRun) {
             const projectedCreateCount =
-                activeFarms.length * operationConfigs.length -
-                skippedExistingCount;
+                eligibleOperationTargetCount - skippedExistingCount;
             return success({
                 dryRun: true,
                 farmCount: activeFarms.length,
                 operationCount: operationConfigs.length,
                 createdCount: projectedCreateCount,
                 projectedCreateCount,
-                skippedCount: skippedExistingCount,
+                eligibleOperationTargetCount,
+                skippedCount: skippedExistingCount + skippedIneligibleCount,
                 skippedExistingCount,
                 skippedScheduledCount: skippedExistingCount,
+                skippedIneligibleCount,
+                skippedIneligibleOperations,
                 repairedScheduledCount,
+                activeOutletOfferCount:
+                    greenhouseOrOutletEligibilitySnapshot?.activeOutletOfferCount ??
+                    null,
+                outletAvailabilityCheckedAt:
+                    greenhouseOrOutletEligibilitySnapshot?.availabilityDate.toISOString() ??
+                    null,
             });
         }
 
@@ -1889,16 +2013,50 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
             createdOperationIds.length === 0 &&
             repairedScheduledOperationIds.length === 0
         ) {
+            if (eligibleOperationTargetCount === 0) {
+                return skip(
+                    'No active farms have greenhouse or outlet plants for the configured farm inventory operations.',
+                    {
+                        farmCount: activeFarms.length,
+                        operationCount: operationConfigs.length,
+                        createdCount: 0,
+                        eligibleOperationTargetCount,
+                        skippedCount:
+                            skippedExistingCount + skippedIneligibleCount,
+                        skippedExistingCount,
+                        skippedScheduledCount: skippedExistingCount,
+                        skippedIneligibleCount,
+                        skippedIneligibleOperations,
+                        repairedScheduledCount: 0,
+                        activeOutletOfferCount:
+                            greenhouseOrOutletEligibilitySnapshot?.activeOutletOfferCount ??
+                            null,
+                        outletAvailabilityCheckedAt:
+                            greenhouseOrOutletEligibilitySnapshot?.availabilityDate.toISOString() ??
+                            null,
+                    },
+                );
+            }
+
             return skip(
                 'All configured farm inventory operations already exist.',
                 {
                     farmCount: activeFarms.length,
                     operationCount: operationConfigs.length,
                     createdCount: 0,
-                    skippedCount: skippedExistingCount,
+                    eligibleOperationTargetCount,
+                    skippedCount: skippedExistingCount + skippedIneligibleCount,
                     skippedExistingCount,
                     skippedScheduledCount: skippedExistingCount,
+                    skippedIneligibleCount,
+                    skippedIneligibleOperations,
                     repairedScheduledCount: 0,
+                    activeOutletOfferCount:
+                        greenhouseOrOutletEligibilitySnapshot?.activeOutletOfferCount ??
+                        null,
+                    outletAvailabilityCheckedAt:
+                        greenhouseOrOutletEligibilitySnapshot?.availabilityDate.toISOString() ??
+                        null,
                 },
             );
         }
@@ -1908,11 +2066,20 @@ const createFarmInventoryOperationsActionModule: AutomationModule = {
             createdCount: createdOperationIds.length,
             repairedScheduledOperationIds,
             repairedScheduledCount: repairedScheduledOperationIds.length,
-            skippedCount: skippedExistingCount,
+            skippedCount: skippedExistingCount + skippedIneligibleCount,
             skippedExistingCount,
             skippedScheduledCount: skippedExistingCount,
+            skippedIneligibleCount,
+            skippedIneligibleOperations,
             farmCount: activeFarms.length,
             operationCount: operationConfigs.length,
+            eligibleOperationTargetCount,
+            activeOutletOfferCount:
+                greenhouseOrOutletEligibilitySnapshot?.activeOutletOfferCount ??
+                null,
+            outletAvailabilityCheckedAt:
+                greenhouseOrOutletEligibilitySnapshot?.availabilityDate.toISOString() ??
+                null,
         });
     },
 };
@@ -1972,37 +2139,28 @@ const createGreenhouseSeedlingWateringOperationsActionModule: AutomationModule =
                 operationConfig.scheduledInDays,
             );
             const rangeEnd = addUtcDays(scheduledDate, 1);
-            const [activeFarms, greenhouseCountsByFarmId, activeOutletOffers] =
-                await Promise.all([
-                    getFarms().then((farms) =>
-                        farms.filter((farm) => !farm.isDeleted),
-                    ),
-                    getGreenhouseFieldCountsByFarmId(),
-                    getOutletOffers({ now: availabilityDate }),
-                ]);
+            const [activeFarms, eligibilitySnapshot] = await Promise.all([
+                getFarms().then((farms) =>
+                    farms.filter((farm) => !farm.isDeleted),
+                ),
+                getGreenhouseOrOutletPlantEligibilitySnapshot(availabilityDate),
+            ]);
 
             if (activeFarms.length === 0) {
                 return skip('No active farms were found.');
             }
 
-            const activeOutletOfferCount = activeOutletOffers.length;
             const eligibleFarms: GreenhouseFarmEligibility[] = [];
             const skippedFarms: GreenhouseFarmSkip[] = [];
 
             for (const farm of activeFarms) {
-                const greenhouseCounts = greenhouseCountsByFarmId.get(farm.id);
-                const greenhouseFieldCount =
-                    greenhouseCounts?.greenhouseFieldCount ?? 0;
-                const greenhouseRaisedBedCount =
-                    greenhouseCounts?.greenhouseRaisedBedIds.size ?? 0;
-                const reasons = [
-                    ...(greenhouseFieldCount > 0 ? ['greenhouseFields'] : []),
-                    ...(activeOutletOfferCount > 0
-                        ? ['activeOutletStock']
-                        : []),
-                ];
+                const eligibility =
+                    getGreenhouseOrOutletPlantEligibilityForFarm({
+                        farmId: farm.id,
+                        snapshot: eligibilitySnapshot,
+                    });
 
-                if (reasons.length === 0) {
+                if (eligibility.reasons.length === 0) {
                     skippedFarms.push({
                         farmId: farm.id,
                         reason: 'No greenhouse-located plants or active outlet seedlings.',
@@ -2010,13 +2168,7 @@ const createGreenhouseSeedlingWateringOperationsActionModule: AutomationModule =
                     continue;
                 }
 
-                eligibleFarms.push({
-                    farmId: farm.id,
-                    greenhouseRaisedBedCount,
-                    greenhouseFieldCount,
-                    activeOutletOfferCount,
-                    reasons,
-                });
+                eligibleFarms.push(eligibility);
             }
 
             const existingOperationSkips: ExistingOperationSkip[] = [];
@@ -2114,8 +2266,10 @@ const createGreenhouseSeedlingWateringOperationsActionModule: AutomationModule =
                 skippedFarmCount: skippedFarms.length,
                 existingOperationSkips,
                 existingOperationSkipCount: existingOperationSkips.length,
-                activeOutletOfferCount,
-                outletAvailabilityCheckedAt: availabilityDate.toISOString(),
+                activeOutletOfferCount:
+                    eligibilitySnapshot.activeOutletOfferCount,
+                outletAvailabilityCheckedAt:
+                    eligibilitySnapshot.availabilityDate.toISOString(),
                 projectedCreateCount:
                     eligibleFarms.length - existingOperationSkips.length,
             };

--- a/packages/storage/tests/automationsRepo.node.spec.ts
+++ b/packages/storage/tests/automationsRepo.node.spec.ts
@@ -24,6 +24,7 @@ import {
     enqueueAutomationRunsFromSchedules,
     ensureDefaultAutomationDefinitions,
     executeAutomationRun,
+    FARM_GREENHOUSE_PLANT_INVENTORY_OPERATION_ID,
     FARM_RAISED_BED_WEEDING_OPERATION_ID,
     FREE_WATERING_OPERATION_ID,
     farmRaisedBedWeedingAutomationKey,
@@ -434,6 +435,61 @@ function dailyScheduleRunInput(date: Date, key: string) {
         occurrenceDate,
         timeZone: 'Europe/Zagreb',
         enqueuedAt: date.toISOString(),
+    };
+}
+
+async function createAutomationRunForMonthlyFarmInventory({
+    enqueuedAt,
+    referenceDate,
+    dryRun = false,
+}: {
+    enqueuedAt?: Date;
+    referenceDate: Date;
+    dryRun?: boolean;
+}) {
+    await ensureDefaultAutomationDefinitions();
+    const definition = await getAutomationDefinitionByKey(
+        monthlyFarmInventoryOperationsAutomationKey,
+    );
+    assert.ok(definition);
+    const occurrenceDate = referenceDate.toISOString().slice(0, 10);
+    const input = {
+        scheduleType: 'monthly',
+        frequency: 'monthly',
+        triggerModuleKey: automationModuleKeys.triggerSchedule,
+        occurrenceKey: `test.monthly-farm-inventory-${randomUUID()}:${occurrenceDate}`,
+        occurrenceDate,
+        timeZone: 'Europe/Zagreb',
+        dayOfMonth: referenceDate.getUTCDate(),
+        enqueuedAt: (enqueuedAt ?? referenceDate).toISOString(),
+    };
+    const run = await createAutomationRun({
+        automationDefinition: definition,
+        source: 'schedule',
+        sourceEventType: automationScheduleEventType,
+        sourceAggregateId: input.occurrenceKey,
+        dryRun,
+        input,
+    });
+    assert.ok(run);
+
+    const startedRun = await startAutomationRun(run.id, {
+        lockedBy: 'automations-test',
+    });
+    assert.ok(startedRun);
+
+    const result = await executeAutomationRun(startedRun);
+    const runWithSteps = await getAutomationRunWithSteps(startedRun.id);
+    const actionStep = runWithSteps?.steps.find(
+        (step) =>
+            step.nodeId === 'create-inventory-operations' &&
+            step.moduleKind === 'action',
+    );
+    assert.ok(actionStep);
+
+    return {
+        result,
+        actionOutput: actionStep.output,
     };
 }
 
@@ -1363,11 +1419,31 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
     const occurrenceDate = new Date('2026-07-01T00:00:00.000Z');
     const enqueuedAt = new Date('2026-06-30T08:00:00.000Z');
     const operationConfigs = monthlyFarmInventoryOperationConfigs;
+    const greenhousePlantInventoryOperationConfigs = operationConfigs.filter(
+        (operationConfig) =>
+            Reflect.get(operationConfig, 'requiresGreenhouseOrOutletPlants') ===
+            true,
+    );
+    const unconditionalOperationConfigs = operationConfigs.filter(
+        (operationConfig) =>
+            Reflect.get(operationConfig, 'requiresGreenhouseOrOutletPlants') !==
+            true,
+    );
+    assert.deepStrictEqual(
+        greenhousePlantInventoryOperationConfigs.map(
+            (operationConfig) => operationConfig.entityId,
+        ),
+        [FARM_GREENHOUSE_PLANT_INVENTORY_OPERATION_ID],
+    );
+    const expectedSkippedIneligibleCount =
+        activeFarms.length * greenhousePlantInventoryOperationConfigs.length;
+    const expectedCreatedCount =
+        activeFarms.length * unconditionalOperationConfigs.length - 1;
     const preexistingFarm = activeFarms[0];
     assert.ok(preexistingFarm);
     const preexistingOperationId = await createOperation({
-        entityId: operationConfigs[0].entityId,
-        entityTypeName: operationConfigs[0].entityTypeName,
+        entityId: unconditionalOperationConfigs[0].entityId,
+        entityTypeName: unconditionalOperationConfigs[0].entityTypeName,
         farmId: preexistingFarm.id,
         timestamp: occurrenceDate,
     });
@@ -1439,9 +1515,13 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
     assert.ok(dryRunActionStep);
     assert.strictEqual(
         dryRunActionStep.output.createdCount,
-        activeFarms.length * operationConfigs.length - 1,
+        expectedCreatedCount,
     );
     assert.strictEqual(dryRunActionStep.output.skippedScheduledCount, 1);
+    assert.strictEqual(
+        dryRunActionStep.output.skippedIneligibleCount,
+        expectedSkippedIneligibleCount,
+    );
     assert.strictEqual(dryRunActionStep.output.repairedScheduledCount, 1);
 
     const processResult = await processDueAutomationRuns({
@@ -1451,14 +1531,13 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
     assert.strictEqual(processResult.succeeded, 1);
     assert.strictEqual(processResult.skipped, 2);
 
-    const expectedScheduledDates = operationConfigs.map((operationConfig) =>
-        addUtcDays(
-            occurrenceDate,
-            operationConfig.scheduledInDays,
-        ).toISOString(),
+    const expectedScheduledDates = unconditionalOperationConfigs.map(
+        (operationConfig) =>
+            addUtcDays(
+                occurrenceDate,
+                operationConfig.scheduledInDays,
+            ).toISOString(),
     );
-    const expectedCreatedCount =
-        activeFarms.length * operationConfigs.length - 1;
     for (const farm of activeFarms) {
         const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
             farmId: farm.id,
@@ -1467,7 +1546,7 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
         });
         const inventoryOperations = farmOperations
             .filter((operation) =>
-                operationConfigs.some(
+                unconditionalOperationConfigs.some(
                     (operationConfig) =>
                         operationConfig.entityId === operation.entityId,
                 ),
@@ -1476,8 +1555,8 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
 
         assert.strictEqual(
             inventoryOperations.length,
-            operationConfigs.length,
-            `Expected ${operationConfigs.length} inventory operations for farm ${farm.id}, got ${JSON.stringify(
+            unconditionalOperationConfigs.length,
+            `Expected ${unconditionalOperationConfigs.length} inventory operations for farm ${farm.id}, got ${JSON.stringify(
                 inventoryOperations.map((operation) => ({
                     id: operation.id,
                     entityId: operation.entityId,
@@ -1526,6 +1605,10 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
     assert.ok(actionStep);
     assert.strictEqual(actionStep.output.createdCount, expectedCreatedCount);
     assert.strictEqual(actionStep.output.skippedScheduledCount, 1);
+    assert.strictEqual(
+        actionStep.output.skippedIneligibleCount,
+        expectedSkippedIneligibleCount,
+    );
     assert.strictEqual(actionStep.output.repairedScheduledCount, 1);
 
     const replayRun = await createAutomationRun({
@@ -1549,12 +1632,15 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
             to: addUtcDays(occurrenceDate, 1),
         });
         const inventoryOperations = farmOperations.filter((operation) =>
-            operationConfigs.some(
+            unconditionalOperationConfigs.some(
                 (operationConfig) =>
                     operationConfig.entityId === operation.entityId,
             ),
         );
-        assert.strictEqual(inventoryOperations.length, operationConfigs.length);
+        assert.strictEqual(
+            inventoryOperations.length,
+            unconditionalOperationConfigs.length,
+        );
     }
     const replayRunWithSteps = await getAutomationRunWithSteps(replayRun.id);
     const replayActionStep = replayRunWithSteps?.steps.find(
@@ -1564,9 +1650,164 @@ test('monthly farm inventory automation creates accepted scheduled farm tasks', 
     assert.strictEqual(replayActionStep.output.createdCount, 0);
     assert.strictEqual(
         replayActionStep.output.skippedScheduledCount,
-        activeFarms.length * operationConfigs.length,
+        activeFarms.length * unconditionalOperationConfigs.length,
+    );
+    assert.strictEqual(
+        replayActionStep.output.skippedIneligibleCount,
+        expectedSkippedIneligibleCount,
     );
     assert.strictEqual(replayActionStep.output.repairedScheduledCount, 0);
+});
+
+test('monthly farm inventory automation creates greenhouse plant inventory for farms with greenhouse fields', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await createFarm({
+        name: 'Automation Inventory Greenhouse Farm',
+        latitude: 45.8,
+        longitude: 15.9,
+    });
+    const gardenId = await createTestGarden({
+        accountId,
+        farmId,
+        name: `Automation Inventory Garden ${accountId}`,
+    });
+    const blockId = await createTestBlock(
+        gardenId,
+        `automation-inventory-block-${accountId}`,
+    );
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+    const otherFarmId = await createFarm({
+        name: 'Automation Inventory No Greenhouse Farm',
+        latitude: 46.2,
+        longitude: 16.3,
+    });
+    const fieldAggregateId = `${raisedBedId}|0`;
+    await upsertRaisedBedField({ raisedBedId, positionIndex: 0 });
+    await createEvent(
+        knownEvents.raisedBedFields.plantPlaceV1(fieldAggregateId, {
+            plantSortId: '101',
+            scheduledDate: '2026-08-20T08:00:00.000Z',
+            sowingLocation: 'greenhouse',
+        }),
+    );
+    await createEvent(
+        knownEvents.raisedBedFields.plantUpdateV1(fieldAggregateId, {
+            status: 'sprouted',
+        }),
+    );
+
+    const { result, actionOutput } =
+        await createAutomationRunForMonthlyFarmInventory({
+            referenceDate: new Date('2026-09-01T00:00:00.000Z'),
+        });
+
+    assert.strictEqual(result.status, 'succeeded');
+    const activeFarmCount = Reflect.get(actionOutput, 'farmCount');
+    if (typeof activeFarmCount !== 'number') {
+        assert.fail('Expected monthly inventory output to include farmCount.');
+    }
+    assert.strictEqual(
+        Reflect.get(actionOutput, 'skippedIneligibleCount'),
+        activeFarmCount - 1,
+    );
+    assert.strictEqual(Reflect.get(actionOutput, 'activeOutletOfferCount'), 0);
+
+    const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
+        farmId,
+        from: new Date('2026-09-01T00:00:00.000Z'),
+        to: new Date('2026-09-02T00:00:00.000Z'),
+    });
+    const greenhouseInventoryOperations = farmOperations.filter(
+        (operation) =>
+            operation.entityId === FARM_GREENHOUSE_PLANT_INVENTORY_OPERATION_ID,
+    );
+    assert.strictEqual(greenhouseInventoryOperations.length, 1);
+    assert.strictEqual(
+        greenhouseInventoryOperations[0]?.scheduledDate?.toISOString(),
+        '2026-09-01T00:00:00.000Z',
+    );
+
+    const otherFarmOperations = await getFarmAcceptedOperationsByScheduleRange({
+        farmId: otherFarmId,
+        from: new Date('2026-09-01T00:00:00.000Z'),
+        to: new Date('2026-09-02T00:00:00.000Z'),
+    });
+    assert.strictEqual(
+        otherFarmOperations.filter(
+            (operation) =>
+                operation.entityId ===
+                FARM_GREENHOUSE_PLANT_INVENTORY_OPERATION_ID,
+        ).length,
+        0,
+    );
+
+    await storage()
+        .update(raisedBeds)
+        .set({ isDeleted: true })
+        .where(eq(raisedBeds.id, raisedBedId));
+    await storage()
+        .update(farms)
+        .set({ isDeleted: true })
+        .where(eq(farms.id, farmId));
+    await storage()
+        .update(farms)
+        .set({ isDeleted: true })
+        .where(eq(farms.id, otherFarmId));
+});
+
+test('monthly farm inventory automation treats active outlet stock as greenhouse plant inventory eligibility', async () => {
+    createTestDb();
+    const firstFarmId = await createFarm({
+        name: 'Automation Inventory Outlet Farm A',
+        latitude: 45.9,
+        longitude: 16.0,
+    });
+    const secondFarmId = await createFarm({
+        name: 'Automation Inventory Outlet Farm B',
+        latitude: 46.0,
+        longitude: 16.1,
+    });
+    const plantSortId = await createTestPlantSortForOutlet();
+    await createOutletOffer({
+        plantSortId,
+        sowingDate: new Date('2026-08-15T00:00:00.000Z'),
+        initialPlantStatus: 'sprouted',
+        imageUrls: [],
+        outletPriceCents: 199,
+        comparePriceCents: 349,
+        quantity: 4,
+        startAt: new Date('2026-08-31T00:00:00.000Z'),
+        endAt: new Date('2026-09-02T00:00:00.000Z'),
+        status: 'published',
+        adminNotes: null,
+    });
+
+    const { result, actionOutput } =
+        await createAutomationRunForMonthlyFarmInventory({
+            referenceDate: new Date('2026-09-01T00:00:00.000Z'),
+            enqueuedAt: new Date('2026-08-31T08:00:00.000Z'),
+        });
+
+    assert.strictEqual(result.status, 'succeeded');
+    assert.strictEqual(Reflect.get(actionOutput, 'activeOutletOfferCount'), 1);
+    assert.strictEqual(Reflect.get(actionOutput, 'skippedIneligibleCount'), 0);
+
+    for (const farmId of [firstFarmId, secondFarmId]) {
+        const farmOperations = await getFarmAcceptedOperationsByScheduleRange({
+            farmId,
+            from: new Date('2026-09-01T00:00:00.000Z'),
+            to: new Date('2026-09-02T00:00:00.000Z'),
+        });
+        assert.strictEqual(
+            farmOperations.filter(
+                (operation) =>
+                    operation.entityId ===
+                    FARM_GREENHOUSE_PLANT_INVENTORY_OPERATION_ID,
+            ).length,
+            1,
+        );
+    }
 });
 
 test('default farm raised-bed weeding automation stays draft until enabled', async () => {


### PR DESCRIPTION
## Summary

- Adds optional greenhouse/outlet plant eligibility to farm inventory operation configs.
- Registers operation `661` (`Inventura biljaka u plasteniku`) in the monthly farm inventory automation with that eligibility gate.
- Reuses the greenhouse/outlet eligibility logic with the existing greenhouse watering automation and documents the config behavior.
- Covers no-plants skip behavior, greenhouse-field eligibility, and outlet-stock eligibility in storage automation tests.

## Validation

- `corepack pnpm --filter @gredice/storage lint`
- `corepack pnpm --filter @gredice/storage test:node automationsRepo.node.spec.ts`
- `git diff --check`
- `corepack pnpm exec tsc --noEmit --project packages/storage/tsconfig.json` currently fails on existing unrelated storage script/spec typing issues, including missing `pg` declarations in `packages/storage/scripts/*`, `gardenDiaryRescheduleRepo.node.spec.ts`, `invoicesRepo.node.spec.ts`, and `shoppingCartRepo.node.spec.ts`. The changed automation files are no longer among the reported errors.