### PR TITLE
feat(admin): show raised bed photo thumbnails

### DIFF
--- a/apps/app/app/admin/accounts/[accountId]/RaisedBedsTableCard.tsx
+++ b/apps/app/app/admin/accounts/[accountId]/RaisedBedsTableCard.tsx
@@ -15,6 +15,7 @@ import {
     scrollableTableCardClassName,
     scrollableTableCardOverflowClassName,
 } from '../../../../components/admin/cards/tableCardLayout';
+import { RaisedBedLatestPhotoThumbnail } from '../../../../components/raised-beds/RaisedBedLatestPhotoThumbnail';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../../src/KnownPages';
 import { RaisedBedStatusItems } from '../../raised-beds/[raisedBedId]/RaisedBedStatusItems';
@@ -113,6 +114,16 @@ export async function RaisedBedsTableCard({
                                             href={KnownPages.RaisedBed(bed.id)}
                                         >
                                             <Row spacing={2}>
+                                                {bed.latestPhotoOperation && (
+                                                    <RaisedBedLatestPhotoThumbnail
+                                                        alt={`Zadnje fotografije gredice ${bed.name}`}
+                                                        imageUrls={
+                                                            bed
+                                                                .latestPhotoOperation
+                                                                .imageUrls
+                                                        }
+                                                    />
+                                                )}
                                                 <RaisedBedIcon
                                                     className="size-6 shrink-0"
                                                     physicalId={bed.physicalId}

--- a/apps/app/components/raised-beds/RaisedBedLatestPhotoThumbnail.tsx
+++ b/apps/app/components/raised-beds/RaisedBedLatestPhotoThumbnail.tsx
@@ -1,0 +1,44 @@
+type RaisedBedLatestPhotoThumbnailProps = {
+    alt: string;
+    imageUrls: string[];
+};
+
+export function RaisedBedLatestPhotoThumbnail({
+    alt,
+    imageUrls,
+}: RaisedBedLatestPhotoThumbnailProps) {
+    const previewImageUrls = imageUrls.slice(0, 3);
+    if (previewImageUrls.length === 0) {
+        return null;
+    }
+
+    return (
+        <span
+            className="relative flex size-9 shrink-0 overflow-hidden rounded-md border border-border bg-muted shadow-sm"
+            title={alt}
+        >
+            {previewImageUrls.map((imageUrl, index) => (
+                <span
+                    key={imageUrl}
+                    className="absolute overflow-hidden rounded-[inherit] border border-white/80 bg-muted"
+                    style={{
+                        inset: index === 0 ? 0 : `${index * 4}px`,
+                        zIndex: previewImageUrls.length - index,
+                        transform:
+                            index === 0
+                                ? undefined
+                                : `translate(${index * 3}px, ${index * -2}px) rotate(${index * 4}deg)`,
+                    }}
+                >
+                    {/** biome-ignore lint/performance/noImgElement: Operation photos come from runtime data and can use external blob hosts. */}
+                    <img
+                        src={imageUrl}
+                        alt={index === 0 ? alt : ''}
+                        className="size-full object-cover"
+                        loading="lazy"
+                    />
+                </span>
+            ))}
+        </span>
+    );
+}

--- a/packages/storage/src/automations/defaults.ts
+++ b/packages/storage/src/automations/defaults.ts
@@ -1,4 +1,8 @@
 import {
+    RAISED_BED_PHOTO_OPERATION_ID,
+    RAISED_BED_PHOTO_OPERATION_NAME,
+} from '../helpers/raisedBedPhotoOperations';
+import {
     initializeAutomationEventCursorToLatest,
     upsertAutomationDefinitionByKey,
 } from '../repositories/automationsRepo';
@@ -6,6 +10,11 @@ import { knownEventTypes } from '../repositories/events/knownEventTypes';
 import { RAISED_BED_WATERING_50L_OPERATION_ID } from '../repositories/seasonalOffersRepo';
 import type { AutomationGraph } from '../schema';
 import { automationModuleKeys } from './modules';
+
+export {
+    RAISED_BED_PHOTO_OPERATION_ID,
+    RAISED_BED_PHOTO_OPERATION_NAME,
+} from '../helpers/raisedBedPhotoOperations';
 
 export const seasonalSowedWateringAutomationKey =
     'default.seasonal-sowed-watering';
@@ -55,8 +64,6 @@ export const monthlyFarmInventoryOperationConfigs = [
         requiresGreenhouseOrOutletPlants: true,
     },
 ];
-export const RAISED_BED_PHOTO_OPERATION_ID = 301;
-export const RAISED_BED_PHOTO_OPERATION_NAME = 'raisedBedFullPhoto';
 export const RAISED_BED_DETAILED_INSPECTION_OPERATION_ID = 652;
 export const RAISED_BED_DETAILED_INSPECTION_OPERATION_NAME =
     'detailedRaisedBedInspection';

--- a/packages/storage/src/helpers/raisedBedPhotoOperations.ts
+++ b/packages/storage/src/helpers/raisedBedPhotoOperations.ts
@@ -1,0 +1,2 @@
+export const RAISED_BED_PHOTO_OPERATION_ID = 301;
+export const RAISED_BED_PHOTO_OPERATION_NAME = 'raisedBedFullPhoto';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -17,6 +17,7 @@ export * from './helpers/entityPageSections';
 export * from './helpers/generatedAttributeValues';
 export * from './helpers/plantHealth';
 export * from './helpers/plantRelationships';
+export * from './helpers/raisedBedPhotoOperations';
 export * from './helpers/timeSlotAutomation';
 export * from './helpers/timezoneUtils';
 export * from './repositories/accountDeletionRepo';

--- a/packages/storage/src/repositories/raisedBedsRepo.ts
+++ b/packages/storage/src/repositories/raisedBedsRepo.ts
@@ -17,6 +17,7 @@ import {
     scheduleCacheTtls,
 } from '../cache/scheduleCache';
 import { generateRaisedBedName } from '../helpers/generateRaisedBedName';
+import { RAISED_BED_PHOTO_OPERATION_ID } from '../helpers/raisedBedPhotoOperations';
 import {
     events,
     farmUsers,
@@ -56,10 +57,24 @@ import { processReferralRewardsForAccount } from './referralsRepo';
 const RAISED_BED_FIELDS_PER_BLOCK = 9;
 
 type RaisedBedFieldPlantCycleEvent = typeof events.$inferSelect;
+export type RaisedBedLatestPhotoOperation = {
+    id: number;
+    completedAt: Date;
+    imageUrls: string[];
+};
 type RaisedBedWithFields = typeof raisedBeds.$inferSelect & {
     fields: RaisedBedFieldWithEvents[];
+    latestPhotoOperation: RaisedBedLatestPhotoOperation | null;
     weedState: RaisedBedWeedState | null;
 };
+
+const raisedBedPhotoOperationStatusEventTypes = [
+    knownEventTypes.operations.schedule,
+    knownEventTypes.operations.complete,
+    knownEventTypes.operations.verify,
+    knownEventTypes.operations.fail,
+    knownEventTypes.operations.cancel,
+];
 
 function parseWeedStateLevel(value: unknown): RaisedBedWeedStateLevel | null {
     switch (value) {
@@ -120,6 +135,127 @@ function latestWeedStateFromEvents(
     }
 
     return weedState;
+}
+
+function imageUrlsFromOperationCompleteData(value: unknown) {
+    if (!value || typeof value !== 'object') {
+        return [];
+    }
+
+    const images = (value as { images?: unknown }).images;
+    return Array.isArray(images)
+        ? images.filter(
+              (imageUrl): imageUrl is string =>
+                  typeof imageUrl === 'string' && imageUrl.trim().length > 0,
+          )
+        : [];
+}
+
+async function getLatestRaisedBedPhotoOperationsByIds(
+    raisedBedIds: number[],
+): Promise<Map<number, RaisedBedLatestPhotoOperation>> {
+    const uniqueRaisedBedIds = Array.from(new Set(raisedBedIds));
+    const latestPhotoOperationsByRaisedBedId = new Map<
+        number,
+        RaisedBedLatestPhotoOperation & { eventId: number }
+    >();
+
+    if (uniqueRaisedBedIds.length === 0) {
+        return new Map();
+    }
+
+    const photoOperations = await storage().query.operations.findMany({
+        columns: {
+            id: true,
+            raisedBedId: true,
+        },
+        where: and(
+            inArray(operations.raisedBedId, uniqueRaisedBedIds),
+            eq(operations.entityId, RAISED_BED_PHOTO_OPERATION_ID),
+            eq(operations.entityTypeName, 'operation'),
+            eq(operations.isDeleted, false),
+            isNotNull(operations.raisedBedId),
+        ),
+    });
+    const raisedBedIdByOperationId = new Map<number, number>();
+    for (const operation of photoOperations) {
+        if (typeof operation.raisedBedId === 'number') {
+            raisedBedIdByOperationId.set(operation.id, operation.raisedBedId);
+        }
+    }
+
+    const operationIds = Array.from(raisedBedIdByOperationId.keys());
+    if (operationIds.length === 0) {
+        return new Map();
+    }
+
+    const operationEvents = await getAllEvents(
+        raisedBedPhotoOperationStatusEventTypes,
+        operationIds.map((operationId) => operationId.toString()),
+    );
+    const latestStatusTypeByOperationId = new Map<number, string>();
+    for (const event of operationEvents) {
+        const operationId = Number(event.aggregateId);
+        if (raisedBedIdByOperationId.has(operationId)) {
+            latestStatusTypeByOperationId.set(operationId, event.type);
+        }
+    }
+
+    for (const event of operationEvents) {
+        if (event.type !== knownEventTypes.operations.complete) {
+            continue;
+        }
+
+        const operationId = Number(event.aggregateId);
+        const latestStatusType = latestStatusTypeByOperationId.get(operationId);
+        if (
+            latestStatusType !== knownEventTypes.operations.complete &&
+            latestStatusType !== knownEventTypes.operations.verify
+        ) {
+            continue;
+        }
+
+        const raisedBedId = raisedBedIdByOperationId.get(operationId);
+        if (!raisedBedId) {
+            continue;
+        }
+
+        const imageUrls = imageUrlsFromOperationCompleteData(event.data);
+        if (imageUrls.length === 0) {
+            continue;
+        }
+
+        const current = latestPhotoOperationsByRaisedBedId.get(raisedBedId);
+        if (
+            current &&
+            (current.completedAt > event.createdAt ||
+                (current.completedAt.getTime() === event.createdAt.getTime() &&
+                    current.eventId > event.id))
+        ) {
+            continue;
+        }
+
+        latestPhotoOperationsByRaisedBedId.set(raisedBedId, {
+            id: operationId,
+            completedAt: event.createdAt,
+            imageUrls,
+            eventId: event.id,
+        });
+    }
+
+    return new Map(
+        Array.from(
+            latestPhotoOperationsByRaisedBedId,
+            ([raisedBedId, item]) => [
+                raisedBedId,
+                {
+                    id: item.id,
+                    completedAt: item.completedAt,
+                    imageUrls: item.imageUrls,
+                },
+            ],
+        ),
+    );
 }
 
 export async function createRaisedBed(
@@ -315,12 +451,16 @@ export async function getRaisedBedsForGardens(
     const beds = await storage().query.raisedBeds.findMany({
         where: and(...whereConditions),
     });
-    const weedStatesByRaisedBedId = await getRaisedBedWeedStatesByIds(
-        beds.map((bed) => bed.id),
-    );
-    const fieldsByRaisedBedId = await getRaisedBedFieldsWithEventsForBeds(
-        beds.map((bed) => bed.id),
-    );
+    const bedIds = beds.map((bed) => bed.id);
+    const [
+        weedStatesByRaisedBedId,
+        fieldsByRaisedBedId,
+        latestPhotoOperationsByRaisedBedId,
+    ] = await Promise.all([
+        getRaisedBedWeedStatesByIds(bedIds),
+        getRaisedBedFieldsWithEventsForBeds(bedIds),
+        getLatestRaisedBedPhotoOperationsByIds(bedIds),
+    ]);
 
     // For each raised bed, fetch and attach fields with event-sourced info
     for (const bed of beds) {
@@ -332,6 +472,8 @@ export async function getRaisedBedsForGardens(
         const bedWithFields = {
             ...bed,
             fields: fieldsByRaisedBedId.get(bed.id) ?? [],
+            latestPhotoOperation:
+                latestPhotoOperationsByRaisedBedId.get(bed.id) ?? null,
             weedState: weedStatesByRaisedBedId.get(bed.id) ?? null,
         };
         if (gardenBeds) {
@@ -345,7 +487,12 @@ export async function getRaisedBedsForGardens(
 }
 
 export async function getRaisedBed(raisedBedId: number) {
-    const [raisedBed, fields, weedStatesByRaisedBedId] = await Promise.all([
+    const [
+        raisedBed,
+        fields,
+        weedStatesByRaisedBedId,
+        latestPhotoOperationsByRaisedBedId,
+    ] = await Promise.all([
         storage().query.raisedBeds.findFirst({
             where: and(
                 eq(raisedBeds.id, raisedBedId),
@@ -354,12 +501,15 @@ export async function getRaisedBed(raisedBedId: number) {
         }),
         getRaisedBedFieldsWithEvents(raisedBedId),
         getRaisedBedWeedStatesByIds([raisedBedId]),
+        getLatestRaisedBedPhotoOperationsByIds([raisedBedId]),
     ]);
     if (!raisedBed) return null;
     // Attach raised bed fields with event-sourced info
     return {
         ...raisedBed,
         fields,
+        latestPhotoOperation:
+            latestPhotoOperationsByRaisedBedId.get(raisedBed.id) ?? null,
         weedState: weedStatesByRaisedBedId.get(raisedBed.id) ?? null,
     };
 }
@@ -714,12 +864,17 @@ async function getAllRaisedBedsUncached() {
         .leftJoin(gardens, eq(raisedBeds.gardenId, gardens.id))
         .where(and(eq(raisedBeds.isDeleted, false), excludeSandboxRaisedBeds));
     const allRaisedBeds = rows.map((row) => row.raisedBed);
-    const fieldsByRaisedBedId = await getRaisedBedFieldsWithEventsForBeds(
-        allRaisedBeds.map((raisedBed) => raisedBed.id),
-    );
+    const raisedBedIds = allRaisedBeds.map((raisedBed) => raisedBed.id);
+    const [fieldsByRaisedBedId, latestPhotoOperationsByRaisedBedId] =
+        await Promise.all([
+            getRaisedBedFieldsWithEventsForBeds(raisedBedIds),
+            getLatestRaisedBedPhotoOperationsByIds(raisedBedIds),
+        ]);
     return allRaisedBeds.map((raisedBed) => ({
         ...raisedBed,
         fields: fieldsByRaisedBedId.get(raisedBed.id) ?? [],
+        latestPhotoOperation:
+            latestPhotoOperationsByRaisedBedId.get(raisedBed.id) ?? null,
     }));
 }
 
@@ -741,13 +896,18 @@ export async function getAllRaisedBedsFiltered(filters?: { status?: string }) {
         .where(and(...whereConditions));
     const allRaisedBeds = rows.map((row) => row.raisedBed);
 
-    const fieldsByRaisedBedId = await getRaisedBedFieldsWithEventsForBeds(
-        allRaisedBeds.map((raisedBed) => raisedBed.id),
-    );
+    const raisedBedIds = allRaisedBeds.map((raisedBed) => raisedBed.id);
+    const [fieldsByRaisedBedId, latestPhotoOperationsByRaisedBedId] =
+        await Promise.all([
+            getRaisedBedFieldsWithEventsForBeds(raisedBedIds),
+            getLatestRaisedBedPhotoOperationsByIds(raisedBedIds),
+        ]);
 
     return allRaisedBeds.map((raisedBed) => ({
         ...raisedBed,
         fields: fieldsByRaisedBedId.get(raisedBed.id) ?? [],
+        latestPhotoOperation:
+            latestPhotoOperationsByRaisedBedId.get(raisedBed.id) ?? null,
     }));
 }
 

--- a/packages/storage/tests/gardensRepo.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.node.spec.ts
@@ -8,11 +8,13 @@ import {
     createEvent,
     createGardenBlock,
     createGardenStack,
+    createOperation,
     deleteGarden,
     deleteGardenBlock,
     deleteGardenStack,
     getAccountGardens,
     getAccountGardensMetadata,
+    getAllRaisedBedsFiltered,
     getGarden,
     getGardenBlock,
     getGardenBlocks,
@@ -24,6 +26,7 @@ import {
     getRaisedBedMetadataByIds,
     getRaisedBeds,
     knownEvents,
+    RAISED_BED_PHOTO_OPERATION_ID,
     updateGarden,
     updateGardenBlock,
     updateGardenStack,
@@ -537,6 +540,120 @@ test('createDefaultGardenForAccount creates garden with default layout', async (
         stack10?.blocks.length,
         2,
         'Stack (1,0) should have 2 blocks (grass + raised bed)',
+    );
+});
+
+test('raised-bed reads include latest images from the last photography operation', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'Raised_Bed');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    const olderPhotoOperationId = await createOperation({
+        accountId,
+        entityId: RAISED_BED_PHOTO_OPERATION_ID,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+    const nonPhotoOperationId = await createOperation({
+        accountId,
+        entityId: 1,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+    const newerPhotoOperationId = await createOperation({
+        accountId,
+        entityId: RAISED_BED_PHOTO_OPERATION_ID,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+    const replannedPhotoOperationId = await createOperation({
+        accountId,
+        entityId: RAISED_BED_PHOTO_OPERATION_ID,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+
+    await createEvent({
+        ...knownEvents.operations.completedV1(
+            olderPhotoOperationId.toString(),
+            {
+                completedBy: 'test-user',
+                images: ['https://cdn.gredice.com/older-photo.jpg'],
+            },
+        ),
+        createdAt: new Date('2026-06-01T08:00:00.000Z'),
+    });
+    await createEvent({
+        ...knownEvents.operations.completedV1(nonPhotoOperationId.toString(), {
+            completedBy: 'test-user',
+            images: ['https://cdn.gredice.com/non-photo.jpg'],
+        }),
+        createdAt: new Date('2026-06-02T08:00:00.000Z'),
+    });
+    await createEvent({
+        ...knownEvents.operations.completedV1(
+            newerPhotoOperationId.toString(),
+            {
+                completedBy: 'test-user',
+                images: [
+                    'https://cdn.gredice.com/latest-photo-1.jpg',
+                    'https://cdn.gredice.com/latest-photo-2.jpg',
+                ],
+            },
+        ),
+        createdAt: new Date('2026-06-03T08:00:00.000Z'),
+    });
+    await createEvent({
+        ...knownEvents.operations.completedV1(
+            replannedPhotoOperationId.toString(),
+            {
+                completedBy: 'test-user',
+                images: ['https://cdn.gredice.com/replanned-photo.jpg'],
+            },
+        ),
+        createdAt: new Date('2026-06-04T08:00:00.000Z'),
+    });
+    await createEvent({
+        ...knownEvents.operations.scheduledV1(
+            replannedPhotoOperationId.toString(),
+            {
+                scheduledDate: '2026-06-06T08:00:00.000Z',
+            },
+        ),
+        createdAt: new Date('2026-06-05T08:00:00.000Z'),
+    });
+
+    const [gardenRaisedBed] = await getRaisedBeds(gardenId);
+    assert.strictEqual(
+        gardenRaisedBed?.latestPhotoOperation?.id,
+        newerPhotoOperationId,
+    );
+    assert.deepStrictEqual(gardenRaisedBed?.latestPhotoOperation?.imageUrls, [
+        'https://cdn.gredice.com/latest-photo-1.jpg',
+        'https://cdn.gredice.com/latest-photo-2.jpg',
+    ]);
+
+    const listedRaisedBed = (await getAllRaisedBedsFiltered()).find(
+        (bed) => bed.id === raisedBedId,
+    );
+    assert.strictEqual(
+        listedRaisedBed?.latestPhotoOperation?.id,
+        newerPhotoOperationId,
+    );
+    assert.notStrictEqual(
+        listedRaisedBed?.latestPhotoOperation?.id,
+        nonPhotoOperationId,
+    );
+    assert.notStrictEqual(
+        listedRaisedBed?.latestPhotoOperation?.id,
+        replannedPhotoOperationId,
     );
 });
 


### PR DESCRIPTION
## Summary
- show a compact latest-photo thumbnail stack next to each raised-bed icon in the admin raised-beds table
- hydrate raised-bed reads with the latest completed raised-bed photography operation images
- share the canonical raised-bed photo operation constants and cover the read model with a storage test

## Validation
- `pnpm --filter @gredice/storage exec biome check --write src/helpers/raisedBedPhotoOperations.ts src/automations/defaults.ts src/index.ts src/repositories/raisedBedsRepo.ts tests/gardensRepo.node.spec.ts`
- `pnpm --filter app exec biome check --write 'app/admin/accounts/[accountId]/RaisedBedsTableCard.tsx' components/raised-beds/RaisedBedLatestPhotoThumbnail.tsx`
- `pnpm --filter @gredice/storage test:node tests/gardensRepo.node.spec.ts`
- `pnpm typecheck --filter app --filter @gredice/storage`
- `git diff --check`

## Notes
- Direct `pnpm --filter app exec tsc --noEmit --pretty false` and `pnpm --filter @gredice/storage exec tsc --noEmit --pretty false` still hit existing baseline errors outside this change.