### PR TITLE
[codex] Adjust raised bed HUD on extra-small screens

### DIFF
--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -7,6 +7,7 @@ import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/Game
 import { useCurrentGarden } from '../../../packages/game/src/hooks/useCurrentGarden';
 import { favoritesQueryKey } from '../../../packages/game/src/hooks/useFavorites';
 import { gardenOperationsQueryKey } from '../../../packages/game/src/hooks/useGardenOperations';
+import { useOutletOffersQueryKey } from '../../../packages/game/src/hooks/useOutletOffers';
 import { queryKeys as raisedBedAiHistoryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedAiHistory';
 import { queryKeys as raisedBedDiaryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedDiaryEntries';
 import { queryKeys as raisedBedFieldDiaryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedFieldDiaryEntries';
@@ -31,14 +32,62 @@ import {
 
 const now = '2026-05-13T00:00:00.000Z';
 
+type MockStackPosition = {
+    clone: () => MockStackPosition;
+    x: number;
+    y: number;
+    z: number;
+};
+
+function createMockStackPosition(
+    x: number,
+    y: number,
+    z: number,
+): MockStackPosition {
+    return {
+        clone: () => createMockStackPosition(x, y, z),
+        x,
+        y,
+        z,
+    };
+}
+
+function buildRaisedBedStacks({
+    blockCount,
+    orientation,
+}: {
+    blockCount: 1 | 2;
+    orientation: 'horizontal' | 'vertical';
+}) {
+    return Array.from({ length: blockCount }, (_, index) => ({
+        position:
+            orientation === 'horizontal'
+                ? createMockStackPosition(0, 0, index)
+                : createMockStackPosition(-index, 0, 0),
+        blocks: [
+            {
+                id: `raised-bed-${index + 1}`,
+                name: 'Raised_Bed',
+                rotation: 0,
+            },
+        ],
+    }));
+}
+
 function buildGarden(scenario: RaisedBedScenario) {
     const fields = scenario.fields.map((config, index) =>
         buildField(config, index + 1),
     );
+    const raisedBedBlockCount = scenario.raisedBedBlockCount ?? 1;
+    const raisedBedOrientation = scenario.raisedBedOrientation ?? 'horizontal';
+
     return {
         id: TEST_GARDEN_ID,
         name: 'Test garden',
-        stacks: [],
+        stacks: buildRaisedBedStacks({
+            blockCount: raisedBedBlockCount,
+            orientation: raisedBedOrientation,
+        }),
         location: { lat: 45.739, lon: 16.572 },
         raisedBeds: [
             {
@@ -51,7 +100,7 @@ function buildGarden(scenario: RaisedBedScenario) {
                 status: scenario.raisedBedStatus ?? 'new',
                 abandonReason: scenario.raisedBedAbandonReason ?? null,
                 isValid: scenario.isRaisedBedValid ?? true,
-                orientation: 'horizontal' as const,
+                orientation: raisedBedOrientation,
                 createdAt: now,
                 updatedAt: now,
             },
@@ -70,6 +119,7 @@ function createScenarioQueryClient(
     });
     const garden = buildGarden(scenario);
 
+    queryClient.setQueryDefaults(useOutletOffersQueryKey, { enabled: false });
     queryClient.setQueryData(['currentUser'], { id: 'test-user' });
     queryClient.setQueryData(['gardens'], [{ id: TEST_GARDEN_ID }]);
     queryClient.setQueryData(
@@ -85,6 +135,8 @@ function createScenarioQueryClient(
     queryClient.setQueryData(['plants'], scenario.plants ?? allPlants);
     queryClient.setQueryData(['sorts'], scenario.sorts ?? allSorts);
     queryClient.setQueryData(['operations'], scenario.operations ?? []);
+    queryClient.setQueryData(useOutletOffersQueryKey, []);
+    queryClient.setQueryData(['raisedBeds', TEST_RAISED_BED_ID, 'sensors'], []);
     const operationHistoryItems = scenario.operationHistoryItems ?? [];
     const raisedBedOperationDiaryEntries =
         scenario.raisedBedOperationDiaryEntries ?? [];
@@ -255,18 +307,28 @@ export function RaisedBedInfoModalStory({
 }
 
 export function RaisedBedCloseupHudStory({
+    height = 620,
     scenario,
+    width = 720,
 }: {
+    height?: number;
     scenario: RaisedBedScenario;
+    width?: number;
 }) {
     return (
         <RaisedBedHudTestProviders scenario={scenario}>
-            <RaisedBedCloseupHudStoryContent />
+            <RaisedBedCloseupHudStoryContent height={height} width={width} />
         </RaisedBedHudTestProviders>
     );
 }
 
-function RaisedBedCloseupHudStoryContent() {
+function RaisedBedCloseupHudStoryContent({
+    height,
+    width,
+}: {
+    height: number;
+    width: number;
+}) {
     const setView = useGameState((state) => state.setView);
 
     useEffect(() => {
@@ -281,7 +343,11 @@ function RaisedBedCloseupHudStoryContent() {
     }, [setView]);
 
     return (
-        <div className="relative h-[620px] w-[720px]">
+        <div
+            className="relative overflow-hidden bg-lime-950/20"
+            data-raised-bed-closeup-story-frame
+            style={{ height, width }}
+        >
             <RaisedBedFieldHud />
         </div>
     );

--- a/apps/garden/tests/raisedBedFieldHudScenarios.ts
+++ b/apps/garden/tests/raisedBedFieldHudScenarios.ts
@@ -210,6 +210,8 @@ export type RaisedBedScenario = {
     }>;
     raisedBedStatus?: string;
     raisedBedAbandonReason?: string | null;
+    raisedBedBlockCount?: 1 | 2;
+    raisedBedOrientation?: 'horizontal' | 'vertical';
     isRaisedBedValid?: boolean;
 };
 

--- a/apps/storybook/stories/apps/garden/RaisedBedCloseupHud.stories.tsx
+++ b/apps/storybook/stories/apps/garden/RaisedBedCloseupHud.stories.tsx
@@ -1,0 +1,109 @@
+import { RaisedBedCloseupHudStory } from '@apps/garden/tests/RaisedBedFieldHudStory';
+import {
+    buildCartItem,
+    type RaisedBedScenario,
+    testSorts,
+} from '@apps/garden/tests/raisedBedFieldHudScenarios';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const closeupScenario: RaisedBedScenario = {
+    raisedBedBlockCount: 2,
+    raisedBedOrientation: 'horizontal',
+    fields: [
+        {
+            positionIndex: 0,
+            plantSortId: testSorts.tomato.id,
+            plantStatus: 'sprouted',
+            plantSowDate: '2026-04-12T00:00:00.000Z',
+            plantGrowthDate: '2026-04-28T00:00:00.000Z',
+        },
+        {
+            positionIndex: 2,
+            plantSortId: testSorts.basil.id,
+            plantStatus: 'sowed',
+            plantScheduledDate: '2026-05-18T00:00:00.000Z',
+            plantSowDate: '2026-05-02T00:00:00.000Z',
+        },
+        {
+            positionIndex: 4,
+            plantSortId: testSorts.lettuce.id,
+            plantStatus: 'ready',
+            plantSowDate: '2026-03-29T00:00:00.000Z',
+            plantGrowthDate: '2026-04-12T00:00:00.000Z',
+            plantReadyDate: '2026-05-08T00:00:00.000Z',
+        },
+        {
+            positionIndex: 9,
+            plantSortId: testSorts.tomato.id,
+            plantStatus: 'planned',
+            plantScheduledDate: '2026-05-22T00:00:00.000Z',
+        },
+        {
+            positionIndex: 13,
+            plantSortId: testSorts.basil.id,
+            plantStatus: 'sprouted',
+            plantSowDate: '2026-04-18T00:00:00.000Z',
+            plantGrowthDate: '2026-05-05T00:00:00.000Z',
+        },
+        {
+            positionIndex: 16,
+            plantSortId: testSorts.lettuce.id,
+            plantStatus: 'sowed',
+            plantSowDate: '2026-05-01T00:00:00.000Z',
+        },
+    ],
+    cartItems: [
+        buildCartItem({
+            id: 1,
+            positionIndex: 7,
+            scheduledDate: '2026-05-24T00:00:00.000Z',
+            sort: testSorts.lettuce,
+        }),
+        buildCartItem({
+            id: 2,
+            positionIndex: 11,
+            sort: testSorts.basil,
+        }),
+    ],
+};
+
+function CloseupFrame({ height, width }: { height: number; width: number }) {
+    return (
+        <div className="flex min-h-screen items-start justify-center bg-[#213614] p-4">
+            <RaisedBedCloseupHudStory
+                height={height}
+                scenario={closeupScenario}
+                width={width}
+            />
+        </div>
+    );
+}
+
+const meta = {
+    title: 'apps/garden/Game/RaisedBedCloseupHud',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Raised-bed closeup HUD examples for checking compact mobile sizing and side controls.',
+            },
+        },
+    },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ExtraSmallPhone: Story = {
+    render: () => <CloseupFrame height={640} width={320} />,
+};
+
+export const SmallPhone: Story = {
+    render: () => <CloseupFrame height={760} width={390} />,
+};
+
+export const RoomyPhone: Story = {
+    render: () => <CloseupFrame height={812} width={414} />,
+};

--- a/packages/game/src/controls/GameCameraRig.tsx
+++ b/packages/game/src/controls/GameCameraRig.tsx
@@ -6,6 +6,7 @@ import { MathUtils, OrthographicCamera, Vector2, Vector3 } from 'three';
 import {
     defaultGameCameraPosition,
     defaultGameCameraTarget,
+    getCloseupGameCameraZoom,
 } from '../gameCamera';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useGameState } from '../useGameState';
@@ -19,7 +20,6 @@ import {
 } from './dragEdgeAutopan';
 import type { GameCameraRigApi, GameCameraSnapshot } from './GameCameraRigApi';
 
-const closeupZoom = 300;
 const animationDurationSeconds = 1;
 const focusAnimationDurationSeconds = 0.65;
 const focusStopDistance = 0.01;
@@ -199,6 +199,14 @@ export function GameCameraRig({
     });
     const scratchForwardRef = useRef(new Vector3());
     const scratchRightRef = useRef(new Vector3());
+    const closeupZoom = useMemo(
+        () =>
+            getCloseupGameCameraZoom({
+                height: size.height,
+                width: size.width,
+            }),
+        [size.height, size.width],
+    );
 
     const closeupTarget = useMemo(() => {
         if (!closeupBlock || !garden) {
@@ -819,7 +827,14 @@ export function GameCameraRig({
             });
         }
         previousViewRef.current = view;
-    }, [camera, closeupTarget, isOrthographicCamera, startAnimation, view]);
+    }, [
+        camera,
+        closeupTarget,
+        closeupZoom,
+        isOrthographicCamera,
+        startAnimation,
+        view,
+    ]);
 
     useFrame((_, delta) => {
         if (!isOrthographicCamera) {

--- a/packages/game/src/gameCamera.ts
+++ b/packages/game/src/gameCamera.ts
@@ -8,3 +8,25 @@ export const defaultGameCameraTarget: [x: number, y: number, z: number] = [
 
 export const defaultGameCameraZoom = 100;
 export const farGameCameraZoom = 75;
+
+export const closeupGameCameraZoom = 300;
+export const extraSmallCloseupGameCameraZoom = 260;
+export const tinyCloseupGameCameraZoom = 240;
+
+export function getCloseupGameCameraZoom({
+    height,
+    width,
+}: {
+    height: number;
+    width: number;
+}) {
+    if (width <= 340 || height <= 620) {
+        return tinyCloseupGameCameraZoom;
+    }
+
+    if (width <= 390 || height <= 700) {
+        return extraSmallCloseupGameCameraZoom;
+    }
+
+    return closeupGameCameraZoom;
+}

--- a/packages/game/src/gameCamera.unit.ts
+++ b/packages/game/src/gameCamera.unit.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    closeupGameCameraZoom,
+    extraSmallCloseupGameCameraZoom,
+    getCloseupGameCameraZoom,
+    tinyCloseupGameCameraZoom,
+} from './gameCamera';
+
+test('closeup camera keeps the default zoom on roomy viewports', () => {
+    assert.equal(
+        getCloseupGameCameraZoom({ height: 812, width: 414 }),
+        closeupGameCameraZoom,
+    );
+});
+
+test('closeup camera zooms out on extra-small phone widths', () => {
+    assert.equal(
+        getCloseupGameCameraZoom({ height: 760, width: 375 }),
+        extraSmallCloseupGameCameraZoom,
+    );
+});
+
+test('closeup camera zooms out further on tiny or short viewports', () => {
+    assert.equal(
+        getCloseupGameCameraZoom({ height: 740, width: 320 }),
+        tinyCloseupGameCameraZoom,
+    );
+    assert.equal(
+        getCloseupGameCameraZoom({ height: 600, width: 414 }),
+        tinyCloseupGameCameraZoom,
+    );
+});

--- a/packages/game/src/hud/RaisedBedFieldHud.module.css
+++ b/packages/game/src/hud/RaisedBedFieldHud.module.css
@@ -1,0 +1,77 @@
+.root {
+    --raised-bed-grid-size: 240px;
+    --raised-bed-grid-half-size: 120px;
+    --raised-bed-grid-height: var(--raised-bed-grid-size);
+    --raised-bed-grid-half-height: var(--raised-bed-grid-half-size);
+    --raised-bed-grid-height-additional: 30px;
+    --raised-bed-grid-height-additional-half: 15px;
+    --raised-bed-button-half-height: 20px;
+    --raised-bed-grid-top-anchor-offset: 10px;
+    --raised-bed-side-panel-gap: 4px;
+    --raised-bed-mobile-close-gap: 2px;
+    --raised-bed-mobile-top-shift: 48px;
+    --raised-bed-title-max-width: 16rem;
+    --raised-bed-action-gap: 0.5rem;
+}
+
+.doubleRaisedBed {
+    --raised-bed-grid-height: calc(
+        var(--raised-bed-grid-size) +
+        var(--raised-bed-grid-size) +
+        var(--raised-bed-grid-height-additional)
+    );
+    --raised-bed-grid-half-height: calc(
+        var(--raised-bed-grid-size) +
+        var(--raised-bed-grid-height-additional-half)
+    );
+}
+
+.root {
+    --raised-bed-ui-top: calc(
+        50% -
+        var(--raised-bed-grid-half-height) -
+        var(--raised-bed-grid-height-additional-half) -
+        var(--raised-bed-button-half-height) -
+        var(--raised-bed-grid-top-anchor-offset)
+    );
+    --raised-bed-ui-top-mobile: calc(
+        var(--raised-bed-ui-top) +
+        var(--raised-bed-mobile-top-shift)
+    );
+    --raised-bed-title-left: calc(50% - var(--raised-bed-grid-half-size));
+    --raised-bed-side-panel-left: calc(
+        50% +
+        var(--raised-bed-grid-half-size) +
+        var(--raised-bed-side-panel-gap)
+    );
+    --raised-bed-close-button-left: calc(
+        50% +
+        var(--raised-bed-grid-half-size) +
+        var(--raised-bed-mobile-close-gap)
+    );
+}
+
+@media (max-width: 390px), (max-height: 700px) {
+    .root {
+        --raised-bed-grid-size: 216px;
+        --raised-bed-grid-half-size: 108px;
+        --raised-bed-grid-height-additional: 24px;
+        --raised-bed-grid-height-additional-half: 12px;
+        --raised-bed-button-half-height: 18px;
+        --raised-bed-grid-top-anchor-offset: 8px;
+        --raised-bed-side-panel-gap: 6px;
+        --raised-bed-mobile-close-gap: 1px;
+        --raised-bed-mobile-top-shift: 40px;
+        --raised-bed-title-max-width: 13.5rem;
+        --raised-bed-action-gap: 0.375rem;
+    }
+}
+
+@media (max-width: 340px) {
+    .root {
+        --raised-bed-grid-size: 204px;
+        --raised-bed-grid-half-size: 102px;
+        --raised-bed-title-max-width: 12.5rem;
+        --raised-bed-action-gap: 0.25rem;
+    }
+}

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -4,7 +4,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { type CSSProperties, useState } from 'react';
+import { useState } from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import {
     useCurrentGarden,
@@ -19,6 +19,7 @@ import {
     findRaisedBedByBlockId,
     getRaisedBedBlockIds,
 } from '../utils/raisedBedBlocks';
+import styles from './RaisedBedFieldHud.module.css';
 import { RaisedBedField } from './raisedBed/RaisedBedField';
 import { RaisedBedFieldSuggestions } from './raisedBed/RaisedBedFieldSuggestions';
 import { RaisedBedGreenhouseSuggestion } from './raisedBed/RaisedBedGreenhouseSuggestion';
@@ -26,18 +27,6 @@ import { RaisedBedInfo } from './raisedBed/RaisedBedInfo';
 import { RaisedBedPhotosModal } from './raisedBed/RaisedBedPhotosModal';
 import { RaisedBedSensorInfo } from './raisedBed/RaisedBedSensorInfo';
 import { RaisedBedWatering } from './raisedBed/RaisedBedWatering';
-
-const GRID_SIZE = 240;
-const GRID_HEIGHT_ADDITIONAL = 30;
-const BUTTON_HEIGHT = 40;
-const GRID_TOP_ANCHOR_OFFSET = 10;
-const SIDE_PANEL_MD_LEFT_OFFSET = GRID_SIZE / 2 + 4;
-const MOBILE_CLOSE_BUTTON_LEFT_OFFSET = GRID_SIZE / 2 + 2;
-
-function centerOffset(offset: number) {
-    const operator = offset >= 0 ? '+' : '-';
-    return `calc(50% ${operator} ${Math.abs(offset)}px)`;
-}
 
 export function RaisedBedFieldHud() {
     const { data: currentGarden } = useCurrentGarden();
@@ -59,35 +48,23 @@ export function RaisedBedFieldHud() {
             ? getRaisedBedBlockIds(currentGarden, raisedBed.id).length
             : 1;
     const isDoubleRaisedBed = raisedBedBlockCount === 2;
-    const gridHeight = isDoubleRaisedBed
-        ? GRID_SIZE * 2 + GRID_HEIGHT_ADDITIONAL
-        : GRID_SIZE;
-    const gridTopOffset = (gridHeight + GRID_HEIGHT_ADDITIONAL) / 2;
-    const uiTopAnchor =
-        -gridTopOffset - BUTTON_HEIGHT / 2 - GRID_TOP_ANCHOR_OFFSET;
-    const hudStyles: CSSProperties & Record<string, string> = {
-        '--raised-bed-side-panel-left': `${SIDE_PANEL_MD_LEFT_OFFSET}px`,
-        '--raised-bed-ui-top': centerOffset(uiTopAnchor),
-        '--raised-bed-ui-top-mobile': `calc(${centerOffset(uiTopAnchor)} + 48px)`,
-        '--raised-bed-title-left': centerOffset(-(GRID_SIZE / 2)),
-        '--raised-bed-close-button-left': centerOffset(
-            MOBILE_CLOSE_BUTTON_LEFT_OFFSET,
-        ),
-        '--raised-bed-grid-size': `${GRID_SIZE}px`,
-        '--raised-bed-grid-height': `${gridHeight}px`,
-    };
 
     return (
         <div
             className={cx(
+                styles.root,
+                isDoubleRaisedBed && styles.doubleRaisedBed,
                 'opacity-0 transition-opacity pointer-events-none duration-300',
                 view === 'closeup' &&
                     'opacity-100 [transition-delay:950ms] pointer-events-auto',
             )}
-            style={hudStyles}
+            data-raised-bed-closeup-hud
         >
             {currentGarden && raisedBed && (
-                <div className="absolute z-40 top-[var(--raised-bed-ui-top)] left-[var(--raised-bed-title-left)]">
+                <div
+                    className="absolute z-40 top-[var(--raised-bed-ui-top)] left-[var(--raised-bed-title-left)]"
+                    data-raised-bed-title
+                >
                     <div className="relative flex items-center">
                         {!isSandbox && (
                             <div className="absolute right-full top-1/2 mr-2 -translate-y-1/2">
@@ -117,7 +94,7 @@ export function RaisedBedFieldHud() {
                             className="overflow-x-hidden"
                             trigger={
                                 <ButtonGreen
-                                    className="max-w-64 md:max-w-[312px]"
+                                    className="max-w-[var(--raised-bed-title-max-width)] md:max-w-[312px]"
                                     data-raised-bed-details-trigger
                                     endDecorator={
                                         <Navigate className="size-4 shrink-0" />
@@ -143,7 +120,10 @@ export function RaisedBedFieldHud() {
                     </div>
                 </div>
             )}
-            <div className="absolute z-0 top-[calc(50%-1px)] left-1/2 -translate-x-1/2 -translate-y-1/2 w-[var(--raised-bed-grid-size)] h-[var(--raised-bed-grid-height)]">
+            <div
+                className="absolute z-0 top-[calc(50%-1px)] left-1/2 -translate-x-1/2 -translate-y-1/2 w-[var(--raised-bed-grid-size)] h-[var(--raised-bed-grid-height)]"
+                data-raised-bed-grid
+            >
                 {view === 'closeup' && currentGarden && raisedBed && (
                     <RaisedBedField
                         gardenId={currentGarden.id}
@@ -152,13 +132,15 @@ export function RaisedBedFieldHud() {
                 )}
             </div>
             <Stack
-                className="absolute z-40 md:left-[calc(50%+var(--raised-bed-side-panel-left))] top-[var(--raised-bed-ui-top-mobile)] md:top-[var(--raised-bed-ui-top)] left-[var(--raised-bed-close-button-left)]"
+                className="absolute z-40 md:left-[var(--raised-bed-side-panel-left)] top-[var(--raised-bed-ui-top-mobile)] md:top-[var(--raised-bed-ui-top)] left-[var(--raised-bed-close-button-left)]"
                 spacing={2}
                 alignItems="center"
+                data-raised-bed-action-rail
+                style={{ gap: 'var(--raised-bed-action-gap)' }}
             >
                 <ButtonGreen
                     variant="plain"
-                    className="rounded-full size-10 md:size-auto"
+                    className="rounded-full size-10 max-[390px]:size-9 md:size-auto"
                     onClick={() => {
                         track('game_raised_bed_closed', {
                             garden_id: currentGarden?.id,

--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -172,7 +172,7 @@ function RaisedBedFieldLayerToggle({
             aria-label={label}
             aria-pressed={isPressed}
             className={cx(
-                'inline-flex size-10 items-center justify-center rounded-md border-2 border-white shadow-md ring-1 ring-black/10 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700',
+                'inline-flex size-10 max-[390px]:size-9 items-center justify-center rounded-md border-2 border-white shadow-md ring-1 ring-black/10 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700',
                 isPressed
                     ? 'bg-gradient-to-br from-lime-100/90 to-lime-100/80 text-primary hover:text-primary/80 dark:from-lime-200/80 dark:to-lime-200/70 dark:text-primary-foreground dark:hover:text-primary-foreground/80'
                     : 'bg-white/85 text-lime-950 hover:bg-white',
@@ -475,7 +475,10 @@ export function RaisedBedField({
                     }
                     storageName="history"
                 >
-                    <History aria-hidden className="size-5" />
+                    <History
+                        aria-hidden
+                        className="size-5 max-[390px]:size-4"
+                    />
                 </RaisedBedFieldLayerToggle>
                 <RaisedBedFieldLayerToggle
                     isPressed={layerPreferences.showRelationshipIndicators}
@@ -492,12 +495,12 @@ export function RaisedBedField({
                     <span className="flex items-center justify-center gap-0.5">
                         <Heart
                             aria-hidden
-                            className="size-3.5 shrink-0 fill-current"
+                            className="size-3.5 max-[390px]:size-3 shrink-0 fill-current"
                             strokeWidth={3}
                         />
                         <Lightning
                             aria-hidden
-                            className="size-4 shrink-0 fill-current"
+                            className="size-4 max-[390px]:size-3.5 shrink-0 fill-current"
                             strokeWidth={3}
                         />
                     </span>

--- a/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedFieldSuggestions.tsx
@@ -160,7 +160,8 @@ const quickSeedOptions: Record<
     },
 };
 
-const quickSowingButtonClassName = 'size-10 rounded-full md:size-auto';
+const quickSowingButtonClassName =
+    'size-10 rounded-full max-[390px]:size-9 md:size-auto';
 
 function getSeasonForDate(date: Date | null): QuickSeedType {
     if (!date || Number.isNaN(date.getTime())) {
@@ -298,7 +299,7 @@ export function RaisedBedFieldSuggestions({
     return (
         <RaisedBedCard
             data-quick-sowing-recommendations
-            className="flex w-fit flex-col items-center gap-1 rounded-full px-2 py-2 md:w-auto md:self-stretch md:gap-2 md:px-2 md:pb-4 md:pt-3"
+            className="flex w-fit flex-col items-center gap-1 rounded-full px-2 py-2 max-[390px]:px-1.5 max-[390px]:py-1.5 md:w-auto md:self-stretch md:gap-2 md:px-2 md:pb-4 md:pt-3"
         >
             <Typography
                 level="body2"
@@ -307,14 +308,14 @@ export function RaisedBedFieldSuggestions({
             >
                 Brzo sijanje
             </Typography>
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-2 max-[390px]:gap-1.5">
                 {/* Seasonal option */}
                 {seasonalOption && (
                     <ButtonGreen
                         variant="plain"
                         className={quickSowingButtonClassName}
                         startDecorator={
-                            <span className="text-xl">
+                            <span className="text-xl max-[390px]:text-lg">
                                 {seasonalOption.emoji}
                             </span>
                         }
@@ -338,7 +339,9 @@ export function RaisedBedFieldSuggestions({
                         variant="plain"
                         className={quickSowingButtonClassName}
                         startDecorator={
-                            <span className="text-xl">{option.emoji}</span>
+                            <span className="text-xl max-[390px]:text-lg">
+                                {option.emoji}
+                            </span>
                         }
                         onClick={() => handleQuickPick(type as QuickSeedType)}
                         loading={

--- a/packages/game/src/hud/raisedBed/RaisedBedGreenhouseSuggestion.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedGreenhouseSuggestion.tsx
@@ -38,11 +38,11 @@ export function RaisedBedGreenhouseSuggestion({
             modal={false}
             onOpenChange={setOpen}
             trigger={
-                <ButtonGreen className="rounded-full size-10 md:size-auto p-0 md:pr-4 gap-0 md:w-full">
+                <ButtonGreen className="rounded-full size-10 max-[390px]:size-9 md:size-auto p-0 md:pr-4 gap-0 md:w-full">
                     <OperationImage
                         size={32}
                         operation={basicGreenhouseOperation}
-                        className="size-10 md:size-14 md:mr-4"
+                        className="size-10 max-[390px]:size-9 md:size-14 md:mr-4"
                     />
                     <span className="hidden md:block -ml-2">Staklenik</span>
                 </ButtonGreen>

--- a/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedSensorInfo.tsx
@@ -663,7 +663,7 @@ export function RaisedBedSensorInfo({
 
     if (sensorGroups.length === 0) {
         return (
-            <div className="flex flex-col w-full md:flex-row gap-2 md:gap-1">
+            <div className="flex flex-col w-full gap-2 max-[390px]:gap-1.5 md:flex-row md:gap-1">
                 <SensorInfoModal
                     icon={
                         <Droplets className="size-7 shrink-0 stroke-blue-500" />
@@ -715,13 +715,13 @@ export function RaisedBedSensorInfo({
                     trigger={
                         <ButtonGreen
                             size="sm"
-                            className="rounded-full px-2"
+                            className="rounded-full px-2 max-[390px]:h-9 max-[390px]:px-1.5 max-[390px]:text-[11px]"
                             fullWidth
                         >
                             <Row spacing={1}>
                                 <Droplet
                                     className={cx(
-                                        'size-5 shrink-0 stroke-blue-400',
+                                        'size-5 max-[390px]:size-4 shrink-0 stroke-blue-400',
                                         Number(0) >= 20 && 'fill-blue-300',
                                     )}
                                 />
@@ -759,13 +759,13 @@ export function RaisedBedSensorInfo({
                     trigger={
                         <ButtonGreen
                             size="sm"
-                            className="rounded-full px-2"
+                            className="rounded-full px-2 max-[390px]:h-9 max-[390px]:px-1.5 max-[390px]:text-[11px]"
                             fullWidth
                         >
                             <Row spacing={1}>
                                 <Thermometer
                                     className={cx(
-                                        'size-5 shrink-0 stroke-red-400',
+                                        'size-5 max-[390px]:size-4 shrink-0 stroke-red-400',
                                         Number(0) >= 20 && 'fill-red-300',
                                     )}
                                 />
@@ -800,7 +800,7 @@ export function RaisedBedSensorInfo({
                     group.soilTemperature?.status ?? group.status;
                 return (
                     <div
-                        className="flex flex-col md:flex-row gap-2 md:gap-0.5"
+                        className="flex flex-col gap-2 max-[390px]:gap-1.5 md:flex-row md:gap-0.5"
                         key={`sensor-${group.id}`}
                     >
                         <SensorInfoModal
@@ -852,11 +852,14 @@ export function RaisedBedSensorInfo({
                                 },
                             ]}
                             trigger={
-                                <ButtonGreen size="sm" className="rounded-full">
+                                <ButtonGreen
+                                    size="sm"
+                                    className="rounded-full max-[390px]:h-9 max-[390px]:px-1.5 max-[390px]:text-[11px]"
+                                >
                                     <Row spacing={1}>
                                         <Droplet
                                             className={cx(
-                                                'size-5 shrink-0 stroke-blue-400',
+                                                'size-5 max-[390px]:size-4 shrink-0 stroke-blue-400',
                                                 !isSensorDataStale(
                                                     group.soilMoisture
                                                         ?.updatedAt,
@@ -909,11 +912,14 @@ export function RaisedBedSensorInfo({
                                 areaGradientEnd: '#fca5a5',
                             }}
                             trigger={
-                                <ButtonGreen size="sm" className="rounded-full">
+                                <ButtonGreen
+                                    size="sm"
+                                    className="rounded-full max-[390px]:h-9 max-[390px]:px-1.5 max-[390px]:text-[11px]"
+                                >
                                     <Row spacing={1}>
                                         <Thermometer
                                             className={cx(
-                                                'size-5 shrink-0 stroke-red-400',
+                                                'size-5 max-[390px]:size-4 shrink-0 stroke-red-400',
                                                 !isSensorDataStale(
                                                     group.soilTemperature
                                                         ?.updatedAt,

--- a/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedWatering.tsx
@@ -23,7 +23,7 @@ export function RaisedBedWatering({
             onOpenChange={setOpen}
             trigger={
                 <ButtonGreen
-                    className="rounded-full size-10 md:w-full p-0 md:pr-4 gap-0"
+                    className="rounded-full size-10 max-[390px]:size-9 md:w-full p-0 md:pr-4 gap-0"
                     fullWidth
                     startDecorator={
                         <BlockImage
@@ -31,7 +31,7 @@ export function RaisedBedWatering({
                             height={56}
                             alt="Zalijevanje"
                             blockName="Bucket"
-                            className="size-10 md:size-14 md:-mt-3"
+                            className="size-10 max-[390px]:size-9 md:size-14 md:-mt-3"
                         />
                     }
                 >


### PR DESCRIPTION
## Summary

- scale the raised-bed closeup camera down on extra-small and short mobile viewports
- move raised-bed closeup HUD dimensions into responsive CSS and compact the action rail, field controls, sensor pills, and quick-sow controls on small phones
- add Storybook scenarios for 320px, 390px, and 414px phone frames so the layout can be evaluated directly

## Why

On very small mobile screens the closeup view used the same 300 zoom and HUD sizing as larger phones. The grid and right-side action rail could overflow the visible frame, and adjacent HUD elements could overlap.

## Impact

Extra-small devices get more breathing room while larger mobile layouts keep the existing closeup sizing. Storybook now includes reproducible raised-bed HUD frames for visual review.

## Validation

- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter storybook typecheck`
- `pnpm --filter storybook build`
- `git diff --check`
- static Storybook Playwright measurement for the 320x640 story: grid, title, and action rail all remain inside the frame; only the expected Vercel analytics script 404 appears under the local static server