### PR TITLE
[App Admin] Migrate farmer documentation table to responsive list

### DIFF
--- a/apps/app/app/admin/farmers/documentation/DocumentationChangeTypeBadge.tsx
+++ b/apps/app/app/admin/farmers/documentation/DocumentationChangeTypeBadge.tsx
@@ -1,24 +1,26 @@
+import { Chip, type ColorPaletteProp } from '@gredice/ui/Chip';
 import {
     documentationChangeLabel,
     type FarmerDocumentationChangeType,
 } from './farmerDocumentationData';
+
+const documentationChangeColor: Record<
+    FarmerDocumentationChangeType,
+    ColorPaletteProp
+> = {
+    discard: 'error',
+    insert: 'success',
+    replace: 'info',
+};
 
 export function DocumentationChangeTypeBadge({
     type,
 }: {
     type: FarmerDocumentationChangeType;
 }) {
-    const className = {
-        discard: 'bg-red-100 text-red-800',
-        insert: 'bg-green-100 text-green-800',
-        replace: 'bg-blue-100 text-blue-800',
-    }[type];
-
     return (
-        <span
-            className={`rounded-md px-2 py-1 text-xs font-medium ${className}`}
-        >
+        <Chip color={documentationChangeColor[type]} size="sm" variant="soft">
             {documentationChangeLabel(type)}
-        </span>
+        </Chip>
     );
 }

--- a/apps/app/app/admin/farmers/documentation/page.tsx
+++ b/apps/app/app/admin/farmers/documentation/page.tsx
@@ -1,10 +1,15 @@
 import { Button } from '@gredice/ui/Button';
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardOverflow,
+    CardTitle,
+} from '@gredice/ui/Card';
 import { Book, Hammer, Printer, Sprout } from '@gredice/ui/icons';
 import { DropdownMenuItem } from '@gredice/ui/Menu';
 import { SplitButton } from '@gredice/ui/SplitButton';
 import { Stack } from '@gredice/ui/Stack';
-import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import { AdminPageHeader } from '../../../../components/admin/navigation';
 import { auth } from '../../../../lib/auth/auth';
@@ -210,48 +215,65 @@ export default async function FarmerDocumentationPage({
                 <CardHeader>
                     <CardTitle>Sadržaj paketa</CardTitle>
                 </CardHeader>
-                <CardContent className="p-0">
+                <CardOverflow className="border-t">
                     {packageRows.length > 0 ? (
-                        <Table>
-                            <Table.Header>
-                                <Table.Row>
-                                    <Table.Head>Kod</Table.Head>
-                                    <Table.Head>Priručnik</Table.Head>
-                                    <Table.Head>Vrsta</Table.Head>
-                                    <Table.Head>Status</Table.Head>
-                                    <Table.Head>Promjena</Table.Head>
-                                    <Table.Head>Sažetak</Table.Head>
-                                </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                                {packageRows.map((row) => (
-                                    <Table.Row
-                                        key={`${row.changeType}-${row.code}`}
-                                    >
-                                        <Table.Cell className="font-mono text-sm">
-                                            {row.code}
-                                        </Table.Cell>
-                                        <Table.Cell>{row.label}</Table.Cell>
-                                        <Table.Cell className="text-muted-foreground">
-                                            {row.documentTypeLabel}
-                                        </Table.Cell>
-                                        <Table.Cell>
+                        <ul className="divide-y">
+                            {packageRows.map((row) => (
+                                <li
+                                    key={`${row.changeType}-${row.code}`}
+                                    className="px-3 py-3 transition-colors hover:bg-muted/40 sm:px-4"
+                                >
+                                    <div className="flex min-w-0 flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                                        <Stack spacing={1} className="min-w-0">
+                                            <div className="flex min-w-0 flex-wrap items-center gap-2">
+                                                <span className="rounded-md bg-muted px-2 py-1 font-mono text-xs font-medium text-muted-foreground">
+                                                    {row.code}
+                                                </span>
+                                                <Typography
+                                                    component="span"
+                                                    level="body3"
+                                                    className="text-muted-foreground"
+                                                >
+                                                    {row.documentTypeLabel}
+                                                </Typography>
+                                            </div>
+                                            <Typography
+                                                level="body2"
+                                                semiBold
+                                                className="min-w-0 break-words"
+                                            >
+                                                {row.label}
+                                            </Typography>
+                                            <Typography
+                                                level="body3"
+                                                className="text-muted-foreground"
+                                            >
+                                                {row.detail}
+                                            </Typography>
+                                        </Stack>
+                                        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center lg:shrink-0 lg:justify-end">
                                             <DocumentationChangeTypeBadge
                                                 type={row.changeType}
                                             />
-                                        </Table.Cell>
-                                        <Table.Cell className="text-muted-foreground">
-                                            {formatDocumentationDateTime(
-                                                row.changedAt,
-                                            )}
-                                        </Table.Cell>
-                                        <Table.Cell className="text-muted-foreground">
-                                            {row.detail}
-                                        </Table.Cell>
-                                    </Table.Row>
-                                ))}
-                            </Table.Body>
-                        </Table>
+                                            <Typography
+                                                component="span"
+                                                level="body3"
+                                                className="text-muted-foreground lg:text-right"
+                                            >
+                                                <span className="sr-only">
+                                                    Promjena:{' '}
+                                                </span>
+                                                <span className="whitespace-nowrap">
+                                                    {formatDocumentationDateTime(
+                                                        row.changedAt,
+                                                    )}
+                                                </span>
+                                            </Typography>
+                                        </div>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
                     ) : (
                         <div className="p-6">
                             <Typography
@@ -263,7 +285,7 @@ export default async function FarmerDocumentationPage({
                             </Typography>
                         </div>
                     )}
-                </CardContent>
+                </CardOverflow>
             </Card>
         </Stack>
     );


### PR DESCRIPTION
## Summary

- Replaced the farmer documentation package table with compact divided list rows.
- Kept the existing auth, data loading, date filter, summary cards, print actions, row sort order, status/date/detail metadata, and empty state intact.
- Reused existing `CardOverflow`, `Stack`, `Typography`, and `Chip` primitives for the responsive admin list presentation.

## Validation

- `pnpm typecheck --filter app` passed for the available Turbo-filtered tasks.
- `pnpm --filter app exec biome check app/admin/farmers/documentation/page.tsx app/admin/farmers/documentation/DocumentationChangeTypeBadge.tsx` passed.
- `git diff --check` passed.
- Direct `pnpm --filter app exec tsc --noEmit --pretty false` still fails on existing app-wide errors outside the edited page/badge; the touched files no longer appear in that error output.
- Local browser verification of `/admin/farmers/documentation` was attempted at 360px, but the browser-control navigation timed out without actionable server logs, so visual verification is not included here.

Closes #3797