### PR TITLE
[Garden] Public visibility toggle and tutorial reward

### DIFF
--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -1,16 +1,15 @@
+import {
+    booleanFlagOptions,
+    publicGardensFlagDefinition,
+} from '@gredice/js/featureFlags';
 import { flag } from 'flags/next';
-
-const booleanOptions = [
-    { label: 'Off', value: false },
-    { label: 'On', value: true },
-];
 
 export const deliveryChargeAtCheckoutFlag = flag<boolean>({
     key: 'deliveryChargeAtCheckout',
     description:
         'Whether to enable charging the delivery while doing checkout.',
     decide: () => false,
-    options: booleanOptions,
+    options: booleanFlagOptions,
 });
 
 export const addressDistanceVerificationFlag = flag<boolean>({
@@ -18,38 +17,43 @@ export const addressDistanceVerificationFlag = flag<boolean>({
     description:
         'Enable address verification and indicator that the address is outside of delivery location.',
     decide: () => false,
-    options: booleanOptions,
+    options: booleanFlagOptions,
 });
 
 export const rainWetOverlayFlag = flag<boolean>({
     key: 'rainWetOverlay',
     description: 'Enable rain wetness overlays on exposed garden entities.',
     decide: () => false,
-    options: booleanOptions,
+    options: booleanFlagOptions,
 });
 
 export const enableDebugCloseupFlag = flag<boolean>({
     key: 'enableDebugCloseup',
     decide: () => false,
-    options: booleanOptions,
+    options: booleanFlagOptions,
 });
 
 export const enableDebugHudFlag = flag<boolean>({
     key: 'enableDebugHud',
     decide: () => false,
-    options: booleanOptions,
+    options: booleanFlagOptions,
 });
 
 export const enableSuncokretChatFlag = flag<boolean>({
     key: 'enableSuncokretChat',
     description: 'Enable the in-game Suncokret AI chat HUD.',
     decide: () => false,
-    options: booleanOptions,
+    options: booleanFlagOptions,
 });
 
 export const enableSuncokretDebugFlag = flag<boolean>({
     key: 'enableSuncokretDebug',
     description: 'Show Suncokret AI debug metadata in chat conversations.',
     decide: () => false,
-    options: booleanOptions,
+    options: booleanFlagOptions,
+});
+
+export const publicGardensFlag = flag<boolean>({
+    ...publicGardensFlagDefinition,
+    decide: () => false,
 });

--- a/apps/garden/app/page.tsx
+++ b/apps/garden/app/page.tsx
@@ -7,6 +7,7 @@ import {
     enableDebugHudFlag,
     enableSuncokretChatFlag,
     enableSuncokretDebugFlag,
+    publicGardensFlag,
     rainWetOverlayFlag,
 } from './flags';
 
@@ -21,6 +22,7 @@ export default async function Home() {
         enableRainWetOverlayFlag: await rainWetOverlayFlag(),
         enableSuncokretChatFlag: await enableSuncokretChatFlag(),
         enableSuncokretDebugFlag: await enableSuncokretDebugFlag(),
+        publicGardensFlag: await publicGardensFlag(),
     };
 
     return (

--- a/packages/game/src/GameFlagsContext.tsx
+++ b/packages/game/src/GameFlagsContext.tsx
@@ -13,6 +13,7 @@ export interface GameFeatureFlags {
     enableRainWetOverlayFlag?: boolean;
     enableSuncokretChatFlag?: boolean;
     enableSuncokretDebugFlag?: boolean;
+    publicGardensFlag?: boolean;
 }
 
 export const GameFlagsContext = createContext<GameFeatureFlags>({});

--- a/packages/game/src/hooks/useUpdateGardenVisibility.ts
+++ b/packages/game/src/hooks/useUpdateGardenVisibility.ts
@@ -1,0 +1,92 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGameState } from '../useGameState';
+import type { useCurrentGarden } from './useCurrentGarden';
+import { currentGardenKeys } from './useCurrentGarden';
+import type { useGardens } from './useGardens';
+import { useGardensKeys } from './useGardens';
+import { tutorialChecklistKeys } from './useTutorialChecklist';
+
+type UpdateGardenVisibilityVariables = {
+    isPublic: boolean;
+};
+
+type CurrentGardenData = ReturnType<typeof useCurrentGarden>['data'];
+type GardensData = ReturnType<typeof useGardens>['data'];
+
+export function useUpdateGardenVisibility(gardenId?: number) {
+    const queryClient = useQueryClient();
+    const winterMode = useGameState((state) => state.winterMode);
+    const gardenQueryKey = currentGardenKeys(winterMode, gardenId);
+
+    return useMutation({
+        mutationFn: async ({ isPublic }: UpdateGardenVisibilityVariables) => {
+            if (!gardenId) {
+                throw new Error(
+                    'Garden ID is required to update garden visibility',
+                );
+            }
+
+            const response = await clientAuthenticated().api.gardens[
+                ':gardenId'
+            ].$patch({
+                param: { gardenId: gardenId.toString() },
+                json: { isPublic },
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to update garden visibility');
+            }
+        },
+        onMutate: async ({ isPublic }) => {
+            await Promise.all([
+                queryClient.cancelQueries({ queryKey: gardenQueryKey }),
+                queryClient.cancelQueries({ queryKey: useGardensKeys }),
+            ]);
+
+            const previousGarden =
+                queryClient.getQueryData<CurrentGardenData>(gardenQueryKey);
+            const previousGardens =
+                queryClient.getQueryData<GardensData>(useGardensKeys);
+
+            queryClient.setQueryData<CurrentGardenData>(
+                gardenQueryKey,
+                (currentGarden) =>
+                    currentGarden
+                        ? { ...currentGarden, isPublic }
+                        : currentGarden,
+            );
+            queryClient.setQueryData<GardensData>(
+                useGardensKeys,
+                (currentGardens) =>
+                    currentGardens?.map((garden) =>
+                        garden.id === gardenId
+                            ? { ...garden, isPublic }
+                            : garden,
+                    ) ?? currentGardens,
+            );
+
+            return { previousGarden, previousGardens };
+        },
+        onError: (error, _variables, context) => {
+            console.error('Failed to update garden visibility:', error);
+            if (context?.previousGarden !== undefined) {
+                queryClient.setQueryData(
+                    gardenQueryKey,
+                    context.previousGarden,
+                );
+            }
+            if (context?.previousGardens !== undefined) {
+                queryClient.setQueryData(
+                    useGardensKeys,
+                    context.previousGardens,
+                );
+            }
+        },
+        onSettled: () => {
+            queryClient.invalidateQueries({ queryKey: gardenQueryKey });
+            queryClient.invalidateQueries({ queryKey: useGardensKeys });
+            queryClient.invalidateQueries({ queryKey: tutorialChecklistKeys });
+        },
+    });
+}

--- a/packages/game/src/knownPages.ts
+++ b/packages/game/src/knownPages.ts
@@ -16,6 +16,8 @@ export const KnownPages = {
     GrediceSunflowers: 'https://www.gredice.com/suncokreti',
     GrediceReferrals: 'https://www.gredice.com/preporuke',
     GrediceContact: 'https://www.gredice.com/kontakt',
+    GredicePublicGarden: (gardenId: number) =>
+        `https://www.gredice.com/vrtovi/${gardenId.toString()}`,
     GrediceFirstRaisedBedGuide: 'https://www.gredice.com/vodic-za-prvu-gredicu',
     GrediceWhatsNew: 'https://www.gredice.com/novosti/sto-je-novo',
     GrediceDeliverySlots: 'https://www.gredice.com/dostava/termini',

--- a/packages/game/src/modals/components/GardenTab.tsx
+++ b/packages/game/src/modals/components/GardenTab.tsx
@@ -21,6 +21,7 @@ import { useCurrentGardenIdParam } from '../../useUrlState';
 import { CreateGardenModal } from './CreateGardenModal';
 import { GardenDangerCard } from './GardenDangerCard';
 import { GardenNameCard } from './GardenNameCard';
+import { GardenVisibilityCard } from './GardenVisibilityCard';
 
 function NoGardensCard() {
     const [createGardenModalOpen, setCreateGardenModalOpen] = useState(false);
@@ -143,6 +144,11 @@ export function GardenTab() {
                                     gardenId={selectedGarden.id}
                                     gardenName={selectedGarden.name}
                                     gardenCreatedAt={selectedGarden.createdAt}
+                                />
+                                <GardenVisibilityCard
+                                    gardenId={selectedGarden.id}
+                                    gardenName={selectedGarden.name}
+                                    isPublic={selectedGarden.isPublic}
                                 />
                                 <GardenDangerCard
                                     gardenId={selectedGarden.id}

--- a/packages/game/src/modals/components/GardenVisibilityCard.tsx
+++ b/packages/game/src/modals/components/GardenVisibilityCard.tsx
@@ -1,0 +1,105 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent } from '@gredice/ui/Card';
+import { ExternalLink, Globe, Warning } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Switch } from '@gredice/ui/Switch';
+import { Typography } from '@gredice/ui/Typography';
+import { useState } from 'react';
+import { useGameFlags } from '../../GameFlagsContext';
+import { useUpdateGardenVisibility } from '../../hooks/useUpdateGardenVisibility';
+import { KnownPages } from '../../knownPages';
+
+type GardenVisibilityCardProps = {
+    gardenId: number;
+    gardenName: string;
+    isPublic: boolean;
+};
+
+export function GardenVisibilityCard({
+    gardenId,
+    gardenName,
+    isPublic,
+}: GardenVisibilityCardProps) {
+    const { publicGardensFlag } = useGameFlags();
+    const updateVisibility = useUpdateGardenVisibility(gardenId);
+    const [error, setError] = useState<string | null>(null);
+    const publicUrl = KnownPages.GredicePublicGarden(gardenId);
+
+    if (!publicGardensFlag) {
+        return null;
+    }
+
+    function handleVisibilityChange(nextPublic: boolean) {
+        setError(null);
+        updateVisibility.mutate(
+            { isPublic: nextPublic },
+            {
+                onError: () => {
+                    setError(
+                        'Nije moguće promijeniti vidljivost vrta. Pokušaj ponovno.',
+                    );
+                },
+            },
+        );
+    }
+
+    return (
+        <Card>
+            <CardContent noHeader>
+                <Stack spacing={4}>
+                    <Row spacing={4} alignItems="start">
+                        <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-sky-100 text-sky-700 ring-4 ring-sky-200/70 dark:bg-sky-900/70 dark:text-sky-100 dark:ring-sky-800/70">
+                            <Globe className="size-5 shrink-0" />
+                        </div>
+                        <Stack spacing={1} className="min-w-0 grow">
+                            <Row
+                                spacing={3}
+                                alignItems="center"
+                                className="justify-between gap-4"
+                            >
+                                <Typography level="body1" semiBold>
+                                    Javni vrt
+                                </Typography>
+                                <Switch
+                                    aria-label={`Javna vidljivost vrta ${gardenName}`}
+                                    checked={isPublic}
+                                    disabled={updateVisibility.isPending}
+                                    onCheckedChange={handleVisibilityChange}
+                                />
+                            </Row>
+                            <Typography level="body2">
+                                {isPublic
+                                    ? 'Svatko s poveznicom može pregledati vrt bez uređivanja.'
+                                    : 'Vrt je privatan i nije dostupan na javnim stranicama.'}
+                            </Typography>
+                        </Stack>
+                    </Row>
+                    {isPublic ? (
+                        <Button
+                            href={publicUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            variant="outlined"
+                            size="sm"
+                            startDecorator={<ExternalLink className="size-4" />}
+                        >
+                            Otvori javni vrt
+                        </Button>
+                    ) : null}
+                    {error ? (
+                        <Alert
+                            color="danger"
+                            startDecorator={
+                                <Warning className="size-4 shrink-0" />
+                            }
+                        >
+                            <Typography level="body2">{error}</Typography>
+                        </Alert>
+                    ) : null}
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+}

--- a/packages/storage/src/repositories/tutorialChecklistRepo.ts
+++ b/packages/storage/src/repositories/tutorialChecklistRepo.ts
@@ -68,6 +68,7 @@ type TutorialChecklistSignal =
     | 'favoriteAdded'
     | 'futureOperationScheduled'
     | 'gardenRenamed'
+    | 'gardenMadePublic'
     | 'hasOperationHistory'
     | 'paidOrder'
     | 'plantingAchievement10'
@@ -428,6 +429,16 @@ const taskDefinitions = [
         actionTarget: 'garden',
     },
     {
+        key: 'make-garden-public',
+        groupId: 'day-3',
+        title: 'Objavi vrt',
+        description: 'U postavkama vrta uključi javni prikaz vrta.',
+        rewardSunflowers: 500,
+        completion: 'derived',
+        signal: 'gardenMadePublic',
+        actionTarget: 'garden',
+    },
+    {
         key: 'open-plant-database',
         groupId: 'day-3',
         title: 'Otvori bazu biljaka',
@@ -576,6 +587,7 @@ function emptySignals(): TutorialChecklistSignals {
         favoriteAdded: false,
         futureOperationScheduled: false,
         gardenRenamed: false,
+        gardenMadePublic: false,
         harvestAchievement1: false,
         hasOperationHistory: false,
         paidOrder: false,
@@ -707,6 +719,7 @@ async function getTutorialChecklistSignals({
         if (!garden.isSandbox) {
             signals.secondGardenCreated ||=
                 gardens.filter((candidate) => !candidate.isSandbox).length >= 2;
+            signals.gardenMadePublic ||= garden.isPublic;
         }
         for (const raisedBed of garden.raisedBeds) {
             signals.activeRaisedBed ||=

--- a/packages/storage/tests/tutorialChecklistRepo.node.spec.ts
+++ b/packages/storage/tests/tutorialChecklistRepo.node.spec.ts
@@ -14,6 +14,7 @@ import {
     markTutorialChecklistTaskReady,
     setUserFavorite,
     TutorialChecklistTaskNotClaimableError,
+    updateGarden,
     upsertEntityType,
     upsertOrRemoveCartItem,
 } from '@gredice/storage';
@@ -107,6 +108,46 @@ test('tutorial checklist treats an active raised bed as first plan progress', as
     assert.strictEqual(task.status, 'ready');
     assert.strictEqual(task.claimable, true);
     assert.strictEqual(task.completed, false);
+});
+
+test('tutorial checklist rewards making a garden public once', async () => {
+    createTestDb();
+    const { accountId, userId } = await createChecklistTestUser();
+    const farmId = await ensureFarmId();
+    const gardenId = await createTestGarden({ accountId, farmId });
+
+    let state = await getTutorialChecklistState({ accountId, userId });
+    let task = findChecklistTask(state, 'make-garden-public');
+    assert.ok(task);
+    assert.strictEqual(task.rewardSunflowers, 500);
+    assert.strictEqual(task.status, 'available');
+    assert.strictEqual(task.claimable, false);
+
+    await updateGarden({ id: gardenId, isPublic: true });
+
+    state = await getTutorialChecklistState({ accountId, userId });
+    task = findChecklistTask(state, 'make-garden-public');
+    assert.ok(task);
+    assert.strictEqual(task.status, 'ready');
+    assert.strictEqual(task.claimable, true);
+
+    await claimTutorialChecklistTask({
+        accountId,
+        userId,
+        taskKey: 'make-garden-public',
+    });
+
+    assert.strictEqual(await getSunflowers(accountId), 1500);
+    await assert.rejects(
+        () =>
+            claimTutorialChecklistTask({
+                accountId,
+                userId,
+                taskKey: 'make-garden-public',
+            }),
+        TutorialChecklistTaskNotClaimableError,
+    );
+    assert.strictEqual(await getSunflowers(accountId), 1500);
 });
 
 test('tutorial checklist notification settings task becomes claimable after visiting settings', async () => {


### PR DESCRIPTION
## Summary
- add shared `publicGardens` flag wiring to the garden app runtime flags
- add a garden settings visibility card with public/private toggle, public URL, and optimistic cache updates
- add the `make-garden-public` tutorial task with a one-time 500 sunflower reward

## Test Plan
- `pnpm --filter @gredice/storage test:node gardensRepo.node.spec.ts tutorialChecklistRepo.node.spec.ts`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden build`
- `git diff --check`

Depends on #3880
Closes #3875
Part of #3873