### PR TITLE
[App Admin] Migrate inventory items table to responsive list

### DIFF
--- a/apps/app/app/admin/inventory/[inventoryId]/InventoryItemsTable.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/InventoryItemsTable.tsx
@@ -1,9 +1,20 @@
 'use client';
 
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
 import { Input } from '@gredice/ui/Input';
-import { Edit, Search } from '@gredice/ui/icons';
+import { ArrowDown, ArrowUp, Edit, Search, Select } from '@gredice/ui/icons';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@gredice/ui/Menu';
 import { Row } from '@gredice/ui/Row';
-import { Table } from '@gredice/ui/Table';
+import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import { useState } from 'react';
 import { InventoryQuantityValue } from '../../../../components/shared/inventory/InventoryQuantityValue';
@@ -31,6 +42,10 @@ type SortKey = 'entity' | 'serialNumber' | 'quantity' | 'notes' | 'createdAt';
 type SortState = {
     key: SortKey;
     direction: SortDirection;
+};
+type SortOption = {
+    key: SortKey;
+    label: string;
 };
 
 const defaultSort: SortState = {
@@ -69,7 +84,19 @@ export function InventoryItemsTable({
     const sortedItems = [...filteredItems].sort((left, right) =>
         compareInventoryItems(left, right, sort),
     );
-    const columnCount = tracksSerialNumbers ? 5 : 4;
+    const sortOptions: SortOption[] = [
+        { key: 'createdAt', label: 'Datum dodavanja' },
+        { key: 'entity', label: 'Entitet' },
+        { key: 'quantity', label: 'Količina' },
+        { key: 'notes', label: 'Bilješke' },
+    ];
+
+    if (tracksSerialNumbers) {
+        sortOptions.splice(2, 0, {
+            key: 'serialNumber',
+            label: 'Serijski br.',
+        });
+    }
     const emptyMessage =
         items.length === 0
             ? 'Nema stavki u zalihi. Dodajte prvu stavku.'
@@ -77,139 +104,250 @@ export function InventoryItemsTable({
               ? 'Nema stavki za odabrano stanje zalihe.'
               : 'Nema stavki za upisanu pretragu.';
 
-    function handleSort(key: SortKey) {
+    function updateSortKey(key: SortKey) {
         setSort((current) =>
             current.key === key
-                ? {
-                      key,
-                      direction: current.direction === 'asc' ? 'desc' : 'asc',
-                  }
+                ? current
                 : { key, direction: defaultSortDirection(key) },
         );
     }
 
-    function sortableHead(key: SortKey, label: string) {
-        const isSorted = sort.key === key;
-        const directionLabel = sort.direction === 'asc' ? 'uzlazno' : 'silazno';
-
-        return (
-            <Table.Head
-                aria-sort={
-                    isSorted
-                        ? sort.direction === 'asc'
-                            ? 'ascending'
-                            : 'descending'
-                        : 'none'
-                }
-            >
-                <button
-                    type="button"
-                    className="flex items-center gap-1 rounded-xs text-left font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-                    onClick={() => handleSort(key)}
-                    aria-label={`Sortiraj ${label.toLowerCase()}`}
-                >
-                    <span>{label}</span>
-                    {isSorted && (
-                        <>
-                            <span aria-hidden>
-                                {sort.direction === 'asc' ? '↑' : '↓'}
-                            </span>
-                            <span className="sr-only">
-                                Sortirano {directionLabel}
-                            </span>
-                        </>
-                    )}
-                </button>
-            </Table.Head>
-        );
+    function toggleSortDirection() {
+        setSort((current) => ({
+            ...current,
+            direction: current.direction === 'asc' ? 'desc' : 'asc',
+        }));
     }
 
     return (
-        <>
-            <div className="border-b px-4 py-3">
-                <Input
-                    aria-label="Pretraži stavke po nazivu ili bilješkama"
-                    className="w-full md:min-w-80"
-                    onChange={(event) => setSearchQuery(event.target.value)}
-                    placeholder="Pretraži naziv ili bilješke"
-                    startDecorator={<Search className="ml-3 size-4 shrink-0" />}
-                    value={searchQuery}
-                />
+        <div className="min-w-0">
+            <div className="flex min-w-0 flex-col gap-3 border-b bg-card px-3 py-3 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center">
+                    <Input
+                        aria-label="Pretraži stavke po nazivu ili bilješkama"
+                        className="w-full sm:w-80"
+                        onChange={(event) => setSearchQuery(event.target.value)}
+                        placeholder="Pretraži naziv ili bilješke"
+                        startDecorator={
+                            <Search className="ml-3 size-4 shrink-0" />
+                        }
+                        value={searchQuery}
+                    />
+                    <Row spacing={2} className="min-w-0 flex-wrap">
+                        <Chip color="neutral" size="sm" variant="soft">
+                            {sortedItems.length}
+                        </Chip>
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Stavke
+                        </Typography>
+                    </Row>
+                </div>
+                <Row
+                    spacing={2}
+                    className="min-w-0 flex-wrap justify-start lg:justify-end"
+                >
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                type="button"
+                                variant="outlined"
+                                size="sm"
+                                color="neutral"
+                                className="rounded-full"
+                                endDecorator={<Select className="size-4" />}
+                            >
+                                Sortiraj: {sortLabel(sortOptions, sort.key)}
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-64">
+                            <DropdownMenuLabel>Sortiraj po</DropdownMenuLabel>
+                            <DropdownMenuSeparator />
+                            {sortOptions.map((option) => (
+                                <DropdownMenuItem
+                                    key={option.key}
+                                    className="cursor-pointer justify-between gap-3"
+                                    onClick={() => updateSortKey(option.key)}
+                                >
+                                    <span className="min-w-0 truncate">
+                                        {option.label}
+                                    </span>
+                                    {sort.key === option.key ? (
+                                        <span
+                                            className="size-2 shrink-0 rounded-full bg-primary"
+                                            aria-hidden
+                                        />
+                                    ) : null}
+                                </DropdownMenuItem>
+                            ))}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                    <Button
+                        type="button"
+                        variant="outlined"
+                        size="sm"
+                        color="neutral"
+                        className="rounded-full"
+                        startDecorator={
+                            sort.direction === 'asc' ? (
+                                <ArrowUp className="size-4" />
+                            ) : (
+                                <ArrowDown className="size-4" />
+                            )
+                        }
+                        onClick={toggleSortDirection}
+                        aria-label={`Sortirano ${
+                            sort.direction === 'asc' ? 'uzlazno' : 'silazno'
+                        }. Promijeni smjer sortiranja.`}
+                    >
+                        {sort.direction === 'asc' ? 'Uzlazno' : 'Silazno'}
+                    </Button>
+                </Row>
             </div>
-            <Table>
-                <Table.Header>
-                    <Table.Row>
-                        {sortableHead('entity', 'Entitet')}
-                        {tracksSerialNumbers &&
-                            sortableHead('serialNumber', 'Serijski br.')}
-                        {sortableHead('quantity', 'Količina')}
-                        {sortableHead('notes', 'Bilješke')}
-                        <Table.Head />
-                    </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                    {sortedItems.length === 0 && (
-                        <Table.Row>
-                            <Table.Cell colSpan={columnCount}>
-                                <NoDataPlaceholder>
-                                    {emptyMessage}
-                                </NoDataPlaceholder>
-                            </Table.Cell>
-                        </Table.Row>
-                    )}
-                    {sortedItems.map((item) => (
-                        <Table.Row key={item.id}>
-                            <Table.Cell>
-                                {item.entityId ? (
-                                    <Link
-                                        href={KnownPages.DirectoryEntity(
-                                            entityTypeName,
-                                            item.entityId,
-                                        )}
-                                        className="text-primary hover:underline"
-                                    >
-                                        {inventoryItemName(
-                                            item,
-                                            entityTypeName,
-                                        )}
-                                    </Link>
-                                ) : (
-                                    '-'
-                                )}
-                            </Table.Cell>
-                            {tracksSerialNumbers && (
-                                <Table.Cell>
-                                    {item.serialNumber ?? '-'}
-                                </Table.Cell>
-                            )}
-                            <Table.Cell>
-                                <InventoryQuantityValue
-                                    quantity={item.quantity}
-                                    lowCountThreshold={item.lowCountThreshold}
-                                />
-                            </Table.Cell>
-                            <Table.Cell>{item.notes ?? '-'}</Table.Cell>
-                            <Table.Cell>
-                                <Row spacing={2}>
-                                    <Link
-                                        href={KnownPages.InventoryItem(
-                                            inventoryConfigId,
-                                            item.id,
-                                        )}
-                                    >
-                                        <Edit className="size-4 text-muted-foreground hover:text-foreground" />
-                                    </Link>
-                                    <DeleteInventoryItemButton
-                                        inventoryConfigId={inventoryConfigId}
-                                        itemId={item.id}
-                                    />
-                                </Row>
-                            </Table.Cell>
-                        </Table.Row>
-                    ))}
-                </Table.Body>
-            </Table>
-        </>
+
+            {sortedItems.length === 0 ? (
+                <div className="p-4">
+                    <NoDataPlaceholder>{emptyMessage}</NoDataPlaceholder>
+                </div>
+            ) : (
+                <ul className="divide-y">
+                    {sortedItems.map((item) => {
+                        const itemState = getInventoryItemState(item);
+
+                        return (
+                            <li
+                                key={item.id}
+                                className="group px-3 py-3 transition-colors hover:bg-muted/40 sm:px-4"
+                            >
+                                <div className="flex min-w-0 flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                                    <div className="min-w-0 flex-1 space-y-2">
+                                        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center">
+                                            <Typography
+                                                component="h3"
+                                                level="body1"
+                                                semiBold
+                                                className="min-w-0"
+                                            >
+                                                {item.entityId ? (
+                                                    <Link
+                                                        href={KnownPages.DirectoryEntity(
+                                                            entityTypeName,
+                                                            item.entityId,
+                                                        )}
+                                                        className="min-w-0 break-words text-primary underline-offset-4 hover:underline"
+                                                    >
+                                                        {inventoryItemName(
+                                                            item,
+                                                            entityTypeName,
+                                                        )}
+                                                    </Link>
+                                                ) : (
+                                                    <span className="text-muted-foreground">
+                                                        Bez entiteta
+                                                    </span>
+                                                )}
+                                            </Typography>
+                                            <Chip
+                                                color="neutral"
+                                                size="sm"
+                                                variant="outlined"
+                                            >
+                                                #{item.id}
+                                            </Chip>
+                                        </div>
+
+                                        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+                                            {tracksSerialNumbers ? (
+                                                <span className="inline-flex min-w-0 max-w-full items-center gap-1">
+                                                    <span className="shrink-0">
+                                                        Serijski br.:
+                                                    </span>
+                                                    <span className="min-w-0 truncate text-foreground">
+                                                        {item.serialNumber ??
+                                                            '-'}
+                                                    </span>
+                                                </span>
+                                            ) : null}
+                                            <span className="inline-flex min-w-0 max-w-full items-start gap-1">
+                                                <span className="shrink-0">
+                                                    Bilješke:
+                                                </span>
+                                                <span className="min-w-0 break-words text-foreground">
+                                                    {item.notes ?? '-'}
+                                                </span>
+                                            </span>
+                                        </div>
+                                    </div>
+
+                                    <div className="flex min-w-0 flex-wrap items-center justify-start gap-2 lg:justify-end">
+                                        <Chip
+                                            color={inventoryItemStateColor(
+                                                itemState,
+                                            )}
+                                            size="sm"
+                                            variant="soft"
+                                        >
+                                            {inventoryItemStateLabel(itemState)}
+                                        </Chip>
+                                        <Chip
+                                            color="neutral"
+                                            size="sm"
+                                            variant="outlined"
+                                        >
+                                            Količina:{' '}
+                                            <InventoryQuantityValue
+                                                quantity={item.quantity}
+                                                lowCountThreshold={
+                                                    item.lowCountThreshold
+                                                }
+                                            />
+                                        </Chip>
+                                        <Typography
+                                            component="div"
+                                            level="body3"
+                                            className="whitespace-nowrap text-muted-foreground"
+                                        >
+                                            Kreirano:{' '}
+                                            <LocalDateTime time={false}>
+                                                {item.createdAt}
+                                            </LocalDateTime>
+                                        </Typography>
+                                        <Row spacing={1} className="shrink-0">
+                                            <Link
+                                                href={KnownPages.InventoryItem(
+                                                    inventoryConfigId,
+                                                    item.id,
+                                                )}
+                                                className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                title="Uredi stavku"
+                                                aria-label={`Uredi stavku #${item.id}`}
+                                            >
+                                                <Edit className="size-4" />
+                                            </Link>
+                                            <DeleteInventoryItemButton
+                                                inventoryConfigId={
+                                                    inventoryConfigId
+                                                }
+                                                itemId={item.id}
+                                            />
+                                        </Row>
+                                    </div>
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </div>
+    );
+}
+
+function sortLabel(sortOptions: SortOption[], sortKey: SortKey) {
+    return (
+        sortOptions.find((option) => option.key === sortKey)?.label ??
+        'Datum dodavanja'
     );
 }
 
@@ -298,4 +436,28 @@ function compareSortValues(left: string | number, right: string | number) {
 
 function defaultSortDirection(key: SortKey): SortDirection {
     return key === 'quantity' || key === 'createdAt' ? 'desc' : 'asc';
+}
+
+function inventoryItemStateColor(state: InventoryStateFilter) {
+    if (state === 'critical') {
+        return 'error';
+    }
+
+    if (state === 'warning') {
+        return 'warning';
+    }
+
+    return 'success';
+}
+
+function inventoryItemStateLabel(state: InventoryStateFilter) {
+    if (state === 'critical') {
+        return 'Kritično';
+    }
+
+    if (state === 'warning') {
+        return 'Upozorenje';
+    }
+
+    return 'OK';
 }


### PR DESCRIPTION
## Summary

- Replaced the inventory items table on `/admin/inventory/[inventoryId]` with compact responsive `ul.divide-y` list rows.
- Moved sort behavior into toolbar controls above the list, preserving entity, optional serial number, quantity, notes, and created-date sorting.
- Preserved local search, URL-backed state filtering, entity/item links, edit/delete actions, quantity warnings, status metadata, created-date metadata, and empty states.

Closes #3807

## Validation

- `pnpm typecheck --filter app` passed. Note: the app package currently has no own `typecheck` task, so Turbo replayed/checks dependency typechecks in scope.
- `pnpm --filter app exec biome check 'app/admin/inventory/[inventoryId]/InventoryItemsTable.tsx'` passed.
- `git diff --check` passed.
- `pnpm --filter app exec tsc --noEmit --pretty false` still fails on existing unrelated project errors, including `PageProps` missing in several admin pages, notification composer prop/action typing, `AddFieldDefinitionForm` Stack `direction`, and generated fiscalization `export type` errors. No errors are reported for `InventoryItemsTable.tsx` after the fix.