### PR TITLE
feat(app): add farm schedule bulk actions

### DIFF
--- a/apps/app/app/admin/schedule/BulkApproveRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkApproveRaisedBedButton.tsx
@@ -21,6 +21,7 @@ type OperationApprovalTarget = {
 
 interface BulkApproveRaisedBedButtonProps {
     physicalId: string;
+    targetLabel?: string;
     fields: FieldApprovalTarget[];
     operations: OperationApprovalTarget[];
     onConfirm?: () => unknown | Promise<unknown>;
@@ -28,6 +29,7 @@ interface BulkApproveRaisedBedButtonProps {
 
 export function BulkApproveRaisedBedButton({
     physicalId,
+    targetLabel,
     fields,
     operations,
     onConfirm,
@@ -36,6 +38,9 @@ export function BulkApproveRaisedBedButton({
 
     const totalItems = fields.length + operations.length;
     const disabled = totalItems === 0 || isSubmitting;
+    const targetText =
+        targetLabel ??
+        (physicalId === 'dan' ? 'za dan' : `za gredicu ${physicalId}`);
 
     const handleConfirm = async () => {
         if (totalItems === 0) {
@@ -70,13 +75,13 @@ export function BulkApproveRaisedBedButton({
         <AcceptRequestModal
             title="Potvrda zadataka"
             header="Potvrda zadataka"
-            label={`sve zadatke (${totalItems}) za gredicu ${physicalId}`}
+            label={`sve zadatke (${totalItems}) ${targetText}`}
             onConfirm={handleConfirm}
             trigger={
                 <IconButton
                     variant="plain"
                     size="xs"
-                    title="Potvrdi sve zadatke gredice"
+                    title="Potvrdi sve zadatke"
                     disabled={disabled}
                     aria-disabled={disabled}
                     loading={isSubmitting}

--- a/apps/app/app/admin/schedule/BulkAssignRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkAssignRaisedBedButton.tsx
@@ -38,6 +38,7 @@ type OperationAssignmentTarget = {
 
 interface BulkAssignRaisedBedButtonProps {
     physicalId: string;
+    targetLabel?: string;
     fields: FieldAssignmentTarget[];
     operations: OperationAssignmentTarget[];
     onSubmit?: (assignedUserIds: string[]) => unknown | Promise<unknown>;
@@ -51,6 +52,7 @@ function getUserLabel(user: AssignableUser) {
 
 export function BulkAssignRaisedBedButton({
     physicalId,
+    targetLabel,
     fields,
     operations,
     onSubmit,
@@ -62,6 +64,9 @@ export function BulkAssignRaisedBedButton({
 
     const totalItems = fields.length + operations.length;
     const disabled = totalItems === 0 || isSubmitting;
+    const targetText =
+        targetLabel ??
+        (physicalId === 'dan' ? 'za dan' : `za gredicu ${physicalId}`);
 
     const selectableUsers = useMemo(() => {
         const targetUsers = [...fields, ...operations].map(
@@ -155,7 +160,7 @@ export function BulkAssignRaisedBedButton({
                 <IconButton
                     variant="plain"
                     size="xs"
-                    title="Dodijeli korisnika svim nepotvrđenim zadacima gredice"
+                    title="Dodijeli korisnika svim zadacima"
                     disabled={disabled}
                     aria-disabled={disabled}
                     loading={isSubmitting}
@@ -167,8 +172,7 @@ export function BulkAssignRaisedBedButton({
             <Stack spacing={4}>
                 <Typography level="h5">Skupna dodjela korisnika</Typography>
                 <Typography>
-                    Odaberi korisnika za sve nepotvrđene zadatke ({totalItems})
-                    za gredicu <strong>{physicalId}</strong>.
+                    {`Odaberi korisnika za sve zadatke (${totalItems}) ${targetText}.`}
                 </Typography>
 
                 <UserPickerField

--- a/apps/app/app/admin/schedule/BulkCancelRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkCancelRaisedBedButton.tsx
@@ -23,6 +23,7 @@ export type OperationCancelTarget = {
 
 interface BulkCancelRaisedBedButtonProps {
     physicalId: string;
+    targetLabel?: string;
     fields: FieldCancelTarget[];
     operations: OperationCancelTarget[];
     onSubmit?: (formData: FormData) => unknown | Promise<unknown>;
@@ -70,14 +71,16 @@ export function buildOperationCancelFormData(
 
 export function BulkCancelRaisedBedButton({
     physicalId,
+    targetLabel,
     fields,
     operations,
     onSubmit,
 }: BulkCancelRaisedBedButtonProps) {
     const totalItems = fields.length + operations.length;
     const disabled = totalItems === 0;
-    const targetLabel =
-        physicalId === 'dan' ? 'za dan' : `za gredicu ${physicalId}`;
+    const targetText =
+        targetLabel ??
+        (physicalId === 'dan' ? 'za dan' : `za gredicu ${physicalId}`);
 
     async function handleSubmit(formData: FormData) {
         if (totalItems === 0) {
@@ -105,7 +108,7 @@ export function BulkCancelRaisedBedButton({
 
     return (
         <CancelRequestModal
-            label={`sve zadatke (${totalItems}) ${targetLabel}`}
+            label={`sve zadatke (${totalItems}) ${targetText}`}
             onSubmit={handleSubmit}
             hiddenFields={null}
             description={`Svi odabrani zadaci (${totalItems}) bit će otkazani.`}

--- a/apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx
+++ b/apps/app/app/admin/schedule/BulkRescheduleRaisedBedButton.tsx
@@ -24,6 +24,7 @@ type OperationRescheduleTarget = {
 
 interface BulkRescheduleRaisedBedButtonProps {
     physicalId: string;
+    targetLabel?: string;
     fields: FieldRescheduleTarget[];
     operations: OperationRescheduleTarget[];
     onSubmit?: (scheduledDate: string) => unknown | Promise<unknown>;
@@ -38,6 +39,7 @@ function formatLocalDate(date: Date): string {
 
 export function BulkRescheduleRaisedBedButton({
     physicalId,
+    targetLabel,
     fields,
     operations,
     onSubmit,
@@ -47,6 +49,9 @@ export function BulkRescheduleRaisedBedButton({
 
     const totalItems = fields.length + operations.length;
     const disabled = totalItems === 0 || isSubmitting;
+    const targetText =
+        targetLabel ??
+        (physicalId === 'dan' ? 'za dan' : `za gredicu ${physicalId}`);
 
     const today = new Date();
     const threeMonthsFromToday = new Date(
@@ -117,7 +122,7 @@ export function BulkRescheduleRaisedBedButton({
                 <IconButton
                     variant="plain"
                     size="xs"
-                    title="Zakaži sve nepotvrđene zadatke gredice"
+                    title="Zakaži sve nepotvrđene zadatke"
                     disabled={disabled}
                     aria-disabled={disabled}
                     loading={isSubmitting}
@@ -131,7 +136,7 @@ export function BulkRescheduleRaisedBedButton({
                     <Typography level="h5">Skupno zakazivanje</Typography>
                     <Typography>
                         Odaberite datum za sve nepotvrđene zadatke ({totalItems}
-                        ) za gredicu <strong>{physicalId}</strong>.
+                        ) {targetText}.
                     </Typography>
 
                     <Input

--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -23,6 +23,13 @@ import {
 } from '../../(actions)/operationActions';
 import { AcceptOperationModal } from './AcceptOperationModal';
 import { AssignOperationModal } from './AssignOperationModal';
+import { BulkApproveRaisedBedButton } from './BulkApproveRaisedBedButton';
+import { BulkAssignRaisedBedButton } from './BulkAssignRaisedBedButton';
+import {
+    BulkCancelRaisedBedButton,
+    buildOperationCancelFormData,
+} from './BulkCancelRaisedBedButton';
+import { BulkRescheduleRaisedBedButton } from './BulkRescheduleRaisedBedButton';
 import { CancelOperationModal } from './CancelOperationModal';
 import { CompleteOperationModal } from './CompleteOperationModal';
 import { OperationCompletionAttachments } from './OperationCompletionAttachments';
@@ -112,6 +119,56 @@ export function FarmOperationsScheduleSection({
         return null;
     }
 
+    const operationById = new Map(
+        dayOperations.map((operation) => [operation.id, operation]),
+    );
+    const farmTargetLabel = `za farmu ${farm.name}`;
+    const operationsToApprove = dayOperations
+        .filter(
+            (operation) =>
+                !operation.isAccepted &&
+                !isOperationCompleted(operation.status) &&
+                !isOperationCancelled(operation.status) &&
+                !!operation.assignedUserId,
+        )
+        .map((operation) => ({
+            id: operation.id,
+            label: getOperationLabel(operation, operationDataById),
+        }));
+    const operationsToReschedule = dayOperations
+        .filter(
+            (operation) =>
+                !operation.isAccepted &&
+                !isOperationCompleted(operation.status) &&
+                !isOperationCancelled(operation.status),
+        )
+        .map((operation) => ({
+            id: operation.id,
+        }));
+    const operationsToAssign = dayOperations
+        .filter(
+            (operation) =>
+                !isOperationCompleted(operation.status) &&
+                !isOperationPendingVerification(operation.status) &&
+                !isOperationCancelled(operation.status),
+        )
+        .map((operation) => ({
+            id: operation.id,
+            farmUsers: assignableFarmUsersByOperationId[operation.id] ?? [],
+        }));
+    const operationsToCancel = dayOperations
+        .filter(
+            (operation) =>
+                !isOperationCompleted(operation.status) &&
+                !isOperationPendingVerification(operation.status) &&
+                !isOperationCancelled(operation.status) &&
+                operation.status !== 'failed',
+        )
+        .map((operation) => ({
+            id: operation.id,
+            label: getOperationLabel(operation, operationDataById),
+        }));
+
     const totalDuration = dayOperations.reduce(
         (sum, operation) =>
             sum +
@@ -124,17 +181,175 @@ export function FarmOperationsScheduleSection({
     return (
         <Stack spacing={2}>
             <Row spacing={2} className="w-full items-center flex-wrap gap-y-1">
-                <Link href={KnownPages.Farm(farm.id)}>
-                    <Typography semiBold>{farm.name}</Typography>
-                </Link>
-                <Typography level="body2" className="text-muted-foreground">
-                    {dayOperations.length} zadataka
-                </Typography>
-                {totalDuration > 0 && (
+                <Row
+                    spacing={2}
+                    className="min-w-0 grow items-center flex-wrap gap-y-1"
+                >
+                    <Link href={KnownPages.Farm(farm.id)}>
+                        <Typography semiBold>{farm.name}</Typography>
+                    </Link>
                     <Typography level="body2" className="text-muted-foreground">
-                        Vrijeme: {formatMinutes(totalDuration)}
+                        {dayOperations.length} zadataka
                     </Typography>
-                )}
+                    {totalDuration > 0 && (
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            Vrijeme: {formatMinutes(totalDuration)}
+                        </Typography>
+                    )}
+                </Row>
+                <Row spacing={1} className="ml-auto shrink-0 items-center">
+                    <BulkApproveRaisedBedButton
+                        physicalId={farm.id.toString()}
+                        targetLabel={farmTargetLabel}
+                        fields={[]}
+                        operations={operationsToApprove}
+                        onConfirm={() =>
+                            runOptimisticAction({
+                                operationPatches: operationsToApprove.map(
+                                    (operation) => ({
+                                        id: operation.id,
+                                        patch: { isAccepted: true },
+                                    }),
+                                ),
+                                action: () =>
+                                    Promise.all(
+                                        operationsToApprove.map((operation) =>
+                                            acceptOperationAction(operation.id),
+                                        ),
+                                    ),
+                                errorLogMessage:
+                                    'Failed to approve all farm operation items:',
+                                errorAlertMessage:
+                                    'Skupna potvrda radnji nije uspjela. Promjena je vraćena.',
+                            })
+                        }
+                    />
+                    <BulkAssignRaisedBedButton
+                        physicalId={farm.id.toString()}
+                        targetLabel={farmTargetLabel}
+                        fields={[]}
+                        operations={operationsToAssign}
+                        onSubmit={(assignedUserIds) =>
+                            runOptimisticAction({
+                                operationPatches: operationsToAssign.map(
+                                    (operation) => {
+                                        const currentOperation =
+                                            operationById.get(operation.id);
+                                        const assignedUsers =
+                                            createOperationAssignedUsers(
+                                                assignedUserIds,
+                                                operation.farmUsers,
+                                                currentOperation?.assignedUsers,
+                                            );
+
+                                        return {
+                                            id: operation.id,
+                                            patch: {
+                                                assignedUser:
+                                                    assignedUsers[0] ?? null,
+                                                assignedUserId:
+                                                    assignedUserIds[0] ?? null,
+                                                assignedUserIds,
+                                                assignedUsers,
+                                            },
+                                        };
+                                    },
+                                ),
+                                action: () =>
+                                    Promise.all(
+                                        operationsToAssign.map((operation) =>
+                                            assignOperationUserAction(
+                                                operation.id,
+                                                assignedUserIds,
+                                            ),
+                                        ),
+                                    ),
+                                errorLogMessage:
+                                    'Failed to assign users for all farm operation items:',
+                                errorAlertMessage:
+                                    'Skupna dodjela radnji nije uspjela. Promjena je vraćena.',
+                            })
+                        }
+                    />
+                    <BulkRescheduleRaisedBedButton
+                        physicalId={farm.id.toString()}
+                        targetLabel={farmTargetLabel}
+                        fields={[]}
+                        operations={operationsToReschedule}
+                        onSubmit={(scheduledDate) =>
+                            runOptimisticAction({
+                                operationPatches: operationsToReschedule.map(
+                                    (operation) => ({
+                                        id: operation.id,
+                                        patch: {
+                                            scheduledDate:
+                                                parseScheduledDateInput(
+                                                    scheduledDate,
+                                                ),
+                                        },
+                                    }),
+                                ),
+                                action: () =>
+                                    Promise.all(
+                                        operationsToReschedule.map(
+                                            (operation) => {
+                                                const formData = new FormData();
+                                                formData.set(
+                                                    'operationId',
+                                                    operation.id.toString(),
+                                                );
+                                                formData.set(
+                                                    'scheduledDate',
+                                                    scheduledDate,
+                                                );
+                                                return rescheduleOperationAction(
+                                                    formData,
+                                                );
+                                            },
+                                        ),
+                                    ),
+                                errorLogMessage:
+                                    'Failed to reschedule all farm operation items:',
+                                errorAlertMessage:
+                                    'Skupno zakazivanje radnji nije uspjelo. Promjena je vraćena.',
+                            })
+                        }
+                    />
+                    <BulkCancelRaisedBedButton
+                        physicalId={farm.id.toString()}
+                        targetLabel={farmTargetLabel}
+                        fields={[]}
+                        operations={operationsToCancel}
+                        onSubmit={(formData) =>
+                            runOptimisticAction({
+                                operationPatches: operationsToCancel.map(
+                                    (operation) => ({
+                                        id: operation.id,
+                                        patch: { status: 'canceled' },
+                                    }),
+                                ),
+                                action: () =>
+                                    Promise.all(
+                                        operationsToCancel.map((operation) =>
+                                            cancelOperationAction(
+                                                buildOperationCancelFormData(
+                                                    operation,
+                                                    formData,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                errorLogMessage:
+                                    'Failed to cancel all farm operation items:',
+                                errorAlertMessage:
+                                    'Skupno otkazivanje radnji nije uspjelo. Promjena je vraćena.',
+                            })
+                        }
+                    />
+                </Row>
             </Row>
             <Stack spacing={0}>
                 {dayOperations.map((operation) => {


### PR DESCRIPTION
## What changed

- Added farm-level bulk controls on the admin schedule page for approving, assigning, scheduling, and canceling farm tasks.
- Reused the existing schedule bulk action buttons and optimistic rollback flow for farm operations.
- Made the shared bulk action dialogs accept scope-specific labels so farm task modals do not refer to a raised bed.

## Impact

Farm task groups in `apps/app` schedule now support the same dense batch workflow as raised-bed operation groups, reducing repeated per-row actions for operations staff.

## Validation

- `corepack pnpm --filter app exec biome check --write app/admin/schedule/FarmOperationsScheduleSection.tsx app/admin/schedule/BulkApproveRaisedBedButton.tsx app/admin/schedule/BulkAssignRaisedBedButton.tsx app/admin/schedule/BulkCancelRaisedBedButton.tsx app/admin/schedule/BulkRescheduleRaisedBedButton.tsx`
- `git diff --check`
- `corepack pnpm --filter app exec tsc --noEmit --pretty false` currently fails on existing unrelated repo errors; reran with an output filter for the touched schedule files and got no matches.