### PR TITLE
fix(ai): hide internal raised-bed suggestion fields

### DIFF
--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -607,7 +607,7 @@ async function buildAnalysisMessages({
             role: 'system' as const,
             content: [
                 'Ti si stručni agronom za urbane vrtove. Piši ISKLJUČIVO na hrvatskom jeziku i vrati odgovor kao uredno formatiran markdown. Korisnik nema fizički pristup gredici; kada preporuka traži rad na gredici, predloži naručivanje najbliže odgovarajuće operacije iz dostupnog popisa umjesto da korisniku kažeš da to sam ručno napravi.',
-                'Nikada u vidljivom odgovoru ne spominji interne nazive ili JSON ključeve poput `positionIndex`, `positionLabel`, `needsRemoval`, `plantStatus`, `plantSortId`, `currentLocation`, `sowingLocation`, `availableOperations`, `raisedBedOperationUrl` ili `plantFieldOperationUrlTemplate`. Ne citiraj `key: value` parove iz JSON-a.',
+                'Nikada u vidljivom odgovoru ne spominji interne nazive ili JSON ključeve poput `positionIndex`, `positionLabel`, `needsRemoval`, `removalRecommendation`, `plantStatus`, `plantSortId`, `currentLocation`, `sowingLocation`, `availableOperations`, `raisedBedOperationUrl` ili `plantFieldOperationUrlTemplate`. Ne citiraj `key: value` parove iz JSON-a.',
                 'Kad trebaš identificirati lokaciju, napiši samo "polje N" koristeći korisniku vidljivu oznaku polja. Nikada ne dodaj 0-bazirani indeks polja u tekst odgovora.',
                 'Statuse, bool vrijednosti i interne oznake pretvori u normalan hrvatski tekst, npr. "označeno za uklanjanje", "spremno za berbu" ili "u stakleniku".',
                 '',

--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -1,4 +1,5 @@
 import { TZDate, tz } from '@date-fns/tz';
+import { sanitizeRaisedBedAiMarkdown } from '@gredice/js/ai';
 import {
     getEntitiesFormatted,
     getOperations,
@@ -542,6 +543,7 @@ async function buildAnalysisMessages({
         .map((field) => {
             const isGreenhouseSeedling = isCurrentlyGreenhouseSeedling(field);
             return {
+                fieldLabel: `polje ${toPositionLabel(field.positionIndex)}`,
                 positionIndex: field.positionIndex,
                 positionLabel: toPositionLabel(field.positionIndex),
                 plantSortId: field.plantSortId,
@@ -562,7 +564,9 @@ async function buildAnalysisMessages({
                     referenceDate,
                 ),
                 daysFromDead: daysSince(field.plantDeadDate, referenceDate),
-                needsRemoval: Boolean(field.toBeRemoved),
+                removalRecommendation: field.toBeRemoved
+                    ? 'označeno za uklanjanje'
+                    : null,
                 isAnalyzedField:
                     typeof positionIndex === 'number' &&
                     field.positionIndex === positionIndex,
@@ -603,19 +607,22 @@ async function buildAnalysisMessages({
             role: 'system' as const,
             content: [
                 'Ti si stručni agronom za urbane vrtove. Piši ISKLJUČIVO na hrvatskom jeziku i vrati odgovor kao uredno formatiran markdown. Korisnik nema fizički pristup gredici; kada preporuka traži rad na gredici, predloži naručivanje najbliže odgovarajuće operacije iz dostupnog popisa umjesto da korisniku kažeš da to sam ručno napravi.',
+                'Nikada u vidljivom odgovoru ne spominji interne nazive ili JSON ključeve poput `positionIndex`, `positionLabel`, `needsRemoval`, `plantStatus`, `plantSortId`, `currentLocation`, `sowingLocation`, `availableOperations`, `raisedBedOperationUrl` ili `plantFieldOperationUrlTemplate`. Ne citiraj `key: value` parove iz JSON-a.',
+                'Kad trebaš identificirati lokaciju, napiši samo "polje N" koristeći korisniku vidljivu oznaku polja. Nikada ne dodaj 0-bazirani indeks polja u tekst odgovora.',
+                'Statuse, bool vrijednosti i interne oznake pretvori u normalan hrvatski tekst, npr. "označeno za uklanjanje", "spremno za berbu" ili "u stakleniku".',
                 '',
                 'Raspored polja u gredici:',
                 `- Standardna gredica ima ${RAISED_BED_COLUMNS} stupca i do ${rows} redova (ukupno do ${totalFields} polja).`,
                 '- Polja su numerirana od 1 nadalje, počevši od donjeg desnog kuta slike i čitajući zdesna nalijevo, red po red prema gore.',
                 '- Donji red: 1 (donje desno) → 2 (donje sredina) → 3 (donje lijevo).',
                 '- Gornji red kod 18-poljne gredice: 16 (gornje desno) → 17 (gornja sredina) → 18 (gornje lijevo).',
-                '- U JSON kontekstu vrijednost `positionLabel` koristi ovo brojanje (1-bazirano), dok `positionIndex` ostaje 0-bazirana interna oznaka (`positionLabel = positionIndex + 1`).',
+                '- U kontekstu koristi korisniku vidljivu oznaku polja. Internu vrijednost polja koristi samo za slaganje URL-a radnje i nikada je ne ispisuj u tekstu.',
                 '- Ponekad su priložene dvije fotografije iste gredice: jedna iz standardne pozicije za gore navedeno numeriranje, a druga s druge strane gredice. Koristi ih kao komplementarne poglede iste gredice; drugi pogled služi za provjeru stanja biljaka, ne kao zasebna gredica ili novi raspored polja.',
                 '- Polja s `currentLocation: "greenhouse"` su presadnice koje trenutno rastu u stakleniku i još nisu presađene u gredicu; polja s `currentLocation: "raisedBed"` su u gredici. `sowingLocation` opisuje gdje je biljka započela.',
                 '- `pastPlantFields` navodi samo nazive biljaka koje su ranije bile u polju; ne sadrži povijest događaja ni datume.',
                 '- `imageDate` je datum fotografija/dnevničkog unosa. Koristi `imageDate`, `analysisReferenceDate` i `weather.historical` za procjenu stanja na fotografijama. `currentDate`, `weather.now` i `weather.forecast` koristi samo za današnje i buduće preporuke za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
-                '- Kada preporučiš konkretnu radnju iz `availableOperations`, napiši je kao markdown poveznicu na apsolutni URL iz `raisedBedOperationUrl` ili `plantFieldOperationUrlTemplate`, npr. `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId})`.',
-                '- Za radnje nad pojedinom biljkom/poljem koristi hash s 0-baziranim `positionIndex`: `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId}&positionIndex={positionIndex})`. Ne koristi `positionLabel` u URL-u.',
+                '- Kada preporučiš konkretnu radnju, napiši je kao markdown poveznicu s apsolutnim URL-om iz konteksta, npr. `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId})`.',
+                '- Za radnje nad pojedinom biljkom/poljem koristi točan URL predložak iz konteksta. Interna vrijednost polja smije postojati samo u URL-u markdown poveznice, nikada u vidljivom tekstu.',
                 '- Koristi samo apsolutne `https://www.gredice.com/radnje/...` URL predloške iz `availableOperations`; ne izmišljaj slugove, ne piši sirovi URL bez markdown oznake i ne dodaj link ako za radnju ne postoji odgovarajući URL predložak.',
             ].join('\n'),
         },
@@ -626,14 +633,15 @@ async function buildAnalysisMessages({
                     type: 'text' as const,
                     text: [
                         typeof positionIndex === 'number'
-                            ? `Analiziraj sve fotografije vrta i kontekst te napiši objedinjene praktične preporuke za označeno polje (positionLabel ${analyzedPositionLabel}) i ostatak gredice.`
+                            ? `Analiziraj sve fotografije vrta i kontekst te napiši objedinjene praktične preporuke za označeno polje ${analyzedPositionLabel} i ostatak gredice.`
                             : 'Analiziraj sve fotografije gredice i kontekst te napiši objedinjene praktične preporuke za cijelu gredicu.',
                         'Fotografije su različiti pogledi istog dnevničkog unosa; nemoj ih tretirati kao zasebne zahtjeve.',
-                        'Odgovor MORA imati ove markdown sekcije:',
+                        'Odgovor MORA imati ove markdown sekcije s točno ovim naslovima:',
                         '## Sažetak stanja',
-                        '## Globalne preporuke (2-4 stavke)',
-                        '## Biljke koje traže najviše pažnje (2-4 biljke, po biljci navedi problem + konkretan idući korak)',
+                        '## Najvažnije preporuke',
+                        '## Biljke koje traže najviše pažnje',
                         '## Plan za sljedeća 3 dana',
+                        'U najvažnijim preporukama napiši 2-4 stavke. U sekciji o biljkama navedi 2-4 biljke; za svaku napiši problem i konkretan idući korak.',
                         '',
                         'Kontekst (JSON):',
                         JSON.stringify(
@@ -698,7 +706,7 @@ export async function streamRaisedBedImageAnalysis(
         messages,
         onFinish: async ({ text, usage }) => {
             await onFinish({
-                markdown: text,
+                markdown: sanitizeRaisedBedAiMarkdown(text),
                 model: AI_MODEL,
                 analyzedAt: new Date().toISOString(),
                 inputTokens: usage.inputTokens ?? 0,

--- a/apps/app/app/admin/ai-analytics/AiAnalyticsTable.tsx
+++ b/apps/app/app/admin/ai-analytics/AiAnalyticsTable.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { sanitizeRaisedBedAiMarkdown } from '@gredice/js/ai';
 import { Card, CardOverflow } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
 import { ImageGallery } from '@gredice/ui/ImageGallery';
@@ -96,6 +97,9 @@ function AiAnalysisDetails({ row }: { row: AiAnalyticsRow }) {
     const markdown = row.data?.markdown?.trim();
     const summary = row.data?.summary?.trim();
     const generatedContent = markdown || summary;
+    const sanitizedGeneratedContent = generatedContent
+        ? sanitizeRaisedBedAiMarkdown(generatedContent)
+        : '';
     const imageCount = row.data?.imageCount ?? images.length;
 
     return (
@@ -176,9 +180,9 @@ function AiAnalysisDetails({ row }: { row: AiAnalyticsRow }) {
                 <Typography level="body2" semiBold>
                     Generirani sadržaj
                 </Typography>
-                {generatedContent ? (
+                {sanitizedGeneratedContent ? (
                     <Markdown className="rounded-md border bg-muted/20 p-3">
-                        {generatedContent}
+                        {sanitizedGeneratedContent}
                     </Markdown>
                 ) : (
                     <NoDataPlaceholder>Nema sadržaja</NoDataPlaceholder>

--- a/packages/game/src/hooks/useRaisedBedAiAnalysis.ts
+++ b/packages/game/src/hooks/useRaisedBedAiAnalysis.ts
@@ -1,4 +1,5 @@
 import { client } from '@gredice/client';
+import { sanitizeRaisedBedAiMarkdown } from '@gredice/js/ai';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
     AiAnalysisRequestError,
@@ -66,10 +67,10 @@ export function useRaisedBedAiAnalysis() {
                 const { done, value } = await reader.read();
                 if (done) break;
                 markdown += decoder.decode(value, { stream: true });
-                onChunk?.(markdown);
+                onChunk?.(sanitizeRaisedBedAiMarkdown(markdown));
             }
 
-            return { markdown };
+            return { markdown: sanitizeRaisedBedAiMarkdown(markdown) };
         },
         onSuccess: async (_data, variables) => {
             await Promise.all([

--- a/packages/game/src/hooks/useRaisedBedFieldAiAnalysis.ts
+++ b/packages/game/src/hooks/useRaisedBedFieldAiAnalysis.ts
@@ -1,4 +1,5 @@
 import { client } from '@gredice/client';
+import { sanitizeRaisedBedAiMarkdown } from '@gredice/js/ai';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
     AiAnalysisRequestError,
@@ -69,10 +70,10 @@ export function useRaisedBedFieldAiAnalysis() {
                 const { done, value } = await reader.read();
                 if (done) break;
                 markdown += decoder.decode(value, { stream: true });
-                onChunk?.(markdown);
+                onChunk?.(sanitizeRaisedBedAiMarkdown(markdown));
             }
 
-            return { markdown };
+            return { markdown: sanitizeRaisedBedAiMarkdown(markdown) };
         },
         onSuccess: async (_data, variables) => {
             await Promise.all([

--- a/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedAiOperationMarkdown.tsx
@@ -1,4 +1,5 @@
 import type { OperationData } from '@gredice/client';
+import { sanitizeRaisedBedAiMarkdown } from '@gredice/js/ai';
 import { Chip } from '@gredice/ui/Chip';
 import { Calendar } from '@gredice/ui/icons';
 import { Children, isValidElement, type ReactNode, useMemo } from 'react';
@@ -212,6 +213,10 @@ export function RaisedBedAiOperationMarkdown({
     children: string;
     gardenId: number;
 }) {
+    const sanitizedMarkdown = useMemo(
+        () => sanitizeRaisedBedAiMarkdown(children),
+        [children],
+    );
     const components = useMemo<Components>(
         () => ({
             a: ({ children: linkChildren, href, ...props }) => {
@@ -241,5 +246,9 @@ export function RaisedBedAiOperationMarkdown({
         [gardenId],
     );
 
-    return <ReactMarkdown components={components}>{children}</ReactMarkdown>;
+    return (
+        <ReactMarkdown components={components}>
+            {sanitizedMarkdown}
+        </ReactMarkdown>
+    );
 }

--- a/packages/game/src/hud/raisedBed/raisedBedAiText.unit.ts
+++ b/packages/game/src/hud/raisedBed/raisedBedAiText.unit.ts
@@ -15,6 +15,7 @@ test('sanitizeRaisedBedAiMarkdown removes internal field names from visible reco
             '',
             "2. **Celer lisnati rebrasti d'elne — polje 4, positionIndex 3**",
             'Problem: označen je kao neizniknut/propao i `needsRemoval: true`; zauzima prostor bez koristi.',
+            'Idući korak: removalRecommendation: označeno za uklanjanje.',
         ].join('\n'),
     );
     const visibleText = visibleMarkdownText(sanitized);
@@ -24,6 +25,7 @@ test('sanitizeRaisedBedAiMarkdown removes internal field names from visible reco
     assert.match(visibleText, /označeno za uklanjanje/);
     assert.doesNotMatch(visibleText, /positionIndex/i);
     assert.doesNotMatch(visibleText, /needsRemoval/i);
+    assert.doesNotMatch(visibleText, /removalRecommendation/i);
 });
 
 test('sanitizeRaisedBedAiMarkdown rewrites bare operation URLs and field labels', () => {

--- a/packages/game/src/hud/raisedBed/raisedBedAiText.unit.ts
+++ b/packages/game/src/hud/raisedBed/raisedBedAiText.unit.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { sanitizeRaisedBedAiMarkdown } from '@gredice/js/ai';
+
+function visibleMarkdownText(markdown: string) {
+    return markdown.replace(/\]\([^)]*\)/g, '');
+}
+
+test('sanitizeRaisedBedAiMarkdown removes internal field names from visible recommendations', () => {
+    const sanitized = sanitizeRaisedBedAiMarkdown(
+        [
+            '1. **Rukola coltivata — polje 10, positionIndex 9**',
+            'Problem: spremna je za berbu.',
+            'Idući korak: naručiti [Branje biljke](https://www.gredice.com/radnje/branje-biljke#raisedBedId=5&positionIndex=9).',
+            '',
+            "2. **Celer lisnati rebrasti d'elne — polje 4, positionIndex 3**",
+            'Problem: označen je kao neizniknut/propao i `needsRemoval: true`; zauzima prostor bez koristi.',
+        ].join('\n'),
+    );
+    const visibleText = visibleMarkdownText(sanitized);
+
+    assert.match(sanitized, /positionIndex=9/);
+    assert.match(visibleText, /Rukola coltivata — polje 10/);
+    assert.match(visibleText, /označeno za uklanjanje/);
+    assert.doesNotMatch(visibleText, /positionIndex/i);
+    assert.doesNotMatch(visibleText, /needsRemoval/i);
+});
+
+test('sanitizeRaisedBedAiMarkdown rewrites bare operation URLs and field labels', () => {
+    const sanitized = sanitizeRaisedBedAiMarkdown(
+        'Naruči https://www.gredice.com/radnje/uklanjanje-biljke#raisedBedId=5&positionIndex=3 za positionLabel 4.',
+    );
+
+    assert.match(sanitized, /poveznica za radnju/);
+    assert.match(sanitized, /polje 4/);
+    assert.doesNotMatch(sanitized, /positionIndex/i);
+    assert.doesNotMatch(sanitized, /positionLabel/i);
+});

--- a/packages/js/src/ai/index.ts
+++ b/packages/js/src/ai/index.ts
@@ -27,6 +27,7 @@ const INTERNAL_TERM_REPLACEMENTS = new Map([
     ['positionIndex', 'polje'],
     ['positionLabel', 'polje'],
     ['raisedBedOperationUrl', 'poveznica za radnju na gredici'],
+    ['removalRecommendation', 'preporuka za uklanjanje'],
     ['requestedStatus', 'predloženo stanje'],
     ['requestedWeedLevel', 'predložena razina korova'],
     ['sowingLocation', 'mjesto sjetve'],
@@ -109,6 +110,10 @@ export function sanitizeRaisedBedAiMarkdown(markdown: string) {
         .replace(
             /`?\b(?:needsRemoval|toBeRemoved)\b`?\s*[:=]?\s*false\b`?/gi,
             'nije označeno za uklanjanje',
+        )
+        .replace(
+            /`?\bremovalRecommendation\b`?\s*[:=]?\s*["'`]?označeno za uklanjanje["'`]?/gi,
+            'označeno za uklanjanje',
         )
         .replace(
             /`?\bcurrentLocation\b`?\s*[:=]?\s*["'`]?greenhouse["'`]?/gi,

--- a/packages/js/src/ai/index.ts
+++ b/packages/js/src/ai/index.ts
@@ -1,0 +1,136 @@
+const MARKDOWN_LINK_DESTINATION_PATTERN = /\]\([^)]*\)/g;
+
+const RAW_OPERATION_URL_PATTERN =
+    /\b(?:https?:\/\/)?(?:www\.)?gredice\.com\/radnje\/[^\s)\]]+/gi;
+
+const INTERNAL_TERM_REPLACEMENTS = new Map([
+    ['allowedTargetStatuses', 'moguća stanja'],
+    ['availableOperations', 'dostupne radnje'],
+    ['currentFieldWeedLevel', 'razina korova'],
+    ['currentFieldWeedState', 'stanje korova'],
+    ['currentLocation', 'trenutačna lokacija'],
+    ['daysFromDead', 'dani od propadanja'],
+    ['daysFromGrowth', 'dani od nicanja'],
+    ['daysFromHarvest', 'dani od berbe'],
+    ['daysFromReady', 'dani od spremnosti za berbu'],
+    ['daysFromSowing', 'dani od sjetve'],
+    ['isAnalyzedField', 'označeno polje'],
+    ['isFocusField', 'označeno polje'],
+    ['isGreenhouseSeedling', 'presadnica'],
+    ['needsRemoval', 'oznaka za uklanjanje'],
+    ['operationUrlFieldIndex', 'oznaka polja za poveznicu'],
+    ['pastPlantFields', 'ranije biljke'],
+    ['plantFieldOperationUrlTemplate', 'poveznica za radnju na polju'],
+    ['plantName', 'naziv biljke'],
+    ['plantSortId', 'biljka'],
+    ['plantStatus', 'stanje biljke'],
+    ['positionIndex', 'polje'],
+    ['positionLabel', 'polje'],
+    ['raisedBedOperationUrl', 'poveznica za radnju na gredici'],
+    ['requestedStatus', 'predloženo stanje'],
+    ['requestedWeedLevel', 'predložena razina korova'],
+    ['sowingLocation', 'mjesto sjetve'],
+    ['toBeRemoved', 'oznaka za uklanjanje'],
+    ['weedProposals', 'prijedlozi za korov'],
+]);
+
+function protectMarkdownLinkDestinations(value: string) {
+    const protectedSegments: string[] = [];
+    const text = value.replace(MARKDOWN_LINK_DESTINATION_PATTERN, (segment) => {
+        const token = `__GREDICE_AI_MARKDOWN_DESTINATION_${protectedSegments.length}__`;
+        protectedSegments.push(segment);
+
+        return token;
+    });
+
+    return {
+        text,
+        restore: (nextValue: string) =>
+            protectedSegments.reduce(
+                (restored, segment, index) =>
+                    restored.replace(
+                        `__GREDICE_AI_MARKDOWN_DESTINATION_${index}__`,
+                        segment,
+                    ),
+                nextValue,
+            ),
+    };
+}
+
+function fieldLabelFromPositionIndex(value: string) {
+    const positionIndex = Number.parseInt(value, 10);
+
+    return Number.isFinite(positionIndex) && positionIndex >= 0
+        ? `polje ${positionIndex + 1}`
+        : 'polje';
+}
+
+function fieldLabelFromPositionLabel(value: string) {
+    const positionLabel = Number.parseInt(value, 10);
+
+    return Number.isFinite(positionLabel) && positionLabel > 0
+        ? `polje ${positionLabel}`
+        : 'polje';
+}
+
+function replaceInternalTerms(value: string) {
+    let nextValue = value;
+
+    for (const [term, replacement] of INTERNAL_TERM_REPLACEMENTS) {
+        nextValue = nextValue.replace(
+            new RegExp(`\`?\\b${term}\\b\`?`, 'gi'),
+            replacement,
+        );
+    }
+
+    return nextValue;
+}
+
+export function sanitizeRaisedBedAiMarkdown(markdown: string) {
+    const protectedMarkdown = protectMarkdownLinkDestinations(markdown);
+    let sanitized = protectedMarkdown.text
+        .replace(RAW_OPERATION_URL_PATTERN, 'poveznica za radnju')
+        .replace(
+            /\b(polje\s+\d+)\s*,\s*`?\bpositionIndex\b`?\s*[:=]?\s*-?\d+\b`?/gi,
+            '$1',
+        )
+        .replace(
+            /`?\bpositionIndex\b`?\s*[:=]?\s*(-?\d+)\b`?/gi,
+            (_match, value: string) => fieldLabelFromPositionIndex(value),
+        )
+        .replace(
+            /`?\bpositionLabel\b`?\s*[:=]?\s*(\d+)\b`?/gi,
+            (_match, value: string) => fieldLabelFromPositionLabel(value),
+        )
+        .replace(
+            /`?\b(?:needsRemoval|toBeRemoved)\b`?\s*[:=]?\s*true\b`?/gi,
+            'označeno za uklanjanje',
+        )
+        .replace(
+            /`?\b(?:needsRemoval|toBeRemoved)\b`?\s*[:=]?\s*false\b`?/gi,
+            'nije označeno za uklanjanje',
+        )
+        .replace(
+            /`?\bcurrentLocation\b`?\s*[:=]?\s*["'`]?greenhouse["'`]?/gi,
+            'trenutačno u stakleniku',
+        )
+        .replace(
+            /`?\bcurrentLocation\b`?\s*[:=]?\s*["'`]?raisedBed["'`]?/gi,
+            'trenutačno u gredici',
+        )
+        .replace(
+            /`?\bsowingLocation\b`?\s*[:=]?\s*["'`]?greenhouse["'`]?/gi,
+            'sijano u stakleniku',
+        )
+        .replace(
+            /`?\bsowingLocation\b`?\s*[:=]?\s*["'`]?direct["'`]?/gi,
+            'direktno sijano',
+        );
+
+    sanitized = replaceInternalTerms(sanitized)
+        .replace(/\bpolje\s+(\d+)\s*,\s*polje\s+\1\b/gi, 'polje $1')
+        .replace(/`true`/gi, 'da')
+        .replace(/`false`/gi, 'ne');
+
+    return protectedMarkdown.restore(sanitized);
+}

--- a/packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts
+++ b/packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts
@@ -1,3 +1,4 @@
+import { sanitizeRaisedBedAiMarkdown } from '@gredice/js/ai';
 import {
     calculatePlantsPerField,
     getImageObservablePlantStatusTargets,
@@ -540,6 +541,7 @@ function buildReviewMessages({
             content: [
                 'Ti si stručni agronom koji pregledava fotografije Gredice i predlaže ISKLJUČIVO sigurne promjene stanja biljaka.',
                 'Vrati strukturirani rezultat prema shemi. Ne vraćaj markdown.',
+                'U poljima `summary` i `evidence` piši normalne hrvatske rečenice. Ne spominji interne nazive ili JSON ključeve kao `positionIndex`, `needsRemoval`, `plantStatus`, `plantSortId`, `currentLocation` ili `sowingLocation`.',
                 'Predloži promjenu samo kada je vizualni dokaz jasan i gotovo siguran; ne pogađaj na temelju kalendara, očekivanih dana rasta ili mutne/zaklonjene fotografije.',
                 'Za svako polje smiješ predložiti plant-status samo iz `allowedTargetStatuses`; ako nema odgovarajućeg statusa, preskoči plant-status prijedlog za to polje.',
                 'Ako je trenutno stanje `sowed` ili `pendingVerification`, a na slici se jasno vide klice za direktno sijanu biljku, predloži `sprouted`.',
@@ -780,7 +782,7 @@ function buildApprovalNote({
         proposal.observedPlantCount !== null
             ? `Uočeni broj biljaka/klica: ${proposal.observedPlantCount}.`
             : null,
-        `Dokaz: ${proposal.evidence}`,
+        `Dokaz: ${sanitizeRaisedBedAiMarkdown(proposal.evidence)}`,
     ]
         .filter((line): line is string => typeof line === 'string')
         .join('\n');
@@ -802,7 +804,7 @@ function buildWeedStateNotes({
         `Polje: ${proposal.positionLabel}.`,
         `Promjena: ${proposal.currentWeedLevel ?? 'none'} -> ${proposal.requestedWeedLevel}.`,
         `Pouzdanost: ${Math.round(proposal.confidence * 100)}%.`,
-        `Dokaz: ${proposal.evidence}`,
+        `Dokaz: ${sanitizeRaisedBedAiMarkdown(proposal.evidence)}`,
     ]
         .filter((line): line is string => typeof line === 'string')
         .join('\n');
@@ -1044,7 +1046,7 @@ export async function runRaisedBedImagePlantStatusReview({
             imageCount: input.imageUrls.length,
             skippedInvalidImageCount: input.skippedInvalidImageCount,
             model: AI_MODEL,
-            summary: output.summary,
+            summary: sanitizeRaisedBedAiMarkdown(output.summary),
             proposalCount: output.proposals.length,
             acceptedProposalCount: accepted.length,
             requestIds,


### PR DESCRIPTION
## Summary
- add a shared raised-bed AI markdown sanitizer for internal field names like `positionIndex` and `needsRemoval`
- apply the sanitizer to streamed game suggestions, saved API output, admin AI analytics, and plant-status review evidence/summary
- tighten the raised-bed AI prompt so future responses use normal Croatian copy and cleaner section titles

## Validation
- `corepack pnpm lint --filter @gredice/js --filter @gredice/game --filter api --filter app --filter @gredice/storage`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/garden/raisedBedAiAnalysisService.node.spec.ts`
- `corepack pnpm --filter @gredice/storage exec node --import tsx --test --conditions=react-server ./tests/raisedBedImagePlantStatusAnalysis.node.spec.ts`
- `git diff --check`

## Notes
- Direct package-wide `tsc --noEmit` for `@gredice/js`, `api`, `@gredice/storage`, and `app` still reports existing unrelated repo errors, so validation used the focused checks above plus the passing `@gredice/game` typecheck.