### PR TITLE
[WWW] Public gardens index and readonly garden pages

### DIFF
--- a/apps/www/app/flags.ts
+++ b/apps/www/app/flags.ts
@@ -1,3 +1,7 @@
+import {
+    booleanFlagOptions,
+    publicGardensFlagDefinition,
+} from '@gredice/js/featureFlags';
 import { flag } from 'flags/next';
 
 function isDevelopmentEnvironment() {
@@ -8,18 +12,17 @@ export const lSystemPlantsFlag = flag<boolean>({
     key: 'lSystemPlants',
     description: 'Enable L-System plants content rendering.',
     decide: () => false,
-    options: [
-        { label: 'Off', value: false },
-        { label: 'On', value: true },
-    ],
+    options: booleanFlagOptions,
 });
 
 export const recipesFlag = flag<boolean>({
     key: 'recipes',
     description: 'Enable recipes pages and recipe detail routes.',
     decide: () => isDevelopmentEnvironment(),
-    options: [
-        { label: 'Off', value: false },
-        { label: 'On', value: true },
-    ],
+    options: booleanFlagOptions,
+});
+
+export const publicGardensFlag = flag<boolean>({
+    ...publicGardensFlagDefinition,
+    decide: () => false,
 });

--- a/apps/www/app/korisnici/[publicId]/ProfilePageClient.tsx
+++ b/apps/www/app/korisnici/[publicId]/ProfilePageClient.tsx
@@ -4,40 +4,12 @@ import { clientPublic } from '@gredice/client';
 import { getAchievementDefinition } from '@gredice/js/achievements';
 import { Stack } from '@gredice/ui/Stack';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { PublicGardenViewerDynamic } from './PublicGardenViewerDynamic';
 
 type ProfilePageClientProps = {
     publicId: string;
 };
-
-function mapStacks(
-    stacks: Record<
-        string,
-        Record<
-            string,
-            {
-                id: string;
-                name: string;
-                rotation?: number | null;
-                variant?: number | null;
-            }[]
-        >
-    >,
-) {
-    return Object.entries(stacks).flatMap(([x, rows]) =>
-        Object.entries(rows).map(([y, blocks]) => ({
-            x: Number(x),
-            y: Number(y),
-            blocks: blocks.map((block) => ({
-                id: block.id,
-                name: block.name,
-                rotation: block.rotation ?? 0,
-                variant: block.variant,
-            })),
-        })),
-    );
-}
 
 export function ProfilePageClient({ publicId }: ProfilePageClientProps) {
     const profileQuery = useQuery({
@@ -84,11 +56,6 @@ export function ProfilePageClient({ publicId }: ProfilePageClientProps) {
         profileQuery.data?.achievements.filter(
             (achievement) => achievement.status === 'approved',
         ) ?? [];
-
-    const gardenStacks = useMemo(
-        () => (gardenQuery.data ? mapStacks(gardenQuery.data.stacks) : []),
-        [gardenQuery.data],
-    );
 
     if (profileQuery.isLoading) {
         return <p>Učitavanje profila...</p>;
@@ -171,7 +138,7 @@ export function ProfilePageClient({ publicId }: ProfilePageClientProps) {
                     ) : (
                         <PublicGardenViewerDynamic
                             className="h-full"
-                            stacks={gardenStacks}
+                            garden={gardenQuery.data}
                         />
                     )}
                 </div>

--- a/apps/www/app/vrtovi/PublicGardenViewerDynamic.tsx
+++ b/apps/www/app/vrtovi/PublicGardenViewerDynamic.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import type { PublicGardenViewerProps } from '@gredice/game';
+import dynamic from 'next/dynamic';
+
+export const PublicGardenViewerDynamic = dynamic<PublicGardenViewerProps>(
+    () => import('@gredice/game').then((mod) => mod.PublicGardenViewer),
+    {
+        ssr: false,
+        loading: () => (
+            <div className="h-full min-h-[520px] animate-pulse rounded-md border border-black/10 bg-background/60" />
+        ),
+    },
+);

--- a/apps/www/app/vrtovi/[gardenId]/page.tsx
+++ b/apps/www/app/vrtovi/[gardenId]/page.tsx
@@ -1,0 +1,79 @@
+import { PageHeader } from '@gredice/ui/PageHeader';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { KnownPages } from '../../../src/KnownPages';
+import { PublicGardenViewerDynamic } from '../PublicGardenViewerDynamic';
+import { getPublicGardenForWww } from '../publicGardenData';
+
+export const dynamic = 'force-dynamic';
+
+function parseGardenId(value: string) {
+    const gardenId = Number.parseInt(value, 10);
+    return Number.isFinite(gardenId) ? gardenId : null;
+}
+
+type PublicGardenPageParams = {
+    gardenId: string;
+};
+
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<PublicGardenPageParams>;
+}): Promise<Metadata> {
+    const { gardenId: rawGardenId } = await params;
+    const gardenId = parseGardenId(rawGardenId);
+    if (!gardenId) {
+        notFound();
+    }
+
+    const garden = await getPublicGardenForWww(gardenId);
+    const title = `${garden.name} - javni vrt`;
+    const description = `Readonly prikaz javnog Gredice vrta ${garden.name}.`;
+    const path = KnownPages.PublicGarden(garden.id);
+
+    return {
+        title,
+        description,
+        alternates: {
+            canonical: path,
+        },
+        openGraph: {
+            title,
+            description,
+            url: path,
+        },
+    };
+}
+
+export default async function PublicGardenPage({
+    params,
+}: {
+    params: Promise<PublicGardenPageParams>;
+}) {
+    const { gardenId: rawGardenId } = await params;
+    const gardenId = parseGardenId(rawGardenId);
+    if (!gardenId) {
+        notFound();
+    }
+
+    const garden = await getPublicGardenForWww(gardenId);
+
+    return (
+        <Stack spacing={6} className="py-8">
+            <PageHeader
+                padded
+                header={garden.name}
+                subHeader="Javni prikaz vrta. Možeš istraživati gredice, biljke i planirane radnje bez uređivanja."
+            />
+            <div className="h-[min(76vh,760px)] min-h-[520px] overflow-hidden rounded-md border border-black/10 bg-background">
+                <PublicGardenViewerDynamic className="h-full" garden={garden} />
+            </div>
+            <Typography level="body2" className="px-2 text-muted-foreground">
+                Prikaz je samo za gledanje.
+            </Typography>
+        </Stack>
+    );
+}

--- a/apps/www/app/vrtovi/page.tsx
+++ b/apps/www/app/vrtovi/page.tsx
@@ -1,0 +1,73 @@
+import { Card, CardContent } from '@gredice/ui/Card';
+import { PageHeader } from '@gredice/ui/PageHeader';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { KnownPages } from '../../src/KnownPages';
+import { getPublicGardensForWww } from './publicGardenData';
+
+const pageDescription =
+    'Pregledaj javne Gredice vrtove i zaviri u biljke, gredice i planirane radnje.';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+    title: 'Javni vrtovi',
+    description: pageDescription,
+    alternates: {
+        canonical: KnownPages.PublicGardens,
+    },
+    openGraph: {
+        title: 'Javni vrtovi',
+        description: pageDescription,
+        url: KnownPages.PublicGardens,
+    },
+};
+
+export default async function PublicGardensPage() {
+    const gardens = await getPublicGardensForWww();
+
+    return (
+        <Stack spacing={8} className="py-8">
+            <PageHeader
+                padded
+                header="Javni vrtovi"
+                subHeader={pageDescription}
+            />
+            {gardens.items.length > 0 ? (
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {gardens.items.map((garden) => (
+                        <Card key={garden.id} className="h-full rounded-md">
+                            <CardContent noHeader>
+                                <Stack spacing={3}>
+                                    <Typography level="h3">
+                                        <Link
+                                            href={KnownPages.PublicGarden(
+                                                garden.id,
+                                            )}
+                                            className="underline-offset-4 hover:underline"
+                                        >
+                                            {garden.name}
+                                        </Link>
+                                    </Typography>
+                                    <Typography
+                                        level="body2"
+                                        className="text-muted-foreground"
+                                    >
+                                        Javni prikaz vrta s biljkama, gredicama
+                                        i aktivnim radnjama.
+                                    </Typography>
+                                </Stack>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+            ) : (
+                <Typography level="body1" className="px-2">
+                    Trenutno nema javno objavljenih vrtova.
+                </Typography>
+            )}
+        </Stack>
+    );
+}

--- a/apps/www/app/vrtovi/publicGardenData.ts
+++ b/apps/www/app/vrtovi/publicGardenData.ts
@@ -1,0 +1,31 @@
+import { clientPublic } from '@gredice/client';
+import { notFound } from 'next/navigation';
+import { publicGardensFlag } from '../flags';
+
+export async function getPublicGardensForWww() {
+    if (!(await publicGardensFlag())) {
+        notFound();
+    }
+
+    const response = await clientPublic().api.gardens.public.$get();
+    if (!response.ok) {
+        notFound();
+    }
+
+    return response.json();
+}
+
+export async function getPublicGardenForWww(gardenId: number) {
+    if (!(await publicGardensFlag())) {
+        notFound();
+    }
+
+    const response = await clientPublic().api.gardens[':gardenId'].public.$get({
+        param: { gardenId: gardenId.toString() },
+    });
+    if (!response.ok) {
+        notFound();
+    }
+
+    return response.json();
+}

--- a/apps/www/next-sitemap.config.cjs
+++ b/apps/www/next-sitemap.config.cjs
@@ -52,11 +52,35 @@ async function addNewsFeedPaths({ baseUrl, sitemapPaths }) {
     );
 }
 
+async function addPublicGardenPaths({ baseUrl, sitemapPaths }) {
+    let response;
+    try {
+        response = await fetch(`${baseUrl}/api/gardens/public`);
+    } catch {
+        return;
+    }
+
+    if (!response.ok) {
+        return;
+    }
+
+    /** @type {{ items?: Array<{ id?: number }> }} */
+    const gardens = await response.json();
+    sitemapPaths.add('/vrtovi');
+    for (const garden of gardens.items ?? []) {
+        if (typeof garden.id !== 'number') {
+            continue;
+        }
+
+        sitemapPaths.add(`/vrtovi/${garden.id}`);
+    }
+}
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
     siteUrl: process.env.SITE_URL || 'https://www.gredice.com',
     generateRobotsTxt: true,
-    exclude: ['/trag/*'],
+    exclude: ['/trag/*', '/vrtovi', '/vrtovi/*'],
     robotsTxtOptions: {
         includeHost: false,
         policies: [
@@ -108,6 +132,7 @@ module.exports = {
         }
 
         await addNewsFeedPaths({ baseUrl, sitemapPaths });
+        await addPublicGardenPaths({ baseUrl, sitemapPaths });
 
         const transformedPaths = await Promise.all(
             Array.from(sitemapPaths).map((path) =>

--- a/apps/www/src/KnownPages.ts
+++ b/apps/www/src/KnownPages.ts
@@ -47,6 +47,9 @@ export const KnownPages = {
     Referrals: '/preporuke',
     News: '/novosti',
     WhatsNew: '/novosti/sto-je-novo',
+    PublicGardens: '/vrtovi',
+    PublicGarden: (gardenId: number) =>
+        `/vrtovi/${gardenId.toString()}` as Route,
 
     LegalPrivacy: '/legalno/politika-privatnosti',
     LegalTerms: '/legalno/uvjeti-koristenja',

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -83,7 +83,11 @@ export {
 } from './viewers/PlantViewer';
 export type {
     PublicGardenBlock,
+    PublicGardenDetail,
     PublicGardenStack,
     PublicGardenViewerProps,
 } from './viewers/PublicGardenViewer';
-export { PublicGardenViewer } from './viewers/PublicGardenViewer';
+export {
+    PublicGardenViewer,
+    publicGardenStacksFromResponse,
+} from './viewers/PublicGardenViewer';

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -1,8 +1,13 @@
 'use client';
 
+import type { PublicGardenResponse } from '@gredice/client';
+import { Button } from '@gredice/ui/Button';
+import { Stack as UiStack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
 import { OrbitControls } from '@react-three/drei';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { type HTMLAttributes, useMemo, useRef } from 'react';
+import { type HTMLAttributes, useMemo, useRef, useState } from 'react';
 import { Vector3 } from 'three';
 import { EntityFactory } from '../entities/EntityFactory';
 import {
@@ -29,8 +34,11 @@ export type PublicGardenStack = {
     blocks: PublicGardenBlock[];
 };
 
+export type PublicGardenDetail = PublicGardenResponse;
+
 export type PublicGardenViewerProps = HTMLAttributes<HTMLDivElement> & {
-    stacks: PublicGardenStack[];
+    garden?: PublicGardenDetail;
+    stacks?: PublicGardenStack[];
     appBaseUrl?: string;
     spriteBaseUrl?: string;
     deferDetails?: boolean;
@@ -44,10 +52,166 @@ function normalizeStacks(stacks: PublicGardenStack[]): Stack[] {
     }));
 }
 
+export function publicGardenStacksFromResponse(
+    stacks: PublicGardenDetail['stacks'],
+): PublicGardenStack[] {
+    return Object.entries(stacks).flatMap(([x, rows]) =>
+        Object.entries(rows).map(([y, blocks]) => ({
+            x: Number(x),
+            y: Number(y),
+            blocks: blocks.map((block) => ({
+                id: block.id,
+                name: block.name,
+                rotation: block.rotation ?? 0,
+                variant: block.variant,
+            })),
+        })),
+    );
+}
+
+function formatDate(value: string | Date | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    return new Intl.DateTimeFormat('hr-HR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+    }).format(new Date(value));
+}
+
+function statusLabel(status: string | null | undefined) {
+    if (!status) {
+        return 'Bez statusa';
+    }
+
+    return status;
+}
+
+function PublicGardenDetailsPanel({ garden }: { garden: PublicGardenDetail }) {
+    const [selectedRaisedBedId, setSelectedRaisedBedId] = useState<
+        number | null
+    >(garden.raisedBeds[0]?.id ?? null);
+    const selectedRaisedBed =
+        garden.raisedBeds.find(
+            (raisedBed) => raisedBed.id === selectedRaisedBedId,
+        ) ??
+        garden.raisedBeds[0] ??
+        null;
+    const plantedFields =
+        selectedRaisedBed?.fields.filter(
+            (field) =>
+                typeof field.plantSortId === 'number' && field.active !== false,
+        ) ?? [];
+
+    return (
+        <aside className="pointer-events-auto absolute inset-x-3 bottom-3 z-10 max-h-[45%] overflow-auto rounded-md border border-black/10 bg-background/95 p-3 shadow-lg backdrop-blur md:inset-x-auto md:bottom-4 md:right-4 md:top-4 md:max-h-none md:w-80">
+            <UiStack spacing={4}>
+                <UiStack spacing={1}>
+                    <Typography level="body1" semiBold>
+                        {garden.name}
+                    </Typography>
+                    <Typography level="body3" className="text-muted-foreground">
+                        {garden.raisedBeds.length.toString()} gredica ·{' '}
+                        {garden.queuedTasks.length.toString()} aktivnih radnji
+                    </Typography>
+                </UiStack>
+
+                {garden.raisedBeds.length > 0 ? (
+                    <div className="flex gap-2 overflow-x-auto pb-1 md:flex-wrap md:overflow-visible">
+                        {garden.raisedBeds.map((raisedBed) => (
+                            <Button
+                                key={raisedBed.id}
+                                type="button"
+                                size="xs"
+                                variant={
+                                    raisedBed.id === selectedRaisedBed?.id
+                                        ? 'solid'
+                                        : 'outlined'
+                                }
+                                onClick={() =>
+                                    setSelectedRaisedBedId(raisedBed.id)
+                                }
+                            >
+                                {raisedBed.name}
+                            </Button>
+                        ))}
+                    </div>
+                ) : null}
+
+                {selectedRaisedBed ? (
+                    <UiStack spacing={2}>
+                        <Typography level="body2" semiBold>
+                            {selectedRaisedBed.name}
+                        </Typography>
+                        <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-sm">
+                            <dt className="text-muted-foreground">Status</dt>
+                            <dd>{statusLabel(selectedRaisedBed.status)}</dd>
+                            <dt className="text-muted-foreground">Biljke</dt>
+                            <dd>{plantedFields.length.toString()}</dd>
+                            <dt className="text-muted-foreground">Ažurirano</dt>
+                            <dd>{formatDate(selectedRaisedBed.updatedAt)}</dd>
+                        </dl>
+                        <div className="space-y-1">
+                            {plantedFields.length > 0 ? (
+                                plantedFields.slice(0, 12).map((field) => (
+                                    <p
+                                        key={field.id}
+                                        className="rounded-sm bg-muted/60 px-2 py-1 text-xs"
+                                    >
+                                        Polje{' '}
+                                        {(field.positionIndex + 1).toString()} ·
+                                        sorta #{field.plantSortId?.toString()} ·{' '}
+                                        {statusLabel(field.plantStatus)}
+                                    </p>
+                                ))
+                            ) : (
+                                <p className="text-sm text-muted-foreground">
+                                    Nema posađenih biljaka.
+                                </p>
+                            )}
+                        </div>
+                    </UiStack>
+                ) : null}
+
+                <UiStack spacing={2}>
+                    <Typography level="body2" semiBold>
+                        Planirane radnje
+                    </Typography>
+                    {garden.queuedTasks.length > 0 ? (
+                        garden.queuedTasks.slice(0, 6).map((task) => (
+                            <div
+                                key={task.id}
+                                className="rounded-sm border border-border bg-background px-2 py-1.5 text-xs"
+                            >
+                                <div className="font-medium">
+                                    {task.targetLabel}
+                                </div>
+                                <div className="text-muted-foreground">
+                                    {statusLabel(task.status)}
+                                    {task.scheduledDate
+                                        ? ` · ${formatDate(task.scheduledDate)}`
+                                        : ''}
+                                </div>
+                            </div>
+                        ))
+                    ) : (
+                        <p className="text-sm text-muted-foreground">
+                            Nema aktivnih radnji.
+                        </p>
+                    )}
+                </UiStack>
+            </UiStack>
+        </aside>
+    );
+}
+
 export function PublicGardenViewer({
     appBaseUrl,
     spriteBaseUrl,
     deferDetails = true,
+    garden,
     stacks,
     className,
 }: PublicGardenViewerProps) {
@@ -69,54 +233,69 @@ export function PublicGardenViewer({
     if (!clientRef.current) {
         clientRef.current = new QueryClient();
     }
-    const normalizedStacks = useMemo(() => normalizeStacks(stacks), [stacks]);
+    const publicStacks = useMemo(
+        () =>
+            garden
+                ? publicGardenStacksFromResponse(garden.stacks)
+                : (stacks ?? []),
+        [garden, stacks],
+    );
+    const normalizedStacks = useMemo(
+        () => normalizeStacks(publicStacks),
+        [publicStacks],
+    );
     const renderDetails = useDeferredSceneDetails(deferDetails);
 
     return (
         <QueryClientProvider client={clientRef.current}>
             <GameStateContext.Provider value={storeRef.current}>
                 <GameSceneDetailContext.Provider value={{ renderDetails }}>
-                    <Scene
-                        position={[-100, 100, -100]}
-                        zoom={90}
-                        className={className}
-                    >
-                        <color attach="background" args={['#d9f2dc']} />
-                        <ambientLight intensity={2} />
-                        <hemisphereLight intensity={3} />
-                        <directionalLight
-                            position={[5, 20, 10]}
-                            intensity={2.8}
-                        />
-                        <group>
-                            {normalizedStacks.map((stack) =>
-                                stack.blocks.map((block) => (
-                                    <EntityFactory
-                                        key={`${stack.position.x}|${stack.position.y}|${block.id}-${block.name}`}
-                                        name={block.name}
-                                        stack={stack}
-                                        block={block}
-                                        stacks={normalizedStacks}
-                                        rotation={block.rotation}
-                                        variant={block.variant}
-                                        noRenderInView={instancedBlockNames}
-                                        noControl
-                                    />
-                                )),
-                            )}
-                            <EntityInstances
-                                stacks={normalizedStacks}
-                                renderDetails={renderDetails}
+                    <div className={cx('relative h-full w-full', className)}>
+                        <Scene
+                            position={[-100, 100, -100]}
+                            zoom={90}
+                            className="h-full w-full"
+                        >
+                            <color attach="background" args={['#d9f2dc']} />
+                            <ambientLight intensity={2} />
+                            <hemisphereLight intensity={3} />
+                            <directionalLight
+                                position={[5, 20, 10]}
+                                intensity={2.8}
                             />
-                        </group>
-                        <OrbitControls
-                            enableRotate={false}
-                            screenSpacePanning={false}
-                            enablePan
-                            minZoom={50}
-                            maxZoom={500}
-                        />
-                    </Scene>
+                            <group>
+                                {normalizedStacks.map((stack) =>
+                                    stack.blocks.map((block) => (
+                                        <EntityFactory
+                                            key={`${stack.position.x}|${stack.position.y}|${block.id}-${block.name}`}
+                                            name={block.name}
+                                            stack={stack}
+                                            block={block}
+                                            stacks={normalizedStacks}
+                                            rotation={block.rotation}
+                                            variant={block.variant}
+                                            noRenderInView={instancedBlockNames}
+                                            noControl
+                                        />
+                                    )),
+                                )}
+                                <EntityInstances
+                                    stacks={normalizedStacks}
+                                    renderDetails={renderDetails}
+                                />
+                            </group>
+                            <OrbitControls
+                                enableRotate={false}
+                                screenSpacePanning={false}
+                                enablePan
+                                minZoom={50}
+                                maxZoom={500}
+                            />
+                        </Scene>
+                        {garden ? (
+                            <PublicGardenDetailsPanel garden={garden} />
+                        ) : null}
+                    </div>
                 </GameSceneDetailContext.Provider>
             </GameStateContext.Provider>
         </QueryClientProvider>


### PR DESCRIPTION
## Summary
- add `/vrtovi` public garden listing and `/vrtovi/[gardenId]` detail route gated by the shared flag and public API
- add SEO metadata and sitemap additions only when public gardens API responds successfully
- extend the readonly `@gredice/game` public garden viewer to show raised bed, plant, and queued task details without mutation UI

## Test Plan
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter www build`
- `git diff --check`

Depends on #3880
Closes #3877
Part of #3873