### PR TITLE
feat(farm): improve schedule task loading

### DIFF
--- a/apps/farm/app/debug/labels/HarvestLabelDebugPage.tsx
+++ b/apps/farm/app/debug/labels/HarvestLabelDebugPage.tsx
@@ -79,7 +79,7 @@ export function HarvestLabelDebugPage() {
     const scaledHeight = Math.round((canvasSize.height * zoom) / 100);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 p-4">
                 <Row spacing={4} justifyContent="space-between">
                     <Row spacing={2} className="items-start">

--- a/apps/farm/app/debug/page.tsx
+++ b/apps/farm/app/debug/page.tsx
@@ -22,7 +22,7 @@ export default function FarmDebugIndexPage() {
     }
 
     return (
-        <main className="min-h-screen w-full bg-muted px-4 py-6 text-foreground sm:px-6 sm:py-8">
+        <main className="min-h-screen w-full bg-background px-4 py-6 text-foreground sm:px-6 sm:py-8">
             <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
                 <header className="flex flex-col gap-4">
                     <HomeButton />

--- a/apps/farm/app/globals.css
+++ b/apps/farm/app/globals.css
@@ -5,7 +5,7 @@
 @layer base {
     :root {
         interpolate-size: allow-keywords;
-        --background: 36 43% 93%;
+        --background: 28 76.5% 98%;
         --foreground: 32 22% 10%;
 
         --muted: 35 38% 88%;
@@ -104,6 +104,12 @@
         font-feature-settings:
             "rlig" 1,
             "calt" 1;
+    }
+
+    @media (max-width: 767px) {
+        html {
+            font-size: 17px;
+        }
     }
 
     button,

--- a/apps/farm/app/greenhouse/page.tsx
+++ b/apps/farm/app/greenhouse/page.tsx
@@ -431,7 +431,7 @@ export default function GreenhousePage() {
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={authFarmer}>
                 <GreenhousePageContent />
             </AuthProtectedSection>

--- a/apps/farm/app/layout.tsx
+++ b/apps/farm/app/layout.tsx
@@ -55,7 +55,7 @@ export default function RootLayout({
                 <meta name="theme-color" content="#8b5e34" />
                 <title>Gredice Farm</title>
             </Head>
-            <body className="antialiased min-h-screen flex w-full min-w-0 overflow-x-hidden bg-muted">
+            <body className="antialiased min-h-screen flex w-full min-w-0 overflow-x-hidden bg-background">
                 {postHogApiKey ? (
                     <PostHogProvider
                         apiKey={postHogApiKey}

--- a/apps/farm/app/operations/[operationId]/page.tsx
+++ b/apps/farm/app/operations/[operationId]/page.tsx
@@ -60,7 +60,7 @@ export default async function OperationDetailPage({
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={authFarmer}>
                 <OperationDetailPageContent operationId={parsedOperationId} />
             </AuthProtectedSection>

--- a/apps/farm/app/operations/page.tsx
+++ b/apps/farm/app/operations/page.tsx
@@ -34,7 +34,7 @@ export default function OperationsHandbookPage() {
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={authFarmer}>
                 <OperationsHandbookContent />
             </AuthProtectedSection>

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -270,7 +270,7 @@ export default function Home() {
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={authFarmer}>
                 <Suspense>
                     <FarmerDashboard />

--- a/apps/farm/app/payouts/page.tsx
+++ b/apps/farm/app/payouts/page.tsx
@@ -531,7 +531,7 @@ export default async function PayoutsPage({ searchParams }: PayoutsPageProps) {
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={authFarmer}>
                 <PayoutsContent selectedFarmId={selectedFarmId} />
             </AuthProtectedSection>

--- a/apps/farm/app/plants/[plantSortId]/page.tsx
+++ b/apps/farm/app/plants/[plantSortId]/page.tsx
@@ -77,7 +77,7 @@ export default async function PlantSortDetailPage({
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={authFarmer}>
                 <PlantSortDetailPageContent plantSortId={parsedPlantSortId} />
             </AuthProtectedSection>

--- a/apps/farm/app/plants/page.tsx
+++ b/apps/farm/app/plants/page.tsx
@@ -34,7 +34,7 @@ export default function PlantsHandbookPage() {
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={authFarmer}>
                 <PlantsHandbookContent />
             </AuthProtectedSection>

--- a/apps/farm/app/prijava/facebook-prijava/povratak/page.tsx
+++ b/apps/farm/app/prijava/facebook-prijava/povratak/page.tsx
@@ -8,7 +8,7 @@ import { UrlAuthForward } from '../../UrlAuthForward';
 
 export default function FacebookCallbackPage() {
     return (
-        <div className="min-h-[100dvh] flex items-center justify-center bg-muted p-4">
+        <div className="min-h-[100dvh] flex items-center justify-center bg-background p-4">
             <Card className="w-full max-w-[350px] p-6 sm:p-12">
                 <CardHeader>
                     <svg

--- a/apps/farm/app/prijava/google-prijava/povratak/page.tsx
+++ b/apps/farm/app/prijava/google-prijava/povratak/page.tsx
@@ -8,7 +8,7 @@ import { UrlAuthForward } from '../../UrlAuthForward';
 
 export default function GoogleCallbackPage() {
     return (
-        <div className="min-h-[100dvh] flex items-center justify-center bg-muted p-4">
+        <div className="min-h-[100dvh] flex items-center justify-center bg-background p-4">
             <Card className="w-full max-w-[350px] p-6 sm:p-12">
                 <CardHeader>
                     <svg

--- a/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
@@ -287,7 +287,7 @@ export default async function RaisedBedDetailPage({
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={authFarmer}>
                 <RaisedBedDetailPageContent raisedBedId={parsedRaisedBedId} />
             </AuthProtectedSection>

--- a/apps/farm/app/raised-beds/page.tsx
+++ b/apps/farm/app/raised-beds/page.tsx
@@ -252,7 +252,7 @@ export default async function RaisedBedsPage() {
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={authFarmer}>
                 <RaisedBedsPageContent />
             </AuthProtectedSection>

--- a/apps/farm/app/schedule/FarmScheduleDay.tsx
+++ b/apps/farm/app/schedule/FarmScheduleDay.tsx
@@ -6,11 +6,16 @@ import { FarmSchedulePlantingsSectionContent } from './FarmSchedulePlantingsSect
 import { FarmScheduleSectionSkeleton } from './FarmScheduleSectionSkeleton';
 import type {
     FarmScheduleDayData,
+    FarmScheduleOperationsDayData,
+    FarmSchedulePlantingsDayData,
     getFarmSchedulePlantSorts,
 } from './scheduleData';
+import { getFarmScheduleRaisedBedPhotoPreviewsForDay } from './scheduleData';
 
 interface FarmScheduleDayProps {
     dayDataPromise: Promise<FarmScheduleDayData>;
+    operationsDayDataPromise: Promise<FarmScheduleOperationsDayData>;
+    plantingsDayDataPromise: Promise<FarmSchedulePlantingsDayData>;
     operationsDataPromise: ReturnType<
         typeof import('./scheduleData').getFarmScheduleOperationsData
     >;
@@ -20,10 +25,15 @@ interface FarmScheduleDayProps {
 
 export function FarmScheduleDay({
     dayDataPromise,
+    operationsDayDataPromise,
     operationsDataPromise,
+    plantingsDayDataPromise,
     plantSortsPromise,
     userId,
 }: FarmScheduleDayProps) {
+    const raisedBedPhotoPreviewByIdPromise =
+        getFarmScheduleRaisedBedPhotoPreviewsForDay(dayDataPromise);
+
     return (
         <Stack spacing={8}>
             <Suspense fallback={null}>
@@ -31,16 +41,22 @@ export function FarmScheduleDay({
             </Suspense>
             <Suspense fallback={<FarmScheduleSectionSkeleton />}>
                 <FarmSchedulePlantingsSectionContent
-                    dayDataPromise={dayDataPromise}
+                    dayDataPromise={plantingsDayDataPromise}
                     plantSortsPromise={plantSortsPromise}
+                    raisedBedPhotoPreviewByIdPromise={
+                        raisedBedPhotoPreviewByIdPromise
+                    }
                     userId={userId}
                 />
             </Suspense>
             <Suspense fallback={<FarmScheduleSectionSkeleton />}>
                 <FarmScheduleOperationsSectionContent
-                    dayDataPromise={dayDataPromise}
+                    dayDataPromise={operationsDayDataPromise}
                     plantSortsPromise={plantSortsPromise}
                     operationsDataPromise={operationsDataPromise}
+                    raisedBedPhotoPreviewByIdPromise={
+                        raisedBedPhotoPreviewByIdPromise
+                    }
                     userId={userId}
                 />
             </Suspense>

--- a/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from '@gredice/ui/Skeleton';
+import { Stack } from '@gredice/ui/Stack';
+import { FarmScheduleSectionSkeleton } from './FarmScheduleSectionSkeleton';
+import { ScheduleDaySummarySkeleton } from './ScheduleDaySummarySkeleton';
+
+export function FarmScheduleLoadingState() {
+    return (
+        <div
+            className="max-w-5xl mx-auto w-full space-y-4 px-2 py-4 sm:p-4"
+            aria-busy="true"
+        >
+            <div className="space-y-2">
+                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-1 sm:gap-2">
+                    <Skeleton className="h-8 w-10 rounded-md sm:h-10 sm:w-12" />
+                    <div className="grid justify-items-center gap-1">
+                        <Skeleton className="h-4 w-16" />
+                        <Skeleton className="h-4 w-24" />
+                    </div>
+                    <ScheduleDaySummarySkeleton />
+                </div>
+                <div className="flex justify-end">
+                    <Skeleton className="h-8 w-24 rounded-md" />
+                </div>
+            </div>
+            <Stack spacing={8}>
+                <FarmScheduleSectionSkeleton />
+                <FarmScheduleSectionSkeleton />
+                <FarmScheduleSectionSkeleton />
+            </Stack>
+        </div>
+    );
+}

--- a/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
+++ b/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { Left, Navigate } from '@gredice/ui/icons';
+import { Link } from '@gredice/ui/Link';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import type { Route } from 'next';
+import { useRouter } from 'next/navigation';
+import type { MouseEvent, ReactNode } from 'react';
+import { useEffect, useState, useTransition } from 'react';
+import { HomeButton } from '../../components/HomeButton';
+import { FarmScheduleSectionSkeleton } from './FarmScheduleSectionSkeleton';
+import { ScheduleDaySummarySkeleton } from './ScheduleDaySummarySkeleton';
+
+interface FarmScheduleNavigationFrameProps {
+    children: ReactNode;
+    labelPrintSlot: ReactNode;
+    selectedDateKey: string;
+    summarySlot: ReactNode;
+}
+
+function formatDateParam(date: Date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function parseDateKey(dateKey: string) {
+    const [year, month, day] = dateKey.split('-').map(Number);
+    const date = new Date();
+    date.setFullYear(year, month - 1, day);
+    date.setHours(0, 0, 0, 0);
+    return date;
+}
+
+function getOffsetDate(date: Date, offset: number) {
+    const newDate = new Date(date);
+    newDate.setDate(newDate.getDate() + offset);
+    return newDate;
+}
+
+function buildScheduleHref(dateKey: string) {
+    return `/schedule?date=${dateKey}` as Route;
+}
+
+function isModifiedClick(event: MouseEvent<HTMLAnchorElement>) {
+    return (
+        event.button !== 0 ||
+        event.metaKey ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.shiftKey
+    );
+}
+
+function FarmSchedulePendingSections() {
+    return (
+        <Stack spacing={8} aria-hidden="true">
+            <FarmScheduleSectionSkeleton />
+            <FarmScheduleSectionSkeleton />
+            <FarmScheduleSectionSkeleton />
+        </Stack>
+    );
+}
+
+export function FarmScheduleNavigationFrame({
+    children,
+    labelPrintSlot,
+    selectedDateKey,
+    summarySlot,
+}: FarmScheduleNavigationFrameProps) {
+    const router = useRouter();
+    const [isRoutePending, startTransition] = useTransition();
+    const [optimisticDateKey, setOptimisticDateKey] = useState(selectedDateKey);
+    const [hasPendingNavigation, setHasPendingNavigation] = useState(false);
+
+    useEffect(() => {
+        setOptimisticDateKey(selectedDateKey);
+        setHasPendingNavigation(false);
+    }, [selectedDateKey]);
+
+    const date = parseDateKey(optimisticDateKey);
+    const dayOfWeek = new Intl.DateTimeFormat('hr-HR', {
+        weekday: 'long',
+    }).format(date);
+    const dateFormatted = new Intl.DateTimeFormat('hr-HR', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+    }).format(date);
+    const isToday = new Date().toDateString() === date.toDateString();
+
+    const prevDateKey = formatDateParam(getOffsetDate(date, -1));
+    const nextDateKey = formatDateParam(getOffsetDate(date, 1));
+    const prevHref = buildScheduleHref(prevDateKey);
+    const nextHref = buildScheduleHref(nextDateKey);
+    const showPendingContent = hasPendingNavigation || isRoutePending;
+
+    useEffect(() => {
+        router.prefetch(prevHref);
+        router.prefetch(nextHref);
+    }, [nextHref, prevHref, router]);
+
+    function navigateToDate(
+        event: MouseEvent<HTMLAnchorElement>,
+        dateKey: string,
+        href: Route,
+    ) {
+        if (event.defaultPrevented || isModifiedClick(event)) {
+            return;
+        }
+
+        event.preventDefault();
+        setOptimisticDateKey(dateKey);
+        setHasPendingNavigation(true);
+        startTransition(() => {
+            router.push(href);
+        });
+    }
+
+    return (
+        <div
+            className="max-w-5xl mx-auto w-full space-y-4 px-2 py-4 sm:p-4"
+            aria-busy={showPendingContent}
+        >
+            <div className="space-y-2">
+                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-1 sm:gap-2">
+                    <div className="justify-self-start">
+                        <HomeButton className="h-8 sm:h-10" />
+                    </div>
+                    <div className="min-w-0 justify-self-center">
+                        <Row className="shrink-0 gap-1 sm:gap-2">
+                            <Link
+                                href={prevHref}
+                                title="Prethodni dan"
+                                aria-label="Prethodni dan"
+                                onClick={(event) =>
+                                    navigateToDate(event, prevDateKey, prevHref)
+                                }
+                                className="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground sm:p-2"
+                            >
+                                <Left className="size-4 shrink-0" />
+                            </Link>
+                            <div className="min-w-16 text-center sm:min-w-20">
+                                <Typography
+                                    level="body2"
+                                    semiBold
+                                    className="capitalize text-xs leading-tight sm:text-sm"
+                                >
+                                    {isToday ? 'Danas' : dayOfWeek}
+                                </Typography>
+                                <Typography
+                                    level="body2"
+                                    className={cx(
+                                        'text-muted-foreground text-xs leading-tight sm:text-sm',
+                                        showPendingContent && 'animate-pulse',
+                                    )}
+                                >
+                                    {dateFormatted}
+                                </Typography>
+                            </div>
+                            <Link
+                                href={nextHref}
+                                title="Sljedeći dan"
+                                aria-label="Sljedeći dan"
+                                onClick={(event) =>
+                                    navigateToDate(event, nextDateKey, nextHref)
+                                }
+                                className="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground sm:p-2"
+                            >
+                                <Navigate className="size-4 shrink-0" />
+                            </Link>
+                        </Row>
+                    </div>
+                    <div className="min-w-0 justify-self-end">
+                        {showPendingContent ? (
+                            <ScheduleDaySummarySkeleton />
+                        ) : (
+                            summarySlot
+                        )}
+                    </div>
+                </div>
+                <div className="flex min-w-0 justify-end">
+                    {showPendingContent ? null : labelPrintSlot}
+                </div>
+            </div>
+            {showPendingContent ? <FarmSchedulePendingSections /> : children}
+        </div>
+    );
+}

--- a/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
@@ -1,17 +1,26 @@
 import type { EntityStandardized } from '@gredice/storage';
 import { Checkbox } from '@gredice/ui/Checkbox';
-import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
-import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { UserAvatar } from '@gredice/ui/UserAvatar';
+import { cx } from '@gredice/ui/utils';
+import { Suspense } from 'react';
 import { CompleteOperationModal } from './CompleteOperationModal';
 import { OperationCompletionAttachments } from './OperationCompletionAttachments';
+import { OperationRequirementIcons } from './OperationRequirementIcons';
+import { RaisedBedScheduleGroupHeader } from './RaisedBedScheduleGroupHeader';
+import { RaisedBedScheduleGroupHeaderWithPhotos } from './RaisedBedScheduleGroupHeaderWithPhotos';
+import { ScheduleSectionSummaryBadges } from './ScheduleSectionSummaryBadges';
 import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
-import type { FarmScheduleDayData } from './scheduleData';
+import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
+import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
+import type {
+    FarmScheduleDayData,
+    FarmScheduleRaisedBedPhotoPreview,
+} from './scheduleData';
 import {
-    formatMinutes,
+    compareScheduleDates,
     getFieldPhysicalPositionIndex,
     getOperationDurationMinutes,
     groupRaisedBedsForSchedule,
@@ -30,6 +39,9 @@ interface FarmScheduleOperationsSectionProps {
     scheduledOperations: FarmScheduleDayData['scheduledOperations'];
     plantSorts: EntityStandardized[] | null | undefined;
     operationsData: EntityStandardized[] | null | undefined;
+    raisedBedPhotoPreviewByIdPromise: Promise<
+        Map<number, FarmScheduleRaisedBedPhotoPreview>
+    >;
     userId: string;
 }
 
@@ -65,6 +77,7 @@ export function FarmScheduleOperationsSection({
     scheduledOperations,
     plantSorts,
     operationsData,
+    raisedBedPhotoPreviewByIdPromise,
     userId,
 }: FarmScheduleOperationsSectionProps) {
     if (scheduledOperations.length === 0) {
@@ -145,23 +158,16 @@ export function FarmScheduleOperationsSection({
         const attachNotesRequired = Boolean(
             operationData?.conditions?.completionAttachNotesRequired,
         );
-        const completionRequirementTexts = [
-            attachImages
-                ? attachImagesRequired
-                    ? 'Slike obavezne'
-                    : 'Slike opcionalne'
-                : null,
-            attachNotes
-                ? attachNotesRequired
-                    ? 'Napomena obavezna'
-                    : 'Napomena opcionalna'
-                : null,
-        ].filter((text): text is string => Boolean(text));
+        const showRequirementIcons =
+            !completed && (attachImages || attachNotes);
 
         return (
             <div
                 key={operation.id}
-                className="rounded-lg border bg-white px-3 py-2"
+                className={cx(
+                    'rounded-lg border px-3 py-2 transition-opacity',
+                    completed ? 'bg-white/70 opacity-70' : 'bg-white',
+                )}
             >
                 <Row
                     spacing={2}
@@ -195,62 +201,32 @@ export function FarmScheduleOperationsSection({
                                 spacing={2}
                                 className="items-center flex-wrap gap-y-1"
                             >
-                                <Typography
-                                    level="body2"
-                                    className={
-                                        completed
-                                            ? 'text-green-600'
-                                            : 'text-muted-foreground'
-                                    }
-                                >
-                                    {completed ? 'Završeno' : 'Potvrđeno'}
-                                </Typography>
-                                {operation.durationMinutes > 0 && (
-                                    <Typography
-                                        level="body2"
-                                        className="text-muted-foreground"
-                                    >
-                                        {formatMinutes(
-                                            operation.durationMinutes,
-                                        )}
-                                    </Typography>
-                                )}
-                                <Typography
-                                    level="body2"
-                                    className="text-muted-foreground"
-                                >
-                                    {operation.scheduledDate ? (
-                                        <>
-                                            Planirano:{' '}
-                                            <LocalDateTime time={false}>
-                                                {operation.scheduledDate}
-                                            </LocalDateTime>
-                                        </>
-                                    ) : (
-                                        'Danas'
-                                    )}
-                                </Typography>
+                                <ScheduleTaskDurationChip
+                                    minutes={operation.durationMinutes}
+                                />
+                                <ScheduleTaskDateChip
+                                    scheduledDate={operation.scheduledDate}
+                                />
                                 {!completed && (
                                     <ScheduleTaskAgeIndicatorChip
                                         scheduledDate={operation.scheduledDate}
                                     />
                                 )}
-                                {!completed &&
-                                    completionRequirementTexts.length > 0 && (
-                                        <Typography
-                                            level="body2"
-                                            className="text-xs text-muted-foreground"
-                                        >
-                                            {completionRequirementTexts.join(
-                                                ' · ',
-                                            )}
-                                        </Typography>
-                                    )}
                             </Row>
                         </Stack>
                     </Row>
-                    {(completed || operation.assignedUser) && (
+                    {(showRequirementIcons ||
+                        completed ||
+                        operation.assignedUser) && (
                         <Row spacing={1} className="shrink-0 items-center">
+                            {showRequirementIcons && (
+                                <OperationRequirementIcons
+                                    attachImages={attachImages}
+                                    attachImagesRequired={attachImagesRequired}
+                                    attachNotes={attachNotes}
+                                    attachNotesRequired={attachNotesRequired}
+                                />
+                            )}
                             {completed && (
                                 <OperationCompletionAttachments
                                     operationId={operation.id}
@@ -283,26 +259,13 @@ export function FarmScheduleOperationsSection({
         );
     }
 
+    const farmTotalDuration = farmOperations.reduce(
+        (sum, operation) => sum + operation.durationMinutes,
+        0,
+    );
+
     return (
-        <Stack spacing={4}>
-            {farmOperations.length > 0 && (
-                <Stack spacing={2}>
-                    <Row spacing={2} className="items-center flex-wrap gap-y-1">
-                        <Typography semiBold>Farma</Typography>
-                        <Typography
-                            level="body2"
-                            className="text-muted-foreground"
-                        >
-                            {farmOperations.length} zadataka
-                        </Typography>
-                    </Row>
-                    <Stack spacing={2}>
-                        {farmOperations.map((operation) =>
-                            renderOperationCard(operation),
-                        )}
-                    </Stack>
-                </Stack>
-            )}
+        <Stack spacing={6}>
             {raisedBedGroups.map(
                 ({ key, physicalId, raisedBeds: groupedRaisedBeds }) => {
                     const dayOperations = scheduledOperations
@@ -331,11 +294,23 @@ export function FarmScheduleOperationsSection({
                                 label,
                             };
                         })
-                        .sort((left, right) =>
-                            left.label.localeCompare(right.label, undefined, {
-                                numeric: true,
-                            }),
-                        );
+                        .sort((left, right) => {
+                            const dateComparison = compareScheduleDates(
+                                left.scheduledDate,
+                                right.scheduledDate,
+                            );
+                            if (dateComparison !== 0) {
+                                return dateComparison;
+                            }
+
+                            return left.label.localeCompare(
+                                right.label,
+                                undefined,
+                                {
+                                    numeric: true,
+                                },
+                            );
+                        });
 
                     const totalDuration = dayOperations.reduce(
                         (sum, operation) => sum + operation.durationMinutes,
@@ -346,38 +321,31 @@ export function FarmScheduleOperationsSection({
                         <Stack key={key} spacing={2}>
                             <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
                                 <div className="min-w-0">
-                                    {physicalId ? (
-                                        <RaisedBedLabel
+                                    <Suspense
+                                        fallback={
+                                            <RaisedBedScheduleGroupHeader
+                                                physicalId={physicalId}
+                                            />
+                                        }
+                                    >
+                                        <RaisedBedScheduleGroupHeaderWithPhotos
                                             physicalId={physicalId}
+                                            raisedBeds={groupedRaisedBeds}
+                                            raisedBedPhotoPreviewByIdPromise={
+                                                raisedBedPhotoPreviewByIdPromise
+                                            }
                                         />
-                                    ) : (
-                                        <Typography
-                                            semiBold
-                                            className="truncate"
-                                        >
-                                            Gredica bez fizičkog ID-a
-                                        </Typography>
-                                    )}
+                                    </Suspense>
                                 </div>
                                 <Row
                                     spacing={2}
                                     className="justify-end text-right"
                                 >
-                                    <Typography
-                                        level="body2"
-                                        className="whitespace-nowrap text-muted-foreground"
-                                    >
-                                        {dayOperations.length} zadataka
-                                    </Typography>
-                                    {totalDuration > 0 && (
-                                        <Typography
-                                            level="body2"
-                                            className="whitespace-nowrap text-muted-foreground"
-                                        >
-                                            Vrijeme:{' '}
-                                            {formatMinutes(totalDuration)}
-                                        </Typography>
-                                    )}
+                                    <ScheduleSectionSummaryBadges
+                                        count={dayOperations.length}
+                                        countLabel="zadataka"
+                                        durationMinutes={totalDuration}
+                                    />
                                 </Row>
                             </div>
                             <Stack spacing={2}>
@@ -413,25 +381,19 @@ export function FarmScheduleOperationsSection({
                                         operationData?.conditions
                                             ?.completionAttachNotesRequired,
                                     );
-                                    const completionRequirementTexts = [
-                                        attachImages
-                                            ? attachImagesRequired
-                                                ? 'Slike obavezne'
-                                                : 'Slike opcionalne'
-                                            : null,
-                                        attachNotes
-                                            ? attachNotesRequired
-                                                ? 'Napomena obavezna'
-                                                : 'Napomena opcionalna'
-                                            : null,
-                                    ].filter((text): text is string =>
-                                        Boolean(text),
-                                    );
+                                    const showRequirementIcons =
+                                        !completed &&
+                                        (attachImages || attachNotes);
 
                                     return (
                                         <div
                                             key={operation.id}
-                                            className="rounded-lg border bg-white px-3 py-2"
+                                            className={cx(
+                                                'rounded-lg border px-3 py-2 transition-opacity',
+                                                completed
+                                                    ? 'bg-white/70 opacity-70'
+                                                    : 'bg-white',
+                                            )}
                                         >
                                             <Row
                                                 spacing={2}
@@ -486,50 +448,16 @@ export function FarmScheduleOperationsSection({
                                                             spacing={2}
                                                             className="items-center flex-wrap gap-y-1"
                                                         >
-                                                            <Typography
-                                                                level="body2"
-                                                                className={
-                                                                    completed
-                                                                        ? 'text-green-600'
-                                                                        : 'text-muted-foreground'
+                                                            <ScheduleTaskDurationChip
+                                                                minutes={
+                                                                    operation.durationMinutes
                                                                 }
-                                                            >
-                                                                {completed
-                                                                    ? 'Završeno'
-                                                                    : 'Potvrđeno'}
-                                                            </Typography>
-                                                            {operation.durationMinutes >
-                                                                0 && (
-                                                                <Typography
-                                                                    level="body2"
-                                                                    className="text-muted-foreground"
-                                                                >
-                                                                    {formatMinutes(
-                                                                        operation.durationMinutes,
-                                                                    )}
-                                                                </Typography>
-                                                            )}
-                                                            <Typography
-                                                                level="body2"
-                                                                className="text-muted-foreground"
-                                                            >
-                                                                {operation.scheduledDate ? (
-                                                                    <>
-                                                                        Planirano:{' '}
-                                                                        <LocalDateTime
-                                                                            time={
-                                                                                false
-                                                                            }
-                                                                        >
-                                                                            {
-                                                                                operation.scheduledDate
-                                                                            }
-                                                                        </LocalDateTime>
-                                                                    </>
-                                                                ) : (
-                                                                    'Danas'
-                                                                )}
-                                                            </Typography>
+                                                            />
+                                                            <ScheduleTaskDateChip
+                                                                scheduledDate={
+                                                                    operation.scheduledDate
+                                                                }
+                                                            />
                                                             {!completed && (
                                                                 <ScheduleTaskAgeIndicatorChip
                                                                     scheduledDate={
@@ -537,27 +465,32 @@ export function FarmScheduleOperationsSection({
                                                                     }
                                                                 />
                                                             )}
-                                                            {!completed &&
-                                                                completionRequirementTexts.length >
-                                                                    0 && (
-                                                                    <Typography
-                                                                        level="body2"
-                                                                        className="text-xs text-muted-foreground"
-                                                                    >
-                                                                        {completionRequirementTexts.join(
-                                                                            ' · ',
-                                                                        )}
-                                                                    </Typography>
-                                                                )}
                                                         </Row>
                                                     </Stack>
                                                 </Row>
-                                                {(completed ||
+                                                {(showRequirementIcons ||
+                                                    completed ||
                                                     operation.assignedUser) && (
                                                     <Row
                                                         spacing={1}
                                                         className="shrink-0 items-center"
                                                     >
+                                                        {showRequirementIcons && (
+                                                            <OperationRequirementIcons
+                                                                attachImages={
+                                                                    attachImages
+                                                                }
+                                                                attachImagesRequired={
+                                                                    attachImagesRequired
+                                                                }
+                                                                attachNotes={
+                                                                    attachNotes
+                                                                }
+                                                                attachNotesRequired={
+                                                                    attachNotesRequired
+                                                                }
+                                                            />
+                                                        )}
                                                         {completed && (
                                                             <OperationCompletionAttachments
                                                                 operationId={
@@ -604,6 +537,23 @@ export function FarmScheduleOperationsSection({
                         </Stack>
                     );
                 },
+            )}
+            {farmOperations.length > 0 && (
+                <Stack spacing={2}>
+                    <Row spacing={2} className="items-center flex-wrap gap-y-1">
+                        <Typography semiBold>Farma</Typography>
+                        <ScheduleSectionSummaryBadges
+                            count={farmOperations.length}
+                            countLabel="zadataka"
+                            durationMinutes={farmTotalDuration}
+                        />
+                    </Row>
+                    <Stack spacing={2}>
+                        {farmOperations.map((operation) =>
+                            renderOperationCard(operation),
+                        )}
+                    </Stack>
+                </Stack>
             )}
         </Stack>
     );

--- a/apps/farm/app/schedule/FarmScheduleOperationsSectionContent.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSectionContent.tsx
@@ -1,13 +1,16 @@
 import { FarmScheduleOperationsSection } from './FarmScheduleOperationsSection';
-import type { FarmScheduleDayData } from './scheduleData';
+import type { FarmScheduleOperationsDayData } from './scheduleData';
 
 interface FarmScheduleOperationsSectionContentProps {
-    dayDataPromise: Promise<FarmScheduleDayData>;
+    dayDataPromise: Promise<FarmScheduleOperationsDayData>;
     plantSortsPromise: ReturnType<
         typeof import('./scheduleData').getFarmSchedulePlantSorts
     >;
     operationsDataPromise: ReturnType<
         typeof import('./scheduleData').getFarmScheduleOperationsData
+    >;
+    raisedBedPhotoPreviewByIdPromise: ReturnType<
+        typeof import('./scheduleData').getFarmScheduleRaisedBedPhotoPreviewsForDay
     >;
     userId: string;
 }
@@ -16,6 +19,7 @@ export async function FarmScheduleOperationsSectionContent({
     dayDataPromise,
     plantSortsPromise,
     operationsDataPromise,
+    raisedBedPhotoPreviewByIdPromise,
     userId,
 }: FarmScheduleOperationsSectionContentProps) {
     const { raisedBeds, scheduledOperations } = await dayDataPromise;
@@ -35,6 +39,7 @@ export async function FarmScheduleOperationsSectionContent({
             scheduledOperations={scheduledOperations}
             plantSorts={plantSorts}
             operationsData={operationsData}
+            raisedBedPhotoPreviewByIdPromise={raisedBedPhotoPreviewByIdPromise}
             userId={userId}
         />
     );

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -5,17 +5,27 @@ import type {
 } from '@gredice/storage';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Chip } from '@gredice/ui/Chip';
-import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
-import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
+import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { UserAvatar } from '@gredice/ui/UserAvatar';
+import { cx } from '@gredice/ui/utils';
+import { Suspense } from 'react';
 import { CompletePlantingModal } from './CompletePlantingModal';
+import { PlantingAssignedUserAvatar } from './PlantingAssignedUserAvatar';
+import { RaisedBedScheduleGroupHeader } from './RaisedBedScheduleGroupHeader';
+import { RaisedBedScheduleGroupHeaderWithPhotos } from './RaisedBedScheduleGroupHeaderWithPhotos';
+import { SchedulePlantVisual } from './SchedulePlantVisual';
+import { ScheduleSectionSummaryBadges } from './ScheduleSectionSummaryBadges';
 import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
-import type { FarmScheduleDayData } from './scheduleData';
+import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
+import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
+import type {
+    FarmScheduleDayData,
+    FarmScheduleRaisedBedPhotoPreview,
+} from './scheduleData';
 import {
-    formatMinutes,
+    compareScheduleDates,
     getFieldPhysicalPositionIndex,
     groupRaisedBedsForSchedule,
     isFieldApproved,
@@ -30,7 +40,12 @@ interface FarmSchedulePlantingsSectionProps {
     scheduledFields: FarmScheduleDayData['scheduledFields'];
     plantSorts: EntityStandardized[] | null | undefined;
     userId: string;
-    assignedUserByFieldId: Map<number, RaisedBedFieldAssignableFarmUser>;
+    assignedUserByFieldIdPromise: Promise<
+        Map<number, RaisedBedFieldAssignableFarmUser>
+    >;
+    raisedBedPhotoPreviewByIdPromise: Promise<
+        Map<number, FarmScheduleRaisedBedPhotoPreview>
+    >;
 }
 
 function buildFieldLabel(
@@ -68,7 +83,8 @@ export function FarmSchedulePlantingsSection({
     scheduledFields,
     plantSorts,
     userId,
-    assignedUserByFieldId,
+    assignedUserByFieldIdPromise,
+    raisedBedPhotoPreviewByIdPromise,
 }: FarmSchedulePlantingsSectionProps) {
     if (scheduledFields.length === 0) {
         return null;
@@ -90,7 +106,7 @@ export function FarmSchedulePlantingsSection({
     );
 
     return (
-        <Stack spacing={4}>
+        <Stack spacing={6}>
             {raisedBedGroups.map(
                 ({ key, physicalId, raisedBeds: groupedRaisedBeds }) => {
                     const dayFields = scheduledFields
@@ -99,10 +115,6 @@ export function FarmSchedulePlantingsSection({
                                 (raisedBed) =>
                                     raisedBed.id === field.raisedBedId,
                             ),
-                        )
-                        .sort(
-                            (left, right) =>
-                                left.positionIndex - right.positionIndex,
                         )
                         .map((field) => {
                             const physicalPositionIndex =
@@ -120,6 +132,20 @@ export function FarmSchedulePlantingsSection({
                                     physicalPositionIndex,
                                 ),
                             };
+                        })
+                        .sort((left, right) => {
+                            const dateComparison = compareScheduleDates(
+                                left.plantScheduledDate,
+                                right.plantScheduledDate,
+                            );
+                            if (dateComparison !== 0) {
+                                return dateComparison;
+                            }
+
+                            return (
+                                left.physicalPositionIndex -
+                                right.physicalPositionIndex
+                            );
                         });
                     const totalDuration =
                         dayFields.length * PLANTING_TASK_DURATION_MINUTES;
@@ -128,38 +154,31 @@ export function FarmSchedulePlantingsSection({
                         <Stack key={key} spacing={2}>
                             <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
                                 <div className="min-w-0">
-                                    {physicalId ? (
-                                        <RaisedBedLabel
+                                    <Suspense
+                                        fallback={
+                                            <RaisedBedScheduleGroupHeader
+                                                physicalId={physicalId}
+                                            />
+                                        }
+                                    >
+                                        <RaisedBedScheduleGroupHeaderWithPhotos
                                             physicalId={physicalId}
+                                            raisedBeds={groupedRaisedBeds}
+                                            raisedBedPhotoPreviewByIdPromise={
+                                                raisedBedPhotoPreviewByIdPromise
+                                            }
                                         />
-                                    ) : (
-                                        <Typography
-                                            semiBold
-                                            className="truncate"
-                                        >
-                                            Gredica bez fizičkog ID-a
-                                        </Typography>
-                                    )}
+                                    </Suspense>
                                 </div>
                                 <Row
                                     spacing={2}
                                     className="justify-end text-right"
                                 >
-                                    <Typography
-                                        level="body2"
-                                        className="whitespace-nowrap text-muted-foreground"
-                                    >
-                                        {dayFields.length} sijanja
-                                    </Typography>
-                                    {totalDuration > 0 && (
-                                        <Typography
-                                            level="body2"
-                                            className="whitespace-nowrap text-muted-foreground"
-                                        >
-                                            Vrijeme:{' '}
-                                            {formatMinutes(totalDuration)}
-                                        </Typography>
-                                    )}
+                                    <ScheduleSectionSummaryBadges
+                                        count={dayFields.length}
+                                        countLabel="sijanja"
+                                        durationMinutes={totalDuration}
+                                    />
                                 </Row>
                             </div>
                             <Stack spacing={2}>
@@ -176,15 +195,28 @@ export function FarmSchedulePlantingsSection({
                                         field.assignedUserId !== userId;
                                     const canComplete =
                                         !completed && !lockedByAssignment;
-                                    const assignedUser =
-                                        assignedUserByFieldId.get(field.id);
                                     const greenhouseSowing =
                                         field.sowingLocation === 'greenhouse';
+                                    const plantSort = field.plantSortId
+                                        ? plantSortById.get(field.plantSortId)
+                                        : undefined;
+                                    const statusText =
+                                        !completed && !approved
+                                            ? 'Nije potvrđeno'
+                                            : null;
 
                                     return (
                                         <div
                                             key={field.id}
-                                            className={`rounded-lg border bg-white px-3 py-2 ${lockedByAssignment ? 'opacity-70' : ''}`}
+                                            className={cx(
+                                                'rounded-lg border px-3 py-2 transition-opacity',
+                                                completed
+                                                    ? 'bg-white/70 opacity-70'
+                                                    : 'bg-white',
+                                                lockedByAssignment &&
+                                                    !completed &&
+                                                    'opacity-70',
+                                            )}
                                         >
                                             <Row
                                                 spacing={2}
@@ -218,6 +250,10 @@ export function FarmSchedulePlantingsSection({
                                                             />
                                                         </div>
                                                     )}
+                                                    <SchedulePlantVisual
+                                                        plantSort={plantSort}
+                                                        label={field.label}
+                                                    />
                                                     <Stack
                                                         spacing={1}
                                                         className="min-w-0 grow"
@@ -235,29 +271,19 @@ export function FarmSchedulePlantingsSection({
                                                             spacing={2}
                                                             className="items-center flex-wrap gap-y-1"
                                                         >
-                                                            <Typography
-                                                                level="body2"
-                                                                className={
-                                                                    completed ||
-                                                                    approved
-                                                                        ? 'text-green-600'
-                                                                        : 'text-muted-foreground'
+                                                            {statusText && (
+                                                                <Typography
+                                                                    level="body2"
+                                                                    className="text-muted-foreground"
+                                                                >
+                                                                    {statusText}
+                                                                </Typography>
+                                                            )}
+                                                            <ScheduleTaskDurationChip
+                                                                minutes={
+                                                                    PLANTING_TASK_DURATION_MINUTES
                                                                 }
-                                                            >
-                                                                {completed
-                                                                    ? 'Završeno'
-                                                                    : approved
-                                                                      ? 'Potvrđeno'
-                                                                      : 'Nije potvrđeno'}
-                                                            </Typography>
-                                                            <Typography
-                                                                level="body2"
-                                                                className="text-muted-foreground"
-                                                            >
-                                                                {formatMinutes(
-                                                                    PLANTING_TASK_DURATION_MINUTES,
-                                                                )}
-                                                            </Typography>
+                                                            />
                                                             {greenhouseSowing && (
                                                                 <Chip
                                                                     size="sm"
@@ -267,27 +293,11 @@ export function FarmSchedulePlantingsSection({
                                                                     Staklenik
                                                                 </Chip>
                                                             )}
-                                                            <Typography
-                                                                level="body2"
-                                                                className="text-muted-foreground"
-                                                            >
-                                                                {field.plantScheduledDate ? (
-                                                                    <>
-                                                                        Planirano:{' '}
-                                                                        <LocalDateTime
-                                                                            time={
-                                                                                false
-                                                                            }
-                                                                        >
-                                                                            {
-                                                                                field.plantScheduledDate
-                                                                            }
-                                                                        </LocalDateTime>
-                                                                    </>
-                                                                ) : (
-                                                                    'Danas'
-                                                                )}
-                                                            </Typography>
+                                                            <ScheduleTaskDateChip
+                                                                scheduledDate={
+                                                                    field.plantScheduledDate
+                                                                }
+                                                            />
                                                             {!completed && (
                                                                 <ScheduleTaskAgeIndicatorChip
                                                                     scheduledDate={
@@ -298,22 +308,19 @@ export function FarmSchedulePlantingsSection({
                                                         </Row>
                                                     </Stack>
                                                 </Row>
-                                                {assignedUser && (
-                                                    <div
-                                                        className="shrink-0"
-                                                        title={`Dodijeljeno: ${assignedUser.displayName ?? assignedUser.userName}`}
+                                                {field.assignedUserId && (
+                                                    <Suspense
+                                                        fallback={
+                                                            <Skeleton className="size-7 shrink-0 rounded-full" />
+                                                        }
                                                     >
-                                                        <UserAvatar
-                                                            avatarUrl={
-                                                                assignedUser.avatarUrl
+                                                        <PlantingAssignedUserAvatar
+                                                            assignedUserByFieldIdPromise={
+                                                                assignedUserByFieldIdPromise
                                                             }
-                                                            displayName={
-                                                                assignedUser.displayName ??
-                                                                assignedUser.userName
-                                                            }
-                                                            className="size-7 rounded-full"
+                                                            fieldId={field.id}
                                                         />
-                                                    </div>
+                                                    </Suspense>
                                                 )}
                                             </Row>
                                         </div>

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSectionContent.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSectionContent.tsx
@@ -3,12 +3,15 @@ import {
     type RaisedBedFieldAssignableFarmUser,
 } from '@gredice/storage';
 import { FarmSchedulePlantingsSection } from './FarmSchedulePlantingsSection';
-import type { FarmScheduleDayData } from './scheduleData';
+import type { FarmSchedulePlantingsDayData } from './scheduleData';
 
 interface FarmSchedulePlantingsSectionContentProps {
-    dayDataPromise: Promise<FarmScheduleDayData>;
+    dayDataPromise: Promise<FarmSchedulePlantingsDayData>;
     plantSortsPromise: ReturnType<
         typeof import('./scheduleData').getFarmSchedulePlantSorts
+    >;
+    raisedBedPhotoPreviewByIdPromise: ReturnType<
+        typeof import('./scheduleData').getFarmScheduleRaisedBedPhotoPreviewsForDay
     >;
     userId: string;
 }
@@ -16,6 +19,7 @@ interface FarmSchedulePlantingsSectionContentProps {
 export async function FarmSchedulePlantingsSectionContent({
     dayDataPromise,
     plantSortsPromise,
+    raisedBedPhotoPreviewByIdPromise,
     userId,
 }: FarmSchedulePlantingsSectionContentProps) {
     const { raisedBeds, scheduledFields } = await dayDataPromise;
@@ -24,18 +28,41 @@ export async function FarmSchedulePlantingsSectionContent({
         return null;
     }
 
-    const [plantSorts, assignableFarmUsersByRaisedBedFieldId] =
-        await Promise.all([
-            plantSortsPromise,
-            getAssignableFarmUsersByRaisedBedFieldIds(
-                scheduledFields.map((field) => field.id),
-            ),
-        ]);
+    const assignedUserByFieldIdPromise =
+        getAssignedUserByFieldId(scheduledFields);
+    const plantSorts = await plantSortsPromise;
+
+    return (
+        <FarmSchedulePlantingsSection
+            raisedBeds={raisedBeds}
+            scheduledFields={scheduledFields}
+            plantSorts={plantSorts}
+            userId={userId}
+            assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
+            raisedBedPhotoPreviewByIdPromise={raisedBedPhotoPreviewByIdPromise}
+        />
+    );
+}
+
+async function getAssignedUserByFieldId(
+    scheduledFields: FarmSchedulePlantingsDayData['scheduledFields'],
+) {
+    const assignedFields = scheduledFields.filter(
+        (field) => field.assignedUserId,
+    );
+    if (assignedFields.length === 0) {
+        return new Map<number, RaisedBedFieldAssignableFarmUser>();
+    }
+
+    const assignableFarmUsersByRaisedBedFieldId =
+        await getAssignableFarmUsersByRaisedBedFieldIds(
+            assignedFields.map((field) => field.id),
+        );
     const assignedUserByFieldId = new Map<
         number,
         RaisedBedFieldAssignableFarmUser
     >();
-    for (const field of scheduledFields) {
+    for (const field of assignedFields) {
         if (!field.assignedUserId) {
             continue;
         }
@@ -47,13 +74,5 @@ export async function FarmSchedulePlantingsSectionContent({
         }
     }
 
-    return (
-        <FarmSchedulePlantingsSection
-            raisedBeds={raisedBeds}
-            scheduledFields={scheduledFields}
-            plantSorts={plantSorts}
-            userId={userId}
-            assignedUserByFieldId={assignedUserByFieldId}
-        />
-    );
+    return assignedUserByFieldId;
 }

--- a/apps/farm/app/schedule/OperationRequirementIcons.tsx
+++ b/apps/farm/app/schedule/OperationRequirementIcons.tsx
@@ -1,0 +1,65 @@
+import { Camera, FileText } from '@gredice/ui/icons';
+import { cx } from '@gredice/ui/utils';
+
+interface OperationRequirementIconsProps {
+    attachImages: boolean;
+    attachImagesRequired: boolean;
+    attachNotes: boolean;
+    attachNotesRequired: boolean;
+}
+
+export function OperationRequirementIcons({
+    attachImages,
+    attachImagesRequired,
+    attachNotes,
+    attachNotesRequired,
+}: OperationRequirementIconsProps) {
+    const requirements = [
+        attachImages
+            ? {
+                  key: 'images',
+                  title: attachImagesRequired
+                      ? 'Slike obavezne'
+                      : 'Slike opcionalne',
+                  required: attachImagesRequired,
+                  Icon: Camera,
+              }
+            : null,
+        attachNotes
+            ? {
+                  key: 'notes',
+                  title: attachNotesRequired
+                      ? 'Napomena obavezna'
+                      : 'Napomena opcionalna',
+                  required: attachNotesRequired,
+                  Icon: FileText,
+              }
+            : null,
+    ].filter((requirement): requirement is NonNullable<typeof requirement> =>
+        Boolean(requirement),
+    );
+
+    if (requirements.length === 0) {
+        return null;
+    }
+
+    return (
+        <span className="inline-flex shrink-0 items-center gap-1">
+            {requirements.map(({ key, title, required, Icon }) => (
+                <span
+                    key={key}
+                    title={title}
+                    className={cx(
+                        'inline-flex size-6 items-center justify-center rounded-md',
+                        required
+                            ? 'text-amber-700 dark:text-amber-300'
+                            : 'text-muted-foreground',
+                    )}
+                >
+                    <Icon className="size-4 shrink-0" aria-hidden="true" />
+                    <span className="sr-only">{title}</span>
+                </span>
+            ))}
+        </span>
+    );
+}

--- a/apps/farm/app/schedule/PlantingAssignedUserAvatar.tsx
+++ b/apps/farm/app/schedule/PlantingAssignedUserAvatar.tsx
@@ -1,0 +1,34 @@
+import type { RaisedBedFieldAssignableFarmUser } from '@gredice/storage';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
+
+interface PlantingAssignedUserAvatarProps {
+    assignedUserByFieldIdPromise: Promise<
+        Map<number, RaisedBedFieldAssignableFarmUser>
+    >;
+    fieldId: number;
+}
+
+export async function PlantingAssignedUserAvatar({
+    assignedUserByFieldIdPromise,
+    fieldId,
+}: PlantingAssignedUserAvatarProps) {
+    const assignedUserByFieldId = await assignedUserByFieldIdPromise;
+    const assignedUser = assignedUserByFieldId.get(fieldId);
+
+    if (!assignedUser) {
+        return null;
+    }
+
+    return (
+        <div
+            className="shrink-0"
+            title={`Dodijeljeno: ${assignedUser.displayName ?? assignedUser.userName}`}
+        >
+            <UserAvatar
+                avatarUrl={assignedUser.avatarUrl}
+                displayName={assignedUser.displayName ?? assignedUser.userName}
+                className="size-7 rounded-full"
+            />
+        </div>
+    );
+}

--- a/apps/farm/app/schedule/RaisedBedPhotoPreview.tsx
+++ b/apps/farm/app/schedule/RaisedBedPhotoPreview.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { ImageGallery } from '@gredice/ui/ImageGallery';
+import { Camera } from '@gredice/ui/icons';
+
+const previewSize = 44;
+const previewLimit = 3;
+
+type RaisedBedPhotoPreviewImage = {
+    src: string;
+    alt: string;
+};
+
+interface RaisedBedPhotoPreviewProps {
+    images: RaisedBedPhotoPreviewImage[];
+    label: string;
+    photoCount: number;
+}
+
+function getPhotoCountLabel(photoCount: number) {
+    if (photoCount === 1) {
+        return '1 fotografija';
+    }
+
+    if (photoCount > 1 && photoCount < 5) {
+        return `${photoCount} fotografije`;
+    }
+
+    return `${photoCount} fotografija`;
+}
+
+export function RaisedBedPhotoPreview({
+    images,
+    label,
+    photoCount,
+}: RaisedBedPhotoPreviewProps) {
+    const title =
+        photoCount > 0
+            ? `${label}: ${getPhotoCountLabel(photoCount)}`
+            : `${label}: nema fotografija`;
+
+    return (
+        <span
+            className="relative block h-11 w-12 shrink-0 overflow-visible"
+            title={title}
+        >
+            {images.length > 0 ? (
+                <ImageGallery
+                    images={images}
+                    previewWidth={previewSize}
+                    previewHeight={previewSize}
+                    previewVariant="stacked"
+                    previewLimitBeforeStack={previewLimit}
+                />
+            ) : (
+                <span className="flex size-11 items-center justify-center rounded-lg border bg-card text-muted-foreground shadow-xs">
+                    <Camera className="size-4" aria-hidden="true" />
+                    <span className="sr-only">{title}</span>
+                </span>
+            )}
+        </span>
+    );
+}

--- a/apps/farm/app/schedule/RaisedBedScheduleGroupHeader.tsx
+++ b/apps/farm/app/schedule/RaisedBedScheduleGroupHeader.tsx
@@ -1,0 +1,30 @@
+import { Row } from '@gredice/ui/Row';
+import { Typography } from '@gredice/ui/Typography';
+import { RaisedBedPhotoPreview } from './RaisedBedPhotoPreview';
+import type { FarmScheduleRaisedBedPhotoPreview } from './scheduleData';
+
+interface RaisedBedScheduleGroupHeaderProps {
+    physicalId: string | null;
+    photoPreview?: FarmScheduleRaisedBedPhotoPreview;
+}
+
+export function RaisedBedScheduleGroupHeader({
+    physicalId,
+    photoPreview,
+}: RaisedBedScheduleGroupHeaderProps) {
+    const label = physicalId ? `Gr ${physicalId}` : 'Gredica bez fizičkog ID-a';
+    const preview = photoPreview ?? { images: [], photoCount: 0 };
+
+    return (
+        <Row spacing={2} className="min-w-0 items-center">
+            <RaisedBedPhotoPreview
+                images={preview.images}
+                label={label}
+                photoCount={preview.photoCount}
+            />
+            <Typography semiBold className="truncate">
+                {label}
+            </Typography>
+        </Row>
+    );
+}

--- a/apps/farm/app/schedule/RaisedBedScheduleGroupHeaderWithPhotos.tsx
+++ b/apps/farm/app/schedule/RaisedBedScheduleGroupHeaderWithPhotos.tsx
@@ -1,0 +1,59 @@
+import { RaisedBedScheduleGroupHeader } from './RaisedBedScheduleGroupHeader';
+import type {
+    FarmScheduleDayData,
+    FarmScheduleRaisedBedPhotoPreview,
+    FarmScheduleRaisedBedPhotoPreviewImage,
+} from './scheduleData';
+
+type FarmRaisedBed = FarmScheduleDayData['raisedBeds'][number];
+
+interface RaisedBedScheduleGroupHeaderWithPhotosProps {
+    physicalId: string | null;
+    raisedBeds: FarmRaisedBed[];
+    raisedBedPhotoPreviewByIdPromise: Promise<
+        Map<number, FarmScheduleRaisedBedPhotoPreview>
+    >;
+}
+
+function getGroupPhotoPreview(
+    raisedBeds: FarmRaisedBed[],
+    raisedBedPhotoPreviewById: Map<number, FarmScheduleRaisedBedPhotoPreview>,
+) {
+    const images: FarmScheduleRaisedBedPhotoPreviewImage[] = [];
+    const seenImageUrls = new Set<string>();
+    const photoCount = raisedBeds.reduce((count, raisedBed) => {
+        const preview = raisedBedPhotoPreviewById.get(raisedBed.id);
+        for (const image of preview?.images ?? []) {
+            if (seenImageUrls.has(image.src)) {
+                continue;
+            }
+
+            seenImageUrls.add(image.src);
+            if (images.length < 3) {
+                images.push(image);
+            }
+        }
+
+        return count + (preview?.photoCount ?? 0);
+    }, 0);
+
+    return { images, photoCount };
+}
+
+export async function RaisedBedScheduleGroupHeaderWithPhotos({
+    physicalId,
+    raisedBeds,
+    raisedBedPhotoPreviewByIdPromise,
+}: RaisedBedScheduleGroupHeaderWithPhotosProps) {
+    const raisedBedPhotoPreviewById = await raisedBedPhotoPreviewByIdPromise;
+
+    return (
+        <RaisedBedScheduleGroupHeader
+            physicalId={physicalId}
+            photoPreview={getGroupPhotoPreview(
+                raisedBeds,
+                raisedBedPhotoPreviewById,
+            )}
+        />
+    );
+}

--- a/apps/farm/app/schedule/SchedulePlantVisual.tsx
+++ b/apps/farm/app/schedule/SchedulePlantVisual.tsx
@@ -1,0 +1,50 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { PlantingSeedIcon } from '@gredice/ui/PlantingSeedIcon';
+import Image from 'next/image';
+
+function getCoverUrl(entity: EntityStandardized | null | undefined) {
+    return entity?.image?.cover?.url ?? entity?.images?.cover?.url ?? null;
+}
+
+function getPlantSortCoverUrl(
+    plantSort: EntityStandardized | null | undefined,
+) {
+    return (
+        getCoverUrl(plantSort) ??
+        getCoverUrl(plantSort?.information?.plant) ??
+        null
+    );
+}
+
+function isHostedImageUrl(url: string | null | undefined): url is string {
+    return !!url && /^https?:\/\//u.test(url);
+}
+
+export function SchedulePlantVisual({
+    plantSort,
+    label,
+}: {
+    plantSort: EntityStandardized | null | undefined;
+    label: string;
+}) {
+    const coverUrl = getPlantSortCoverUrl(plantSort);
+
+    return (
+        <span className="flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-md bg-primary/10 text-primary">
+            {isHostedImageUrl(coverUrl) ? (
+                <Image
+                    src={coverUrl}
+                    alt={label}
+                    width={28}
+                    height={28}
+                    className="size-full object-cover"
+                />
+            ) : (
+                <PlantingSeedIcon
+                    aria-hidden="true"
+                    className="size-4 shrink-0"
+                />
+            )}
+        </span>
+    );
+}

--- a/apps/farm/app/schedule/ScheduleSectionSummaryBadges.tsx
+++ b/apps/farm/app/schedule/ScheduleSectionSummaryBadges.tsx
@@ -1,0 +1,42 @@
+import { Chip } from '@gredice/ui/Chip';
+import { ListTodo, Timer } from '@gredice/ui/icons';
+import { formatMinutes } from './scheduleShared';
+
+interface ScheduleSectionSummaryBadgesProps {
+    count: number;
+    countLabel: string;
+    durationMinutes: number;
+}
+
+export function ScheduleSectionSummaryBadges({
+    count,
+    countLabel,
+    durationMinutes,
+}: ScheduleSectionSummaryBadgesProps) {
+    return (
+        <span className="inline-flex flex-wrap items-center justify-end gap-1.5">
+            <Chip
+                size="sm"
+                color="neutral"
+                variant="soft"
+                title="Broj zadataka"
+                className="bg-muted/60 text-muted-foreground"
+                startDecorator={<ListTodo aria-hidden="true" />}
+            >
+                {count} {countLabel}
+            </Chip>
+            {durationMinutes > 0 && (
+                <Chip
+                    size="sm"
+                    color="neutral"
+                    variant="soft"
+                    title="Vrijeme"
+                    className="bg-muted/60 text-muted-foreground"
+                    startDecorator={<Timer aria-hidden="true" />}
+                >
+                    {formatMinutes(durationMinutes)}
+                </Chip>
+            )}
+        </span>
+    );
+}

--- a/apps/farm/app/schedule/ScheduleTaskDateChip.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskDateChip.tsx
@@ -1,0 +1,36 @@
+import { Chip } from '@gredice/ui/Chip';
+import { Calendar } from '@gredice/ui/icons';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { getScheduleDateFormat, isScheduleDatePast } from './scheduleShared';
+
+interface ScheduleTaskDateChipProps {
+    scheduledDate: Date | string | null | undefined;
+}
+
+export function ScheduleTaskDateChip({
+    scheduledDate,
+}: ScheduleTaskDateChipProps) {
+    const isPast = isScheduleDatePast(scheduledDate);
+
+    return (
+        <Chip
+            size="sm"
+            color={isPast ? 'warning' : 'neutral'}
+            variant="soft"
+            title={isPast ? 'Planirani datum je u prošlosti' : 'Planirano'}
+            className={isPast ? undefined : 'bg-muted/60 text-muted-foreground'}
+            startDecorator={<Calendar aria-hidden="true" />}
+        >
+            {scheduledDate ? (
+                <LocalDateTime
+                    time={false}
+                    format={getScheduleDateFormat(scheduledDate)}
+                >
+                    {scheduledDate}
+                </LocalDateTime>
+            ) : (
+                'Danas'
+            )}
+        </Chip>
+    );
+}

--- a/apps/farm/app/schedule/ScheduleTaskDurationChip.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskDurationChip.tsx
@@ -1,0 +1,28 @@
+import { Chip } from '@gredice/ui/Chip';
+import { Timer } from '@gredice/ui/icons';
+import { formatMinutes } from './scheduleShared';
+
+interface ScheduleTaskDurationChipProps {
+    minutes: number;
+}
+
+export function ScheduleTaskDurationChip({
+    minutes,
+}: ScheduleTaskDurationChipProps) {
+    if (minutes <= 0) {
+        return null;
+    }
+
+    return (
+        <Chip
+            size="sm"
+            color="neutral"
+            variant="soft"
+            title="Trajanje"
+            className="bg-muted/60 text-muted-foreground"
+            startDecorator={<Timer aria-hidden="true" />}
+        >
+            {formatMinutes(minutes)}
+        </Chip>
+    );
+}

--- a/apps/farm/app/schedule/loading.tsx
+++ b/apps/farm/app/schedule/loading.tsx
@@ -1,0 +1,9 @@
+import { FarmScheduleLoadingState } from './FarmScheduleLoadingState';
+
+export default function FarmScheduleLoading() {
+    return (
+        <div className="min-h-[100dvh] w-full bg-background">
+            <FarmScheduleLoadingState />
+        </div>
+    );
+}

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -1,70 +1,120 @@
-import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
-import { ScheduleDateNavigation } from '@gredice/ui/ScheduleDateNavigation';
 import { Suspense } from 'react';
 import LoginDialog from '../../components/auth/LoginDialog';
-import { HomeButton } from '../../components/HomeButton';
 import { auth } from '../../lib/auth/auth';
 import { FarmScheduleDay } from './FarmScheduleDay';
+import { FarmScheduleNavigationFrame } from './FarmScheduleNavigationFrame';
 import { ScheduleDaySummarySection } from './ScheduleDaySummarySection';
 import { ScheduleDaySummarySkeleton } from './ScheduleDaySummarySkeleton';
 import { ScheduleLabelPrintSection } from './ScheduleLabelPrintSection';
 import {
     getFarmScheduleDayData,
     getFarmScheduleOperationsData,
+    getFarmScheduleOperationsDayData,
+    getFarmSchedulePlantingsDayData,
     getFarmSchedulePlantSorts,
 } from './scheduleData';
 
 export const dynamic = 'force-dynamic';
 
-async function FarmScheduleContent({ date }: { date: Date }) {
-    const { userId } = await auth(['farmer', 'admin']);
+function formatDateParam(date: Date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function parseDateParam(dateParam?: string) {
+    if (!dateParam) {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        return today;
+    }
+
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateParam);
+    if (!match) {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        return today;
+    }
+
+    const year = Number.parseInt(match[1], 10);
+    const monthIndex = Number.parseInt(match[2], 10) - 1;
+    const day = Number.parseInt(match[3], 10);
+    const date = new Date(year, monthIndex, day);
+    date.setHours(0, 0, 0, 0);
+
+    if (
+        Number.isNaN(date.getTime()) ||
+        date.getFullYear() !== year ||
+        date.getMonth() !== monthIndex ||
+        date.getDate() !== day
+    ) {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        return today;
+    }
+
+    return date;
+}
+
+async function getFarmAuth() {
+    try {
+        return await auth(['farmer', 'admin']);
+    } catch {
+        return null;
+    }
+}
+
+function FarmScheduleContent({ date, userId }: { date: Date; userId: string }) {
     const isToday = new Date().toDateString() === date.toDateString();
     const dateKey = date.toISOString();
+    const selectedDateKey = formatDateParam(date);
     const dayDataPromise = getFarmScheduleDayData(userId, dateKey, isToday);
+    const plantingsDayDataPromise = getFarmSchedulePlantingsDayData(
+        userId,
+        dateKey,
+        isToday,
+    );
+    const operationsDayDataPromise = getFarmScheduleOperationsDayData(
+        userId,
+        dateKey,
+        isToday,
+    );
     const operationsDataPromise = getFarmScheduleOperationsData();
     const plantSortsPromise = getFarmSchedulePlantSorts();
 
     return (
-        <div className="max-w-5xl mx-auto w-full space-y-4 px-2 py-4 sm:p-4">
-            <div className="space-y-2">
-                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-1 sm:gap-2">
-                    <div className="justify-self-start">
-                        <HomeButton className="h-8 sm:h-10" />
-                    </div>
-                    <div className="min-w-0 justify-self-center">
-                        <ScheduleDateNavigation
-                            date={date}
-                            basePath="/schedule"
-                            compact
-                        />
-                    </div>
-                    <div className="min-w-0 justify-self-end">
-                        <Suspense fallback={<ScheduleDaySummarySkeleton />}>
-                            <ScheduleDaySummarySection
-                                dayDataPromise={dayDataPromise}
-                                operationsDataPromise={operationsDataPromise}
-                            />
-                        </Suspense>
-                    </div>
-                </div>
-                <div className="flex min-w-0 justify-end">
-                    <Suspense fallback={null}>
-                        <ScheduleLabelPrintSection
-                            dayDataPromise={dayDataPromise}
-                            operationsDataPromise={operationsDataPromise}
-                            plantSortsPromise={plantSortsPromise}
-                            date={date}
-                        />
-                    </Suspense>
-                </div>
-            </div>
+        <FarmScheduleNavigationFrame
+            selectedDateKey={selectedDateKey}
+            summarySlot={
+                <Suspense fallback={<ScheduleDaySummarySkeleton />}>
+                    <ScheduleDaySummarySection
+                        dayDataPromise={dayDataPromise}
+                        operationsDataPromise={operationsDataPromise}
+                    />
+                </Suspense>
+            }
+            labelPrintSlot={
+                <Suspense fallback={null}>
+                    <ScheduleLabelPrintSection
+                        dayDataPromise={dayDataPromise}
+                        operationsDataPromise={operationsDataPromise}
+                        plantSortsPromise={plantSortsPromise}
+                        date={date}
+                    />
+                </Suspense>
+            }
+        >
             <FarmScheduleDay
+                key={selectedDateKey}
                 dayDataPromise={dayDataPromise}
+                plantingsDayDataPromise={plantingsDayDataPromise}
+                operationsDayDataPromise={operationsDayDataPromise}
                 operationsDataPromise={operationsDataPromise}
                 plantSortsPromise={plantSortsPromise}
                 userId={userId}
             />
-        </div>
+        </FarmScheduleNavigationFrame>
     );
 }
 
@@ -74,23 +124,16 @@ export default async function FarmSchedulePage({
     searchParams: Promise<{ date?: string }>;
 }) {
     const { date: dateParam } = await searchParams;
-    const date = new Date();
-    if (dateParam) {
-        const [year, month, day] = dateParam.split('-').map(Number);
-        date.setFullYear(year, month - 1, day);
-    }
-    date.setHours(0, 0, 0, 0);
-
-    const authFarmer = auth.bind(null, ['farmer', 'admin']);
+    const date = parseDateParam(dateParam);
+    const authContext = await getFarmAuth();
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
-            <AuthProtectedSection auth={authFarmer}>
-                <FarmScheduleContent date={date} />
-            </AuthProtectedSection>
-            <SignedOut auth={authFarmer}>
+        <div className="min-h-[100dvh] w-full bg-background">
+            {authContext ? (
+                <FarmScheduleContent date={date} userId={authContext.userId} />
+            ) : (
                 <LoginDialog />
-            </SignedOut>
+            )}
         </div>
     );
 }

--- a/apps/farm/app/schedule/scheduleData.ts
+++ b/apps/farm/app/schedule/scheduleData.ts
@@ -5,13 +5,16 @@ import {
     type EntityStandardized,
     getEntitiesFormatted,
     getFarmUserAcceptedOperations,
+    getFarmUserAcceptedOperationsByScheduleRange,
     getFarmUserRaisedBeds,
+    getRaisedBedPhotoPreviews,
     scheduleCacheKeys,
     scheduleCacheTtls,
 } from '@gredice/storage';
 import { cache } from 'react';
 
 const operationsBackDays = 90;
+const raisedBedPhotoPreviewImageLimit = 3;
 const SCHEDULE_FIELD_STATUSES = new Set([
     'planned',
     'pendingVerification',
@@ -34,6 +37,16 @@ function startOfDaysAgo(days: number) {
     const date = startOfToday();
     date.setDate(date.getDate() - days);
     return date;
+}
+
+function getDayRange(date: Date) {
+    const from = new Date(date);
+    from.setHours(0, 0, 0, 0);
+
+    const to = new Date(date);
+    to.setHours(23, 59, 59, 999);
+
+    return { from, to };
 }
 
 function dedupeById<T extends { id: number }>(items: T[]) {
@@ -87,8 +100,7 @@ function getScheduledFieldsForDay(
         });
 }
 
-function getScheduledOperationsForDay(
-    isToday: boolean,
+function getSelectedDateOperationsForDay(
     date: Date,
     operations: FarmScheduleOperation[],
 ) {
@@ -117,18 +129,54 @@ function getScheduledOperationsForDay(
         const scheduledDate = operation.scheduledDate
             ? new Date(operation.scheduledDate)
             : undefined;
-        const sameDay =
-            scheduledDate !== undefined &&
-            normalizedDate.toDateString() === scheduledDate.toDateString();
-        const isUnscheduledToday = scheduledDate === undefined && isToday;
-        const isOverdueToday =
-            scheduledDate !== undefined &&
-            isToday &&
-            normalizedDate > scheduledDate &&
-            !isOperationCompleted(operation.status);
 
-        return sameDay || isUnscheduledToday || isOverdueToday;
+        return (
+            scheduledDate !== undefined &&
+            normalizedDate.toDateString() === scheduledDate.toDateString()
+        );
     });
+}
+
+function getCarryoverOperationsForToday(
+    isToday: boolean,
+    date: Date,
+    operations: FarmScheduleOperation[],
+) {
+    if (!isToday) {
+        return [];
+    }
+
+    const normalizedDate = new Date(date);
+    normalizedDate.setHours(0, 0, 0, 0);
+
+    return operations.filter((operation) => {
+        if (!SCHEDULE_OPERATION_STATUSES.has(operation.status)) {
+            return false;
+        }
+
+        if (isOperationCompleted(operation.status)) {
+            return false;
+        }
+
+        if (
+            operation.raisedBedId === null &&
+            typeof operation.farmId !== 'number'
+        ) {
+            return false;
+        }
+
+        if (!operation.scheduledDate) {
+            return true;
+        }
+
+        return normalizedDate > new Date(operation.scheduledDate);
+    });
+}
+
+function sortOperationsNewestFirst(operations: FarmScheduleOperation[]) {
+    return operations.sort(
+        (left, right) => right.timestamp.getTime() - left.timestamp.getTime(),
+    );
 }
 
 export type FarmScheduleRaisedBed = Awaited<
@@ -137,10 +185,23 @@ export type FarmScheduleRaisedBed = Awaited<
 export type FarmScheduleOperation = Awaited<
     ReturnType<typeof getFarmUserAcceptedOperations>
 >[number];
-export type FarmScheduleDayData = {
+export type FarmSchedulePlantingsDayData = {
     raisedBeds: FarmScheduleRaisedBed[];
     scheduledFields: FarmScheduleRaisedBed['fields'];
+};
+export type FarmScheduleOperationsDayData = {
+    raisedBeds: FarmScheduleRaisedBed[];
     scheduledOperations: FarmScheduleOperation[];
+};
+export type FarmScheduleDayData = FarmSchedulePlantingsDayData &
+    FarmScheduleOperationsDayData;
+export type FarmScheduleRaisedBedPhotoPreviewImage = {
+    src: string;
+    alt: string;
+};
+export type FarmScheduleRaisedBedPhotoPreview = {
+    images: FarmScheduleRaisedBedPhotoPreviewImage[];
+    photoCount: number;
 };
 
 export const getFarmScheduleRaisedBeds = cache(async (userId: string) => {
@@ -154,6 +215,65 @@ export const getFarmSchedulePlantSorts = cache(async () => {
 export const getFarmScheduleOperationsData = cache(async () => {
     return getEntitiesFormatted<EntityStandardized>('operation');
 });
+
+export async function getFarmScheduleRaisedBedPhotoPreviewsForDay(
+    dayDataPromise: Promise<FarmScheduleDayData>,
+) {
+    const dayData = await dayDataPromise;
+    const visibleRaisedBedIds = Array.from(
+        new Set([
+            ...dayData.scheduledFields.map((field) => field.raisedBedId),
+            ...dayData.scheduledOperations
+                .map((operation) => operation.raisedBedId)
+                .filter((id): id is number => id !== null),
+        ]),
+    ).sort((left, right) => left - right);
+
+    if (visibleRaisedBedIds.length === 0) {
+        return new Map<number, FarmScheduleRaisedBedPhotoPreview>();
+    }
+
+    const visibleRaisedBedIdSet = new Set(visibleRaisedBedIds);
+    const visibleRaisedBeds = dayData.raisedBeds.filter((raisedBed) =>
+        visibleRaisedBedIdSet.has(raisedBed.id),
+    );
+    const previews = await cacheScheduleRead(
+        scheduleCacheKeys.farmRaisedBedPhotoPreviews(visibleRaisedBedIds),
+        () =>
+            getRaisedBedPhotoPreviews(
+                visibleRaisedBedIds,
+                raisedBedPhotoPreviewImageLimit,
+            ),
+        scheduleCacheTtls.operations,
+    );
+    const previewByRaisedBedId = new Map(
+        previews.map((preview) => [preview.raisedBedId, preview]),
+    );
+
+    return new Map<number, FarmScheduleRaisedBedPhotoPreview>(
+        visibleRaisedBeds.map(
+            (raisedBed): [number, FarmScheduleRaisedBedPhotoPreview] => {
+                const preview = previewByRaisedBedId.get(raisedBed.id);
+                const label = raisedBed.physicalId
+                    ? `Gr ${raisedBed.physicalId}`
+                    : `gredice ${raisedBed.id}`;
+
+                return [
+                    raisedBed.id,
+                    {
+                        images: (preview?.imageUrls ?? []).map(
+                            (imageUrl, index) => ({
+                                src: imageUrl,
+                                alt: `Fotografija ${label} ${index + 1}`,
+                            }),
+                        ),
+                        photoCount: preview?.photoCount ?? 0,
+                    },
+                ];
+            },
+        ),
+    );
+}
 
 export const getFarmScheduleOperations = cache(async (userId: string) => {
     const from = startOfDaysAgo(operationsBackDays);
@@ -187,6 +307,102 @@ export const getFarmScheduleOperations = cache(async (userId: string) => {
     );
 });
 
+export const getFarmScheduleOperationsForDay = cache(
+    async (userId: string, dateKey: string, isToday: boolean) => {
+        const [selectedDateOperations, carryoverOperations] = await Promise.all(
+            [
+                getFarmScheduleSelectedDateOperationsForDay(userId, dateKey),
+                getFarmScheduleCarryoverOperationsForDay(
+                    userId,
+                    dateKey,
+                    isToday,
+                ),
+            ],
+        );
+
+        return sortOperationsNewestFirst(
+            dedupeById([...carryoverOperations, ...selectedDateOperations]),
+        );
+    },
+);
+
+export const getFarmScheduleSelectedDateOperationsForDay = cache(
+    async (userId: string, dateKey: string) => {
+        const date = new Date(dateKey);
+        const { from, to } = getDayRange(date);
+        const [scheduledOperations, completedOperations] = await Promise.all([
+            getFarmUserAcceptedOperationsByScheduleRange({
+                userId,
+                from,
+                to,
+            }),
+            getFarmUserAcceptedOperations(userId, {
+                completedFrom: from,
+                completedTo: to,
+                status: ['pendingVerification', 'completed'],
+            }),
+        ]);
+
+        return getSelectedDateOperationsForDay(
+            date,
+            sortOperationsNewestFirst(
+                dedupeById([...scheduledOperations, ...completedOperations]),
+            ),
+        );
+    },
+);
+
+export const getFarmScheduleCarryoverOperationsForDay = cache(
+    async (userId: string, dateKey: string, isToday: boolean) => {
+        if (!isToday) {
+            return [];
+        }
+
+        const date = new Date(dateKey);
+        const operations = await getFarmScheduleOperations(userId);
+
+        return getCarryoverOperationsForToday(isToday, date, operations);
+    },
+);
+
+export const getFarmSchedulePlantingsDayData = cache(
+    async (
+        userId: string,
+        dateKey: string,
+        isToday: boolean,
+    ): Promise<FarmSchedulePlantingsDayData> => {
+        const date = new Date(dateKey);
+        const raisedBeds = await getFarmScheduleRaisedBeds(userId);
+
+        return {
+            raisedBeds,
+            scheduledFields: getScheduledFieldsForDay(
+                isToday,
+                date,
+                raisedBeds,
+            ),
+        };
+    },
+);
+
+export const getFarmScheduleOperationsDayData = cache(
+    async (
+        userId: string,
+        dateKey: string,
+        isToday: boolean,
+    ): Promise<FarmScheduleOperationsDayData> => {
+        const [raisedBeds, scheduledOperations] = await Promise.all([
+            getFarmScheduleRaisedBeds(userId),
+            getFarmScheduleOperationsForDay(userId, dateKey, isToday),
+        ]);
+
+        return {
+            raisedBeds,
+            scheduledOperations,
+        };
+    },
+);
+
 export const getFarmScheduleDayData = cache(
     async (
         userId: string,
@@ -196,24 +412,24 @@ export const getFarmScheduleDayData = cache(
         return cacheScheduleRead(
             scheduleCacheKeys.farmUserDay(userId, dateKey, isToday),
             async () => {
-                const date = new Date(dateKey);
-                const [raisedBeds, operations] = await Promise.all([
-                    getFarmScheduleRaisedBeds(userId),
-                    getFarmScheduleOperations(userId),
-                ]);
+                const [plantingsDayData, scheduledOperations] =
+                    await Promise.all([
+                        getFarmSchedulePlantingsDayData(
+                            userId,
+                            dateKey,
+                            isToday,
+                        ),
+                        getFarmScheduleOperationsForDay(
+                            userId,
+                            dateKey,
+                            isToday,
+                        ),
+                    ]);
 
                 return {
-                    raisedBeds,
-                    scheduledFields: getScheduledFieldsForDay(
-                        isToday,
-                        date,
-                        raisedBeds,
-                    ),
-                    scheduledOperations: getScheduledOperationsForDay(
-                        isToday,
-                        date,
-                        operations,
-                    ),
+                    raisedBeds: plantingsDayData.raisedBeds,
+                    scheduledFields: plantingsDayData.scheduledFields,
+                    scheduledOperations,
                 };
             },
             scheduleCacheTtls.day,

--- a/apps/farm/app/schedule/scheduleShared.ts
+++ b/apps/farm/app/schedule/scheduleShared.ts
@@ -102,6 +102,57 @@ export function formatMinutes(minutes: number) {
     return `${Math.ceil(Math.max(0, minutes))} min`;
 }
 
+export function getScheduleDateFormat(
+    scheduledDate: Date | string | null | undefined,
+    referenceDate = new Date(),
+): Intl.DateTimeFormatOptions {
+    const parsedScheduledDate = parseScheduleDate(scheduledDate);
+    const includeYear =
+        !parsedScheduledDate ||
+        parsedScheduledDate.getFullYear() !== referenceDate.getFullYear();
+
+    return includeYear
+        ? {
+              day: '2-digit',
+              month: '2-digit',
+              year: 'numeric',
+          }
+        : {
+              day: '2-digit',
+              month: '2-digit',
+          };
+}
+
+export function isScheduleDatePast(
+    scheduledDate: Date | string | null | undefined,
+    referenceDate = new Date(),
+) {
+    const parsedScheduledDate = parseScheduleDate(scheduledDate);
+    if (!parsedScheduledDate) {
+        return false;
+    }
+
+    return (
+        getLocalDayNumber(parsedScheduledDate) <
+        getLocalDayNumber(referenceDate)
+    );
+}
+
+function getScheduleDateSortValue(date: Date | string | null | undefined) {
+    const parsedDate = parseScheduleDate(date);
+
+    return parsedDate
+        ? getLocalDayNumber(parsedDate)
+        : Number.POSITIVE_INFINITY;
+}
+
+export function compareScheduleDates(
+    left: Date | string | null | undefined,
+    right: Date | string | null | undefined,
+) {
+    return getScheduleDateSortValue(left) - getScheduleDateSortValue(right);
+}
+
 export function getOperationDurationMinutes(
     operationData: EntityStandardized | undefined,
 ) {

--- a/apps/farm/app/settings/page.tsx
+++ b/apps/farm/app/settings/page.tsx
@@ -21,7 +21,7 @@ export default function FarmSettingsPage() {
     const authFarmer = auth.bind(null, ['farmer', 'admin']);
 
     return (
-        <div className="min-h-[100dvh] w-full bg-muted">
+        <div className="min-h-[100dvh] w-full bg-background">
             <AuthProtectedSection auth={authFarmer}>
                 <FarmSettingsContent />
             </AuthProtectedSection>

--- a/apps/farm/next.config.ts
+++ b/apps/farm/next.config.ts
@@ -21,6 +21,12 @@ const nextConfig: NextConfig = {
         remotePatterns: [
             {
                 protocol: 'https',
+                hostname: 'www.gredice.com',
+                port: '',
+                pathname: '/assets/**',
+            },
+            {
+                protocol: 'https',
                 hostname: 'cdn.gredice.com',
             },
             {
@@ -32,6 +38,7 @@ const nextConfig: NextConfig = {
                 hostname: '7ql7fvz1vzzo6adz.public.blob.vercel-storage.com',
             },
         ],
+        qualities: [75, 100],
     },
     productionBrowserSourceMaps: !process.env.CI,
     allowedDevOrigins: getAppAllowedDevOrigins(app),

--- a/packages/storage/src/cache/scheduleCache.ts
+++ b/packages/storage/src/cache/scheduleCache.ts
@@ -85,6 +85,10 @@ export const scheduleCacheKeys = {
         `schedule:farm:user:${safePart(userId)}:operations:${rangePart(input)}:${CACHE_VERSION}`,
     farmUserActiveOperations: (userId: string, from: Date) =>
         `schedule:farm:user:${safePart(userId)}:operations:active:from:${dateTimePart(from)}:${CACHE_VERSION}`,
+    farmUserScheduledOperations: (userId: string, from: Date, to: Date) =>
+        `schedule:farm:user:${safePart(userId)}:operations:scheduled:from:${dateTimePart(from)}:to:${dateTimePart(to)}:${CACHE_VERSION}`,
+    farmRaisedBedPhotoPreviews: (raisedBedIds: number[]) =>
+        `schedule:farm:raisedBedPhotoPreviews:${raisedBedIds.map(safePart).join(',')}:${CACHE_VERSION}`,
     farmUserDay: (userId: string, date: Date | string, isToday: boolean) =>
         `schedule:farm:user:${safePart(userId)}:day:${localDateKey(date)}:today:${isToday ? '1' : '0'}:${CACHE_VERSION}`,
     deliveryRequestsSummary: (input: DeliveryRequestsSummaryCacheInput) =>

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -532,6 +532,109 @@ export async function getOperationsPage(
     };
 }
 
+export type RaisedBedPhotoPreview = {
+    raisedBedId: number;
+    imageUrls: string[];
+    photoCount: number;
+};
+
+function getCompletionEventImageUrls(data: unknown) {
+    if (!data || typeof data !== 'object') {
+        return [];
+    }
+
+    const images = Reflect.get(data, 'images');
+    if (!Array.isArray(images)) {
+        return [];
+    }
+
+    return images.filter(
+        (url): url is string =>
+            typeof url === 'string' && url.trim().length > 0,
+    );
+}
+
+export async function getRaisedBedPhotoPreviews(
+    raisedBedIds: number[],
+    imageLimit = 3,
+): Promise<RaisedBedPhotoPreview[]> {
+    const uniqueRaisedBedIds = Array.from(new Set(raisedBedIds)).sort(
+        (left, right) => left - right,
+    );
+
+    if (uniqueRaisedBedIds.length === 0) {
+        return [];
+    }
+
+    const rows = await storage()
+        .select({
+            raisedBedId: operations.raisedBedId,
+            data: events.data,
+        })
+        .from(operations)
+        .innerJoin(events, eq(events.aggregateId, sql`${operations.id}::text`))
+        .where(
+            and(
+                eq(operations.isDeleted, false),
+                inArray(operations.raisedBedId, uniqueRaisedBedIds),
+                eq(events.type, knownEventTypes.operations.complete),
+                sql`jsonb_typeof(${events.data}->'images') = 'array'`,
+                sql`jsonb_array_length(${events.data}->'images') > 0`,
+            ),
+        )
+        .orderBy(
+            asc(operations.raisedBedId),
+            desc(events.createdAt),
+            desc(events.id),
+        );
+
+    const previewByRaisedBedId = new Map<number, RaisedBedPhotoPreview>(
+        uniqueRaisedBedIds.map((raisedBedId) => [
+            raisedBedId,
+            {
+                raisedBedId,
+                imageUrls: [],
+                photoCount: 0,
+            },
+        ]),
+    );
+    const seenImageUrlsByRaisedBedId = new Map<number, Set<string>>();
+    const safeImageLimit = Math.max(1, imageLimit);
+
+    for (const row of rows) {
+        if (row.raisedBedId === null) {
+            continue;
+        }
+
+        const preview = previewByRaisedBedId.get(row.raisedBedId);
+        if (!preview) {
+            continue;
+        }
+
+        const imageUrls = getCompletionEventImageUrls(row.data);
+        preview.photoCount += imageUrls.length;
+
+        let seenImageUrls = seenImageUrlsByRaisedBedId.get(row.raisedBedId);
+        if (!seenImageUrls) {
+            seenImageUrls = new Set();
+            seenImageUrlsByRaisedBedId.set(row.raisedBedId, seenImageUrls);
+        }
+
+        for (const imageUrl of imageUrls) {
+            if (seenImageUrls.has(imageUrl)) {
+                continue;
+            }
+
+            seenImageUrls.add(imageUrl);
+            if (preview.imageUrls.length < safeImageLimit) {
+                preview.imageUrls.push(imageUrl);
+            }
+        }
+    }
+
+    return [...previewByRaisedBedId.values()];
+}
+
 export async function getAppliedRaisedBedOperationsForGarden(
     accountId: string,
     gardenId: number,
@@ -953,6 +1056,60 @@ export async function getFarmUserAcceptedOperationById(
     const operations = await getFarmUserAcceptedOperationsByIds(userId, [id]);
     const [operationWithAggregates] = await fillOperationAggregates(operations);
     return operationWithAggregates ?? null;
+}
+
+export async function getFarmUserAcceptedOperationsByScheduleRange({
+    userId,
+    from,
+    to,
+}: {
+    userId: string;
+    from: Date;
+    to: Date;
+}) {
+    return cacheScheduleRead(
+        scheduleCacheKeys.farmUserScheduledOperations(userId, from, to),
+        async () => {
+            const scheduledDateExpression = sql<string>`${events.data} ->> 'scheduledDate'`;
+            const scheduledRows = await storage()
+                .selectDistinct({ id: operations.id })
+                .from(operations)
+                .leftJoin(raisedBeds, eq(operations.raisedBedId, raisedBeds.id))
+                .leftJoin(
+                    gardens,
+                    eq(gardens.id, operationGardenIdExpression()),
+                )
+                .innerJoin(
+                    farmUsers,
+                    eq(farmUsers.farmId, operationFarmIdExpression()),
+                )
+                .innerJoin(
+                    events,
+                    and(
+                        sql`${events.aggregateId} = cast(${operations.id} as text)`,
+                        eq(events.type, knownEventTypes.operations.schedule),
+                    ),
+                )
+                .where(
+                    and(
+                        eq(farmUsers.userId, userId),
+                        eq(operations.isAccepted, true),
+                        eq(operations.isDeleted, false),
+                        operationLocationIntegrityWhere(),
+                        gte(scheduledDateExpression, from.toISOString()),
+                        lte(scheduledDateExpression, to.toISOString()),
+                    ),
+                );
+
+            const acceptedOperations = await getFarmUserAcceptedOperationsByIds(
+                userId,
+                scheduledRows.map((row) => row.id),
+            );
+
+            return fillOperationAggregates(acceptedOperations);
+        },
+        scheduleCacheTtls.operations,
+    );
 }
 
 export async function getAssignableFarmUsersByOperationIds(


### PR DESCRIPTION
## Summary

- Refresh the farm schedule UI with compact task badges, right-aligned requirement/status indicators, plant visuals, completed-task dimming, and the theme background.
- Add raised-bed photo thumbnails in schedule group headers using the existing stacked gallery preview, without duplicating the physical identifier.
- Improve schedule navigation/loading with optimistic date skeletons, route-level skeletons, cached day/operation reads, and deferred enrichment for photo previews and planting assignee avatars.
- Keep farm-level tasks at the bottom and keep raised-bed task ordering scoped inside each raised-bed group.

## Validation

- `corepack pnpm lint --filter farm`
- `corepack pnpm --filter farm exec tsc --noEmit --pretty false`
- `corepack pnpm lint --filter @gredice/storage`
- `corepack pnpm --filter farm build`
- `git diff --check`

Note: a localhost `/schedule` smoke check was attempted, but no dev server was running on port 3472 after rebasing onto `origin/main`.
