### PR TITLE
[codex] Redesign outlet experience

### DIFF
--- a/apps/www/app/outlet/OutletLandingOfferCard.tsx
+++ b/apps/www/app/outlet/OutletLandingOfferCard.tsx
@@ -1,0 +1,101 @@
+import { Discount } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import Link from 'next/link';
+import { KnownPages } from '../../src/KnownPages';
+import { type OutletOffer, outletOfferImage } from './outletData';
+import {
+    compactDateFormatter,
+    currencyFormatter,
+    outletDiscountLabel,
+} from './outletPresentation';
+
+export function OutletLandingOfferCard({
+    featured,
+    offer,
+}: {
+    featured?: boolean;
+    offer: OutletOffer;
+}) {
+    const imageUrl = outletOfferImage(offer);
+
+    return (
+        <Link
+            className={cx(
+                'group grid h-full overflow-hidden rounded-2xl border border-tertiary border-b-4 bg-card text-card-foreground shadow-sm transition-all hover:-translate-y-0.5 hover:border-muted-foreground/50 hover:shadow-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                featured && 'sm:grid-cols-[minmax(11rem,0.9fr)_1fr]',
+            )}
+            href={`${KnownPages.Outlet}?offer=${offer.id}`}
+        >
+            <div
+                className={cx(
+                    'relative aspect-[4/3] overflow-hidden bg-muted',
+                    featured && 'sm:aspect-auto',
+                )}
+            >
+                {imageUrl ? (
+                    <>
+                        {/** biome-ignore lint/performance/noImgElement: Offer images come from API data and may use configured external origins. */}
+                        <img
+                            alt={offer.plantSort.name}
+                            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                            src={imageUrl}
+                        />
+                    </>
+                ) : (
+                    <div className="flex h-full min-h-48 items-center justify-center bg-tertiary/15 p-5 text-center">
+                        <Typography level="body2" secondary>
+                            Fotografija sadnice uskoro stiže
+                        </Typography>
+                    </div>
+                )}
+            </div>
+            <div className="flex h-full flex-col gap-4 p-4 sm:p-5">
+                <div className="flex flex-wrap items-center gap-2">
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-900 dark:bg-amber-950 dark:text-amber-200">
+                        <Discount aria-hidden className="size-3.5" />
+                        {outletDiscountLabel(offer)}
+                    </span>
+                    <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+                        preostalo {offer.remainingQuantity}
+                    </span>
+                </div>
+                <div>
+                    <Typography level="h5" component="h3">
+                        {offer.plantSort.name}
+                    </Typography>
+                    <Typography level="body3" tertiary>
+                        Sjetva{' '}
+                        {compactDateFormatter.format(
+                            new Date(offer.sowingDate),
+                        )}
+                    </Typography>
+                </div>
+                <div className="mt-auto flex items-end justify-between gap-3">
+                    <div>
+                        <Typography level="body3" tertiary>
+                            Outlet cijena
+                        </Typography>
+                        <Typography level="h4" component="p">
+                            {currencyFormatter.format(offer.outletPrice)}
+                        </Typography>
+                    </div>
+                    {typeof offer.comparePrice === 'number' ? (
+                        <div className="text-right">
+                            <Typography level="body3" tertiary>
+                                redovna cijena
+                            </Typography>
+                            <Typography
+                                level="body2"
+                                secondary
+                                className="line-through"
+                            >
+                                {currencyFormatter.format(offer.comparePrice)}
+                            </Typography>
+                        </div>
+                    ) : null}
+                </div>
+            </div>
+        </Link>
+    );
+}

--- a/apps/www/app/outlet/OutletLandingSection.tsx
+++ b/apps/www/app/outlet/OutletLandingSection.tsx
@@ -1,13 +1,11 @@
+import { Discount, Sprout } from '@gredice/ui/icons';
 import { NavigatingButton } from '@gredice/ui/NavigatingButton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
 import { KnownPages } from '../../src/KnownPages';
