### PR TITLE
[codex] Increase notification dismiss hit target

### DIFF
--- a/packages/game/src/hud/NotificationList.tsx
+++ b/packages/game/src/hud/NotificationList.tsx
@@ -79,6 +79,9 @@ function NotificationListItem({
     }, [linkUrl, raisedBed]);
 
     const isRead = Boolean(readAt);
+    const readToggleLabel = isRead
+        ? 'Označi kao nepročitano'
+        : 'Označi kao pročitano';
 
     function handleSetNotificationRead() {
         track('game_notification_read_toggled', {
@@ -164,11 +167,10 @@ function NotificationListItem({
             />
             <button
                 type="button"
-                title={
-                    isRead ? 'Označi kao nepročitano' : 'Označi kao pročitano'
-                }
+                aria-label={readToggleLabel}
+                title={readToggleLabel}
                 className={cx(
-                    'size-4 rounded-full hover:outline outline-offset-2 outline-2 absolute top-2.5 right-2 group',
+                    "absolute top-2.5 right-2 size-4 rounded-full outline-2 outline-offset-2 hover:outline focus-visible:outline group before:absolute before:-inset-3 before:rounded-full before:content-['']",
                     isRead ? 'border' : 'bg-green-600',
                 )}
                 onClick={handleSetNotificationRead}


### PR DESCRIPTION
## Summary

- Enlarges the transparent hit target around the garden notification read/unread control.
- Keeps the visible control at the same `size-4` dimensions and absolute position so list spacing and padding do not change.
- Adds an explicit accessible label matching the existing tooltip text.

## Validation

- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `git diff --check`