### PR TITLE
Remove repeated cart copy from operation cards

### DIFF
--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -41,7 +41,15 @@ test.describe('Garden operations HUD', () => {
             page.getByText('Zakazano: 21. svibnja 2026.'),
         ).toBeVisible();
         await expect(page.getByText('Zakazano: sutra')).toBeVisible();
-        await expect(page.getByText('U košari').last()).toBeVisible();
+        await expect(page.getByText('U košari', { exact: true })).toHaveCount(
+            0,
+        );
+        await expect(page.getByText('U košari, još nije kupljeno')).toHaveCount(
+            0,
+        );
+        await expect(
+            page.getByRole('button', { name: 'Otvori košaru' }),
+        ).toHaveCount(1);
 
         await expect(page.getByText('Zakazano', { exact: true })).toHaveCount(
             2,

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1639,12 +1639,10 @@ function CartOperationCard({
     item,
     operationData,
     targetDetails,
-    onOpenCart,
 }: {
     item: ShoppingCartItemData;
     operationData?: OperationData;
     targetDetails: OperationTargetDetails;
-    onOpenCart: () => void;
 }) {
     const scheduledDate = getCartItemScheduledDate(item);
     const scheduledDateLabel = parseScheduledDate(item.additionalData)
@@ -1694,45 +1692,13 @@ function CartOperationCard({
                             iconClassName="dark:text-amber-100/85"
                         />
                     </Stack>
-                    <Row spacing={2} className="flex-wrap">
-                        <Typography
-                            level="body3"
-                            secondary
-                            className="dark:text-amber-100/80"
-                        >
-                            U košari, još nije kupljeno
-                        </Typography>
-                        <Typography
-                            level="body3"
-                            secondary
-                            className="dark:text-amber-100/80"
-                        >
-                            Zakazano: {scheduledDateLabel}
-                        </Typography>
-                    </Row>
-                    <Row justifyContent="space-between" spacing={2}>
-                        <Row
-                            spacing={1}
-                            className="text-amber-600 dark:text-amber-300"
-                        >
-                            <ShoppingCart className="size-3.5 shrink-0" />
-                            <Typography
-                                level="body3"
-                                semiBold
-                                className="dark:text-amber-200"
-                            >
-                                U košari
-                            </Typography>
-                        </Row>
-                        <Button
-                            variant="link"
-                            size="sm"
-                            className="px-0 dark:text-amber-50 dark:hover:text-white"
-                            onClick={onOpenCart}
-                        >
-                            Otvori košaru
-                        </Button>
-                    </Row>
+                    <Typography
+                        level="body3"
+                        secondary
+                        className="dark:text-amber-100/80"
+                    >
+                        Zakazano: {scheduledDateLabel}
+                    </Typography>
                 </Stack>
             </Row>
         </div>
@@ -2085,9 +2051,6 @@ export function GardenOperationsHud() {
                                                 }
                                                 targetDetails={
                                                     cartOperation.targetDetails
-                                                }
-                                                onOpenCart={() =>
-                                                    setShoppingCartOpen(true)
                                                 }
                                             />
                                         ))}


### PR DESCRIPTION
## Summary

- Removes the per-card `U košari` status copy and per-card `Otvori košaru` button from active cart operation cards.
- Keeps the top `Radnje u košari` section heading and cart link as the single cart-level cue.
- Updates the Garden Operations HUD component spec to assert the repeated per-card copy is gone.

## Validation

- `pnpm lint --filter @gredice/game --filter garden`
- `pnpm typecheck --filter @gredice/game --filter garden`
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden exec playwright test tests/garden-operations-hud.spec.tsx`
- `git diff --check`