### PR TITLE
[App] Admin garden visibility controls

### DIFF
--- a/apps/app/app/.well-known/vercel/flags/route.ts
+++ b/apps/app/app/.well-known/vercel/flags/route.ts
@@ -1,0 +1,4 @@
+import { createFlagsDiscoveryEndpoint, getProviderData } from 'flags/next';
+import * as flags from '../../../../app/flags';
+
+export const GET = createFlagsDiscoveryEndpoint(() => getProviderData(flags));

--- a/apps/app/app/admin/gardens/GardensTable.tsx
+++ b/apps/app/app/admin/gardens/GardensTable.tsx
@@ -1,11 +1,15 @@
 import type { SelectGarden } from '@gredice/storage';
+import { Chip } from '@gredice/ui/Chip';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import { NoDataPlaceholder } from '../../../components/shared/placeholders/NoDataPlaceholder';
 import { KnownPages } from '../../../src/KnownPages';
 
-type GardenRow = Pick<SelectGarden, 'accountId' | 'createdAt' | 'id' | 'name'>;
+type GardenRow = Pick<
+    SelectGarden,
+    'accountId' | 'createdAt' | 'id' | 'isPublic' | 'name'
+>;
 
 type GardensTableProps = {
     gardens: GardenRow[];
@@ -43,6 +47,16 @@ export function GardensTable({
                             >
                                 {garden.name}
                             </Link>
+                            {garden.isPublic ? (
+                                <Chip
+                                    color="success"
+                                    size="sm"
+                                    variant="soft"
+                                    className="mt-1"
+                                >
+                                    Public
+                                </Chip>
+                            ) : null}
                         </div>
                         <div className="flex min-w-0 flex-col gap-1 text-left sm:items-end sm:text-right">
                             {showAccountColumn && (

--- a/apps/app/app/admin/gardens/[gardenId]/AdminGardenVisibilityToggle.tsx
+++ b/apps/app/app/admin/gardens/[gardenId]/AdminGardenVisibilityToggle.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { ExternalLink, Warning } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Switch } from '@gredice/ui/Switch';
+import { Typography } from '@gredice/ui/Typography';
+import { useState, useTransition } from 'react';
+import { updateGardenVisibilityAction } from './actions';
+
+type AdminGardenVisibilityToggleProps = {
+    enabled: boolean;
+    gardenId: number;
+    isPublic: boolean;
+    publicUrl: string;
+};
+
+export function AdminGardenVisibilityToggle({
+    enabled,
+    gardenId,
+    isPublic,
+    publicUrl,
+}: AdminGardenVisibilityToggleProps) {
+    const [checked, setChecked] = useState(isPublic);
+    const [message, setMessage] = useState<string | null>(null);
+    const [isPending, startTransition] = useTransition();
+
+    function handleChange(nextPublic: boolean) {
+        setChecked(nextPublic);
+        setMessage(null);
+        startTransition(async () => {
+            const result = await updateGardenVisibilityAction({
+                gardenId,
+                isPublic: nextPublic,
+            });
+            if (!result.success) {
+                setChecked(!nextPublic);
+                setMessage(result.message);
+            }
+        });
+    }
+
+    return (
+        <Stack spacing={3} className="p-4">
+            <Row spacing={3} className="justify-between">
+                <Stack spacing={0} className="min-w-0">
+                    <Typography level="body2" semiBold>
+                        Public visibility
+                    </Typography>
+                    <Typography level="body3" className="text-muted-foreground">
+                        {enabled
+                            ? checked
+                                ? 'Garden is visible on www.'
+                                : 'Garden is private.'
+                            : 'Feature flag is disabled.'}
+                    </Typography>
+                </Stack>
+                <Switch
+                    aria-label="Public garden visibility"
+                    checked={checked}
+                    disabled={!enabled || isPending}
+                    onCheckedChange={handleChange}
+                />
+            </Row>
+            {checked && enabled ? (
+                <Button
+                    href={publicUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    variant="outlined"
+                    size="sm"
+                    startDecorator={<ExternalLink className="size-4" />}
+                >
+                    Open public page
+                </Button>
+            ) : null}
+            {message ? (
+                <Alert
+                    color="danger"
+                    startDecorator={<Warning className="size-4 shrink-0" />}
+                >
+                    <Typography level="body2">{message}</Typography>
+                </Alert>
+            ) : null}
+        </Stack>
+    );
+}

--- a/apps/app/app/admin/gardens/[gardenId]/actions.ts
+++ b/apps/app/app/admin/gardens/[gardenId]/actions.ts
@@ -1,0 +1,44 @@
+'use server';
+
+import { getGarden, updateGarden } from '@gredice/storage';
+import { revalidatePath } from 'next/cache';
+import { auth } from '../../../../lib/auth/auth';
+import { KnownPages } from '../../../../src/KnownPages';
+import { publicGardensFlag } from '../../../flags';
+
+export async function updateGardenVisibilityAction({
+    gardenId,
+    isPublic,
+}: {
+    gardenId: number;
+    isPublic: boolean;
+}) {
+    await auth(['admin']);
+
+    if (!(await publicGardensFlag())) {
+        return {
+            success: false,
+            message: 'Public gardens feature flag is disabled.',
+        };
+    }
+
+    const garden = await getGarden(gardenId);
+    if (!garden) {
+        return {
+            success: false,
+            message: 'Garden not found.',
+        };
+    }
+
+    await updateGarden({ id: gardenId, isPublic });
+
+    revalidatePath(KnownPages.Gardens);
+    revalidatePath(KnownPages.Garden(gardenId));
+    revalidatePath('/vrtovi');
+    revalidatePath(`/vrtovi/${gardenId.toString()}`);
+
+    return {
+        success: true,
+        message: isPublic ? 'Garden is public.' : 'Garden is private.',
+    };
+}

--- a/apps/app/app/admin/gardens/[gardenId]/page.tsx
+++ b/apps/app/app/admin/gardens/[gardenId]/page.tsx
@@ -1,6 +1,7 @@
 import { getGarden } from '@gredice/storage';
 import { Breadcrumbs } from '@gredice/ui/Breadcrumbs';
 import { Card, CardOverflow } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import Image from 'next/image';
@@ -20,7 +21,9 @@ import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navig
 import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
+import { publicGardensFlag } from '../../../flags';
 import { RaisedBedsTableCard } from '../../accounts/[accountId]/RaisedBedsTableCard';
+import { AdminGardenVisibilityToggle } from './AdminGardenVisibilityToggle';
 
 export const dynamic = 'force-dynamic';
 
@@ -53,14 +56,23 @@ export default async function GardenPage({
 }) {
     const { gardenId } = await params;
     await auth(['admin']);
-    const garden = await getGarden(gardenId);
+    const [garden, publicGardensEnabled] = await Promise.all([
+        getGarden(gardenId),
+        publicGardensFlag(),
+    ]);
 
     if (!garden) {
         notFound();
     }
+    const publicGardenUrl = KnownPages.GredicePublicGarden(garden.id);
     const propertyItems: EntityDetailsPropertyListItem[] = [
         { id: 'id', label: 'ID vrta', value: garden.id, mono: true },
         { id: 'name', label: 'Naziv', value: garden.name },
+        {
+            id: 'public',
+            label: 'Javan',
+            value: garden.isPublic ? 'Da' : 'Ne',
+        },
         {
             id: 'account',
             label: 'Račun',
@@ -89,6 +101,27 @@ export default async function GardenPage({
         <EntityDetailsPropertiesPanel>
             <EntityDetailsPanelCard title="Detalji">
                 <EntityDetailsPropertyList items={propertyItems} />
+            </EntityDetailsPanelCard>
+            <EntityDetailsPanelCard
+                title="Vidljivost"
+                action={
+                    garden.isPublic ? (
+                        <Chip color="success" size="sm" variant="soft">
+                            Public
+                        </Chip>
+                    ) : (
+                        <Chip color="neutral" size="sm" variant="soft">
+                            Private
+                        </Chip>
+                    )
+                }
+            >
+                <AdminGardenVisibilityToggle
+                    enabled={publicGardensEnabled}
+                    gardenId={garden.id}
+                    isPublic={garden.isPublic}
+                    publicUrl={publicGardenUrl}
+                />
             </EntityDetailsPanelCard>
         </EntityDetailsPropertiesPanel>
     );

--- a/apps/app/app/flags.ts
+++ b/apps/app/app/flags.ts
@@ -1,0 +1,7 @@
+import { publicGardensFlagDefinition } from '@gredice/js/featureFlags';
+import { flag } from 'flags/next';
+
+export const publicGardensFlag = flag<boolean>({
+    ...publicGardensFlagDefinition,
+    decide: () => false,
+});

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -33,6 +33,7 @@
         "@vvo/tzdb": "6.198.0",
         "@xyflow/react": "12.10.2",
         "drizzle-orm": "0.45.2",
+        "flags": "4.0.6",
         "next": "16.2.9",
         "next-themes": "0.4.6",
         "pg": "8.21.0",

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -146,4 +146,6 @@ export const KnownPages = {
         `https://www.gredice.com/radnje/${slugify(operationAlias)}`,
     GrediceUser: (publicId: string) =>
         `https://www.gredice.com/korisnici/${publicId}`,
+    GredicePublicGarden: (gardenId: number) =>
+        `https://www.gredice.com/vrtovi/${gardenId.toString()}`,
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.21.0)
+      flags:
+        specifier: 4.0.6
+        version: 4.0.6(@opentelemetry/api@1.9.1)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
         specifier: 16.2.9
         version: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)


### PR DESCRIPTION
## Summary
- add admin app `publicGardens` flag adapter and discovery endpoint
- add public/private status to garden lists and garden detail properties
- add admin-only visibility toggle with page revalidation for admin and public garden routes

## Test Plan
- `pnpm --filter app build`
- targeted `pnpm --filter app exec tsc --noEmit --pretty false` scan for new admin files
- `git diff --check`

Note: the broad direct app tsc command still reports existing unrelated errors outside these files.

Depends on #3880
Closes #3876
Part of #3873