### PR TITLE
[codex] Add outlet raised bed picker

### DIFF
--- a/apps/garden/tests/OutletHudStory.tsx
+++ b/apps/garden/tests/OutletHudStory.tsx
@@ -1,0 +1,225 @@
+import * as ReactQuery from '@tanstack/react-query';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { type PropsWithChildren, useMemo } from 'react';
+import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
+import { currentGardenKeys } from '../../../packages/game/src/hooks/useCurrentGarden';
+import type { OutletOfferData } from '../../../packages/game/src/hooks/useOutletOffers';
+import { OutletHud } from '../../../packages/game/src/hud/OutletHud';
+import {
+    createGameState,
+    GameStateContext,
+} from '../../../packages/game/src/useGameState';
+
+const now = '2026-07-01T00:00:00.000Z';
+const TEST_GARDEN_ID = 1;
+
+const outletOffers = [
+    {
+        id: 301,
+        plantSort: {
+            id: 101,
+            name: 'Rajčica mini red cherry',
+            description: 'Mock outlet tomato.',
+            imageUrl: null,
+            plant: { id: 1, name: 'Rajčica' },
+        },
+        sowingDate: '2026-04-28T00:00:00.000Z',
+        initialPlantStatus: 'sprouted',
+        imageUrls: [],
+        outletPrice: 2.99,
+        comparePrice: 3.99,
+        quantity: 1,
+        remainingQuantity: 1,
+        reservedQuantity: 0,
+        soldQuantity: 0,
+        startAt: '2026-07-01T00:00:00.000Z',
+        endAt: '2026-07-08T00:00:00.000Z',
+        url: 'https://www.gredice.test/outlet?offer=301',
+    },
+    {
+        id: 302,
+        plantSort: {
+            id: 102,
+            name: 'Paprika Zlata Snack Paprika',
+            description: 'Mock outlet pepper.',
+            imageUrl: null,
+            plant: { id: 2, name: 'Paprika' },
+        },
+        sowingDate: '2026-06-29T00:00:00.000Z',
+        initialPlantStatus: 'sprouted',
+        imageUrls: [],
+        outletPrice: 2.99,
+        comparePrice: 3.99,
+        quantity: 3,
+        remainingQuantity: 3,
+        reservedQuantity: 0,
+        soldQuantity: 0,
+        startAt: '2026-07-01T00:00:00.000Z',
+        endAt: '2026-07-08T00:00:00.000Z',
+        url: 'https://www.gredice.test/outlet?offer=302',
+    },
+] satisfies OutletOfferData[];
+
+function emptyField(positionIndex: number) {
+    return {
+        id: positionIndex + 1,
+        positionIndex,
+        active: false,
+        plantSortId: null,
+        plantStatus: null,
+        plantSowedAt: null,
+        plantReadyToHarvestAt: null,
+        plantHarvestedAt: null,
+        plantRemovedAt: null,
+        plantSort: null,
+        plantStage: null,
+        plantStageId: null,
+        plantStageUpdatedAt: null,
+        plantSowingLocation: 'direct',
+    };
+}
+
+function plantedField(positionIndex: number, plantSortId: number) {
+    return {
+        ...emptyField(positionIndex),
+        active: true,
+        plantSortId,
+        plantStatus: 'sowed',
+    };
+}
+
+function createOutletHudQueryClient() {
+    const queryClient = new ReactQuery.QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: Infinity },
+        },
+    });
+    const garden = {
+        id: TEST_GARDEN_ID,
+        name: 'Test garden',
+        isSandbox: false,
+        backgroundPalette: 'default',
+        farmId: null,
+        location: { lat: 45.739, lon: 16.572 },
+        raisedBeds: [
+            {
+                id: 11,
+                name: 'Aktivna gredica',
+                blockId: 'raised-bed-active',
+                physicalId: 'A1',
+                fields: [
+                    plantedField(0, 901),
+                    ...Array.from({ length: 8 }, (_, index) =>
+                        emptyField(index + 1),
+                    ),
+                ],
+                appliedOperations: [],
+                weedState: null,
+                status: 'active',
+                abandonReason: null,
+                isValid: true,
+                orientation: 'horizontal',
+                createdAt: now,
+                updatedAt: now,
+            },
+            {
+                id: 12,
+                name: 'Nova gredica',
+                blockId: 'raised-bed-new',
+                physicalId: 'N1',
+                fields: Array.from({ length: 9 }, (_, index) =>
+                    emptyField(index),
+                ),
+                appliedOperations: [],
+                weedState: null,
+                status: 'new',
+                abandonReason: null,
+                isValid: true,
+                orientation: 'horizontal',
+                createdAt: now,
+                updatedAt: now,
+            },
+        ],
+        stacks: [
+            {
+                position: { x: 0, y: 0, z: 0 },
+                blocks: [
+                    {
+                        id: 'raised-bed-active',
+                        name: 'Raised_Bed',
+                        rotation: 0,
+                    },
+                ],
+            },
+            {
+                position: { x: 2, y: 0, z: 0 },
+                blocks: [
+                    { id: 'raised-bed-new', name: 'Raised_Bed', rotation: 0 },
+                ],
+            },
+        ],
+    };
+
+    queryClient.setQueryData(['currentUser'], { id: 'test-user' });
+    queryClient.setQueryData(
+        ['gardens'],
+        [{ id: TEST_GARDEN_ID, name: 'Test garden', isSandbox: false }],
+    );
+    queryClient.setQueryData(
+        currentGardenKeys('summer', TEST_GARDEN_ID),
+        garden,
+    );
+    queryClient.setQueryData(['outlet-offers'], outletOffers);
+    queryClient.setQueryData(['shopping-cart'], {
+        allowPurchase: true,
+        hasDeliverableItems: false,
+        id: 1,
+        items: [],
+        notes: [],
+        total: 0,
+        totalSunflowers: 0,
+    });
+
+    return queryClient;
+}
+
+function OutletHudTestProviders({
+    children,
+    searchParams = 'vrt=1&outlet=1',
+}: PropsWithChildren<{ searchParams?: string }>) {
+    const queryClient = useMemo(() => createOutletHudQueryClient(), []);
+    const gameStore = useMemo(
+        () =>
+            createGameState({
+                appBaseUrl: 'http://localhost',
+                freezeTime: new Date('2026-07-01T12:00:00.000Z'),
+                isMock: false,
+                winterMode: 'summer',
+            }),
+        [],
+    );
+
+    return (
+        <NuqsTestingAdapter hasMemory searchParams={searchParams}>
+            <ReactQuery.QueryClientProvider client={queryClient}>
+                <GameStateContext.Provider value={gameStore}>
+                    <GameAnalyticsProvider capture={() => undefined}>
+                        {children}
+                    </GameAnalyticsProvider>
+                </GameStateContext.Provider>
+            </ReactQuery.QueryClientProvider>
+        </NuqsTestingAdapter>
+    );
+}
+
+export function OutletHudStory({
+    searchParams,
+}: {
+    searchParams?: string;
+} = {}) {
+    return (
+        <OutletHudTestProviders searchParams={searchParams}>
+            <OutletHud />
+        </OutletHudTestProviders>
+    );
+}

