### PR TITLE
fix(garden): allow outlet cart sunflower payment

### DIFF
--- a/apps/api/app/api/[...route]/shoppingCartRoutes.ts
+++ b/apps/api/app/api/[...route]/shoppingCartRoutes.ts
@@ -170,9 +170,16 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     400,
                 );
             }
-            if (outletOfferId && currency && currency !== 'eur') {
+            if (
+                outletOfferId &&
+                currency &&
+                currency !== 'eur' &&
+                currency !== 'sunflower'
+            ) {
                 return context.json(
-                    { error: 'Outlet offers can only be paid in euros' },
+                    {
+                        error: 'Outlet offers can only be paid in euros or sunflowers',
+                    },
                     400,
                 );
             }

--- a/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
+++ b/apps/garden/tests/ShoppingCartOptimisticToggleStory.tsx
@@ -46,10 +46,15 @@ const cartItem = {
 } as unknown as ShoppingCartItemData;
 
 function createOutletCartItem() {
+    const plantSortItem = createPlantSortCartItem();
+
     return {
-        ...cartItem,
+        ...plantSortItem,
+        raisedBedId: 2,
+        positionIndex: 0,
+        additionalData: null,
         shopData: {
-            ...cartItem.shopData,
+            ...plantSortItem.shopData,
             discountDescription: 'Outlet sadnica',
             discountPrice: 1.2,
         },

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -204,15 +204,38 @@ test('shopping cart outlet item shows a live reservation countdown', async ({
     mount,
     page,
 }) => {
+    let resolvePayload:
+        | ((payload: Record<string, unknown>) => void)
+        | undefined;
+    const postedPayload = new Promise<Record<string, unknown>>((resolve) => {
+        resolvePayload = resolve;
+    });
+
+    await page.route('**/api/gredice/**/shopping-cart', async (route) => {
+        if (route.request().method() !== 'POST') {
+            await route.fallback();
+            return;
+        }
+
+        const payload: unknown = route.request().postDataJSON();
+        if (isRecord(payload)) {
+            resolvePayload?.(payload);
+        }
+        await route.fulfill({
+            body: JSON.stringify({ success: true }),
+            contentType: 'application/json',
+            status: 200,
+        });
+    });
+
     await mount(<ShoppingCartOutletCountdownStory />);
 
     await expect(page.getByText('Outlet sadnica').first()).toBeVisible();
     await expect(page.getByText(/Istječe za 1:[0-5]\d/u)).toBeVisible();
-    await expect(
-        page.getByRole('switch', {
-            name: /Plaćanje eurima, prebaci na 1\.200 suncokreta/u,
-        }),
-    ).toBeVisible();
+    const paymentSwitch = page.getByRole('switch', {
+        name: /Plaćanje eurima, prebaci na 1\.200 suncokreta/u,
+    });
+    await expect(paymentSwitch).toBeVisible();
 
     const badges = page.locator('[data-shopping-cart-item-badges]');
     await expect(badges).toContainText('Outlet sadnica');
@@ -221,4 +244,9 @@ test('shopping cart outlet item shows a live reservation countdown', async ({
     await expect(badges).toContainText('Staklenik');
     await expect(page.getByText('Nova gredica')).toBeVisible();
     await expect(page.getByText('Poz.1')).toBeVisible();
+
+    await paymentSwitch.click();
+    const payload = await postedPayload;
+    expect(payload.currency).toBe('sunflower');
+    expect(payload.outletOfferId).toBe(1);
 });

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -208,4 +208,17 @@ test('shopping cart outlet item shows a live reservation countdown', async ({
 
     await expect(page.getByText('Outlet sadnica').first()).toBeVisible();
     await expect(page.getByText(/Istječe za 1:[0-5]\d/u)).toBeVisible();
+    await expect(
+        page.getByRole('switch', {
+            name: /Plaćanje eurima, prebaci na 1\.200 suncokreta/u,
+        }),
+    ).toBeVisible();
+
+    const badges = page.locator('[data-shopping-cart-item-badges]');
+    await expect(badges).toContainText('Outlet sadnica');
+    await expect(badges).toContainText(/Istječe za 1:[0-5]\d/u);
+    await expect(badges).toContainText('15. 04. 2026.');
+    await expect(badges).toContainText('Staklenik');
+    await expect(page.getByText('Nova gredica')).toBeVisible();
+    await expect(page.getByText('Poz.1')).toBeVisible();
 });

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -5,7 +5,6 @@ import { Input } from '@gredice/ui/Input';
 import {
     Close,
     Delete,
-    Euro,
     Hammer,
     Navigate,
     Sprout,
@@ -281,6 +280,7 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
             invItem.entityTypeName === item.entityTypeName &&
             invItem.entityId === item.entityId,
     )?.amount;
+    const hasAvailableInventory = (availableFromInventory ?? 0) > 0;
 
     async function handleChangePaymentType(isSunflower: boolean) {
         track('game_cart_payment_method_changed', {
@@ -507,6 +507,28 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
         );
     }
 
+    function renderOutletReservationBadges() {
+        if (!item.outlet) {
+            return null;
+        }
+
+        return (
+            <>
+                <Chip className="bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-100">
+                    <Typography level="body3">Outlet sadnica</Typography>
+                </Chip>
+                <Chip
+                    className={outletReservationChipClassName}
+                    title={outletReservationTitle}
+                >
+                    <Typography level="body3">
+                        {outletReservationText}
+                    </Typography>
+                </Chip>
+            </>
+        );
+    }
+
     return (
         <Row spacing={4} alignItems="start">
             {plantSort ? (
@@ -540,38 +562,12 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                 />
             )}
             <Stack className="grow">
-                <div className="grid grid-cols-[1fr_auto] items-center">
+                <div className="grid grid-cols-[1fr_auto] items-center gap-2">
                     <Typography level="body1" noWrap>
                         {item.shopData.name}
                     </Typography>
-                    {!hasDiscount && (
-                        <Row spacing={2}>
-                            {!usesInventory && availableFromInventory && (
-                                <IconButton
-                                    title="Iskoristi iz ruksaka"
-                                    size="sm"
-                                    variant="solid"
-                                    onClick={handleToggleInventory}
-                                >
-                                    <BackpackIcon className="size-5 shrink-0" />
-                                </IconButton>
-                            )}
-                            <ButtonPricePickPaymentMethod
-                                price={item.shopData.price}
-                                isSunflower={item.currency === 'sunflower'}
-                                onChange={handleChangePaymentType}
-                                availableSunflowers={
-                                    account?.sunflowers.amount ?? 0
-                                }
-                                discountPrice={item.shopData.discountPrice}
-                                disabled={
-                                    changeCurrencyShoppingCartItem.isPending
-                                }
-                            />
-                        </Row>
-                    )}
-                    <Row spacing={2} className="flex-wrap justify-end">
-                        {usesInventory && (
+                    <Row spacing={2} className="justify-end">
+                        {usesInventory ? (
                             <Row spacing={1}>
                                 <BackpackIcon className="size-4 shrink-0" />
                                 <Typography level="body2">
@@ -586,50 +582,45 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                                     <Close className="size-4 shrink-0" />
                                 </IconButton>
                             </Row>
+                        ) : (
+                            <>
+                                {hasAvailableInventory && (
+                                    <IconButton
+                                        title="Iskoristi iz ruksaka"
+                                        size="sm"
+                                        variant="solid"
+                                        onClick={handleToggleInventory}
+                                    >
+                                        <BackpackIcon className="size-5 shrink-0" />
+                                    </IconButton>
+                                )}
+                                <ButtonPricePickPaymentMethod
+                                    price={item.shopData.price}
+                                    isSunflower={item.currency === 'sunflower'}
+                                    onChange={handleChangePaymentType}
+                                    availableSunflowers={
+                                        account?.sunflowers.amount ?? 0
+                                    }
+                                    discountPrice={item.shopData.discountPrice}
+                                    disabled={
+                                        changeCurrencyShoppingCartItem.isPending
+                                    }
+                                />
+                            </>
                         )}
                     </Row>
                 </div>
                 {hasDiscount &&
                     typeof item.shopData.discountPrice === 'number' &&
                     typeof item.shopData.price === 'number' && (
-                        <Row justifyContent="space-between" spacing={2}>
-                            <Typography
-                                level="body3"
-                                secondary
-                                className="text-green-600"
-                            >
-                                {`Popust: ${(100 - (item.shopData.discountPrice / item.shopData.price) * 100).toFixed(0)}% - ${item.shopData.discountDescription}`}
-                            </Typography>
-                            <Row spacing={1}>
-                                <Typography
-                                    level="body1"
-                                    bold
-                                    className="text-green-600"
-                                >
-                                    {item.shopData.discountPrice?.toFixed(2) ??
-                                        'Nevaljan iznos'}
-                                </Typography>
-                                <Euro className="size-4 stroke-green-600" />
-                            </Row>
-                        </Row>
-                    )}
-                {item.outlet ? (
-                    <Row className="flex-wrap" spacing={1}>
-                        <Chip className="bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-100">
-                            <Typography level="body3">
-                                Outlet sadnica
-                            </Typography>
-                        </Chip>
-                        <Chip
-                            className={outletReservationChipClassName}
-                            title={outletReservationTitle}
+                        <Typography
+                            level="body3"
+                            secondary
+                            className="text-green-600"
                         >
-                            <Typography level="body3">
-                                {outletReservationText}
-                            </Typography>
-                        </Chip>
-                    </Row>
-                ) : null}
+                            {`Popust: ${(100 - (item.shopData.discountPrice / item.shopData.price) * 100).toFixed(0)}% - ${item.shopData.discountDescription}`}
+                        </Typography>
+                    )}
                 <Row justifyContent="space-between">
                     <Stack spacing={1}>
                         <Row spacing={2}>
@@ -667,7 +658,12 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                                 )}
                             </Row>
                         </Row>
-                        <Row spacing={1} className="flex-wrap">
+                        <Row
+                            spacing={1}
+                            className="flex-wrap"
+                            data-shopping-cart-item-badges
+                        >
+                            {renderOutletReservationBadges()}
                             {renderScheduledDateControl()}
                             {renderGreenhouseSowingControl()}
                         </Row>

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -20,6 +20,7 @@ import { Typography } from '@gredice/ui/Typography';
 import { useQueryClient } from '@tanstack/react-query';
 import { type CSSProperties, useEffect, useState } from 'react';
 import { useGameAnalytics } from '../../../analytics/GameAnalyticsContext';
+import { getCartItemOutletOfferId } from '../../../hooks/shoppingCartPositionPayload';
 import { useCurrentAccount } from '../../../hooks/useCurrentAccount';
 import { useCurrentGarden } from '../../../hooks/useCurrentGarden';
 import { useInventory } from '../../../hooks/useInventory';
@@ -283,6 +284,8 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
     const hasAvailableInventory = (availableFromInventory ?? 0) > 0;
 
     async function handleChangePaymentType(isSunflower: boolean) {
+        const outletOfferId = getCartItemOutletOfferId(item);
+
         track('game_cart_payment_method_changed', {
             entity_id: item.entityId,
             entity_type: item.entityTypeName,
@@ -298,6 +301,7 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
             positionIndex: item.positionIndex ?? undefined,
             gardenId: item.gardenId ?? undefined,
             raisedBedId: item.raisedBedId ?? undefined,
+            outletOfferId,
         });
     }
 


### PR DESCRIPTION
## Summary
- Show the euro/sunflower payment switch for discounted cart items, including outlet seedlings.
- Move outlet reservation badges into the same wrapping metadata row as the scheduled date and greenhouse badges.
- Expand the cart component test fixture/assertions to cover outlet plant-sort reservations.

## Validation
- `corepack pnpm --dir packages/game exec biome check --write src/hud/components/shopping-cart/ShoppingCartItem.tsx`
- `corepack pnpm --dir apps/garden exec biome check --write tests/ShoppingCartOptimisticToggleStory.tsx tests/shopping-cart-optimistic-toggle.spec.tsx`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --dir apps/garden run test:prepare`
- `corepack pnpm --dir apps/garden exec playwright test tests/shopping-cart-optimistic-toggle.spec.tsx`