-import { getOutletOffers, outletOfferImage } from './outletData';
-
-const currencyFormatter = new Intl.NumberFormat('hr-HR', {
-    style: 'currency',
-    currency: 'EUR',
-});
+import { OutletLandingOfferCard } from './OutletLandingOfferCard';
+import { getOutletOffers } from './outletData';
 
 export async function OutletLandingSection() {
     const offers = await getOutletOffers();
@@ -17,21 +15,42 @@ export async function OutletLandingSection() {
     }
 
     return (
-        <section className="my-20 border-y border-tertiary bg-card/60 py-10">
-            <Stack spacing={6}>
-                <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-                    <Stack spacing={2} className="max-w-2xl">
+        <section className="my-20">
+            <div className="grid gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.25fr)] lg:items-center">
+                <Stack spacing={5}>
+                    <div className="inline-flex w-fit items-center gap-2 rounded-full border border-amber-300/70 bg-amber-100 px-3 py-1.5 text-sm font-medium text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+                        <Discount aria-hidden className="size-4" />
+                        Outlet cijena, Gredice kvaliteta
+                    </div>
+                    <Stack spacing={2} className="max-w-xl">
                         <Typography level="body1" semiBold tertiary>
                             Gredice Outlet
                         </Typography>
                         <Typography level="h2">
-                            Presadnice iz staklenika
+                            Presadnice koje čekaju svoju gredicu
                         </Typography>
                         <Typography level="body1" secondary>
-                            Ograničene količine presadnica koje su već krenule u
-                            rast, dostupne po nižoj cijeni dok traje ponuda.
+                            Kad u stakleniku ostane nekoliko zdravih presadnica
+                            koje su već krenule u rast, ponudimo ih po outlet
+                            cijeni da brzo pronađu svoje mjesto u gredici.
                         </Typography>
                     </Stack>
+                    <div className="flex flex-wrap gap-2">
+                        <span className="inline-flex items-center gap-1.5 rounded-full bg-card px-3 py-1.5 text-sm text-secondary-foreground ring-1 ring-tertiary">
+                            <Sprout
+                                aria-hidden
+                                className="size-4 text-primary"
+                            />
+                            Već krenule u rast
+                        </span>
+                        <span className="inline-flex items-center gap-1.5 rounded-full bg-card px-3 py-1.5 text-sm text-secondary-foreground ring-1 ring-tertiary">
+                            <Discount
+                                aria-hidden
+                                className="size-4 text-amber-600 dark:text-amber-300"
+                            />
+                            Ograničena outlet cijena
+                        </span>
+                    </div>
                     <NavigatingButton
                         href={KnownPages.Outlet}
                         variant="outlined"
@@ -39,44 +58,24 @@ export async function OutletLandingSection() {
                     >
                         Pogledaj outlet
                     </NavigatingButton>
+                </Stack>
+                <div
+                    className={cx(
+                        'grid gap-4',
+                        highlightedOffers.length === 1
+                            ? 'max-w-2xl'
+                            : 'sm:grid-cols-2 xl:grid-cols-3',
+                    )}
+                >
+                    {highlightedOffers.map((offer) => (
+                        <OutletLandingOfferCard
+                            featured={highlightedOffers.length === 1}
+                            key={offer.id}
+                            offer={offer}
+                        />
+                    ))}
                 </div>
-                <div className="grid gap-4 md:grid-cols-3">
-                    {highlightedOffers.map((offer) => {
-                        const imageUrl = outletOfferImage(offer);
-                        return (
-                            <a
-                                key={offer.id}
-                                href={`${KnownPages.Outlet}?offer=${offer.id}`}
-                                className="group overflow-hidden rounded-lg border border-tertiary bg-background transition-colors hover:bg-muted"
-                            >
-                                <div className="aspect-[4/3] bg-muted">
-                                    {imageUrl ? (
-                                        <>
-                                            {/** biome-ignore lint/performance/noImgElement: Offer images come from API data and may use configured external origins. */}
-                                            <img
-                                                alt={offer.plantSort.name}
-                                                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-                                                src={imageUrl}
-                                            />
-                                        </>
-                                    ) : null}
-                                </div>
-                                <div className="p-4">
-                                    <Typography level="h5" component="h3">
-                                        {offer.plantSort.name}
-                                    </Typography>
-                                    <Typography level="body2" secondary>
-                                        {currencyFormatter.format(
-                                            offer.outletPrice,
-                                        )}{' '}
-                                        · preostalo {offer.remainingQuantity}
-                                    </Typography>
-                                </div>
-                            </a>
-                        );
-                    })}
-                </div>
-            </Stack>
+            </div>
         </section>
     );
 }

--- a/apps/www/app/outlet/OutletOfferCard.tsx
+++ b/apps/www/app/outlet/OutletOfferCard.tsx
@@ -1,3 +1,4 @@
+import { Calendar, Discount, Sprout, Timer } from '@gredice/ui/icons';
 import { NavigatingButton } from '@gredice/ui/NavigatingButton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -6,37 +7,26 @@ import {
     outletGardenUrl,
     outletOfferImage,
 } from './outletData';
