### PR TITLE
feat(game): add outlet icons to garden badges

### DIFF
--- a/apps/garden/tests/raised-bed-plant-picker.spec.tsx
+++ b/apps/garden/tests/raised-bed-plant-picker.spec.tsx
@@ -205,6 +205,7 @@ test('plant list shows outlet availability before sort selection', async ({
     const basilRow = page.locator('[data-plant-picker-plant-id="2"]');
 
     await expect(tomatoRow).toContainText('Outlet 2 ponude');
+    await expect(tomatoRow.locator('[data-outlet-badge] svg')).toHaveCount(1);
     await expect(basilRow).not.toContainText('Outlet');
 });
 
@@ -227,6 +228,7 @@ test('outlet sorts keep planned sowing selected by default', async ({
         sowingMode.getByRole('radio', { name: /Planirano sijanje/ }),
     ).toBeChecked();
     await expect(sowingMode.getByText('Outlet sadnica')).toHaveCount(2);
+    await expect(sowingMode.locator('svg').first()).toBeVisible();
     await expect(
         page.getByRole('textbox', { name: 'Datum sijanja' }),
     ).toBeVisible();

--- a/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
+++ b/apps/garden/tests/shopping-cart-optimistic-toggle.spec.tsx
@@ -231,6 +231,7 @@ test('shopping cart outlet item shows a live reservation countdown', async ({
     await mount(<ShoppingCartOutletCountdownStory />);
 
     await expect(page.getByText('Outlet sadnica').first()).toBeVisible();
+    await expect(page.locator('[data-outlet-badge] svg')).toBeVisible();
     await expect(page.getByText(/Istječe za 1:[0-5]\d/u)).toBeVisible();
     const paymentSwitch = page.getByRole('switch', {
         name: /Plaćanje eurima, prebaci na 1\.200 suncokreta/u,

--- a/packages/game/src/hud/components/OutletBadge.tsx
+++ b/packages/game/src/hud/components/OutletBadge.tsx
@@ -1,0 +1,28 @@
+import { Chip, type ChipProps } from '@gredice/ui/Chip';
+import { Discount } from '@gredice/ui/icons';
+
+type OutletBadgeProps = Omit<
+    ChipProps,
+    'children' | 'color' | 'startDecorator' | 'variant'
+> & {
+    children: ChipProps['children'];
+};
+
+export function OutletBadge({
+    children,
+    size = 'sm',
+    ...props
+}: OutletBadgeProps) {
+    return (
+        <Chip
+            color="success"
+            data-outlet-badge
+            size={size}
+            startDecorator={<Discount aria-hidden />}
+            variant="soft"
+            {...props}
+        >
+            {children}
+        </Chip>
+    );
+}

--- a/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
+++ b/packages/game/src/hud/components/shopping-cart/ShoppingCartItem.tsx
@@ -30,6 +30,7 @@ import {
     useShoppingCartQueryKey,
 } from '../../../hooks/useShoppingCart';
 import { RaisedBedWateringCalendar } from '../../raisedBed/RaisedBedWateringCalendar';
+import { OutletBadge } from '../OutletBadge';
 import { ButtonPricePickPaymentMethod } from './ButtonPricePickPaymentMethod';
 import { GreenhouseSowingToggle } from './GreenhouseSowingToggle';
 
@@ -203,12 +204,12 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                 },
             )}.`
           : undefined;
-    const outletReservationChipClassName = outletReservationExpired
-        ? 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-100'
+    const outletReservationChipColor = outletReservationExpired
+        ? 'error'
         : (outletReservationRemainingMs ?? Number.POSITIVE_INFINITY) <=
             urgentOutletReservationThresholdMs
-          ? 'bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-100'
-          : 'bg-muted';
+          ? 'warning'
+          : 'neutral';
     const changeCurrencyShoppingCartItem = useSetShoppingCartItem();
     const removeShoppingCartItem = useSetShoppingCartItem();
     const changeScheduledDateShoppingCartItem = useSetShoppingCartItem();
@@ -427,10 +428,12 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
 
         return (
             <Chip
-                className="bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-100"
+                color="success"
+                size="sm"
                 startDecorator={<Sprout />}
+                variant="soft"
             >
-                <Typography level="body3">Staklenik</Typography>
+                Staklenik
             </Chip>
         );
     }
@@ -452,14 +455,14 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
                 trigger={
                     <Chip
                         startDecorator={<Timer className="size-4" />}
-                        className="bg-muted"
+                        color="neutral"
                         disabled={changeScheduledDateShoppingCartItem.isPending}
                         onClick={() => setDatePickerError(null)}
+                        size="sm"
                         title={`Promijeni datum: ${scheduledDateLabel}`}
+                        variant="soft"
                     >
-                        <Typography level="body3" secondary>
-                            {scheduledDateLabel}
-                        </Typography>
+                        {scheduledDateLabel}
                     </Chip>
                 }
             >
@@ -497,16 +500,16 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
         ) : (
             <Chip
                 startDecorator={<Timer className="size-4" />}
-                className="bg-muted"
+                color="neutral"
+                size="sm"
                 title={
                     scheduledDateInfo.source === 'outlet'
                         ? 'Datum sjetve outlet sadnice'
                         : 'Datum'
                 }
+                variant="soft"
             >
-                <Typography level="body3" secondary>
-                    {scheduledDateLabel}
-                </Typography>
+                {scheduledDateLabel}
             </Chip>
         );
     }
@@ -518,16 +521,14 @@ export function ShoppingCartItem({ item }: { item: ShoppingCartItemData }) {
 
         return (
             <>
-                <Chip className="bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-100">
-                    <Typography level="body3">Outlet sadnica</Typography>
-                </Chip>
+                <OutletBadge>Outlet sadnica</OutletBadge>
                 <Chip
-                    className={outletReservationChipClassName}
+                    color={outletReservationChipColor}
+                    size="sm"
                     title={outletReservationTitle}
+                    variant="soft"
                 >
-                    <Typography level="body3">
-                        {outletReservationText}
-                    </Typography>
+                    {outletReservationText}
                 </Chip>
             </>
         );

--- a/packages/game/src/hud/raisedBed/PlantsList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsList.tsx
@@ -18,6 +18,7 @@ import { sortFavoritesFirst, useFavoriteIds } from '../../hooks/useFavorites';
 import type { OutletOfferData } from '../../hooks/useOutletOffers';
 import { usePlants } from '../../hooks/usePlants';
 import { KnownPages } from '../../knownPages';
+import { OutletBadge } from '../components/OutletBadge';
 import { FavoriteToggleButton } from './FavoriteToggleButton';
 import { PlantListItemSkeleton } from './PlantListItemSkeleton';
 import {
@@ -282,9 +283,9 @@ export function PlantsList({
                                     <SeedTimeInformationBadge size="sm" />
                                 )}
                                 {outletOffers?.length ? (
-                                    <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-700 dark:bg-green-900/50 dark:text-green-200">
+                                    <OutletBadge>
                                         {outletOfferBadgeLabel(outletOffers)}
-                                    </span>
+                                    </OutletBadge>
                                 ) : null}
                                 <PlantRelationshipSignalChips
                                     signal={relationshipSignal}

--- a/packages/game/src/hud/raisedBed/PlantsSortList.tsx
+++ b/packages/game/src/hud/raisedBed/PlantsSortList.tsx
@@ -21,6 +21,7 @@ import {
     useAnimateFlyToShoppingCart,
 } from '../../indicators/AnimateFlyTo';
 import { KnownPages } from '../../knownPages';
+import { OutletBadge } from '../components/OutletBadge';
 import { FavoriteToggleButton } from './FavoriteToggleButton';
 import { PlantListItemSkeleton } from './PlantListItemSkeleton';
 import { PlantRelationshipSignalChips } from './PlantsList';
@@ -170,9 +171,9 @@ function PlantSortListItem({
             >
                 <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                     {outletOffers?.length ? (
-                        <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-700 dark:bg-green-900/50 dark:text-green-200">
+                        <OutletBadge>
                             {outletOfferBadgeLabel(outletOffers)}
-                        </span>
+                        </OutletBadge>
                     ) : null}
                     {relationshipSignal ? (
                         <PlantRelationshipSignalChips

--- a/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedPlantPicker.tsx
@@ -6,6 +6,7 @@ import {
     Calendar,
     Check,
     Close,
+    Discount,
     Left,
     Search,
     ShoppingCart,
@@ -924,8 +925,14 @@ export function PlantPicker({
                                                                             level="body2"
                                                                             semiBold
                                                                         >
-                                                                            Outlet
-                                                                            sadnica
+                                                                            <span className="inline-flex items-center gap-1.5">
+                                                                                <Discount
+                                                                                    aria-hidden
+                                                                                    className="size-4 shrink-0"
+                                                                                />
+                                                                                Outlet
+                                                                                sadnica
+                                                                            </span>
                                                                         </Typography>
                                                                         <Typography
                                                                             level="body3"


### PR DESCRIPTION
## Summary

- Add a shared garden `OutletBadge` that uses the standard `Chip` success/soft palette and the existing outlet/discount icon.
- Replace hand-styled outlet badges in plant/sort selection and shopping cart with the shared badge.
- Normalize cart chip colors to component `color`/`variant` props so nested typography no longer overrides badge text colors.
- Cover the outlet badge icon in focused garden component tests.

## Validation

- `corepack pnpm lint --filter @gredice/game --filter garden`
- `corepack pnpm typecheck --filter @gredice/game --filter garden`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/raised-bed-plant-picker.spec.tsx tests/shopping-cart-optimistic-toggle.spec.tsx`