### PR TITLE
[codex] Remove redundant survey contact fields

### DIFF
--- a/apps/garden/app/ankete/[assignmentId]/SurveyResponseClient.tsx
+++ b/apps/garden/app/ankete/[assignmentId]/SurveyResponseClient.tsx
@@ -46,6 +46,7 @@ type SurveyRuntime = {
     questions: SurveyQuestion[];
     response: { id: string } | null;
     survey: {
+        key: string;
         title: string;
     };
     version: {
@@ -57,7 +58,14 @@ type SurveyRuntime = {
     };
 };
 
-type AnswerState = Record<string, number | string | undefined>;
+type ContactValue = {
+    email?: string;
+    firstName?: string;
+    lastName?: string;
+    phone?: string;
+};
+
+type AnswerState = Record<string, number | string | ContactValue | undefined>;
 
 function assignmentUrl(assignmentId: string) {
     return `/api/gredice/api/surveys/assignments/${encodeURIComponent(
@@ -69,8 +77,52 @@ async function readJson<T>(response: Response) {
     return (await response.json()) as T;
 }
 
-function visibleIntroDescription(description: string | null) {
+function isLegacyDeliveryContactQuestion(
+    surveyKey: string,
+    question: SurveyQuestion,
+) {
+    return (
+        surveyKey === 'delivery_satisfaction' &&
+        question.type === 'contact_info' &&
+        question.key === 'contact_info'
+    );
+}
+
+function visibleIntroDescription(
+    description: string | null,
+    hidesLegacyContactQuestion: boolean,
+) {
+    if (!hidesLegacyContactQuestion) return description;
     return description?.replace(', a kontakt podatke možeš preskočiti.', '.');
+}
+
+function isContactValue(value: AnswerState[string]): value is ContactValue {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasContactValue(value: AnswerState[string]) {
+    if (!isContactValue(value)) return false;
+    return Boolean(
+        value.firstName || value.lastName || value.phone || value.email,
+    );
+}
+
+function contactFieldLabel(field: string) {
+    return (
+        {
+            email: 'Email',
+            first_name: 'Ime',
+            last_name: 'Prezime',
+            phone: 'Telefon',
+        }[field] ?? field
+    );
+}
+
+function contactFieldKey(field: string): keyof ContactValue {
+    if (field === 'first_name') return 'firstName';
+    if (field === 'last_name') return 'lastName';
+    if (field === 'phone') return 'phone';
+    return 'email';
 }
 
 export function SurveyResponseClient({
@@ -131,14 +183,19 @@ export function SurveyResponseClient({
         };
     }, [assignmentId]);
 
-    const questions = useMemo(
-        () =>
-            runtime?.questions
-                .filter((question) => question.type !== 'contact_info')
-                .slice()
-                .sort((left, right) => left.sortOrder - right.sortOrder) ?? [],
-        [runtime?.questions],
-    );
+    const questions = useMemo(() => {
+        if (!runtime) return [];
+        return runtime.questions
+            .filter(
+                (question) =>
+                    !isLegacyDeliveryContactQuestion(
+                        runtime.survey.key,
+                        question,
+                    ),
+            )
+            .slice()
+            .sort((left, right) => left.sortOrder - right.sortOrder);
+    }, [runtime]);
 
     function setAnswer(questionId: string, value: AnswerState[string]) {
         setAnswers((current) => ({ ...current, [questionId]: value }));
@@ -159,7 +216,11 @@ export function SurveyResponseClient({
                 answers: questions.map((question) => ({
                     questionId: question.id,
                     questionKey: question.key,
-                    value: answers[question.id] ?? null,
+                    value:
+                        question.type === 'contact_info' &&
+                        !hasContactValue(answers[question.id])
+                            ? null
+                            : (answers[question.id] ?? null),
                 })),
                 metadata: {
                     submittedFrom: 'garden_survey_route',
@@ -249,6 +310,9 @@ export function SurveyResponseClient({
 
     const introDescription = visibleIntroDescription(
         runtime.version.introDescription,
+        runtime.questions.some((question) =>
+            isLegacyDeliveryContactQuestion(runtime.survey.key, question),
+        ),
     );
 
     return (
@@ -386,6 +450,15 @@ function QuestionBlock({
                 />
             ) : null}
 
+            {question.type === 'contact_info' &&
+            question.settings.type === 'contact_info' ? (
+                <ContactFields
+                    fields={question.settings.fields}
+                    value={isContactValue(answer) ? answer : {}}
+                    onChange={setAnswer}
+                />
+            ) : null}
+
             {error ? (
                 <Typography level="body2" className="text-red-700">
                     {error}
@@ -428,6 +501,42 @@ function OpinionScale({
                     {item}
                 </button>
             ))}
+        </div>
+    );
+}
+
+function ContactFields({
+    fields,
+    onChange,
+    value,
+}: {
+    fields: Array<'first_name' | 'last_name' | 'phone' | 'email'>;
+    onChange: (value: ContactValue) => void;
+    value: ContactValue;
+}) {
+    return (
+        <div className="grid gap-3 sm:grid-cols-2">
+            {fields.map((field) => {
+                const key = contactFieldKey(field);
+                return (
+                    <label className="space-y-1" key={field}>
+                        <span className="block text-sm font-medium text-foreground">
+                            {contactFieldLabel(field)}
+                        </span>
+                        <input
+                            className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-hidden focus:border-ring focus:ring-2 focus:ring-ring/30"
+                            type={field === 'email' ? 'email' : 'text'}
+                            value={value[key] ?? ''}
+                            onChange={(event) =>
+                                onChange({
+                                    ...value,
+                                    [key]: event.target.value,
+                                })
+                            }
+                        />
+                    </label>
+                );
+            })}
         </div>
     );
 }

--- a/apps/garden/app/ankete/[assignmentId]/SurveyResponseClient.tsx
+++ b/apps/garden/app/ankete/[assignmentId]/SurveyResponseClient.tsx
@@ -57,14 +57,7 @@ type SurveyRuntime = {
     };
 };
 
-type ContactValue = {
-    email?: string;
-    firstName?: string;
-    lastName?: string;
-    phone?: string;
-};
-
-type AnswerState = Record<string, number | string | ContactValue | undefined>;
+type AnswerState = Record<string, number | string | undefined>;
 
 function assignmentUrl(assignmentId: string) {
     return `/api/gredice/api/surveys/assignments/${encodeURIComponent(
@@ -76,29 +69,8 @@ async function readJson<T>(response: Response) {
     return (await response.json()) as T;
 }
 
-function hasContactValue(value: ContactValue | undefined) {
-    if (!value) return false;
-    return Boolean(
-        value.firstName || value.lastName || value.phone || value.email,
-    );
-}
-
-function contactFieldLabel(field: string) {
-    return (
-        {
-            email: 'Email',
-            first_name: 'Ime',
-            last_name: 'Prezime',
-            phone: 'Telefon',
-        }[field] ?? field
-    );
-}
-
-function contactFieldKey(field: string): keyof ContactValue {
-    if (field === 'first_name') return 'firstName';
-    if (field === 'last_name') return 'lastName';
-    if (field === 'phone') return 'phone';
-    return 'email';
+function visibleIntroDescription(description: string | null) {
+    return description?.replace(', a kontakt podatke možeš preskočiti.', '.');
 }
 
 export function SurveyResponseClient({
@@ -162,6 +134,7 @@ export function SurveyResponseClient({
     const questions = useMemo(
         () =>
             runtime?.questions
+                .filter((question) => question.type !== 'contact_info')
                 .slice()
                 .sort((left, right) => left.sortOrder - right.sortOrder) ?? [],
         [runtime?.questions],
@@ -186,11 +159,7 @@ export function SurveyResponseClient({
                 answers: questions.map((question) => ({
                     questionId: question.id,
                     questionKey: question.key,
-                    value:
-                        question.type === 'contact_info' &&
-                        !hasContactValue(answers[question.id] as ContactValue)
-                            ? null
-                            : (answers[question.id] ?? null),
+                    value: answers[question.id] ?? null,
                 })),
                 metadata: {
                     submittedFrom: 'garden_survey_route',
@@ -278,6 +247,10 @@ export function SurveyResponseClient({
         );
     }
 
+    const introDescription = visibleIntroDescription(
+        runtime.version.introDescription,
+    );
+
     return (
         <Card className="mx-auto max-w-2xl bg-background">
             <CardHeader>
@@ -288,9 +261,9 @@ export function SurveyResponseClient({
                     <CardTitle>
                         {runtime.version.introTitle ?? runtime.version.title}
                     </CardTitle>
-                    {runtime.version.introDescription ? (
+                    {introDescription ? (
                         <Typography className="text-muted-foreground">
-                            {runtime.version.introDescription}
+                            {introDescription}
                         </Typography>
                     ) : null}
                 </Stack>
@@ -413,19 +386,6 @@ function QuestionBlock({
                 />
             ) : null}
 
-            {question.type === 'contact_info' &&
-            question.settings.type === 'contact_info' ? (
-                <ContactFields
-                    fields={question.settings.fields}
-                    value={
-                        typeof answer === 'object' && !Array.isArray(answer)
-                            ? (answer as ContactValue)
-                            : {}
-                    }
-                    onChange={setAnswer}
-                />
-            ) : null}
-
             {error ? (
                 <Typography level="body2" className="text-red-700">
                     {error}
@@ -468,42 +428,6 @@ function OpinionScale({
                     {item}
                 </button>
             ))}
-        </div>
-    );
-}
-
-function ContactFields({
-    fields,
-    onChange,
-    value,
-}: {
-    fields: Array<'first_name' | 'last_name' | 'phone' | 'email'>;
-    onChange: (value: ContactValue) => void;
-    value: ContactValue;
-}) {
-    return (
-        <div className="grid gap-3 sm:grid-cols-2">
-            {fields.map((field) => {
-                const key = contactFieldKey(field);
-                return (
-                    <label className="space-y-1" key={field}>
-                        <span className="block text-sm font-medium text-foreground">
-                            {contactFieldLabel(field)}
-                        </span>
-                        <input
-                            className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-hidden focus:border-ring focus:ring-2 focus:ring-ring/30"
-                            type={field === 'email' ? 'email' : 'text'}
-                            value={value[key] ?? ''}
-                            onChange={(event) =>
-                                onChange({
-                                    ...value,
-                                    [key]: event.target.value,
-                                })
-                            }
-                        />
-                    </label>
-                );
-            })}
         </div>
     );
 }

--- a/docs/in-app-surveys.md
+++ b/docs/in-app-surveys.md
@@ -28,7 +28,7 @@ In-app surveys replace the delivery Typeform flow with auditable survey definiti
 
 Survey definitions have draft, published, or archived status. Published survey versions are immutable; changing copy or questions creates a new version. Assignments are unique by version, target key, and context key, so a delivery account/month can only receive one assignment for a given version. Responses store the version/question IDs that the customer saw, preserving historical meaning even after a later version is published.
 
-Question types in the first rollout are 0-10 opinion scale, long text, and optional contact info. Opinion questions carry score metadata with `internalScore` and `publicScore`; the delivery seed keeps public scoring disabled until a later reporting rollout defines public thresholds and sample-size rules.
+Question types in the first rollout are 0-10 opinion scale, long text, and optional contact info for custom surveys. Opinion questions carry score metadata with `internalScore` and `publicScore`; the delivery seed keeps public scoring disabled until a later reporting rollout defines public thresholds and sample-size rules. Delivery satisfaction surveys do not ask for separate contact details because the customer route requires login and submissions are linked to the assignment's account/user.
 
 ## Delivery Survey Path
 

--- a/packages/storage/src/repositories/surveysRepo.ts
+++ b/packages/storage/src/repositories/surveysRepo.ts
@@ -1562,7 +1562,7 @@ export async function seedDeliverySatisfactionSurveyDefinition({
         category: 'delivery',
         introTitle: 'Anketa zadovoljstva',
         introDescription:
-            'Anketa je o zadovoljstvu dostavom povrća iz digitalnog vrta. Odgovori su povezani s dostavnim razdobljem kako bismo mogli bolje razumjeti povratnu informaciju, a kontakt podatke možeš preskočiti.',
+            'Anketa je o zadovoljstvu dostavom povrća iz digitalnog vrta. Odgovori su povezani s dostavnim razdobljem kako bismo mogli bolje razumjeti povratnu informaciju.',
         thankYouTitle: 'Hvala ti na odgovoru!',
         thankYouDescription:
             'Tvoj odgovor pomaže da sljedeća dostava bude još bolja.',
@@ -1633,18 +1633,6 @@ export async function seedDeliverySatisfactionSurveyDefinition({
                 settings: {
                     type: 'long_text',
                     maxLength: 2000,
-                },
-            },
-            {
-                key: 'contact_info',
-                title: 'Unesi svoje kontakt podatke ako želiš da te kontaktiramo ukoliko budemo imali pitanja.',
-                description: '(neobavezno - možeš preskočiti kontakt podatke)',
-                type: 'contact_info',
-                required: false,
-                settings: {
-                    type: 'contact_info',
-                    fields: ['first_name', 'last_name', 'phone', 'email'],
-                    phoneDefaultCountry: 'HR',
                 },
             },
         ],

--- a/packages/storage/tests/surveysRepo.node.spec.ts
+++ b/packages/storage/tests/surveysRepo.node.spec.ts
@@ -80,7 +80,7 @@ async function createPublishedSurvey() {
     return { surveyId, versionId };
 }
 
-test('delivery satisfaction seed is idempotent and preserves Typeform question contract', async () => {
+test('delivery satisfaction seed is idempotent and skips redundant contact questions', async () => {
     createTestDb();
 
     const first = await seedDeliverySatisfactionSurveyDefinition({
@@ -131,12 +131,6 @@ test('delivery satisfaction seed is idempotent and preserves Typeform question c
                 required: false,
                 sortOrder: 4,
                 type: 'long_text',
-            },
-            {
-                key: 'contact_info',
-                required: false,
-                sortOrder: 5,
-                type: 'contact_info',
             },
         ],
     );


### PR DESCRIPTION
## Summary

- Confirms the garden questionnaire remains account-gated and removes the visible contact-info step from the customer survey flow.
- Updates the delivery satisfaction survey seed so new versions contain only the four feedback questions.
- Updates the storage regression test and in-app survey docs to document that delivery satisfaction responses are linked through the authenticated assignment account/user.

## Validation

- `pnpm --filter garden run typecheck`
- `pnpm --filter @gredice/storage test surveysRepo.node.spec.ts`
- `pnpm --filter garden exec biome check 'app/ankete/[assignmentId]/SurveyResponseClient.tsx'`
- `pnpm --filter @gredice/storage exec biome check src/repositories/surveysRepo.ts tests/surveysRepo.node.spec.ts`
- `git diff --check`

## Note

`pnpm --filter @gredice/storage exec tsc --noEmit --pretty false` still fails on unrelated existing script/test type errors in the storage package.