-
-const dateFormatter = new Intl.DateTimeFormat('hr-HR', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-});
-
-const timeFormatter = new Intl.DateTimeFormat('hr-HR', {
-    day: 'numeric',
-    month: 'short',
-    hour: '2-digit',
-    minute: '2-digit',
-});
-
-const currencyFormatter = new Intl.NumberFormat('hr-HR', {
-    style: 'currency',
-    currency: 'EUR',
-});
+import {
+    currencyFormatter,
+    longDateFormatter,
+    offerEndFormatter,
+    outletDiscountLabel,
+    outletRemainingLabel,
+} from './outletPresentation';
 
 export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
     const imageUrl = outletOfferImage(offer);
 
     return (
-        <article className="grid overflow-hidden rounded-lg border border-tertiary bg-card shadow-sm md:grid-cols-[minmax(220px,0.8fr)_1fr]">
-            <div className="relative aspect-[4/3] bg-muted md:aspect-auto">
+        <article className="grid overflow-hidden rounded-2xl border border-tertiary border-b-4 bg-card shadow-sm md:grid-cols-[minmax(220px,0.8fr)_1fr]">
+            <div className="relative aspect-[4/3] overflow-hidden bg-muted md:aspect-auto">
                 {imageUrl ? (
                     <>
                         {/** biome-ignore lint/performance/noImgElement: Offer images come from API data and may use configured external origins. */}
                         <img
                             alt={offer.plantSort.name}
-                            className="h-full w-full object-cover"
+                            className="h-full w-full object-cover transition-transform duration-300 hover:scale-[1.02]"
                             src={imageUrl}
                         />
                     </>
@@ -47,12 +37,21 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                         </Typography>
                     </div>
                 )}
+                <div className="absolute left-3 top-3 flex flex-wrap gap-2">
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-900 shadow-sm dark:bg-amber-950 dark:text-amber-200">
+                        <Discount aria-hidden className="size-3.5" />
+                        {outletDiscountLabel(offer)}
+                    </span>
+                    <span className="rounded-full bg-background/90 px-2.5 py-1 text-xs font-medium text-primary shadow-sm">
+                        {outletRemainingLabel(offer)}
+                    </span>
+                </div>
             </div>
             <div className="p-5 sm:p-6">
-                <Stack spacing={5}>
+                <Stack spacing={6}>
                     <Stack spacing={2}>
                         <div className="flex flex-wrap items-start justify-between gap-3">
-                            <div>
+                            <div className="min-w-0">
                                 <Typography level="h3" component="h2">
                                     {offer.plantSort.name}
                                 </Typography>
@@ -62,8 +61,11 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                                     </Typography>
                                 ) : null}
                             </div>
-                            <div className="text-right">
-                                <Typography level="h4" component="p">
+                            <div className="rounded-xl bg-muted/60 px-4 py-3 text-right">
+                                <Typography level="body3" tertiary>
+                                    Outlet cijena
+                                </Typography>
+                                <Typography level="h3" component="p">
                                     {currencyFormatter.format(
                                         offer.outletPrice,
                                     )}
@@ -91,36 +93,55 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                             </Typography>
                         ) : null}
                     </Stack>
-                    <dl className="grid gap-3 text-sm sm:grid-cols-3">
+                    <dl className="grid gap-4 border-y border-tertiary py-4 text-sm sm:grid-cols-3">
                         <div>
