### PR TITLE
[codex] Hide unverified task evidence

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -75,6 +75,7 @@ import {
 } from '../../../lib/garden/appliedRaisedBedOperations';
 import { resolveGardenBlockPlacement } from '../../../lib/garden/blockPlacementService';
 import { deleteGardenBlock } from '../../../lib/garden/gardenBlocksService';
+import { serializeGardenOperationEvidence } from '../../../lib/garden/gardenOperationsSerialization';
 import { synchronizeGardenStacksAndRaisedBeds } from '../../../lib/garden/gardenStacksSyncService';
 import {
     generateGardenVisitSummaryFacts,
@@ -339,6 +340,7 @@ function serializeGardenOperation(
         : isAssigned
           ? 'assigned'
           : operation.status;
+    const evidence = serializeGardenOperationEvidence(operation);
 
     const statusHistory = [
         {
@@ -404,8 +406,8 @@ function serializeGardenOperation(
         verifiedAt: operation.verifiedAt?.toISOString() ?? null,
         canceledAt: operation.canceledAt?.toISOString() ?? null,
         cancellationReason: operation.cancelReason ?? null,
-        imageUrls: operation.imageUrls ?? [],
-        completionNotes: operation.completionNotes ?? null,
+        imageUrls: evidence.imageUrls,
+        completionNotes: evidence.completionNotes,
         targetLabel:
             (operation.raisedBedFieldId
                 ? targetsByRaisedBedFieldId.get(operation.raisedBedFieldId)
@@ -2665,8 +2667,10 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 return context.json({ error: 'Raised bed not found' }, 404);
             }
 
-            const diaryEntries =
-                await getRaisedBedDiaryEntries(raisedBedIdNumber);
+            const diaryEntries = await getRaisedBedDiaryEntries(
+                raisedBedIdNumber,
+                { includeUnverifiedOperationEvidence: false },
+            );
             return context.json(diaryEntries);
         },
     )
@@ -3587,6 +3591,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const diaryEntries = await getRaisedBedFieldDiaryEntries(
                 raisedBedIdNumber,
                 positionIndexNumber,
+                { includeUnverifiedOperationEvidence: false },
             );
             return context.json(diaryEntries);
         },

--- a/apps/api/lib/garden/gardenOperationsSerialization.node.spec.ts
+++ b/apps/api/lib/garden/gardenOperationsSerialization.node.spec.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { serializeGardenOperationEvidence } from './gardenOperationsSerialization';
+
+test('garden operation evidence is hidden until operation verification completes', () => {
+    assert.deepStrictEqual(
+        serializeGardenOperationEvidence({
+            status: 'pendingVerification',
+            imageUrls: ['https://example.com/pending.jpg'],
+            completionNotes: 'Pending review note',
+        }),
+        {
+            imageUrls: [],
+            completionNotes: null,
+        },
+    );
+});
+
+test('garden operation evidence is visible after operation verification', () => {
+    assert.deepStrictEqual(
+        serializeGardenOperationEvidence({
+            status: 'completed',
+            imageUrls: ['https://example.com/completed.jpg'],
+            completionNotes: 'Verified note',
+        }),
+        {
+            imageUrls: ['https://example.com/completed.jpg'],
+            completionNotes: 'Verified note',
+        },
+    );
+});

--- a/apps/api/lib/garden/gardenOperationsSerialization.ts
+++ b/apps/api/lib/garden/gardenOperationsSerialization.ts
@@ -1,0 +1,21 @@
+type GardenOperationEvidenceInput = {
+    status: string;
+    imageUrls?: string[] | null;
+    completionNotes?: string | null;
+};
+
+export function serializeGardenOperationEvidence(
+    operation: GardenOperationEvidenceInput,
+) {
+    if (operation.status !== 'completed') {
+        return {
+            imageUrls: [],
+            completionNotes: null,
+        };
+    }
+
+    return {
+        imageUrls: operation.imageUrls ?? [],
+        completionNotes: operation.completionNotes ?? null,
+    };
+}

--- a/apps/app/app/(actions)/operationActions.ts
+++ b/apps/app/app/(actions)/operationActions.ts
@@ -5,7 +5,10 @@ import {
     RAISED_BED_ABANDONED_ACTIONS_DISABLED_MESSAGE,
     RAISED_BED_ABANDONED_DUE_TO_INACTIVITY_MESSAGE,
 } from '@gredice/js/raisedBeds';
-import { getRaisedBedCloseupUrl } from '@gredice/js/urls';
+import {
+    getRaisedBedCloseupUrl,
+    validateHostedImageUrl,
+} from '@gredice/js/urls';
 import {
     notifyOperationAssignedUsers,
     notifyOperationUpdate,
@@ -36,6 +39,7 @@ import { KnownPages } from '../../src/KnownPages';
 import { operationDefinitionMatchesTargetScope } from '../admin/operations/operationScope';
 
 const MAX_COMPLETION_NOTES_LENGTH = 2000;
+const MAX_COMPLETION_IMAGE_COUNT = 20;
 
 function normalizeCompletionNotes(notes?: string) {
     const normalizedNotes = notes?.trim();
@@ -48,6 +52,45 @@ function normalizeCompletionNotes(notes?: string) {
     }
 
     return normalizedNotes;
+}
+
+function normalizeCompletionImageUrls(
+    value: unknown,
+    existingImageUrls: string[],
+) {
+    if (!Array.isArray(value)) {
+        throw new Error('Popis slika nije ispravan.');
+    }
+
+    const allowedExistingImageUrls = new Set(
+        existingImageUrls.map((imageUrl) => imageUrl.trim()).filter(Boolean),
+    );
+    const uniqueUrls = new Set<string>();
+    for (const item of value) {
+        if (typeof item !== 'string') {
+            throw new Error('Popis slika nije ispravan.');
+        }
+
+        const imageUrl = item.trim();
+        if (!imageUrl) {
+            continue;
+        }
+
+        const urlError = validateHostedImageUrl(imageUrl);
+        if (urlError && !allowedExistingImageUrls.has(imageUrl)) {
+            throw new Error('Slike moraju biti učitane kroz Gredice.');
+        }
+
+        uniqueUrls.add(imageUrl);
+    }
+
+    if (uniqueUrls.size > MAX_COMPLETION_IMAGE_COUNT) {
+        throw new Error(
+            `Zapis završetka može imati najviše ${MAX_COMPLETION_IMAGE_COUNT} slika.`,
+        );
+    }
+
+    return Array.from(uniqueUrls);
 }
 
 function buildRaisedBedNotificationLink(
@@ -702,6 +745,7 @@ async function revalidateOperationPaths(
 ) {
     revalidatePath(KnownPages.Schedule);
     revalidatePath(KnownPages.Operations);
+    revalidatePath(KnownPages.Approvals);
     revalidatePath(KnownPages.Operation(operation.id));
     if (operation.accountId)
         revalidatePath(KnownPages.Account(operation.accountId));
@@ -904,6 +948,43 @@ export async function completeOperationWithImageUrls(
         throw new Error('Operation ID is required');
     }
     return completeOperation(operationId, imageUrls, notes);
+}
+
+export async function updateOperationCompletionEvidenceAction(
+    operationId: number,
+    imageUrls: unknown,
+    notes?: string,
+) {
+    const { userId } = await auth(['admin']);
+    const operation = await getOperationById(operationId);
+    if (!operation) {
+        throw new Error(`Operation with ID ${operationId} not found.`);
+    }
+
+    if (operation.status !== 'pendingVerification') {
+        throw new Error(
+            'Zapis završetka može se urediti samo prije verifikacije.',
+        );
+    }
+
+    await createEvent(
+        knownEvents.operations.completionEvidenceUpdatedV1(
+            operationId.toString(),
+            {
+                updatedBy: userId,
+                images: normalizeCompletionImageUrls(
+                    imageUrls,
+                    operation.imageUrls ?? [],
+                ),
+                notes: normalizeCompletionNotes(notes) ?? '',
+            },
+        ),
+    );
+
+    const updatedOperation = await getOperationById(operationId);
+    await revalidateOperationPaths(updatedOperation);
+
+    return { success: true };
 }
 
 export async function verifyOperationAction(operationId: number) {

--- a/apps/app/app/admin/approvals/page.tsx
+++ b/apps/app/app/admin/approvals/page.tsx
@@ -11,6 +11,7 @@ import {
     type AdminApprovalTask,
     getPendingAdminApprovalTasks,
 } from '../../../src/approvalTasks';
+import { KnownPages } from '../../../src/KnownPages';
 import {
     approveApprovalRequestAction,
     approveScheduleOperationTaskAction,
@@ -214,19 +215,30 @@ export default async function AdminApprovalsPage() {
                                                     </>
                                                 ) : task.kind ===
                                                   'scheduleOperationVerification' ? (
-                                                    <form
-                                                        action={approveScheduleOperationTaskAction.bind(
-                                                            null,
-                                                            task.operationId,
-                                                        )}
-                                                    >
+                                                    <>
                                                         <Button
-                                                            type="submit"
+                                                            href={KnownPages.Operation(
+                                                                task.operationId,
+                                                            )}
                                                             size="sm"
+                                                            variant="outlined"
                                                         >
-                                                            Verificiraj
+                                                            Uredi
                                                         </Button>
-                                                    </form>
+                                                        <form
+                                                            action={approveScheduleOperationTaskAction.bind(
+                                                                null,
+                                                                task.operationId,
+                                                            )}
+                                                        >
+                                                            <Button
+                                                                type="submit"
+                                                                size="sm"
+                                                            >
+                                                                Verificiraj
+                                                            </Button>
+                                                        </form>
+                                                    </>
                                                 ) : (
                                                     <form
                                                         action={approveSchedulePlantingTaskAction.bind(

--- a/apps/app/app/admin/operations/[operationId]/page.tsx
+++ b/apps/app/app/admin/operations/[operationId]/page.tsx
@@ -46,6 +46,7 @@ import type { EntityStandardized } from '../../../../lib/@types/EntityStandardiz
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
 import { AcceptOperationModal } from '../../schedule/AcceptOperationModal';
+import { OperationCompletionEvidenceEditModal } from '../../schedule/OperationCompletionEvidenceEditModal';
 import { VerifyOperationModal } from '../../schedule/VerifyOperationModal';
 import { operationDefinitionMatchesTargetScope } from '../operationScope';
 
@@ -564,10 +565,22 @@ export default async function OperationDetailsPage({
                     actions={
                         <Row className="items-center" spacing={2}>
                             {operation.status === 'pendingVerification' && (
-                                <VerifyOperationModal
-                                    operationId={operation.id}
-                                    label={operationTitle}
-                                />
+                                <>
+                                    <OperationCompletionEvidenceEditModal
+                                        operationId={operation.id}
+                                        label={operationTitle}
+                                        initialNotes={
+                                            operation.completionNotes ?? ''
+                                        }
+                                        initialImageUrls={
+                                            operation.imageUrls ?? []
+                                        }
+                                    />
+                                    <VerifyOperationModal
+                                        operationId={operation.id}
+                                        label={operationTitle}
+                                    />
+                                </>
                             )}
                             {operation.isAccepted ? (
                                 <OperationUnacceptButton

--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -4,7 +4,7 @@ import type { OperationAssignableFarmUser } from '@gredice/storage';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
-import { Calendar, Close } from '@gredice/ui/icons';
+import { Calendar, Close, Edit } from '@gredice/ui/icons';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -33,6 +33,7 @@ import { BulkRescheduleRaisedBedButton } from './BulkRescheduleRaisedBedButton';
 import { CancelOperationModal } from './CancelOperationModal';
 import { CompleteOperationModal } from './CompleteOperationModal';
 import { OperationCompletionAttachments } from './OperationCompletionAttachments';
+import { OperationCompletionEvidenceEditModal } from './OperationCompletionEvidenceEditModal';
 import { OperationRequirementIcons } from './OperationRequirementIcons';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
 import { ScheduleOperationVisual } from './ScheduleTaskVisual';
@@ -600,6 +601,28 @@ export function FarmOperationsScheduleSection({
                                         operationId={operation.id}
                                         notes={operation.completionNotes}
                                         imageUrls={operation.imageUrls}
+                                    />
+                                )}
+                                {operationPendingVerification && (
+                                    <OperationCompletionEvidenceEditModal
+                                        operationId={operation.id}
+                                        label={operationLabel}
+                                        initialNotes={
+                                            operation.completionNotes ?? ''
+                                        }
+                                        initialImageUrls={
+                                            operation.imageUrls ?? []
+                                        }
+                                        trigger={
+                                            <IconButton
+                                                title="Uredi zapis završetka"
+                                                type="button"
+                                                size="xs"
+                                                variant="plain"
+                                            >
+                                                <Edit className="size-4 shrink-0" />
+                                            </IconButton>
+                                        }
                                     />
                                 )}
                                 <AssignOperationModal

--- a/apps/app/app/admin/schedule/OperationCompletionEvidenceEditModal.tsx
+++ b/apps/app/app/admin/schedule/OperationCompletionEvidenceEditModal.tsx
@@ -1,0 +1,362 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Clear, Edit } from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import {
+    Fragment,
+    type ReactElement,
+    useCallback,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import {
+    ImageUploadManager,
+    type ImageUploadManagerHandle,
+    type ImageUploadManagerState,
+} from '../../../components/shared/media/ImageUploadManager';
+import { updateOperationCompletionEvidenceAction } from '../../(actions)/operationActions';
+
+const MAX_COMPLETION_IMAGE_COUNT = 20;
+const MAX_COMPLETION_NOTES_LENGTH = 2000;
+
+type EditOperationCompletionEvidenceTriggerProps = {
+    isSubmitting: boolean;
+    openModal: () => void;
+    defaultTrigger: ReactElement;
+};
+
+type EditOperationCompletionEvidenceModalBaseProps = {
+    operationId: number;
+    label: string;
+    initialNotes?: string | null;
+    initialImageUrls?: string[] | null;
+};
+
+type EditOperationCompletionEvidenceModalProps =
+    EditOperationCompletionEvidenceModalBaseProps &
+        (
+            | {
+                  trigger?: ReactElement;
+                  renderTrigger?: never;
+              }
+            | {
+                  trigger?: never;
+                  renderTrigger: (
+                      props: EditOperationCompletionEvidenceTriggerProps,
+                  ) => ReactElement;
+              }
+        );
+
+function normalizeImageUrls(imageUrls?: string[] | null) {
+    return Array.from(
+        new Set(
+            (imageUrls ?? [])
+                .map((imageUrl) => imageUrl.trim())
+                .filter(Boolean),
+        ),
+    );
+}
+
+export function OperationCompletionEvidenceEditModal({
+    operationId,
+    label,
+    initialNotes,
+    initialImageUrls,
+    trigger,
+    renderTrigger,
+}: EditOperationCompletionEvidenceModalProps) {
+    const router = useRouter();
+    const initialUrls = useMemo(
+        () => normalizeImageUrls(initialImageUrls),
+        [initialImageUrls],
+    );
+    const [open, setOpen] = useState(false);
+    const [notes, setNotes] = useState(initialNotes ?? '');
+    const [imageUrls, setImageUrls] = useState(initialUrls);
+    const [uploadItemCount, setUploadItemCount] = useState(0);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const imageUploaderRef = useRef<ImageUploadManagerHandle>(null);
+
+    const resetForm = useCallback(() => {
+        setNotes(initialNotes ?? '');
+        setImageUrls(initialUrls);
+        setUploadItemCount(0);
+        setErrorMessage(null);
+        imageUploaderRef.current?.reset();
+    }, [initialNotes, initialUrls]);
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        setOpen(nextOpen);
+        if (nextOpen) {
+            resetForm();
+        } else if (!isSubmitting) {
+            resetForm();
+        }
+    };
+
+    const handleUploadStateChange = useCallback(
+        (state: ImageUploadManagerState) => {
+            setUploadItemCount(state.count);
+            if (state.count > 0) {
+                setErrorMessage(null);
+            }
+        },
+        [],
+    );
+
+    const operationImageUploadPath = useCallback(
+        ({
+            attempt,
+            file,
+            itemId,
+        }: {
+            attempt: number;
+            file: File;
+            itemId: string;
+        }) => {
+            const extension = file.name.includes('.')
+                ? file.name.slice(file.name.lastIndexOf('.'))
+                : '';
+
+            return `operations/${operationId}/${itemId}-${attempt}${extension}`;
+        },
+        [operationId],
+    );
+
+    const removeImageUrl = (imageUrlToRemove: string) => {
+        setImageUrls((currentImageUrls) =>
+            currentImageUrls.filter(
+                (imageUrl) => imageUrl !== imageUrlToRemove,
+            ),
+        );
+        setErrorMessage(null);
+    };
+
+    const handleSave = async () => {
+        try {
+            setErrorMessage(null);
+            const trimmedNotes = notes.trim();
+            if (trimmedNotes.length > MAX_COMPLETION_NOTES_LENGTH) {
+                setErrorMessage(
+                    `Napomena može imati najviše ${MAX_COMPLETION_NOTES_LENGTH} znakova.`,
+                );
+                return;
+            }
+
+            setIsSubmitting(true);
+            const uploadedImageUrls =
+                uploadItemCount > 0
+                    ? await imageUploaderRef.current?.uploadPendingImages()
+                    : [];
+            if (!uploadedImageUrls) {
+                setErrorMessage(
+                    'Neke slike nisu učitane. Neuspjele stavke možete pokušati ponovno bez ponovnog odabira.',
+                );
+                return;
+            }
+
+            const nextImageUrls = normalizeImageUrls([
+                ...imageUrls,
+                ...uploadedImageUrls,
+            ]);
+            if (nextImageUrls.length > MAX_COMPLETION_IMAGE_COUNT) {
+                setErrorMessage(
+                    `Zapis završetka može imati najviše ${MAX_COMPLETION_IMAGE_COUNT} slika.`,
+                );
+                return;
+            }
+
+            await updateOperationCompletionEvidenceAction(
+                operationId,
+                nextImageUrls,
+                trimmedNotes,
+            );
+            setOpen(false);
+            resetForm();
+            router.refresh();
+        } catch (error) {
+            console.error(
+                'Error updating operation completion evidence:',
+                error,
+            );
+            setErrorMessage(
+                'Spremanje izmjena nije uspjelo. Pokušajte ponovno.',
+            );
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const remainingImageSlots = Math.max(
+        0,
+        MAX_COMPLETION_IMAGE_COUNT - imageUrls.length,
+    );
+    const defaultTrigger = (
+        <Button
+            variant="outlined"
+            size="xs"
+            title="Uredi zapis završetka"
+            startDecorator={<Edit className="size-3.5" />}
+            loading={isSubmitting}
+        >
+            Uredi zapis
+        </Button>
+    );
+
+    return (
+        <Fragment>
+            {renderTrigger?.({
+                isSubmitting,
+                openModal: () => handleOpenChange(true),
+                defaultTrigger,
+            })}
+            <Modal
+                title="Uređivanje zapisa završetka"
+                open={open}
+                onOpenChange={handleOpenChange}
+                trigger={
+                    renderTrigger ? undefined : (trigger ?? defaultTrigger)
+                }
+                className="max-w-2xl"
+            >
+                <Stack spacing={4}>
+                    <Stack spacing={1}>
+                        <Typography level="h5">
+                            Uredi zapis završetka
+                        </Typography>
+                        <Typography
+                            level="body2"
+                            className="text-muted-foreground"
+                        >
+                            {label}
+                        </Typography>
+                    </Stack>
+                    <Stack spacing={2}>
+                        <label
+                            htmlFor={`operation-${operationId}-completion-notes`}
+                            className="text-sm font-medium"
+                        >
+                            Napomena
+                        </label>
+                        <textarea
+                            id={`operation-${operationId}-completion-notes`}
+                            value={notes}
+                            onChange={(event) => {
+                                setNotes(event.target.value);
+                                setErrorMessage(null);
+                            }}
+                            disabled={isSubmitting}
+                            rows={5}
+                            maxLength={MAX_COMPLETION_NOTES_LENGTH}
+                            className="min-h-28 w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs outline-hidden focus:border-primary focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                        />
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            {notes.trim().length}/{MAX_COMPLETION_NOTES_LENGTH}
+                        </Typography>
+                    </Stack>
+                    <Stack spacing={2}>
+                        <Typography level="body2" semiBold>
+                            Slike
+                        </Typography>
+                        {imageUrls.length > 0 ? (
+                            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                                {imageUrls.map((imageUrl, index) => (
+                                    <div
+                                        key={imageUrl}
+                                        className="relative overflow-hidden rounded-md border bg-muted"
+                                    >
+                                        <Image
+                                            src={imageUrl}
+                                            alt={`Slika završetka radnje ${operationId}-${index + 1}`}
+                                            width={240}
+                                            height={180}
+                                            className="aspect-[4/3] w-full object-cover"
+                                        />
+                                        <IconButton
+                                            aria-label={`Ukloni sliku ${index + 1}`}
+                                            type="button"
+                                            size="xs"
+                                            variant="solid"
+                                            color="danger"
+                                            className="absolute right-2 top-2"
+                                            disabled={isSubmitting}
+                                            onClick={() =>
+                                                removeImageUrl(imageUrl)
+                                            }
+                                        >
+                                            <Clear className="size-3.5" />
+                                        </IconButton>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <Typography
+                                level="body2"
+                                className="rounded-md border border-dashed border-input bg-muted/20 px-3 py-4 text-muted-foreground"
+                            >
+                                Nema slika u zapisu završetka.
+                            </Typography>
+                        )}
+                        {remainingImageSlots > 0 ? (
+                            <ImageUploadManager
+                                ref={imageUploaderRef}
+                                disabled={isSubmitting}
+                                handleUploadUrl="/api/operations/images/upload"
+                                clientPayload={JSON.stringify({ operationId })}
+                                maxItems={remainingImageSlots}
+                                uploadPath={operationImageUploadPath}
+                                addLabel="Dodaj nove slike"
+                                addMoreLabel="Dodaj još novih slika"
+                                emptyLabel="Dodajte slike koje će se spremiti u zapis završetka."
+                                onStateChange={handleUploadStateChange}
+                            />
+                        ) : (
+                            <Typography
+                                level="body2"
+                                className="text-muted-foreground"
+                            >
+                                Dosegnut je najveći broj slika.
+                            </Typography>
+                        )}
+                    </Stack>
+                    {errorMessage && (
+                        <Typography level="body2" className="text-red-600">
+                            {errorMessage}
+                        </Typography>
+                    )}
+                    <Row spacing={2} justifyContent="end">
+                        <Button
+                            variant="outlined"
+                            onClick={() => handleOpenChange(false)}
+                            disabled={isSubmitting}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            variant="solid"
+                            onClick={handleSave}
+                            loading={isSubmitting}
+                            disabled={isSubmitting}
+                        >
+                            Spremi izmjene
+                        </Button>
+                    </Row>
+                </Stack>
+            </Modal>
+        </Fragment>
+    );
+}
+
+export default OperationCompletionEvidenceEditModal;

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -4,7 +4,7 @@ import type { OperationAssignableFarmUser } from '@gredice/storage';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
-import { Calendar, Close } from '@gredice/ui/icons';
+import { Calendar, Close, Edit } from '@gredice/ui/icons';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { Row } from '@gredice/ui/Row';
@@ -35,6 +35,7 @@ import { CancelOperationModal } from './CancelOperationModal';
 import { CompleteOperationModal } from './CompleteOperationModal';
 import { CopyTasksButton } from './CopyTasksButton';
 import { OperationCompletionAttachments } from './OperationCompletionAttachments';
+import { OperationCompletionEvidenceEditModal } from './OperationCompletionEvidenceEditModal';
 import { OperationRequirementIcons } from './OperationRequirementIcons';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
 import { ScheduleOperationVisual } from './ScheduleTaskVisual';
@@ -690,6 +691,28 @@ export function RaisedBedOperationsScheduleSection({
                                             operationId={operation.id}
                                             notes={operation.completionNotes}
                                             imageUrls={operation.imageUrls}
+                                        />
+                                    )}
+                                    {operationPendingVerification && (
+                                        <OperationCompletionEvidenceEditModal
+                                            operationId={operation.id}
+                                            label={operationLabel}
+                                            initialNotes={
+                                                operation.completionNotes ?? ''
+                                            }
+                                            initialImageUrls={
+                                                operation.imageUrls ?? []
+                                            }
+                                            trigger={
+                                                <IconButton
+                                                    title="Uredi zapis završetka"
+                                                    type="button"
+                                                    size="xs"
+                                                    variant="plain"
+                                                >
+                                                    <Edit className="size-4 shrink-0" />
+                                                </IconButton>
+                                            }
                                         />
                                     )}
                                     <AssignOperationModal

--- a/packages/storage/src/repositories/events/knownEventTypes.ts
+++ b/packages/storage/src/repositories/events/knownEventTypes.ts
@@ -57,6 +57,7 @@ export const knownEventTypes = {
         assign: 'operation.assign',
         schedule: 'operation.schedule',
         complete: 'operation.complete',
+        completionEvidenceUpdate: 'operation.completionEvidence.update',
         verify: 'operation.verify',
         fail: 'operation.fail',
         cancel: 'operation.cancel',

--- a/packages/storage/src/repositories/events/knownEvents.ts
+++ b/packages/storage/src/repositories/events/knownEvents.ts
@@ -27,6 +27,7 @@ import type {
     OperationAssignPayload,
     OperationCancelPayload,
     OperationCompletePayload,
+    OperationCompletionEvidenceUpdatePayload,
     OperationFailPayload,
     OperationSchedulePayload,
     OperationVerifyPayload,
@@ -358,6 +359,15 @@ export const knownEvents = {
         }),
         completedV1: (aggregateId: string, data: OperationCompletePayload) => ({
             type: knownEventTypes.operations.complete,
+            version: 1,
+            aggregateId,
+            data,
+        }),
+        completionEvidenceUpdatedV1: (
+            aggregateId: string,
+            data: OperationCompletionEvidenceUpdatePayload,
+        ) => ({
+            type: knownEventTypes.operations.completionEvidenceUpdate,
             version: 1,
             aggregateId,
             data,

--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -91,6 +91,7 @@ const scheduleInvalidatingEventTypes = new Set<string>([
     knownEventTypes.operations.assign,
     knownEventTypes.operations.schedule,
     knownEventTypes.operations.complete,
+    knownEventTypes.operations.completionEvidenceUpdate,
     knownEventTypes.operations.verify,
     knownEventTypes.operations.fail,
     knownEventTypes.operations.cancel,

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -291,6 +291,12 @@ export type OperationCompletePayload = {
     notes?: string;
 };
 
+export type OperationCompletionEvidenceUpdatePayload = {
+    updatedBy: string;
+    images: string[];
+    notes: string;
+};
+
 export type OperationVerifyPayload = {
     verifiedBy: string;
 };
@@ -310,6 +316,7 @@ export type OperationEventsPayload =
     | OperationAssignPayload
     | OperationSchedulePayload
     | OperationCompletePayload
+    | OperationCompletionEvidenceUpdatePayload
     | OperationVerifyPayload
     | OperationFailPayload
     | OperationCancelPayload;
@@ -318,6 +325,7 @@ export type OperationEventsAnyPayload = Partial<
     OperationAssignPayload &
         OperationSchedulePayload &
         OperationCompletePayload &
+        OperationCompletionEvidenceUpdatePayload &
         OperationVerifyPayload &
         OperationFailPayload &
         OperationCancelPayload

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -151,6 +151,7 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
         knownEventTypes.operations.assign,
         knownEventTypes.operations.schedule,
         knownEventTypes.operations.complete,
+        knownEventTypes.operations.completionEvidenceUpdate,
         knownEventTypes.operations.verify,
         knownEventTypes.operations.fail,
         knownEventTypes.operations.cancel,
@@ -224,11 +225,21 @@ async function fillOperationAggregates(operations: SelectOperation[]) {
                 completedBy = asString(data?.completedBy) ?? completedBy;
                 completedAt = completedAt ?? event.createdAt;
                 if (Array.isArray(data?.images)) {
-                    imageUrls = (data.images as unknown[]).filter(
+                    imageUrls = data.images.filter(
                         (url): url is string => typeof url === 'string',
                     );
                 }
                 completionNotes = asString(data?.notes) ?? completionNotes;
+            } else if (
+                event.type ===
+                knownEventTypes.operations.completionEvidenceUpdate
+            ) {
+                if (Array.isArray(data?.images)) {
+                    imageUrls = data.images.filter(
+                        (url): url is string => typeof url === 'string',
+                    );
+                }
+                completionNotes = asString(data?.notes) ?? '';
             } else if (event.type === knownEventTypes.operations.verify) {
                 status = 'completed';
                 verifiedBy = asString(data?.verifiedBy) ?? verifiedBy;

--- a/packages/storage/src/repositories/raisedBedDiaryRepo.ts
+++ b/packages/storage/src/repositories/raisedBedDiaryRepo.ts
@@ -6,7 +6,28 @@ import { getAllEvents, knownEventTypes } from './eventsRepo';
 import type { getRaisedBedFieldsWithEvents } from './raisedBedFieldsRepo';
 import { getRaisedBed } from './raisedBedsRepo';
 
-export async function getRaisedBedDiaryEntries(raisedBedId: number) {
+type RaisedBedDiaryEntriesOptions = {
+    includeUnverifiedOperationEvidence?: boolean;
+};
+
+function operationDiaryImageUrls(
+    operation: DiaryOperation,
+    options?: RaisedBedDiaryEntriesOptions,
+) {
+    if (
+        options?.includeUnverifiedOperationEvidence === false &&
+        operation.status !== 'completed'
+    ) {
+        return undefined;
+    }
+
+    return operation.imageUrls;
+}
+
+export async function getRaisedBedDiaryEntries(
+    raisedBedId: number,
+    options?: RaisedBedDiaryEntriesOptions,
+) {
     const raisedBed = await getRaisedBed(raisedBedId);
     if (!raisedBed) {
         throw new Error(`Raised bed with ID ${raisedBedId} not found`);
@@ -96,7 +117,7 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
             )?.information?.shortDescription,
             status: operationStatusToLabel(op.status),
             timestamp: operationDiaryTimestamp(op),
-            imageUrls: op.imageUrls,
+            imageUrls: operationDiaryImageUrls(op, options),
             rescheduleTarget: operationDiaryRescheduleTarget(op),
         }))
         .filter((op) => op.name)
@@ -116,6 +137,7 @@ export async function getRaisedBedDiaryEntries(raisedBedId: number) {
 export async function getRaisedBedFieldDiaryEntries(
     raisedBedId: number,
     positionIndex: number,
+    options?: RaisedBedDiaryEntriesOptions,
 ) {
     const raisedBed = await getRaisedBed(raisedBedId);
     if (!raisedBed) {
@@ -247,7 +269,7 @@ export async function getRaisedBedFieldDiaryEntries(
             )?.information?.shortDescription,
             status: operationStatusToLabel(op.status),
             timestamp: operationDiaryTimestamp(op),
-            imageUrls: op.imageUrls,
+            imageUrls: operationDiaryImageUrls(op, options),
             rescheduleTarget: operationDiaryRescheduleTarget(op, positionIndex),
         }))
         .filter((op) => op.name)

--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -829,6 +829,94 @@ test('diary entries expose operation and field reschedule targets', async () => 
     });
 });
 
+test('diary entries can hide unverified operation images', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    await upsertRaisedBedField({
+        raisedBedId,
+        positionIndex: 0,
+    });
+    const raisedBed = await getRaisedBed(raisedBedId);
+    const raisedBedFieldId = raisedBed?.fields[0]?.id;
+    if (!raisedBedFieldId) {
+        throw new Error('Expected test raised bed field.');
+    }
+
+    const raisedBedOperationId = await createOperation({
+        accountId,
+        entityId: 1,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+    });
+    const fieldOperationId = await createOperation({
+        accountId,
+        entityId: 1,
+        entityTypeName: 'operation',
+        gardenId,
+        raisedBedId,
+        raisedBedFieldId,
+    });
+
+    await createEvent(
+        knownEvents.operations.completedV1(raisedBedOperationId.toString(), {
+            completedBy: 'test-user',
+            images: ['https://cdn.gredice.com/raised-bed-pending.jpg'],
+        }),
+    );
+    await createEvent(
+        knownEvents.operations.completedV1(fieldOperationId.toString(), {
+            completedBy: 'test-user',
+            images: ['https://cdn.gredice.com/field-pending.jpg'],
+        }),
+    );
+
+    const defaultRaisedBedEntries = await getRaisedBedDiaryEntries(raisedBedId);
+    assert.deepEqual(
+        defaultRaisedBedEntries.find(
+            (entry) => entry.id === raisedBedOperationId,
+        )?.imageUrls,
+        ['https://cdn.gredice.com/raised-bed-pending.jpg'],
+    );
+
+    const publicRaisedBedEntries = await getRaisedBedDiaryEntries(raisedBedId, {
+        includeUnverifiedOperationEvidence: false,
+    });
+    assert.equal(
+        publicRaisedBedEntries.find(
+            (entry) => entry.id === raisedBedOperationId,
+        )?.imageUrls,
+        undefined,
+    );
+
+    const publicFieldEntries = await getRaisedBedFieldDiaryEntries(
+        raisedBedId,
+        0,
+        { includeUnverifiedOperationEvidence: false },
+    );
+    assert.equal(
+        publicFieldEntries.find((entry) => entry.id === fieldOperationId)
+            ?.imageUrls,
+        undefined,
+    );
+
+    await createEvent(
+        knownEvents.operations.verifiedV1(raisedBedOperationId.toString(), {
+            verifiedBy: 'admin-user',
+        }),
+    );
+
+    const verifiedPublicEntries = await getRaisedBedDiaryEntries(raisedBedId, {
+        includeUnverifiedOperationEvidence: false,
+    });
+    assert.deepEqual(
+        verifiedPublicEntries.find((entry) => entry.id === raisedBedOperationId)
+            ?.imageUrls,
+        ['https://cdn.gredice.com/raised-bed-pending.jpg'],
+    );
+});
+
 test('raised bed diary entries order operations by scheduled or completed dates', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =

--- a/packages/storage/tests/operationsRepo.node.spec.ts
+++ b/packages/storage/tests/operationsRepo.node.spec.ts
@@ -342,6 +342,83 @@ test('completed operations expose completion notes and image URLs', async () => 
     assert.strictEqual(operation.completionNotes, 'Zaliveno nakon berbe.');
 });
 
+test('pending operation completion evidence updates replace notes and images', async () => {
+    createTestDb();
+
+    const completedBy = randomUUID();
+    const updatedBy = randomUUID();
+    const operationId = await createOperation({
+        entityId: 1,
+        entityTypeName: 'operation',
+        accountId: randomUUID(),
+    });
+    await acceptOperation(operationId);
+
+    await createEvent(
+        knownEvents.operations.completedV1(operationId.toString(), {
+            completedBy,
+            images: ['https://cdn.gredice.com/original.jpg'],
+            notes: 'Original note.',
+        }),
+    );
+    const initialOperation = await getOperationById(operationId);
+
+    await createEvent(
+        knownEvents.operations.completionEvidenceUpdatedV1(
+            operationId.toString(),
+            {
+                updatedBy,
+                images: ['https://cdn.gredice.com/reviewed.jpg'],
+                notes: 'Reviewed note.',
+            },
+        ),
+    );
+
+    const operation = await getOperationById(operationId);
+
+    assert.strictEqual(operation.status, 'pendingVerification');
+    assert.strictEqual(operation.completedBy, completedBy);
+    assert.deepStrictEqual(operation.imageUrls, [
+        'https://cdn.gredice.com/reviewed.jpg',
+    ]);
+    assert.strictEqual(operation.completionNotes, 'Reviewed note.');
+    assert.deepStrictEqual(operation.completedAt, initialOperation.completedAt);
+});
+
+test('pending operation completion evidence updates can clear notes and images', async () => {
+    createTestDb();
+
+    const operationId = await createOperation({
+        entityId: 1,
+        entityTypeName: 'operation',
+        accountId: randomUUID(),
+    });
+    await acceptOperation(operationId);
+
+    await createEvent(
+        knownEvents.operations.completedV1(operationId.toString(), {
+            completedBy: randomUUID(),
+            images: ['https://cdn.gredice.com/original.jpg'],
+            notes: 'Original note.',
+        }),
+    );
+    await createEvent(
+        knownEvents.operations.completionEvidenceUpdatedV1(
+            operationId.toString(),
+            {
+                updatedBy: randomUUID(),
+                images: [],
+                notes: '',
+            },
+        ),
+    );
+
+    const operation = await getOperationById(operationId);
+
+    assert.deepStrictEqual(operation.imageUrls, []);
+    assert.strictEqual(operation.completionNotes, '');
+});
+
 test('switchOperationEntity changes only the selected operation entity', async () => {
     createTestDb();
 


### PR DESCRIPTION
## Summary

- Hide operation completion notes/images from garden operation and diary API responses until the operation is verified.
- Add an admin edit modal for pending completion evidence so notes can be adjusted and images removed or newly uploaded before verification.
- Store admin evidence edits as a non-status operation event so completion timestamps and reports are not changed.

## Validation

- `pnpm --filter api exec tsx --conditions=react-server --test lib/garden/gardenOperationsSerialization.node.spec.ts`
- `pnpm --filter @gredice/storage test -- operationsRepo.node.spec.ts gardenDiaryRescheduleRepo.node.spec.ts`
- `git diff --check`

Note: direct workspace `tsc --noEmit` reports existing unrelated type errors outside this change, so the targeted tests above were used as the validation gate.