### PR TITLE
[codex] Add outlet sowing flow

### DIFF
--- a/apps/garden/tests/PlantPickerTestStory.tsx
+++ b/apps/garden/tests/PlantPickerTestStory.tsx
@@ -293,9 +293,11 @@ function PlantPickerTestProviders({
     children,
     favorites = [],
     inventoryItems = [],
+    searchParams,
 }: PropsWithChildren<{
     favorites?: FavoriteItem[];
     inventoryItems?: TestInventoryItem[];
+    searchParams?: string;
 }>) {
     const queryClient = useMemo(
         () => createPlantPickerQueryClient({ favorites, inventoryItems }),
@@ -313,7 +315,7 @@ function PlantPickerTestProviders({
     );
 
     return (
-        <NuqsTestingAdapter>
+        <NuqsTestingAdapter hasMemory searchParams={searchParams}>
             <ReactQuery.QueryClientProvider client={queryClient}>
                 <GameStateContext.Provider value={gameStore}>
                     {children}
@@ -345,16 +347,19 @@ function OutletOfferRefetchTestHook() {
 export function PlantPickerTestStory({
     favorites,
     inventoryItems,
+    searchParams,
     showOutletRefetchControl = false,
 }: {
     favorites?: FavoriteItem[];
     inventoryItems?: TestInventoryItem[];
+    searchParams?: string;
     showOutletRefetchControl?: boolean;
 } = {}) {
     return (
         <PlantPickerTestProviders
             favorites={favorites}
             inventoryItems={inventoryItems}
+            searchParams={searchParams}
         >
             {showOutletRefetchControl ? <OutletOfferRefetchTestHook /> : null}
             <PlantPicker

--- a/apps/garden/tests/RaisedBedDiaryStory.tsx
+++ b/apps/garden/tests/RaisedBedDiaryStory.tsx
@@ -1,6 +1,10 @@
 import * as ReactQuery from '@tanstack/react-query';
 import { type PropsWithChildren, useMemo } from 'react';
 import { RaisedBedDiary } from '../../../packages/game/src/hud/raisedBed/RaisedBedDiary';
+import {
+    createGameState,
+    GameStateContext,
+} from '../../../packages/game/src/useGameState';
 import { Card, CardOverflow } from '../../../packages/ui/src/Card';
 import { buildOperation } from './raisedBedFieldHudScenarios';
 
@@ -143,10 +147,22 @@ function createRaisedBedDiaryQueryClient() {
 
 function RaisedBedDiaryTestProviders({ children }: PropsWithChildren) {
     const queryClient = useMemo(() => createRaisedBedDiaryQueryClient(), []);
+    const gameStore = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: 'http://localhost',
+                freezeTime: null,
+                isMock: false,
+                winterMode: 'summer',
+            }),
+        [],
+    );
 
     return (
         <ReactQuery.QueryClientProvider client={queryClient}>
-            {children}
+            <GameStateContext.Provider value={gameStore}>
+                {children}
+            </GameStateContext.Provider>
         </ReactQuery.QueryClientProvider>
     );
 }

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -689,7 +689,7 @@ function daysAgoIso(days: number): string {
 }
 
 function daysFromNowIso(days: number): string {
-    const date = new Date();
+    const date = new Date('2026-05-13T12:00:00.000Z');
     date.setDate(date.getDate() + days);
     return date.toISOString();
 }
@@ -1340,15 +1340,6 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(
             scheduleDialog.locator('[data-event-calendar]'),
         ).toBeVisible();
-
-        await expect(
-            scheduleDialog.getByRole('button', {
-                name: 'Prethodni mjesec',
-            }),
-        ).toBeEnabled();
-        await scheduleDialog
-            .getByRole('button', { name: 'Prethodni mjesec' })
-            .click();
 
         await expect(
             scheduleDialog.locator('[data-event-calendar-month="2026-05"]'),

--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -193,6 +193,21 @@ test('plant search keeps keyboard focus while filtering sowing options', async (
     await expect(page.getByRole('button', { name: /Bosiljak/ })).toHaveCount(0);
 });
 
+test('plant list shows outlet availability before sort selection', async ({
+    mount,
+    page,
+}) => {
+    await mount(<PlantPickerTestStory />);
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+
+    const tomatoRow = page.locator('[data-plant-picker-plant-id="1"]');
+    const basilRow = page.locator('[data-plant-picker-plant-id="2"]');
+
+    await expect(tomatoRow).toContainText('Outlet 2 ponude');
+    await expect(basilRow).not.toContainText('Outlet');
+});
+
 test('outlet sorts keep planned sowing selected by default', async ({
     mount,
     page,
@@ -289,6 +304,40 @@ test('outlet sowing sends the selected outlet offer', async ({
         name: /Preostalo 3/,
     });
     await sowingMode.getByText('Preostalo 3').click();
+    await expect(laterOutletOffer).toBeChecked();
+    await expect(
+        page.getByRole('textbox', { name: 'Datum sijanja' }),
+    ).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Dodaj u košaru' }).click();
+
+    await expect.poll(() => posts.length).toBe(1);
+    const post = posts[0];
+    expect(isRecord(post)).toBe(true);
+    if (!isRecord(post)) {
+        return;
+    }
+    expect(post.outletOfferId).toBe(302);
+    expect(post.additionalData).toBe(JSON.stringify({ outletOfferId: 302 }));
+});
+
+test('outlet selection param opens the selected outlet offer', async ({
+    mount,
+    page,
+}) => {
+    const posts = await mockShoppingCartPosts(page);
+
+    await mount(<PlantPickerTestStory searchParams="outlet-ponuda=302" />);
+
+    await page.getByRole('button', { name: 'Sijanje' }).click();
+
+    await expect(page.getByText('Odabir sorte').last()).toBeVisible();
+    const sowingMode = page.getByRole('radiogroup', {
+        name: 'Način sijanja',
+    });
+    const laterOutletOffer = sowingMode.getByRole('radio', {
+        name: /Preostalo 3/,
+    });
     await expect(laterOutletOffer).toBeChecked();
     await expect(
         page.getByRole('textbox', { name: 'Datum sijanja' }),

--- a/packages/game/src/hud/OutletHud.tsx
+++ b/packages/game/src/hud/OutletHud.tsx
@@ -1,14 +1,25 @@
 import { Button } from '@gredice/ui/Button';
-import { Discount } from '@gredice/ui/icons';
+import { Discount, Navigate } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
+import { useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import type { OutletOfferData } from '../hooks/useOutletOffers';
 import { useOutletOffers } from '../hooks/useOutletOffers';
 import { GameModal } from '../shared-ui/game-modal';
-import { useOutletOpenParam } from '../useUrlState';
+import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
+import {
+    useOutletOfferSelectionParam,
+    useOutletOpenParam,
+} from '../useUrlState';
 import { HudCard } from './components/HudCard';
+import {
+    findFirstEmptyRaisedBedField,
+    waitForPlantPickerTrigger,
+} from './raisedBed/plantPickerNavigation';
 
 const currencyFormatter = new Intl.NumberFormat('hr-HR', {
     style: 'currency',
@@ -29,13 +40,52 @@ function offerImageUrl(offer: {
 
 export function OutletHud() {
     const { data: offers, isLoading, isError } = useOutletOffers();
+    const { data: currentGarden } = useCurrentGarden();
     const [outletParam, setOutletParam] = useOutletOpenParam();
+    const [, setOutletOfferSelectionParam] = useOutletOfferSelectionParam();
+    const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
     const { track } = useGameAnalytics();
+    const [pendingOfferId, setPendingOfferId] = useState<number | null>(null);
     const isOpen = outletParam !== null;
     const highlightedOfferId =
         outletParam && outletParam !== '1'
             ? Number.parseInt(outletParam, 10)
             : null;
+    const selectedOffer =
+        offers?.find((offer) => offer.id === highlightedOfferId) ??
+        offers?.[0] ??
+        null;
+    const emptyFieldTarget = findFirstEmptyRaisedBedField(currentGarden);
+
+    async function handleStartPlanting(offer: OutletOfferData) {
+        if (!emptyFieldTarget || pendingOfferId !== null) {
+            return;
+        }
+
+        setPendingOfferId(offer.id);
+        track('game_outlet_offer_planting_started', {
+            garden_id: currentGarden?.id,
+            outlet_offer_id: offer.id,
+            plant_sort_id: offer.plantSort.id,
+            position_index: emptyFieldTarget.positionIndex,
+            raised_bed_id: emptyFieldTarget.raisedBedId,
+        });
+
+        try {
+            await setOutletOfferSelectionParam(offer.id);
+            await setOutletParam(null);
+            await Promise.resolve(
+                setRaisedBedCloseupParam(
+                    emptyFieldTarget.raisedBedName,
+                    emptyFieldTarget.positionIndex,
+                ),
+            );
+            const trigger = await waitForPlantPickerTrigger(emptyFieldTarget);
+            trigger?.click();
+        } finally {
+            setPendingOfferId(null);
+        }
+    }
 
     if (!isLoading && !offers?.length && !isOpen) {
         return null;
@@ -76,8 +126,8 @@ export function OutletHud() {
             >
                 <Stack spacing={4}>
                     <Typography level="body2" secondary>
-                        Odaberi prazno polje u gredici i u popisu sorti uključi
-                        Outlet cijenu za dostupnu presadnicu.
+                        Odaberi outlet sadnicu i nastavi na prvo prazno polje u
+                        aktivnoj gredici.
                     </Typography>
                     {isLoading ? (
                         <Typography level="body2">Učitavanje...</Typography>
@@ -95,10 +145,11 @@ export function OutletHud() {
                     <div className="grid gap-3">
                         {offers?.map((offer) => {
                             const imageUrl = offerImageUrl(offer);
-                            const highlighted = highlightedOfferId === offer.id;
+                            const highlighted = selectedOffer?.id === offer.id;
 
                             return (
                                 <button
+                                    aria-pressed={highlighted}
                                     key={offer.id}
                                     type="button"
                                     className={cx(
@@ -154,6 +205,32 @@ export function OutletHud() {
                             );
                         })}
                     </div>
+                    {selectedOffer ? (
+                        <Stack spacing={2}>
+                            {!emptyFieldTarget ? (
+                                <Typography level="body2" secondary>
+                                    Za outlet sadnicu treba prazno polje u
+                                    aktivnoj gredici.
+                                </Typography>
+                            ) : null}
+                            <Row justifyContent="end">
+                                <Button
+                                    disabled={!emptyFieldTarget}
+                                    loading={
+                                        pendingOfferId === selectedOffer.id
+                                    }
+                                    onClick={() =>
+                                        void handleStartPlanting(selectedOffer)
+                                    }
+                                    startDecorator={
+                                        <Navigate className="size-5 shrink-0" />
+                                    }
+                                >
+                                    Nastavi na sijanje
+                                </Button>
+                            </Row>
+                        </Stack>
+                    ) : null}
                 </Stack>
             </GameModal>
         </HudCard>

--- a/packages/game/src/hud/OutletHud.tsx
+++ b/packages/game/src/hud/OutletHud.tsx
@@ -9,6 +9,7 @@ import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import type { OutletOfferData } from '../hooks/useOutletOffers';
 import { useOutletOffers } from '../hooks/useOutletOffers';
+import { useShoppingCart } from '../hooks/useShoppingCart';
 import { GameModal } from '../shared-ui/game-modal';
 import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
 import {
@@ -41,6 +42,7 @@ function offerImageUrl(offer: {
 export function OutletHud() {
     const { data: offers, isLoading, isError } = useOutletOffers();
     const { data: currentGarden } = useCurrentGarden();
+    const { data: cart } = useShoppingCart();
     const [outletParam, setOutletParam] = useOutletOpenParam();
     const [, setOutletOfferSelectionParam] = useOutletOfferSelectionParam();
     const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
@@ -55,7 +57,10 @@ export function OutletHud() {
         offers?.find((offer) => offer.id === highlightedOfferId) ??
         offers?.[0] ??
         null;
-    const emptyFieldTarget = findFirstEmptyRaisedBedField(currentGarden);
+    const emptyFieldTarget = findFirstEmptyRaisedBedField(
+        currentGarden,
+        cart?.items,
+    );
 
     async function handleStartPlanting(offer: OutletOfferData) {
         if (!emptyFieldTarget || pendingOfferId !== null) {

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -28,26 +28,18 @@ import { KnownPages } from '../knownPages';
 import { GameModal } from '../shared-ui/game-modal';
 import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
 import { useBackpackOpenParam, useShoppingCartOpenParam } from '../useUrlState';
-import { getRaisedBedBlockIds } from '../utils/raisedBedBlocks';
-import { isRaisedBedFieldOccupied } from '../utils/raisedBedFields';
 import { formatSunflowers } from '../utils/sunflowerPricing';
 import { HudCard } from './components/HudCard';
 import { RAISED_BED_ONBOARDING_OPEN_EVENT } from './RaisedBedOnboardingModal';
+import {
+    findFirstEmptyRaisedBedField,
+    waitForPlantPickerTrigger,
+} from './raisedBed/plantPickerNavigation';
 import styles from './TutorialChecklistHud.module.css';
 
 const tutorialTaskListIconSrc = '/assets/hud/tutorial-task-list.png';
 const completedChecklistDismissedStorageKey =
     'game:tutorial-checklist:completed-dismissed-v1';
-
-type CurrentGardenData = NonNullable<
-    ReturnType<typeof useCurrentGarden>['data']
->;
-
-type EmptyRaisedBedFieldTarget = {
-    positionIndex: number;
-    raisedBedId: number;
-    raisedBedName: string;
-};
 
 function RewardText({ task }: { task: TutorialChecklistTask }) {
     if (task.rewardLabel) {
@@ -331,87 +323,6 @@ function waitForChecklistClose() {
             window.requestAnimationFrame(() => resolve());
         }, 0);
     });
-}
-
-function waitForPlantPickerTrigger({
-    positionIndex,
-    raisedBedId,
-}: EmptyRaisedBedFieldTarget) {
-    if (typeof document === 'undefined') {
-        return Promise.resolve(null);
-    }
-
-    const selector = [
-        'button[data-raised-bed-plant-picker-trigger="true"]',
-        `[data-raised-bed-id="${raisedBedId.toString()}"]`,
-        `[data-position-index="${positionIndex.toString()}"]`,
-    ].join('');
-
-    return new Promise<HTMLButtonElement | null>((resolve) => {
-        const deadline = Date.now() + 2500;
-
-        function check() {
-            const button = document.querySelector<HTMLButtonElement>(selector);
-            if (button) {
-                resolve(button);
-                return;
-            }
-
-            if (Date.now() >= deadline) {
-                resolve(null);
-                return;
-            }
-
-            window.requestAnimationFrame(check);
-        }
-
-        check();
-    });
-}
-
-function findFirstEmptyRaisedBedField(
-    garden: CurrentGardenData | null | undefined,
-): EmptyRaisedBedFieldTarget | null {
-    if (!garden || garden.isSandbox) {
-        return null;
-    }
-
-    for (const raisedBed of garden.raisedBeds) {
-        const raisedBedName = raisedBed.name?.trim();
-        if (
-            !raisedBedName ||
-            raisedBed.status !== 'active' ||
-            !raisedBed.isValid
-        ) {
-            continue;
-        }
-
-        const blockCount = Math.max(
-            getRaisedBedBlockIds(garden, raisedBed.id).length,
-            1,
-        );
-        const occupiedPositionIndices = new Set(
-            raisedBed.fields
-                .filter(isRaisedBedFieldOccupied)
-                .map((field) => field.positionIndex),
-        );
-
-        for (
-            let positionIndex = 0;
-            positionIndex < blockCount * 9;
-            positionIndex += 1
-        ) {
-            if (!occupiedPositionIndices.has(positionIndex)) {
-                return {
-                    positionIndex,
-                    raisedBedId: raisedBed.id,
-                    raisedBedName,
-                };
-            }
-        }
-    }
-
-    return null;
 }
 
 function openExternalTaskTarget(task: TutorialChecklistTask) {

--- a/packages/game/src/hud/TutorialChecklistHud.tsx
+++ b/packages/game/src/hud/TutorialChecklistHud.tsx
@@ -15,6 +15,7 @@ import { parseAsString, useQueryState } from 'nuqs';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useShoppingCart } from '../hooks/useShoppingCart';
 import {
     type TutorialChecklistGroup,
     type TutorialChecklistState,
@@ -354,13 +355,14 @@ function shouldCloseChecklistBeforeOpen(task: TutorialChecklistTask) {
 
 function useOpenTaskTarget(onChecklistOpenChange: (open: boolean) => void) {
     const { data: currentGarden } = useCurrentGarden();
+    const { data: cart } = useShoppingCart();
     const [, setBackpackOpen] = useBackpackOpenParam();
     const [, setCartOpen] = useShoppingCartOpenParam();
     const [, setOverviewTab] = useQueryState('pregled', parseAsString);
     const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
 
     async function openFirstEmptyRaisedBedPlantPicker() {
-        const target = findFirstEmptyRaisedBedField(currentGarden);
+        const target = findFirstEmptyRaisedBedField(currentGarden, cart?.items);
         if (!target) {
             return false;
         }

--- a/packages/game/src/hud/raisedBed/PlantsList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsList.tsx
@@ -15,6 +15,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
 import { sortFavoritesFirst, useFavoriteIds } from '../../hooks/useFavorites';
+import type { OutletOfferData } from '../../hooks/useOutletOffers';
 import { usePlants } from '../../hooks/usePlants';
 import { KnownPages } from '../../knownPages';
 import { FavoriteToggleButton } from './FavoriteToggleButton';
@@ -61,6 +62,19 @@ function formatNeighborPlantNames(names: string[]) {
         : visibleNames.join(', ');
 }
 
+const outletCurrencyFormatter = new Intl.NumberFormat('hr-HR', {
+    style: 'currency',
+    currency: 'EUR',
+});
+
+function outletOfferBadgeLabel(outletOffers: OutletOfferData[]) {
+    if (outletOffers.length === 1) {
+        return `Outlet ${outletCurrencyFormatter.format(outletOffers[0].outletPrice)}`;
+    }
+
+    return `Outlet ${outletOffers.length} ponude`;
+}
+
 export function PlantRelationshipSignalChips({
     signal,
 }: {
@@ -101,10 +115,12 @@ export function PlantRelationshipSignalChips({
 export function PlantsList({
     neighborPlants = [],
     onChange,
+    outletOffersByPlantId,
     search,
 }: {
     neighborPlants?: NeighborPlantSummary[];
     onChange: (plant: PlantData) => void;
+    outletOffersByPlantId?: Map<number, OutletOfferData[]>;
     search: string;
 }) {
     const { track } = useGameAnalytics();
@@ -181,6 +197,7 @@ export function PlantsList({
                         <PlantListItemSkeleton key={index} />
                     ))}
                 {sortedPlants?.map((plant) => {
+                    const outletOffers = outletOffersByPlantId?.get(plant.id);
                     const relationshipSignal =
                         relationshipSignalsByPlantId.get(plant.id) ??
                         getPlantRelationshipSignal({
@@ -264,6 +281,11 @@ export function PlantsList({
                                 {plant.isRecommended && (
                                     <SeedTimeInformationBadge size="sm" />
                                 )}
+                                {outletOffers?.length ? (
+                                    <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-700 dark:bg-green-900/50 dark:text-green-200">
+                                        {outletOfferBadgeLabel(outletOffers)}
+                                    </span>
+                                ) : null}
                                 <PlantRelationshipSignalChips
                                     signal={relationshipSignal}
                                 />

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldLifecycleTab.tsx
@@ -8,6 +8,7 @@ import { ShovelIcon } from '@gredice/ui/ShovelIcon';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { useLiveTime } from '../../hooks/useLiveTime';
 import { usePlantSort } from '../../hooks/usePlantSorts';
 import { useRaisedBedFieldRemove } from '../../hooks/useRaisedBedFieldRemove';
 import { KnownPages } from '../../knownPages';
@@ -36,6 +37,7 @@ export function useRaisedBedFieldLifecycleData(
     fieldOverride?: RaisedBedFieldPlantHistoryEntry,
 ) {
     const { data: garden } = useCurrentGarden();
+    const now = useLiveTime();
     const raisedBed = garden?.raisedBeds.find((bed) => bed.id === raisedBedId);
     const field =
         fieldOverride ??
@@ -46,6 +48,7 @@ export function useRaisedBedFieldLifecycleData(
     const { data: plantSort } = usePlantSort(plantSortId);
     return getPlantLifecycleProgressData({
         field: raisedBed && field && plantSort ? field : null,
+        now,
         plantAttributes: plantSort?.information.plant.attributes,
     });
 }

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -48,6 +48,7 @@ import {
 } from '../../hooks/useShoppingCartTransientHub';
 import { KnownPages } from '../../knownPages';
 import { GameModal } from '../../shared-ui/game-modal';
+import { useOutletOfferSelectionParam } from '../../useUrlState';
 import { PlantsList } from './PlantsList';
 import { PlantsSortList } from './PlantsSortList';
 import {
@@ -123,6 +124,33 @@ function groupOutletOffersBySortId(outletOffers: OutletOfferData[] = []) {
     return offersBySortId;
 }
 
+function groupOutletOffersByPlantId(
+    outletOffers: OutletOfferData[] | undefined,
+    allSorts: PlantSortData[] | undefined,
+) {
+    const offersByPlantId = new Map<number, OutletOfferData[]>();
+
+    for (const offer of outletOffers ?? []) {
+        const plantId = outletOfferPlantId(offer, allSorts);
+        if (!plantId) {
+            continue;
+        }
+
+        const plantOffers = offersByPlantId.get(plantId);
+        if (plantOffers) {
+            plantOffers.push(offer);
+        } else {
+            offersByPlantId.set(plantId, [offer]);
+        }
+    }
+
+    for (const plantOffers of offersByPlantId.values()) {
+        plantOffers.sort(compareOutletOffers);
+    }
+
+    return offersByPlantId;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -142,6 +170,18 @@ function parseAdditionalData(additionalData?: string | null) {
 
 function isGreenhouseSowing(additionalData?: string | null) {
     return parseAdditionalData(additionalData).sowingLocation === 'greenhouse';
+}
+
+function outletOfferPlantId(
+    offer: OutletOfferData,
+    allSorts: PlantSortData[] | undefined,
+) {
+    return (
+        offer.plantSort.plant?.id ??
+        allSorts?.find((sort) => sort.id === offer.plantSort.id)?.information
+            .plant.id ??
+        null
+    );
 }
 
 type PlantPickerOptions = {
@@ -186,6 +226,8 @@ export function PlantPicker({
     const raisedBed = currentGarden?.raisedBeds.find(
         (bed) => bed.id === raisedBedId,
     );
+    const [outletOfferSelectionParam, setOutletOfferSelectionParam] =
+        useOutletOfferSelectionParam();
     const { data: allSorts } = useAllSorts();
     const { data: outletOffers } = useOutletOffers();
     const setCartItem = useSetShoppingCartItem();
@@ -435,6 +477,30 @@ export function PlantPicker({
             });
         }
         setOpen(open);
+
+        const selectedOutletOfferFromParam =
+            open && typeof outletOfferSelectionParam === 'number'
+                ? outletOffers?.find(
+                      (offer) => offer.id === outletOfferSelectionParam,
+                  )
+                : undefined;
+        const selectedOutletPlantId = selectedOutletOfferFromParam
+            ? outletOfferPlantId(selectedOutletOfferFromParam, allSorts)
+            : null;
+
+        if (selectedOutletOfferFromParam && selectedOutletPlantId) {
+            setSelectedPlantId(selectedOutletPlantId);
+            setSelectedSortId(selectedOutletOfferFromParam.plantSort.id);
+            setPlantOptions(null);
+            setUseInventoryItem(false);
+            setUseOutletOffer(true);
+            setSowInGreenhouse(false);
+            setSelectedOutletOfferId(selectedOutletOfferFromParam.id);
+            void setOutletOfferSelectionParam(null);
+            resetSearch();
+            return;
+        }
+
         setSelectedPlantId(preselectedPlantId ?? null);
         setSelectedSortId(preselectedSortId ?? null);
         setPlantOptions(preselectedPlantOptions ?? null);
@@ -510,6 +576,10 @@ export function PlantPicker({
     const outletOffersBySortId = useMemo(
         () => groupOutletOffersBySortId(outletOffers),
         [outletOffers],
+    );
+    const outletOffersByPlantId = useMemo(
+        () => groupOutletOffersByPlantId(outletOffers, allSorts),
+        [allSorts, outletOffers],
     );
     const selectedOutletOffers = selectedSortId
         ? (outletOffersBySortId.get(selectedSortId) ?? [])
@@ -644,6 +714,7 @@ export function PlantPicker({
                 {currentStep === 0 && (
                     <PlantsList
                         neighborPlants={neighborPlants}
+                        outletOffersByPlantId={outletOffersByPlantId}
                         search={search}
                         onChange={handlePlantSelect}
                     />

--- a/packages/game/src/hud/raisedBed/RaisedBedWateringCalendar.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWateringCalendar.tsx
@@ -247,6 +247,7 @@ export function RaisedBedWateringCalendar({
     previewDate,
     previewOperation,
     raisedBedId,
+    referenceDate,
     selectedDate,
     visibleFrom,
     visibleTo,
@@ -260,11 +261,13 @@ export function RaisedBedWateringCalendar({
     previewDate?: Date | null;
     previewOperation?: OperationData;
     raisedBedId: number;
+    referenceDate?: Date;
     selectedDate?: Date | null;
     visibleFrom?: Date;
     visibleTo?: Date;
 }) {
-    const referenceDate = useLiveTime();
+    const liveReferenceDate = useLiveTime();
+    const resolvedReferenceDate = referenceDate ?? liveReferenceDate;
     const { data: operations, isError: isOperationsError } = useOperations();
     const { data: cart } = useShoppingCart();
     const history = useGardenOperations({
@@ -316,7 +319,7 @@ export function RaisedBedWateringCalendar({
                 gardenId,
                 operationsById,
                 raisedBedId,
-                referenceDate,
+                referenceDate: resolvedReferenceDate,
             }),
             ...buildPreviewEntry({
                 operation: previewOperation,
@@ -331,7 +334,7 @@ export function RaisedBedWateringCalendar({
             previewDate,
             previewOperation,
             raisedBedId,
-            referenceDate,
+            resolvedReferenceDate,
         ],
     );
 
@@ -352,7 +355,7 @@ export function RaisedBedWateringCalendar({
             maxSelectableDate={maxSelectableDate}
             minSelectableDate={minSelectableDate}
             onDateSelect={onDateSelect}
-            referenceDate={referenceDate}
+            referenceDate={resolvedReferenceDate}
             selectedDate={selectedDate}
             visibleFrom={visibleFrom}
             visibleTo={visibleTo}

--- a/packages/game/src/hud/raisedBed/plantPickerNavigation.ts
+++ b/packages/game/src/hud/raisedBed/plantPickerNavigation.ts
@@ -1,10 +1,37 @@
-import type { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import type { Stack } from '../../types/Stack';
 import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
 
-type CurrentGardenData = NonNullable<
-    ReturnType<typeof useCurrentGarden>['data']
->;
+type RaisedBedTargetField = {
+    active?: boolean | null;
+    plantSortId?: number | null;
+    positionIndex: number;
+};
+
+type RaisedBedTarget = {
+    blockId: string | null;
+    fields: RaisedBedTargetField[];
+    id: number;
+    isValid: boolean;
+    name?: string | null;
+    orientation?: 'vertical' | 'horizontal';
+    status: string;
+};
+
+export type RaisedBedFieldTargetGarden = {
+    id: number;
+    isSandbox?: boolean | null;
+    raisedBeds: RaisedBedTarget[];
+    stacks: Stack[];
+};
+
+export type RaisedBedFieldTargetCartItem = {
+    entityTypeName?: string | null;
+    gardenId?: number | null;
+    positionIndex?: number | null;
+    raisedBedId?: number | null;
+    status?: string | null;
+};
 
 export type EmptyRaisedBedFieldTarget = {
     positionIndex: number;
@@ -12,8 +39,23 @@ export type EmptyRaisedBedFieldTarget = {
     raisedBedName: string;
 };
 
+function isRaisedBedCartPlantItem(
+    item: RaisedBedFieldTargetCartItem,
+    gardenId: number,
+    raisedBedId: number,
+): item is RaisedBedFieldTargetCartItem & { positionIndex: number } {
+    return (
+        item.gardenId === gardenId &&
+        item.raisedBedId === raisedBedId &&
+        item.entityTypeName === 'plantSort' &&
+        item.status === 'new' &&
+        typeof item.positionIndex === 'number'
+    );
+}
+
 export function findFirstEmptyRaisedBedField(
-    garden: CurrentGardenData | null | undefined,
+    garden: RaisedBedFieldTargetGarden | null | undefined,
+    cartItems?: RaisedBedFieldTargetCartItem[] | null,
 ): EmptyRaisedBedFieldTarget | null {
     if (!garden || garden.isSandbox) {
         return null;
@@ -38,6 +80,11 @@ export function findFirstEmptyRaisedBedField(
                 .filter(isRaisedBedFieldOccupied)
                 .map((field) => field.positionIndex),
         );
+        for (const item of cartItems ?? []) {
+            if (isRaisedBedCartPlantItem(item, garden.id, raisedBed.id)) {
+                occupiedPositionIndices.add(item.positionIndex);
+            }
+        }
 
         for (
             let positionIndex = 0;

--- a/packages/game/src/hud/raisedBed/plantPickerNavigation.ts
+++ b/packages/game/src/hud/raisedBed/plantPickerNavigation.ts
@@ -1,0 +1,94 @@
+import type { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
+import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
+
+type CurrentGardenData = NonNullable<
+    ReturnType<typeof useCurrentGarden>['data']
+>;
+
+export type EmptyRaisedBedFieldTarget = {
+    positionIndex: number;
+    raisedBedId: number;
+    raisedBedName: string;
+};
+
+export function findFirstEmptyRaisedBedField(
+    garden: CurrentGardenData | null | undefined,
+): EmptyRaisedBedFieldTarget | null {
+    if (!garden || garden.isSandbox) {
+        return null;
+    }
+
+    for (const raisedBed of garden.raisedBeds) {
+        const raisedBedName = raisedBed.name?.trim();
+        if (
+            !raisedBedName ||
+            raisedBed.status !== 'active' ||
+            !raisedBed.isValid
+        ) {
+            continue;
+        }
+
+        const blockCount = Math.max(
+            getRaisedBedBlockIds(garden, raisedBed.id).length,
+            1,
+        );
+        const occupiedPositionIndices = new Set(
+            raisedBed.fields
+                .filter(isRaisedBedFieldOccupied)
+                .map((field) => field.positionIndex),
+        );
+
+        for (
+            let positionIndex = 0;
+            positionIndex < blockCount * 9;
+            positionIndex += 1
+        ) {
+            if (!occupiedPositionIndices.has(positionIndex)) {
+                return {
+                    positionIndex,
+                    raisedBedId: raisedBed.id,
+                    raisedBedName,
+                };
+            }
+        }
+    }
+
+    return null;
+}
+
+export function waitForPlantPickerTrigger({
+    positionIndex,
+    raisedBedId,
+}: EmptyRaisedBedFieldTarget) {
+    if (typeof document === 'undefined') {
+        return Promise.resolve(null);
+    }
+
+    const selector = [
+        'button[data-raised-bed-plant-picker-trigger="true"]',
+        `[data-raised-bed-id="${raisedBedId.toString()}"]`,
+        `[data-position-index="${positionIndex.toString()}"]`,
+    ].join('');
+
+    return new Promise<HTMLButtonElement | null>((resolve) => {
+        const deadline = Date.now() + 2500;
+
+        function check() {
+            const button = document.querySelector<HTMLButtonElement>(selector);
+            if (button) {
+                resolve(button);
+                return;
+            }
+
+            if (Date.now() >= deadline) {
+                resolve(null);
+                return;
+            }
+
+            window.requestAnimationFrame(check);
+        }
+
+        check();
+    });
+}

--- a/packages/game/src/hud/raisedBed/plantPickerNavigation.unit.ts
+++ b/packages/game/src/hud/raisedBed/plantPickerNavigation.unit.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    findFirstEmptyRaisedBedField,
+    type RaisedBedFieldTargetCartItem,
+    type RaisedBedFieldTargetGarden,
+} from './plantPickerNavigation';
+
+const garden = {
+    id: 1,
+    isSandbox: false,
+    raisedBeds: [
+        {
+            blockId: 'raised-bed-1',
+            fields: [
+                { active: true, plantSortId: 101, positionIndex: 0 },
+                { active: false, plantSortId: null, positionIndex: 1 },
+                { active: false, plantSortId: null, positionIndex: 2 },
+            ],
+            id: 11,
+            isValid: true,
+            name: 'Plavi Vjetar',
+            orientation: 'vertical',
+            status: 'active',
+        },
+    ],
+    stacks: [],
+} satisfies RaisedBedFieldTargetGarden;
+
+test('findFirstEmptyRaisedBedField skips pending cart plant positions', () => {
+    const cartItems = [
+        {
+            entityTypeName: 'plantSort',
+            gardenId: 1,
+            positionIndex: 1,
+            raisedBedId: 11,
+            status: 'new',
+        },
+    ] satisfies RaisedBedFieldTargetCartItem[];
+
+    assert.deepEqual(findFirstEmptyRaisedBedField(garden, cartItems), {
+        positionIndex: 2,
+        raisedBedId: 11,
+        raisedBedName: 'Plavi Vjetar',
+    });
+});

--- a/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
+++ b/packages/game/src/hud/raisedBed/shared/OperationScheduleModal.tsx
@@ -11,6 +11,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
+import { useLiveTime } from '../../../hooks/useLiveTime';
 import { GameModal } from '../../../shared-ui/game-modal';
 import { formatLocalDate } from '../RaisedBedPlantPicker';
 import {
@@ -53,7 +54,7 @@ export function OperationScheduleModal({
         null,
     );
 
-    const today = new Date();
+    const today = useLiveTime();
     const tomorrow = new Date(
         today.getFullYear(),
         today.getMonth(),
@@ -173,6 +174,7 @@ export function OperationScheduleModal({
                             previewDate={selectedDate}
                             previewOperation={operation}
                             raisedBedId={raisedBedId}
+                            referenceDate={today}
                             selectedDate={selectedDate}
                             visibleFrom={tomorrow}
                             visibleTo={threeMonthsFromTomorrow}
@@ -189,6 +191,7 @@ export function OperationScheduleModal({
                             positionIndex={positionIndex}
                             previewDate={selectedDate}
                             raisedBedId={raisedBedId}
+                            referenceDate={today}
                             selectedDate={selectedDate}
                             visibleFrom={tomorrow}
                             visibleTo={threeMonthsFromTomorrow}
@@ -202,6 +205,7 @@ export function OperationScheduleModal({
                             maxSelectableDate={threeMonthsFromTomorrow}
                             minSelectableDate={tomorrow}
                             onDateSelect={handleDateSelect}
+                            referenceDate={today}
                             selectedDate={selectedDate}
                             visibleFrom={tomorrow}
                             visibleTo={threeMonthsFromTomorrow}

--- a/packages/game/src/useUrlState.tsx
+++ b/packages/game/src/useUrlState.tsx
@@ -16,6 +16,10 @@ export function useOutletOpenParam() {
     return useQueryState('outlet', parseAsString);
 }
 
+export function useOutletOfferSelectionParam() {
+    return useQueryState('outlet-ponuda', parseAsInteger);
+}
+
 // Backpack/Inventory modal parameter (Croatian: "ruksak" = backpack)
 export function useBackpackOpenParam() {
     return useQueryState('ruksak', parseAsBoolean.withDefault(false));
@@ -79,6 +83,7 @@ export function useCurrentGardenIdParam() {
 export const urlStateSerializer = createSerializer({
     kosarica: parseAsBoolean,
     outlet: parseAsString,
+    'outlet-ponuda': parseAsInteger,
     ruksak: parseAsBoolean,
     'ruksak-kartica': parseAsString,
     gredica: parseAsString,


### PR DESCRIPTION
## Summary

- Make the outlet HUD actionable by routing selected outlet offers into the existing raised-bed plant picker flow.
- Add a plant-picker URL state handoff so outlet offers can preselect the matching plant, sort, and outlet sowing mode.
- Surface outlet availability one step earlier on plant rows and reuse the first-empty-field navigation helper with the tutorial checklist.

## Validation

- Biome on touched game/garden files
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden exec playwright test tests/raised-bed-plant-picker.spec.tsx --project=chromium`
- `pnpm --filter garden build`