-                            <dt className="text-muted-foreground">Sjetva</dt>
-                            <dd className="font-medium">
-                                {dateFormatter.format(
+                            <dt className="flex items-center gap-1.5 text-muted-foreground">
+                                <Sprout aria-hidden className="size-4" />
+                                Sjetva
+                            </dt>
+                            <dd className="mt-1 font-medium">
+                                {longDateFormatter.format(
                                     new Date(offer.sowingDate),
                                 )}
                             </dd>
                         </div>
                         <div>
-                            <dt className="text-muted-foreground">Preostalo</dt>
-                            <dd className="font-medium">
+                            <dt className="flex items-center gap-1.5 text-muted-foreground">
+                                <Calendar aria-hidden className="size-4" />
+                                Preostalo
+                            </dt>
+                            <dd className="mt-1 font-medium">
                                 {offer.remainingQuantity} od {offer.quantity}
                             </dd>
                         </div>
                         <div>
-                            <dt className="text-muted-foreground">
+                            <dt className="flex items-center gap-1.5 text-muted-foreground">
+                                <Timer aria-hidden className="size-4" />
                                 Ponuda traje do
                             </dt>
-                            <dd className="font-medium">
-                                {timeFormatter.format(new Date(offer.endAt))}
+                            <dd className="mt-1 font-medium">
+                                {offerEndFormatter.format(
+                                    new Date(offer.endAt),
+                                )}
                             </dd>
                         </div>
                     </dl>
-                    <NavigatingButton
-                        href={outletGardenUrl(offer.id)}
-                        className="w-fit"
-                    >
-                        Odaberi u vrtu
-                    </NavigatingButton>
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <Typography
+                            level="body2"
+                            secondary
+                            className="max-w-md text-pretty"
+                        >
+                            Outlet presadnicu rezerviraš odabirom praznog polja
+                            u svom vrtu.
+                        </Typography>
+                        <NavigatingButton
+                            href={outletGardenUrl(offer.id)}
+                            className="w-fit"
+                        >
+                            Odaberi u vrtu
+                        </NavigatingButton>
+                    </div>
                 </Stack>
             </div>
         </article>

--- a/apps/www/app/outlet/outletPresentation.ts
+++ b/apps/www/app/outlet/outletPresentation.ts
@@ -1,0 +1,49 @@
+import type { OutletOffer } from './outletData';
+
+export const currencyFormatter = new Intl.NumberFormat('hr-HR', {
+    style: 'currency',
+    currency: 'EUR',
+});
+
+export const compactDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'short',
+});
+
+export const longDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+});
+
+export const offerEndFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+});
+
+export function outletDiscountPercentage(offer: OutletOffer) {
+    if (
+        typeof offer.comparePrice !== 'number' ||
+        offer.comparePrice <= offer.outletPrice
+    ) {
+        return null;
+    }
+
+    return Math.round(
+        ((offer.comparePrice - offer.outletPrice) / offer.comparePrice) * 100,
+    );
+}
+
+export function outletDiscountLabel(offer: OutletOffer) {
+    const percentage = outletDiscountPercentage(offer);
+
+    return percentage ? `Uštedi ${percentage}%` : 'Outlet cijena';
+}
+
+export function outletRemainingLabel(offer: OutletOffer) {
+    return offer.remainingQuantity === 1
+        ? 'Samo 1 preostala'
+        : `preostalo ${offer.remainingQuantity}`;
+}

--- a/apps/www/app/outlet/page.tsx
+++ b/apps/www/app/outlet/page.tsx
@@ -1,4 +1,6 @@
 import { Container } from '@gredice/ui/Container';
+import { Discount, ShoppingCart, Sprout, Timer } from '@gredice/ui/icons';
+import { NavigatingButton } from '@gredice/ui/NavigatingButton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
@@ -6,6 +8,7 @@ import { StructuredDataScript } from '../../components/shared/seo/StructuredData
 import { KnownPages } from '../../src/KnownPages';
 import { OutletOfferCard } from './OutletOfferCard';
 import { getOutletOffers, outletOfferImage } from './outletData';
+import { currencyFormatter, offerEndFormatter } from './outletPresentation';
 
 export const dynamic = 'force-dynamic';
 
