### PR TITLE
feat(admin): convert operations table to list

### DIFF
--- a/apps/app/app/admin/operations/operationsListConfig.ts
+++ b/apps/app/app/admin/operations/operationsListConfig.ts
@@ -1,0 +1,18 @@
+import type {
+    OperationsListSort,
+    OperationsListSortDirection,
+    OperationsListSortKey,
+} from './operationsListTypes';
+
+export const defaultOperationsListSort: OperationsListSort = {
+    key: 'date',
+    direction: 'desc',
+};
+
+export function defaultOperationsListSortDirection(
+    key: OperationsListSortKey,
+): OperationsListSortDirection {
+    return key === 'name' || key === 'place' || key === 'status'
+        ? 'asc'
+        : 'desc';
+}

--- a/apps/app/app/admin/operations/operationsListData.ts
+++ b/apps/app/app/admin/operations/operationsListData.ts
@@ -1,0 +1,270 @@
+import 'server-only';
+
+import {
+    getAccounts,
+    getAllOperations,
+    getAllRaisedBeds,
+    getEntitiesFormatted,
+    getFarms,
+    getGardens,
+} from '@gredice/storage';
+import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
+import { defaultOperationsListSort } from './operationsListConfig';
+import type {
+    OperationsListOperation,
+    OperationsListPage,
+    OperationsListSort,
+    OperationsListSortDirection,
+    OperationsListSortKey,
+} from './operationsListTypes';
+
+type RawOperations = Awaited<ReturnType<typeof getAllOperations>>;
+type RawOperation = RawOperations[number];
+
+type OperationsListContext = {
+    accounts: Awaited<ReturnType<typeof getAccounts>>;
+    farms: Awaited<ReturnType<typeof getFarms>>;
+    gardens: Awaited<ReturnType<typeof getGardens>>;
+    operationDefinitions: EntityStandardized[];
+    raisedBeds: Awaited<ReturnType<typeof getAllRaisedBeds>>;
+};
+
+export const operationsListPageSize = 40;
+const maxOperationsListPageSize = 100;
+
+export function normalizeOperationsListSortDirection(
+    value: string | null,
+): OperationsListSortDirection {
+    return value === 'asc' ? 'asc' : 'desc';
+}
+
+export function normalizeOperationsListSortKey(
+    value: string | null,
+): OperationsListSortKey {
+    if (
+        value === 'date' ||
+        value === 'createdAt' ||
+        value === 'name' ||
+        value === 'place' ||
+        value === 'status'
+    ) {
+        return value;
+    }
+
+    return defaultOperationsListSort.key;
+}
+
+function normalizeLimit(limit: number | undefined) {
+    if (!limit || !Number.isFinite(limit)) {
+        return operationsListPageSize;
+    }
+
+    return Math.min(Math.max(Math.trunc(limit), 1), maxOperationsListPageSize);
+}
+
+function toIsoString(value: Date | string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    return typeof value === 'string' ? value : value.toISOString();
+}
+
+function operationDefinitionLabel(
+    operation: RawOperation,
+    operationDefinitions: EntityStandardized[],
+) {
+    const operationDefinition = operationDefinitions.find(
+        (definition) => definition.id === operation.entityId,
+    );
+
+    return operationDefinition?.information?.label ?? `Radnja ${operation.id}`;
+}
+
+function operationPlaceLabel(operation: OperationsListOperation) {
+    return [
+        operation.accountUserNames.join(', '),
+        operation.farmName,
+        operation.gardenName,
+        operation.raisedBedPhysicalId
+            ? `Gr ${operation.raisedBedPhysicalId}`
+            : null,
+        operation.raisedBedFieldPosition
+            ? operation.raisedBedFieldPosition.toString()
+            : null,
+    ]
+        .filter(Boolean)
+        .join(' ');
+}
+
+function operationSortValue(
+    operation: OperationsListOperation,
+    key: OperationsListSortKey,
+) {
+    if (key === 'name') {
+        return operation.label;
+    }
+
+    if (key === 'status') {
+        return operation.status;
+    }
+
+    if (key === 'place') {
+        return operationPlaceLabel(operation);
+    }
+
+    if (key === 'createdAt') {
+        return operation.createdAt
+            ? new Date(operation.createdAt).getTime()
+            : 0;
+    }
+
+    return new Date(operation.timestamp).getTime();
+}
+
+function compareSortValues(left: string | number, right: string | number) {
+    if (typeof left === 'number' && typeof right === 'number') {
+        return left - right;
+    }
+
+    return String(left).localeCompare(String(right), 'hr', {
+        numeric: true,
+        sensitivity: 'base',
+    });
+}
+
+function compareOperations(
+    left: OperationsListOperation,
+    right: OperationsListOperation,
+    sort: OperationsListSort,
+) {
+    const compared = compareSortValues(
+        operationSortValue(left, sort.key),
+        operationSortValue(right, sort.key),
+    );
+
+    if (compared === 0) {
+        return right.id - left.id;
+    }
+
+    return sort.direction === 'asc' ? compared : -compared;
+}
+
+function serializeOperation(
+    operation: RawOperation,
+    context: OperationsListContext,
+): OperationsListOperation {
+    const account = operation.accountId
+        ? context.accounts.find((item) => item.id === operation.accountId)
+        : undefined;
+    const farm = operation.farmId
+        ? context.farms.find((item) => item.id === operation.farmId)
+        : undefined;
+    const garden = operation.gardenId
+        ? context.gardens.find((item) => item.id === operation.gardenId)
+        : undefined;
+    const raisedBed = operation.raisedBedId
+        ? context.raisedBeds.find((item) => item.id === operation.raisedBedId)
+        : undefined;
+    const raisedBedField =
+        raisedBed && operation.raisedBedFieldId
+            ? raisedBed.fields.find(
+                  (field) => field.id === operation.raisedBedFieldId,
+              )
+            : undefined;
+
+    return {
+        id: operation.id,
+        entityId: operation.entityId,
+        entityTypeName: operation.entityTypeName,
+        label: operationDefinitionLabel(
+            operation,
+            context.operationDefinitions,
+        ),
+        status: operation.status,
+        accountUserNames:
+            account?.accountUsers
+                .map((accountUser) => accountUser.user.userName)
+                .filter(Boolean) ?? [],
+        farmName: farm?.name ?? null,
+        gardenName: garden?.name ?? null,
+        raisedBedPhysicalId: raisedBed?.physicalId ?? null,
+        raisedBedName: raisedBed?.name ?? null,
+        raisedBedFieldPosition:
+            raisedBedField?.positionIndex === undefined
+                ? null
+                : raisedBedField.positionIndex + 1,
+        timestamp:
+            toIsoString(operation.timestamp) ?? new Date(0).toISOString(),
+        createdAt: toIsoString(operation.createdAt),
+        scheduledDate: toIsoString(operation.scheduledDate),
+        completedAt: toIsoString(operation.completedAt),
+    };
+}
+
+export async function getOperationsListContext(): Promise<OperationsListContext> {
+    const [operationDefinitions, accounts, farms, gardens, raisedBeds] =
+        await Promise.all([
+            getEntitiesFormatted<EntityStandardized>('operation'),
+            getAccounts(),
+            getFarms(),
+            getGardens(),
+            getAllRaisedBeds(),
+        ]);
+
+    return {
+        accounts,
+        farms,
+        gardens,
+        operationDefinitions: operationDefinitions ?? [],
+        raisedBeds,
+    };
+}
+
+export async function listOperationsPageFromContext({
+    context,
+    fromDate,
+    limit,
+    offset = 0,
+    sort = defaultOperationsListSort,
+}: {
+    context: OperationsListContext;
+    fromDate?: Date;
+    limit?: number;
+    offset?: number;
+    sort?: OperationsListSort;
+}): Promise<OperationsListPage> {
+    const pageSize = normalizeLimit(limit);
+    const operations = await getAllOperations(
+        fromDate ? { from: fromDate } : undefined,
+    );
+    const serializedOperations = operations
+        .map((operation) => serializeOperation(operation, context))
+        .toSorted((left, right) => compareOperations(left, right, sort));
+    const safeOffset = Math.max(0, Math.trunc(offset));
+    const pageOperations = serializedOperations.slice(
+        safeOffset,
+        safeOffset + pageSize + 1,
+    );
+    const hasMore = pageOperations.length > pageSize;
+
+    return {
+        operations: pageOperations.slice(0, pageSize),
+        hasMore,
+        nextOffset: hasMore ? safeOffset + pageSize : null,
+        pageSize,
+        totalCount: serializedOperations.length,
+    };
+}
+
+export async function listOperationsPage({
+    fromDate,
+    ...options
+}: Omit<Parameters<typeof listOperationsPageFromContext>[0], 'context'>) {
+    const context = await getOperationsListContext();
+    return listOperationsPageFromContext({
+        ...options,
+        context,
+        fromDate,
+    });
+}

