### PR TITLE
feat(scene): fix inverted sun trajectory

### DIFF
--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -4,7 +4,7 @@ import { useFrame, useThree } from '@react-three/fiber';
 import chroma from 'chroma-js';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import * as SunCalc from 'suncalc';
-import { Color, Quaternion, Vector3 } from 'three';
+import { Color, type Vector3 } from 'three';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { useWeatherNow } from '../hooks/useWeatherNow';
@@ -24,6 +24,7 @@ import { ShadowMapController } from './ShadowMapController';
 import Snow from './Snow/Snow';
 import { Stars } from './Stars';
 import { SunMoon } from './SunMoon';
+import { altAzToScenePosition, timeOfDayToDate } from './sunPosition';
 import {
     getVisualDaylightAmount,
     getVisualNightAmount,
@@ -31,12 +32,6 @@ import {
     visualDayNightTimes,
 } from './visualDayNight';
 import { resolveWaterColors } from './waterColors';
-
-const degreesToRadiansScale = Math.PI / 180;
-
-export function degreesToRadians(degrees: number) {
-    return degrees * degreesToRadiansScale;
-}
 
 const backgroundColorScale = chroma
     .scale([
@@ -284,38 +279,6 @@ function useBlendedWeather(
     });
 
     return blendedWeather;
-}
-
-export function timeOfDayToDate(currentTime: Date, timeOfDay: number) {
-    const hours = Math.trunc(timeOfDay * 24);
-    const minutes = Math.trunc((timeOfDay * 24 - hours) * 60);
-    return new Date(
-        currentTime.getFullYear(),
-        currentTime.getMonth(),
-        currentTime.getDate(),
-        hours,
-        minutes,
-        0,
-    );
-}
-
-// Maps SunCalc altitude/azimuth degrees into the stylized scene sky so both
-// the visible sun/moon discs and the directional light share the same trajectory.
-export function altAzToScenePosition(
-    altitudeDegrees: number,
-    azimuthDegrees: number,
-) {
-    const altitude = degreesToRadians(altitudeDegrees);
-    const azimuth = degreesToRadians(azimuthDegrees);
-    const pos = new Vector3(5, 20, 0);
-    const hinge = new Quaternion();
-    const rotator = new Quaternion();
-    rotator.setFromAxisAngle(new Vector3(0, -1, 0), altitude);
-    hinge.premultiply(rotator);
-    rotator.setFromAxisAngle(new Vector3(0.8, 0, 0), azimuth);
-    hinge.premultiply(rotator);
-    pos.applyQuaternion(hinge);
-    return pos;
 }
 
 function getSunPosition(

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -20,7 +20,7 @@ import {
     altAzToScenePosition,
     degreesToRadians,
     timeOfDayToDate,
-} from './Environment';
+} from './sunPosition';
 import { visualDayNightTimes } from './visualDayNight';
 
 // World-space size of the billboard planes. The visible disc is a fraction of

--- a/packages/game/src/scene/sunPosition.ts
+++ b/packages/game/src/scene/sunPosition.ts
@@ -1,0 +1,47 @@
+import { Quaternion, Vector3 } from 'three';
+
+const degreesToRadiansScale = Math.PI / 180;
+
+export function degreesToRadians(degrees: number) {
+    return degrees * degreesToRadiansScale;
+}
+
+export function timeOfDayToDate(currentTime: Date, timeOfDay: number) {
+    const hours = Math.trunc(timeOfDay * 24);
+    const minutes = Math.trunc((timeOfDay * 24 - hours) * 60);
+    return new Date(
+        currentTime.getFullYear(),
+        currentTime.getMonth(),
+        currentTime.getDate(),
+        hours,
+        minutes,
+        0,
+    );
+}
+
+// SunCalc v2 reports azimuth clockwise from north. The scene trajectory math
+// expects the older SunCalc convention: 0 at south with west positive.
+function sunCalcAzimuthToSceneAzimuth(azimuthDegrees: number) {
+    return azimuthDegrees - 180;
+}
+
+// Maps SunCalc altitude/azimuth degrees into the stylized scene sky so both
+// the visible sun/moon discs and the directional light share the same trajectory.
+export function altAzToScenePosition(
+    altitudeDegrees: number,
+    azimuthDegrees: number,
+) {
+    const altitude = degreesToRadians(altitudeDegrees);
+    const azimuth = degreesToRadians(
+        sunCalcAzimuthToSceneAzimuth(azimuthDegrees),
+    );
+    const pos = new Vector3(5, 20, 0);
+    const hinge = new Quaternion();
+    const rotator = new Quaternion();
+    rotator.setFromAxisAngle(new Vector3(0, -1, 0), altitude);
+    hinge.premultiply(rotator);
+    rotator.setFromAxisAngle(new Vector3(0.8, 0, 0), azimuth);
+    hinge.premultiply(rotator);
+    pos.applyQuaternion(hinge);
+    return pos;
+}

--- a/packages/game/src/scene/sunPosition.unit.ts
+++ b/packages/game/src/scene/sunPosition.unit.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { altAzToScenePosition, timeOfDayToDate } from './sunPosition';
+
+function round(value: number) {
+    return Number(value.toFixed(6));
+}
+
+test('maps the SunCalc v2 day arc upward before noon and downward after noon', () => {
+    const sunrise = altAzToScenePosition(6.9, 63.9);
+    const morning = altAzToScenePosition(26.8, 83.8);
+    const noon = altAzToScenePosition(64.4, 147.8);
+    const afternoon = altAzToScenePosition(46.9, 253.8);
+    const sunset = altAzToScenePosition(6.3, 296.8);
+
+    assert.ok(morning.y > sunrise.y);
+    assert.ok(noon.y > morning.y);
+    assert.ok(noon.y > afternoon.y);
+    assert.ok(afternoon.y > sunset.y);
+});
+
+test('keeps south-facing sun above east and west horizon positions', () => {
+    const east = altAzToScenePosition(0, 90);
+    const south = altAzToScenePosition(60, 180);
+    const west = altAzToScenePosition(0, 270);
+
+    assert.ok(south.y > east.y);
+    assert.ok(south.y > west.y);
+    assert.equal(round(east.y), round(west.y));
+});
+
+test('creates a scene date on the same local day for the normalized game time', () => {
+    const date = timeOfDayToDate(new Date(2026, 6, 3, 18, 49, 0), 0.75);
+
+    assert.equal(date.getFullYear(), 2026);
+    assert.equal(date.getMonth(), 6);
+    assert.equal(date.getDate(), 3);
+    assert.equal(date.getHours(), 18);
+    assert.equal(date.getMinutes(), 0);
+});


### PR DESCRIPTION
## Summary
- Move sun-position helpers into a dedicated `sunPosition` module
- Correct the SunCalc azimuth conversion so the sun and moon follow the intended arc
- Add unit coverage for the scene position mapping and time-of-day date normalization

## Testing
- Not run (not requested)