@@ -64,35 +67,163 @@ function outletStructuredData(
     };
 }
 
+function outletSummary(offers: Awaited<ReturnType<typeof getOutletOffers>>) {
+    const remainingQuantity = offers.reduce(
+        (total, offer) => total + offer.remainingQuantity,
+        0,
+    );
+    const lowestOutletPrice = offers.reduce<number | null>(
+        (lowestPrice, offer) =>
+            lowestPrice === null
+                ? offer.outletPrice
+                : Math.min(lowestPrice, offer.outletPrice),
+        null,
+    );
+    const nextEndingOffer = offers.reduce<(typeof offers)[number] | null>(
+        (nextOffer, offer) =>
+            nextOffer === null ||
+            new Date(offer.endAt).getTime() <
+                new Date(nextOffer.endAt).getTime()
+                ? offer
+                : nextOffer,
+        null,
+    );
+
+    return {
+        lowestOutletPrice,
+        nextEndingOffer,
+        remainingQuantity,
+    };
+}
+
 export default async function OutletPage() {
     const offers = await getOutletOffers();
+    const { lowestOutletPrice, nextEndingOffer, remainingQuantity } =
+        outletSummary(offers);
 
     return (
         <Container className="py-10 sm:py-14">
             {offers.length > 0 ? (
                 <StructuredDataScript data={outletStructuredData(offers)} />
             ) : null}
-            <Stack spacing={8}>
-                <Stack spacing={3} className="max-w-3xl">
-                    <Typography level="body1" semiBold tertiary>
-                        Gredice Outlet
-                    </Typography>
-                    <Typography level="h1">Outlet sadnica</Typography>
-                    <Typography level="body1" secondary>
-                        Presadnice koje su ostale u našem stakleniku nudimo po
-                        nižoj cijeni dok traju zalihe i naznačeno vrijeme
-                        ponude.
-                    </Typography>
-                </Stack>
+            <Stack spacing={10}>
+                <section className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.55fr)] lg:items-end">
+                    <Stack spacing={5} className="max-w-3xl">
+                        <div className="inline-flex w-fit items-center gap-2 rounded-full border border-amber-300/70 bg-amber-100 px-3 py-1.5 text-sm font-medium text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+                            <Discount aria-hidden className="size-4" />
+                            Outlet cijena, Gredice kvaliteta
+                        </div>
+                        <Stack spacing={3}>
+                            <Typography level="body1" semiBold tertiary>
+                                Gredice Outlet
+                            </Typography>
+                            <Typography level="h1">
+                                Presadnice po outlet cijeni
+                            </Typography>
+                            <Typography
+                                level="body1"
+                                secondary
+                                className="max-w-2xl text-pretty"
+                            >
+                                Zdrave presadnice koje su već krenule u rast iz
+                                našeg staklenika možeš dodati u svoju gredicu po
+                                povoljnijoj cijeni. Ponude su vremenski i
+                                količinski ograničene.
+                            </Typography>
+                        </Stack>
+                        <div className="flex flex-wrap gap-2">
+                            <span className="inline-flex items-center gap-1.5 rounded-full bg-card px-3 py-1.5 text-sm text-secondary-foreground ring-1 ring-tertiary">
+                                <Sprout
+                                    aria-hidden
+                                    className="size-4 text-primary"
+                                />
+                                Spremne za tvoju gredicu
+                            </span>
+                            <span className="inline-flex items-center gap-1.5 rounded-full bg-card px-3 py-1.5 text-sm text-secondary-foreground ring-1 ring-tertiary">
+                                <ShoppingCart
+                                    aria-hidden
+                                    className="size-4 text-primary"
+                                />
+                                Rezervacija kroz vrt
+                            </span>
+                        </div>
+                    </Stack>
+                    {offers.length > 0 ? (
+                        <dl className="grid grid-cols-3 gap-2 sm:gap-3">
+                            <div className="rounded-2xl border border-tertiary border-b-4 bg-card p-3 sm:p-4">
+                                <dt className="text-sm text-muted-foreground">
+                                    Ponude
+                                </dt>
+                                <dd className="mt-1 text-3xl">
+                                    {offers.length}
+                                </dd>
+                            </div>
+                            <div className="rounded-2xl border border-tertiary border-b-4 bg-card p-3 sm:p-4">
+                                <dt className="text-sm text-muted-foreground">
+                                    Sadnice
+                                </dt>
+                                <dd className="mt-1 text-3xl">
+                                    {remainingQuantity}
+                                </dd>
+                            </div>
+                            <div className="rounded-2xl border border-tertiary border-b-4 bg-card p-3 sm:p-4">
+                                <dt className="text-sm text-muted-foreground">
+                                    Od
+                                </dt>
+                                <dd className="mt-1 text-3xl">
+                                    {lowestOutletPrice === null
+                                        ? '-'
+                                        : currencyFormatter.format(
+                                              lowestOutletPrice,
+                                          )}
+                                </dd>
+                            </div>
+                        </dl>
+                    ) : null}
+                </section>
                 {offers.length > 0 ? (
-                    <div className="grid gap-5">
-                        {offers.map((offer) => (
-                            <OutletOfferCard key={offer.id} offer={offer} />
-                        ))}
-                    </div>
+                    <section
+                        aria-labelledby="outlet-offers-heading"
+                        className="grid gap-5"
+                    >
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                            <Stack spacing={1}>
+                                <Typography
+                                    id="outlet-offers-heading"
+                                    level="h2"
+                                >
+                                    Dostupne outlet sadnice
+                                </Typography>
+                                {nextEndingOffer ? (
+                                    <Typography level="body2" secondary>
+                                        Sljedeća ponuda istječe{' '}
+                                        {offerEndFormatter.format(
+                                            new Date(nextEndingOffer.endAt),
+                                        )}
+                                        .
+                                    </Typography>
+                                ) : null}
+                            </Stack>
+                            <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-card px-3 py-1.5 text-sm text-secondary-foreground ring-1 ring-tertiary">
+                                <Timer
+                                    aria-hidden
+                                    className="size-4 text-amber-600 dark:text-amber-300"
+                                />
+                                Dok traju zalihe
+                            </span>
+                        </div>
+                        <div className="grid gap-5">
+                            {offers.map((offer) => (
+                                <OutletOfferCard key={offer.id} offer={offer} />
+                            ))}
+                        </div>
+                    </section>
                 ) : (
-                    <div className="rounded-lg border border-tertiary bg-card p-6">
-                        <Stack spacing={2}>
+                    <div className="rounded-2xl border border-tertiary border-b-4 bg-card p-6 sm:p-8">
+                        <Stack spacing={4} className="max-w-2xl">
+                            <div className="flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+                                <Sprout aria-hidden className="size-6" />
+                            </div>
                             <Typography level="h3" component="h2">
                                 Trenutno nema aktivnih outlet ponuda
                             </Typography>
@@ -101,6 +232,13 @@ export default async function OutletPage() {
                                 prikazat ćemo ih ovdje s rokom ponude i
                                 preostalom količinom.
                             </Typography>
+                            <NavigatingButton
+                                href={KnownPages.Plants}
+                                variant="outlined"
+                                className="w-fit"
+                            >
+                                Pregledaj biljke
+                            </NavigatingButton>
                         </Stack>
                     </div>
                 )}


### PR DESCRIPTION
## Summary

- Redesign the homepage outlet section so it matches the rest of the public www app.
- Improve `/outlet` with a clearer hero, compact availability stats, timed-offer messaging, and a stronger empty state.
- Add richer outlet offer cards with savings, outlet price, regular price, stock, sowing date, offer end time, and a clear garden reservation CTA.
- Address the automated accessibility comment by letting the homepage offer link derive its accessible name from the visible card content.

## Validation

- `pnpm --filter www exec biome check --write app/outlet/page.tsx app/outlet/OutletOfferCard.tsx app/outlet/OutletLandingOfferCard.tsx app/outlet/outletPresentation.ts`
- `pnpm --filter www typecheck`
- `git diff --check`
- Local browser verification on `/outlet` desktop and mobile viewports; page rendered, one offer card appeared, no framework overlay, and no horizontal overflow.
- Local mobile browser verification on the `/outlet` offer card; no card overflow.