### PR TITLE
Consolidate game modal shell

### DIFF
--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -15,7 +15,6 @@ import {
     Navigate,
     ShoppingCart,
 } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { Popper } from '@gredice/ui/Popper';
 import { PlantOrSortImage } from '@gredice/ui/plants';
@@ -56,6 +55,7 @@ import {
     type ShoppingCartItemData,
     useShoppingCart,
 } from '../hooks/useShoppingCart';
+import { GameModal } from '../shared-ui/game-modal';
 import { ScrollView } from '../shared-ui/ScrollView';
 import { useShoppingCartOpenParam } from '../useUrlState';
 import { sortOperationTasksNewestFirst } from './gardenOperationOrdering';
@@ -1757,7 +1757,7 @@ function HistoryModal({
     referenceDate: Date;
 }) {
     return (
-        <Modal
+        <GameModal
             title="Povijest radnji"
             trigger={trigger}
             className="md:max-w-4xl"
@@ -1855,7 +1855,7 @@ function HistoryModal({
                     </Stack>
                 </ScrollView>
             </Stack>
-        </Modal>
+        </GameModal>
     );
 }
 

--- a/packages/game/src/hud/GardenVisitSummaryModal.tsx
+++ b/packages/game/src/hud/GardenVisitSummaryModal.tsx
@@ -11,7 +11,6 @@ import {
     Sprout,
     Timer,
 } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -33,6 +32,7 @@ import {
     useGardenVisitSummary,
     useMarkGardenVisitSummarySeen,
 } from '../hooks/useGardenVisitSummary';
+import { GameModal } from '../shared-ui/game-modal';
 import { useGameState } from '../useGameState';
 import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
 
@@ -331,10 +331,10 @@ export function GardenVisitSummaryModalContent({
     open,
 }: GardenVisitSummaryModalContentProps) {
     return (
-        <Modal
+        <GameModal
             title="Od zadnjeg posjeta"
             open={open}
-            className="max-w-xl overflow-hidden border-tertiary border-b-4 p-0"
+            className="max-w-xl overflow-hidden p-0"
             dismissible={false}
         >
             <div className="flex max-h-[calc(100dvh-2rem)] min-h-0 flex-col">
@@ -453,6 +453,6 @@ export function GardenVisitSummaryModalContent({
                     </Button>
                 </Row>
             </div>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/hud/InventoryHud.tsx
+++ b/packages/game/src/hud/InventoryHud.tsx
@@ -4,7 +4,6 @@ import { BlockImage } from '@gredice/ui/BlockImage';
 import { Button } from '@gredice/ui/Button';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Add } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Row } from '@gredice/ui/Row';
@@ -23,6 +22,7 @@ import { useGardenBoxPlaceBlock } from '../hooks/useGardenBoxPlaceBlock';
 import { useInventory } from '../hooks/useInventory';
 import { useOperations } from '../hooks/useOperations';
 import { useSorts } from '../hooks/usePlantSorts';
+import { GameModal } from '../shared-ui/game-modal';
 import { useGameState } from '../useGameState';
 import {
     normalizeBackpackTab,
@@ -320,7 +320,7 @@ function InventoryItemModal({
     }
 
     return (
-        <Modal
+        <GameModal
             open={open}
             onOpenChange={(isOpen) => !isOpen && onClose()}
             title={displayName}
@@ -437,7 +437,7 @@ function InventoryItemModal({
                     </Stack>
                 )}
             </Stack>
-        </Modal>
+        </GameModal>
     );
 }
 
@@ -637,10 +637,11 @@ export function InventoryHud() {
 
     return (
         <HudCard open position="floating" className="static p-0.5">
-            <Modal
+            <GameModal
                 open={isOpen}
                 onOpenChange={handleOpenChange}
                 title="Inventar"
+                headerIcon={<BackpackIcon className="size-7 shrink-0" />}
                 trigger={
                     <IconButton
                         variant="plain"
@@ -667,12 +668,6 @@ export function InventoryHud() {
                 }
             >
                 <Stack spacing={4}>
-                    <Row spacing={2}>
-                        <BackpackIcon className="size-8 shrink-0" />
-                        <Typography level="h6" className="font-bold">
-                            Inventar
-                        </Typography>
-                    </Row>
                     <Tabs
                         value={backpackTab}
                         onValueChange={handleTabChange}
@@ -771,7 +766,7 @@ export function InventoryHud() {
                         </TabsContent>
                     </Tabs>
                 </Stack>
-            </Modal>
+            </GameModal>
 
             {selectedItem && (
                 <InventoryItemModal

--- a/packages/game/src/hud/OutletHud.tsx
+++ b/packages/game/src/hud/OutletHud.tsx
@@ -56,6 +56,7 @@ export function OutletHud() {
                 title="Outlet sadnica"
                 className="md:max-w-2xl"
                 headerIcon={<Discount className="size-7 shrink-0" />}
+                hudLayer
                 trigger={
                     <Button
                         title="Outlet sadnica"

--- a/packages/game/src/hud/OutletHud.tsx
+++ b/packages/game/src/hud/OutletHud.tsx
@@ -1,12 +1,12 @@
 import { Button } from '@gredice/ui/Button';
 import { Discount } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useOutletOffers } from '../hooks/useOutletOffers';
+import { GameModal } from '../shared-ui/game-modal';
 import { useOutletOpenParam } from '../useUrlState';
 import { HudCard } from './components/HudCard';
 
@@ -43,7 +43,7 @@ export function OutletHud() {
 
     return (
         <HudCard open position="floating" className="static p-0.5">
-            <Modal
+            <GameModal
                 open={isOpen}
                 onOpenChange={(open) => {
                     setOutletParam(open ? '1' : null);
@@ -54,8 +54,8 @@ export function OutletHud() {
                     }
                 }}
                 title="Outlet sadnica"
-                className="z-[46] border-tertiary border-b-4 md:max-w-2xl"
-                overlayClassName="z-[46]"
+                className="md:max-w-2xl"
+                headerIcon={<Discount className="size-7 shrink-0" />}
                 trigger={
                     <Button
                         title="Outlet sadnica"
@@ -154,7 +154,7 @@ export function OutletHud() {
                         })}
                     </div>
                 </Stack>
-            </Modal>
+            </GameModal>
         </HudCard>
     );
 }

--- a/packages/game/src/hud/PaymentSuccessfulMessage.tsx
+++ b/packages/game/src/hud/PaymentSuccessfulMessage.tsx
@@ -3,13 +3,13 @@
 import { Button } from '@gredice/ui/Button';
 import { useSearchParam } from '@gredice/ui/hooks';
 import { Navigate } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Image from 'next/image';
 import { useState } from 'react';
 import Confetti from 'react-confetti-boom';
 import { useGameAudio } from '../hooks/useGameAudio';
+import { GameModal } from '../shared-ui/game-modal';
 
 export function PaymentSuccessfulMessage() {
     const [showSuccessMessage, setShowSuccessMessage] =
@@ -35,11 +35,11 @@ export function PaymentSuccessfulMessage() {
     };
 
     return (
-        <Modal
+        <GameModal
             title={title}
             open={open}
             onOpenChange={handleOpenChange}
-            className="max-w-screen-md border-tertiary border-b-4"
+            className="max-w-screen-md"
         >
             <div className="grid md:grid-cols-2 [grid-template-areas:'sunflower'_'content'] md:[grid-template-areas:'content_sunflower'] md:p-4 gap-4">
                 <Stack spacing={6} className="[grid-area:content]">
@@ -76,6 +76,6 @@ export function PaymentSuccessfulMessage() {
                     </div>
                 </div>
             </div>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -1,5 +1,4 @@
 import { Check, Navigate } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -13,6 +12,7 @@ import {
 } from '../hooks/useCurrentGarden';
 import { isRaisedBedAbandoned } from '../raisedBedConstants';
 import { ButtonGreen } from '../shared-ui/ButtonGreen';
+import { GameModal } from '../shared-ui/game-modal';
 import { useGameState } from '../useGameState';
 import { useRemoveRaisedBedCloseupParam } from '../useRaisedBedCloseup';
 import {
@@ -100,7 +100,7 @@ export function RaisedBedFieldHud() {
                                 />
                             </div>
                         )}
-                        <Modal
+                        <GameModal
                             open={isInfoOpen}
                             onOpenChange={(open) => {
                                 if (open) {
@@ -114,7 +114,7 @@ export function RaisedBedFieldHud() {
                             }}
                             title="Informacije o gredici"
                             modal={false}
-                            className="overflow-x-hidden md:border-tertiary md:border-b-4"
+                            className="overflow-x-hidden"
                             trigger={
                                 <ButtonGreen
                                     className="max-w-64 md:max-w-[312px]"
@@ -139,7 +139,7 @@ export function RaisedBedFieldHud() {
                                 gardenId={currentGarden.id}
                                 raisedBed={raisedBed}
                             />
-                        </Modal>
+                        </GameModal>
                     </div>
                 </div>
             )}

--- a/packages/game/src/hud/RaisedBedOnboardingModal.tsx
+++ b/packages/game/src/hud/RaisedBedOnboardingModal.tsx
@@ -15,7 +15,6 @@ import {
     ShoppingCart,
     Sprout,
 } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -42,6 +41,7 @@ import {
     showShoppingCartTransientHub,
 } from '../hooks/useShoppingCartTransientHub';
 import { KnownPages } from '../knownPages';
+import { GameModal } from '../shared-ui/game-modal';
 import { useGameState } from '../useGameState';
 import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
 import { isRaisedBedFieldOccupied } from '../utils/raisedBedFields';
@@ -1072,7 +1072,7 @@ export function RaisedBedOnboardingModal({
     );
 
     const modal = (
-        <Modal
+        <GameModal
             title="Brzi plan gredice"
             open={open}
             onOpenChange={(nextOpen) => {
@@ -1500,7 +1500,7 @@ export function RaisedBedOnboardingModal({
                     </Stack>
                 </div>
             </div>
-        </Modal>
+        </GameModal>
     );
 
     if (showTrigger) {

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -7,7 +7,6 @@ import {
     Navigate,
     ShoppingCart as ShoppingCartIcon,
 } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { ModalConfirm } from '@gredice/ui/ModalConfirm';
 import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
 import { Row } from '@gredice/ui/Row';
@@ -25,6 +24,7 @@ import {
     type DeliverySelectionData,
     DeliveryStep,
 } from '../shared-ui/delivery/DeliveryStep';
+import { GameModal } from '../shared-ui/game-modal';
 import { useShoppingCartOpenParam } from '../useUrlState';
 import {
     calculateSunflowerAmountFromPrices,
@@ -133,12 +133,6 @@ export function ShoppingCart() {
 
     return (
         <Stack spacing={4}>
-            <Row spacing={4}>
-                <div className="rounded-full bg-tertiary/40 p-3 flex items-center justify-center">
-                    <ShoppingCartIcon className="size-7 shrink-0" />
-                </div>
-                <Typography level="h3">Košara</Typography>
-            </Row>
             <Stack>
                 <div
                     className={cx(
@@ -299,7 +293,7 @@ export function ShoppingCartHud() {
     return (
         <HudCard open position="floating" className="static p-0.5">
             <Row spacing={2}>
-                <Modal
+                <GameModal
                     open={isOpen}
                     onOpenChange={(open) => {
                         if (open) {
@@ -311,8 +305,10 @@ export function ShoppingCartHud() {
                         setIsOpen(open);
                     }}
                     title="Košara"
-                    className="z-[46] border-tertiary border-b-4 md:max-w-2xl"
-                    overlayClassName="z-[46]"
+                    className="md:max-w-2xl"
+                    headerIcon={
+                        <ShoppingCartIcon className="size-7 shrink-0" />
+                    }
                     trigger={
                         <Button
                             title="Košara"
@@ -345,7 +341,7 @@ export function ShoppingCartHud() {
                     }
                 >
                     <ShoppingCart />
-                </Modal>
+                </GameModal>
             </Row>
         </HudCard>
     );

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -309,6 +309,7 @@ export function ShoppingCartHud() {
                     headerIcon={
                         <ShoppingCartIcon className="size-7 shrink-0" />
                     }
+                    hudLayer
                     trigger={
                         <Button
                             title="Košara"

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -966,6 +966,7 @@ export function TutorialChecklistHud() {
             )}
             <GameModal
                 className="md:max-w-3xl"
+                hudLayer
                 onOpenChange={handleOpenChange}
                 open={isOpen}
                 title="Zadaci za novi vrt"

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -5,7 +5,6 @@ import { Chip } from '@gredice/ui/Chip';
 import { DotIndicator } from '@gredice/ui/DotIndicator';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Check, ExpandDown } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -26,6 +25,7 @@ import {
     useTutorialChecklist,
 } from '../hooks/useTutorialChecklist';
 import { KnownPages } from '../knownPages';
+import { GameModal } from '../shared-ui/game-modal';
 import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
 import { useBackpackOpenParam, useShoppingCartOpenParam } from '../useUrlState';
 import { getRaisedBedBlockIds } from '../utils/raisedBedBlocks';
@@ -964,11 +964,10 @@ export function TutorialChecklistHud() {
                     <DotIndicator color="success" size={16} />
                 </div>
             )}
-            <Modal
-                className="z-[46] border-tertiary border-b-4 md:max-w-3xl"
+            <GameModal
+                className="md:max-w-3xl"
                 onOpenChange={handleOpenChange}
                 open={isOpen}
-                overlayClassName="z-[46]"
                 title="Zadaci za novi vrt"
                 trigger={
                     <IconButton
@@ -1029,7 +1028,7 @@ export function TutorialChecklistHud() {
                     onDismissCompleted={handleDismissCompleted}
                     onOpenChange={handleOpenChange}
                 />
-            </Modal>
+            </GameModal>
         </HudCard>
     );
 }

--- a/packages/game/src/hud/WelcomeMessage.tsx
+++ b/packages/game/src/hud/WelcomeMessage.tsx
@@ -3,7 +3,6 @@
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
-import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Image from 'next/image';
@@ -15,6 +14,7 @@ import {
     AnimateFlyToItem,
     useAnimateFlyToSunflowersHud,
 } from '../indicators/AnimateFlyTo';
+import { GameModal } from '../shared-ui/game-modal';
 import { useGameState } from '../useGameState';
 
 const messageTypes = {
@@ -155,10 +155,10 @@ export function WelcomeMessage({ onClosed }: { onClosed?: () => void }) {
     }
 
     return (
-        <Modal
+        <GameModal
             title={title}
             open={open}
-            className="max-w-screen-md border-tertiary border-b-4"
+            className="max-w-screen-md"
             dismissible={false}
         >
             <div className="grid md:grid-cols-2 [grid-template-areas:'sunflower'_'content'] md:[grid-template-areas:'content_sunflower'] md:p-4 gap-4">
@@ -238,6 +238,6 @@ export function WelcomeMessage({ onClosed }: { onClosed?: () => void }) {
                     </div>
                 </div>
             </div>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/hud/WhatsNewWidget.tsx
+++ b/packages/game/src/hud/WhatsNewWidget.tsx
@@ -5,7 +5,6 @@ import { Button } from '@gredice/ui/Button';
 import { CmsMediaImage } from '@gredice/ui/cms';
 import { Close, ExternalLink } from '@gredice/ui/icons';
 import { Markdown } from '@gredice/ui/Markdown';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
@@ -28,6 +27,7 @@ import {
     whatsNewEntriesAudienceTag,
 } from '../hooks/useWhatsNewEntries';
 import { KnownPages } from '../knownPages';
+import { GameModal } from '../shared-ui/game-modal';
 
 function formatEntryDate(value: Date | null) {
     if (!value) {
@@ -370,8 +370,8 @@ export function WhatsNewWidget({
                     </div>
                 </div>
             ) : null}
-            <Modal
-                className="max-w-2xl overflow-hidden border-tertiary border-b-4 p-0"
+            <GameModal
+                className="max-w-2xl overflow-hidden p-0"
                 onOpenChange={setModalOpen}
                 open={modalOpen}
                 title="Što je novo"
@@ -514,7 +514,7 @@ export function WhatsNewWidget({
                         </Stack>
                     </div>
                 </div>
-            </Modal>
+            </GameModal>
         </>
     );
 }

--- a/packages/game/src/hud/components/weather/WeatherHistoryModal.tsx
+++ b/packages/game/src/hud/components/weather/WeatherHistoryModal.tsx
@@ -5,7 +5,6 @@ import {
     getWeatherDataBounds,
     type WeatherMetricKey,
 } from '@gredice/js/weather';
-import { Modal } from '@gredice/ui/Modal';
 import {
     WeatherCharts,
     type WeatherChartsRange,
@@ -16,6 +15,7 @@ import {
     useWeatherHistory,
     useWeatherHistoryRange,
 } from '../../../hooks/useWeatherHistory';
+import { GameModal } from '../../../shared-ui/game-modal';
 
 export function WeatherHistoryPanel({
     className,
@@ -75,7 +75,7 @@ export function WeatherHistoryModal({
     }
 
     return (
-        <Modal
+        <GameModal
             trigger={trigger}
             open={isOpen}
             onOpenChange={handleOpenChange}
@@ -83,6 +83,6 @@ export function WeatherHistoryModal({
             className="w-full max-w-3xl"
         >
             <WeatherHistoryPanel className="pt-2" enabled={isOpen} />
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -3,7 +3,6 @@ import { Chip } from '@gredice/ui/Chip';
 import { ImageGallery } from '@gredice/ui/ImageGallery';
 import { List } from '@gredice/ui/List';
 import { ListItem } from '@gredice/ui/ListItem';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Spinner } from '@gredice/ui/Spinner';
 import { Stack } from '@gredice/ui/Stack';
@@ -18,6 +17,7 @@ import {
     type DiaryRescheduleTarget,
     isDiaryRescheduleTargetEligible,
 } from '../../hooks/useRescheduleDiaryEntry';
+import { GameModal } from '../../shared-ui/game-modal';
 import { RaisedBedAiOperationMarkdown } from './RaisedBedAiOperationMarkdown';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
 import { RaisedBedDiaryCancelAction } from './RaisedBedDiaryCancelAction';
@@ -173,7 +173,7 @@ function SavedAiDiaryEntryButton({
     gardenId: number;
 }) {
     return (
-        <Modal
+        <GameModal
             title={entry.name}
             className="md:max-w-3xl"
             trigger={
@@ -202,7 +202,7 @@ function SavedAiDiaryEntryButton({
                     {entry.timestamp.toLocaleDateString('hr-HR')}
                 </Typography>
             </Stack>
-        </Modal>
+        </GameModal>
     );
 }
 

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryAiAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryAiAction.tsx
@@ -1,6 +1,5 @@
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -10,6 +9,7 @@ import { AiAnalysisRequestError } from '../../hooks/aiAnalysisError';
 import { useRaisedBedAiAnalysis } from '../../hooks/useRaisedBedAiAnalysis';
 import { useRaisedBedFieldAiAnalysis } from '../../hooks/useRaisedBedFieldAiAnalysis';
 import { ButtonGreen } from '../../shared-ui/ButtonGreen';
+import { GameModal } from '../../shared-ui/game-modal';
 import { RaisedBedAiOperationMarkdown } from './RaisedBedAiOperationMarkdown';
 import styles from './RaisedBedDiaryAiAction.module.css';
 
@@ -279,7 +279,7 @@ export function RaisedBedDiaryAiAction({
                         : 'Pitaj suncokret za savjete'}
                 </ButtonGreen>
             </Stack>
-            <Modal
+            <GameModal
                 open={open}
                 onOpenChange={handleOpenChange}
                 title="AI analiza fotografije"
@@ -479,7 +479,7 @@ export function RaisedBedDiaryAiAction({
                         </Row>
                     </Stack>
                 </div>
-            </Modal>
+            </GameModal>
         </>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryCancelAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryCancelAction.tsx
@@ -2,7 +2,6 @@ import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Close, Warning } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@gredice/ui/Tooltip';
@@ -12,6 +11,7 @@ import {
     type DiaryCancelTarget,
     useCancelDiaryEntry,
 } from '../../hooks/useCancelDiaryEntry';
+import { GameModal } from '../../shared-ui/game-modal';
 
 export function RaisedBedDiaryCancelAction({
     disabledReason,
@@ -79,7 +79,7 @@ export function RaisedBedDiaryCancelAction({
     }
 
     return (
-        <Modal
+        <GameModal
             title={`Otkaži ${entryName}`}
             open={open}
             onOpenChange={(nextOpen) => {
@@ -134,6 +134,6 @@ export function RaisedBedDiaryCancelAction({
                     </Button>
                 </Row>
             </Stack>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
@@ -2,7 +2,6 @@ import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Input } from '@gredice/ui/Input';
 import { Calendar } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@gredice/ui/Tooltip';
@@ -14,6 +13,7 @@ import {
     getMinimumDiaryRescheduleDateInput,
     useRescheduleDiaryEntry,
 } from '../../hooks/useRescheduleDiaryEntry';
+import { GameModal } from '../../shared-ui/game-modal';
 
 export function RaisedBedDiaryRescheduleAction({
     disabledReason,
@@ -97,7 +97,7 @@ export function RaisedBedDiaryRescheduleAction({
     }
 
     return (
-        <Modal
+        <GameModal
             title={`${modalActionLabel} ${entryName}`}
             open={open}
             onOpenChange={(nextOpen) => {
@@ -160,6 +160,6 @@ export function RaisedBedDiaryRescheduleAction({
                     </Row>
                 </Stack>
             </form>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemPlanted.tsx
@@ -14,7 +14,6 @@ import {
     Warning,
 } from '@gredice/ui/icons';
 import { Link } from '@gredice/ui/Link';
-import { Modal } from '@gredice/ui/Modal';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Row } from '@gredice/ui/Row';
 import { SegmentedCircularProgress } from '@gredice/ui/SegmentedCircularProgress';
@@ -26,6 +25,7 @@ import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { usePlantSort } from '../../hooks/usePlantSorts';
 import { KnownPages } from '../../knownPages';
+import { GameModal } from '../../shared-ui/game-modal';
 import { ScrollView } from '../../shared-ui/ScrollView';
 import {
     findRaisedBedFieldWithPlant,
@@ -429,7 +429,7 @@ export function RaisedBedFieldItemPlanted({
         triggerOverride === undefined ? defaultTrigger : triggerOverride;
 
     const modal = (
-        <Modal
+        <GameModal
             open={open}
             onOpenChange={(nextOpen) => {
                 if (nextOpen) {
@@ -447,7 +447,7 @@ export function RaisedBedFieldItemPlanted({
                 onOpenChange?.(nextOpen);
             }}
             title={modalTitle}
-            className="max-w-xl overflow-x-hidden md:border-tertiary md:border-b-4"
+            className="max-w-xl overflow-x-hidden"
             trigger={trigger ?? undefined}
         >
             <Stack spacing={4} className="min-w-0 max-w-full">
@@ -638,7 +638,7 @@ export function RaisedBedFieldItemPlanted({
                     Zatvori
                 </button>
             </Stack>
-        </Modal>
+        </GameModal>
     );
 
     if (triggerOverride === undefined && triggerVariant === 'field') {

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldPlantHistoryModal.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldPlantHistoryModal.tsx
@@ -1,10 +1,10 @@
 import { plantFieldStatusLabel } from '@gredice/js/plants';
-import { Modal } from '@gredice/ui/Modal';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { type ReactElement, useMemo, useState } from 'react';
 import { useSorts } from '../../hooks/usePlantSorts';
+import { GameModal } from '../../shared-ui/game-modal';
 import type { RaisedBedFieldPlantHistoryEntry } from '../../utils/raisedBedFields';
 import { RaisedBedFieldItemPlanted } from './RaisedBedFieldItemPlanted';
 
@@ -52,11 +52,11 @@ export function RaisedBedFieldPlantHistoryModal({
 
     return (
         <>
-            <Modal
+            <GameModal
                 title="Povijest polja"
                 trigger={trigger}
                 modal={false}
-                className="md:border-tertiary md:border-b-4 max-w-xl"
+                className="max-w-xl"
             >
                 <Stack spacing={4}>
                     <Typography level="body2" className="text-muted-foreground">
@@ -127,7 +127,7 @@ export function RaisedBedFieldPlantHistoryModal({
                         );
                     })}
                 </Stack>
-            </Modal>
+            </GameModal>
             {selectedEntry && (
                 <RaisedBedFieldItemPlanted
                     key={selectedEntryKey}

--- a/packages/game/src/hud/raisedBed/RaisedBedGreenhouseSuggestion.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedGreenhouseSuggestion.tsx
@@ -1,11 +1,11 @@
 import type { OperationData } from '@gredice/client';
-import { Modal } from '@gredice/ui/Modal';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
 import { useOperations } from '../../hooks/useOperations';
 import { ButtonGreen } from '../../shared-ui/ButtonGreen';
+import { GameModal } from '../../shared-ui/game-modal';
 import { OperationsList } from './shared/OperationsList';
 
 function greenhouseOperationsFilter(operation: OperationData) {
@@ -32,8 +32,7 @@ export function RaisedBedGreenhouseSuggestion({
     }
 
     return (
-        <Modal
-            className="border border-tertiary border-b-4"
+        <GameModal
             title="Zalijevanje"
             open={open}
             modal={false}
@@ -60,6 +59,6 @@ export function RaisedBedGreenhouseSuggestion({
                     filterFunc={greenhouseOperationsFilter}
                 />
             </Stack>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
@@ -4,7 +4,6 @@ import { Button } from '@gredice/ui/Button';
 import { Chip } from '@gredice/ui/Chip';
 import { ImageGallery } from '@gredice/ui/ImageGallery';
 import { Camera, Navigate } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
 import { Row } from '@gredice/ui/Row';
 import { Spinner } from '@gredice/ui/Spinner';
@@ -16,6 +15,7 @@ import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useGardenOperations } from '../../hooks/useGardenOperations';
 import { useOperations } from '../../hooks/useOperations';
 import { useRaisedBedAiHistory } from '../../hooks/useRaisedBedAiHistory';
+import { GameModal } from '../../shared-ui/game-modal';
 import { sortOperationTasksNewestFirst } from '../gardenOperationOrdering';
 import { RaisedBedDiaryAiAction } from './RaisedBedDiaryAiAction';
 import {
@@ -292,9 +292,9 @@ export function RaisedBedPhotosModal({
         );
 
     return (
-        <Modal
+        <GameModal
             title={modalTitle}
-            className="overflow-x-hidden md:max-w-5xl md:border-tertiary md:border-b-4"
+            className="overflow-x-hidden md:max-w-5xl"
             trigger={trigger}
         >
             <Stack
@@ -473,6 +473,6 @@ export function RaisedBedPhotosModal({
                     </Button>
                 )}
             </Stack>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -11,7 +11,6 @@ import {
     ShoppingCart,
     Sprout,
 } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { PlantingSeedIcon } from '@gredice/ui/PlantingSeedIcon';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -48,6 +47,7 @@ import {
     showShoppingCartTransientHub,
 } from '../../hooks/useShoppingCartTransientHub';
 import { KnownPages } from '../../knownPages';
+import { GameModal } from '../../shared-ui/game-modal';
 import { PlantsList } from './PlantsList';
 import { PlantsSortList } from './PlantsSortList';
 import {
@@ -520,13 +520,13 @@ export function PlantPicker({
     });
 
     return (
-        <Modal
+        <GameModal
             trigger={trigger}
             open={open}
             onOpenChange={handleOpenChange}
             title={'Sijanje biljke'}
             modal={false}
-            className="md:border-tertiary md:border-b-4 md:max-w-2xl"
+            className="md:max-w-2xl"
         >
             <Stack spacing={4}>
                 <SegmentedProgress
@@ -1020,6 +1020,6 @@ export function PlantPicker({
                     </>
                 )}
             </Stack>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
@@ -10,7 +10,6 @@ import {
     Up,
     Warning,
 } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Skeleton } from '@gredice/ui/Skeleton';
 import { Spinner } from '@gredice/ui/Spinner';
@@ -34,6 +33,7 @@ import { useRaisedBedSensors } from '../../hooks/useRaisedBedSensors';
 import { useSetShoppingCartItem } from '../../hooks/useSetShoppingCartItem';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
 import { ButtonGreen } from '../../shared-ui/ButtonGreen';
+import { GameModal } from '../../shared-ui/game-modal';
 import { useNeighboringRaisedBeds } from './useNeighboringRaisedBeds';
 
 interface TooltipPayload {
@@ -257,7 +257,7 @@ function SensorInfoModal({
     }
 
     return (
-        <Modal
+        <GameModal
             trigger={trigger}
             title="Detalji senzora"
             className="max-w-3xl overflow-hidden"
@@ -596,7 +596,7 @@ function SensorInfoModal({
                     </div>
                 )}
             </div>
-        </Modal>
+        </GameModal>
     );
 }
 

--- a/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
@@ -1,9 +1,9 @@
 import { BlockImage } from '@gredice/ui/BlockImage';
-import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
 import { ButtonGreen } from '../../shared-ui/ButtonGreen';
+import { GameModal } from '../../shared-ui/game-modal';
 import { RaisedBedWateringCalendar } from './RaisedBedWateringCalendar';
 import { OperationsList } from './shared/OperationsList';
 
@@ -17,8 +17,7 @@ export function RaisedBedWatering({
     const [open, setOpen] = useState(false);
 
     return (
-        <Modal
-            className="border border-tertiary border-b-4"
+        <GameModal
             title="Zalijevanje"
             open={open}
             onOpenChange={setOpen}
@@ -61,6 +60,6 @@ export function RaisedBedWatering({
                     raisedBedId={raisedBedId}
                 />
             </Stack>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
@@ -6,12 +6,12 @@ import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { EventCalendar } from '@gredice/ui/EventCalendar';
 import { Calendar } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
+import { GameModal } from '../../../shared-ui/game-modal';
 import { formatLocalDate } from '../RaisedBedPlantPicker';
 import {
     isWateringOperation,
@@ -103,8 +103,7 @@ export function OperationScheduleModal({
     };
 
     return (
-        <Modal
-            className="border border-tertiary border-b-4"
+        <GameModal
             trigger={trigger}
             title={`Zakaži radnju: ${operation.information.label}`}
             open={open}
@@ -230,6 +229,6 @@ export function OperationScheduleModal({
                     </Row>
                 </Stack>
             </form>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/modals/GiftBoxModal.tsx
+++ b/packages/game/src/modals/GiftBoxModal.tsx
@@ -2,13 +2,13 @@
 
 import { BlockImage } from '@gredice/ui/BlockImage';
 import { Button } from '@gredice/ui/Button';
-import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useEffect, useMemo, useState } from 'react';
 import Confetti from 'react-confetti-boom';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useOpenGiftBox } from '../hooks/useOpenGiftBox';
+import { GameModal } from '../shared-ui/game-modal';
 import { useGiftBoxParam } from '../useUrlState';
 import { GiftBoxRewardScreen } from './GiftBoxRewardScreen';
 
@@ -62,7 +62,7 @@ export function GiftBoxModal() {
     };
 
     return (
-        <Modal
+        <GameModal
             open={isOpen}
             onOpenChange={(open) => !open && handleClose()}
             title="Poklon kutija"
@@ -136,6 +136,6 @@ export function GiftBoxModal() {
                     )}
                 </Stack>
             )}
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/modals/OverviewModal.tsx
+++ b/packages/game/src/modals/OverviewModal.tsx
@@ -1,7 +1,6 @@
 import { useSearchParam } from '@gredice/ui/hooks';
 import { List } from '@gredice/ui/List';
 import { ListItem } from '@gredice/ui/ListItem';
-import { Modal } from '@gredice/ui/Modal';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -14,6 +13,7 @@ import {
     notificationsFilterSearchParam,
     notificationsViewSearchParam,
 } from '../notificationFilters';
+import { GameModal } from '../shared-ui/game-modal';
 import { ProfileInfo } from '../shared-ui/ProfileInfo';
 import { AccountUsersTab } from './components/AccountUsersTab';
 import { AchievementsTab } from './components/AchievementsTab';
@@ -168,10 +168,10 @@ export function OverviewModal() {
     };
 
     return (
-        <Modal
+        <GameModal
             open={Boolean(settingsMode)}
             onOpenChange={handleOpenChange}
-            className="max-h-[90dvh] overflow-hidden md:min-w-full lg:min-w-[80%] xl:min-w-[60%] md:min-h-[70%] md:max-h-full md:border-tertiary md:border-b-4"
+            className="max-h-[90dvh] overflow-hidden md:min-w-full lg:min-w-[80%] xl:min-w-[60%] md:min-h-[70%] md:max-h-full"
             title="Profil"
         >
             <div className="grid max-h-[calc(90dvh-5rem)] min-h-0 grid-rows-[auto_1fr] gap-4 overflow-y-auto pr-1 md:gap-0 md:grid-rows-1 md:grid-cols-[minmax(230px,auto)_1fr] md:overflow-hidden md:pr-0">
@@ -234,6 +234,6 @@ export function OverviewModal() {
                     {settingsMode === 'preporuke' && <ReferralsTab />}
                 </div>
             </div>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/modals/advent/AdventModal.tsx
+++ b/packages/game/src/modals/advent/AdventModal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useSearchParam } from '@gredice/ui/hooks';
-import { Modal } from '@gredice/ui/Modal';
 import { Spinner } from '@gredice/ui/Spinner';
 import { useCallback, useEffect, useState } from 'react';
 import { useAdventCalendar } from '../../hooks/useAdventCalendar';
 import { useOpenAdventDay } from '../../hooks/useOpenAdventDay';
+import { GameModal } from '../../shared-ui/game-modal';
 import { AdventAlreadyOpenedScreen } from './AdventAlreadyOpenedScreen';
 import { AdventAwardScreen } from './AdventAwardScreen';
 import { AdventCalendarScreen } from './AdventCalendarScreen';
@@ -224,13 +224,13 @@ export function AdventModal() {
     };
 
     return (
-        <Modal
+        <GameModal
             title="Adventski kalendar"
             open={isOpen}
             onOpenChange={(open) => !open && handleClose()}
-            className="md:max-w-sm border-tertiary border-b-4 p-0 overflow-hidden"
+            className="md:max-w-sm p-0 overflow-hidden"
         >
             <div className="bg-background">{renderContent()}</div>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/modals/components/AccountUsersCard.tsx
+++ b/packages/game/src/modals/components/AccountUsersCard.tsx
@@ -1,13 +1,13 @@
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { Add } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Spinner } from '@gredice/ui/Spinner';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { UserAvatar } from '@gredice/ui/UserAvatar';
 import { useCurrentAccountUsers } from '../../hooks/useCurrentAccountUsers';
+import { GameModal } from '../../shared-ui/game-modal';
 import { InviteUserForm } from './InviteUserForm';
 import { PendingInvitationsList } from './PendingInvitationsList';
 
@@ -32,7 +32,7 @@ export function AccountUsersCard() {
                                 korisnike.
                             </Typography>
                         </Stack>
-                        <Modal
+                        <GameModal
                             trigger={
                                 <Button
                                     variant="solid"
@@ -54,7 +54,7 @@ export function AccountUsersCard() {
                                 </Typography>
                                 <InviteUserForm />
                             </Stack>
-                        </Modal>
+                        </GameModal>
                     </Row>
                     {accountUsers.isLoading && (
                         <Spinner

--- a/packages/game/src/modals/components/CreateGardenModal.tsx
+++ b/packages/game/src/modals/components/CreateGardenModal.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@gredice/ui/Button';
 import { Input } from '@gredice/ui/Input';
-import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { type SubmitEvent, useState } from 'react';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { useCreateGarden } from '../../hooks/useCreateGarden';
+import { GameModal } from '../../shared-ui/game-modal';
 
 type CreateGardenModalProps = {
     open: boolean;
@@ -55,7 +55,7 @@ export function CreateGardenModal({
     };
 
     return (
-        <Modal
+        <GameModal
             open={open}
             onOpenChange={onOpenChange}
             title={isSandbox ? 'Kreiraj vrt za igru' : 'Kreiraj novi vrt'}
@@ -89,6 +89,6 @@ export function CreateGardenModal({
                     </Button>
                 </Stack>
             </form>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/modals/components/ReferralsTab.tsx
+++ b/packages/game/src/modals/components/ReferralsTab.tsx
@@ -5,7 +5,6 @@ import { Card, CardActions, CardContent } from '@gredice/ui/Card';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Input } from '@gredice/ui/Input';
 import { Check, Copy, Edit, ExternalLink, Info } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { UserAvatar } from '@gredice/ui/UserAvatar';
@@ -16,6 +15,7 @@ import { currentAccountKeys } from '../../hooks/useCurrentAccount';
 import { useReferrals } from '../../hooks/useReferrals';
 import { tutorialChecklistKeys } from '../../hooks/useTutorialChecklist';
 import { KnownPages } from '../../knownPages';
+import { GameModal } from '../../shared-ui/game-modal';
 
 async function errorMessageFromResponse(response: Response, fallback: string) {
     const payload: unknown = await response.json().catch(() => null);
@@ -295,7 +295,7 @@ export function ReferralsTab() {
                         />
                     </CardContent>
                 </Card>
-                <Modal
+                <GameModal
                     onOpenChange={setChangeCodeOpen}
                     open={changeCodeOpen}
                     title="Promijeni kod preporuke"
@@ -338,7 +338,7 @@ export function ReferralsTab() {
                             </div>
                         </Stack>
                     </form>
-                </Modal>
+                </GameModal>
                 <Card>
                     <CardContent noHeader>
                         {usedReferral ? (

--- a/packages/game/src/shared-ui/achievements/AchievementsOverview.tsx
+++ b/packages/game/src/shared-ui/achievements/AchievementsOverview.tsx
@@ -3,13 +3,13 @@
 import { getAchievementDefinitions } from '@gredice/js/achievements';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { IconButton } from '@gredice/ui/IconButton';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Spinner } from '@gredice/ui/Spinner';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useMemo, useState } from 'react';
 import { useAccountAchievements } from '../../hooks/useAccountAchievements';
+import { GameModal } from '../game-modal';
 
 type AccountAchievement = NonNullable<
     ReturnType<typeof useAccountAchievements>['data']
@@ -191,7 +191,7 @@ export function AchievementsOverview() {
             </div>
 
             {/* Achievement Details Modal */}
-            <Modal
+            <GameModal
                 open={Boolean(selectedAchievement)}
                 onOpenChange={(open) => {
                     if (!open) setSelectedAchievement(null);
@@ -316,7 +316,7 @@ export function AchievementsOverview() {
                         </Stack>
                     </Stack>
                 )}
-            </Modal>
+            </GameModal>
         </>
     );
 }

--- a/packages/game/src/shared-ui/delivery/DeliveryAddressesSection.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryAddressesSection.tsx
@@ -5,7 +5,6 @@ import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
 import { Input } from '@gredice/ui/Input';
 import { Add, Delete, Edit } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { ModalConfirm } from '@gredice/ui/ModalConfirm';
 import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
 import { Row } from '@gredice/ui/Row';
@@ -21,6 +20,7 @@ import {
     useDeleteDeliveryAddress,
     useUpdateDeliveryAddress,
 } from '../../hooks/useDeliveryAddressMutations';
+import { GameModal } from '../game-modal';
 
 interface AddressFormData {
     label: string;
@@ -342,7 +342,7 @@ export function DeliveryAddressesSection() {
         <Stack spacing={4}>
             <Row justifyContent="space-between">
                 <Typography level="h5">Adrese za dostavu</Typography>
-                <Modal
+                <GameModal
                     open={isCreating}
                     onOpenChange={setIsCreating}
                     title="Dodaj novu adresu"
@@ -360,7 +360,7 @@ export function DeliveryAddressesSection() {
                         onCancel={() => setIsCreating(false)}
                         isLoading={createAddress.isPending}
                     />
-                </Modal>
+                </GameModal>
             </Row>
 
             {isLoading ? (

--- a/packages/game/src/shared-ui/delivery/DeliveryCancelRequestModal.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryCancelRequestModal.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent } from '@gredice/ui/Card';
 import { Input } from '@gredice/ui/Input';
 import { Close, Info, ShoppingCart, Truck } from '@gredice/ui/icons';
 import { TimeRange } from '@gredice/ui/LocalDateTime';
-import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Stack } from '@gredice/ui/Stack';
@@ -12,6 +11,7 @@ import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
 import { useCancelDeliveryRequest } from '../../hooks/useDeliveryRequestMutations';
 import type { DeliveryRequestData } from '../../hooks/useDeliveryRequests';
+import { GameModal } from '../game-modal';
 
 export const CANCEL_REASON_OPTIONS = [
     { value: 'USER_CHANGE_MIND', label: 'Predomislio/la sam se' },
@@ -70,7 +70,7 @@ export function DeliveryCancelRequestModal({
     };
 
     return (
-        <Modal
+        <GameModal
             open={isOpen}
             onOpenChange={setIsOpen}
             title="Otkaži dostavu"
@@ -201,6 +201,6 @@ export function DeliveryCancelRequestModal({
                     </Button>
                 </Row>
             </Stack>
-        </Modal>
+        </GameModal>
     );
 }

--- a/packages/game/src/shared-ui/game-modal/GameModal.tsx
+++ b/packages/game/src/shared-ui/game-modal/GameModal.tsx
@@ -1,0 +1,48 @@
+import { Modal, type ModalProps } from '@gredice/ui/Modal';
+import { cx } from '@gredice/ui/utils';
+import type { ReactNode } from 'react';
+import { GameModalHeader } from './GameModalHeader';
+
+export type GameModalProps = ModalProps & {
+    headerAction?: ReactNode;
+    headerClassName?: string;
+    headerDescription?: ReactNode;
+    headerIcon?: ReactNode;
+    showHeader?: boolean;
+};
+
+export function GameModal({
+    children,
+    className,
+    headerAction,
+    headerClassName,
+    headerDescription,
+    headerIcon,
+    overlayClassName,
+    showHeader,
+    title,
+    ...rest
+}: GameModalProps) {
+    const shouldShowHeader =
+        showHeader ?? Boolean(headerIcon || headerAction || headerDescription);
+
+    return (
+        <Modal
+            className={cx('z-[46] border-tertiary border-b-4', className)}
+            overlayClassName={cx('z-[46]', overlayClassName)}
+            title={title}
+            {...rest}
+        >
+            {shouldShowHeader ? (
+                <GameModalHeader
+                    action={headerAction}
+                    className={headerClassName}
+                    description={headerDescription}
+                    icon={headerIcon}
+                    title={title}
+                />
+            ) : null}
+            {children}
+        </Modal>
+    );
+}

--- a/packages/game/src/shared-ui/game-modal/GameModal.tsx
+++ b/packages/game/src/shared-ui/game-modal/GameModal.tsx
@@ -8,6 +8,7 @@ export type GameModalProps = ModalProps & {
     headerClassName?: string;
     headerDescription?: ReactNode;
     headerIcon?: ReactNode;
+    hudLayer?: boolean;
     showHeader?: boolean;
 };
 
@@ -18,6 +19,7 @@ export function GameModal({
     headerClassName,
     headerDescription,
     headerIcon,
+    hudLayer,
     overlayClassName,
     showHeader,
     title,
@@ -28,8 +30,12 @@ export function GameModal({
 
     return (
         <Modal
-            className={cx('z-[46] border-tertiary border-b-4', className)}
-            overlayClassName={cx('z-[46]', overlayClassName)}
+            className={cx(
+                'border-tertiary border-b-4',
+                hudLayer && 'z-[46]',
+                className,
+            )}
+            overlayClassName={cx(hudLayer && 'z-[46]', overlayClassName)}
             title={title}
             {...rest}
         >

--- a/packages/game/src/shared-ui/game-modal/GameModalHeader.tsx
+++ b/packages/game/src/shared-ui/game-modal/GameModalHeader.tsx
@@ -1,0 +1,54 @@
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import type { ReactNode } from 'react';
+
+export type GameModalHeaderProps = {
+    title: ReactNode;
+    description?: ReactNode;
+    icon?: ReactNode;
+    action?: ReactNode;
+    className?: string;
+};
+
+export function GameModalHeader({
+    action,
+    className,
+    description,
+    icon,
+    title,
+}: GameModalHeaderProps) {
+    return (
+        <Row
+            spacing={4}
+            className={cx('min-w-0 pr-8', className)}
+            alignItems="center"
+        >
+            {icon ? (
+                <div
+                    aria-hidden="true"
+                    className="flex size-12 shrink-0 items-center justify-center rounded-full bg-tertiary/40 text-foreground"
+                >
+                    {icon}
+                </div>
+            ) : null}
+            <Stack spacing={0.5} className="min-w-0 flex-1">
+                <Typography
+                    level="h3"
+                    component="h2"
+                    noWrap
+                    className="text-2xl md:text-3xl"
+                >
+                    {title}
+                </Typography>
+                {description ? (
+                    <Typography level="body2" secondary>
+                        {description}
+                    </Typography>
+                ) : null}
+            </Stack>
+            {action}
+        </Row>
+    );
+}

--- a/packages/game/src/shared-ui/game-modal/index.ts
+++ b/packages/game/src/shared-ui/game-modal/index.ts
@@ -1,0 +1,5 @@
+export { GameModal, type GameModalProps } from './GameModal';
+export {
+    GameModalHeader,
+    type GameModalHeaderProps,
+} from './GameModalHeader';


### PR DESCRIPTION
## Summary
- Add a game-owned `GameModal` wrapper that centralizes the cart-style modal chrome: overlay z-index and tertiary bottom border.
- Add a reusable `GameModalHeader` for the icon/title treatment used by cart, inventory, and outlet modals.
- Migrate garden runtime modal callers to the wrapper and remove redundant per-modal border/z-index classes.

## Validation
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter garden build`
- `pnpm --filter garden exec playwright test tests/inventory-hud.spec.tsx tests/shopping-cart-optimistic-toggle.spec.tsx --project=chromium`