### PR TITLE
[App Admin] Migrate accounts table to responsive list

### DIFF
--- a/apps/app/app/admin/accounts/AccountsTable.tsx
+++ b/apps/app/app/admin/accounts/AccountsTable.tsx
@@ -1,6 +1,8 @@
 import { getAccounts } from '@gredice/storage';
+import { List, ListItem } from '@gredice/ui/List';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
-import { Table } from '@gredice/ui/Table';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../src/KnownPages';
@@ -19,48 +21,81 @@ export async function AccountsTable({ from }: { from?: Date | null }) {
         });
     }
 
+    if (filteredAccounts.length === 0) {
+        return (
+            <div className="p-4">
+                <NoDataPlaceholder>Nema računa</NoDataPlaceholder>
+            </div>
+        );
+    }
+
     return (
-        <Table>
-            <Table.Header>
-                <Table.Row>
-                    <Table.Head>ID</Table.Head>
-                    <Table.Head>Korisnicko ime</Table.Head>
-                    <Table.Head>Datum kreiranja</Table.Head>
-                </Table.Row>
-            </Table.Header>
-            <Table.Body>
-                {filteredAccounts.length === 0 && (
-                    <Table.Row>
-                        <Table.Cell colSpan={3}>
-                            <NoDataPlaceholder>Nema računa</NoDataPlaceholder>
-                        </Table.Cell>
-                    </Table.Row>
-                )}
-                {filteredAccounts.map((account) => {
-                    const user = account.accountUsers.at(0)?.user;
-                    return (
-                        <Table.Row key={account.id}>
-                            <Table.Cell>
-                                <Link href={KnownPages.Account(account.id)}>
-                                    {account.id}
-                                </Link>
-                            </Table.Cell>
-                            <Table.Cell>
-                                <Link href={KnownPages.User(user?.id ?? '')}>
-                                    {user?.displayName ||
-                                        user?.userName ||
-                                        'N/A'}
-                                </Link>
-                            </Table.Cell>
-                            <Table.Cell>
-                                <LocalDateTime time={false}>
-                                    {account.createdAt}
-                                </LocalDateTime>
-                            </Table.Cell>
-                        </Table.Row>
-                    );
-                })}
-            </Table.Body>
-        </Table>
+        <List className="min-w-0 divide-y">
+            {filteredAccounts.map((account) => {
+                const user = account.accountUsers.at(0)?.user;
+                const username = user?.displayName || user?.userName || 'N/A';
+
+                return (
+                    <ListItem
+                        key={account.id}
+                        className="rounded-none px-3 py-3 hover:bg-muted/40 sm:px-4"
+                        label={
+                            <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                <Stack spacing={1} className="min-w-0">
+                                    <Link
+                                        href={KnownPages.Account(account.id)}
+                                        className="min-w-0 truncate text-sm font-medium text-primary underline-offset-4 hover:underline"
+                                    >
+                                        {username}
+                                    </Link>
+                                    {user ? (
+                                        <Link
+                                            href={KnownPages.User(user.id)}
+                                            className="min-w-0 truncate text-xs text-muted-foreground underline-offset-4 hover:underline"
+                                        >
+                                            Profil korisnika
+                                        </Link>
+                                    ) : (
+                                        <Typography
+                                            level="body3"
+                                            className="text-muted-foreground"
+                                        >
+                                            Nema povezanog korisnika
+                                        </Typography>
+                                    )}
+                                </Stack>
+                                <div className="flex min-w-0 flex-col gap-1 text-left sm:items-end sm:text-right">
+                                    <Typography
+                                        component="div"
+                                        level="body3"
+                                        className="flex min-w-0 max-w-full items-center gap-1 text-muted-foreground"
+                                    >
+                                        <span className="shrink-0">ID</span>
+                                        <Link
+                                            href={KnownPages.Account(
+                                                account.id,
+                                            )}
+                                            title={account.id}
+                                            className="min-w-0 truncate font-mono text-primary underline-offset-4 hover:underline"
+                                        >
+                                            {account.id}
+                                        </Link>
+                                    </Typography>
+                                    <Typography
+                                        component="div"
+                                        level="body3"
+                                        className="whitespace-nowrap text-muted-foreground"
+                                    >
+                                        <LocalDateTime time={false}>
+                                            {account.createdAt}
+                                        </LocalDateTime>
+                                    </Typography>
+                                </div>
+                            </div>
+                        }
+                    />
+                );
+            })}
+        </List>
     );
 }


### PR DESCRIPTION
## Summary
- Replaced `/admin/accounts` table markup with a responsive `List`/`ListItem` surface inside the existing card frame.
- Kept account data loading, time filtering, empty state, account links, user profile links, and created-date display intact.
- Moved account ID and created date into compact metadata that stacks under the primary username/account link on mobile widths.

## Validation
- `pnpm typecheck --filter app`
- `pnpm --filter app exec biome check app/admin/accounts/AccountsTable.tsx`
- `pnpm --filter app exec tsc --ignoreConfig --noEmit --pretty false --jsx react-jsx --module esnext --target esnext --moduleResolution bundler --lib dom,dom.iterable,esnext --allowJs --skipLibCheck --strict --esModuleInterop --allowImportingTsExtensions --isolatedModules app/admin/accounts/AccountsTable.tsx`
- `git diff --check`

## Notes
- Local route visual verification at 360/390px was attempted with `pnpm --filter app dev`, but `/admin/accounts` returned `401 Unauthorized` from the admin layout without a local admin session.
- Direct full-app `pnpm --filter app exec tsc --noEmit --pretty false` is currently blocked by unrelated pre-existing TypeScript errors outside this change.

Closes #3785