--- a/apps/app/app/admin/operations/operationsListTypes.ts
+++ b/apps/app/app/admin/operations/operationsListTypes.ts
@@ -1,0 +1,47 @@
+export type OperationsListSortDirection = 'asc' | 'desc';
+
+export type OperationsListSortKey =
+    | 'date'
+    | 'createdAt'
+    | 'name'
+    | 'place'
+    | 'status';
+
+export type OperationsListSort = {
+    key: OperationsListSortKey;
+    direction: OperationsListSortDirection;
+};
+
+export type OperationsListStatus =
+    | 'new'
+    | 'planned'
+    | 'pendingVerification'
+    | 'completed'
+    | 'failed'
+    | 'canceled';
+
+export type OperationsListOperation = {
+    id: number;
+    entityId: number;
+    entityTypeName: string;
+    label: string;
+    status: OperationsListStatus;
+    accountUserNames: string[];
+    farmName: string | null;
+    gardenName: string | null;
+    raisedBedPhysicalId: string | null;
+    raisedBedName: string | null;
+    raisedBedFieldPosition: number | null;
+    timestamp: string;
+    createdAt: string | null;
+    scheduledDate: string | null;
+    completedAt: string | null;
+};
+
+export type OperationsListPage = {
+    operations: OperationsListOperation[];
+    hasMore: boolean;
+    nextOffset: number | null;
+    pageSize: number;
+    totalCount: number;
+};