--- a/apps/garden/tests/outlet-hud.spec.tsx
+++ b/apps/garden/tests/outlet-hud.spec.tsx
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { OutletHudStory } from './OutletHudStory';
+
+test('outlet modal collapses offers and lets user pick a not-yet-active raised bed', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 900, height: 720 });
+    await mount(<OutletHudStory searchParams="vrt=1&outlet=1" />);
+
+    const dialog = page.getByRole('dialog', { name: 'Outlet sadnica' });
+    await expect(dialog.locator('[data-outlet-offer-list]')).toBeVisible();
+    await expect(dialog.locator('[data-outlet-raised-bed-picker]')).toHaveCount(
+        0,
+    );
+
+    await dialog
+        .getByRole('button', { name: /Paprika Zlata Snack Paprika/ })
+        .click();
+
+    await expect(dialog.locator('[data-outlet-offer-list]')).toHaveCount(0);
+    await expect(dialog.locator('[data-outlet-selected-offer]')).toContainText(
+        'Paprika Zlata Snack Paprika',
+    );
+
+    const raisedBedOptions = dialog.locator('[data-outlet-raised-bed-option]');
+    await expect(raisedBedOptions).toHaveCount(2);
+    await expect(raisedBedOptions.nth(0)).toContainText('Aktivna gredica');
+    await expect(raisedBedOptions.nth(0)).toContainText('Prvo prazno polje 2');
+    await expect(raisedBedOptions.nth(1)).toContainText('Nova gredica');
+    await expect(raisedBedOptions.nth(1)).toContainText('Prvo prazno polje 1');
+
+    await raisedBedOptions.nth(1).click();
+    await expect(raisedBedOptions.nth(1)).toHaveAttribute(
+        'aria-pressed',
+        'true',
+    );
+    await expect(
+        dialog.getByRole('button', { name: 'Nastavi na sijanje' }),
+    ).toBeEnabled();
+});
+
+test('selected outlet offer starts collapsed from the URL', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 900, height: 720 });
+    await mount(<OutletHudStory searchParams="vrt=1&outlet=302" />);
+
+    const dialog = page.getByRole('dialog', { name: 'Outlet sadnica' });
+    await expect(dialog.locator('[data-outlet-offer-list]')).toHaveCount(0);
+    await expect(dialog.locator('[data-outlet-selected-offer]')).toContainText(
+        'Paprika Zlata Snack Paprika',
+    );
+    await expect(dialog.locator('[data-outlet-raised-bed-option]')).toHaveCount(
+        2,
+    );
+});

