### PR TITLE
feat(garden): allow deleting inactive gardens

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -21,6 +21,7 @@ import {
     createGardenBlock,
     createGardenStack,
     createSandboxGarden,
+    deleteGardenIfNoActiveRaisedBeds,
     deleteGardenStack,
     deleteSandboxGardenCompletely,
     type EntityStandardized,
@@ -1260,7 +1261,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
         '/:gardenId',
         describeRoute({
             description:
-                'Delete a sandbox garden accessible to the current user, including related blocks, raised beds, notifications, operations, cart rows, transactions, and events. Real gardens cannot be deleted from this endpoint. Large deletions may return 202 and should be retried until complete.',
+                'Delete a garden accessible to the current user. Sandbox gardens are deleted completely, including related blocks, raised beds, notifications, operations, cart rows, transactions, and events. Real gardens are soft-deleted only when they have no active raised beds. Large sandbox deletions may return 202 and should be retried until complete.',
             security: authSecurity,
         }),
         zValidator(
@@ -1291,9 +1292,25 @@ const app = new Hono<{ Variables: AuthVariables }>()
             }
 
             if (!garden.isSandbox) {
+                const result =
+                    await deleteGardenIfNoActiveRaisedBeds(gardenIdNumber);
+                if (result.activeRaisedBedCount > 0) {
+                    return context.json(
+                        {
+                            error: 'Garden cannot be deleted while it has active raised beds',
+                            activeRaisedBedCount: result.activeRaisedBedCount,
+                        },
+                        409,
+                    );
+                }
+
                 return context.json(
-                    { error: 'Only sandbox gardens can be deleted' },
-                    400,
+                    {
+                        success: true,
+                        complete: true,
+                        deletedRows: result.deleted ? 1 : 0,
+                    },
+                    200,
                 );
             }
 

--- a/apps/garden/tests/GardenTabStory.tsx
+++ b/apps/garden/tests/GardenTabStory.tsx
@@ -1,0 +1,107 @@
+import * as ReactQuery from '@tanstack/react-query';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { type PropsWithChildren, useMemo } from 'react';
+import { currentGardenKeys } from '../../../packages/game/src/hooks/useCurrentGarden';
+import { gardenAccountGroupsKeys } from '../../../packages/game/src/hooks/useGardenAccountGroups';
+import { useGardensKeys } from '../../../packages/game/src/hooks/useGardens';
+import { GardenTab } from '../../../packages/game/src/modals/components/GardenTab';
+import {
+    createGameState,
+    GameStateContext,
+} from '../../../packages/game/src/useGameState';
+
+type GardenTabStoryProps = {
+    activeRaisedBedCount?: number;
+};
+
+const garden = {
+    id: 1,
+    name: 'Test',
+    isSandbox: false,
+    backgroundPalette: 'current',
+    createdAt: '2026-06-01T00:00:00.000Z',
+};
+
+function raisedBed(id: number, status: string) {
+    return {
+        id,
+        name: `Gredica ${id.toString()}`,
+        status,
+        fields: [],
+        latestPhotoOperation: null,
+        weedState: null,
+    };
+}
+
+function createGardenTabQueryClient(activeRaisedBedCount = 0) {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: Infinity },
+        },
+    });
+    const raisedBeds = [
+        ...Array.from({ length: activeRaisedBedCount }, (_value, index) =>
+            raisedBed(index + 1, 'active'),
+        ),
+        raisedBed(activeRaisedBedCount + 1, 'abandoned'),
+    ];
+
+    queryClient.setQueryData(useGardensKeys, [garden]);
+    queryClient.setQueryData(gardenAccountGroupsKeys, [
+        {
+            accountId: 'test-account',
+            name: 'test@example.com račun',
+            isCurrent: true,
+            gardens: [garden],
+        },
+    ]);
+    queryClient.setQueryData(currentGardenKeys('summer', garden.id), {
+        id: garden.id,
+        name: garden.name,
+        isSandbox: garden.isSandbox,
+        stacks: [],
+        location: { lat: 45.739, lon: 16.572 },
+        raisedBeds,
+    });
+
+    return queryClient;
+}
+
+function GardenTabTestProviders({
+    activeRaisedBedCount,
+    children,
+}: PropsWithChildren<GardenTabStoryProps>) {
+    const queryClient = useMemo(
+        () => createGardenTabQueryClient(activeRaisedBedCount),
+        [activeRaisedBedCount],
+    );
+    const gameState = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: '',
+                freezeTime: new Date('2026-06-01T00:00:00.000Z'),
+                isMock: false,
+            }),
+        [],
+    );
+
+    return (
+        <ReactQuery.QueryClientProvider client={queryClient}>
+            <NuqsTestingAdapter>
+                <GameStateContext.Provider value={gameState}>
+                    {children}
+                </GameStateContext.Provider>
+            </NuqsTestingAdapter>
+        </ReactQuery.QueryClientProvider>
+    );
+}
+
+export function GardenTabStory({ activeRaisedBedCount }: GardenTabStoryProps) {
+    return (
+        <div className="min-h-96 max-w-2xl p-4">
+            <GardenTabTestProviders activeRaisedBedCount={activeRaisedBedCount}>
+                <GardenTab />
+            </GardenTabTestProviders>
+        </div>
+    );
+}

