### PR TITLE
feat(admin): add delivery slot close countdown

### DIFF
--- a/apps/app/app/admin/delivery/slots/SlotClosingCountdown.tsx
+++ b/apps/app/app/admin/delivery/slots/SlotClosingCountdown.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Typography } from '@gredice/ui/Typography';
+import { useEffect, useState } from 'react';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function formatCountdown(closeAtMs: number, nowMs: number) {
+    const remainingMs = closeAtMs - nowMs;
+    const absoluteMs = Math.abs(remainingMs);
+
+    if (remainingMs > 0) {
+        if (remainingMs < HOUR_MS) {
+            return 'Još < 1 h';
+        }
+
+        return `Još ${Math.ceil(remainingMs / HOUR_MS).toLocaleString('hr-HR')} h`;
+    }
+
+    if (absoluteMs < HOUR_MS) {
+        return 'Isteklo prije < 1 h';
+    }
+
+    return `Isteklo prije ${Math.ceil(absoluteMs / HOUR_MS).toLocaleString('hr-HR')} h`;
+}
+
+export function SlotClosingCountdown({
+    closeAt,
+    sourceLabel,
+}: {
+    closeAt: string;
+    sourceLabel: string;
+}) {
+    const [nowMs, setNowMs] = useState<number | null>(null);
+    const closeAtMs = new Date(closeAt).getTime();
+    const countdownLabel =
+        nowMs == null || Number.isNaN(closeAtMs)
+            ? null
+            : formatCountdown(closeAtMs, nowMs);
+
+    useEffect(() => {
+        const updateNow = () => setNowMs(Date.now());
+        updateNow();
+
+        const intervalId = window.setInterval(updateNow, 60_000);
+
+        return () => window.clearInterval(intervalId);
+    }, []);
+
+    return (
+        <div className="min-w-36 whitespace-nowrap">
+            <Typography
+                level="body2"
+                component="div"
+                semiBold
+                className="tabular-nums"
+            >
+                <LocalDateTime>{closeAt}</LocalDateTime>
+            </Typography>
+            <Typography
+                level="body3"
+                component="div"
+                className="tabular-nums text-muted-foreground"
+            >
+                {countdownLabel
+                    ? `${countdownLabel} - ${sourceLabel}`
+                    : sourceLabel}
+            </Typography>
+        </div>
+    );
+}

--- a/apps/app/app/admin/delivery/slots/TimeSlotsTable.tsx
+++ b/apps/app/app/admin/delivery/slots/TimeSlotsTable.tsx
@@ -1,16 +1,17 @@
 import {
+    AUTO_CLOSE_WINDOW_HOURS,
     getAllTimeSlots,
     getPickupLocations,
     getTimeSlotEffectiveClosesAt,
     TimeSlotStatuses,
 } from '@gredice/storage';
 import { Chip } from '@gredice/ui/Chip';
-import { LocalDateTime, TimeRange } from '@gredice/ui/LocalDateTime';
-import { Stack } from '@gredice/ui/Stack';
+import { TimeRange } from '@gredice/ui/LocalDateTime';
 import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { SlotActionButtons } from './SlotActionButtons';
+import { SlotClosingCountdown } from './SlotClosingCountdown';
 
 export async function TimeSlotsTable({
     status = 'active',
@@ -116,21 +117,14 @@ export async function TimeSlotsTable({
                                 </Typography>
                             </Table.Cell>
                             <Table.Cell>
-                                <Stack spacing={1}>
-                                    <Typography level="body2">
-                                        <LocalDateTime>
-                                            {closesAt}
-                                        </LocalDateTime>
-                                    </Typography>
-                                    <Typography
-                                        level="body3"
-                                        className="text-muted-foreground"
-                                    >
-                                        {slot.closesAt
+                                <SlotClosingCountdown
+                                    closeAt={closesAt.toISOString()}
+                                    sourceLabel={
+                                        slot.closesAt
                                             ? 'Ručno postavljeno'
-                                            : 'Automatski 48 h prije'}
-                                    </Typography>
-                                </Stack>
+                                            : `Automatski ${AUTO_CLOSE_WINDOW_HOURS} h prije`
+                                    }
+                                />
                             </Table.Cell>
                             <Table.Cell>
                                 <Chip color={getStatusColor(slot.status)}>


### PR DESCRIPTION
## Summary

- add a live hour countdown to the delivery slot `Zatvaranje` column
- keep the existing effective close deadline logic, including manual close overrides and the automatic 48h fallback
- move the ticking display into a focused client component so the table can stay server-rendered

## Validation

- `corepack pnpm --filter app exec biome check --write app/admin/delivery/slots/TimeSlotsTable.tsx app/admin/delivery/slots/SlotClosingCountdown.tsx`
- `corepack pnpm --filter app exec tsc --ignoreConfig --noEmit --pretty false --skipLibCheck --jsx react-jsx --moduleResolution bundler --module esnext --target esnext --lib dom,dom.iterable,esnext --strict app/admin/delivery/slots/TimeSlotsTable.tsx app/admin/delivery/slots/SlotClosingCountdown.tsx`
- `git diff --check`