### PR TITLE
feat(app): move schedule nav to management root

### DIFF
--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -626,6 +626,13 @@ export function Nav({
             </NavSection>
             <NavSection label="Upravljanje" compact={compact}>
                 <NavItem
+                    href={adminPages.Schedule.href}
+                    label={adminPages.Schedule.label}
+                    icon={<Calendar className="size-5" />}
+                    onClick={onItemClick}
+                    compact={compact}
+                />
+                <NavItem
                     href={adminPages.Approvals.href}
                     label={adminPages.Approvals.label}
                     icon={<Inbox className="size-5" />}
@@ -663,20 +670,11 @@ export function Nav({
                     label="Logistika"
                     icon={<Truck className="size-5" />}
                     forceOpen={includesSelectedPath(pathname, [
-                        adminPages.Schedule.href,
                         adminPages.DeliverySlots.href,
                         adminPages.DeliveryRequests.href,
                     ])}
                     compact={compact}
                 >
-                    <NavItem
-                        href={adminPages.Schedule.href}
-                        label={adminPages.Schedule.label}
-                        icon={<Calendar className="size-5" />}
-                        onClick={onItemClick}
-                        compact={compact}
-                        nested
-                    />
                     <NavItem
                         href={adminPages.DeliverySlots.href}
                         label={adminPages.DeliverySlots.label}


### PR DESCRIPTION
## Summary

Moves the admin `Raspored` navigation item out of the nested `Logistika` group and places it first in the root `Upravljanje` section.

## Impact

- `Raspored` is now immediately visible under `Upravljanje`.
- `Logistika` now only expands for delivery slots and delivery requests.

## Validation

- `pnpm lint --filter app`
- `git diff --check`
