### PR TITLE
feat(app): document farmer payout price table

### DIFF
--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.ts
@@ -8,12 +8,17 @@ import {
 import {
     type EntityStandardized,
     entityRevisions,
+    getAllOperationPrices,
     getAttributeDefinitions,
     getEntitiesFormatted,
+    getFarms,
     type SelectEntityRevision,
+    type SelectFarm,
+    type SelectOperationPrice,
     storage,
 } from '@gredice/storage';
 import { and, desc, gte, inArray } from 'drizzle-orm';
+import { isMissingPayoutSchemaError } from '../payoutSchemaStatus';
 
 export type FarmerDocumentationChangeType = 'insert' | 'replace' | 'discard';
 export type FarmerDocumentationEntityTypeName =
@@ -75,6 +80,31 @@ export type FarmerDocumentationDiscard = {
     revisionActions: string[];
 };
 
+export type FarmerDocumentationPayoutPriceRow = {
+    code: string;
+    label: string;
+    sublabel: string | null;
+    userFacingPriceLabel: string;
+    durationLabel: string;
+    farmerPriceLabel: string;
+    farmerPricePerMinuteLabel: string;
+    hasFarmerPrice: boolean;
+};
+
+export type FarmerDocumentationPayoutPriceFarm = {
+    farmId: number;
+    farmName: string;
+    rows: FarmerDocumentationPayoutPriceRow[];
+};
+
+export type FarmerDocumentationPayoutPrices = {
+    schemaAvailable: boolean;
+    farms: FarmerDocumentationPayoutPriceFarm[];
+    totalRows: number;
+    configuredRows: number;
+    missingRows: number;
+};
+
 export type FarmerDocumentationPackage = {
     since: Date | null;
     generatedAt: Date;
@@ -88,6 +118,7 @@ export type FarmerDocumentationPackage = {
     discardedOperations: FarmerDocumentationDiscard[];
     discardedPlants: FarmerDocumentationDiscard[];
     discardedPlantSorts: FarmerDocumentationDiscard[];
+    payoutPrices: FarmerDocumentationPayoutPrices;
 };
 
 export type FarmerDocumentationRevision = Pick<
@@ -207,6 +238,32 @@ const calendarDetails = [
     { key: 'sowing', title: 'Sjetva na otvorenom' },
     { key: 'planting', title: 'Presađivanje' },
     { key: 'harvest', title: 'Berba' },
+];
+
+const payoutPriceSyntheticRows: Array<{
+    code: string;
+    entityTypeName: string;
+    entityId: null;
+    label: string;
+    sublabel: string;
+    userFacingPriceNote: string;
+}> = [
+    {
+        code: 'SOW-DIRECT',
+        entityTypeName: 'sowing',
+        entityId: null,
+        label: 'Sijanje (direktno)',
+        sublabel: 'sowing',
+        userFacingPriceNote: 'prema cijeni biljke',
+    },
+    {
+        code: 'SOW-GREENHOUSE',
+        entityTypeName: 'sowingGreenhouse',
+        entityId: null,
+        label: 'Sijanje (staklenički rasad)',
+        sublabel: 'sowingGreenhouse',
+        userFacingPriceNote: 'prema cijeni biljke',
+    },
 ];
 
 export function getFarmerDocumentationCode(
@@ -353,6 +410,8 @@ export async function getFarmerDocumentationPackage({
         operationAttributeDefinitions,
         plantAttributeDefinitions,
         plantSortAttributeDefinitions,
+        farms,
+        operationPrices,
     ] = await Promise.all([
         getEntitiesFormatted<EntityStandardized>('operation').catch(
             (): EntityStandardized[] => [],
@@ -367,6 +426,8 @@ export async function getFarmerDocumentationPackage({
         getAttributeDefinitions('operation').catch(() => []),
         getAttributeDefinitions('plant').catch(() => []),
         getAttributeDefinitions('plantSort').catch(() => []),
+        getFarms(),
+        getOperationPricesForDocumentation(),
     ]);
 
     return buildFarmerDocumentationPackage({
@@ -386,6 +447,9 @@ export async function getFarmerDocumentationPackage({
         plantSortPlantAttributeDefinitionIds:
             plantSortPlantAttributeDefinitionIds(plantSortAttributeDefinitions),
         generatedAt: new Date(),
+        farms,
+        operationPrices: operationPrices.prices,
+        operationPricesSchemaAvailable: operationPrices.schemaAvailable,
         since,
     });
 }
@@ -393,7 +457,10 @@ export async function getFarmerDocumentationPackage({
 export function buildFarmerDocumentationPackage({
     generatedAt,
     labelAttributeDefinitionIds,
+    farms = [],
     operations,
+    operationPrices = [],
+    operationPricesSchemaAvailable = true,
     plants,
     plantSorts,
     plantSortPlantAttributeDefinitionIds,
@@ -405,7 +472,10 @@ export function buildFarmerDocumentationPackage({
         FarmerDocumentationEntityTypeName,
         ReadonlySet<number>
     >;
+    farms?: SelectFarm[];
     operations: EntityStandardized[];
+    operationPrices?: SelectOperationPrice[];
+    operationPricesSchemaAvailable?: boolean;
     plants: EntityStandardized[];
     plantSorts: EntityStandardized[];
     plantSortPlantAttributeDefinitionIds: ReadonlySet<number>;
@@ -511,7 +581,210 @@ export function buildFarmerDocumentationPackage({
             labelAttributeDefinitionIds: labelAttributeDefinitionIds.plantSort,
             revisionsByEntityKey,
         }),
+        payoutPrices: buildPayoutPriceDocumentation({
+            farms,
+            operations: sortedOperations,
+            operationPrices,
+            plants: sortedPlants,
+            schemaAvailable: operationPricesSchemaAvailable,
+        }),
     };
+}
+
+async function getOperationPricesForDocumentation(): Promise<{
+    prices: SelectOperationPrice[];
+    schemaAvailable: boolean;
+}> {
+    try {
+        return {
+            prices: await getAllOperationPrices(),
+            schemaAvailable: true,
+        };
+    } catch (error) {
+        if (!isMissingPayoutSchemaError(error)) {
+            throw error;
+        }
+
+        console.warn(
+            'Operation price tables are not available for farmer documentation.',
+        );
+        return {
+            prices: [],
+            schemaAvailable: false,
+        };
+    }
+}
+
+function buildPayoutPriceDocumentation({
+    farms,
+    operations,
+    operationPrices,
+    plants,
+    schemaAvailable,
+}: {
+    farms: SelectFarm[];
+    operations: EntityStandardized[];
+    operationPrices: SelectOperationPrice[];
+    plants: EntityStandardized[];
+    schemaAvailable: boolean;
+}): FarmerDocumentationPayoutPrices {
+    if (!schemaAvailable) {
+        return {
+            schemaAvailable: false,
+            farms: [],
+            totalRows: 0,
+            configuredRows: 0,
+            missingRows: 0,
+        };
+    }
+
+    const operationPriceByKey = new Map(
+        operationPrices.map((price) => [
+            operationPriceKey(
+                price.farmId,
+                price.entityTypeName,
+                price.entityId,
+            ),
+            price,
+        ]),
+    );
+    const plantPriceRange = plantPriceRangeLabel(plants);
+    const payoutPriceFarms = farms.map((farm) => {
+        const syntheticRows = payoutPriceSyntheticRows.map((row) =>
+            syntheticPayoutPriceRow({
+                plantPriceRange,
+                price: operationPriceByKey.get(
+                    operationPriceKey(
+                        farm.id,
+                        row.entityTypeName,
+                        row.entityId,
+                    ),
+                ),
+                row,
+            }),
+        );
+        const operationRows = operations.map((operation) =>
+            operationPayoutPriceRow({
+                operation,
+                price: operationPriceByKey.get(
+                    operationPriceKey(farm.id, 'operation', operation.id),
+                ),
+            }),
+        );
+
+        return {
+            farmId: farm.id,
+            farmName: farm.name,
+            rows: [...syntheticRows, ...operationRows],
+        };
+    });
+    const allRows = payoutPriceFarms.flatMap((farm) => farm.rows);
+    const configuredRows = allRows.filter((row) => row.hasFarmerPrice).length;
+
+    return {
+        schemaAvailable: true,
+        farms: payoutPriceFarms,
+        totalRows: allRows.length,
+        configuredRows,
+        missingRows: allRows.length - configuredRows,
+    };
+}
+
+function syntheticPayoutPriceRow({
+    plantPriceRange,
+    price,
+    row,
+}: {
+    plantPriceRange: string | null;
+    price: SelectOperationPrice | undefined;
+    row: (typeof payoutPriceSyntheticRows)[number];
+}): FarmerDocumentationPayoutPriceRow {
+    const farmerPrice = parseDecimalPrice(price?.pricePerUnit);
+
+    return {
+        code: row.code,
+        label: row.label,
+        sublabel: row.sublabel,
+        userFacingPriceLabel: plantPriceRange
+            ? `${plantPriceRange} (${row.userFacingPriceNote})`
+            : row.userFacingPriceNote,
+        durationLabel: 'Nije primjenjivo',
+        farmerPriceLabel:
+            farmerPrice === null
+                ? 'Nije definirano'
+                : formatEuroPrice(farmerPrice, price?.currency),
+        farmerPricePerMinuteLabel: '-',
+        hasFarmerPrice: farmerPrice !== null,
+    };
+}
+
+function operationPayoutPriceRow({
+    operation,
+    price,
+}: {
+    operation: EntityStandardized;
+    price: SelectOperationPrice | undefined;
+}): FarmerDocumentationPayoutPriceRow {
+    const farmerPrice = parseDecimalPrice(price?.pricePerUnit);
+    const durationMinutes = operationDurationMinutes(operation);
+
+    return {
+        code: getFarmerDocumentationCode('operation', operation.id),
+        label: getOperationLabel(operation),
+        sublabel: operation.information?.name?.trim() || null,
+        userFacingPriceLabel: operationPriceLabel(operation),
+        durationLabel: operationDurationLabel(operation),
+        farmerPriceLabel:
+            farmerPrice === null
+                ? 'Nije definirano'
+                : formatEuroPrice(farmerPrice, price?.currency),
+        farmerPricePerMinuteLabel:
+            farmerPrice !== null && durationMinutes !== null
+                ? `${formatEuroPrice(farmerPrice / durationMinutes, price?.currency)} / min`
+                : '-',
+        hasFarmerPrice: farmerPrice !== null,
+    };
+}
+
+function operationPriceKey(
+    farmId: number,
+    entityTypeName: string,
+    entityId: number | null,
+) {
+    return `${farmId}:${entityTypeName}:${entityId ?? 'null'}`;
+}
+
+function plantPriceRangeLabel(plants: EntityStandardized[]) {
+    const prices = plants
+        .map((plant) => plant.prices?.perPlant)
+        .filter((price): price is number => Number.isFinite(price));
+
+    if (prices.length === 0) {
+        return null;
+    }
+
+    const min = Math.min(...prices);
+    const max = Math.max(...prices);
+
+    return min === max
+        ? formatEuroPrice(min)
+        : `${formatEuroPrice(min)} - ${formatEuroPrice(max)}`;
+}
+
+function parseDecimalPrice(value: string | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatEuroPrice(value: number, currency = 'eur') {
+    return `${value.toLocaleString('hr-HR', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    })} ${currency.toUpperCase()}`;
 }
 
 function getDocumentationRevisionsSince(since: Date | null) {
@@ -1039,16 +1312,26 @@ function entityCoverUrl(entity: EntityStandardized | null | undefined) {
     return typeof url === 'string' && url.trim().length > 0 ? url.trim() : null;
 }
 
-function operationDurationLabel(operation: EntityStandardized) {
+function operationDurationMinutes(operation: EntityStandardized) {
     const duration = operation.attributes?.duration;
     const minutes =
         typeof duration === 'number'
             ? duration
             : typeof duration === 'string'
-              ? Number.parseInt(duration, 10)
+              ? Number.parseFloat(duration)
               : 0;
 
     if (!Number.isFinite(minutes) || minutes <= 0) {
+        return null;
+    }
+
+    return minutes;
+}
+
+function operationDurationLabel(operation: EntityStandardized) {
+    const minutes = operationDurationMinutes(operation);
+
+    if (minutes === null) {
         return 'Nije definirano';
     }
 
@@ -1069,7 +1352,7 @@ function operationPriceLabel(operation: EntityStandardized) {
         return 'Nije definirano';
     }
 
-    return `${price.toFixed(2).replace('.', ',')} EUR`;
+    return formatEuroPrice(price);
 }
 
 function operationPhotoProofLabel(operation: EntityStandardized) {

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationData.unit.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { inflateSync } from 'node:zlib';
-import type { EntityStandardized } from '@gredice/storage';
+import type {
+    EntityStandardized,
+    SelectFarm,
+    SelectOperationPrice,
+} from '@gredice/storage';
 import {
     buildFarmerDocumentationPackage,
     currentDocumentationPages,
@@ -233,6 +237,114 @@ test('builds insert, replace, and discard instructions from manual revisions', (
     );
 });
 
+test('builds farmer payout price tables per farm', () => {
+    const documentationPackage = buildFarmerDocumentationPackage({
+        generatedAt,
+        since: null,
+        labelAttributeDefinitionIds: {
+            operation: new Set(),
+            plant: new Set(),
+            plantSort: new Set(),
+        },
+        farms: [farmFixture({ id: 7, name: 'Testna farma' })],
+        operations: [
+            operationFixture(
+                4,
+                'Zalijevanje',
+                {
+                    duration: 25,
+                    application: 'raisedBedFull',
+                },
+                { perOperation: 2.5 },
+            ),
+            operationFixture(6, 'Okopavanje', {
+                duration: 30,
+                application: 'raisedBed',
+            }),
+        ],
+        operationPrices: [
+            operationPriceFixture({
+                id: 1,
+                farmId: 7,
+                entityTypeName: 'sowing',
+                entityId: null,
+                pricePerUnit: '0.40',
+            }),
+            operationPriceFixture({
+                id: 2,
+                farmId: 7,
+                entityTypeName: 'operation',
+                entityId: 4,
+                pricePerUnit: '1.25',
+            }),
+        ],
+        plants: [
+            plantFixture({ prices: { perPlant: 1.25 } }),
+            plantFixture({
+                id: 2020,
+                label: 'Paprika',
+                prices: { perPlant: 2.5 },
+            }),
+        ],
+        plantSorts: [],
+        plantSortPlantAttributeDefinitionIds: new Set(),
+        revisions: [],
+    });
+
+    assert.equal(documentationPackage.payoutPrices.totalRows, 4);
+    assert.equal(documentationPackage.payoutPrices.configuredRows, 2);
+    assert.equal(documentationPackage.payoutPrices.missingRows, 2);
+    assert.deepEqual(
+        documentationPackage.payoutPrices.farms[0]?.rows.map((row) => [
+            row.code,
+            row.label,
+            row.userFacingPriceLabel,
+            row.durationLabel,
+            row.farmerPriceLabel,
+            row.farmerPricePerMinuteLabel,
+            row.hasFarmerPrice,
+        ]),
+        [
+            [
+                'SOW-DIRECT',
+                'Sijanje (direktno)',
+                '1,25 EUR - 2,50 EUR (prema cijeni biljke)',
+                'Nije primjenjivo',
+                '0,40 EUR',
+                '-',
+                true,
+            ],
+            [
+                'SOW-GREENHOUSE',
+                'Sijanje (staklenički rasad)',
+                '1,25 EUR - 2,50 EUR (prema cijeni biljke)',
+                'Nije primjenjivo',
+                'Nije definirano',
+                '-',
+                false,
+            ],
+            [
+                'OP-0004',
+                'Zalijevanje',
+                '2,50 EUR',
+                '25 min',
+                '1,25 EUR',
+                '0,05 EUR / min',
+                true,
+            ],
+            [
+                'OP-0006',
+                'Okopavanje',
+                'Nije definirano',
+                '30 min',
+                'Nije definirano',
+                '-',
+                false,
+            ],
+        ],
+    );
+});
+
 test('regenerates the previous plant page when a sort moves plants', () => {
     const tomato = plantFixture();
     const pepper = plantFixture({
@@ -312,6 +424,7 @@ test('generates a guide-first PDF without page numbering text', async () => {
             plant: new Set(),
             plantSort: new Set(),
         },
+        farms: [farmFixture({ id: 7, name: 'Testna farma' })],
         plantSortPlantAttributeDefinitionIds: new Set(),
         operations: [
             operationFixture(
@@ -330,6 +443,22 @@ test('generates a guide-first PDF without page numbering text', async () => {
             operationFixture(8, 'Berba', {
                 duration: 35,
                 application: 'raisedBed',
+            }),
+        ],
+        operationPrices: [
+            operationPriceFixture({
+                id: 1,
+                farmId: 7,
+                entityTypeName: 'sowing',
+                entityId: null,
+                pricePerUnit: '0.40',
+            }),
+            operationPriceFixture({
+                id: 2,
+                farmId: 7,
+                entityTypeName: 'operation',
+                entityId: 4,
+                pricePerUnit: '1.25',
             }),
         ],
         plants: [plantFixture()],
@@ -386,6 +515,11 @@ test('generates a guide-first PDF without page numbering text', async () => {
     assertPdfText(content, 'Cherry rajčica');
     assertPdfText(content, 'Rajčica');
     assertPdfText(content, 'Vlažno tlo');
+    assertPdfText(content, 'CJENIK ISPLATA FARMERA');
+    assertPdfText(content, 'Testna farma');
+    assertPdfText(content, 'SOW-DIRECT');
+    assertPdfText(content, '0,40 EUR');
+    assertPdfText(content, '0,05 EUR / min');
     assert.match(
         content,
         /\/Differences \[128 \/Ccaron \/ccaron \/Cacute \/cacute \/Dcroat \/dcroat \/Scaron \/scaron \/Zcaron \/zcaron\]/,
@@ -735,6 +869,51 @@ function operationFixture(
     };
 }
 
+function farmFixture({
+    id = 1,
+    name = 'Farma',
+}: {
+    id?: number;
+    name?: string;
+} = {}): SelectFarm {
+    return {
+        id,
+        name,
+        latitude: 45.8,
+        longitude: 16,
+        slackChannelId: null,
+        snowAccumulation: 0,
+        createdAt: generatedAt,
+        updatedAt: generatedAt,
+        isDeleted: false,
+    };
+}
+
+function operationPriceFixture({
+    entityId,
+    entityTypeName,
+    farmId,
+    id,
+    pricePerUnit,
+}: {
+    entityId: number | null;
+    entityTypeName: string;
+    farmId: number;
+    id: number;
+    pricePerUnit: string;
+}): SelectOperationPrice {
+    return {
+        id,
+        farmId,
+        entityTypeName,
+        entityId,
+        pricePerUnit,
+        currency: 'eur',
+        createdAt: generatedAt,
+        updatedAt: generatedAt,
+    };
+}
+
 function plantSortFixture(
     id: number,
     label: string,
@@ -759,23 +938,30 @@ function plantFixture({
     id = 1014,
     label = 'Rajčica',
     origin = 'Južna Amerika',
+    prices,
     storage,
 }: {
     description?: string;
     id?: number;
     label?: string;
     origin?: string;
+    prices?: EntityStandardized['prices'];
     storage?: string;
 } = {}): EntityStandardized {
+    const information: NonNullable<EntityStandardized['information']> & {
+        origin?: string;
+        storage?: string;
+    } = {
+        label,
+        name: label,
+        description,
+        origin,
+        ...(storage ? { storage } : {}),
+    };
+
     return {
         id,
-        information: {
-            label,
-            name: label,
-            description,
-            origin,
-            ...(storage ? { storage } : {}),
-        },
+        information,
         image: { cover: { url: plantImageDataUrl } },
         attributes: {
             seedingDistance: 30,
@@ -789,6 +975,7 @@ function plantFixture({
             yieldType: 'perPlant',
             cleanHarvest: false,
         },
+        ...(prices === undefined ? {} : { prices }),
     };
 }
 

--- a/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
+++ b/apps/app/app/admin/farmers/documentation/farmerDocumentationPdf.ts
@@ -10,6 +10,7 @@ import {
     type FarmerDocumentationPackage,
     type FarmerDocumentationPackageContent,
     type FarmerDocumentationPage,
+    type FarmerDocumentationPayoutPriceFarm,
     type FarmerDocumentationSection,
     formatDocumentationDateTime,
     getFarmerAppOrigin,
@@ -614,6 +615,7 @@ function drawOrganizationGuide({
         'Ako dvije stranice imaju isti naslov, zadrži redoslijed prema kodu.',
         'Kod dodavanja ili zamjene stranica novu verziju umetni na mjesto navedeno u uputama ispod.',
     ]);
+    context = drawPayoutPriceGuide(context, data, content);
 
     context = drawActionList(
         context,
@@ -636,6 +638,57 @@ function drawOrganizationGuide({
     ]);
 
     drawFooter(context.page);
+}
+
+function drawPayoutPriceGuide(
+    context: FlowContext,
+    data: FarmerDocumentationPackage,
+    content: FarmerDocumentationPackageContent,
+) {
+    if (content === 'plants') {
+        return context;
+    }
+
+    if (!data.payoutPrices.schemaAvailable) {
+        return drawSection(context, 'Cjenik isplata farmera', [
+            'Tablice za cijene radnji nisu dostupne u ovoj bazi. Nakon migracije cjenik će se moći dodati u paket dokumentacije.',
+        ]);
+    }
+
+    if (data.payoutPrices.farms.length === 0) {
+        return drawSection(context, 'Cjenik isplata farmera', [
+            'Nema farmi u sustavu.',
+        ]);
+    }
+
+    return drawMarkdownSection(context, 'Cjenik isplata farmera', [
+        payoutPricesMarkdown(data),
+    ]);
+}
+
+function payoutPricesMarkdown(data: FarmerDocumentationPackage) {
+    return [
+        `Definirano ${data.payoutPrices.configuredRows} od ${data.payoutPrices.totalRows} cijena. Cjenik prikazuje aktualno stanje na dan generiranja paketa i ne filtrira se po zadnjem ispisu.`,
+        '',
+        ...data.payoutPrices.farms.flatMap(payoutPriceFarmMarkdown),
+    ].join('\n');
+}
+
+function payoutPriceFarmMarkdown(farm: FarmerDocumentationPayoutPriceFarm) {
+    return [
+        `### ${farm.farmName}`,
+        '| Kod | Radnja | Korisnik | Trajanje | Farmer | EUR/min |',
+        '| --- | --- | --- | --- | --- | --- |',
+        ...farm.rows.map(
+            (row) =>
+                `| ${markdownTableCell(row.code)} | ${markdownTableCell(row.label)} | ${markdownTableCell(row.userFacingPriceLabel)} | ${markdownTableCell(row.durationLabel)} | ${markdownTableCell(row.farmerPriceLabel)} | ${markdownTableCell(row.farmerPricePerMinuteLabel)} |`,
+        ),
+        '',
+    ];
+}
+
+function markdownTableCell(value: string) {
+    return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
 }
 
 function farmerDocumentationFilenameContentPart(

--- a/apps/app/app/admin/farmers/documentation/page.tsx
+++ b/apps/app/app/admin/farmers/documentation/page.tsx
@@ -21,6 +21,8 @@ import {
     documentationPackageContentQueryValue,
     type FarmerDocumentationChangeType,
     type FarmerDocumentationPackageContent,
+    type FarmerDocumentationPayoutPriceFarm,
+    type FarmerDocumentationPayoutPrices,
     formatDocumentationDateTime,
     getFarmerDocumentationPackage,
     includedDocumentationPages,
@@ -211,6 +213,10 @@ export default async function FarmerDocumentationPage({
                 />
             </div>
 
+            <PayoutPriceDocumentationCard
+                payoutPrices={documentationPackage.payoutPrices}
+            />
+
             <Card>
                 <CardHeader>
                     <CardTitle>Sadržaj paketa</CardTitle>
@@ -343,4 +349,142 @@ function packageTableRows(
             }),
         ),
     ].sort((left, right) => left.code.localeCompare(right.code));
+}
+
+function PayoutPriceDocumentationCard({
+    payoutPrices,
+}: {
+    payoutPrices: FarmerDocumentationPayoutPrices;
+}) {
+    if (!payoutPrices.schemaAvailable) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle>Cjenik isplata farmera</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Typography level="body2" className="text-muted-foreground">
+                        Tablice za cijene radnji nisu dostupne u ovoj bazi.
+                        Nakon migracije cjenik će se dodavati u dokumentaciju.
+                    </Typography>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    if (payoutPrices.farms.length === 0) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle>Cjenik isplata farmera</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Typography level="body2" className="text-muted-foreground">
+                        Nema farmâ u sustavu.
+                    </Typography>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Cjenik isplata farmera</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <Typography level="body2" className="text-muted-foreground">
+                    Definirano {payoutPrices.configuredRows} od{' '}
+                    {payoutPrices.totalRows} cijena.
+                </Typography>
+            </CardContent>
+            <CardOverflow className="border-t">
+                {payoutPrices.farms.map((farm) => (
+                    <PayoutPriceFarmTable key={farm.farmId} farm={farm} />
+                ))}
+            </CardOverflow>
+        </Card>
+    );
+}
+
+function PayoutPriceFarmTable({
+    farm,
+}: {
+    farm: FarmerDocumentationPayoutPriceFarm;
+}) {
+    const configuredRows = farm.rows.filter((row) => row.hasFarmerPrice).length;
+
+    return (
+        <section className="border-b last:border-b-0">
+            <div className="flex flex-wrap items-center justify-between gap-2 bg-muted/30 px-3 py-3 sm:px-4">
+                <Typography level="body2" semiBold>
+                    {farm.farmName}
+                </Typography>
+                <Typography level="body3" className="text-muted-foreground">
+                    {configuredRows}/{farm.rows.length} definirano
+                </Typography>
+            </div>
+            <div className="overflow-x-auto">
+                <table className="min-w-[860px] w-full text-left text-sm">
+                    <thead className="border-y bg-muted/20 text-xs text-muted-foreground">
+                        <tr>
+                            <th className="px-3 py-2 font-medium sm:px-4">
+                                Kod
+                            </th>
+                            <th className="px-3 py-2 font-medium">Radnja</th>
+                            <th className="px-3 py-2 font-medium">
+                                Korisnička cijena
+                            </th>
+                            <th className="px-3 py-2 font-medium">Trajanje</th>
+                            <th className="px-3 py-2 font-medium">
+                                Farmer cijena
+                            </th>
+                            <th className="px-3 py-2 font-medium sm:pr-4">
+                                Farmer EUR/min
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y">
+                        {farm.rows.map((row) => (
+                            <tr key={row.code} className="align-top">
+                                <td className="px-3 py-3 sm:px-4">
+                                    <span className="rounded-md bg-muted px-2 py-1 font-mono text-xs font-medium text-muted-foreground">
+                                        {row.code}
+                                    </span>
+                                </td>
+                                <td className="px-3 py-3">
+                                    <div className="font-medium">
+                                        {row.label}
+                                    </div>
+                                    {row.sublabel && (
+                                        <div className="mt-1 font-mono text-xs text-muted-foreground">
+                                            {row.sublabel}
+                                        </div>
+                                    )}
+                                </td>
+                                <td className="px-3 py-3 text-muted-foreground">
+                                    {row.userFacingPriceLabel}
+                                </td>
+                                <td className="px-3 py-3 text-muted-foreground">
+                                    {row.durationLabel}
+                                </td>
+                                <td
+                                    className={
+                                        row.hasFarmerPrice
+                                            ? 'px-3 py-3 font-medium tabular-nums'
+                                            : 'px-3 py-3 font-medium text-amber-700'
+                                    }
+                                >
+                                    {row.farmerPriceLabel}
+                                </td>
+                                <td className="px-3 py-3 tabular-nums text-muted-foreground sm:pr-4">
+                                    {row.farmerPricePerMinuteLabel}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    );
 }


### PR DESCRIPTION
## Summary
- Add current farmer payout price rows to farmer documentation data, grouped by farm.
- Render the cjenik in the admin documentation preview and in the PDF organization guide for full/operations packages.
- Cover data shaping and PDF output with farmer payout price assertions.

## Validation
- `corepack pnpm --filter app exec biome check app/admin/farmers/documentation/farmerDocumentationData.ts app/admin/farmers/documentation/farmerDocumentationData.unit.ts app/admin/farmers/documentation/farmerDocumentationPdf.ts app/admin/farmers/documentation/page.tsx`
- `corepack pnpm --filter app exec node --conditions=react-server --import tsx --test app/admin/farmers/documentation/farmerDocumentationData.unit.ts`
- `corepack pnpm typecheck --filter app`
- `git diff --check`

Note: direct `tsc --noEmit` for `apps/app` still reports existing errors outside the touched farmer-documentation files; a filtered scan returned no diagnostics for this change.