### PR TITLE
Neutralize www user-facing copy

### DIFF
--- a/apps/www/app/[...slug]/sourceCmsPages.ts
+++ b/apps/www/app/[...slug]/sourceCmsPages.ts
@@ -192,9 +192,9 @@ export const qualityHarvestSafetyCmsPage: SourceCmsPage = {
         {
             component: 'TextBlock',
             tagline: 'Model usluge',
-            header: 'Urod ostaje korisnikov urod',
+            header: 'Urod ostaje tvoj urod',
             description:
-                'Gredice pružaju uslugu planiranja, uzgoja, njege, berbe i dostave uroda naručitelju. U trenutnom modelu urod ne predstavljamo kao vlastiti gotov prehrambeni proizvod, nego kao svježe ubrano povrće i bilje koje korisnik preuzima i priprema za vlastitu upotrebu.',
+                'Gredice pružaju uslugu planiranja, uzgoja, njege, berbe i dostave tvojeg uroda. U trenutnom modelu urod ne predstavljamo kao vlastiti gotov prehrambeni proizvod, nego kao svježe ubrano povrće i bilje koje preuzimaš i pripremaš za vlastitu upotrebu.',
         },
         {
             component: 'Feature1',
@@ -231,7 +231,7 @@ export const qualityHarvestSafetyCmsPage: SourceCmsPage = {
                     iconName: 'traceability',
                     header: 'Sljedivost',
                     description:
-                        'Povezivanje korisnika, gredice, sezone, berbe i dostave kako bi se u slučaju pitanja moglo provjeriti što se dogodilo.',
+                        'Povezivanje računa, gredice, sezone, berbe i dostave kako bi se u slučaju pitanja moglo provjeriti što se dogodilo.',
                 },
                 {
                     iconName: 'deviation',
@@ -246,7 +246,7 @@ export const qualityHarvestSafetyCmsPage: SourceCmsPage = {
             tagline: 'Obvezna napomena',
             header: 'Svježi urod treba oprati i pripremiti prije konzumacije',
             description:
-                'Urod je svježe ubrano povrće i bilje. Prije konzumacije korisnik ga treba oprati i pripremiti na uobičajen higijenski način.',
+                'Urod je svježe ubrano povrće i bilje. Prije konzumacije treba ga oprati i pripremiti na uobičajen higijenski način.',
         },
         {
             component: 'MarkdownBlock',
@@ -261,24 +261,24 @@ export const qualityHarvestSafetyCmsPage: SourceCmsPage = {
                 'Najkraći odgovori na pitanja o načinu rada, higijeni i granici javnih tvrdnji.',
             features: [
                 {
-                    header: 'Komunicirate li formalnu HACCP certifikaciju?',
+                    header: 'Postoji li formalna HACCP certifikacija?',
                     description:
                         'Ne. Trenutno govorimo o internim postupcima temeljenima na dobroj praksi, sljedivosti, evidencijama, korektivnim radnjama i načelima HACCP-a.',
                 },
                 {
-                    header: 'Znači li to da ne pratite sigurnost uroda?',
+                    header: 'Znači li to da se sigurnost uroda ne prati?',
                     description:
                         'Ne. Pratimo rizike, čistoću, rukovanje, berbu, dostavu i prigovore kako bi se svaka sumnja mogla procijeniti i zapisati.',
                 },
                 {
                     header: 'Može li se urod jesti bez pranja?',
                     description:
-                        'Ne komuniciramo takvu tvrdnju. Urod je svježe ubrano povrće i bilje koje korisnik prije konzumacije treba oprati i pripremiti.',
+                        'Ne komuniciramo takvu tvrdnju. Urod je svježe ubrano povrće i bilje koje prije konzumacije treba oprati i pripremiti.',
                 },
                 {
                     header: 'Što radite ako postoji sumnja na problem?',
                     description:
-                        'Urod se zadržava ili izdvaja dok se situacija ne procijeni. Problem se zapisuje, provodi se korektivna radnja i po potrebi se korisniku daje jasna uputa.',
+                        'Urod se zadržava ili izdvaja dok se situacija ne procijeni. Problem se zapisuje, provodi se korektivna radnja i po potrebi šaljemo jasnu uputu.',
                 },
             ],
         },

--- a/apps/www/app/development/page.tsx
+++ b/apps/www/app/development/page.tsx
@@ -107,7 +107,7 @@ function getDevelopmentSections(hosts: EnvironmentHosts): DevelopmentSection[] {
                 {
                     title: 'Aplikacija',
                     description:
-                        'Interno aplikacijsko sučelje za prijavljene korisnike i dijeljene značajke proizvoda.',
+                        'Interno aplikacijsko sučelje za prijavu i dijeljene značajke proizvoda.',
                     href: hosts.app,
                     icon: '🧩',
                 },

--- a/apps/www/app/legalno/licenca/page.tsx
+++ b/apps/www/app/legalno/licenca/page.tsx
@@ -25,9 +25,9 @@ export default function PolitikaPrivatnostiPage() {
                         <a href="https://github.com/gredice/gredice/blob/main/LICENSE">
                             AGPL-3.0
                         </a>
-                        . To znači da možete pregledati, preuzeti, mijenjati i
-                        distribuirati izvorni kod aplikacije pod uvjetima ove
-                        licence.
+                        . To znači da je dopušteno pregledati, preuzeti,
+                        mijenjati i distribuirati izvorni kod aplikacije pod
+                        uvjetima ove licence.
                     </p>
                     <p>
                         Izvorni kod dostupan je na{' '}
@@ -35,8 +35,8 @@ export default function PolitikaPrivatnostiPage() {
                         repozitoriju.
                     </p>
                     <p>
-                        Ukoliko imate bilo kakvih pitanja o licenci ili
-                        korištenju izvornog koda, slobodno nas kontaktirajte na{' '}
+                        Ako imaš bilo kakvih pitanja o licenci ili korištenju
+                        izvornog koda, slobodno nas kontaktiraj na{' '}
                         <a href="mailto:kontakt@gredice.com">
                             kontakt@gredice.com
                         </a>

--- a/apps/www/app/legalno/politika-kolacica/page.tsx
+++ b/apps/www/app/legalno/politika-kolacica/page.tsx
@@ -24,9 +24,9 @@ export default function PolitikaKolacicaPage() {
                     <h2>Što su kolačići?</h2>
                     <p>
                         Kolačići su male tekstualne datoteke koje se pohranjuju
-                        na vašem uređaju prilikom posjeta našoj web stranici.
-                        Oni omogućuju web stranici da prepozna vaš uređaj i
-                        prikupi informacije o vašem posjetu.
+                        na tvojem uređaju prilikom posjeta našoj web stranici.
+                        Oni omogućuju web stranici da prepozna tvoj uređaj i
+                        prikupi informacije o tvojem posjetu.
                     </p>
                     <h2>Kolačići koje koristimo</h2>
                     <p>
@@ -34,14 +34,14 @@ export default function PolitikaKolacicaPage() {
                         kolačići su bitni za ispravno funkcioniranje web
                         stranice i ne mogu se isključiti u našim sustavima.
                         Obično se postavljaju samo kao odgovor na radnje koje
-                        ste poduzeli, kao što su postavljanje vaših postavki
+                        poduzmeš, kao što su postavljanje tvojih postavki
                         privatnosti, prijava ili dovršavanje obrazaca.
                     </p>
                     <p>Primjeri nužnih kolačića uključuju:</p>
                     <ul>
                         <li>
                             <strong>Kolačići za autentikaciju</strong>: Ovi
-                            kolačići omogućuju vam pristup sigurnim dijelovima
+                            kolačići omogućuju ti pristup sigurnim dijelovima
                             naše web stranice.
                         </li>
                         <li>
@@ -51,31 +51,29 @@ export default function PolitikaKolacicaPage() {
                             stranice.
                         </li>
                     </ul>
-                    <h2>Kako možete upravljati kolačićima</h2>
+                    <h2>Kako možeš upravljati kolačićima</h2>
                     <p>
                         Većina web preglednika automatski prihvaća kolačiće, ali
-                        vi možete odabrati hoćete li ih prihvatiti ili ne. Ako
-                        ne želite primati kolačiće, možete postaviti svoje
-                        preglednike da ih odbijaju ili vas upozore kada se
-                        kolačići šalju.
+                        možeš odabrati želiš li ih prihvatiti ili ne. Ako ne
+                        želiš primati kolačiće, možeš postaviti preglednik da ih
+                        odbija ili te upozori kada se kolačići šalju.
                     </p>
                     <p>
-                        Imajte na umu da, ako onemogućite kolačiće, neke
-                        dijelove naše web stranice možda neće pravilno
-                        funkcionirati.
+                        Imaj na umu da, ako onemogućiš kolačiće, neke dijelove
+                        naše web stranice možda neće pravilno funkcionirati.
                     </p>
-                    <h2>Prava korisnika</h2>
+                    <h2>Tvoja prava</h2>
                     <p>
-                        Imate pravo znati koje informacije prikupljamo putem
-                        kolačića i za što se koriste. Također imate pravo
+                        Imaš pravo znati koje informacije prikupljamo putem
+                        kolačića i za što se koriste. Također imaš pravo
                         zatražiti brisanje ili ispravak informacija koje smo
                         prikupili.
                     </p>
                     <h2>Kontakt informacije</h2>
                     <p>
-                        Ako imate bilo kakva pitanja ili trebate više
-                        informacija o našoj politici kolačića, slobodno nas
-                        kontaktirajte putem adrese e-pošte na{' '}
+                        Ako imaš bilo kakva pitanja ili trebaš više informacija
+                        o našoj politici kolačića, slobodno nas kontaktiraj
+                        putem adrese e-pošte na{' '}
                         <a href="mailto:kontakt@gredice.com">
                             kontakt@gredice.com
                         </a>

--- a/apps/www/app/legalno/politika-privatnosti/page.tsx
+++ b/apps/www/app/legalno/politika-privatnosti/page.tsx
@@ -26,10 +26,10 @@ export default function PolitikaPrivatnostiPage() {
                         Naša web stranica (
                         <a href="https://www.gredice.com">www.gredice.com</a>,
                         uključujući sve podstranice) pruža usluge upravljanja i
-                        dostave povrća i vrtnih proizvoda. Vaša privatnost nam
+                        dostave povrća i vrtnih proizvoda. Tvoja privatnost nam
                         je važna, stoga smo izradili ovu Politiku privatnosti
-                        kako bismo vam objasnili kako prikupljamo, koristimo i
-                        štitimo vaše osobne podatke.
+                        kako bismo ti objasnili kako prikupljamo, koristimo i
+                        štitimo tvoje osobne podatke.
                     </p>
                     <h2>Prikupljanje Podataka</h2>
                     <p>
@@ -43,32 +43,32 @@ export default function PolitikaPrivatnostiPage() {
                         </li>
                         <li>
                             <strong>Podaci o narudžbama</strong>: informacije
-                            vezane uz vaše narudžbe, uključujući isporuku i
+                            vezane uz tvoje narudžbe, uključujući isporuku i
                             odabrane proizvode.
                         </li>
                         <li>
                             <strong>Podaci o korištenju</strong>: informacije
                             prikupljene putem alata za analitiku (Vercel
-                            Analytics) koje nam pomažu da razumijemo kako
-                            koristite našu web stranicu.
+                            Analytics) koje nam pomažu da razumijemo korištenje
+                            naše web stranice.
                         </li>
                     </ul>
                     <p>
-                        Svi podaci prikupljaju se s vašim pristankom ili na
+                        Svi podaci prikupljaju se s tvojim pristankom ili na
                         temelju zakonskih obveza.
                     </p>
                     <h2>Korištenje Podataka</h2>
-                    <p>Vaše osobne podatke koristimo u sljedeće svrhe:</p>
+                    <p>Tvoje osobne podatke koristimo u sljedeće svrhe:</p>
                     <ul>
                         <li>
                             <strong>Obrada narudžbi</strong>: kako bismo
-                            ispunili vašu narudžbu i osigurali kvalitetnu
+                            ispunili tvoju narudžbu i osigurali kvalitetnu
                             uslugu.
                         </li>
                         <li>
                             <strong>Komunikacija:</strong> za slanje obavijesti
-                            o vašim narudžbama, sustavnih e-poruka i za
-                            odgovaranje na vaše upite.
+                            o tvojim narudžbama, sustavnih e-poruka i za
+                            odgovaranje na tvoje upite.
                         </li>
                         <li>
                             <strong>Poboljšanje usluga</strong>: analizom
@@ -77,30 +77,30 @@ export default function PolitikaPrivatnostiPage() {
                         </li>
                         <li>
                             <strong>Planiranje marketinških aktivnosti</strong>:
-                            ako ste nam dali izričiti pristanak, vaši kontakt
+                            ako nam daš izričiti pristanak, tvoji kontaktni
                             podaci (npr. adresa e-pošte) mogu se interno
                             dijeliti s našim ovlaštenim suradnicima radi
                             osmišljavanja marketinških kampanja i poboljšanja
                             korisničkog iskustva. Ove aktivnosti nikada ne
-                            uključuju slanje poruka bez vašeg pristanka.
+                            uključuju slanje poruka bez tvojeg pristanka.
                         </li>
                         <li>
                             <strong>Interna komunikacija sa suradnicima</strong>
-                            : vaši podaci mogu se koristiti za internu
+                            : tvoji podaci mogu se koristiti za internu
                             komunikaciju s našim suradnicima kako bismo
                             osigurali kvalitetnu uslugu.
                         </li>
                     </ul>
                     <h2>Mjere Zaštite</h2>
                     <p>
-                        Razumijemo važnost zaštite vaših osobnih podataka.
+                        Razumijemo važnost zaštite tvojih osobnih podataka.
                         Poduzeli smo sve moguće mjere zaštite, uključujući:
                     </p>
                     <ul>
                         <li>
                             <strong>Tehničke mjere</strong>: korištenje sigurnih
                             poslužitelja i enkripcije podataka kako bismo
-                            zaštitili vaše informacije.
+                            zaštitili tvoje informacije.
                         </li>
                         <li>
                             <strong>Organizacijske mjere</strong>: ograničavanje
@@ -108,38 +108,38 @@ export default function PolitikaPrivatnostiPage() {
                             zaposlenike koji ih trebaju za obradu.
                         </li>
                     </ul>
-                    <h2>Prava Korisnika</h2>
+                    <h2>Tvoja prava</h2>
                     <p>
-                        Kao korisnik naše web stranice imate prava koja
+                        Pri korištenju naše web stranice imaš prava koja
                         uključuju:
                     </p>
                     <ul>
                         <li>
-                            <strong>Pravo na pristup</strong>: možete zatražiti
+                            <strong>Pravo na pristup</strong>: možeš zatražiti
                             kopiju svojih osobnih podataka.
                         </li>
                         <li>
-                            <strong>Pravo na ispravak</strong>: imate pravo
+                            <strong>Pravo na ispravak</strong>: imaš pravo
                             ispraviti svoje osobne podatke ako su netočni ili
                             nepotpuni.
                         </li>
                         <li>
-                            <strong>Pravo na brisanje</strong>: možete tražiti
+                            <strong>Pravo na brisanje</strong>: možeš tražiti
                             brisanje svojih osobnih podataka pod određenim
                             uvjetima.
                         </li>
                         <li>
-                            <strong>Pravo na pritužbu</strong>: imate pravo
-                            podnijeti pritužbu nadležnom tijelu ako smatrate da
-                            su vaši podaci korišteni protivno zakonu.
+                            <strong>Pravo na pritužbu</strong>: imaš pravo
+                            podnijeti pritužbu nadležnom tijelu ako smatraš da
+                            su tvoji podaci korišteni protivno zakonu.
                         </li>
                     </ul>
                     <h2>Treće Strane</h2>
                     <p>
-                        Možemo dijeliti vaše osobne podatke s trećim stranama
+                        Možemo dijeliti tvoje osobne podatke s trećim stranama
                         isključivo u svrhu opskrbe naših usluga, uključujući
                         pružatelje usluga dostave i analitičke alate. Uvijek
-                        ćemo se pobrinuti da te treće strane poštuju vašu
+                        ćemo se pobrinuti da te treće strane poštuju tvoju
                         privatnost u skladu s ovom politikom.
                     </p>
                     <p>
@@ -148,10 +148,10 @@ export default function PolitikaPrivatnostiPage() {
                         marketinški savjetnici ili kreatori kampanja) radi
                         planiranja i razvoja marketinških strategija i
                         unapređenja korisničkog iskustva. Ove aktivnosti nikada
-                        ne uključuju slanje marketinških poruka bez vašeg
+                        ne uključuju slanje marketinških poruka bez tvojeg
                         izričitog pristanka. Niti dijeljenje osobnih podataka s
                         trećim stranama u svrhu slanja marketinških poruka bez
-                        vašeg pristanka.
+                        tvojeg pristanka.
                     </p>
                     <h2>Dijagnostika i Praćenje Grešaka</h2>
                     <p>
@@ -159,7 +159,7 @@ export default function PolitikaPrivatnostiPage() {
                         stabilnosti naše platforme koristimo uslugu{' '}
                         <strong>Posthog</strong>
                         Posthog nam pomaže identificirati i otkloniti tehničke
-                        probleme kako bismo vam pružili bolju i pouzdaniju
+                        probleme kako bismo ti pružili bolju i pouzdaniju
                         uslugu.
                     </p>
                     <p>
@@ -173,10 +173,10 @@ export default function PolitikaPrivatnostiPage() {
                             mrežnih problema.
                         </li>
                         <li>
-                            <strong>Korisnički identifikator</strong>: ako ste
-                            prijavljeni, vaš korisnički ID može biti povezan s
-                            prijavljenim greškama radi bržeg rješavanja
-                            problema.
+                            <strong>Korisnički identifikator</strong>: kada
+                            postoji prijava u račun, korisnički ID može biti
+                            povezan s prijavljenim greškama radi bržeg
+                            rješavanja problema.
                         </li>
                         <li>
                             <strong>Tehničke informacije</strong>: vrsta
@@ -191,7 +191,7 @@ export default function PolitikaPrivatnostiPage() {
                         čime osiguravamo usklađenost s Općom uredbom o zaštiti
                         podataka (GDPR). Posthog je certificiran prema
                         standardima zaštite podataka i primjenjuje odgovarajuće
-                        tehničke i organizacijske mjere za zaštitu vaših
+                        tehničke i organizacijske mjere za zaštitu tvojih
                         podataka.
                     </p>
                     <p>
@@ -208,17 +208,15 @@ export default function PolitikaPrivatnostiPage() {
                     </p>
                     <h2>Kontakt</h2>
                     <p>
-                        Ako imate bilo kakva pitanja ili brige u vezi s ovom
-                        politikom privatnosti, slobodno nas kontaktirajte putem
+                        Ako imaš bilo kakva pitanja ili brige u vezi s ovom
+                        politikom privatnosti, slobodno nas kontaktiraj putem
                         e-pošte na{' '}
                         <a href="mailto:kontakt@gredice.com">
                             kontakt@gredice.com
                         </a>
                         .
                     </p>
-                    <p>
-                        Zahvaljujemo vam na povjerenju i što koristite Gredice!
-                    </p>
+                    <p>Hvala ti na povjerenju i što koristiš Gredice!</p>
                 </StyledHtml>
                 <Typography level="body2" secondary className="mt-8">
                     Zadnja izmjena: 5. prosinca 2025.

--- a/apps/www/app/legalno/trece-strane/page.tsx
+++ b/apps/www/app/legalno/trece-strane/page.tsx
@@ -75,7 +75,7 @@ const thirdPartyPlatforms = [
                 name: 'Vercel Analytics',
                 category: 'Web analitika',
                 description:
-                    'Alat za analitiku koji nam pomaže razumjeti kako korisnici koriste našu web stranicu.',
+                    'Alat za analitiku koji nam pomaže razumjeti korištenje naše web stranice.',
                 iconUrl: 'https://vercel.com/favicon.ico',
                 website: 'https://vercel.com',
             },
@@ -214,8 +214,8 @@ export default function UvjetiKoristenjaPage() {
                     <p>
                         Zadržavamo pravo izmjene ovih informacija u bilo kojem
                         trenutku, uključujući dodavanje ili uklanjanje platformi
-                        trećih strana. Ukoliko platforma nije navedena na ovoj
-                        stranici, molimo kontaktirajte nas na{' '}
+                        trećih strana. Ako platforma nije navedena na ovoj
+                        stranici, slobodno nas kontaktiraj na{' '}
                         <a href="mailto:kontakt@gredice.com">
                             kontakt@gredice.com
                         </a>

--- a/apps/www/app/legalno/tvrtka/page.tsx
+++ b/apps/www/app/legalno/tvrtka/page.tsx
@@ -61,10 +61,9 @@ export default function UvjetiKoristenjaPage() {
                         IBAN: <span>HR5223400091111312385</span>
                         <br />
                         <small>
-                            Molimo vas da ne uplaćujete na gore navedeni račun
-                            bez prethodne najave i dogovora s našim prodajnim
-                            timom. Ovaj podatak je ovdje isključivo u zakonske
-                            svrhe.
+                            Molimo te da ne uplaćuješ na gore navedeni račun bez
+                            prethodne najave i dogovora s našim prodajnim timom.
+                            Ovaj podatak je ovdje isključivo u zakonske svrhe.
                         </small>
                     </p>
 

--- a/apps/www/app/legalno/uvjeti-koristenja/page.tsx
+++ b/apps/www/app/legalno/uvjeti-koristenja/page.tsx
@@ -30,9 +30,9 @@ export default function UvjetiKoristenjaPage() {
                         društvo s ograničenom odgovornošću za proizvodnju,
                         trgovinu i usluge, sa sjedištem na Ulica Julija Knifera
                         3, Zagreb, Hrvatska, OIB: 86171547809. Korištenje
-                        Platforme podrazumijeva suglasnost s ovim Uvjetima.
-                        Ukoliko se ne slažete s Uvjetima, molimo vas da ne
-                        koristite Platformu.
+                        Platforme podrazumijeva suglasnost s ovim Uvjetima. Ako
+                        se ne slažeš s Uvjetima, molimo te da ne koristiš
+                        Platformu.
                     </p>
                     <h2>Definicije</h2>
                     <p>
@@ -40,10 +40,6 @@ export default function UvjetiKoristenjaPage() {
                         slovom imaju sljedeća značenja:
                     </p>
                     <ul>
-                        <li>
-                            &quot;<strong>Korisnik</strong>&quot; označava svaku
-                            fizičku ili pravnu osobu koja koristi Platformu.
-                        </li>
                         <li>
                             &quot;<strong>Sadržaj</strong>&quot; odnosi se na
                             sve informacije, tekst, slike, videozapise i druge
@@ -56,11 +52,11 @@ export default function UvjetiKoristenjaPage() {
                             drugim korisnicima i dijeljenje sadržaja.
                         </li>
                     </ul>
-                    <h2>Prava i obveze Korisnika</h2>
-                    <p>Korisnik se obvezuje:</p>
+                    <h2>Prava i obveze pri korištenju Platforme</h2>
+                    <p>Korištenjem Platforme potrebno je:</p>
                     <ul>
                         <li>
-                            Korištenje Platforme isključivo u svrhe koje su u
+                            Koristiti Platformu isključivo u svrhe koje su u
                             skladu s važećim zakonima i propisima.
                         </li>
                         <li>
@@ -69,7 +65,7 @@ export default function UvjetiKoristenjaPage() {
                             obmanjujući ili koji krši prava trećih osoba.
                         </li>
                         <li>
-                            Održavati sigurnost svog korisničkog računa i
+                            Održavati sigurnost korisničkog računa i
                             pravovremeno obavještavati Platformu o bilo kakvim
                             neovlaštenim pristupima.
                         </li>
@@ -82,9 +78,8 @@ export default function UvjetiKoristenjaPage() {
                             neprikladnim ili nesukladnim ovim Uvjetima.
                         </li>
                         <li>
-                            Pružiti Korisnicima podršku u vezi s korištenjem
-                            Usluga, ali ne jamči neprekidnu ili potpuno sigurnu
-                            uslugu.
+                            Pružiti podršku u vezi s korištenjem Usluga, ali ne
+                            jamči neprekidnu ili potpuno sigurnu uslugu.
                         </li>
                         <li>
                             Izmijeniti, suspendirati ili prekinuti dostupnost
@@ -97,8 +92,8 @@ export default function UvjetiKoristenjaPage() {
                         ograničavajući se na, dizajn, logotipe, softver i
                         Sadržaj, zaštićeni su zakonima o autorskim pravima i
                         drugim pravima intelektualnog vlasništva osim ako nije
-                        drugačije navedeno. Korisnici se obvezuju ne koristiti
-                        te elemente bez izričitog pisanog odobrenja Platforme.
+                        drugačije navedeno. Nije dopušteno koristiti te elemente
+                        bez izričitog pisanog odobrenja Platforme.
                     </p>
                     <h2>Odgovornost</h2>
                     <p>
@@ -115,14 +110,14 @@ export default function UvjetiKoristenjaPage() {
                     </p>
                     <h2>Završne odredbe</h2>
                     <p>
-                        Ovi Uvjeti predstavljaju cjelokupni sporazum između
-                        Korisnika i Platforme u vezi s korištenjem Platforme.
-                        Platforma zadržava pravo izmjene ovih Uvjeta, a
-                        Korisnici će biti obaviješteni o svim promjenama.
+                        Ovi Uvjeti predstavljaju cjelokupni sporazum o
+                        korištenju Platforme. Platforma zadržava pravo izmjene
+                        ovih Uvjeta, a obavijest o promjenama bit će dostupna
+                        putem Platforme.
                     </p>
                     <p>
-                        Za sve dodatne informacije ili upite, molimo
-                        kontaktirajte nas putem e-pošte na{' '}
+                        Za sve dodatne informacije ili upite, slobodno nas
+                        kontaktiraj putem e-pošte na{' '}
                         <a href="mailto:kontakt@gredice.com">
                             kontakt@gredice.com
                         </a>

--- a/apps/www/app/vodic-za-prvu-gredicu/page.tsx
+++ b/apps/www/app/vodic-za-prvu-gredicu/page.tsx
@@ -56,7 +56,7 @@ export default function FirstRaisedBedGuidePage() {
                             platna. Aplikacija pita što želiš jesti i kakav
                             ritam brige želiš, predloži nekoliko rasporeda i
                             popuni 12 polja u košari. Šest polja ostaje prazno
-                            kako bi ih kasnije mogao urediti po svome.
+                            za kasnije ručno uređivanje po svome.
                         </Typography>
                         <Row className="flex-wrap" spacing={2}>
                             <Chip color="success" variant="soft">
@@ -157,7 +157,7 @@ export default function FirstRaisedBedGuidePage() {
                             Onboarding možeš preskočiti ili zatvoriti u bilo
                             kojem trenutku. Tvoj vrt ostaje dostupan, a prazna
                             polja možeš urediti ručno iz closeup prikaza gredice
-                            kada budeš spreman.
+                            kada ti bude odgovaralo.
                         </Typography>
                         <Row className="flex-wrap" spacing={3}>
                             <Button href={KnownPages.GardenApp}>

--- a/apps/www/components/community-edits/CommunityEditButton.tsx
+++ b/apps/www/components/community-edits/CommunityEditButton.tsx
@@ -541,7 +541,7 @@ export function CommunityEditButton({
                 ) : !user ? (
                     <Stack spacing={3}>
                         <Typography level="body2">
-                            Za slanje prijedloga trebaš biti prijavljen.
+                            Za slanje prijedloga treba se prijaviti.
                         </Typography>
                         <Button href={KnownPages.GardenApp} variant="outlined">
                             Prijavi se u vrt

--- a/apps/www/lib/plants/qualityHarvestSafetyFaq.ts
+++ b/apps/www/lib/plants/qualityHarvestSafetyFaq.ts
@@ -48,26 +48,26 @@ export const qualityHarvestSafetyFaqEntries: FaqData[] = [
     faqEntry({
         id: -45101,
         slug: 'kvaliteta-haccp-certifikacija',
-        header: 'Komunicirate li formalnu HACCP certifikaciju?',
-        content: `Ne. Gredice u ovom modelu pružaju uslugu planiranja, uzgoja, njege, berbe i dostave korisnikova uroda. Trenutno javno komuniciramo interne postupke temeljene na dobroj praksi, sljedivosti, evidencijama, korektivnim radnjama i načelima HACCP-a. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
+        header: 'Postoji li formalna HACCP certifikacija?',
+        content: `Ne. Gredice u ovom modelu pružaju uslugu planiranja, uzgoja, njege, berbe i dostave tvojeg uroda. Trenutno javno komuniciramo interne postupke temeljene na dobroj praksi, sljedivosti, evidencijama, korektivnim radnjama i načelima HACCP-a. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
     }),
     faqEntry({
         id: -45102,
         slug: 'kvaliteta-pracenje-sigurnosti',
-        header: 'Znači li to da ne pratite sigurnost uroda?',
+        header: 'Znači li to da se sigurnost uroda ne prati?',
         content: `Ne. Pratimo rizike, čistoću, rukovanje, berbu, dostavu i prigovore kako bi se svaka sumnja mogla procijeniti i zapisati. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
     }),
     faqEntry({
         id: -45103,
         slug: 'kvaliteta-dokumentirani-postupci',
-        header: 'Koje postupke imate dokumentirane?',
+        header: 'Koji su postupci dokumentirani?',
         content: `Dokumentirani su postupci za osobnu higijenu, edukaciju, procjenu gredice, vodu, inpute, čišćenje alata i gajbi, berbu, sortiranje, dostavu, sljedivost, prigovore i godišnju reviziju. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
     }),
     faqEntry({
         id: -45104,
         slug: 'kvaliteta-pranje-uroda',
         header: 'Može li se urod jesti bez pranja?',
-        content: `Ne komuniciramo takvu tvrdnju. Urod je svježe ubrano povrće i bilje koje korisnik prije konzumacije treba oprati i pripremiti na uobičajen higijenski način. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
+        content: `Ne komuniciramo takvu tvrdnju. Urod je svježe ubrano povrće i bilje koje prije konzumacije treba oprati i pripremiti na uobičajen higijenski način. Više: [Kvaliteta i sigurnost uroda](${QUALITY_HARVEST_SAFETY_PATH}).`,
     }),
     faqEntry({
         id: -45105,

--- a/apps/www/tests/community-edit-button.spec.tsx
+++ b/apps/www/tests/community-edit-button.spec.tsx
@@ -19,7 +19,7 @@ test('prompts anonymous users before editing', async ({ mount, page }) => {
     await page.getByTitle('Predloži izmjenu').click();
 
     await expect(
-        page.getByText('Za slanje prijedloga trebaš biti prijavljen.'),
+        page.getByText('Za slanje prijedloga treba se prijaviti.'),
     ).toBeVisible();
 });
 


### PR DESCRIPTION
## Summary
- Replace formal `Vi/vas/vaš` style with friendly singular or neutral phrasing across www legal/content pages.
- Remove gendered direct-user copy from the first raised-bed guide, community edit login prompt, and quality/safety FAQ/CMS content.
- Keep `/podignuta-gredica` out of this PR because that page is already covered by the existing raised-bed page PR.

## Validation
- `pnpm --filter www lint`
- `pnpm --filter www typecheck`
- `pnpm --filter www test:cms-pages`
- `pnpm --filter www exec playwright test --project=chromium tests/community-edit-button.spec.tsx`
- `pnpm --filter www build`
- `git diff --check`

## Audit
- `Vi/vas/vaš` and plural-formality scan now only finds the raised-bed page copy covered by the separate PR.
- `Korisnik/korisnici/naručitelj` direct-copy scan returns no matches in `apps/www`.