### PR TITLE
[codex] Improve garden raised bed dark controls

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1438,7 +1438,9 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         const photoButton = page.getByRole('button', {
             name: /Fotografije gredice Raised Bed 1/u,
         });
+        const titleCluster = page.locator('[data-raised-bed-title-cluster]');
         const detailsButton = page.locator('[data-raised-bed-details-trigger]');
+        await expect(titleCluster).toBeVisible();
         await expect(photoButton).toBeVisible();
         await expect(detailsButton).toBeVisible();
         await expect(photoButton.locator('img')).toBeVisible();
@@ -1457,7 +1459,8 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
 
                 return (
                     photoBox.x < detailsBox.x &&
-                    Math.abs(photoBox.height - detailsBox.height) <= 1
+                    Math.abs(photoBox.height - detailsBox.height) <= 1 &&
+                    Math.abs(detailsBox.x - (photoBox.x + photoBox.width)) <= 1
                 );
             })
             .toBe(true);
@@ -1517,6 +1520,80 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         expect(aiButtonClassName).not.toContain('dark:from-lime-200');
         expect(aiButtonClassName).not.toContain('dark:to-lime-200');
         expect(aiButtonClassName).not.toContain('dark:text-primary-foreground');
+    });
+
+    test('closeup HUD controls use dark surfaces in dark mode', async ({
+        mount,
+        page,
+    }) => {
+        await page.evaluate(() =>
+            document.documentElement.classList.add('dark'),
+        );
+
+        await mount(<RaisedBedCloseupHudStory scenario={emptyScenario()} />);
+
+        const titleCluster = page.locator('[data-raised-bed-title-cluster]');
+        const detailsButton = page.locator('[data-raised-bed-details-trigger]');
+        const fieldButton = page
+            .locator('[data-raised-bed-plant-picker-trigger="true"]')
+            .first();
+        const fieldPositionLabel = fieldButton.locator(
+            '[data-raised-bed-field-position-label]',
+        );
+
+        await expect(titleCluster).toBeVisible();
+        await expect(detailsButton).toBeVisible();
+        await expect(fieldButton).toBeVisible();
+        await expect(fieldPositionLabel).toBeVisible();
+
+        await expect(titleCluster).toHaveCSS(
+            'background-image',
+            /linear-gradient/u,
+        );
+        await expect(fieldButton).toHaveCSS(
+            'background-image',
+            /linear-gradient/u,
+        );
+
+        const [
+            titleClusterStyles,
+            detailsButtonStyles,
+            fieldButtonStyles,
+            fieldPositionLabelStyles,
+        ] = await Promise.all([
+            titleCluster.evaluate((element) => {
+                const styles = window.getComputedStyle(element);
+                return {
+                    backgroundImage: styles.backgroundImage,
+                    color: styles.color,
+                };
+            }),
+            detailsButton.evaluate((element) => {
+                const styles = window.getComputedStyle(element);
+                return { color: styles.color };
+            }),
+            fieldButton.evaluate((element) => {
+                const styles = window.getComputedStyle(element);
+                return {
+                    backgroundImage: styles.backgroundImage,
+                    color: styles.color,
+                };
+            }),
+            fieldPositionLabel.evaluate((element) => {
+                const styles = window.getComputedStyle(element);
+                return { color: styles.color };
+            }),
+        ]);
+
+        expect(titleClusterStyles.backgroundImage).not.toContain(
+            '217, 249, 157',
+        );
+        expect(fieldButtonStyles.backgroundImage).not.toContain(
+            '217, 249, 157',
+        );
+        expect(detailsButtonStyles.color).toBe(titleClusterStyles.color);
+        expect(fieldButtonStyles.color).toBe(titleClusterStyles.color);
+        expect(fieldPositionLabelStyles.color).not.toContain('77, 124, 15');
     });
 
     test('closeup HUD photo shortcut searches older history pages before hiding', async ({

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1447,6 +1447,11 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(
             photoButton.locator('[data-raised-bed-photo-count]'),
         ).toHaveCount(0);
+        const photoButtonClassName = await photoButton.evaluate(
+            (element) => element.className,
+        );
+        expect(photoButtonClassName).not.toContain('!ring-0');
+        expect(photoButtonClassName).toContain('focus-visible:!ring-2');
 
         await expect
             .poll(async () => {

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -88,17 +88,19 @@ export function RaisedBedFieldHud() {
         >
             {currentGarden && raisedBed && (
                 <div className="absolute z-40 top-[var(--raised-bed-ui-top)] left-[var(--raised-bed-title-left)]">
-                    <div className="relative flex items-center">
+                    <div
+                        className="relative flex max-w-72 items-stretch overflow-hidden rounded-xl bg-gradient-to-br from-lime-100/95 to-lime-100/85 text-green-950 shadow-lg ring-1 ring-black/10 dark:from-emerald-950/95 dark:to-lime-950/90 dark:text-lime-50 dark:ring-lime-100/10 md:max-w-[360px]"
+                        data-raised-bed-title-cluster
+                    >
                         {!isSandbox && (
-                            <div className="absolute right-full top-1/2 mr-2 -translate-y-1/2">
-                                <RaisedBedPhotosModal
-                                    gardenId={currentGarden.id}
-                                    raisedBedId={raisedBed.id}
-                                    subjectName={raisedBed.name}
-                                    triggerPlacement="hud"
-                                    hideWhenEmpty
-                                />
-                            </div>
+                            <RaisedBedPhotosModal
+                                gardenId={currentGarden.id}
+                                raisedBedId={raisedBed.id}
+                                subjectName={raisedBed.name}
+                                triggerPlacement="hud"
+                                hideWhenEmpty
+                                className="rounded-l-xl rounded-r-none border-r border-green-950/10 dark:border-lime-100/10 !shadow-none !ring-0"
+                            />
                         )}
                         <GameModal
                             open={isInfoOpen}
@@ -117,7 +119,7 @@ export function RaisedBedFieldHud() {
                             className="overflow-x-hidden"
                             trigger={
                                 <ButtonGreen
-                                    className="max-w-64 md:max-w-[312px]"
+                                    className="min-w-0 flex-1 justify-between rounded-none px-3 !bg-transparent !bg-none !text-green-950 shadow-none hover:!bg-white/30 hover:!text-green-900 dark:!text-lime-50 dark:hover:!bg-white/10 dark:hover:!text-lime-100"
                                     data-raised-bed-details-trigger
                                     endDecorator={
                                         <Navigate className="size-4 shrink-0" />

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -99,7 +99,7 @@ export function RaisedBedFieldHud() {
                                 subjectName={raisedBed.name}
                                 triggerPlacement="hud"
                                 hideWhenEmpty
-                                className="rounded-l-xl rounded-r-none border-r border-green-950/10 dark:border-lime-100/10 !shadow-none !ring-0"
+                                className="rounded-l-xl rounded-r-none border-r border-green-950/10 ring-0 !shadow-none focus-visible:!ring-2 focus-visible:!ring-lime-700 focus-visible:!ring-offset-2 dark:border-lime-100/10"
                             />
                         )}
                         <GameModal

--- a/packages/game/src/hud/raisedBed/RaisedBedCard.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedCard.tsx
@@ -8,7 +8,7 @@ export function RaisedBedCard({
     return (
         <div
             className={cx(
-                'bg-gradient-to-br from-lime-100/90 dark:from-lime-200/80 to-lime-100/80 dark:to-lime-200/70 dark:text-green-950 rounded-xs md:rounded-3xl',
+                'rounded-xs bg-gradient-to-br from-lime-100/90 to-lime-100/80 text-primary dark:from-emerald-950/95 dark:to-lime-950/90 dark:text-lime-50 md:rounded-3xl',
                 className,
             )}
             {...rest}

--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -174,8 +174,8 @@ function RaisedBedFieldLayerToggle({
             className={cx(
                 'inline-flex size-10 items-center justify-center rounded-md border-2 border-white shadow-md ring-1 ring-black/10 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700',
                 isPressed
-                    ? 'bg-gradient-to-br from-lime-100/90 to-lime-100/80 text-primary hover:text-primary/80 dark:from-lime-200/80 dark:to-lime-200/70 dark:text-primary-foreground dark:hover:text-primary-foreground/80'
-                    : 'bg-white/85 text-lime-950 hover:bg-white',
+                    ? 'bg-gradient-to-br from-lime-100/90 to-lime-100/80 text-primary hover:text-primary/80 dark:from-emerald-950/95 dark:to-lime-950/90 dark:text-lime-50 dark:hover:from-emerald-900/95 dark:hover:to-lime-900/90'
+                    : 'bg-white/85 text-lime-950 hover:bg-white dark:bg-slate-950/90 dark:text-lime-100 dark:hover:bg-slate-900',
             )}
             data-raised-bed-layer-control={storageName}
             onClick={onClick}

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemButton.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemButton.tsx
@@ -21,13 +21,19 @@ export function RaisedBedFieldItemButton({
     return (
         <ButtonGreen
             className={cx(
-                'p-0 relative size-full flex items-center justify-center rounded-xs',
+                'relative flex size-full items-center justify-center rounded-xs p-0 dark:ring-1 dark:ring-lime-100/10',
                 className,
             )}
             {...rest}
         >
-            <div className="absolute left-0.5 top-0">
-                <Typography level="body3" className="text-lime-700">
+            <div
+                className="absolute left-0.5 top-0"
+                data-raised-bed-field-position-label
+            >
+                <Typography
+                    level="body3"
+                    className="text-lime-700 dark:text-lime-200"
+                >
                     {positionIndex + 1}
                 </Typography>
             </div>

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldItemEmpty.tsx
@@ -127,7 +127,7 @@ export function RaisedBedFieldItemEmpty({
                         data-raised-bed-plant-picker-trigger="true"
                     >
                         {(isLoading || !cartPlantItem) && (
-                            <PlantingSeedIcon className="size-8 text-green-800" />
+                            <PlantingSeedIcon className="size-8 text-green-800 dark:text-lime-200" />
                         )}
                         {!isLoading && cartPlantItem && (
                             <>

--- a/packages/game/src/shared-ui/ButtonGreen.tsx
+++ b/packages/game/src/shared-ui/ButtonGreen.tsx
@@ -6,8 +6,8 @@ export function ButtonGreen({ className, ...rest }: ButtonProps) {
         <Button
             className={cx(
                 'min-h-10',
-                'bg-gradient-to-br from-lime-100/90 dark:from-lime-200/80 to-lime-100/80 dark:to-lime-200/70 hover:bg-white dark:hover:bg-white/50',
-                'text-primary dark:text-primary-foreground dark:hover:text-primary-foreground/80 hover:text-primary/80',
+                'bg-gradient-to-br from-lime-100/90 to-lime-100/80 dark:from-emerald-950/95 dark:to-lime-950/90 hover:bg-white dark:hover:from-emerald-900/95 dark:hover:to-lime-900/90',
+                'text-primary hover:text-primary/80 dark:text-lime-50 dark:hover:text-lime-100',
                 'transition-colors',
                 className,
             )}


### PR DESCRIPTION
## Summary

- Darkened the garden green button/card palette in dark mode so raised-bed controls and field tiles are no longer overly bright.
- Integrated the raised-bed photo thumbnail into the title control cluster so it reads as part of the raised-bed label instead of floating beside it.
- Added component coverage for the title/photo adjacency and dark-mode closeup HUD surfaces.

## Validation

- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter garden lint`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/raised-bed-field-hud.spec.tsx --grep "closeup HUD (photo shortcut opens the raised bed photos modal|photo AI action keeps dark mode button colors|controls use dark surfaces in dark mode)"`