### PR TITLE
[codex] Add greenhouse plant overview HUD

### DIFF
--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -10,6 +10,7 @@ import { gardenOperationsQueryKey } from '../../../packages/game/src/hooks/useGa
 import { queryKeys as raisedBedAiHistoryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedAiHistory';
 import { queryKeys as raisedBedDiaryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedDiaryEntries';
 import { queryKeys as raisedBedFieldDiaryQueryKeys } from '../../../packages/game/src/hooks/useRaisedBedFieldDiaryEntries';
+import { GreenhouseOverviewHud } from '../../../packages/game/src/hud/GreenhouseOverviewHud';
 import { RaisedBedFieldHud } from '../../../packages/game/src/hud/RaisedBedFieldHud';
 import { RaisedBedField } from '../../../packages/game/src/hud/raisedBed/RaisedBedField';
 import { RaisedBedFieldItem } from '../../../packages/game/src/hud/raisedBed/RaisedBedFieldItem';
@@ -318,6 +319,18 @@ export function RaisedBedFieldSuggestionsStory({
                 gardenId={TEST_GARDEN_ID}
                 raisedBedId={TEST_RAISED_BED_ID}
             />
+        </RaisedBedHudTestProviders>
+    );
+}
+
+export function GreenhouseOverviewHudStory({
+    scenario,
+}: {
+    scenario: RaisedBedScenario;
+}) {
+    return (
+        <RaisedBedHudTestProviders scenario={scenario}>
+            <GreenhouseOverviewHud />
         </RaisedBedHudTestProviders>
     );
 }

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -6,6 +6,7 @@ import type {
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Locator, Page } from '@playwright/test';
 import {
+    GreenhouseOverviewHudStory,
     RaisedBedCloseupHudStory,
     RaisedBedFieldDndDialogStory,
     RaisedBedFieldHudStory,
@@ -387,6 +388,45 @@ function greenhouseSeedlingScenario(): RaisedBedScenario {
                 stageLabel: 'Održavanje',
                 relativeDays: 2,
             }),
+            buildOperation({
+                id: 593,
+                name: 'seedlingTranslanting',
+                label: 'Presađivanje sadnice',
+                stageName: 'planting',
+                stageLabel: 'Sadnja',
+                relativeDays: 14,
+            }),
+        ],
+    };
+}
+
+function greenhouseOverviewScenario(): RaisedBedScenario {
+    return {
+        fields: [
+            {
+                positionIndex: 0,
+                plantSortId: testSorts.tomato.id,
+                plantStatus: 'sprouted',
+                sowingLocation: 'greenhouse',
+                plantSowDate: '2026-05-01T00:00:00.000Z',
+                plantGrowthDate: '2026-05-10T00:00:00.000Z',
+            },
+            {
+                positionIndex: 1,
+                plantSortId: testSorts.basil.id,
+                plantStatus: 'sowed',
+                sowingLocation: 'greenhouse',
+                plantSowDate: '2026-05-12T00:00:00.000Z',
+            },
+            {
+                positionIndex: 2,
+                plantSortId: testSorts.lettuce.id,
+                plantStatus: 'sprouted',
+                plantSowDate: '2026-05-01T00:00:00.000Z',
+                plantGrowthDate: '2026-05-10T00:00:00.000Z',
+            },
+        ],
+        operations: [
             buildOperation({
                 id: 593,
                 name: 'seedlingTranslanting',
@@ -878,6 +918,43 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         await expect(
             dialog.locator('[data-greenhouse-transplant-action]'),
         ).toContainText('Presađivanje sadnice');
+    });
+
+    test('greenhouse overview lists greenhouse seedlings and progress', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <GreenhouseOverviewHudStory
+                scenario={greenhouseOverviewScenario()}
+            />,
+        );
+
+        await page
+            .getByRole('button', { name: 'Staklenik: 2 sadnice' })
+            .click();
+
+        const overview = page.locator('[data-greenhouse-overview-panel]');
+        await expect(overview).toBeVisible();
+        await expect(
+            overview.locator('[data-greenhouse-overview-item]'),
+        ).toHaveCount(2);
+        await expect(overview.getByText('Cherry rajčica')).toBeVisible();
+        await expect(overview.getByText('Klasični bosiljak')).toBeVisible();
+        await expect(overview.getByText('Maslac salata')).toHaveCount(0);
+        await expect(
+            overview.getByText('Raised Bed 1 · Polje 1'),
+        ).toBeVisible();
+        await expect(
+            overview.getByText('U stakleniku', { exact: true }),
+        ).toBeVisible();
+        await expect(
+            overview.getByText('Klijanje', { exact: true }),
+        ).toBeVisible();
+        await expect(
+            overview.locator('[data-greenhouse-overview-progress]').first(),
+        ).toHaveAttribute('aria-valuenow', '56');
+        await expect(overview.getByText('56%')).toBeVisible();
     });
 
     test('ready-to-harvest field shows the sprout status badge', async ({

--- a/packages/game/src/GameHud.tsx
+++ b/packages/game/src/GameHud.tsx
@@ -14,6 +14,7 @@ import { ControlsTooltipHud } from './hud/ControlsTooltipHud';
 import { DebugHud } from './hud/DebugHud';
 import { GardenVisitSummaryHighlightHud } from './hud/GardenVisitSummaryHighlightHud';
 import { GardenVisitSummaryModal } from './hud/GardenVisitSummaryModal';
+import { GreenhouseOverviewHud } from './hud/GreenhouseOverviewHud';
 import { InventoryHud } from './hud/InventoryHud';
 import { ItemsHud } from './hud/ItemsHud';
 import { OutletHud } from './hud/OutletHud';
@@ -156,6 +157,11 @@ export function GameHud({
                 {!isSandbox && (
                     <div className={closeupHiddenHudClassName}>
                         <InventoryHud />
+                    </div>
+                )}
+                {!isSandbox && (
+                    <div className={closeupHiddenHudClassName}>
+                        <GreenhouseOverviewHud />
                     </div>
                 )}
                 {!isSandbox && (

--- a/packages/game/src/hud/GreenhouseOverviewHud.tsx
+++ b/packages/game/src/hud/GreenhouseOverviewHud.tsx
@@ -1,0 +1,318 @@
+import type { OperationData, PlantSortData } from '@gredice/client';
+import { Button } from '@gredice/ui/Button';
+import { Divider } from '@gredice/ui/Divider';
+import { Home } from '@gredice/ui/icons';
+import { Progress } from '@gredice/ui/Progress';
+import { PlantOrSortImage } from '@gredice/ui/plants';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useMemo } from 'react';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useOperations } from '../hooks/useOperations';
+import { useAllSorts } from '../hooks/usePlantSorts';
+import { useSnapshotTime } from '../hooks/useSnapshotTime';
+import { GameModal } from '../shared-ui/game-modal';
+import { ScrollView } from '../shared-ui/ScrollView';
+import { HudCard } from './components/HudCard';
+import {
+    getGreenhouseSeedlingProgressData,
+    getGreenhouseSeedlingProgressPercentage,
+    isGreenhouseSeedlingField,
+    isSeedlingTransplantingOperation,
+} from './raisedBed/greenhouseSeedlings';
+
+type CurrentGardenData = NonNullable<
+    ReturnType<typeof useCurrentGarden>['data']
+>;
+type RaisedBedData = CurrentGardenData['raisedBeds'][number];
+type RaisedBedFieldData = RaisedBedData['fields'][number];
+
+type GreenhouseOverviewItem = {
+    expectedReplantingDate: Date | null;
+    field: RaisedBedFieldData;
+    plantSort: PlantSortData;
+    positionIndex: number;
+    progressPercentage: number;
+    raisedBedName: string;
+    stageLabel: string;
+};
+
+const dateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'short',
+});
+
+function greenhouseSeedlingCountLabel(count: number) {
+    if (count === 1) {
+        return '1 sadnica';
+    }
+
+    const lastTwoDigits = count % 100;
+    const lastDigit = count % 10;
+    if (
+        lastDigit >= 2 &&
+        lastDigit <= 4 &&
+        (lastTwoDigits < 12 || lastTwoDigits > 14)
+    ) {
+        return `${count.toString()} sadnice`;
+    }
+
+    return `${count.toString()} sadnica`;
+}
+
+function greenhouseSeedlingStageLabel({
+    field,
+    progressPercentage,
+}: {
+    field: RaisedBedFieldData;
+    progressPercentage: number;
+}) {
+    if (field.plantStatus === 'pendingVerification') {
+        return 'Čeka potvrdu';
+    }
+    if (!field.plantSowDate || !field.plantGrowthDate) {
+        return 'Klijanje';
+    }
+    if (field.plantReadyDate || progressPercentage >= 100) {
+        return 'Spremno za presađivanje';
+    }
+
+    return 'U stakleniku';
+}
+
+function buildGreenhouseOverviewItems({
+    garden,
+    now,
+    sorts,
+    transplantOperation,
+}: {
+    garden: CurrentGardenData | null | undefined;
+    now: Date;
+    sorts: PlantSortData[] | null | undefined;
+    transplantOperation: OperationData | null | undefined;
+}) {
+    if (!garden || !sorts) {
+        return [];
+    }
+
+    const sortsById = new Map(sorts.map((sort) => [sort.id, sort]));
+    const items: GreenhouseOverviewItem[] = [];
+
+    for (const raisedBed of garden.raisedBeds) {
+        for (const field of raisedBed.fields) {
+            if (!isGreenhouseSeedlingField(field)) {
+                continue;
+            }
+
+            const plantSortId = field.plantSortId;
+            const plantSort =
+                typeof plantSortId === 'number'
+                    ? sortsById.get(plantSortId)
+                    : undefined;
+
+            if (!plantSort) {
+                continue;
+            }
+
+            const progressData = getGreenhouseSeedlingProgressData({
+                field,
+                now,
+                plantAttributes: plantSort.information.plant.attributes,
+                transplantOperation,
+            });
+            const progressPercentage =
+                getGreenhouseSeedlingProgressPercentage(progressData);
+
+            items.push({
+                expectedReplantingDate: progressData.expectedReplantingDate,
+                field,
+                plantSort,
+                positionIndex: field.positionIndex,
+                progressPercentage,
+                raisedBedName: raisedBed.name,
+                stageLabel: greenhouseSeedlingStageLabel({
+                    field,
+                    progressPercentage,
+                }),
+            });
+        }
+    }
+
+    return items.sort(
+        (left, right) =>
+            left.raisedBedName.localeCompare(right.raisedBedName, 'hr') ||
+            left.positionIndex - right.positionIndex,
+    );
+}
+
+export function GreenhouseOverviewHud() {
+    const { data: currentGarden } = useCurrentGarden();
+    const { data: sorts } = useAllSorts();
+    const { data: operations } = useOperations();
+    const now = useSnapshotTime();
+    const transplantOperation = useMemo(
+        () => operations?.find(isSeedlingTransplantingOperation),
+        [operations],
+    );
+    const items = useMemo(
+        () =>
+            buildGreenhouseOverviewItems({
+                garden: currentGarden,
+                now,
+                sorts,
+                transplantOperation,
+            }),
+        [currentGarden, now, sorts, transplantOperation],
+    );
+
+    if (items.length === 0) {
+        return null;
+    }
+
+    const countLabel = greenhouseSeedlingCountLabel(items.length);
+    const headerDescription =
+        items.length === 1
+            ? `U vrtu je ${countLabel} iz gredica.`
+            : `U vrtu su ${countLabel} iz gredica.`;
+
+    return (
+        <HudCard
+            open
+            position="floating"
+            className="static p-0.5"
+            data-greenhouse-overview-hud
+        >
+            <GameModal
+                title="Staklenik"
+                headerIcon={<Home className="size-7 shrink-0" />}
+                headerDescription={headerDescription}
+                className="md:max-w-2xl"
+                hudLayer
+                trigger={
+                    <Button
+                        title="Staklenik"
+                        variant="plain"
+                        aria-label={`Staklenik: ${countLabel}`}
+                        className="relative rounded-full p-2 gap-2"
+                    >
+                        <Home className="size-6 shrink-0" />
+                        <Typography
+                            level="body2"
+                            semiBold
+                            className="text-foreground"
+                        >
+                            Staklenik
+                        </Typography>
+                        <span
+                            aria-hidden="true"
+                            className="absolute -right-1 -top-1 flex min-w-5 items-center justify-center rounded-full border border-background bg-emerald-600 px-1 text-xs font-semibold leading-5 text-white shadow-xs"
+                        >
+                            {items.length}
+                        </span>
+                    </Button>
+                }
+            >
+                <Stack spacing={4} data-greenhouse-overview-panel>
+                    <Typography level="body2" secondary>
+                        Pregled sadnica koje su posijane za gredice i trenutno
+                        su u stakleniku.
+                    </Typography>
+                    <Divider />
+                    <ScrollView
+                        className="-mx-2"
+                        viewportClassName="max-h-[min(60vh,32rem)]"
+                        contentClassName="grid gap-3 px-2 py-1"
+                    >
+                        {items.map((item) => (
+                            <div
+                                className="grid grid-cols-[56px_minmax(0,1fr)] gap-3 rounded-lg border bg-card p-3"
+                                data-greenhouse-overview-item
+                                key={`${item.field.id.toString()}-${item.positionIndex.toString()}`}
+                            >
+                                <div className="relative size-14 overflow-hidden rounded-full border border-emerald-500/60 bg-emerald-50 dark:bg-emerald-950/50">
+                                    <PlantOrSortImage
+                                        plantSort={item.plantSort}
+                                        width={56}
+                                        height={56}
+                                        className="size-full rounded-full object-cover"
+                                    />
+                                </div>
+                                <Stack spacing={2} className="min-w-0">
+                                    <Row
+                                        justifyContent="space-between"
+                                        alignItems="start"
+                                        className="min-w-0 gap-3"
+                                    >
+                                        <Stack
+                                            spacing={0.5}
+                                            className="min-w-0"
+                                        >
+                                            <Typography
+                                                level="body1"
+                                                semiBold
+                                                noWrap
+                                                title={
+                                                    item.plantSort.information
+                                                        .name
+                                                }
+                                            >
+                                                {
+                                                    item.plantSort.information
+                                                        .name
+                                                }
+                                            </Typography>
+                                            <Typography
+                                                level="body3"
+                                                secondary
+                                                noWrap
+                                            >
+                                                {item.raisedBedName} · Polje{' '}
+                                                {item.positionIndex + 1}
+                                            </Typography>
+                                        </Stack>
+                                        <Typography
+                                            level="body2"
+                                            semiBold
+                                            className="shrink-0 tabular-nums text-emerald-700 dark:text-emerald-300"
+                                        >
+                                            {item.progressPercentage}%
+                                        </Typography>
+                                    </Row>
+                                    <Stack spacing={1}>
+                                        <Row
+                                            justifyContent="space-between"
+                                            className="gap-3"
+                                        >
+                                            <Typography level="body3" semiBold>
+                                                {item.stageLabel}
+                                            </Typography>
+                                            {item.expectedReplantingDate ? (
+                                                <Typography
+                                                    level="body3"
+                                                    secondary
+                                                    className="shrink-0"
+                                                >
+                                                    Očekivano{' '}
+                                                    {dateFormatter.format(
+                                                        item.expectedReplantingDate,
+                                                    )}
+                                                </Typography>
+                                            ) : null}
+                                        </Row>
+                                        <Progress
+                                            aria-label={`Napredak sadnice ${item.plantSort.information.name}`}
+                                            data-greenhouse-overview-progress
+                                            value={item.progressPercentage}
+                                            trackClassName="bg-emerald-500"
+                                        />
+                                    </Stack>
+                                </Stack>
+                            </div>
+                        ))}
+                    </ScrollView>
+                </Stack>
+            </GameModal>
+        </HudCard>
+    );
+}

--- a/packages/game/src/hud/raisedBed/greenhouseSeedlings.ts
+++ b/packages/game/src/hud/raisedBed/greenhouseSeedlings.ts
@@ -161,6 +161,16 @@ export function getGreenhouseSeedlingProgressData({
     return result;
 }
 
+export function getGreenhouseSeedlingProgressPercentage(
+    progressData: GreenhouseSeedlingProgressData,
+) {
+    return Math.round(
+        (progressData.germinationValue * progressData.germinationPercentage +
+            progressData.seedlingValue * progressData.seedlingPercentage) /
+            100,
+    );
+}
+
 function getDateTime(value: Date | string | null | undefined) {
     if (!value) {
         return null;


### PR DESCRIPTION
## What changed

- Added an in-game `Staklenik` HUD entry that appears when the current garden has active greenhouse seedlings in raised-bed fields.
- The overview modal lists each greenhouse seedling with plant image/name, raised-bed field, current stage, expected transplant date when known, and overall progress.
- Reused existing greenhouse seedling lifecycle logic and added a shared helper for total progress percentage.
- Added a focused component test covering the overview list and progress calculation.

## Impact

Garden users can now see all greenhouse seedlings for the selected garden without opening each raised-bed field individually.

## Validation

- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden lint`
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden exec playwright test -c playwright.config.ts tests/raised-bed-field-hud.spec.tsx -g "greenhouse overview"`
- `git diff --check`