--- a/apps/garden/tests/GardenTabStory.tsx
+++ b/apps/garden/tests/GardenTabStory.tsx
@@ -12,9 +12,10 @@ import {
 
 type GardenTabStoryProps = {
     activeRaisedBedCount?: number;
+    isSandbox?: boolean;
 };
 
-const garden = {
+const baseGarden = {
     id: 1,
     name: 'Test',
     isSandbox: false,
@@ -33,12 +34,19 @@ function raisedBed(id: number, status: string) {
     };
 }
 
-function createGardenTabQueryClient(activeRaisedBedCount = 0) {
+function createGardenTabQueryClient(
+    activeRaisedBedCount = 0,
+    isSandbox = false,
+) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
             queries: { retry: false, staleTime: Infinity },
         },
     });
+    const garden = {
+        ...baseGarden,
+        isSandbox,
+    };
     const raisedBeds = [
         ...Array.from({ length: activeRaisedBedCount }, (_value, index) =>
             raisedBed(index + 1, 'active'),
@@ -69,11 +77,12 @@ function createGardenTabQueryClient(activeRaisedBedCount = 0) {
 
 function GardenTabTestProviders({
     activeRaisedBedCount,
+    isSandbox,
     children,
 }: PropsWithChildren<GardenTabStoryProps>) {
     const queryClient = useMemo(
-        () => createGardenTabQueryClient(activeRaisedBedCount),
-        [activeRaisedBedCount],
+        () => createGardenTabQueryClient(activeRaisedBedCount, isSandbox),
+        [activeRaisedBedCount, isSandbox],
     );
     const gameState = useMemo(
         () =>
@@ -96,10 +105,16 @@ function GardenTabTestProviders({
     );
 }
 
-export function GardenTabStory({ activeRaisedBedCount }: GardenTabStoryProps) {
+export function GardenTabStory({
+    activeRaisedBedCount,
+    isSandbox,
+}: GardenTabStoryProps) {
     return (
         <div className="min-h-96 max-w-2xl p-4">
-            <GardenTabTestProviders activeRaisedBedCount={activeRaisedBedCount}>
+            <GardenTabTestProviders
+                activeRaisedBedCount={activeRaisedBedCount}
+                isSandbox={isSandbox}
+            >
                 <GardenTab />
             </GardenTabTestProviders>
         </div>

--- a/apps/garden/tests/garden-tab.spec.tsx
+++ b/apps/garden/tests/garden-tab.spec.tsx
@@ -56,6 +56,40 @@ test.describe('Garden tab', () => {
         await expect.poll(() => deleteRequests.length).toBe(1);
     });
 
+    test('retries incomplete sandbox garden deletion until complete', async ({
+        mount,
+        page,
+    }) => {
+        let deleteRequestCount = 0;
+        await page.route('**/api/gredice/api/gardens/1', async (route) => {
+            if (route.request().method() === 'DELETE') {
+                deleteRequestCount += 1;
+                await route.fulfill({
+                    contentType: 'application/json',
+                    status: deleteRequestCount === 1 ? 202 : 200,
+                    body: JSON.stringify({
+                        success: true,
+                        complete: deleteRequestCount !== 1,
+                    }),
+                });
+                return;
+            }
+
+            await route.fallback();
+        });
+
+        await mount(<GardenTabStory activeRaisedBedCount={0} isSandbox />);
+
+        await page.getByRole('button', { name: 'Obriši vrt' }).click();
+        const dialog = page.getByRole('alertdialog', {
+            name: 'Brisanje vrta',
+        });
+        await dialog.getByLabel('Upiši "Test" za potvrdu').fill('Test');
+        await dialog.getByRole('button', { name: 'Obriši vrt' }).click();
+
+        await expect.poll(() => deleteRequestCount).toBe(2);
+    });
+
     test('shows blocked delete errors returned by the API', async ({
         mount,
         page,

--- a/apps/garden/tests/garden-tab.spec.tsx
+++ b/apps/garden/tests/garden-tab.spec.tsx
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { GardenTabStory } from './GardenTabStory';
+
+test.describe('Garden tab', () => {
+    test('disables garden deletion while raised beds are active', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<GardenTabStory activeRaisedBedCount={2} />);
+
+        await expect(page.getByText('Brisanje vrta')).toBeVisible();
+        await expect(
+            page.getByText(
+                'Vrt ima 2 aktivnih gredica. Prvo napusti aktivne gredice, zatim obriši vrt.',
+            ),
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Obriši vrt' }),
+        ).toBeDisabled();
+    });
+
+    test('requires typed confirmation before deleting a garden', async ({
+        mount,
+        page,
+    }) => {
+        const deleteRequests: string[] = [];
+        await page.route('**/api/gredice/api/gardens/1', async (route) => {
+            if (route.request().method() === 'DELETE') {
+                deleteRequests.push(route.request().url());
+                await route.fulfill({
+                    contentType: 'application/json',
+                    status: 200,
+                    body: JSON.stringify({ success: true, complete: true }),
+                });
+                return;
+            }
+
+            await route.fallback();
+        });
+
+        await mount(<GardenTabStory activeRaisedBedCount={0} />);
+
+        await page.getByRole('button', { name: 'Obriši vrt' }).click();
+        const dialog = page.getByRole('alertdialog', {
+            name: 'Brisanje vrta',
+        });
+        await expect(dialog).toBeVisible();
+        await expect(
+            dialog.getByRole('button', { name: 'Obriši vrt' }),
+        ).toBeDisabled();
+        expect(deleteRequests).toHaveLength(0);
+
+        await dialog.getByLabel('Upiši "Test" za potvrdu').fill('Test');
+        await dialog.getByRole('button', { name: 'Obriši vrt' }).click();
+
+        await expect.poll(() => deleteRequests.length).toBe(1);
+    });
+
+    test('shows blocked delete errors returned by the API', async ({
+        mount,
+        page,
+    }) => {
+        await page.route('**/api/gredice/api/gardens/1', async (route) => {
+            if (route.request().method() === 'DELETE') {
+                await route.fulfill({
+                    contentType: 'application/json',
+                    status: 409,
+                    body: JSON.stringify({
+                        error: 'Garden cannot be deleted while it has active raised beds',
+                        activeRaisedBedCount: 1,
+                    }),
+                });
+                return;
+            }
+
+            await route.fallback();
+        });
+
+        await mount(<GardenTabStory activeRaisedBedCount={0} />);
+
+        await page.getByRole('button', { name: 'Obriši vrt' }).click();
+        const dialog = page.getByRole('alertdialog', {
+            name: 'Brisanje vrta',
+        });
+        await dialog.getByLabel('Upiši "Test" za potvrdu').fill('Test');
+        await dialog.getByRole('button', { name: 'Obriši vrt' }).click();
+
+        await expect(
+            page.getByText('Prije brisanja vrta napusti 1 aktivnu gredicu.'),
+        ).toBeVisible();
+    });
+});

--- a/packages/game/src/hooks/useDeleteGarden.ts
+++ b/packages/game/src/hooks/useDeleteGarden.ts
@@ -1,0 +1,92 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGameState } from '../useGameState';
+import { useCurrentGardenIdParam } from '../useUrlState';
+import { currentGardenKeys } from './useCurrentGarden';
+import { useGardensKeys } from './useGardens';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
+
+type DeleteGardenVariables = {
+    gardenId: number;
+};
+
+const mutationKey = ['gardens', 'delete'];
+const GARDEN_DELETE_FAILED_MESSAGE =
+    'Došlo je do greške prilikom brisanja vrta. Pokušaj ponovno.';
+
+function activeRaisedBedsMessage(count: number) {
+    return count === 1
+        ? 'Prije brisanja vrta napusti 1 aktivnu gredicu.'
+        : `Prije brisanja vrta napusti ${count.toString()} aktivnih gredica.`;
+}
+
+async function getDeleteGardenErrorMessage(response: Response) {
+    try {
+        const body: unknown = await response.json();
+        if (
+            typeof body === 'object' &&
+            body !== null &&
+            'activeRaisedBedCount' in body
+        ) {
+            const { activeRaisedBedCount } = body;
+            if (
+                typeof activeRaisedBedCount === 'number' &&
+                activeRaisedBedCount > 0
+            ) {
+                return activeRaisedBedsMessage(activeRaisedBedCount);
+            }
+        }
+
+        if (typeof body === 'object' && body !== null && 'error' in body) {
+            const { error } = body;
+            if (typeof error === 'string' && error.trim()) {
+                return error;
+            }
+        }
+    } catch {
+        return GARDEN_DELETE_FAILED_MESSAGE;
+    }
+
+    return GARDEN_DELETE_FAILED_MESSAGE;
+}
+
+export function useDeleteGarden() {
+    const queryClient = useQueryClient();
+    const winterMode = useGameState((state) => state.winterMode);
+    const [selectedGardenId, setSelectedGardenId] = useCurrentGardenIdParam();
+
+    return useMutation({
+        mutationKey,
+        mutationFn: async ({ gardenId }: DeleteGardenVariables) => {
+            const response = await clientAuthenticated().api.gardens[
+                ':gardenId'
+            ].$delete({
+                param: {
+                    gardenId: gardenId.toString(),
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(await getDeleteGardenErrorMessage(response));
+            }
+        },
+        onSuccess: async (_data, { gardenId }) => {
+            if (selectedGardenId === gardenId) {
+                void setSelectedGardenId(null);
+            }
+
+            await Promise.all([
+                queryClient.invalidateQueries({ queryKey: useGardensKeys }),
+                queryClient.invalidateQueries({
+                    queryKey: currentGardenKeys(winterMode),
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: tutorialChecklistKeys,
+                }),
+            ]);
+        },
+        onError: (error) => {
+            console.error('Failed to delete garden:', error);
+        },
+    });
+}

--- a/packages/game/src/hooks/useDeleteGarden.ts
+++ b/packages/game/src/hooks/useDeleteGarden.ts
@@ -10,9 +10,21 @@ type DeleteGardenVariables = {
     gardenId: number;
 };
 
+type DeleteGardenResponse = {
+    complete?: boolean;
+};
+
 const mutationKey = ['gardens', 'delete'];
 const GARDEN_DELETE_FAILED_MESSAGE =
     'Došlo je do greške prilikom brisanja vrta. Pokušaj ponovno.';
+const GARDEN_DELETE_TIMEOUT_MESSAGE =
+    'Brisanje vrta nije završilo na vrijeme. Pokušaj ponovno.';
+const retryableTimeoutStatuses = new Set([408, 425, 429, 502, 503, 504]);
+const maxDeleteAttempts = 1_000;
+
+function waitForRetry() {
+    return new Promise((resolve) => setTimeout(resolve, 250));
+}
 
 function activeRaisedBedsMessage(count: number) {
     return count === 1
@@ -50,6 +62,28 @@ async function getDeleteGardenErrorMessage(response: Response) {
     return GARDEN_DELETE_FAILED_MESSAGE;
 }
 
+async function getDeleteGardenResponse(
+    response: Response,
+): Promise<DeleteGardenResponse> {
+    try {
+        const body: unknown = await response.json();
+        if (
+            typeof body !== 'object' ||
+            body === null ||
+            !('complete' in body)
+        ) {
+            return {};
+        }
+
+        const { complete } = body;
+        return {
+            complete: typeof complete === 'boolean' ? complete : undefined,
+        } satisfies DeleteGardenResponse;
+    } catch {
+        return {};
+    }
+}
+
 export function useDeleteGarden() {
     const queryClient = useQueryClient();
     const winterMode = useGameState((state) => state.winterMode);
@@ -58,17 +92,55 @@ export function useDeleteGarden() {
     return useMutation({
         mutationKey,
         mutationFn: async ({ gardenId }: DeleteGardenVariables) => {
-            const response = await clientAuthenticated().api.gardens[
-                ':gardenId'
-            ].$delete({
-                param: {
-                    gardenId: gardenId.toString(),
-                },
-            });
+            let lastError: unknown;
 
-            if (!response.ok) {
-                throw new Error(await getDeleteGardenErrorMessage(response));
+            for (let attempt = 0; attempt < maxDeleteAttempts; attempt += 1) {
+                let response: Awaited<
+                    ReturnType<
+                        ReturnType<
+                            typeof clientAuthenticated
+                        >['api']['gardens'][':gardenId']['$delete']
+                    >
+                >;
+
+                try {
+                    response = await clientAuthenticated().api.gardens[
+                        ':gardenId'
+                    ].$delete({
+                        param: {
+                            gardenId: gardenId.toString(),
+                        },
+                    });
+                } catch (error) {
+                    lastError = error;
+                    await waitForRetry();
+                    continue;
+                }
+
+                if (!response.ok) {
+                    if (retryableTimeoutStatuses.has(response.status)) {
+                        await waitForRetry();
+                        continue;
+                    }
+
+                    throw new Error(
+                        await getDeleteGardenErrorMessage(response),
+                    );
+                }
+
+                const result = await getDeleteGardenResponse(response);
+                if (result.complete !== false) {
+                    return result;
+                }
+
+                await waitForRetry();
             }
+
+            if (lastError instanceof Error) {
+                throw lastError;
+            }
+
+            throw new Error(GARDEN_DELETE_TIMEOUT_MESSAGE);
         },
         onSuccess: async (_data, { gardenId }) => {
             if (selectedGardenId === gardenId) {

--- a/packages/game/src/modals/components/GardenDangerCard.tsx
+++ b/packages/game/src/modals/components/GardenDangerCard.tsx
@@ -1,0 +1,139 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent } from '@gredice/ui/Card';
+import { Delete, Warning } from '@gredice/ui/icons';
+import { ModalConfirm } from '@gredice/ui/ModalConfirm';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useState } from 'react';
+import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { useDeleteGarden } from '../../hooks/useDeleteGarden';
+
+type GardenDangerCardProps = {
+    gardenId: number;
+    gardenName: string;
+};
+
+const fallbackDeleteError =
+    'Došlo je do greške prilikom brisanja vrta. Pokušaj ponovno.';
+
+function gardenDeleteAvailabilityMessage(activeRaisedBedCount?: number) {
+    if (activeRaisedBedCount === undefined) {
+        return 'Provjeravamo status gredica prije brisanja vrta.';
+    }
+
+    if (activeRaisedBedCount === 0) {
+        return 'Vrt nema aktivnih gredica i možeš ga obrisati.';
+    }
+
+    if (activeRaisedBedCount === 1) {
+        return 'Vrt ima 1 aktivnu gredicu. Prvo napusti aktivnu gredicu, zatim obriši vrt.';
+    }
+
+    return `Vrt ima ${activeRaisedBedCount.toString()} aktivnih gredica. Prvo napusti aktivne gredice, zatim obriši vrt.`;
+}
+
+export function GardenDangerCard({
+    gardenId,
+    gardenName,
+}: GardenDangerCardProps) {
+    const { data: currentGarden } = useCurrentGarden();
+    const deleteGarden = useDeleteGarden();
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+    const activeRaisedBedCount =
+        currentGarden?.id === gardenId
+            ? currentGarden.raisedBeds.filter(
+                  (raisedBed) => raisedBed.status === 'active',
+              ).length
+            : undefined;
+    const isDeleteAllowed = activeRaisedBedCount === 0;
+    const isDeleteDisabled = !isDeleteAllowed || deleteGarden.isPending;
+
+    function handleDeleteGarden() {
+        if (isDeleteDisabled) {
+            return;
+        }
+
+        setDeleteError(null);
+        deleteGarden.mutate(
+            { gardenId },
+            {
+                onError: (error) => {
+                    setDeleteError(
+                        error instanceof Error
+                            ? error.message
+                            : fallbackDeleteError,
+                    );
+                },
+            },
+        );
+    }
+
+    return (
+        <Card className="border-red-200 bg-red-50/80 shadow-xs dark:border-red-900/60 dark:bg-red-950/80">
+            <CardContent noHeader>
+                <Stack spacing={4}>
+                    <Row spacing={4} alignItems="start">
+                        <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-red-100 text-red-700 ring-4 ring-red-200/70 dark:bg-red-900/70 dark:text-red-100 dark:ring-red-800/70">
+                            <Warning className="size-5 shrink-0" />
+                        </div>
+                        <Stack spacing={1} className="min-w-0">
+                            <Typography level="body1" semiBold>
+                                Brisanje vrta
+                            </Typography>
+                            <Typography level="body2">
+                                Brisanjem se vrt uklanja iz aplikacije. Ova
+                                radnja se ne može poništiti.
+                            </Typography>
+                        </Stack>
+                    </Row>
+                    <Typography level="body2">
+                        {gardenDeleteAvailabilityMessage(activeRaisedBedCount)}
+                    </Typography>
+                    {deleteError ? (
+                        <Alert
+                            color="danger"
+                            startDecorator={
+                                <Warning className="size-4 shrink-0" />
+                            }
+                        >
+                            <Typography level="body2">{deleteError}</Typography>
+                        </Alert>
+                    ) : null}
+                    <ModalConfirm
+                        title="Potvrdi brisanje vrta"
+                        header="Brisanje vrta"
+                        expectedConfirm={gardenName}
+                        promptLabel={`Upiši "${gardenName}" za potvrdu`}
+                        confirmLabel="Obriši vrt"
+                        onConfirm={handleDeleteGarden}
+                        trigger={
+                            <Button
+                                type="button"
+                                variant="solid"
+                                color="danger"
+                                disabled={isDeleteDisabled}
+                                loading={deleteGarden.isPending}
+                                startDecorator={<Delete className="size-4" />}
+                            >
+                                Obriši vrt
+                            </Button>
+                        }
+                    >
+                        <Stack spacing={4}>
+                            <Typography>
+                                Jeste li sigurni da želite obrisati vrt{' '}
+                                <strong>{gardenName}</strong>?
+                            </Typography>
+                            <Typography level="body2">
+                                Vrt će nestati iz popisa vrtova. Brisanje je
+                                dostupno samo kada vrt nema aktivnih gredica.
+                            </Typography>
+                        </Stack>
+                    </ModalConfirm>
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+}

--- a/packages/game/src/modals/components/GardenTab.tsx
+++ b/packages/game/src/modals/components/GardenTab.tsx
@@ -19,6 +19,7 @@ import { useGardens } from '../../hooks/useGardens';
 import { GardenAccountMenuItems } from '../../hud/GardenAccountMenuItems';
 import { useCurrentGardenIdParam } from '../../useUrlState';
 import { CreateGardenModal } from './CreateGardenModal';
+import { GardenDangerCard } from './GardenDangerCard';
 import { GardenNameCard } from './GardenNameCard';
 
 function NoGardensCard() {
@@ -137,11 +138,17 @@ export function GardenTab() {
                     <>
                         <GardensSelector />
                         {selectedGarden && (
-                            <GardenNameCard
-                                gardenId={selectedGarden.id}
-                                gardenName={selectedGarden.name}
-                                gardenCreatedAt={selectedGarden.createdAt}
-                            />
+                            <>
+                                <GardenNameCard
+                                    gardenId={selectedGarden.id}
+                                    gardenName={selectedGarden.name}
+                                    gardenCreatedAt={selectedGarden.createdAt}
+                                />
+                                <GardenDangerCard
+                                    gardenId={selectedGarden.id}
+                                    gardenName={selectedGarden.name}
+                                />
+                            </>
                         )}
                     </>
                 ) : (

--- a/packages/storage/src/repositories/gardensRepo.ts
+++ b/packages/storage/src/repositories/gardensRepo.ts
@@ -152,6 +152,26 @@ export async function accountHasActiveRaisedBed(accountId: string) {
     return (result[0]?.count ?? 0) > 0;
 }
 
+export async function countActiveRaisedBedsForGarden(
+    gardenId: number,
+    db: DatabaseClient = storage(),
+) {
+    const result = await db
+        .select({ count: count() })
+        .from(raisedBeds)
+        .innerJoin(gardens, eq(raisedBeds.gardenId, gardens.id))
+        .where(
+            and(
+                eq(gardens.id, gardenId),
+                eq(gardens.isDeleted, false),
+                eq(raisedBeds.status, 'active'),
+                eq(raisedBeds.isDeleted, false),
+            ),
+        );
+
+    return result[0]?.count ?? 0;
+}
+
 export async function getAccountGardens(
     accountId: string,
     filter?: {
@@ -221,6 +241,41 @@ export async function deleteGarden(gardenId: number) {
         .where(eq(gardens.id, gardenId));
     await createEvent(knownEvents.gardens.deletedV1(gardenId.toString()));
     await bustScheduleCache();
+}
+
+export async function deleteGardenIfNoActiveRaisedBeds(gardenId: number) {
+    let deleted = false;
+    const activeRaisedBedCount = await storage().transaction(async (tx) => {
+        const activeCount = await countActiveRaisedBedsForGarden(gardenId, tx);
+        if (activeCount > 0) {
+            return activeCount;
+        }
+
+        const [updatedGarden] = await tx
+            .update(gardens)
+            .set({ isDeleted: true })
+            .where(and(eq(gardens.id, gardenId), eq(gardens.isDeleted, false)))
+            .returning({ id: gardens.id });
+
+        if (updatedGarden) {
+            deleted = true;
+            await createEvent(
+                knownEvents.gardens.deletedV1(gardenId.toString()),
+                tx,
+            );
+        }
+
+        return 0;
+    });
+
+    if (deleted) {
+        await bustScheduleCache();
+    }
+
+    return {
+        activeRaisedBedCount,
+        deleted,
+    };
 }
 
 export async function getGardenBlocks(gardenId: number) {

--- a/packages/storage/tests/gardensRepo.node.spec.ts
+++ b/packages/storage/tests/gardensRepo.node.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     accountHasActiveRaisedBed,
+    countActiveRaisedBedsForGarden,
     countRaisedBedsByAccount,
     createAccount,
     createDefaultGardenForAccount,
@@ -11,6 +12,7 @@ import {
     createOperation,
     deleteGarden,
     deleteGardenBlock,
+    deleteGardenIfNoActiveRaisedBeds,
     deleteGardenStack,
     getAccountGardens,
     getAccountGardensMetadata,
@@ -223,6 +225,77 @@ test('accountHasActiveRaisedBed ignores active beds in soft-deleted gardens', as
     await deleteGarden(gardenId);
 
     assert.strictEqual(await accountHasActiveRaisedBed(accountId), false);
+});
+
+test('countActiveRaisedBedsForGarden counts only active beds in the requested garden', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const otherAccountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const otherGardenId = await createTestGarden({
+        accountId: otherAccountId,
+        farmId,
+    });
+    const activeBlockId = await createTestBlock(gardenId, 'Raised_Bed');
+    const inactiveBlockId = await createTestBlock(gardenId, 'Raised_Bed');
+    const otherBlockId = await createTestBlock(otherGardenId, 'Raised_Bed');
+    const activeRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        activeBlockId,
+    );
+    await createTestRaisedBed(gardenId, accountId, inactiveBlockId);
+    const otherRaisedBedId = await createTestRaisedBed(
+        otherGardenId,
+        otherAccountId,
+        otherBlockId,
+    );
+
+    await updateRaisedBed({ id: activeRaisedBedId, status: 'active' });
+    await updateRaisedBed({ id: otherRaisedBedId, status: 'active' });
+
+    assert.strictEqual(await countActiveRaisedBedsForGarden(gardenId), 1);
+});
+
+test('deleteGardenIfNoActiveRaisedBeds blocks gardens with active raised beds', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const blockId = await createTestBlock(gardenId, 'Raised_Bed');
+    const raisedBedId = await createTestRaisedBed(gardenId, accountId, blockId);
+
+    await updateRaisedBed({ id: raisedBedId, status: 'active' });
+
+    assert.deepStrictEqual(await deleteGardenIfNoActiveRaisedBeds(gardenId), {
+        activeRaisedBedCount: 1,
+        deleted: false,
+    });
+    assert.ok(await getGarden(gardenId));
+});
+
+test('deleteGardenIfNoActiveRaisedBeds deletes gardens with only inactive or abandoned beds', async () => {
+    createTestDb();
+    const accountId = await createAccount();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+    const newBlockId = await createTestBlock(gardenId, 'Raised_Bed');
+    const abandonedBlockId = await createTestBlock(gardenId, 'Raised_Bed');
+    await createTestRaisedBed(gardenId, accountId, newBlockId);
+    const abandonedRaisedBedId = await createTestRaisedBed(
+        gardenId,
+        accountId,
+        abandonedBlockId,
+    );
+
+    await updateRaisedBed({ id: abandonedRaisedBedId, status: 'abandoned' });
+
+    assert.deepStrictEqual(await deleteGardenIfNoActiveRaisedBeds(gardenId), {
+        activeRaisedBedCount: 0,
+        deleted: true,
+    });
+    assert.strictEqual(await getGarden(gardenId), null);
 });
 
 test('accountHasActiveRaisedBed uses the garden owner instead of the raised-bed account', async () => {

--- a/packages/ui/src/ModalConfirm/ModalConfirm.tsx
+++ b/packages/ui/src/ModalConfirm/ModalConfirm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
-import type { FormEvent, HTMLAttributes, ReactNode } from 'react';
+import type { FormEvent, HTMLAttributes, MouseEvent, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { Button } from '../Button';
 import { Input } from '../Input';
@@ -88,14 +88,23 @@ export function ModalConfirm({
         onOpenChange?.(nextOpen);
     }
 
-    function handleSubmit(event: FormEvent<HTMLFormElement>) {
-        event.preventDefault();
+    function confirm() {
         if (!canConfirm) {
             return;
         }
 
         setOpen(false);
         onConfirm?.();
+    }
+
+    function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        confirm();
+    }
+
+    function handleConfirmClick(event: MouseEvent<HTMLButtonElement>) {
+        event.preventDefault();
+        confirm();
     }
 
     return (
@@ -169,6 +178,7 @@ export function ModalConfirm({
                                     <Button
                                         disabled={!canConfirm}
                                         type="submit"
+                                        onClick={handleConfirmClick}
                                     >
                                         {confirmLabel}
                                     </Button>


### PR DESCRIPTION
## What changed

- Added a guarded garden delete path for real gardens: regular gardens are soft-deleted only when they have no active raised beds, while sandbox garden deletion keeps the existing complete cleanup path.
- Added a dangerous delete section to the Vrt settings tab with red styling, disabled active-bed messaging, and typed garden-name confirmation before deleting.
- Added a dedicated delete hook that localizes blocked-delete errors and refreshes garden-related query state after success.
- Fixed `ModalConfirm` so clicking the confirm action reliably invokes `onConfirm`; Enter-submit behavior remains supported.
- Covered the storage guard and garden settings delete UI with focused tests.

## Validation

- `corepack pnpm --filter @gredice/storage lint`
- `corepack pnpm --filter @gredice/ui lint`
- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter garden lint`
- `corepack pnpm --filter api lint`
- `corepack pnpm --filter @gredice/storage test:node`
- `corepack pnpm --filter @gredice/ui typecheck`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter api build`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/garden-tab.spec.tsx`
- `corepack pnpm --filter garden build`
- `git diff --check`