### PR TITLE
[App Admin] Use list rows for accounts

### DIFF
--- a/apps/app/app/admin/accounts/AccountsTable.tsx
+++ b/apps/app/app/admin/accounts/AccountsTable.tsx
@@ -1,5 +1,4 @@
 import { getAccounts } from '@gredice/storage';
-import { List, ListItem } from '@gredice/ui/List';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -30,72 +29,69 @@ export async function AccountsTable({ from }: { from?: Date | null }) {
     }
 
     return (
-        <List className="min-w-0 divide-y">
+        <ul className="min-w-0 divide-y">
             {filteredAccounts.map((account) => {
                 const user = account.accountUsers.at(0)?.user;
                 const username = user?.displayName || user?.userName || 'N/A';
 
                 return (
-                    <ListItem
+                    <li
                         key={account.id}
-                        className="rounded-none px-3 py-3 hover:bg-muted/40 sm:px-4"
-                        label={
-                            <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                <Stack spacing={1} className="min-w-0">
+                        className="px-3 py-3 transition-colors hover:bg-muted/40 sm:px-4"
+                    >
+                        <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <Stack spacing={1} className="min-w-0">
+                                {user ? (
                                     <Link
-                                        href={KnownPages.Account(account.id)}
+                                        href={KnownPages.User(user.id)}
                                         className="min-w-0 truncate text-sm font-medium text-primary underline-offset-4 hover:underline"
                                     >
                                         {username}
                                     </Link>
-                                    {user ? (
-                                        <Link
-                                            href={KnownPages.User(user.id)}
-                                            className="min-w-0 truncate text-xs text-muted-foreground underline-offset-4 hover:underline"
-                                        >
-                                            Profil korisnika
-                                        </Link>
-                                    ) : (
-                                        <Typography
-                                            level="body3"
-                                            className="text-muted-foreground"
-                                        >
-                                            Nema povezanog korisnika
-                                        </Typography>
-                                    )}
-                                </Stack>
-                                <div className="flex min-w-0 flex-col gap-1 text-left sm:items-end sm:text-right">
+                                ) : (
                                     <Typography
-                                        component="div"
-                                        level="body3"
-                                        className="flex min-w-0 max-w-full items-center gap-1 text-muted-foreground"
+                                        level="body2"
+                                        className="text-muted-foreground"
                                     >
-                                        <span className="shrink-0">ID</span>
-                                        <Link
-                                            href={KnownPages.Account(
-                                                account.id,
-                                            )}
-                                            title={account.id}
-                                            className="min-w-0 truncate font-mono text-primary underline-offset-4 hover:underline"
-                                        >
-                                            {account.id}
-                                        </Link>
+                                        {username}
                                     </Typography>
-                                    <Typography
-                                        component="div"
-                                        level="body3"
-                                        className="whitespace-nowrap text-muted-foreground"
+                                )}
+                                <Typography
+                                    level="body3"
+                                    className="text-muted-foreground"
+                                >
+                                    Korisničko ime
+                                </Typography>
+                            </Stack>
+                            <div className="flex min-w-0 flex-col gap-1 text-left sm:items-end sm:text-right">
+                                <Typography
+                                    component="div"
+                                    level="body3"
+                                    className="flex min-w-0 max-w-full items-center gap-1 text-muted-foreground"
+                                >
+                                    <span className="shrink-0">ID</span>
+                                    <Link
+                                        href={KnownPages.Account(account.id)}
+                                        title={account.id}
+                                        className="min-w-0 truncate font-mono text-primary underline-offset-4 hover:underline"
                                     >
-                                        <LocalDateTime time={false}>
-                                            {account.createdAt}
-                                        </LocalDateTime>
-                                    </Typography>
-                                </div>
+                                        {account.id}
+                                    </Link>
+                                </Typography>
+                                <Typography
+                                    component="div"
+                                    level="body3"
+                                    className="whitespace-nowrap text-muted-foreground"
+                                >
+                                    <LocalDateTime time={false}>
+                                        {account.createdAt}
+                                    </LocalDateTime>
+                                </Typography>
                             </div>
-                        }
-                    />
+                        </div>
+                    </li>
                 );
             })}
-        </List>
+        </ul>
     );
 }


### PR DESCRIPTION
## Summary
- Follow-up to #3845 after the #3783 coordination note: replace the merged `ListItem` wrapper with compact `ul.divide-y` / `li` rows.
- Preserve `/admin/accounts` `from=last-30-days` filtering, `getAccounts()`, account ID link, first account user display fallback, user link, created date, current auth behavior, and empty copy.
- Preserve every visible table column in the responsive row: username on the left, account ID and created date as compact metadata.

## Validation
- `pnpm typecheck --filter app`
- `pnpm --filter app exec biome check app/admin/accounts/AccountsTable.tsx`
- `pnpm --filter app exec tsc --ignoreConfig --noEmit --pretty false --jsx react-jsx --module esnext --target esnext --moduleResolution bundler --lib dom,dom.iterable,esnext --allowJs --skipLibCheck --strict --esModuleInterop --allowImportingTsExtensions --isolatedModules app/admin/accounts/AccountsTable.tsx`
- `git diff --check`

## Notes
- Local route visual verification at 360/390px remains blocked by `/admin/accounts` returning `401 Unauthorized` without a local admin session.

Closes #3785