### PR TITLE
Improve outlet offer card layout

### DIFF
--- a/apps/www/app/outlet/OutletLandingOfferCard.tsx
+++ b/apps/www/app/outlet/OutletLandingOfferCard.tsx
@@ -8,6 +8,7 @@ import {
     compactDateFormatter,
     currencyFormatter,
     outletDiscountLabel,
+    outletRemainingLabel,
 } from './outletPresentation';
 
 export function OutletLandingOfferCard({
@@ -52,12 +53,12 @@ export function OutletLandingOfferCard({
             </div>
             <div className="flex h-full flex-col gap-4 p-4 sm:p-5">
                 <div className="flex flex-wrap items-center gap-2">
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-900 dark:bg-amber-950 dark:text-amber-200">
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-medium text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200">
                         <Discount aria-hidden className="size-3.5" />
                         {outletDiscountLabel(offer)}
                     </span>
                     <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
-                        preostalo {offer.remainingQuantity}
+                        {outletRemainingLabel(offer)}
                     </span>
                 </div>
                 <div>

--- a/apps/www/app/outlet/OutletOfferCard.tsx
+++ b/apps/www/app/outlet/OutletOfferCard.tsx
@@ -19,8 +19,8 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
     const imageUrl = outletOfferImage(offer);
 
     return (
-        <article className="grid grid-cols-[7.5rem_minmax(0,1fr)] overflow-hidden rounded-xl border border-tertiary border-b-4 bg-card shadow-sm sm:grid-cols-[minmax(9rem,11rem)_minmax(0,1fr)] lg:grid-cols-[minmax(10rem,13rem)_minmax(0,1fr)_auto]">
-            <div className="relative min-h-36 overflow-hidden bg-muted lg:min-h-44">
+        <article className="grid h-full grid-cols-[7.5rem_minmax(0,1fr)] overflow-hidden rounded-xl border border-tertiary border-b-4 bg-card shadow-sm sm:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)]">
+            <div className="relative min-h-36 overflow-hidden bg-muted sm:min-h-44">
                 {imageUrl ? (
                     <>
                         {/** biome-ignore lint/performance/noImgElement: Offer images come from API data and may use configured external origins. */}
@@ -38,7 +38,7 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                     </div>
                 )}
                 <div className="absolute left-3 top-3 flex flex-wrap gap-2">
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-900 shadow-sm dark:bg-amber-950 dark:text-amber-200">
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-medium text-emerald-900 shadow-sm dark:bg-emerald-950 dark:text-emerald-200">
                         <Discount aria-hidden className="size-3.5" />
                         {outletDiscountLabel(offer)}
                     </span>
@@ -47,7 +47,7 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                     </span>
                 </div>
             </div>
-            <div className="p-3 sm:p-4 lg:p-5 lg:pr-4">
+            <div className="p-3 sm:p-4">
                 <Stack spacing={3}>
                     <Stack spacing={1}>
                         <div className="min-w-0">
@@ -68,13 +68,13 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                             <Typography
                                 level="body2"
                                 secondary
-                                className="hidden max-w-2xl text-pretty sm:line-clamp-2 sm:block"
+                                className="hidden max-w-2xl text-pretty lg:line-clamp-2 lg:block"
                             >
                                 {offer.plantSort.description}
                             </Typography>
                         ) : null}
                     </Stack>
-                    <dl className="grid gap-2 border-t border-tertiary pt-2 text-xs sm:grid-cols-3 sm:text-sm lg:gap-3 lg:pt-3">
+                    <dl className="grid gap-2 border-t border-tertiary pt-2 text-xs sm:text-sm lg:grid-cols-3">
                         <div>
                             <dt className="flex items-center gap-1.5 text-muted-foreground">
                                 <Sprout
@@ -118,7 +118,7 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                     </dl>
                 </Stack>
             </div>
-            <div className="col-span-2 flex items-end justify-between gap-3 border-t border-tertiary p-3 sm:p-4 lg:col-span-1 lg:flex-col lg:items-end lg:border-l lg:border-t-0 lg:text-right">
+            <div className="col-span-2 flex items-end justify-between gap-3 border-t border-tertiary p-3 sm:p-4">
                 <div>
                     <Typography level="body3" tertiary>
                         Outlet cijena

--- a/apps/www/app/outlet/outletPresentation.ts
+++ b/apps/www/app/outlet/outletPresentation.ts
@@ -45,5 +45,5 @@ export function outletDiscountLabel(offer: OutletOffer) {
 export function outletRemainingLabel(offer: OutletOffer) {
     return offer.remainingQuantity === 1
         ? 'Samo 1 preostala'
-        : `preostalo ${offer.remainingQuantity}`;
+        : `Preostalo ${offer.remainingQuantity}`;
 }

--- a/apps/www/app/outlet/page.tsx
+++ b/apps/www/app/outlet/page.tsx
@@ -8,7 +8,7 @@ import { StructuredDataScript } from '../../components/shared/seo/StructuredData
 import { KnownPages } from '../../src/KnownPages';
 import { OutletOfferCard } from './OutletOfferCard';
 import { getOutletOffers, outletOfferImage } from './outletData';
-import { currencyFormatter, offerEndFormatter } from './outletPresentation';
+import { currencyFormatter } from './outletPresentation';
 
 export const dynamic = 'force-dynamic';
 
@@ -79,27 +79,15 @@ function outletSummary(offers: Awaited<ReturnType<typeof getOutletOffers>>) {
                 : Math.min(lowestPrice, offer.outletPrice),
         null,
     );
-    const nextEndingOffer = offers.reduce<(typeof offers)[number] | null>(
-        (nextOffer, offer) =>
-            nextOffer === null ||
-            new Date(offer.endAt).getTime() <
-                new Date(nextOffer.endAt).getTime()
-                ? offer
-                : nextOffer,
-        null,
-    );
-
     return {
         lowestOutletPrice,
-        nextEndingOffer,
         remainingQuantity,
     };
 }
 
 export default async function OutletPage() {
     const offers = await getOutletOffers();
-    const { lowestOutletPrice, nextEndingOffer, remainingQuantity } =
-        outletSummary(offers);
+    const { lowestOutletPrice, remainingQuantity } = outletSummary(offers);
 
     return (
         <Container className="py-10 sm:py-14">
@@ -194,15 +182,6 @@ export default async function OutletPage() {
                                 >
                                     Dostupne outlet sadnice
                                 </Typography>
-                                {nextEndingOffer ? (
-                                    <Typography level="body2" secondary>
-                                        Sljedeća ponuda istječe{' '}
-                                        {offerEndFormatter.format(
-                                            new Date(nextEndingOffer.endAt),
-                                        )}
-                                        .
-                                    </Typography>
-                                ) : null}
                             </Stack>
                             <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-card px-3 py-1.5 text-sm text-secondary-foreground ring-1 ring-tertiary">
                                 <Timer
@@ -212,7 +191,7 @@ export default async function OutletPage() {
                                 Dok traju zalihe
                             </span>
                         </div>
-                        <div className="grid gap-5">
+                        <div className="grid gap-5 md:grid-cols-2">
                             {offers.map((offer) => (
                                 <OutletOfferCard key={offer.id} offer={offer} />
                             ))}


### PR DESCRIPTION
## Summary
- show outlet offer cards in a two-column grid on tablet and desktop
- remove the next-expiring offer helper text from the outlet page
- switch outlet savings badges to green and capitalize remaining-quantity labels

## Validation
- corepack pnpm lint --filter www
- corepack pnpm typecheck --filter www
- git diff --check
- Playwright visual/DOM check at 1280px and 900px against local /outlet with public API data