### PR TITLE
feat(garden): enable public garden sharing by default

### DIFF
--- a/apps/api/app/.well-known/vercel/flags/route.ts
+++ b/apps/api/app/.well-known/vercel/flags/route.ts
@@ -1,4 +1,0 @@
-import { createFlagsDiscoveryEndpoint, getProviderData } from 'flags/next';
-import * as flags from '../../../../app/flags';
-
-export const GET = createFlagsDiscoveryEndpoint(() => getProviderData(flags));

--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -108,7 +108,6 @@ import {
 import { queryBooleanSchema } from '../../../lib/http/queryBoolean';
 import { openAdventGiftBox } from '../../../lib/occasions/adventGiftBox';
 import { getPostHogClient } from '../../../lib/posthog-server';
-import { publicGardensFlag } from '../../flags';
 
 const DEFAULT_TIMEZONE = 'Europe/Paris';
 
@@ -711,13 +710,6 @@ const app = new Hono<{ Variables: AuthVariables }>()
             security: publicSecurity,
         }),
         async (context) => {
-            if (!(await publicGardensFlag())) {
-                return context.json(
-                    { error: 'Public gardens are disabled' },
-                    404,
-                );
-            }
-
             const publicGardens = await getPublicGardens();
 
             return context.json({
@@ -1224,10 +1216,6 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 return context.json({ error: 'Invalid garden ID' }, 400);
             }
 
-            if (!(await publicGardensFlag())) {
-                return context.json({ error: 'Garden not found' }, 404);
-            }
-
             const [garden, blocks] = await Promise.all([
                 getPublicGarden(gardenIdNumber),
                 getGardenBlocks(gardenIdNumber),
@@ -1284,13 +1272,6 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const gardenIdNumber = parseInt(gardenId, 10);
             if (Number.isNaN(gardenIdNumber)) {
                 return context.json({ error: 'Invalid garden ID' }, 400);
-            }
-
-            if (isPublic !== undefined && !(await publicGardensFlag())) {
-                return context.json(
-                    { error: 'Public gardens are disabled' },
-                    403,
-                );
             }
 
             const { accountId } = context.get('authContext');

--- a/apps/api/app/api/[...route]/usersRoutes.ts
+++ b/apps/api/app/api/[...route]/usersRoutes.ts
@@ -26,7 +26,6 @@ import {
     MIN_BIRTH_YEAR,
     startOfUtcDay,
 } from '../../../lib/users/birthdayUtils';
-import { publicGardensFlag } from '../../flags';
 
 const currentYear = new Date().getUTCFullYear();
 const birthdaySchema = z
@@ -139,10 +138,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 getAccountGardens(primaryAccountId),
                 getAccountAchievements(primaryAccountId),
             ]);
-            const publicGardensEnabled = await publicGardensFlag();
-            const visibleGardens = publicGardensEnabled
-                ? gardens.filter((garden) => garden.isPublic)
-                : [];
+            const visibleGardens = gardens.filter((garden) => garden.isPublic);
 
             return context.json({
                 user: {

--- a/apps/api/app/flags.ts
+++ b/apps/api/app/flags.ts
@@ -1,7 +1,0 @@
-import { publicGardensFlagDefinition } from '@gredice/js/featureFlags';
-import { flag } from 'flags/next';
-
-export const publicGardensFlag = flag<boolean>({
-    ...publicGardensFlagDefinition,
-    decide: () => false,
-});

--- a/apps/api/biome.json
+++ b/apps/api/biome.json
@@ -13,7 +13,6 @@
             "!.next",
             "!dist",
             "!build",
-            "!lib/flags/generated",
             "!**/*.d.ts"
         ]
     },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,7 +40,6 @@
         "ai": "7.0.9",
         "date-fns": "4.4.0",
         "drizzle-orm": "0.45.2",
-        "flags": "4.2.0",
         "hono": "4.12.27",
         "hono-openapi": "1.3.0",
         "next": "16.2.9",

--- a/apps/app/app/.well-known/vercel/flags/route.ts
+++ b/apps/app/app/.well-known/vercel/flags/route.ts
@@ -1,4 +1,0 @@
-import { createFlagsDiscoveryEndpoint, getProviderData } from 'flags/next';
-import * as flags from '../../../../app/flags';
-
-export const GET = createFlagsDiscoveryEndpoint(() => getProviderData(flags));

--- a/apps/app/app/admin/gardens/[gardenId]/AdminGardenVisibilityToggle.tsx
+++ b/apps/app/app/admin/gardens/[gardenId]/AdminGardenVisibilityToggle.tsx
@@ -11,14 +11,12 @@ import { useState, useTransition } from 'react';
 import { updateGardenVisibilityAction } from './actions';
 
 type AdminGardenVisibilityToggleProps = {
-    enabled: boolean;
     gardenId: number;
     isPublic: boolean;
     publicUrl: string;
 };
 
 export function AdminGardenVisibilityToggle({
-    enabled,
     gardenId,
     isPublic,
     publicUrl,
@@ -50,21 +48,19 @@ export function AdminGardenVisibilityToggle({
                         Public visibility
                     </Typography>
                     <Typography level="body3" className="text-muted-foreground">
-                        {enabled
-                            ? checked
-                                ? 'Garden is visible on www.'
-                                : 'Garden is private.'
-                            : 'Feature flag is disabled.'}
+                        {checked
+                            ? 'Garden is visible on www.'
+                            : 'Garden is private.'}
                     </Typography>
                 </Stack>
                 <Switch
                     aria-label="Public garden visibility"
                     checked={checked}
-                    disabled={!enabled || isPending}
+                    disabled={isPending}
                     onCheckedChange={handleChange}
                 />
             </Row>
-            {checked && enabled ? (
+            {checked ? (
                 <Button
                     href={publicUrl}
                     target="_blank"

--- a/apps/app/app/admin/gardens/[gardenId]/actions.ts
+++ b/apps/app/app/admin/gardens/[gardenId]/actions.ts
@@ -4,7 +4,6 @@ import { getGarden, updateGarden } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
-import { publicGardensFlag } from '../../../flags';
 
 export async function updateGardenVisibilityAction({
     gardenId,
@@ -14,13 +13,6 @@ export async function updateGardenVisibilityAction({
     isPublic: boolean;
 }) {
     await auth(['admin']);
-
-    if (!(await publicGardensFlag())) {
-        return {
-            success: false,
-            message: 'Public gardens feature flag is disabled.',
-        };
-    }
 
     const garden = await getGarden(gardenId);
     if (!garden) {

--- a/apps/app/app/admin/gardens/[gardenId]/page.tsx
+++ b/apps/app/app/admin/gardens/[gardenId]/page.tsx
@@ -21,7 +21,6 @@ import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navig
 import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { auth } from '../../../../lib/auth/auth';
 import { KnownPages } from '../../../../src/KnownPages';
-import { publicGardensFlag } from '../../../flags';
 import { RaisedBedsTableCard } from '../../accounts/[accountId]/RaisedBedsTableCard';
 import { AdminGardenVisibilityToggle } from './AdminGardenVisibilityToggle';
 
@@ -56,10 +55,7 @@ export default async function GardenPage({
 }) {
     const { gardenId } = await params;
     await auth(['admin']);
-    const [garden, publicGardensEnabled] = await Promise.all([
-        getGarden(gardenId),
-        publicGardensFlag(),
-    ]);
+    const garden = await getGarden(gardenId);
 
     if (!garden) {
         notFound();
@@ -117,7 +113,6 @@ export default async function GardenPage({
                 }
             >
                 <AdminGardenVisibilityToggle
-                    enabled={publicGardensEnabled}
                     gardenId={garden.id}
                     isPublic={garden.isPublic}
                     publicUrl={publicGardenUrl}

--- a/apps/app/app/flags.ts
+++ b/apps/app/app/flags.ts
@@ -1,7 +1,0 @@
-import { publicGardensFlagDefinition } from '@gredice/js/featureFlags';
-import { flag } from 'flags/next';
-
-export const publicGardensFlag = flag<boolean>({
-    ...publicGardensFlagDefinition,
-    decide: () => false,
-});

--- a/apps/app/biome.json
+++ b/apps/app/biome.json
@@ -7,14 +7,7 @@
     },
     "files": {
         "ignoreUnknown": true,
-        "includes": [
-            "**",
-            "!node_modules",
-            "!.next",
-            "!dist",
-            "!build",
-            "!lib/flags/generated"
-        ]
+        "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
     },
     "formatter": {
         "enabled": true,

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -33,7 +33,6 @@
         "@vvo/tzdb": "6.198.0",
         "@xyflow/react": "12.11.1",
         "drizzle-orm": "0.45.2",
-        "flags": "4.2.0",
         "next": "16.2.9",
         "next-themes": "0.4.6",
         "pg": "8.22.0",

--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -1,7 +1,4 @@
-import {
-    booleanFlagOptions,
-    publicGardensFlagDefinition,
-} from '@gredice/js/featureFlags';
+import { booleanFlagOptions } from '@gredice/js/featureFlags';
 import { flag } from 'flags/next';
 
 export const deliveryChargeAtCheckoutFlag = flag<boolean>({
@@ -51,9 +48,4 @@ export const enableSuncokretDebugFlag = flag<boolean>({
     description: 'Show Suncokret AI debug metadata in chat conversations.',
     decide: () => false,
     options: booleanFlagOptions,
-});
-
-export const publicGardensFlag = flag<boolean>({
-    ...publicGardensFlagDefinition,
-    decide: () => false,
 });

--- a/apps/garden/app/page.tsx
+++ b/apps/garden/app/page.tsx
@@ -7,7 +7,6 @@ import {
     enableDebugHudFlag,
     enableSuncokretChatFlag,
     enableSuncokretDebugFlag,
-    publicGardensFlag,
     rainWetOverlayFlag,
 } from './flags';
 
@@ -22,7 +21,6 @@ export default async function Home() {
         enableRainWetOverlayFlag: await rainWetOverlayFlag(),
         enableSuncokretChatFlag: await enableSuncokretChatFlag(),
         enableSuncokretDebugFlag: await enableSuncokretDebugFlag(),
-        publicGardensFlag: await publicGardensFlag(),
     };
 
     return (

--- a/apps/garden/app/vrtovi/[id]/opengraph-image.tsx
+++ b/apps/garden/app/vrtovi/[id]/opengraph-image.tsx
@@ -11,6 +11,9 @@ export const dynamic = 'force-dynamic';
 export const contentType = 'image/png';
 export const maxDuration = 10;
 
+const gardenOgImageCacheControl =
+    'public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400';
+
 export default async function GardenOgImage({
     params,
 }: {
@@ -108,6 +111,9 @@ export default async function GardenOgImage({
         {
             width: 1200,
             height: 630,
+            headers: {
+                'Cache-Control': gardenOgImageCacheControl,
+            },
         },
     );
 }

--- a/apps/www/app/flags.ts
+++ b/apps/www/app/flags.ts
@@ -1,7 +1,4 @@
-import {
-    booleanFlagOptions,
-    publicGardensFlagDefinition,
-} from '@gredice/js/featureFlags';
+import { booleanFlagOptions } from '@gredice/js/featureFlags';
 import { flag } from 'flags/next';
 
 function isDevelopmentEnvironment() {
@@ -20,9 +17,4 @@ export const recipesFlag = flag<boolean>({
     description: 'Enable recipes pages and recipe detail routes.',
     decide: () => isDevelopmentEnvironment(),
     options: booleanFlagOptions,
-});
-
-export const publicGardensFlag = flag<boolean>({
-    ...publicGardensFlagDefinition,
-    decide: () => false,
 });

--- a/apps/www/app/vrtovi/page.tsx
+++ b/apps/www/app/vrtovi/page.tsx
@@ -3,6 +3,7 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
+import Image from 'next/image';
 import Link from 'next/link';
 import { KnownPages } from '../../src/KnownPages';
 import { getPublicGardensForWww } from './publicGardenData';
@@ -25,6 +26,10 @@ export const metadata: Metadata = {
     },
 };
 
+function gardenOgImageUrl(gardenId: number) {
+    return `${KnownPages.GardenApp}${KnownPages.PublicGarden(gardenId)}/opengraph-image`;
+}
+
 export default async function PublicGardensPage() {
     const gardens = await getPublicGardensForWww();
 
@@ -38,9 +43,27 @@ export default async function PublicGardensPage() {
             {gardens.items.length > 0 ? (
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                     {gardens.items.map((garden) => (
-                        <Card key={garden.id} className="h-full rounded-md">
+                        <Card
+                            key={garden.id}
+                            className="h-full overflow-hidden rounded-md"
+                        >
                             <CardContent noHeader>
                                 <Stack spacing={3}>
+                                    <Link
+                                        href={KnownPages.PublicGarden(
+                                            garden.id,
+                                        )}
+                                        className="block overflow-hidden rounded-sm bg-muted"
+                                    >
+                                        <Image
+                                            src={gardenOgImageUrl(garden.id)}
+                                            alt={`Javni prikaz vrta ${garden.name}`}
+                                            width={1200}
+                                            height={630}
+                                            sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                                            className="aspect-[1200/630] w-full object-cover transition-transform duration-300 hover:scale-[1.02]"
+                                        />
+                                    </Link>
                                     <Typography level="h3">
                                         <Link
                                             href={KnownPages.PublicGarden(

--- a/apps/www/app/vrtovi/publicGardenData.ts
+++ b/apps/www/app/vrtovi/publicGardenData.ts
@@ -1,12 +1,7 @@
 import { clientPublic } from '@gredice/client';
 import { notFound } from 'next/navigation';
-import { publicGardensFlag } from '../flags';
 
 export async function getPublicGardensForWww() {
-    if (!(await publicGardensFlag())) {
-        notFound();
-    }
-
     const response = await clientPublic().api.gardens.public.$get();
     if (!response.ok) {
         notFound();
@@ -16,10 +11,6 @@ export async function getPublicGardensForWww() {
 }
 
 export async function getPublicGardenForWww(gardenId: number) {
-    if (!(await publicGardensFlag())) {
-        notFound();
-    }
-
     const response = await clientPublic().api.gardens[':gardenId'].public.$get({
         param: { gardenId: gardenId.toString() },
     });

--- a/apps/www/next.config.ts
+++ b/apps/www/next.config.ts
@@ -117,6 +117,12 @@ const nextConfig: NextConfig = {
             },
             {
                 protocol: 'https',
+                hostname: 'vrt.gredice.com',
+                port: '',
+                pathname: '/vrtovi/**',
+            },
+            {
+                protocol: 'https',
                 hostname: '*.public.blob.vercel-storage.com',
                 port: '',
                 pathname: '/**',

--- a/packages/game/src/GameFlagsContext.tsx
+++ b/packages/game/src/GameFlagsContext.tsx
@@ -13,7 +13,6 @@ export interface GameFeatureFlags {
     enableRainWetOverlayFlag?: boolean;
     enableSuncokretChatFlag?: boolean;
     enableSuncokretDebugFlag?: boolean;
-    publicGardensFlag?: boolean;
 }
 
 export const GameFlagsContext = createContext<GameFeatureFlags>({});

--- a/packages/game/src/modals/components/GardenVisibilityCard.tsx
+++ b/packages/game/src/modals/components/GardenVisibilityCard.tsx
@@ -7,7 +7,6 @@ import { Stack } from '@gredice/ui/Stack';
 import { Switch } from '@gredice/ui/Switch';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
-import { useGameFlags } from '../../GameFlagsContext';
 import { useUpdateGardenVisibility } from '../../hooks/useUpdateGardenVisibility';
 import { KnownPages } from '../../knownPages';
 
@@ -22,14 +21,9 @@ export function GardenVisibilityCard({
     gardenName,
     isPublic,
 }: GardenVisibilityCardProps) {
-    const { publicGardensFlag } = useGameFlags();
     const updateVisibility = useUpdateGardenVisibility(gardenId);
     const [error, setError] = useState<string | null>(null);
     const publicUrl = KnownPages.GredicePublicGarden(gardenId);
-
-    if (!publicGardensFlag) {
-        return null;
-    }
 
     function handleVisibilityChange(nextPublic: boolean) {
         setError(null);

--- a/packages/js/src/featureFlags/index.ts
+++ b/packages/js/src/featureFlags/index.ts
@@ -2,10 +2,3 @@ export const booleanFlagOptions = [
     { label: 'Off', value: false },
     { label: 'On', value: true },
 ];
-
-export const publicGardensFlagDefinition = {
-    key: 'publicGardens',
-    description:
-        'Enable opt-in public gardens, public garden pages, and visibility controls.',
-    options: booleanFlagOptions,
-};

--- a/packages/ui/src/PublicChrome/PublicFooter.tsx
+++ b/packages/ui/src/PublicChrome/PublicFooter.tsx
@@ -128,6 +128,13 @@ function sectionsData(linkMode: PublicChromeLinkMode): SectionData[] {
                             ),
                         },
                         {
+                            label: 'Vrtovi',
+                            href: publicChromeHref(
+                                PublicPagePaths.PublicGardens,
+                                linkMode,
+                            ),
+                        },
+                        {
                             label: 'Biljke',
                             href: publicChromeHref(
                                 PublicPagePaths.Plants,

--- a/packages/ui/src/PublicChrome/links.ts
+++ b/packages/ui/src/PublicChrome/links.ts
@@ -9,6 +9,7 @@ export const PublicPagePaths = {
     Blocks: '/blokovi',
     Sunflowers: '/suncokreti',
     RaisedBeds: '/podignuta-gredica',
+    PublicGardens: '/vrtovi',
     Sowing: '/sjetva',
     Operations: '/radnje',
     FAQ: '/cesta-pitanja',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,6 @@ importers:
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@electric-sql/pglite@0.5.3)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.22.0)
-      flags:
-        specifier: 4.2.0
-        version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       hono:
         specifier: 4.12.27
         version: 4.12.27
@@ -270,9 +267,6 @@ importers:
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@electric-sql/pglite@0.5.3)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(pg@8.22.0)
-      flags:
-        specifier: 4.2.0
-        version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
         specifier: 16.2.9
         version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0)


### PR DESCRIPTION
## Summary

- remove the `publicGardens` feature flag definition and app-level flag wrappers
- make public garden list/detail API routes and www loaders available by default
- keep per-garden `isPublic` privacy checks while enabling the admin and garden visibility controls unconditionally
- verify the existing `apps/www` `/vrtovi` list page and sitemap wiring for public garden exploration
- render garden OG images as thumbnails in the `apps/www` `/vrtovi` list
- add 24h `Cache-Control` headers to generated garden OG images
- add a `Vrtovi` link to the shared public footer so visitors can find the list
- drop unused `flags` dependencies and stale Vercel flags discovery routes from apps that only used them for this gate

## Validation

- `corepack pnpm install --lockfile-only`
- `corepack pnpm lint --filter api --filter app --filter garden --filter www --filter @gredice/game --filter @gredice/js`
- `corepack pnpm typecheck --filter garden --filter www --filter @gredice/game`
- `corepack pnpm --filter @gredice/ui exec biome check --write src/PublicChrome/PublicFooter.tsx src/PublicChrome/links.ts`
- `corepack pnpm typecheck --filter @gredice/ui --filter www`
- path-scoped Biome checks for the touched API, app, garden, www, game, and js files
- `corepack pnpm --filter www exec biome check --write app/vrtovi/page.tsx`
- `corepack pnpm --filter garden exec biome check --write 'app/vrtovi/[id]/opengraph-image.tsx'`
- `corepack pnpm typecheck --filter www`
- `corepack pnpm build --filter www --filter garden`
- `corepack pnpm build --filter api --filter app`
- `git diff --check`
- local browser smoke for `apps/www` `/vrtovi` reached the route, but the production API still returns the gated/not-found state until this PR deploys
- `corepack pnpm --filter api exec tsc --noEmit --pretty false` (fails on existing `lib/notifications/webPushSender.node.spec.ts` errors; touched-path scan clean)
- `corepack pnpm --filter app exec tsc --noEmit --pretty false` (fails on existing app-wide errors; touched-path scan clean)
