### PR TITLE
[codex] Compact operation and diary actions

### DIFF
--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -1,8 +1,26 @@
 import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator } from '@playwright/test';
 import {
     DenseGardenOperationsHudStory,
     GardenOperationsHudStory,
 } from './GardenOperationsHudStory';
+
+async function expectSameControlRow(
+    leftControl: Locator,
+    rightControl: Locator,
+) {
+    const leftBox = await leftControl.boundingBox();
+    const rightBox = await rightControl.boundingBox();
+
+    if (!leftBox || !rightBox) {
+        throw new Error('Expected both controls to be visible');
+    }
+
+    const leftCenterY = leftBox.y + leftBox.height / 2;
+    const rightCenterY = rightBox.y + rightBox.height / 2;
+
+    expect(Math.abs(leftCenterY - rightCenterY)).toBeLessThanOrEqual(8);
+}
 
 test.describe('Garden operations HUD', () => {
     test('shows operation items that are still in the shopping cart', async ({
@@ -64,6 +82,14 @@ test.describe('Garden operations HUD', () => {
             name: '22. svibnja 2026.',
         });
         await expect(operationDateButton).toBeVisible();
+        const reschedulableOperationCard = page
+            .locator('[data-garden-operation-card]')
+            .filter({ has: operationDateButton })
+            .first();
+        await expectSameControlRow(
+            operationDateButton,
+            reschedulableOperationCard.getByRole('button', { name: 'Otkaži' }),
+        );
         await expect(
             page.locator('[data-operation-media="plant"]').first(),
         ).toBeVisible();
@@ -113,11 +139,14 @@ test.describe('Garden operations HUD', () => {
         const reschedulableHistoryCard = dialog
             .locator('[data-garden-operation-card]')
             .filter({ hasText: 'Zalijevanje u košari' });
-        await expect(
-            reschedulableHistoryCard.getByRole('button', {
-                name: '20. svibnja 2026.',
-            }),
-        ).toBeVisible();
+        const historyDateButton = reschedulableHistoryCard.getByRole('button', {
+            name: '20. svibnja 2026.',
+        });
+        await expect(historyDateButton).toBeVisible();
+        await expectSameControlRow(
+            historyDateButton,
+            reschedulableHistoryCard.getByRole('button', { name: 'Otkaži' }),
+        );
         await expect(
             reschedulableHistoryCard.getByRole('button', { name: 'Otkaži' }),
         ).toBeVisible();

--- a/apps/garden/tests/raised-bed-diary.spec.tsx
+++ b/apps/garden/tests/raised-bed-diary.spec.tsx
@@ -150,6 +150,23 @@ async function expectNoHorizontalOverflow(locator: Locator) {
     expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
 }
 
+async function expectSameControlRow(
+    leftControl: Locator,
+    rightControl: Locator,
+) {
+    const leftBox = await leftControl.boundingBox();
+    const rightBox = await rightControl.boundingBox();
+
+    if (!leftBox || !rightBox) {
+        throw new Error('Expected both controls to be visible');
+    }
+
+    const leftCenterY = leftBox.y + leftBox.height / 2;
+    const rightCenterY = rightBox.y + rightBox.height / 2;
+
+    expect(Math.abs(leftCenterY - rightCenterY)).toBeLessThanOrEqual(8);
+}
+
 async function openSavedAiDiaryEntry(page: Page) {
     const aiEntry = page.locator('[data-diary-entry]').nth(1);
 
@@ -249,6 +266,12 @@ test('future planned diary entries expose cancel confirmation', async ({
         name: 'Otkaži',
     });
     await expect(cancelButtons).toHaveCount(1);
+
+    const firstEntry = page.locator('[data-diary-entry]').first();
+    await expectSameControlRow(
+        firstEntry.getByRole('button', { name: 'Prerasporedi' }),
+        firstEntry.getByRole('button', { name: 'Otkaži' }),
+    );
 
     await cancelButtons.first().click();
 

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1327,7 +1327,9 @@ function OperationSchedule({
 }) {
     const scheduledDate = formatDate(operation.scheduledDate);
     const scheduleContent = scheduleAction ? (
-        <div className="min-w-0 max-w-full">{scheduleAction}</div>
+        <div className="min-w-0 max-w-full overflow-hidden">
+            {scheduleAction}
+        </div>
     ) : scheduledDate ? (
         <Row
             spacing={1}
@@ -1347,10 +1349,10 @@ function OperationSchedule({
     return (
         <Row
             spacing={0.5}
-            className="min-w-0 max-w-full flex-wrap items-center justify-end gap-y-0.5"
+            className="min-w-0 max-w-full flex-nowrap items-center justify-end overflow-hidden"
         >
             {scheduleContent}
-            {cancelAction}
+            {cancelAction && <div className="shrink-0">{cancelAction}</div>}
         </Row>
     );
 }
@@ -1614,7 +1616,7 @@ export function GardenOperationCard({
                         </Stack>
                         <Stack
                             spacing={0.25}
-                            className="max-w-[52%] shrink-0 items-end"
+                            className="min-w-0 max-w-[52%] shrink-0 items-end overflow-hidden"
                         >
                             <OperationStatusSummary
                                 operation={operation}

--- a/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiary.tsx
@@ -40,6 +40,11 @@ type DiaryEntryAiHistory = {
     entries: DiaryEntry[];
 };
 
+type DiaryEntryActions = {
+    compactActions?: ReactNode;
+    detailAction?: ReactNode;
+};
+
 function relateAiHistory(entries: DiaryEntry[] | undefined) {
     const aiHistoryByEntryId = new Map<number, DiaryEntryAiHistory>();
 
@@ -156,13 +161,16 @@ function diaryEntryActions({
         return null;
     }
 
-    return (
-        <Row spacing={2} className="flex-wrap items-center">
-            {rescheduleAction}
-            {cancelAction}
-            {aiAction}
-        </Row>
-    );
+    return {
+        compactActions:
+            rescheduleAction || cancelAction ? (
+                <>
+                    {rescheduleAction}
+                    {cancelAction}
+                </>
+            ) : undefined,
+        detailAction: aiAction,
+    };
 }
 
 function SavedAiDiaryEntryButton({
@@ -220,7 +228,7 @@ function DiaryList({
     renderEntryAction?: (
         entry: DiaryEntry,
         aiHistory?: DiaryEntryAiHistory,
-    ) => ReactNode;
+    ) => DiaryEntryActions | null | undefined;
 }) {
     const aiHistoryByEntryId = relateAiHistory(entries);
 
@@ -253,7 +261,7 @@ function DiaryList({
             )}
             {entries?.map((entry) => {
                 const aiHistory = aiHistoryByEntryId.get(entry.id);
-                const entryAction = renderEntryAction?.(entry, aiHistory);
+                const entryActions = renderEntryAction?.(entry, aiHistory);
 
                 return (
                     <div
@@ -354,9 +362,11 @@ function DiaryList({
                                                 >
                                                     {entry.description}
                                                 </Typography>
-                                                {entryAction && (
+                                                {entryActions?.detailAction && (
                                                     <div className="mt-2 w-fit max-w-full">
-                                                        {entryAction}
+                                                        {
+                                                            entryActions.detailAction
+                                                        }
                                                     </div>
                                                 )}
                                             </Stack>
@@ -385,11 +395,21 @@ function DiaryList({
                                                     {entry.status}
                                                 </Chip>
                                             )}
-                                            <Typography level="body2" noWrap>
-                                                {entry.timestamp.toLocaleDateString(
-                                                    'hr-HR',
-                                                )}
-                                            </Typography>
+                                            <Row
+                                                spacing={1}
+                                                className="min-w-0 max-w-full flex-nowrap items-center self-start sm:self-end"
+                                            >
+                                                <Typography
+                                                    level="body2"
+                                                    noWrap
+                                                    className="min-w-0"
+                                                >
+                                                    {entry.timestamp.toLocaleDateString(
+                                                        'hr-HR',
+                                                    )}
+                                                </Typography>
+                                                {entryActions?.compactActions}
+                                            </Row>
                                         </Stack>
                                     </Row>
                                 }

--- a/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedDiaryRescheduleAction.tsx
@@ -40,15 +40,25 @@ export function RaisedBedDiaryRescheduleAction({
     const actionLabel =
         triggerLabel ?? (hasScheduledDate ? 'Prerasporedi' : 'Zakaži');
     const modalActionLabel = hasScheduledDate ? 'Prerasporedi' : 'Zakaži';
+    const triggerTitle =
+        typeof actionLabel === 'string' ? actionLabel : undefined;
+    const actionLabelContent =
+        typeof actionLabel === 'string' ? (
+            <span className="min-w-0 truncate">{actionLabel}</span>
+        ) : (
+            actionLabel
+        );
     const triggerButton = (
         <Button
             type="button"
             size="xs"
             variant="plain"
             disabled={Boolean(disabledReason)}
+            title={triggerTitle}
+            className="max-w-full shrink"
             startDecorator={<Calendar className="size-3.5 shrink-0" />}
         >
-            {actionLabel}
+            {actionLabelContent}
         </Button>
     );
 


### PR DESCRIPTION
## Summary
- Keep operation card schedule/date controls and cancel action on one compact row instead of wrapping the cancel icon onto an empty line.
- Split raised-bed diary actions so compact schedule/cancel controls stay beside the date while longer AI advice actions remain under the entry content.
- Add component regression checks for active operations, history operations, and raised-bed diary entries to keep those controls aligned.

## Root cause
The shared operation and diary action rows allowed independent wrapping. On narrow game cards, the date or status metadata stayed on one line while the cancel icon wrapped into its own blank-looking row, increasing list height across active operations, history, raised-bed diary, and plant field diary views.

## Validation
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden lint`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden test:prepare`
- `GREDICE_PLAYWRIGHT_REUSE_SERVER=true pnpm --filter garden test:run tests/garden-operations-hud.spec.tsx tests/raised-bed-diary.spec.tsx`