--- a/apps/app/app/admin/operations/page.tsx
+++ b/apps/app/app/admin/operations/page.tsx
@@ -8,11 +8,15 @@ import {
 import { Card, CardOverflow } from '@gredice/ui/Card';
 import { Stack } from '@gredice/ui/Stack';
 import { AdminPageHeader } from '../../../components/admin/navigation';
-import { OperationsTable } from '../../../components/operations/OperationsTable';
+import { OperationsList } from '../../../components/operations/OperationsList';
 import { auth } from '../../../lib/auth/auth';
 import { getDateFromTimeFilter } from '../../../lib/utils/timeFilters';
 import { BulkOperationCreateModal } from './BulkOperationCreateModal';
 import { OperationsFilters } from './OperationsFilters';
+import {
+    getOperationsListContext,
+    listOperationsPageFromContext,
+} from './operationsListData';
 import { SingleOperationCreateModal } from './SingleOperationCreateModal';
 
 export const dynamic = 'force-dynamic';
@@ -56,6 +60,11 @@ export default async function OperationsPage({
     const fromFilter =
         typeof params.from === 'string' ? params.from : 'last-14-days';
     const fromDate = getDateFromTimeFilter(fromFilter);
+    const operationsListContext = await getOperationsListContext();
+    const initialOperationsPage = await listOperationsPageFromContext({
+        context: operationsListContext,
+        fromDate,
+    });
 
     return (
         <Stack spacing={4}>
@@ -80,7 +89,10 @@ export default async function OperationsPage({
             <OperationsFilters />
             <Card>
                 <CardOverflow>
-                    <OperationsTable fromDate={fromDate} />
+                    <OperationsList
+                        fromFilter={fromFilter}
+                        initialPage={initialOperationsPage}
+                    />
                 </CardOverflow>
             </Card>
         </Stack>

--- a/apps/app/app/api/admin/operations/route.ts
+++ b/apps/app/app/api/admin/operations/route.ts
@@ -1,0 +1,48 @@
+import { withAuth } from '../../../../lib/auth/auth';
+import { getDateFromTimeFilter } from '../../../../lib/utils/timeFilters';
+import {
+    listOperationsPage,
+    normalizeOperationsListSortDirection,
+    normalizeOperationsListSortKey,
+    operationsListPageSize,
+} from '../../../admin/operations/operationsListData';
+
+export const dynamic = 'force-dynamic';
+
+function parseInteger(value: string | null, fallback: number) {
+    if (!value) {
+        return fallback;
+    }
+
+    const parsed = Number(value);
+
+    return Number.isInteger(parsed) ? parsed : fallback;
+}
+
+export async function GET(request: Request) {
+    return await withAuth(['admin'], async () => {
+        const searchParams = new URL(request.url).searchParams;
+        const page = await listOperationsPage({
+            fromDate: getDateFromTimeFilter(
+                searchParams.get('from') ?? 'last-14-days',
+            ),
+            sort: {
+                key: normalizeOperationsListSortKey(searchParams.get('sort')),
+                direction: normalizeOperationsListSortDirection(
+                    searchParams.get('direction'),
+                ),
+            },
+            limit: parseInteger(
+                searchParams.get('limit'),
+                operationsListPageSize,
+            ),
+            offset: Math.max(0, parseInteger(searchParams.get('offset'), 0)),
+        });
+
+        return Response.json(page, {
+            headers: {
+                'Cache-Control': 'no-store',
+            },
+        });
+    });
+}

--- a/apps/app/components/operations/OperationListItem.tsx
+++ b/apps/app/components/operations/OperationListItem.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { Chip } from '@gredice/ui/Chip';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Calendar, Check } from '@gredice/ui/icons';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Row } from '@gredice/ui/Row';
+import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import Link from 'next/link';
+import type { OperationsListOperation } from '../../app/admin/operations/operationsListTypes';
+import { VerifyOperationModal } from '../../app/admin/schedule/VerifyOperationModal';
+import { KnownPages } from '../../src/KnownPages';
+import { OperationCancelButton } from './OperationCancelButton';
+import { OperationRescheduleButton } from './OperationRescheduleButton';
+
+function statusColor(status: OperationsListOperation['status']) {
+    if (status === 'completed') {
+        return 'success';
+    }
+
+    if (status === 'planned') {
+        return 'info';
+    }
+
+    if (status === 'canceled') {
+        return 'neutral';
+    }
+
+    return 'warning';
+}
+
+function statusLabel(status: OperationsListOperation['status']) {
+    return status === 'pendingVerification' ? 'Čeka verifikaciju' : status;
+}
+
+function statusDate(operation: OperationsListOperation) {
+    if (operation.status === 'planned') {
+        return operation.scheduledDate;
+    }
+
+    if (
+        operation.status === 'completed' ||
+        operation.status === 'pendingVerification'
+    ) {
+        return operation.completedAt;
+    }
+
+    return null;
+}
+
+function dateForAction(value: string | null) {
+    return value ? new Date(value) : undefined;
+}
+
+function operationActionPayload(operation: OperationsListOperation) {
+    return {
+        id: operation.id,
+        entityId: operation.entityId,
+        scheduledDate: dateForAction(operation.scheduledDate),
+        status: operation.status,
+    };
+}
+
+export function OperationListItem({
+    operation,
+}: {
+    operation: OperationsListOperation;
+}) {
+    const actionPayload = operationActionPayload(operation);
+    const currentStatusDate = statusDate(operation);
+
+    return (
+        <li className="group px-3 py-3 transition-colors hover:bg-muted/40 sm:px-4">
+            <div className="flex min-w-0 flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <Stack spacing={1} className="min-w-0 flex-1">
+                    <Link
+                        href={KnownPages.Operation(operation.id)}
+                        className="min-w-0 truncate font-medium text-primary underline-offset-4 hover:underline"
+                    >
+                        {operation.label}
+                    </Link>
+                    <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+                        {operation.accountUserNames.length ? (
+                            <span className="max-w-full truncate">
+                                {operation.accountUserNames.join(', ')}
+                            </span>
+                        ) : null}
+                        {operation.farmName ? (
+                            <span className="max-w-full truncate">
+                                {operation.farmName}
+                            </span>
+                        ) : null}
+                        {operation.gardenName ? (
+                            <span className="max-w-full truncate">
+                                {operation.gardenName}
+                            </span>
+                        ) : null}
+                        {operation.raisedBedPhysicalId ||
+                        operation.raisedBedName ? (
+                            <RaisedBedLabel
+                                size="compact"
+                                physicalId={operation.raisedBedPhysicalId}
+                                name={operation.raisedBedName}
+                            />
+                        ) : null}
+                        {operation.raisedBedFieldPosition ? (
+                            <span>{operation.raisedBedFieldPosition}</span>
+                        ) : null}
+                    </div>
+                </Stack>
+                <div className="flex min-w-0 flex-wrap items-center justify-start gap-2 md:justify-end">
+                    <Chip
+                        className="w-fit"
+                        color={statusColor(operation.status)}
+                        size="sm"
+                    >
+                        {statusLabel(operation.status)}
+                    </Chip>
+                    {currentStatusDate ? (
+                        <Row
+                            spacing={2}
+                            className="whitespace-nowrap text-muted-foreground"
+                        >
+                            {operation.status === 'planned' ? (
+                                <Calendar className="size-4 shrink-0" />
+                            ) : null}
+                            <Typography level="body3">
+                                <LocalDateTime time={false}>
+                                    {currentStatusDate}
+                                </LocalDateTime>
+                            </Typography>
+                        </Row>
+                    ) : null}
+                    <Chip color="neutral" size="sm" variant="outlined">
+                        Datum:{' '}
+                        <LocalDateTime time={false}>
+                            {operation.timestamp}
+                        </LocalDateTime>
+                    </Chip>
+                    <Typography
+                        level="body3"
+                        className="whitespace-nowrap text-muted-foreground"
+                    >
+                        Stvoreno:{' '}
+                        <LocalDateTime time={false}>
+                            {operation.createdAt}
+                        </LocalDateTime>
+                    </Typography>
+                    {operation.status === 'pendingVerification' ? (
+                        <VerifyOperationModal
+                            operationId={operation.id}
+                            label={operation.label}
+                            trigger={
+                                <IconButton
+                                    variant="plain"
+                                    title="Verificiraj operaciju"
+                                >
+                                    <Check className="size-4 shrink-0" />
+                                </IconButton>
+                            }
+                        />
+                    ) : null}
+                    <OperationRescheduleButton
+                        operation={actionPayload}
+                        operationLabel={operation.label}
+                    />
+                    <OperationCancelButton
+                        operation={actionPayload}
+                        operationLabel={operation.label}
+                    />
+                </div>
+            </div>
+        </li>
+    );
+}

--- a/apps/app/components/operations/OperationsList.tsx
+++ b/apps/app/components/operations/OperationsList.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { LoaderSpinner } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { defaultOperationsListSort } from '../../app/admin/operations/operationsListConfig';
+import type {
+    OperationsListPage,
+    OperationsListSort,
+} from '../../app/admin/operations/operationsListTypes';
+import { NoDataPlaceholder } from '../shared/placeholders/NoDataPlaceholder';
+import { OperationListItem } from './OperationListItem';
+import { OperationsListToolbar } from './OperationsListToolbar';
+
+async function fetchOperationsPage({
+    direction,
+    fromFilter,
+    limit,
+    offset,
+    sortKey,
+}: {
+    direction: OperationsListSort['direction'];
+    fromFilter: string;
+    limit: number;
+    offset: number;
+    sortKey: OperationsListSort['key'];
+}) {
+    const searchParams = new URLSearchParams({
+        direction,
+        from: fromFilter,
+        limit: String(limit),
+        offset: String(offset),
+        sort: sortKey,
+    });
+    const response = await fetch(
+        `/api/admin/operations?${searchParams.toString()}`,
+        { cache: 'no-store' },
+    );
+
+    if (!response.ok) {
+        throw new Error('Failed to load operations.');
+    }
+
+    const page: OperationsListPage = await response.json();
+    return page;
+}
+
+export function OperationsList({
+    fromFilter,
+    initialPage,
+}: {
+    fromFilter: string;
+    initialPage: OperationsListPage;
+}) {
+    const sentinelRef = useRef<HTMLDivElement | null>(null);
+    const [sort, setSort] = useState<OperationsListSort>(
+        defaultOperationsListSort,
+    );
+    const shouldUseInitialPage =
+        sort.key === defaultOperationsListSort.key &&
+        sort.direction === defaultOperationsListSort.direction;
+    const operationsQuery = useInfiniteQuery({
+        queryKey: ['admin-operations', fromFilter, sort.key, sort.direction],
+        queryFn: ({ pageParam }) =>
+            fetchOperationsPage({
+                direction: sort.direction,
+                fromFilter,
+                limit: initialPage.pageSize,
+                offset: pageParam,
+                sortKey: sort.key,
+            }),
+        initialData: shouldUseInitialPage
+            ? {
+                  pages: [initialPage],
+                  pageParams: [0],
+              }
+            : undefined,
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+        staleTime: 5000,
+    });
+    const pages = operationsQuery.data?.pages ?? [];
+    const operations = useMemo(
+        () => pages.flatMap((page) => page.operations),
+        [pages],
+    );
+    const totalCount = pages[0]?.totalCount ?? initialPage.totalCount;
+
+    useEffect(() => {
+        const sentinel = sentinelRef.current;
+
+        if (
+            !sentinel ||
+            !operationsQuery.hasNextPage ||
+            operationsQuery.isFetchingNextPage
+        ) {
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) {
+                    void operationsQuery.fetchNextPage();
+                }
+            },
+            { rootMargin: '360px 0px' },
+        );
+
+        observer.observe(sentinel);
+
+        return () => observer.disconnect();
+    }, [
+        operationsQuery.fetchNextPage,
+        operationsQuery.hasNextPage,
+        operationsQuery.isFetchingNextPage,
+    ]);
+
+    return (
+        <div className="min-w-0">
+            <OperationsListToolbar
+                isRefreshing={
+                    operationsQuery.isFetching &&
+                    !operationsQuery.isFetchingNextPage
+                }
+                onSortChange={setSort}
+                sort={sort}
+                totalCount={totalCount}
+            />
+
+            {operationsQuery.isPending ? (
+                <div className="flex items-center justify-center gap-2 p-8 text-muted-foreground">
+                    <LoaderSpinner className="size-4 animate-spin" />
+                    <Typography level="body2">Učitavanje radnji</Typography>
+                </div>
+            ) : operationsQuery.isError ? (
+                <div className="p-4">
+                    <NoDataPlaceholder>
+                        Nije moguće učitati radnje.
+                    </NoDataPlaceholder>
+                </div>
+            ) : operations.length === 0 ? (
+                <div className="p-4">
+                    <NoDataPlaceholder />
+                </div>
+            ) : (
+                <ul className="divide-y">
+                    {operations.map((operation) => (
+                        <OperationListItem
+                            key={operation.id}
+                            operation={operation}
+                        />
+                    ))}
+                </ul>
+            )}
+
+            <div ref={sentinelRef} className="h-px" aria-hidden />
+
+            {operationsQuery.hasNextPage ? (
+                <div className="border-t p-3">
+                    <Button
+                        type="button"
+                        variant="outlined"
+                        color="neutral"
+                        fullWidth
+                        loading={operationsQuery.isFetchingNextPage}
+                        onClick={() => {
+                            void operationsQuery.fetchNextPage();
+                        }}
+                    >
+                        Učitaj još
+                    </Button>
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/app/components/operations/OperationsListToolbar.tsx
+++ b/apps/app/components/operations/OperationsListToolbar.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
+import { ArrowDown, ArrowUp, LoaderSpinner, Select } from '@gredice/ui/icons';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@gredice/ui/Menu';
+import { Row } from '@gredice/ui/Row';
+import { Typography } from '@gredice/ui/Typography';
+import { defaultOperationsListSortDirection } from '../../app/admin/operations/operationsListConfig';
+import type {
+    OperationsListSort,
+    OperationsListSortKey,
+} from '../../app/admin/operations/operationsListTypes';
+
+type SortOption = {
+    key: OperationsListSortKey;
+    label: string;
+};
+
+const sortOptions: SortOption[] = [
+    { key: 'date', label: 'Datum' },
+    { key: 'createdAt', label: 'Datum stvaranja' },
+    { key: 'name', label: 'Naziv' },
+    { key: 'place', label: 'Mjesto' },
+    { key: 'status', label: 'Status' },
+];
+
+function sortLabel(sortKey: OperationsListSortKey) {
+    return (
+        sortOptions.find((option) => option.key === sortKey)?.label ?? 'Datum'
+    );
+}
+
+export function OperationsListToolbar({
+    isRefreshing,
+    onSortChange,
+    sort,
+    totalCount,
+}: {
+    isRefreshing: boolean;
+    onSortChange: (sort: OperationsListSort) => void;
+    sort: OperationsListSort;
+    totalCount: number;
+}) {
+    function updateSortKey(key: OperationsListSortKey) {
+        onSortChange({
+            key,
+            direction:
+                sort.key === key
+                    ? sort.direction
+                    : defaultOperationsListSortDirection(key),
+        });
+    }
+
+    function toggleSortDirection() {
+        onSortChange({
+            ...sort,
+            direction: sort.direction === 'asc' ? 'desc' : 'asc',
+        });
+    }
+
+    return (
+        <div className="flex min-w-0 flex-col gap-2 border-b bg-card px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+            <Row spacing={2} className="min-w-0 flex-wrap">
+                <Chip color="neutral" size="sm" variant="soft">
+                    {totalCount}
+                </Chip>
+                <Typography level="body3" className="text-muted-foreground">
+                    {isRefreshing ? 'Osvježavanje radnji' : 'Radnje'}
+                </Typography>
+            </Row>
+            <Row spacing={2} className="min-w-0 flex-wrap justify-end">
+                {isRefreshing ? (
+                    <LoaderSpinner className="size-4 animate-spin text-muted-foreground" />
+                ) : null}
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            type="button"
+                            variant="outlined"
+                            size="sm"
+                            color="neutral"
+                            className="rounded-full"
+                            endDecorator={<Select className="size-4" />}
+                        >
+                            Sortiraj: {sortLabel(sort.key)}
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-64">
+                        <DropdownMenuLabel>Sortiraj po</DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        {sortOptions.map((option) => (
+                            <DropdownMenuItem
+                                key={option.key}
+                                className="cursor-pointer justify-between"
+                                onClick={() => updateSortKey(option.key)}
+                            >
+                                <span className="truncate">{option.label}</span>
+                                {sort.key === option.key ? (
+                                    <span className="size-2 rounded-full bg-primary" />
+                                ) : null}
+                            </DropdownMenuItem>
+                        ))}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+                <Button
+                    type="button"
+                    variant="outlined"
+                    size="sm"
+                    color="neutral"
+                    className="rounded-full"
+                    startDecorator={
+                        sort.direction === 'asc' ? (
+                            <ArrowUp className="size-4" />
+                        ) : (
+                            <ArrowDown className="size-4" />
+                        )
+                    }
+                    onClick={toggleSortDirection}
+                >
+                    {sort.direction === 'asc' ? 'Uzlazno' : 'Silazno'}
+                </Button>
+            </Row>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- replace the admin operations table with a paginated list layout
- add a server-backed operations page API for lazy loading
- move sort controls above the list while preserving the date filter and existing row actions

## Validation
- pnpm --dir apps/app exec next typegen
- pnpm --dir apps/app exec tsc --noEmit --pretty false --noErrorTruncation (filtered touched-file diagnostics)
- pnpm --dir apps/app exec biome check app/admin/operations/page.tsx app/admin/operations/operationsListTypes.ts app/admin/operations/operationsListConfig.ts app/admin/operations/operationsListData.ts app/api/admin/operations/route.ts components/operations/OperationsList.tsx components/operations/OperationsListToolbar.tsx components/operations/OperationListItem.tsx
- git diff --check
- local dev smoke: /admin/operations and /api/admin/operations compile and return 401 behind admin auth