### PR TITLE
fix(game): preserve outlet options when moving plants

### DIFF
--- a/packages/game/src/hooks/shoppingCartPositionPayload.ts
+++ b/packages/game/src/hooks/shoppingCartPositionPayload.ts
@@ -1,0 +1,76 @@
+import type { ShoppingCartItemData } from './useShoppingCart';
+
+export type ShoppingCartPositionCartItem = {
+    id: ShoppingCartItemData['id'];
+    entityId: ShoppingCartItemData['entityId'];
+    entityTypeName: ShoppingCartItemData['entityTypeName'];
+    amount: ShoppingCartItemData['amount'];
+    gardenId?: ShoppingCartItemData['gardenId'];
+    raisedBedId?: ShoppingCartItemData['raisedBedId'];
+    additionalData?: ShoppingCartItemData['additionalData'];
+    currency?: ShoppingCartItemData['currency'];
+    outlet?: { offerId?: number | null } | null;
+};
+
+export type ShoppingCartPositionUpdatePayload = {
+    id: ShoppingCartPositionCartItem['id'];
+    entityId: ShoppingCartPositionCartItem['entityId'];
+    entityTypeName: ShoppingCartPositionCartItem['entityTypeName'];
+    amount: ShoppingCartPositionCartItem['amount'];
+    gardenId?: number;
+    raisedBedId?: number;
+    positionIndex?: number;
+    additionalData?: ShoppingCartPositionCartItem['additionalData'];
+    currency?: ShoppingCartPositionCartItem['currency'];
+    outletOfferId?: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function outletOfferIdFromAdditionalData(additionalData?: string | null) {
+    if (!additionalData) {
+        return undefined;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(additionalData);
+        if (!isRecord(parsed)) {
+            return undefined;
+        }
+
+        return typeof parsed.outletOfferId === 'number'
+            ? parsed.outletOfferId
+            : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+export function getCartItemOutletOfferId(item: ShoppingCartPositionCartItem) {
+    return typeof item.outlet?.offerId === 'number'
+        ? item.outlet.offerId
+        : outletOfferIdFromAdditionalData(item.additionalData);
+}
+
+export function shoppingCartPositionUpdatePayload(
+    item: ShoppingCartPositionCartItem,
+    positionIndex: number | undefined,
+): ShoppingCartPositionUpdatePayload {
+    const outletOfferId = getCartItemOutletOfferId(item);
+
+    return {
+        id: item.id,
+        entityTypeName: item.entityTypeName,
+        entityId: item.entityId,
+        amount: item.amount,
+        gardenId: typeof item.gardenId === 'number' ? item.gardenId : undefined,
+        raisedBedId:
+            typeof item.raisedBedId === 'number' ? item.raisedBedId : undefined,
+        positionIndex,
+        additionalData: item.additionalData,
+        currency: item.currency,
+        ...(typeof outletOfferId === 'number' ? { outletOfferId } : {}),
+    };
+}

--- a/packages/game/src/hooks/shoppingCartPositionPayload.unit.ts
+++ b/packages/game/src/hooks/shoppingCartPositionPayload.unit.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getCartItemOutletOfferId,
+    type ShoppingCartPositionCartItem,
+    shoppingCartPositionUpdatePayload,
+} from './shoppingCartPositionPayload';
+
+function cartItem(
+    overrides: Partial<ShoppingCartPositionCartItem> = {},
+): ShoppingCartPositionCartItem {
+    return {
+        id: 11,
+        entityTypeName: 'plantSort',
+        entityId: '101',
+        amount: 1,
+        gardenId: 1,
+        raisedBedId: 2,
+        additionalData: null,
+        currency: 'eur',
+        ...overrides,
+    };
+}
+
+test('shoppingCartPositionUpdatePayload keeps the outlet offer from cart info', () => {
+    const payload = shoppingCartPositionUpdatePayload(
+        cartItem({
+            outlet: { offerId: 302 },
+            additionalData: JSON.stringify({ outletOfferId: 302 }),
+        }),
+        8,
+    );
+
+    assert.deepEqual(payload, {
+        id: 11,
+        entityTypeName: 'plantSort',
+        entityId: '101',
+        amount: 1,
+        gardenId: 1,
+        raisedBedId: 2,
+        positionIndex: 8,
+        additionalData: JSON.stringify({ outletOfferId: 302 }),
+        currency: 'eur',
+        outletOfferId: 302,
+    });
+});
+
+test('getCartItemOutletOfferId falls back to optimistic additional data', () => {
+    assert.equal(
+        getCartItemOutletOfferId(
+            cartItem({
+                additionalData: JSON.stringify({ outletOfferId: 301 }),
+            }),
+        ),
+        301,
+    );
+});
+
+test('shoppingCartPositionUpdatePayload leaves ordinary plant sorts ordinary', () => {
+    const payload = shoppingCartPositionUpdatePayload(
+        cartItem({
+            additionalData: JSON.stringify({
+                scheduledDate: '2026-07-01T00:00:00.000Z',
+            }),
+        }),
+        4,
+    );
+
+    assert.equal('outletOfferId' in payload, false);
+    assert.equal(payload.positionIndex, 4);
+    assert.equal(
+        payload.additionalData,
+        JSON.stringify({ scheduledDate: '2026-07-01T00:00:00.000Z' }),
+    );
+});

--- a/packages/game/src/hooks/useSwapShoppingCartPositions.ts
+++ b/packages/game/src/hooks/useSwapShoppingCartPositions.ts
@@ -1,5 +1,6 @@
 import { clientAuthenticated } from '@gredice/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { shoppingCartPositionUpdatePayload } from './shoppingCartPositionPayload';
 import {
     type ShoppingCartData,
     type ShoppingCartItemData,
@@ -29,16 +30,11 @@ export function useSwapShoppingCartPositions() {
             // Update item A to the target position
             await clientAuthenticated().api['shopping-cart'].$post({
                 json: {
-                    id: itemA.id,
+                    ...shoppingCartPositionUpdatePayload(
+                        itemA,
+                        targetPositionIndex,
+                    ),
                     cartId: cart.id,
-                    entityTypeName: itemA.entityTypeName,
-                    entityId: itemA.entityId,
-                    amount: itemA.amount,
-                    gardenId: itemA.gardenId ?? undefined,
-                    raisedBedId: itemA.raisedBedId ?? undefined,
-                    positionIndex: targetPositionIndex,
-                    additionalData: itemA.additionalData,
-                    currency: itemA.currency,
                 },
             });
 
@@ -46,16 +42,11 @@ export function useSwapShoppingCartPositions() {
             if (itemB) {
                 await clientAuthenticated().api['shopping-cart'].$post({
                     json: {
-                        id: itemB.id,
+                        ...shoppingCartPositionUpdatePayload(
+                            itemB,
+                            itemA.positionIndex ?? undefined,
+                        ),
                         cartId: cart.id,
-                        entityTypeName: itemB.entityTypeName,
-                        entityId: itemB.entityId,
-                        amount: itemB.amount,
-                        gardenId: itemB.gardenId ?? undefined,
-                        raisedBedId: itemB.raisedBedId ?? undefined,
-                        positionIndex: itemA.positionIndex ?? undefined,
-                        additionalData: itemB.additionalData,
-                        currency: itemB.currency,
                     },
                 });
             }


### PR DESCRIPTION
## What changed
- Preserve outlet offer metadata when a pending plant sort is moved or swapped between raised-bed fields.
- Share the cart-position payload builder so both moved items keep existing additional data, currency, garden/bed placement, and outlet reservation identifiers.
- Add unit coverage for outlet reservation preservation, optimistic additional-data fallback, and ordinary scheduled plant moves.

## Why
Moving a selected outlet plant used the normal cart update payload without `outletOfferId`. The API then treated the update as a non-outlet cart item and released the outlet reservation, so plant options could change just from dragging the item to another field.

## Validation
- `corepack pnpm --filter @gredice/game exec biome check --write src/hooks/useSwapShoppingCartPositions.ts src/hooks/shoppingCartPositionPayload.ts src/hooks/shoppingCartPositionPayload.unit.ts`
- `corepack pnpm --filter @gredice/game exec tsx --test src/hooks/shoppingCartPositionPayload.unit.ts`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter @gredice/game test`
- `git diff --check`