### PR TITLE
fix(accounts): return sunflower history newest-first when paginated

### DIFF
--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -5,7 +5,7 @@ import { accounts, accountUsers, ensureAccountAchievement, storage } from '..';
 import {
     createEvent,
     getAllEvents,
-    getEvents,
+    getLatestEvents,
     knownEvents,
     knownEventTypes,
 } from './eventsRepo';
@@ -151,7 +151,7 @@ export async function getSunflowersHistory(
     offset: number = 0,
     limit: number = 10,
 ) {
-    const earnEvents = await getEvents(
+    const earnEvents = await getLatestEvents(
         [
             knownEventTypes.accounts.earnSunflowers,
             knownEventTypes.accounts.earnSunflowerDrop,
@@ -161,7 +161,7 @@ export async function getSunflowersHistory(
         offset,
         limit,
     );
-    return earnEvents.reverse().map((event) => {
+    return earnEvents.map((event) => {
         const { amount, reason } = parseSunflowerEventData(event.data);
         return {
             ...event,

--- a/packages/storage/tests/accountsRepo.node.spec.ts
+++ b/packages/storage/tests/accountsRepo.node.spec.ts
@@ -227,3 +227,23 @@ test('getSunflowersHistory returns correct history', async () => {
     assert.ok(history.some((e) => e.reason === 'test-earn'));
     assert.ok(history.some((e) => e.reason === 'test-spend'));
 });
+
+test('getSunflowersHistory returns newest events first when limited', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    await earnSunflowers(accountId, 1, 'history-old');
+    await earnSunflowers(accountId, 2, 'history-middle');
+    await earnSunflowers(accountId, 3, 'history-newest');
+
+    const firstPage = await getSunflowersHistory(accountId, 0, 2);
+    assert.deepStrictEqual(
+        firstPage.map((event) => event.reason),
+        ['history-newest', 'history-middle'],
+    );
+
+    const secondPage = await getSunflowersHistory(accountId, 2, 1);
+    assert.deepStrictEqual(
+        secondPage.map((event) => event.reason),
+        ['history-old'],
+    );
+});


### PR DESCRIPTION
## Summary
- Switch sunflower history reads to `getLatestEvents` so limited pages stay in newest-first order
- Remove the extra reverse so returned history matches the pagination order
- Add a node test covering first- and second-page ordering

## Testing
- Added unit coverage for paginated sunflower history ordering