### PR TITLE
[App Admin] Migrate notifications table to responsive list

### DIFF
--- a/apps/app/components/notifications/NotificationsTable.tsx
+++ b/apps/app/components/notifications/NotificationsTable.tsx
@@ -5,13 +5,12 @@ import { Checkbox } from '@gredice/ui/Checkbox';
 import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
 import { ImageViewer } from '@gredice/ui/ImageViewer';
-import { Delete } from '@gredice/ui/icons';
+import { Delete, ExternalLink } from '@gredice/ui/icons';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Markdown } from '@gredice/ui/Markdown';
 import { Row } from '@gredice/ui/Row';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
-import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import { useEffect, useMemo, useState, useTransition } from 'react';
@@ -23,6 +22,7 @@ export type NotificationTableRow = {
     accountId: string | null;
     accountLabel: string | null;
     blockId: string | null;
+    category: string;
     content: string;
     createdAt: string;
     gardenId: number | null;
@@ -34,6 +34,8 @@ export type NotificationTableRow = {
     raisedBedPhysicalId: string | null;
     readAt: string | null;
     timestamp: string;
+    type: string;
+    primaryChannel: string;
     userId: string | null;
 };
 
@@ -72,6 +74,23 @@ function getCreatedTimestampDistance(row: NotificationTableRow) {
     );
 }
 
