### PR TITLE
[codex] Refine outlet card actions

### DIFF
--- a/apps/www/app/outlet/OutletLandingOfferCard.tsx
+++ b/apps/www/app/outlet/OutletLandingOfferCard.tsx
@@ -5,9 +5,10 @@ import Link from 'next/link';
 import { KnownPages } from '../../src/KnownPages';
 import { type OutletOffer, outletOfferImage } from './outletData';
 import {
-    compactDateFormatter,
     currencyFormatter,
+    formatOutletSowingDate,
     outletDiscountLabel,
+    outletIsLowStock,
     outletRemainingLabel,
 } from './outletPresentation';
 
@@ -57,9 +58,11 @@ export function OutletLandingOfferCard({
                         <Discount aria-hidden className="size-3.5" />
                         {outletDiscountLabel(offer)}
                     </span>
-                    <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
-                        {outletRemainingLabel(offer)}
-                    </span>
+                    {outletIsLowStock(offer) ? (
+                        <span className="rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-900 dark:bg-amber-950 dark:text-amber-200">
+                            {outletRemainingLabel(offer)}
+                        </span>
+                    ) : null}
                 </div>
                 <div>
                     <Typography level="h5" component="h3">
@@ -67,9 +70,7 @@ export function OutletLandingOfferCard({
                     </Typography>
                     <Typography level="body3" tertiary>
                         Sjetva{' '}
-                        {compactDateFormatter.format(
-                            new Date(offer.sowingDate),
-                        )}
+                        {formatOutletSowingDate(new Date(offer.sowingDate))}
                     </Typography>
                 </div>
                 <div className="mt-auto flex items-end justify-between gap-3">

--- a/apps/www/app/outlet/OutletOfferCard.tsx
+++ b/apps/www/app/outlet/OutletOfferCard.tsx
@@ -2,6 +2,7 @@ import { Calendar, Discount, Sprout, Timer } from '@gredice/ui/icons';
 import { NavigatingButton } from '@gredice/ui/NavigatingButton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
+import { KnownPages } from '../../src/KnownPages';
 import {
     type OutletOffer,
     outletGardenUrl,
@@ -9,14 +10,19 @@ import {
 } from './outletData';
 import {
     currencyFormatter,
-    longDateFormatter,
+    formatOutletSowingDate,
     offerEndFormatter,
     outletDiscountLabel,
+    outletIsLowStock,
     outletRemainingLabel,
 } from './outletPresentation';
 
 export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
     const imageUrl = outletOfferImage(offer);
+    const plantName = offer.plantSort.plant?.name;
+    const detailsHref = plantName
+        ? KnownPages.PlantSort(plantName, offer.plantSort.name)
+        : KnownPages.Plants;
 
     return (
         <article className="grid h-full grid-cols-[7.5rem_minmax(0,1fr)] overflow-hidden rounded-xl border border-tertiary border-b-4 bg-card shadow-sm sm:grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)]">
@@ -42,9 +48,11 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                         <Discount aria-hidden className="size-3.5" />
                         {outletDiscountLabel(offer)}
                     </span>
-                    <span className="rounded-full bg-background/90 px-2.5 py-1 text-xs font-medium text-primary shadow-sm">
-                        {outletRemainingLabel(offer)}
-                    </span>
+                    {outletIsLowStock(offer) ? (
+                        <span className="rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-900 shadow-sm dark:bg-amber-950 dark:text-amber-200">
+                            {outletRemainingLabel(offer)}
+                        </span>
+                    ) : null}
                 </div>
             </div>
             <div className="p-3 sm:p-4">
@@ -74,7 +82,7 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                             </Typography>
                         ) : null}
                     </Stack>
-                    <dl className="grid gap-2 border-t border-tertiary pt-2 text-xs sm:text-sm lg:grid-cols-3">
+                    <dl className="grid gap-2 text-xs sm:text-sm lg:grid-cols-3">
                         <div>
                             <dt className="flex items-center gap-1.5 text-muted-foreground">
                                 <Sprout
@@ -84,7 +92,7 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                                 Sjetva
                             </dt>
                             <dd className="mt-1 font-medium">
-                                {longDateFormatter.format(
+                                {formatOutletSowingDate(
                                     new Date(offer.sowingDate),
                                 )}
                             </dd>
@@ -136,13 +144,23 @@ export function OutletOfferCard({ offer }: { offer: OutletOffer }) {
                         </Typography>
                     ) : null}
                 </div>
-                <NavigatingButton
-                    href={outletGardenUrl(offer.id)}
-                    size="sm"
-                    className="w-fit shrink-0"
-                >
-                    Odaberi u vrtu
-                </NavigatingButton>
+                <div className="flex flex-wrap justify-end gap-2">
+                    <NavigatingButton
+                        href={detailsHref}
+                        size="sm"
+                        variant="outlined"
+                        className="w-fit shrink-0"
+                    >
+                        Detalji sorte
+                    </NavigatingButton>
+                    <NavigatingButton
+                        href={outletGardenUrl(offer.id)}
+                        size="sm"
+                        className="w-fit shrink-0"
+                    >
+                        Sadi u vrtu
+                    </NavigatingButton>
+                </div>
             </div>
         </article>
     );

--- a/apps/www/app/outlet/outletPresentation.ts
+++ b/apps/www/app/outlet/outletPresentation.ts
@@ -16,6 +16,11 @@ export const longDateFormatter = new Intl.DateTimeFormat('hr-HR', {
     year: 'numeric',
 });
 
+export const longDateWithoutYearFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'long',
+});
+
 export const offerEndFormatter = new Intl.DateTimeFormat('hr-HR', {
     day: 'numeric',
     month: 'short',
@@ -42,8 +47,18 @@ export function outletDiscountLabel(offer: OutletOffer) {
     return percentage ? `Uštedi ${percentage}%` : 'Outlet cijena';
 }
 
+export function outletIsLowStock(offer: OutletOffer) {
+    return offer.remainingQuantity < 4;
+}
+
 export function outletRemainingLabel(offer: OutletOffer) {
     return offer.remainingQuantity === 1
         ? 'Samo 1 preostala'
         : `Preostalo ${offer.remainingQuantity}`;
+}
+
+export function formatOutletSowingDate(date: Date, currentDate = new Date()) {
+    return date.getFullYear() === currentDate.getFullYear()
+        ? longDateWithoutYearFormatter.format(date)
+        : longDateFormatter.format(date);
 }


### PR DESCRIPTION
## Summary
- Show the remaining-stock badge only for low-stock outlet offers and use warning styling.
- Rename the garden CTA to `Sadi u vrtu` and add a secondary `Detalji sorte` link to the public plant sort page.
- Remove the divider between description and offer metadata, and hide the sowing year when the date is in the current year.
- Apply the same low-stock/date presentation to the homepage outlet teaser card.

## Validation
- `pnpm --filter www exec biome check --write app/outlet/OutletOfferCard.tsx app/outlet/OutletLandingOfferCard.tsx app/outlet/outletPresentation.ts`
- `pnpm --filter www typecheck`
- `git diff --check`
- Local Playwright check for `/outlet` at desktop and mobile widths: 16 cards rendered, no horizontal overflow or main-content text clipping, first card has `Sadi u vrtu`, `Detalji sorte`, low-stock badges only below 4, and same-year sowing date without year.