### PR TITLE
[codex] fix dark AI suggestion button colors

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1483,6 +1483,42 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         ).toBeVisible();
     });
 
+    test('closeup HUD photo AI action keeps dark mode button colors', async ({
+        mount,
+        page,
+    }) => {
+        await page.evaluate(() =>
+            document.documentElement.classList.add('dark'),
+        );
+        await mount(
+            <RaisedBedCloseupHudStory
+                scenario={plantedGrowingWithOperationHistoryScenario()}
+            />,
+        );
+
+        await page
+            .getByRole('button', {
+                name: /Fotografije gredice Raised Bed 1/u,
+            })
+            .click();
+
+        const photosModal = page.locator('[data-raised-bed-photos-modal]');
+        const aiButton = photosModal.getByRole('button', {
+            name: /Pregledaj savjete suncokreta/u,
+        });
+        await expect(aiButton).toBeVisible();
+
+        const aiButtonClassName = await aiButton.evaluate(
+            (element) => element.className,
+        );
+        expect(aiButtonClassName).toContain('dark:from-green-700');
+        expect(aiButtonClassName).toContain('dark:to-green-800');
+        expect(aiButtonClassName).toContain('dark:text-white');
+        expect(aiButtonClassName).not.toContain('dark:from-lime-200');
+        expect(aiButtonClassName).not.toContain('dark:to-lime-200');
+        expect(aiButtonClassName).not.toContain('dark:text-primary-foreground');
+    });
+
     test('closeup HUD photo shortcut searches older history pages before hiding', async ({
         mount,
         page,

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryAiAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryAiAction.tsx
@@ -260,7 +260,7 @@ export function RaisedBedDiaryAiAction({
             <Stack spacing={2} className="items-end">
                 <ButtonGreen
                     size="sm"
-                    className="w-fit self-end px-3"
+                    className="w-fit self-end px-3 dark:from-green-700 dark:to-green-800 dark:text-white dark:hover:from-green-600 dark:hover:to-green-700 dark:hover:text-white"
                     onClick={(event) => {
                         event.stopPropagation();
                         handlePrimaryAction();


### PR DESCRIPTION
## What changed

- Updated the raised-bed AI suggestion action so dark mode uses a darker green gradient with white text.
- Added a garden component regression test that opens the raised-bed photos modal in dark mode and verifies the AI suggestion button no longer carries the pale lime dark-mode classes.

## Why

When the garden is in night/dark mode, the AI suggestion button inherited the shared light lime `ButtonGreen` dark-mode gradient, which made the button look incorrectly colored on dark photo cards.

## Validation

- `pnpm --filter garden test:prepare`
- `pnpm --filter garden exec playwright test tests/raised-bed-field-hud.spec.tsx -g "closeup HUD photo AI action keeps dark mode button colors"`
- `pnpm lint --filter garden --filter @gredice/game`
- `pnpm typecheck --filter garden --filter @gredice/game`