### PR TITLE
[codex] Improve plant picker sowing controls

### DIFF
--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -460,6 +460,43 @@ describe('processItem', () => {
         assert.equal(callsNamed(calls, 'createOperation').length, 0);
     });
 
+    it('uses greenhouse sowing location from scheduled plant additional data', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls);
+
+        await processItem(
+            {
+                accountId: 'account-1',
+                amount_total: 2500,
+                additionalData: {
+                    scheduledDate: '2026-07-01',
+                    sowingLocation: 'greenhouse',
+                },
+                cartId: 100,
+                cartItemId: 1,
+                currency: 'eur',
+                entityId: '42',
+                entityTypeName: 'plantSort',
+                gardenId: 200,
+                positionIndex: 2,
+                raisedBedId: 300,
+            },
+            dependencies,
+        );
+
+        assert.deepStrictEqual(callsNamed(calls, 'createEvent')[0]?.args, [
+            {
+                type: 'raisedBedFields.plantPlace',
+                aggregateId: '300|2',
+                data: {
+                    plantSortId: '42',
+                    scheduledDate: '2026-07-01',
+                    sowingLocation: 'greenhouse',
+                },
+            },
+        ]);
+    });
+
     it('continues operation processing when earning sunflowers fails', async () => {
         const calls: RecordedCall[] = [];
         const dependencies = makeDependencies(calls, {

--- a/apps/garden/tests/PlantPickerTestStory.tsx
+++ b/apps/garden/tests/PlantPickerTestStory.tsx
@@ -210,7 +210,19 @@ const tomatoOutletOffers = [
     },
 ] satisfies OutletOfferData[];
 
-function createPlantPickerQueryClient(favorites: FavoriteItem[] = []) {
+type TestInventoryItem = {
+    entityTypeName: string;
+    entityId: string;
+    amount: number;
+};
+
+function createPlantPickerQueryClient({
+    favorites = [],
+    inventoryItems = [],
+}: {
+    favorites?: FavoriteItem[];
+    inventoryItems?: TestInventoryItem[];
+} = {}) {
     const queryClient = new ReactQuery.QueryClient({
         defaultOptions: {
             queries: {
@@ -267,7 +279,7 @@ function createPlantPickerQueryClient(favorites: FavoriteItem[] = []) {
         items: [],
     });
     queryClient.setQueryData(['inventory'], {
-        items: [],
+        items: inventoryItems,
     });
     queryClient.setQueryData(['outlet-offers'], tomatoOutletOffers);
     queryClient.setQueryData(favoritesQueryKey, favorites);
@@ -280,10 +292,14 @@ function createPlantPickerQueryClient(favorites: FavoriteItem[] = []) {
 function PlantPickerTestProviders({
     children,
     favorites = [],
-}: PropsWithChildren<{ favorites?: FavoriteItem[] }>) {
+    inventoryItems = [],
+}: PropsWithChildren<{
+    favorites?: FavoriteItem[];
+    inventoryItems?: TestInventoryItem[];
+}>) {
     const queryClient = useMemo(
-        () => createPlantPickerQueryClient(favorites),
-        [favorites],
+        () => createPlantPickerQueryClient({ favorites, inventoryItems }),
+        [favorites, inventoryItems],
     );
     const gameStore = useMemo(
         () =>
@@ -328,13 +344,18 @@ function OutletOfferRefetchTestHook() {
 
 export function PlantPickerTestStory({
     favorites,
+    inventoryItems,
     showOutletRefetchControl = false,
 }: {
     favorites?: FavoriteItem[];
+    inventoryItems?: TestInventoryItem[];
     showOutletRefetchControl?: boolean;
 } = {}) {
     return (
-        <PlantPickerTestProviders favorites={favorites}>
+        <PlantPickerTestProviders
+            favorites={favorites}
+            inventoryItems={inventoryItems}
+        >
             {showOutletRefetchControl ? <OutletOfferRefetchTestHook /> : null}
             <PlantPicker
                 gardenId={1}

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -216,7 +216,7 @@ test('outlet sorts keep planned sowing selected by default', async ({
         page.getByRole('textbox', { name: 'Datum sijanja' }),
     ).toBeVisible();
     await expect(
-        page.getByRole('switch', { name: 'Staklenik' }),
+        page.getByRole('switch', { name: 'Sijanje u stakleniku' }),
     ).toHaveAttribute('aria-checked', 'false');
 
     await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
@@ -243,7 +243,9 @@ test('planned greenhouse sowing sends greenhouse location', async ({
     await page.getByRole('button', { name: /Rajčica/ }).click();
     await page.getByRole('button', { name: /Cherry rajčica/ }).click();
 
-    const greenhouseSwitch = page.getByRole('switch', { name: 'Staklenik' });
+    const greenhouseSwitch = page.getByRole('switch', {
+        name: 'Sijanje u stakleniku',
+    });
     await expect(greenhouseSwitch).toHaveAttribute('aria-checked', 'false');
     await greenhouseSwitch.click();
     await expect(greenhouseSwitch).toHaveAttribute('aria-checked', 'true');
@@ -302,6 +304,105 @@ test('outlet sowing sends the selected outlet offer', async ({
     }
     expect(post.outletOfferId).toBe(302);
     expect(post.additionalData).toBe(JSON.stringify({ outletOfferId: 302 }));
+});
+
+test('sort rows show backpack action only for available backpack items', async ({
+    mount,
+    page,
+}) => {
+    const posts = await mockShoppingCartPosts(page);
+
+    await mount(
+        <PlantPickerTestStory
+            inventoryItems={[
+                {
+                    entityId: '101',
+                    entityTypeName: 'plantSort',
+                    amount: 2,
+                },
+            ]}
+        />,
+    );
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+    await page.getByRole('button', { name: /Rajčica/ }).click();
+
+    const cherrySort = page.locator('[data-plant-picker-sort-id="101"]');
+    const saintPierreSort = page.locator('[data-plant-picker-sort-id="102"]');
+    const backpackButton = cherrySort.getByRole('button', {
+        name: 'Koristi iz ruksaka (2)',
+    });
+    await expect(backpackButton).toBeVisible();
+    await expect(
+        saintPierreSort.getByRole('button', { name: /ruksaka/ }),
+    ).toHaveCount(0);
+    await expect(page.getByText(/^U ruksaku/u)).toHaveCount(0);
+
+    await backpackButton.click();
+    await expect(
+        cherrySort.getByRole('button', { name: 'Ne koristi iz ruksaka' }),
+    ).toHaveAttribute('aria-pressed', 'true');
+
+    await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
+
+    await expect.poll(() => posts.length).toBe(1);
+    const post = posts[0];
+    expect(isRecord(post)).toBe(true);
+    if (!isRecord(post)) {
+        return;
+    }
+    expect(post.entityId).toBe('101');
+    expect(post.currency).toBe('inventory');
+});
+
+test('scheduled greenhouse sowing sends date and sowing location together', async ({
+    mount,
+    page,
+}) => {
+    const posts = await mockShoppingCartPosts(page);
+
+    await mount(<PlantPickerTestStory />);
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+    await page.getByRole('button', { name: /Rajčica/ }).click();
+    await page.getByRole('button', { name: /Cherry rajčica/ }).click();
+
+    const dateInput = page.getByRole('textbox', { name: 'Datum sijanja' });
+    const greenhouseSwitch = page.getByRole('switch', {
+        name: 'Sijanje u stakleniku',
+    });
+    await expect(dateInput).toBeVisible();
+    await expect(greenhouseSwitch).toBeVisible();
+
+    const dateBox = await dateInput.boundingBox();
+    const switchBox = await greenhouseSwitch.boundingBox();
+    expect(dateBox).not.toBeNull();
+    expect(switchBox).not.toBeNull();
+    expect(Math.abs((dateBox?.y ?? 0) - (switchBox?.y ?? 0))).toBeLessThan(48);
+
+    await dateInput.fill('2026-07-01');
+    await greenhouseSwitch.click();
+    await expect(greenhouseSwitch).toBeChecked();
+    await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
+
+    await expect.poll(() => posts.length).toBe(1);
+    const post = posts[0];
+    expect(isRecord(post)).toBe(true);
+    if (!isRecord(post)) {
+        return;
+    }
+    expect(typeof post.additionalData).toBe('string');
+    if (typeof post.additionalData !== 'string') {
+        return;
+    }
+
+    const additionalData: unknown = JSON.parse(post.additionalData);
+    expect(isRecord(additionalData)).toBe(true);
+    if (!isRecord(additionalData)) {
+        return;
+    }
+    expect(additionalData.sowingLocation).toBe('greenhouse');
+    expect(additionalData.scheduledDate).toBe('2026-07-01T00:00:00.000Z');
 });
 
 test('outlet refetch does not replace a missing selected offer', async ({

--- a/packages/game/src/hud/raisedBed/PlantsSortList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsSortList.tsx
@@ -1,6 +1,8 @@
 import type { PlantSortData } from '@gredice/client';
 import { Alert } from '@gredice/ui/Alert';
+import { BackpackIcon } from '@gredice/ui/BackpackIcon';
 import { Button } from '@gredice/ui/Button';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Check } from '@gredice/ui/icons';
 import { List } from '@gredice/ui/List';
 import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
@@ -9,7 +11,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { useEffect, useMemo } from 'react';
+import { type MouseEvent, useEffect, useMemo } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { sortFavoritesFirst, useFavoriteIds } from '../../hooks/useFavorites';
 import type { OutletOfferData } from '../../hooks/useOutletOffers';
@@ -36,6 +38,9 @@ type PlantsSortListProps = {
     flyToShoppingCart?: boolean;
     neighborPlants?: NeighborPlantSummary[];
     outletOffersBySortId?: Map<number, OutletOfferData[]>;
+    inventoryAvailabilityBySortId?: Map<number, number>;
+    inventorySelectedSortId?: number | null;
+    onInventoryToggle?: (sort: PlantSortData) => void;
 };
 
 const currencyFormatter = new Intl.NumberFormat('hr-HR', {
@@ -58,6 +63,9 @@ function PlantSortListItem({
     flyToShoppingCart,
     neighborPlants,
     outletOffers,
+    availableFromInventory,
+    inventorySelected,
+    onInventoryToggle,
 }: {
     sort: PlantSortData;
     selectedSortId: number | null;
@@ -65,6 +73,9 @@ function PlantSortListItem({
     flyToShoppingCart?: boolean;
     neighborPlants: NeighborPlantSummary[];
     outletOffers?: OutletOfferData[];
+    availableFromInventory?: number;
+    inventorySelected?: boolean;
+    onInventoryToggle?: (sort: PlantSortData) => void;
 }) {
     const animateFlyToShoppingCart = useAnimateFlyToShoppingCart();
     const { track } = useGameAnalytics();
@@ -87,6 +98,12 @@ function PlantSortListItem({
         animateFlyToShoppingCart.reset,
         animateFlyToShoppingCart.run,
     ]);
+
+    function handleInventoryToggle(event: MouseEvent<HTMLButtonElement>) {
+        event.preventDefault();
+        event.stopPropagation();
+        onInventoryToggle?.(sort);
+    }
 
     return (
         <Stack
@@ -163,30 +180,55 @@ function PlantSortListItem({
                         />
                     ) : null}
                 </div>
-                <Button
-                    title="Više informacija"
-                    href={KnownPages.GredicePlantSort(
-                        sort.information.plant.information?.name ?? 'nepoznato',
-                        sort.information.name,
-                    )}
-                    variant="link"
-                    size="sm"
-                    onClick={() =>
-                        track('game_plant_sort_details_opened', {
-                            plant_name:
-                                sort.information.plant.information?.name,
-                            sort_id: sort.id,
-                            sort_name: sort.information.name,
-                        })
-                    }
-                >
-                    Više informacija...
-                </Button>
-                <FavoriteToggleButton
-                    entityId={sort.id}
-                    entityType="plantSort"
-                    label={sort.information.name}
-                />
+                <div className="flex items-center gap-1">
+                    <Button
+                        title="Više informacija"
+                        href={KnownPages.GredicePlantSort(
+                            sort.information.plant.information?.name ??
+                                'nepoznato',
+                            sort.information.name,
+                        )}
+                        variant="link"
+                        size="sm"
+                        onClick={() =>
+                            track('game_plant_sort_details_opened', {
+                                plant_name:
+                                    sort.information.plant.information?.name,
+                                sort_id: sort.id,
+                                sort_name: sort.information.name,
+                            })
+                        }
+                    >
+                        Više informacija...
+                    </Button>
+                    {availableFromInventory ? (
+                        <IconButton
+                            aria-pressed={inventorySelected}
+                            className={cx(
+                                'size-8 shrink-0',
+                                inventorySelected &&
+                                    'text-green-700 dark:text-green-300',
+                            )}
+                            color={inventorySelected ? 'success' : 'neutral'}
+                            onClick={handleInventoryToggle}
+                            size="sm"
+                            title={
+                                inventorySelected
+                                    ? 'Ne koristi iz ruksaka'
+                                    : `Koristi iz ruksaka (${availableFromInventory})`
+                            }
+                            type="button"
+                            variant={inventorySelected ? 'soft' : 'plain'}
+                        >
+                            <BackpackIcon aria-hidden className="size-4" />
+                        </IconButton>
+                    ) : null}
+                    <FavoriteToggleButton
+                        entityId={sort.id}
+                        entityType="plantSort"
+                        label={sort.information.name}
+                    />
+                </div>
             </Row>
         </Stack>
     );
@@ -200,6 +242,9 @@ export function PlantsSortList({
     flyToShoppingCart,
     neighborPlants = [],
     outletOffersBySortId,
+    inventoryAvailabilityBySortId,
+    inventorySelectedSortId,
+    onInventoryToggle,
 }: PlantsSortListProps) {
     const { data: plantSorts, isLoading, isError } = usePlantSorts(plantId);
     const favoriteSortIds = useFavoriteIds('plantSort');
@@ -258,6 +303,11 @@ export function PlantsSortList({
                         onChange={onChange}
                         neighborPlants={neighborPlants}
                         outletOffers={outletOffersBySortId?.get(sort.id)}
+                        availableFromInventory={inventoryAvailabilityBySortId?.get(
+                            sort.id,
+                        )}
+                        inventorySelected={inventorySelectedSortId === sort.id}
+                        onInventoryToggle={onInventoryToggle}
                         flyToShoppingCart={
                             flyToShoppingCart && selectedSortId === sort.id
                         }

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -16,21 +16,45 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
 }
 
-function parseScheduledSowingDate(additionalData: string | null | undefined) {
+type CartPlantOptions = {
+    scheduledDate: Date | null;
+    sowingLocation: 'direct' | 'greenhouse';
+};
+
+function defaultCartPlantOptions(): CartPlantOptions {
+    return {
+        scheduledDate: null,
+        sowingLocation: 'direct',
+    };
+}
+
+function parseCartPlantOptions(
+    additionalData: string | null | undefined,
+): CartPlantOptions {
     if (!additionalData) {
-        return null;
+        return defaultCartPlantOptions();
     }
 
     try {
         const parsed: unknown = JSON.parse(additionalData);
-        if (!isRecord(parsed) || typeof parsed.scheduledDate !== 'string') {
-            return null;
+        if (!isRecord(parsed)) {
+            return defaultCartPlantOptions();
         }
 
-        const date = new Date(parsed.scheduledDate);
-        return Number.isNaN(date.getTime()) ? null : date;
+        const date =
+            typeof parsed.scheduledDate === 'string'
+                ? new Date(parsed.scheduledDate)
+                : null;
+
+        return {
+            scheduledDate: date && !Number.isNaN(date.getTime()) ? date : null,
+            sowingLocation:
+                parsed.sowingLocation === 'greenhouse'
+                    ? 'greenhouse'
+                    : 'direct',
+        };
     } catch {
-        return null;
+        return defaultCartPlantOptions();
     }
 }
 
@@ -62,12 +86,9 @@ export function RaisedBedFieldItemEmpty({
 
     const cartPlantSort = cartPlantItem?.entityData;
     const cartPlantId = cartPlantSort?.information?.plant?.id;
-    const scheduledDate = parseScheduledSowingDate(
+    const cartPlantOptions = parseCartPlantOptions(
         cartPlantItem?.additionalData,
     );
-    const cartPlantOptions = {
-        scheduledDate,
-    };
     const plantPickerProps = {
         gardenId,
         inShoppingCart: Boolean(cartPlantItem),
@@ -119,9 +140,9 @@ export function RaisedBedFieldItemEmpty({
                                     width={50}
                                     height={50}
                                 />
-                                {scheduledDate && (
+                                {cartPlantOptions.scheduledDate && (
                                     <ScheduledSowingDateBadge
-                                        date={scheduledDate}
+                                        date={cartPlantOptions.scheduledDate}
                                     />
                                 )}
                             </>

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -1,9 +1,9 @@
 import type { PlantData, PlantSortData } from '@gredice/client';
-import { BackpackIcon } from '@gredice/ui/BackpackIcon';
 import { Button } from '@gredice/ui/Button';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Input } from '@gredice/ui/Input';
 import {
+    Calendar,
     Check,
     Close,
     Left,
@@ -144,6 +144,10 @@ function isGreenhouseSowing(additionalData?: string | null) {
     return parseAdditionalData(additionalData).sowingLocation === 'greenhouse';
 }
 
+type PlantPickerOptions = {
+    scheduledDate: Date | null | undefined;
+};
+
 type PlantPickerProps = {
     positionIndex: number;
     gardenId: number;
@@ -152,7 +156,7 @@ type PlantPickerProps = {
     inShoppingCart?: boolean;
     selectedPlantId?: number | null;
     selectedSortId?: number | null;
-    selectedPlantOptions?: { scheduledDate: Date | null | undefined } | null;
+    selectedPlantOptions?: PlantPickerOptions | null;
 };
 
 export function PlantPicker({
@@ -202,9 +206,9 @@ export function PlantPicker({
     const [selectedSortId, setSelectedSortId] = useState<number | null>(
         preselectedSortId ?? null,
     );
-    const [plantOptions, setPlantOptions] = useState<{
-        scheduledDate: Date | null | undefined;
-    } | null>(preselectedPlantOptions ?? null);
+    const [plantOptions, setPlantOptions] = useState<PlantPickerOptions | null>(
+        preselectedPlantOptions ?? null,
+    );
     const [flyToShoppingCart, setFlyToShoppingCart] = useState(false);
     const [useInventoryItem, setUseInventoryItem] = useState(false);
     const [useOutletOffer, setUseOutletOffer] = useState(false);
@@ -475,17 +479,34 @@ export function PlantPicker({
     const plantDate = formatLocalDate(plantOptions?.scheduledDate ?? tomorrow);
     function handlePlantDateChange(date: string) {
         const parsedDate = date ? new Date(date) : null;
-        setPlantOptions({ scheduledDate: parsedDate });
+        setPlantOptions({
+            scheduledDate: parsedDate,
+        });
     }
 
     const min = formatLocalDate(tomorrow);
     const max = formatLocalDate(threeMonthsFromTomorrow);
 
-    const availableFromInventory = inventory?.items?.find(
-        (item) =>
-            item.entityTypeName === 'plantSort' &&
-            item.entityId === selectedSortId?.toString(),
-    )?.amount;
+    const inventoryAvailabilityBySortId = useMemo(() => {
+        const availabilityBySortId = new Map<number, number>();
+        for (const item of inventory?.items ?? []) {
+            if (item.entityTypeName !== 'plantSort') {
+                continue;
+            }
+
+            const sortId = Number(item.entityId);
+            if (!Number.isInteger(sortId) || item.amount <= 0) {
+                continue;
+            }
+
+            availabilityBySortId.set(
+                sortId,
+                (availabilityBySortId.get(sortId) ?? 0) + item.amount,
+            );
+        }
+
+        return availabilityBySortId;
+    }, [inventory?.items]);
     const outletOffersBySortId = useMemo(
         () => groupOutletOffersBySortId(outletOffers),
         [outletOffers],
@@ -518,6 +539,23 @@ export function PlantPicker({
         raisedBedId,
         sorts: allSorts,
     });
+    function handleSortInventoryToggle(sort: PlantSortData) {
+        const nextUseInventory = !(
+            selectedSortId === sort.id && useInventoryItem
+        );
+        track('game_plant_inventory_toggled', {
+            garden_id: gardenId,
+            position_index: positionIndex,
+            raised_bed_id: raisedBedId,
+            sort_id: sort.id,
+            use_inventory: nextUseInventory,
+        });
+        setSelectedSortId(sort.id);
+        setUseOutletOffer(false);
+        setSelectedOutletOfferId(null);
+        setUseInventoryItem(nextUseInventory);
+        resetSearch();
+    }
 
     return (
         <Modal
@@ -621,6 +659,13 @@ export function PlantPicker({
                                 neighborPlants={neighborPlants}
                                 flyToShoppingCart={flyToShoppingCart}
                                 outletOffersBySortId={outletOffersBySortId}
+                                inventoryAvailabilityBySortId={
+                                    inventoryAvailabilityBySortId
+                                }
+                                inventorySelectedSortId={
+                                    useInventoryItem ? selectedSortId : null
+                                }
+                                onInventoryToggle={handleSortInventoryToggle}
                             />
                             {isSandbox ? (
                                 <Stack spacing={1}>
@@ -857,45 +902,6 @@ export function PlantPicker({
                                             ) : null}
                                         </Stack>
                                     ) : null}
-                                    <Row spacing={2} className="flex-wrap">
-                                        <Button
-                                            variant={
-                                                availableFromInventory &&
-                                                useInventoryItem
-                                                    ? 'solid'
-                                                    : 'outlined'
-                                            }
-                                            size="sm"
-                                            disabled={
-                                                !availableFromInventory ||
-                                                Boolean(selectedOutletOffer) ||
-                                                selectedOutletOfferUnavailable
-                                            }
-                                            startDecorator={
-                                                <BackpackIcon className="size-5 shrink-0" />
-                                            }
-                                            onClick={() => {
-                                                track(
-                                                    'game_plant_inventory_toggled',
-                                                    {
-                                                        garden_id: gardenId,
-                                                        position_index:
-                                                            positionIndex,
-                                                        raised_bed_id:
-                                                            raisedBedId,
-                                                        sort_id: selectedSortId,
-                                                        use_inventory:
-                                                            !useInventoryItem,
-                                                    },
-                                                );
-                                                setUseInventoryItem(
-                                                    (previous) => !previous,
-                                                );
-                                            }}
-                                        >
-                                            {`U ruksaku (${availableFromInventory ?? 0})`}
-                                        </Button>
-                                    </Row>
                                     {selectedOutletOffer ? (
                                         <div className="rounded-lg border border-green-300 bg-green-50 p-3 text-sm text-green-900 dark:border-green-900 dark:bg-green-950/40 dark:text-green-100">
                                             Presadnica je posijana{' '}
@@ -908,37 +914,23 @@ export function PlantPicker({
                                             kratko nakon dodavanja u košaru.
                                         </div>
                                     ) : selectedOutletOfferUnavailable ? null : (
-                                        <>
-                                            <div
-                                                className={cx(
-                                                    'rounded-lg border p-3 transition-colors',
-                                                    sowInGreenhouse
-                                                        ? 'border-green-500 bg-green-50 text-green-950 dark:border-green-700 dark:bg-green-950/40 dark:text-green-100'
-                                                        : 'border-input bg-card',
-                                                )}
-                                            >
-                                                <Switch
-                                                    checked={sowInGreenhouse}
-                                                    onCheckedChange={
-                                                        handleGreenhouseSowingChange
-                                                    }
-                                                    size="sm"
-                                                    label={
-                                                        <span className="inline-flex items-center gap-1">
-                                                            <Sprout className="size-4 shrink-0" />
-                                                            <span>
-                                                                Staklenik
-                                                            </span>
-                                                        </span>
-                                                    }
-                                                    description="Sadnica počinje u stakleniku i kasnije se presađuje u gredicu."
-                                                />
-                                            </div>
+                                        <div
+                                            className={cx(
+                                                'grid gap-2 rounded-lg border p-3 transition-colors md:grid-cols-[minmax(0,1fr)_auto] md:items-end',
+                                                sowInGreenhouse
+                                                    ? 'border-green-500 bg-green-50 text-green-950 dark:border-green-700 dark:bg-green-950/40 dark:text-green-100'
+                                                    : 'border-green-200 bg-green-50/70 dark:border-green-900 dark:bg-green-950/30',
+                                            )}
+                                        >
                                             <Input
                                                 type="date"
                                                 label="Datum sijanja"
                                                 name="plantDate"
-                                                className="w-full bg-card"
+                                                className="w-full border-green-200 bg-card dark:border-green-900"
+                                                fullWidth
+                                                startDecorator={
+                                                    <Calendar className="ml-3 size-4 shrink-0 text-green-700 dark:text-green-300" />
+                                                }
                                                 value={plantDate}
                                                 onChange={(e) =>
                                                     handlePlantDateChange(
@@ -948,7 +940,21 @@ export function PlantPicker({
                                                 min={min}
                                                 max={max}
                                             />
-                                        </>
+                                            <Switch
+                                                checked={sowInGreenhouse}
+                                                className="data-[state=checked]:border-green-700 data-[state=checked]:bg-green-700"
+                                                label={
+                                                    <span className="inline-flex items-center gap-1.5">
+                                                        <Sprout className="size-4 text-green-700 dark:text-green-300" />
+                                                        Sijanje u stakleniku
+                                                    </span>
+                                                }
+                                                onCheckedChange={
+                                                    handleGreenhouseSowingChange
+                                                }
+                                                size="sm"
+                                            />
+                                        </div>
                                     )}
                                 </>
                             )}


### PR DESCRIPTION
## Summary

- Move plant-sort backpack usage into icon-only row actions shown only for sorts available in the backpack.
- Replace the separate scheduled sowing controls with a greenhouse-styled date card and inline greenhouse switch.
- Persist scheduled greenhouse sowing through cart additional data and checkout plant placement events.

## Validation

- `pnpm lint --filter @gredice/game --filter garden --filter api`
- `pnpm typecheck --filter @gredice/game --filter garden`
- `pnpm --filter api exec node --import tsx --test --conditions=react-server lib/stripe/processCheckoutSession.node.spec.ts`
- `pnpm --filter garden run test:prepare`
- `pnpm --filter garden exec playwright test tests/raised-bed-plant-picker.spec.tsx`