--- a/packages/game/src/hud/OutletHud.tsx
+++ b/packages/game/src/hud/OutletHud.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@gredice/ui/Button';
-import { Discount, Navigate } from '@gredice/ui/icons';
+import { Check, Discount, Navigate } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import type { OutletOfferData } from '../hooks/useOutletOffers';
@@ -18,7 +18,8 @@ import {
 } from '../useUrlState';
 import { HudCard } from './components/HudCard';
 import {
-    findFirstEmptyRaisedBedField,
+    type EmptyRaisedBedFieldTarget,
+    findEmptyRaisedBedFieldTargets,
     waitForPlantPickerTrigger,
 } from './raisedBed/plantPickerNavigation';
 
@@ -48,22 +49,46 @@ export function OutletHud() {
     const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
     const { track } = useGameAnalytics();
     const [pendingOfferId, setPendingOfferId] = useState<number | null>(null);
+    const [selectedRaisedBedId, setSelectedRaisedBedId] = useState<
+        number | null
+    >(null);
+    const [isOfferListExpanded, setIsOfferListExpanded] = useState(false);
     const isOpen = outletParam !== null;
     const highlightedOfferId =
         outletParam && outletParam !== '1'
             ? Number.parseInt(outletParam, 10)
             : null;
     const selectedOffer =
-        offers?.find((offer) => offer.id === highlightedOfferId) ??
-        offers?.[0] ??
-        null;
-    const emptyFieldTarget = findFirstEmptyRaisedBedField(
-        currentGarden,
-        cart?.items,
+        offers?.find((offer) => offer.id === highlightedOfferId) ?? null;
+    const selectedOfferId = selectedOffer?.id ?? null;
+    const emptyFieldTargets = useMemo(
+        () =>
+            findEmptyRaisedBedFieldTargets(currentGarden, cart?.items, {
+                includeNotYetActiveRaisedBeds: true,
+            }),
+        [cart?.items, currentGarden],
     );
+    const selectedFieldTarget =
+        emptyFieldTargets.find(
+            (target) => target.raisedBedId === selectedRaisedBedId,
+        ) ??
+        emptyFieldTargets[0] ??
+        null;
 
-    async function handleStartPlanting(offer: OutletOfferData) {
-        if (!emptyFieldTarget || pendingOfferId !== null) {
+    useEffect(() => {
+        if (!isOpen) {
+            setIsOfferListExpanded(false);
+            return;
+        }
+
+        setIsOfferListExpanded(selectedOfferId === null);
+    }, [isOpen, selectedOfferId]);
+
+    async function handleStartPlanting(
+        offer: OutletOfferData,
+        fieldTarget: EmptyRaisedBedFieldTarget | null,
+    ) {
+        if (!fieldTarget || pendingOfferId !== null) {
             return;
         }
 
@@ -72,8 +97,8 @@ export function OutletHud() {
             garden_id: currentGarden?.id,
             outlet_offer_id: offer.id,
             plant_sort_id: offer.plantSort.id,
-            position_index: emptyFieldTarget.positionIndex,
-            raised_bed_id: emptyFieldTarget.raisedBedId,
+            position_index: fieldTarget.positionIndex,
+            raised_bed_id: fieldTarget.raisedBedId,
         });
 
         try {
@@ -81,11 +106,11 @@ export function OutletHud() {
             await setOutletParam(null);
             await Promise.resolve(
                 setRaisedBedCloseupParam(
-                    emptyFieldTarget.raisedBedName,
-                    emptyFieldTarget.positionIndex,
+                    fieldTarget.raisedBedName,
+                    fieldTarget.positionIndex,
                 ),
             );
-            const trigger = await waitForPlantPickerTrigger(emptyFieldTarget);
+            const trigger = await waitForPlantPickerTrigger(fieldTarget);
             trigger?.click();
         } finally {
             setPendingOfferId(null);
@@ -131,8 +156,8 @@ export function OutletHud() {
             >
                 <Stack spacing={4}>
                     <Typography level="body2" secondary>
-                        Odaberi outlet sadnicu i nastavi na prvo prazno polje u
-                        aktivnoj gredici.
+                        Odaberi outlet sadnicu, gredicu i nastavi na prvo prazno
+                        polje.
                     </Typography>
                     {isLoading ? (
                         <Typography level="body2">Učitavanje...</Typography>
@@ -147,85 +172,253 @@ export function OutletHud() {
                             Trenutno nema aktivnih outlet ponuda.
                         </Typography>
                     ) : null}
-                    <div className="grid gap-3">
-                        {offers?.map((offer) => {
-                            const imageUrl = offerImageUrl(offer);
-                            const highlighted = selectedOffer?.id === offer.id;
+                    {selectedOffer && !isOfferListExpanded ? (
+                        <Stack spacing={2}>
+                            {(() => {
+                                const imageUrl = offerImageUrl(selectedOffer);
 
-                            return (
-                                <button
-                                    aria-pressed={highlighted}
-                                    key={offer.id}
-                                    type="button"
-                                    className={cx(
-                                        'grid grid-cols-[72px_1fr] gap-3 rounded-lg border bg-card p-2 text-left transition-colors hover:bg-muted',
-                                        highlighted
-                                            ? 'border-green-500'
-                                            : 'border-tertiary',
-                                    )}
-                                    onClick={() => {
-                                        setOutletParam(offer.id.toString());
-                                        track('game_outlet_offer_viewed', {
-                                            outlet_offer_id: offer.id,
-                                            plant_sort_id: offer.plantSort.id,
-                                        });
-                                    }}
-                                >
-                                    <div className="aspect-square overflow-hidden rounded-md bg-muted">
-                                        {imageUrl ? (
-                                            <>
-                                                {/** biome-ignore lint/performance/noImgElement: Offer images come from API data and may use configured external origins. */}
-                                                <img
-                                                    alt={offer.plantSort.name}
-                                                    className="h-full w-full object-cover"
-                                                    src={imageUrl}
-                                                />
-                                            </>
-                                        ) : null}
-                                    </div>
-                                    <Stack spacing={1}>
-                                        <Row justifyContent="space-between">
-                                            <Typography level="body1" semiBold>
-                                                {offer.plantSort.name}
-                                            </Typography>
-                                            <Typography level="body1" bold>
-                                                {currencyFormatter.format(
-                                                    offer.outletPrice,
+                                return (
+                                    <div
+                                        data-outlet-selected-offer
+                                        className={cx(
+                                            'grid grid-cols-[72px_1fr] gap-3 rounded-lg border bg-card p-2 text-left transition-colors hover:bg-muted',
+                                            'border-green-500',
+                                        )}
+                                    >
+                                        <div className="aspect-square overflow-hidden rounded-md bg-muted">
+                                            {imageUrl ? (
+                                                <>
+                                                    {/** biome-ignore lint/performance/noImgElement: Offer images come from API data and may use configured external origins. */}
+                                                    <img
+                                                        alt={
+                                                            selectedOffer
+                                                                .plantSort.name
+                                                        }
+                                                        className="h-full w-full object-cover"
+                                                        src={imageUrl}
+                                                    />
+                                                </>
+                                            ) : null}
+                                        </div>
+                                        <Stack spacing={1}>
+                                            <Row justifyContent="space-between">
+                                                <Typography
+                                                    level="body1"
+                                                    semiBold
+                                                >
+                                                    {
+                                                        selectedOffer.plantSort
+                                                            .name
+                                                    }
+                                                </Typography>
+                                                <Typography level="body1" bold>
+                                                    {currencyFormatter.format(
+                                                        selectedOffer.outletPrice,
+                                                    )}
+                                                </Typography>
+                                            </Row>
+                                            <Typography level="body3" secondary>
+                                                Sjetva{' '}
+                                                {dateFormatter.format(
+                                                    new Date(
+                                                        selectedOffer.sowingDate,
+                                                    ),
+                                                )}{' '}
+                                                · preostalo{' '}
+                                                {
+                                                    selectedOffer.remainingQuantity
+                                                }{' '}
+                                                · do{' '}
+                                                {dateFormatter.format(
+                                                    new Date(
+                                                        selectedOffer.endAt,
+                                                    ),
                                                 )}
                                             </Typography>
-                                        </Row>
-                                        <Typography level="body3" secondary>
-                                            Sjetva{' '}
-                                            {dateFormatter.format(
-                                                new Date(offer.sowingDate),
-                                            )}{' '}
-                                            · preostalo{' '}
-                                            {offer.remainingQuantity} · do{' '}
-                                            {dateFormatter.format(
-                                                new Date(offer.endAt),
-                                            )}
-                                        </Typography>
-                                    </Stack>
-                                </button>
-                            );
-                        })}
-                    </div>
-                    {selectedOffer ? (
-                        <Stack spacing={2}>
-                            {!emptyFieldTarget ? (
+                                        </Stack>
+                                    </div>
+                                );
+                            })()}
+                            {(offers?.length ?? 0) > 1 ? (
+                                <Row justifyContent="end">
+                                    <Button
+                                        variant="plain"
+                                        onClick={() =>
+                                            setIsOfferListExpanded(true)
+                                        }
+                                    >
+                                        Promijeni sadnicu
+                                    </Button>
+                                </Row>
+                            ) : null}
+                        </Stack>
+                    ) : (
+                        <div className="grid gap-3" data-outlet-offer-list>
+                            {offers?.map((offer) => {
+                                const imageUrl = offerImageUrl(offer);
+                                const highlighted =
+                                    selectedOffer?.id === offer.id;
+
+                                return (
+                                    <button
+                                        aria-pressed={highlighted}
+                                        key={offer.id}
+                                        type="button"
+                                        className={cx(
+                                            'grid grid-cols-[72px_1fr] gap-3 rounded-lg border bg-card p-2 text-left transition-colors hover:bg-muted',
+                                            highlighted
+                                                ? 'border-green-500'
+                                                : 'border-tertiary',
+                                        )}
+                                        onClick={() => {
+                                            setOutletParam(offer.id.toString());
+                                            setIsOfferListExpanded(false);
+                                            track('game_outlet_offer_viewed', {
+                                                outlet_offer_id: offer.id,
+                                                plant_sort_id:
+                                                    offer.plantSort.id,
+                                            });
+                                        }}
+                                    >
+                                        <div className="aspect-square overflow-hidden rounded-md bg-muted">
+                                            {imageUrl ? (
+                                                <>
+                                                    {/** biome-ignore lint/performance/noImgElement: Offer images come from API data and may use configured external origins. */}
+                                                    <img
+                                                        alt={
+                                                            offer.plantSort.name
+                                                        }
+                                                        className="h-full w-full object-cover"
+                                                        src={imageUrl}
+                                                    />
+                                                </>
+                                            ) : null}
+                                        </div>
+                                        <Stack spacing={1}>
+                                            <Row justifyContent="space-between">
+                                                <Typography
+                                                    level="body1"
+                                                    semiBold
+                                                >
+                                                    {offer.plantSort.name}
+                                                </Typography>
+                                                <Typography level="body1" bold>
+                                                    {currencyFormatter.format(
+                                                        offer.outletPrice,
+                                                    )}
+                                                </Typography>
+                                            </Row>
+                                            <Typography level="body3" secondary>
+                                                Sjetva{' '}
+                                                {dateFormatter.format(
+                                                    new Date(offer.sowingDate),
+                                                )}{' '}
+                                                · preostalo{' '}
+                                                {offer.remainingQuantity} · do{' '}
+                                                {dateFormatter.format(
+                                                    new Date(offer.endAt),
+                                                )}
+                                            </Typography>
+                                        </Stack>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    )}
+                    {selectedOffer && !isOfferListExpanded ? (
+                        <Stack spacing={3}>
+                            {emptyFieldTargets.length > 0 ? (
+                                <Stack
+                                    spacing={2}
+                                    data-outlet-raised-bed-picker
+                                >
+                                    <Typography level="body2" semiBold>
+                                        Gredica
+                                    </Typography>
+                                    <div className="grid gap-2 sm:grid-cols-2">
+                                        {emptyFieldTargets.map((target) => {
+                                            const selected =
+                                                target.raisedBedId ===
+                                                selectedFieldTarget?.raisedBedId;
+
+                                            return (
+                                                <button
+                                                    aria-pressed={selected}
+                                                    data-outlet-raised-bed-option
+                                                    key={target.raisedBedId}
+                                                    type="button"
+                                                    className={cx(
+                                                        'rounded-lg border bg-card p-3 text-left transition-colors hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700',
+                                                        selected
+                                                            ? 'border-green-500'
+                                                            : 'border-tertiary',
+                                                    )}
+                                                    onClick={() => {
+                                                        setSelectedRaisedBedId(
+                                                            target.raisedBedId,
+                                                        );
+                                                        track(
+                                                            'game_outlet_raised_bed_selected',
+                                                            {
+                                                                garden_id:
+                                                                    currentGarden?.id,
+                                                                outlet_offer_id:
+                                                                    selectedOffer.id,
+                                                                position_index:
+                                                                    target.positionIndex,
+                                                                raised_bed_id:
+                                                                    target.raisedBedId,
+                                                            },
+                                                        );
+                                                    }}
+                                                >
+                                                    <Row
+                                                        justifyContent="space-between"
+                                                        className="min-w-0"
+                                                    >
+                                                        <Typography
+                                                            level="body2"
+                                                            semiBold
+                                                            className="min-w-0"
+                                                        >
+                                                            {
+                                                                target.raisedBedName
+                                                            }
+                                                        </Typography>
+                                                        {selected ? (
+                                                            <Check className="size-4 shrink-0 text-green-600" />
+                                                        ) : null}
+                                                    </Row>
+                                                    <Typography
+                                                        level="body3"
+                                                        secondary
+                                                    >
+                                                        Prvo prazno polje{' '}
+                                                        {target.positionIndex +
+                                                            1}
+                                                    </Typography>
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </Stack>
+                            ) : (
                                 <Typography level="body2" secondary>
                                     Za outlet sadnicu treba prazno polje u
-                                    aktivnoj gredici.
+                                    dostupnoj gredici.
                                 </Typography>
-                            ) : null}
+                            )}
                             <Row justifyContent="end">
                                 <Button
-                                    disabled={!emptyFieldTarget}
+                                    disabled={!selectedFieldTarget}
                                     loading={
                                         pendingOfferId === selectedOffer.id
                                     }
                                     onClick={() =>
-                                        void handleStartPlanting(selectedOffer)
+                                        void handleStartPlanting(
+                                            selectedOffer,
+                                            selectedFieldTarget,
+                                        )
                                     }
                                     startDecorator={
                                         <Navigate className="size-5 shrink-0" />

--- a/packages/game/src/hud/raisedBed/plantPickerNavigation.ts
+++ b/packages/game/src/hud/raisedBed/plantPickerNavigation.ts
@@ -1,3 +1,4 @@
+import { isRaisedBedAbandoned } from '../../raisedBedConstants';
 import type { Stack } from '../../types/Stack';
 import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
@@ -39,6 +40,10 @@ export type EmptyRaisedBedFieldTarget = {
     raisedBedName: string;
 };
 
+type EmptyRaisedBedFieldTargetOptions = {
+    includeNotYetActiveRaisedBeds?: boolean;
+};
+
 function isRaisedBedCartPlantItem(
     item: RaisedBedFieldTargetCartItem,
     gardenId: number,
@@ -53,20 +58,37 @@ function isRaisedBedCartPlantItem(
     );
 }
 
-export function findFirstEmptyRaisedBedField(
+function isRaisedBedEligibleForEmptyFieldTarget(
+    raisedBed: RaisedBedTarget,
+    options: EmptyRaisedBedFieldTargetOptions,
+) {
+    if (!raisedBed.isValid) {
+        return false;
+    }
+
+    if (options.includeNotYetActiveRaisedBeds) {
+        return !isRaisedBedAbandoned(raisedBed.status);
+    }
+
+    return raisedBed.status === 'active';
+}
+
+export function findEmptyRaisedBedFieldTargets(
     garden: RaisedBedFieldTargetGarden | null | undefined,
     cartItems?: RaisedBedFieldTargetCartItem[] | null,
-): EmptyRaisedBedFieldTarget | null {
+    options: EmptyRaisedBedFieldTargetOptions = {},
+): EmptyRaisedBedFieldTarget[] {
     if (!garden || garden.isSandbox) {
-        return null;
+        return [];
     }
+
+    const targets: EmptyRaisedBedFieldTarget[] = [];
 
     for (const raisedBed of garden.raisedBeds) {
         const raisedBedName = raisedBed.name?.trim();
         if (
             !raisedBedName ||
-            raisedBed.status !== 'active' ||
-            !raisedBed.isValid
+            !isRaisedBedEligibleForEmptyFieldTarget(raisedBed, options)
         ) {
             continue;
         }
@@ -92,16 +114,27 @@ export function findFirstEmptyRaisedBedField(
             positionIndex += 1
         ) {
             if (!occupiedPositionIndices.has(positionIndex)) {
-                return {
+                targets.push({
                     positionIndex,
                     raisedBedId: raisedBed.id,
                     raisedBedName,
-                };
+                });
+                break;
             }
         }
     }
 
-    return null;
+    return targets;
+}
+
+export function findFirstEmptyRaisedBedField(
+    garden: RaisedBedFieldTargetGarden | null | undefined,
+    cartItems?: RaisedBedFieldTargetCartItem[] | null,
+    options: EmptyRaisedBedFieldTargetOptions = {},
+): EmptyRaisedBedFieldTarget | null {
+    return (
+        findEmptyRaisedBedFieldTargets(garden, cartItems, options)[0] ?? null
+    );
 }
 
 export function waitForPlantPickerTrigger({

--- a/packages/game/src/hud/raisedBed/plantPickerNavigation.unit.ts
+++ b/packages/game/src/hud/raisedBed/plantPickerNavigation.unit.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    findEmptyRaisedBedFieldTargets,
     findFirstEmptyRaisedBedField,
     type RaisedBedFieldTargetCartItem,
     type RaisedBedFieldTargetGarden,
@@ -23,6 +24,18 @@ const garden = {
             orientation: 'vertical',
             status: 'active',
         },
+        {
+            blockId: 'raised-bed-2',
+            fields: [
+                { active: true, plantSortId: 102, positionIndex: 0 },
+                { active: false, plantSortId: null, positionIndex: 1 },
+            ],
+            id: 12,
+            isValid: true,
+            name: 'Novi Vjetar',
+            orientation: 'vertical',
+            status: 'new',
+        },
     ],
     stacks: [],
 } satisfies RaisedBedFieldTargetGarden;
@@ -43,4 +56,34 @@ test('findFirstEmptyRaisedBedField skips pending cart plant positions', () => {
         raisedBedId: 11,
         raisedBedName: 'Plavi Vjetar',
     });
+});
+
+test('findEmptyRaisedBedFieldTargets keeps active-only behavior by default', () => {
+    assert.deepEqual(findEmptyRaisedBedFieldTargets(garden), [
+        {
+            positionIndex: 1,
+            raisedBedId: 11,
+            raisedBedName: 'Plavi Vjetar',
+        },
+    ]);
+});
+
+test('findEmptyRaisedBedFieldTargets includes not-yet-active beds for outlet planting', () => {
+    assert.deepEqual(
+        findEmptyRaisedBedFieldTargets(garden, null, {
+            includeNotYetActiveRaisedBeds: true,
+        }),
+        [
+            {
+                positionIndex: 1,
+                raisedBedId: 11,
+                raisedBedName: 'Plavi Vjetar',
+            },
+            {
+                positionIndex: 1,
+                raisedBedId: 12,
+                raisedBedName: 'Novi Vjetar',
+            },
+        ],
+    );
 });


### PR DESCRIPTION
## Summary

- Let outlet planting target any valid non-abandoned raised bed, including new/not-yet-active beds.
- Add a raised-bed picker in the outlet modal so users can choose among available beds before continuing.
- Collapse the outlet offer list after a selection and keep only the selected offer visible with the bed picker/action.

## Validation

- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden exec playwright test tests/outlet-hud.spec.tsx --project=chromium`
- `pnpm --filter garden exec playwright test tests/tutorial-checklist-hud.spec.tsx --project=chromium`
- `pnpm --filter garden exec playwright test tests/raised-bed-plant-picker.spec.tsx --project=chromium`
- `git diff --check`