### PR TITLE
Display internal operation labels in diary views

### DIFF
--- a/apps/garden/tests/GardenOperationsHudStory.tsx
+++ b/apps/garden/tests/GardenOperationsHudStory.tsx
@@ -7,6 +7,7 @@ import {
     type GardenOperationItem,
     gardenOperationsQueryKey,
 } from '../../../packages/game/src/hooks/useGardenOperations';
+import { operationDefinitionsQueryKey } from '../../../packages/game/src/hooks/useOperations';
 import type { ShoppingCartItemData } from '../../../packages/game/src/hooks/useShoppingCart';
 import { GardenOperationsHud } from '../../../packages/game/src/hud/GardenOperationsHud';
 import {
@@ -58,6 +59,23 @@ export const cartOperation = {
     },
     createdAt: now,
     updatedAt: now,
+} satisfies OperationData;
+
+const internalOperation = {
+    ...cartOperation,
+    id: 999_002,
+    slug: 'mock-raised-bed-detailed-inspection',
+    attributes: {
+        ...cartOperation.attributes,
+        application: 'raisedBedFull',
+        internal: true,
+    },
+    information: {
+        ...cartOperation.information,
+        name: 'raised-bed-detailed-inspection',
+        label: 'Detaljan pregled gredice',
+        shortDescription: 'Interna radnja za detaljan pregled gredice.',
+    },
 } satisfies OperationData;
 
 function buildGarden() {
@@ -180,11 +198,15 @@ function buildOperationCartItem({
 
 function buildHudOperationItem({
     cancellationReason,
+    entityId = cartOperation.id,
     id,
+    raisedBedFieldId = 1,
     status,
 }: {
     cancellationReason?: string;
+    entityId?: number;
     id: number;
+    raisedBedFieldId?: number | null;
     status: GardenOperationItem['status'];
 }): GardenOperationItem {
     const day = String(Math.max(1, 30 - (id % 20))).padStart(2, '0');
@@ -196,10 +218,10 @@ function buildHudOperationItem({
 
     return {
         id,
-        entityId: cartOperation.id,
+        entityId,
         entityTypeName: 'operation',
         raisedBedId: TEST_RAISED_BED_ID,
-        raisedBedFieldId: 1,
+        raisedBedFieldId,
         status,
         createdAt: `2026-05-${day}T00:00:00.000Z`,
         scheduledDate: `2026-05-${day}T00:00:00.000Z`,
@@ -293,6 +315,12 @@ function createQueryClient({
                   id: 610,
                   status: 'confirmed',
               }),
+              buildHudOperationItem({
+                  entityId: internalOperation.id,
+                  id: 611,
+                  raisedBedFieldId: null,
+                  status: 'confirmed',
+              }),
           ];
     const pendingOperationPage = {
         pages: [
@@ -323,6 +351,10 @@ function createQueryClient({
     );
     queryClient.setQueryData(['sorts'], allSorts);
     queryClient.setQueryData(['operations'], [cartOperation]);
+    queryClient.setQueryData(operationDefinitionsQueryKey.all, [
+        cartOperation,
+        internalOperation,
+    ]);
     queryClient.setQueryData(['shopping-cart'], {
         id: 1,
         items: [

--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -7,6 +7,7 @@ import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/Game
 import { useCurrentGarden } from '../../../packages/game/src/hooks/useCurrentGarden';
 import { favoritesQueryKey } from '../../../packages/game/src/hooks/useFavorites';
 import { gardenOperationsQueryKey } from '../../../packages/game/src/hooks/useGardenOperations';
+import { operationDefinitionsQueryKey } from '../../../packages/game/src/hooks/useOperations';
 import { queryKeys as raisedBedAiHistoryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedAiHistory';
 import { queryKeys as raisedBedDiaryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedDiaryEntries';
 import { queryKeys as raisedBedFieldDiaryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedFieldDiaryEntries';
@@ -85,6 +86,10 @@ function createScenarioQueryClient(
     queryClient.setQueryData(['plants'], scenario.plants ?? allPlants);
     queryClient.setQueryData(['sorts'], scenario.sorts ?? allSorts);
     queryClient.setQueryData(['operations'], scenario.operations ?? []);
+    queryClient.setQueryData(
+        operationDefinitionsQueryKey.all,
+        scenario.operations ?? [],
+    );
     const operationHistoryItems = scenario.operationHistoryItems ?? [];
     const raisedBedOperationDiaryEntries =
         scenario.raisedBedOperationDiaryEntries ?? [];

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -98,6 +98,24 @@ test.describe('Garden operations HUD', () => {
         ).toBeVisible();
     });
 
+    test('shows internal operation labels in operation cards', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<GardenOperationsHudStory />);
+
+        await page.getByTitle('Status radnji').click();
+        await page.getByRole('button', { name: 'Prikaži sve radnje' }).click();
+
+        const dialog = page
+            .getByRole('dialog')
+            .filter({ hasText: 'Povijest radnji' });
+        await expect(
+            dialog.getByText('Detaljan pregled gredice'),
+        ).toBeVisible();
+        await expect(dialog.getByText('Radnja #611')).toHaveCount(0);
+    });
+
     test('shows completed sowing tasks in operation history', async ({
         mount,
         page,

--- a/packages/game/src/hooks/useOperations.ts
+++ b/packages/game/src/hooks/useOperations.ts
@@ -6,10 +6,21 @@ import {
 } from '../operationVisualRewardDebugProfile';
 import { useOptionalGameState } from '../useGameState';
 
-async function getOperations() {
+export const operationDefinitionsQueryKey = {
+    all: ['operation-definitions'] as const,
+    byProfile: (profile?: string | null) =>
+        profile
+            ? (['operation-definitions', profile] as const)
+            : (['operation-definitions'] as const),
+};
+
+async function getOperations({ includeInternal = false } = {}) {
     const operations = await directoriesClient().GET('/entities/operation');
     return (operations.data ?? [])
-        .filter((operation) => operation.attributes.internal !== true)
+        .filter(
+            (operation) =>
+                includeInternal || operation.attributes.internal !== true,
+        )
         .sort((a, b) => a.information.name.localeCompare(b.information.name));
 }
 
@@ -30,6 +41,27 @@ export function useOperations() {
             isOperationRewardDebug
                 ? operationVisualRewardDebugOperationDefinitions
                 : getOperations(),
+        staleTime: 1000 * 60 * 60, // 1 hour
+    });
+}
+
+export function useOperationDefinitions() {
+    const isMock = useOptionalGameState((state) => state.isMock, false);
+    const mockGardenProfile = useOptionalGameState(
+        (state) => state.mockGardenProfile,
+        'default',
+    );
+    const isOperationRewardDebug =
+        isMock && isOperationVisualRewardDebugProfile(mockGardenProfile);
+
+    return useQuery({
+        queryKey: operationDefinitionsQueryKey.byProfile(
+            isOperationRewardDebug ? mockGardenProfile : null,
+        ),
+        queryFn: async () =>
+            isOperationRewardDebug
+                ? operationVisualRewardDebugOperationDefinitions
+                : getOperations({ includeInternal: true }),
         staleTime: 1000 * 60 * 60, // 1 hour
     });
 }

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -44,7 +44,7 @@ import {
     useGardenOperations,
 } from '../hooks/useGardenOperations';
 import { useLiveTime } from '../hooks/useLiveTime';
-import { useOperations } from '../hooks/useOperations';
+import { useOperationDefinitions } from '../hooks/useOperations';
 import { useSorts } from '../hooks/usePlantSorts';
 import {
     type DiaryRescheduleTarget,
@@ -63,7 +63,7 @@ import { RaisedBedDiaryCancelAction } from './raisedBed/RaisedBedDiaryCancelActi
 import { RaisedBedDiaryRescheduleAction } from './raisedBed/RaisedBedDiaryRescheduleAction';
 
 type OperationData = NonNullable<
-    ReturnType<typeof useOperations>['data']
+    ReturnType<typeof useOperationDefinitions>['data']
 >[number];
 type PlantSortData = NonNullable<ReturnType<typeof useSorts>['data']>[number];
 type CurrentGardenData = NonNullable<
@@ -1833,7 +1833,7 @@ export function GardenOperationsHud() {
     const { track } = useGameAnalytics();
     const referenceDate = useLiveTime();
     const { data: currentGarden } = useCurrentGarden();
-    const { data: operationsData } = useOperations();
+    const { data: operationsData } = useOperationDefinitions();
     const { data: cart } = useShoppingCart();
     const [, setShoppingCartOpen] = useShoppingCartOpenParam();
     const pending = useGardenOperations({

--- a/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedOperationHistoryList.tsx
@@ -11,7 +11,7 @@ import {
     useGardenOperations,
 } from '../../hooks/useGardenOperations';
 import { useLiveTime } from '../../hooks/useLiveTime';
-import { useOperations } from '../../hooks/useOperations';
+import { useOperationDefinitions } from '../../hooks/useOperations';
 import { useSorts } from '../../hooks/usePlantSorts';
 import { useRaisedBedAiHistory } from '../../hooks/useRaisedBedAiHistory';
 import {
@@ -87,7 +87,7 @@ export function RaisedBedOperationHistoryList({
 }) {
     const referenceDate = useLiveTime();
     const { data: currentGarden } = useCurrentGarden();
-    const { data: operationsData } = useOperations();
+    const { data: operationsData } = useOperationDefinitions();
     const shouldLoadAiHistory = Boolean(currentGarden?.id && raisedBedId);
     const { data: aiHistoryEntries } = useRaisedBedAiHistory(
         currentGarden?.id ?? 0,

--- a/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPhotosModal.tsx
@@ -13,7 +13,7 @@ import { cx } from '@gredice/ui/utils';
 import { type ReactNode, useEffect, useMemo } from 'react';
 import { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useGardenOperations } from '../../hooks/useGardenOperations';
-import { useOperations } from '../../hooks/useOperations';
+import { useOperationDefinitions } from '../../hooks/useOperations';
 import { useRaisedBedAiHistory } from '../../hooks/useRaisedBedAiHistory';
 import { GameModal } from '../../shared-ui/game-modal';
 import { sortOperationTasksNewestFirst } from '../gardenOperationOrdering';
@@ -117,7 +117,7 @@ export function RaisedBedPhotosModal({
     className,
 }: RaisedBedPhotosModalProps) {
     const { data: currentGarden } = useCurrentGarden();
-    const { data: operationsData } = useOperations();
+    const { data: operationsData } = useOperationDefinitions();
     const history = useGardenOperations({
         includeCompleted: true,
         pageSize: PHOTO_PAGE_SIZE,


### PR DESCRIPTION
## Summary
- Add a display-only operation definitions query that includes internal operation entities.
- Use that full definition list for garden operation history, raised-bed operation history, and raised-bed photos so internal operations render their normal labels.
- Keep the existing orderable operations hook filtered so users still cannot order internal operations.

## Validation
- `pnpm --filter game lint`
- `pnpm --filter garden lint`
- `pnpm --filter game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter game test`
- `pnpm --filter garden run test:prepare`
- `pnpm --filter garden exec playwright test tests/garden-operations-hud.spec.tsx --config playwright.config.ts`