+function formatNotificationMeta(value: string) {
+    return value.replaceAll('_', ' ');
+}
+
+function getNotificationChannelLabel(channel: string) {
+    switch (channel) {
+        case 'in_app':
+            return 'In-app';
+        case 'push':
+            return 'Push';
+        case 'email':
+            return 'Email';
+        default:
+            return formatNotificationMeta(channel);
+    }
+}
+
 export function NotificationsTable({
     deleteContext,
     deleteNotificationsAction,
@@ -89,7 +108,6 @@ export function NotificationsTable({
         : selectedCount > 0
           ? 'indeterminate'
           : false;
-    const emptyStateColumnCount = showAccountColumn ? 9 : 8;
 
     const selectedNotificationIds = useMemo(
         () => notifications.map((notification) => notification.id),
@@ -160,9 +178,28 @@ export function NotificationsTable({
     }
 
     return (
-        <Stack spacing={2}>
-            <Row justifyContent="space-between" className="px-4 pt-3">
-                <Typography level="body2">Odabrano: {selectedCount}</Typography>
+        <Stack spacing={0} className="min-w-0">
+            <Row
+                justifyContent="space-between"
+                className="gap-3 border-b px-3 py-3 sm:px-4"
+            >
+                <div className="flex min-w-0 items-center gap-3">
+                    <Checkbox
+                        aria-label="Odaberi sve obavijesti"
+                        checked={headerChecked}
+                        disabled={!hasNotifications || isPending}
+                        onCheckedChange={(checked) =>
+                            setAllSelected(checked === true)
+                        }
+                    />
+                    <Typography
+                        component="span"
+                        level="body2"
+                        className="whitespace-nowrap"
+                    >
+                        Odabrano: {selectedCount}
+                    </Typography>
+                </div>
                 <Button
                     type="button"
                     size="sm"
@@ -171,205 +208,313 @@ export function NotificationsTable({
                     startDecorator={<Delete className="size-4" />}
                     disabled={selectedCount === 0 || isPending}
                     loading={isPending}
+                    className="shrink-0"
                     onClick={() => handleDelete(Array.from(selectedIds))}
                 >
                     Obriši odabrane
                 </Button>
             </Row>
-            <Table>
-                <Table.Header>
-                    <Table.Row>
-                        <Table.Head className="w-12">
-                            <Checkbox
-                                aria-label="Odaberi sve obavijesti"
-                                checked={headerChecked}
-                                disabled={!hasNotifications || isPending}
-                                onCheckedChange={(checked) =>
-                                    setAllSelected(checked === true)
-                                }
-                            />
-                        </Table.Head>
-                        <Table.Head>Sadržaj</Table.Head>
-                        <Table.Head>Link</Table.Head>
-                        <Table.Head>Mjesto</Table.Head>
-                        {showAccountColumn && <Table.Head>Račun</Table.Head>}
-                        <Table.Head>Korisnik</Table.Head>
-                        <Table.Head>Pročitano</Table.Head>
-                        <Table.Head>Datum</Table.Head>
-                        <Table.Head>Akcije</Table.Head>
-                    </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                    {!hasNotifications && (
-                        <Table.Row>
-                            <Table.Cell colSpan={emptyStateColumnCount}>
-                                <NoDataPlaceholder>
-                                    Nema obavjesti
-                                </NoDataPlaceholder>
-                            </Table.Cell>
-                        </Table.Row>
-                    )}
+            {!hasNotifications ? (
+                <div className="p-4">
+                    <NoDataPlaceholder>Nema obavjesti</NoDataPlaceholder>
+                </div>
+            ) : (
+                <ul className="divide-y">
                     {notifications.map((notification) => {
                         const isSelected = selectedIds.has(notification.id);
+                        const hasLocation = Boolean(
+                            notification.gardenId ||
+                                notification.raisedBedId ||
+                                notification.blockId,
+                        );
 
                         return (
-                            <Table.Row key={notification.id}>
-                                <Table.Cell>
-                                    <Checkbox
-                                        aria-label={`Odaberi obavijest ${notification.header}`}
-                                        checked={isSelected}
-                                        disabled={isPending}
-                                        onCheckedChange={(checked) =>
-                                            setNotificationSelected(
-                                                notification.id,
-                                                checked === true,
-                                            )
-                                        }
-                                    />
-                                </Table.Cell>
-                                <Table.Cell className="max-w-xs whitespace-pre-wrap">
-                                    <Row spacing={4}>
+                            <li
+                                key={notification.id}
+                                className="px-3 py-3 transition-colors hover:bg-muted/40 sm:px-4"
+                            >
+                                <div className="grid min-w-0 gap-3 2xl:grid-cols-[minmax(0,1fr)_minmax(12rem,0.5fr)_minmax(14rem,0.5fr)] 2xl:items-start">
+                                    <div className="flex min-w-0 items-start gap-3">
+                                        <Checkbox
+                                            aria-label={`Odaberi obavijest ${notification.header}`}
+                                            checked={isSelected}
+                                            disabled={isPending}
+                                            className="mt-1 shrink-0"
+                                            onCheckedChange={(checked) =>
+                                                setNotificationSelected(
+                                                    notification.id,
+                                                    checked === true,
+                                                )
+                                            }
+                                        />
                                         {notification.imageUrl && (
-                                            <div className="shrink-0 aspect-square">
+                                            <div className="shrink-0 overflow-hidden rounded-md">
                                                 <ImageViewer
                                                     src={notification.imageUrl}
                                                     alt={notification.header}
-                                                    previewWidth={80}
-                                                    previewHeight={80}
+                                                    previewWidth={64}
+                                                    previewHeight={64}
                                                 />
                                             </div>
                                         )}
-                                        <Stack>
-                                            <Typography level="body2" bold>
+                                        <Stack
+                                            spacing={1}
+                                            className="min-w-0 flex-1"
+                                        >
+                                            <Typography
+                                                level="body2"
+                                                bold
+                                                className="break-words"
+                                            >
                                                 {notification.header}
                                             </Typography>
-                                            <Markdown>
+                                            <Markdown className="min-w-0 break-words text-sm text-secondary-foreground prose-p:my-1 prose-a:break-all prose-pre:whitespace-pre-wrap prose-pre:break-words prose-code:break-words">
                                                 {notification.content}
                                             </Markdown>
+                                            <Typography
+                                                component="div"
+                                                level="body3"
+                                                className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1"
+                                            >
+                                                <span className="font-medium">
+                                                    Link:
+                                                </span>
+                                                {notification.linkUrl ? (
+                                                    <a
+                                                        href={
+                                                            notification.linkUrl
+                                                        }
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        className="inline-flex min-w-0 max-w-full items-center gap-1 break-all text-primary underline-offset-4 hover:underline"
+                                                    >
+                                                        <ExternalLink className="size-3.5 shrink-0" />
+                                                        <span>Otvori</span>
+                                                    </a>
+                                                ) : (
+                                                    <span>-</span>
+                                                )}
+                                            </Typography>
                                         </Stack>
-                                    </Row>
-                                </Table.Cell>
-                                <Table.Cell>
-                                    {notification.linkUrl ? (
-                                        <a
-                                            href={notification.linkUrl}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="text-primary underline"
-                                        >
-                                            Otvori
-                                        </a>
-                                    ) : (
-                                        '-'
-                                    )}
-                                </Table.Cell>
-                                <Table.Cell>
-                                    <Stack>
-                                        {notification.gardenId && (
-                                            <Link
-                                                href={KnownPages.Garden(
-                                                    notification.gardenId,
-                                                )}
-                                                className="text-primary underline"
+                                    </div>
+
+                                    <div className="grid min-w-0 gap-2 text-sm sm:grid-cols-2 2xl:grid-cols-1 2xl:gap-1">
+                                        <Stack spacing={1} className="min-w-0">
+                                            <Typography
+                                                component="span"
+                                                level="body3"
+                                                className="font-medium uppercase"
                                             >
-                                                {notification.gardenName ??
-                                                    'N/A'}
-                                            </Link>
-                                        )}
-                                        {notification.raisedBedId && (
-                                            <RaisedBedLabel
-                                                physicalId={
-                                                    notification.raisedBedPhysicalId
-                                                }
-                                            />
-                                        )}
-                                        {notification.blockId && (
-                                            <span>
-                                                Blok: {notification.blockId}
-                                            </span>
-                                        )}
-                                    </Stack>
-                                </Table.Cell>
-                                {showAccountColumn && (
-                                    <Table.Cell>
-                                        {notification.accountId ? (
-                                            <Link
-                                                href={KnownPages.Account(
-                                                    notification.accountId,
-                                                )}
-                                                className="text-primary underline"
-                                            >
-                                                {notification.accountLabel ??
-                                                    notification.accountId}
-                                            </Link>
-                                        ) : (
-                                            '-'
-                                        )}
-                                    </Table.Cell>
-                                )}
-                                <Table.Cell>
-                                    {notification.userId ? (
-                                        <Link
-                                            href={KnownPages.User(
-                                                notification.userId,
+                                                Mjesto
+                                            </Typography>
+                                            {hasLocation ? (
+                                                <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                                                    {notification.gardenId && (
+                                                        <Link
+                                                            href={KnownPages.Garden(
+                                                                notification.gardenId,
+                                                            )}
+                                                            className="min-w-0 break-words text-primary underline-offset-4 hover:underline"
+                                                        >
+                                                            {notification.gardenName ??
+                                                                'N/A'}
+                                                        </Link>
+                                                    )}
+                                                    {notification.raisedBedId && (
+                                                        <RaisedBedLabel
+                                                            physicalId={
+                                                                notification.raisedBedPhysicalId
+                                                            }
+                                                        />
+                                                    )}
+                                                    {notification.blockId && (
+                                                        <Typography
+                                                            component="span"
+                                                            level="body3"
+                                                            className="break-all"
+                                                        >
+                                                            Blok:{' '}
+                                                            {
+                                                                notification.blockId
+                                                            }
+                                                        </Typography>
+                                                    )}
+                                                </div>
+                                            ) : (
+                                                <Typography
+                                                    component="span"
+                                                    level="body3"
+                                                >
+                                                    -
+                                                </Typography>
                                             )}
-                                            className="text-primary underline"
+                                        </Stack>
+
+                                        {showAccountColumn && (
+                                            <Stack
+                                                spacing={1}
+                                                className="min-w-0"
+                                            >
+                                                <Typography
+                                                    component="span"
+                                                    level="body3"
+                                                    className="font-medium uppercase"
+                                                >
+                                                    Račun
+                                                </Typography>
+                                                {notification.accountId ? (
+                                                    <Link
+                                                        href={KnownPages.Account(
+                                                            notification.accountId,
+                                                        )}
+                                                        className="min-w-0 break-words text-primary underline-offset-4 hover:underline"
+                                                    >
+                                                        {notification.accountLabel ??
+                                                            notification.accountId}
+                                                    </Link>
+                                                ) : (
+                                                    <Typography
+                                                        component="span"
+                                                        level="body3"
+                                                    >
+                                                        -
+                                                    </Typography>
+                                                )}
+                                            </Stack>
+                                        )}
+
+                                        <Stack spacing={1} className="min-w-0">
+                                            <Typography
+                                                component="span"
+                                                level="body3"
+                                                className="font-medium uppercase"
+                                            >
+                                                Korisnik
+                                            </Typography>
+                                            {notification.userId ? (
+                                                <Link
+                                                    href={KnownPages.User(
+                                                        notification.userId,
+                                                    )}
+                                                    className="min-w-0 break-all text-primary underline-offset-4 hover:underline"
+                                                >
+                                                    {notification.userId}
+                                                </Link>
+                                            ) : (
+                                                <Typography
+                                                    component="span"
+                                                    level="body3"
+                                                >
+                                                    -
+                                                </Typography>
+                                            )}
+                                        </Stack>
+                                    </div>
+
+                                    <div className="flex min-w-0 flex-col gap-2 2xl:items-end">
+                                        <div className="flex min-w-0 flex-wrap items-center gap-2 2xl:justify-end">
+                                            <Chip
+                                                color={
+                                                    notification.readAt
+                                                        ? 'success'
+                                                        : 'neutral'
+                                                }
+                                                size="sm"
+                                                className="w-fit"
+                                            >
+                                                {notification.readAt
+                                                    ? 'Pročitano'
+                                                    : 'Nepročitano'}
+                                            </Chip>
+                                            <Chip
+                                                color="info"
+                                                size="sm"
+                                                variant="soft"
+                                                title="Kanal"
+                                            >
+                                                {getNotificationChannelLabel(
+                                                    notification.primaryChannel,
+                                                )}
+                                            </Chip>
+                                            <Chip
+                                                color="neutral"
+                                                size="sm"
+                                                variant="outlined"
+                                                className="shrink whitespace-normal break-words"
+                                                title="Tip"
+                                            >
+                                                {formatNotificationMeta(
+                                                    notification.type,
+                                                )}
+                                            </Chip>
+                                            <Chip
+                                                color="neutral"
+                                                size="sm"
+                                                variant="outlined"
+                                                className="shrink whitespace-normal break-words"
+                                                title="Kategorija"
+                                            >
+                                                {formatNotificationMeta(
+                                                    notification.category,
+                                                )}
+                                            </Chip>
+                                            <IconButton
+                                                type="button"
+                                                title="Obriši obavijest"
+                                                size="sm"
+                                                color="danger"
+                                                disabled={isPending}
+                                                onClick={() =>
+                                                    handleDelete([
+                                                        notification.id,
+                                                    ])
+                                                }
+                                            >
+                                                <Delete className="size-5" />
+                                            </IconButton>
+                                        </div>
+                                        <Stack
+                                            spacing={1}
+                                            className="min-w-0 2xl:items-end"
                                         >
-                                            {notification.userId}
-                                        </Link>
-                                    ) : (
-                                        '-'
-                                    )}
-                                </Table.Cell>
-                                <Table.Cell>
-                                    <Chip
-                                        color={
-                                            notification.readAt
-                                                ? 'success'
-                                                : 'neutral'
-                                        }
-                                        size="sm"
-                                        className="w-fit"
-                                    >
-                                        {notification.readAt
-                                            ? 'Pročitano'
-                                            : 'Nepročitano'}
-                                    </Chip>
-                                </Table.Cell>
-                                <Table.Cell>
-                                    <Typography level="body3">
-                                        <LocalDateTime>
-                                            {notification.createdAt}
-                                        </LocalDateTime>
-                                    </Typography>
-                                    {getCreatedTimestampDistance(notification) >
-                                        1000 && (
-                                        <Typography level="body3">
-                                            <LocalDateTime>
-                                                {notification.timestamp}
-                                            </LocalDateTime>
-                                        </Typography>
-                                    )}
-                                </Table.Cell>
-                                <Table.Cell>
-                                    <IconButton
-                                        type="button"
-                                        title="Obriši obavijest"
-                                        size="sm"
-                                        color="danger"
-                                        disabled={isPending}
-                                        onClick={() =>
-                                            handleDelete([notification.id])
-                                        }
-                                    >
-                                        <Delete className="size-5" />
-                                    </IconButton>
-                                </Table.Cell>
-                            </Table.Row>
+                                            <Typography
+                                                component="span"
+                                                level="body3"
+                                                className="text-muted-foreground 2xl:text-right"
+                                            >
+                                                Kreirano:{' '}
+                                                <span className="whitespace-nowrap">
+                                                    <LocalDateTime>
+                                                        {notification.createdAt}
+                                                    </LocalDateTime>
+                                                </span>
+                                            </Typography>
+                                            {getCreatedTimestampDistance(
+                                                notification,
+                                            ) > 1000 && (
+                                                <Typography
+                                                    component="span"
+                                                    level="body3"
+                                                    className="text-muted-foreground 2xl:text-right"
+                                                >
+                                                    Poslano:{' '}
+                                                    <span className="whitespace-nowrap">
+                                                        <LocalDateTime>
+                                                            {
+                                                                notification.timestamp
+                                                            }
+                                                        </LocalDateTime>
+                                                    </span>
+                                                </Typography>
+                                            )}
+                                        </Stack>
+                                    </div>
+                                </div>
+                            </li>
                         );
                     })}
-                </Table.Body>
-            </Table>
+                </ul>
+            )}
         </Stack>
     );
 }

--- a/apps/app/components/notifications/NotificationsTableCard.tsx
+++ b/apps/app/components/notifications/NotificationsTableCard.tsx
@@ -110,6 +110,7 @@ export async function NotificationsTableCard({
                   notification.accountId
                 : null,
             blockId: notification.blockId,
+            category: notification.category,
             content: notification.content,
             createdAt: notification.createdAt.toISOString(),
             gardenId: notification.gardenId,
@@ -125,6 +126,8 @@ export async function NotificationsTableCard({
                 : null,
             readAt: notification.readAt?.toISOString() ?? null,
             timestamp: notification.timestamp.toISOString(),
+            type: notification.type,
+            primaryChannel: notification.primaryChannel,
             userId: notification.userId,
         }),
     );


### PR DESCRIPTION
## Summary
- Replace the admin notifications table with compact responsive `ul`/`li` list rows.
- Preserve selection, bulk delete, row delete, empty state, links, recipient/location/account/user metadata, read status, notification type/category/channel chips, and created/sent date display.
- Keep the shared `NotificationsTable` contract usable from the main notifications route and detail-page card contexts.

## Validation
- `pnpm --filter app exec biome check --write components/notifications/NotificationsTable.tsx components/notifications/NotificationsTableCard.tsx`
- `pnpm typecheck --filter app`
- `pnpm --filter app exec tsc --ignoreConfig --noEmit --pretty false --jsx react-jsx --moduleResolution bundler --module esnext --target esnext --lib dom,dom.iterable,esnext --skipLibCheck --strict --esModuleInterop --allowJs --resolveJsonModule components/notifications/NotificationsTable.tsx components/notifications/NotificationsTableCard.tsx`
- `git diff --check`

Closes #3793