### PR TITLE
fix(garden): let operation names use available card space

### DIFF
--- a/apps/garden/tests/GardenOperationsHudStory.tsx
+++ b/apps/garden/tests/GardenOperationsHudStory.tsx
@@ -78,6 +78,18 @@ const internalOperation = {
     },
 } satisfies OperationData;
 
+const longLabelOperation = {
+    ...cartOperation,
+    id: 999_003,
+    slug: 'mock-surface-raised-bed-watering',
+    information: {
+        ...cartOperation.information,
+        name: 'surface-raised-bed-watering',
+        label: 'Površinsko zalijevanje gredice',
+        shortDescription: 'Dugačak naziv radnje za provjeru prikaza.',
+    },
+} satisfies OperationData;
+
 function buildGarden() {
     return {
         id: TEST_GARDEN_ID,
@@ -271,6 +283,8 @@ function createQueryClient({
         ? Array.from({ length: 14 }, (_, index) =>
               buildHudOperationItem({
                   id: 700 + index,
+                  entityId:
+                      index === 0 ? longLabelOperation.id : cartOperation.id,
                   status: index % 2 === 0 ? 'confirmed' : 'assigned',
               }),
           )
@@ -354,6 +368,7 @@ function createQueryClient({
     queryClient.setQueryData(operationDefinitionsQueryKey.all, [
         cartOperation,
         internalOperation,
+        longLabelOperation,
     ]);
     queryClient.setQueryData(['shopping-cart'], {
         id: 1,

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -266,6 +266,39 @@ test.describe('Garden operations HUD', () => {
         await expect(topFade).toHaveAttribute('data-visible', 'true');
     });
 
+    test('lets operation names use the space before the status badge', async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width: 448, height: 720 });
+        await mount(<DenseGardenOperationsHudStory />);
+
+        await page.getByTitle('Status radnji').click();
+
+        const card = page
+            .locator('[data-garden-operation-card]')
+            .filter({ hasText: 'Površinsko zalijevanje gredice' })
+            .first();
+        const operationName = card.getByText('Površinsko zalijevanje gredice');
+        const statusButton = card
+            .getByRole('button', { name: /Status radnje:/ })
+            .first();
+
+        await expect(operationName).toBeVisible();
+        await expect(statusButton).toBeVisible();
+
+        const nameBox = await operationName.boundingBox();
+        const statusBox = await statusButton.boundingBox();
+
+        if (!nameBox || !statusBox) {
+            throw new Error('Expected operation name and status to be visible');
+        }
+
+        const gapBeforeStatus = statusBox.x - (nameBox.x + nameBox.width);
+
+        expect(gapBeforeStatus).toBeLessThanOrEqual(16);
+    });
+
     test('keeps history operation cards full height in scrollable modal', async ({
         mount,
         page,

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -1596,39 +1596,46 @@ export function GardenOperationCard({
                     spacing={1.5}
                     className="min-w-0 max-w-full flex-1 overflow-hidden"
                 >
-                    <Row
-                        spacing={1}
-                        alignItems="start"
-                        className="min-w-0 max-w-full gap-y-1"
-                    >
-                        <Stack spacing={0.5} className="min-w-0 flex-1">
+                    <Stack spacing={0.5} className="min-w-0 max-w-full">
+                        <Row
+                            spacing={1}
+                            alignItems="start"
+                            className="min-w-0 max-w-full"
+                        >
                             <Typography
                                 level="body2"
                                 semiBold
                                 noWrap
-                                className="min-w-0"
+                                className="min-w-0 flex-1"
                             >
                                 {resolvedOperationName}
                             </Typography>
-                            <OperationTargetLabel
-                                targetDetails={targetDetails}
-                            />
-                        </Stack>
-                        <Stack
-                            spacing={0.25}
-                            className="min-w-0 max-w-[52%] shrink-0 items-end overflow-hidden"
+                            <div className="min-w-0 max-w-[45%] shrink-0 overflow-hidden">
+                                <OperationStatusSummary
+                                    operation={operation}
+                                    status={displayStatus}
+                                />
+                            </div>
+                        </Row>
+                        <Row
+                            spacing={1}
+                            alignItems="start"
+                            className="min-w-0 max-w-full gap-y-1"
                         >
-                            <OperationStatusSummary
-                                operation={operation}
-                                status={displayStatus}
-                            />
-                            <OperationSchedule
-                                operation={operation}
-                                cancelAction={cancelAction}
-                                scheduleAction={scheduleAction}
-                            />
-                        </Stack>
-                    </Row>
+                            <div className="min-w-0 flex-1">
+                                <OperationTargetLabel
+                                    targetDetails={targetDetails}
+                                />
+                            </div>
+                            <div className="min-w-0 max-w-[58%] shrink-0 overflow-hidden">
+                                <OperationSchedule
+                                    operation={operation}
+                                    cancelAction={cancelAction}
+                                    scheduleAction={scheduleAction}
+                                />
+                            </div>
+                        </Row>
+                    </Stack>
                     <OperationEvidence operation={operation} />
                     {action && <div className="flex justify-end">{action}</div>}
                 </Stack>


### PR DESCRIPTION
## Summary

- Split garden operation cards so the operation name shares a row only with the status badge.
- Keep target details and schedule/cancel controls on the next row, so date controls no longer force early name truncation.
- Add a component-test fixture and assertion for the long Croatian operation label spacing.

## Root Cause

The card used one right-side column for both status and schedule controls. The wider date/cancel row determined that column width, leaving empty space beside shorter statuses like `Potvrđeno` while the operation name was already ellipsized.

## Validation

- `corepack pnpm --filter @gredice/game exec biome check --write src/hud/GardenOperationsHud.tsx`
- `corepack pnpm --filter garden exec biome check --write tests/GardenOperationsHudStory.tsx tests/garden-operations-hud.spec.tsx`
- `corepack pnpm typecheck --filter @gredice/game --filter garden`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/garden-operations-hud.spec.tsx -g "lets operation names use the space before the status badge"`
- `corepack pnpm --filter garden exec playwright test tests/garden-operations-hud.spec.tsx`