### PR TITLE
feat(garden): improve public garden experience

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -47,6 +47,7 @@ import {
     getRaisedBedFieldDiaryEntries,
     getRaisedBedIdsByAccount,
     getRaisedBedSensors,
+    getRaisedBedsForGardens,
     getSandboxGardenDeletionCandidate,
     knownEvents,
     knownEventTypes,
@@ -82,7 +83,10 @@ import {
     hashGardenVisitSummaryFacts,
 } from '../../../lib/garden/gardenVisitSummaryService';
 import { isBlockPurchaseAvailableNow } from '../../../lib/garden/nightOnlyBlockPurchases';
-import { serializePublicRaisedBedField } from '../../../lib/garden/publicGardenSerialization';
+import {
+    countPublicGardenActivePlants,
+    serializePublicRaisedBedField,
+} from '../../../lib/garden/publicGardenSerialization';
 import { purchaseGardenBlock } from '../../../lib/garden/purchaseGardenBlockService';
 import {
     AI_REQUEST_QUOTAS,
@@ -711,16 +715,26 @@ const app = new Hono<{ Variables: AuthVariables }>()
         }),
         async (context) => {
             const publicGardens = await getPublicGardens();
+            const raisedBedsByGardenId = await getRaisedBedsForGardens(
+                publicGardens.map((garden) => garden.id),
+            );
 
             return context.json({
-                items: publicGardens.map((garden) => ({
-                    id: garden.id,
-                    name: garden.name,
-                    isSandbox: garden.isSandbox,
-                    backgroundPalette: garden.backgroundPalette,
-                    createdAt: garden.createdAt,
-                    updatedAt: garden.updatedAt,
-                })),
+                items: publicGardens.map((garden) => {
+                    const raisedBeds =
+                        raisedBedsByGardenId.get(garden.id) ?? [];
+
+                    return {
+                        id: garden.id,
+                        name: garden.name,
+                        isSandbox: garden.isSandbox,
+                        backgroundPalette: garden.backgroundPalette,
+                        activePlantCount:
+                            countPublicGardenActivePlants(raisedBeds),
+                        createdAt: garden.createdAt,
+                        updatedAt: garden.updatedAt,
+                    };
+                }),
             });
         },
     )

--- a/apps/api/lib/garden/publicGardenSerialization.node.spec.ts
+++ b/apps/api/lib/garden/publicGardenSerialization.node.spec.ts
@@ -1,58 +1,73 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { RaisedBedFieldWithEvents } from '@gredice/storage';
-import { serializePublicRaisedBedField } from './publicGardenSerialization';
+import {
+    countPublicGardenActivePlants,
+    serializePublicRaisedBedField,
+} from './publicGardenSerialization';
+
+function createPlantCycle(
+    overrides: Partial<RaisedBedFieldWithEvents['plantCycles'][number]> = {},
+): RaisedBedFieldWithEvents['plantCycles'][number] {
+    return {
+        aggregateId: 'field-10',
+        positionIndex: 0,
+        plantPlaceEventId: 100,
+        eventIds: [100, 101],
+        startedAt: new Date('2026-06-01T08:00:00.000Z'),
+        endedAt: new Date('2026-06-02T08:00:00.000Z'),
+        endedEventId: 101,
+        active: true,
+        plantStatus: 'sowed',
+        plantSortId: 7,
+        sowingLocation: 'direct',
+        statusChanges: [],
+        toBeRemoved: false,
+        assignedUserId: 'user-1',
+        assignedUserIds: ['user-1', 'user-2'],
+        assignedBy: 'admin-1',
+        assignedAt: new Date('2026-06-01T07:30:00.000Z'),
+        ...overrides,
+    };
+}
+
+function createField(
+    overrides: Partial<RaisedBedFieldWithEvents> = {},
+): RaisedBedFieldWithEvents {
+    return {
+        id: 10,
+        raisedBedId: 20,
+        positionIndex: 0,
+        createdAt: new Date('2026-06-01T07:00:00.000Z'),
+        updatedAt: new Date('2026-06-01T07:00:00.000Z'),
+        isDeleted: false,
+        plantCycles: [createPlantCycle()],
+        plantStatus: 'sowed',
+        plantSortId: 7,
+        plantScheduledDate: undefined,
+        sowingLocation: 'direct',
+        plantSowDate: undefined,
+        plantGrowthDate: undefined,
+        plantReadyDate: undefined,
+        plantDeadDate: undefined,
+        plantHarvestedDate: undefined,
+        plantRemovedDate: undefined,
+        active: true,
+        toBeRemoved: false,
+        stoppedDate: undefined,
+        assignedUserId: 'user-1',
+        assignedUserIds: ['user-1'],
+        assignedBy: 'admin-1',
+        assignedAt: new Date('2026-06-01T07:30:00.000Z'),
+        cancellationReason: undefined,
+        weedState: null,
+        ...overrides,
+    };
+}
 
 describe('serializePublicRaisedBedField', () => {
     it('omits assignment metadata from fields and nested plant cycles', () => {
-        const field: RaisedBedFieldWithEvents = {
-            id: 10,
-            raisedBedId: 20,
-            positionIndex: 0,
-            createdAt: new Date('2026-06-01T07:00:00.000Z'),
-            updatedAt: new Date('2026-06-01T07:00:00.000Z'),
-            isDeleted: false,
-            plantCycles: [
-                {
-                    aggregateId: 'field-10',
-                    positionIndex: 0,
-                    plantPlaceEventId: 100,
-                    eventIds: [100, 101],
-                    startedAt: new Date('2026-06-01T08:00:00.000Z'),
-                    endedAt: new Date('2026-06-02T08:00:00.000Z'),
-                    endedEventId: 101,
-                    active: true,
-                    plantStatus: 'sowed',
-                    plantSortId: 7,
-                    sowingLocation: 'direct',
-                    statusChanges: [],
-                    toBeRemoved: false,
-                    assignedUserId: 'user-1',
-                    assignedUserIds: ['user-1', 'user-2'],
-                    assignedBy: 'admin-1',
-                    assignedAt: new Date('2026-06-01T07:30:00.000Z'),
-                },
-            ],
-            plantStatus: 'sowed',
-            plantSortId: 7,
-            plantScheduledDate: undefined,
-            sowingLocation: 'direct',
-            plantSowDate: undefined,
-            plantGrowthDate: undefined,
-            plantReadyDate: undefined,
-            plantDeadDate: undefined,
-            plantHarvestedDate: undefined,
-            plantRemovedDate: undefined,
-            active: true,
-            toBeRemoved: false,
-            stoppedDate: undefined,
-            assignedUserId: 'user-1',
-            assignedUserIds: ['user-1'],
-            assignedBy: 'admin-1',
-            assignedAt: new Date('2026-06-01T07:30:00.000Z'),
-            cancellationReason: undefined,
-            weedState: null,
-        };
+        const field = createField();
 
         const publicField = serializePublicRaisedBedField(field);
 
@@ -69,5 +84,23 @@ describe('serializePublicRaisedBedField', () => {
         assert.equal('assignedBy' in plantCycle, false);
         assert.equal('assignedAt' in plantCycle, false);
         assert.equal(plantCycle.plantSortId, 7);
+    });
+
+    it('counts only active planted fields for public garden summaries', () => {
+        assert.equal(
+            countPublicGardenActivePlants([
+                {
+                    fields: [
+                        createField({ active: true, plantSortId: 7 }),
+                        createField({ active: false, plantSortId: 8 }),
+                        createField({ active: true, plantSortId: undefined }),
+                    ],
+                },
+                {
+                    fields: [createField({ active: true, plantSortId: 9 })],
+                },
+            ]),
+            2,
+        );
     });
 });

--- a/apps/api/lib/garden/publicGardenSerialization.ts
+++ b/apps/api/lib/garden/publicGardenSerialization.ts
@@ -60,3 +60,17 @@ export function serializePublicRaisedBedField(
         plantCycles: plantCycles.map(serializePublicPlantCycle),
     };
 }
+
+export function countPublicGardenActivePlants(
+    raisedBeds: Array<{ fields: RaisedBedFieldWithEvents[] }>,
+): number {
+    return raisedBeds.reduce(
+        (total, raisedBed) =>
+            total +
+            raisedBed.fields.filter(
+                (field) =>
+                    field.active && typeof field.plantSortId === 'number',
+            ).length,
+        0,
+    );
+}

--- a/apps/garden/app/vrtovi/[id]/opengraph-image.tsx
+++ b/apps/garden/app/vrtovi/[id]/opengraph-image.tsx
@@ -1,6 +1,13 @@
 import { clientPublic, directoriesClient } from '@gredice/client';
+import { getBlockImageUrl } from '@gredice/ui/BlockImage';
 import { ImageResponse } from 'next/og';
-import { GardenDisplay2D } from '../../../components/GardenDisplay2D';
+import sharp from 'sharp';
+import {
+    GardenDisplay2D,
+    type GardenDisplay2DProps,
+    getGardenDisplayBlockImageKey,
+    getGardenDisplayRotationSuffix,
+} from '../../../components/GardenDisplay2D';
 import { Logotype } from '../../../components/Logotype';
 
 export const size = {
@@ -10,9 +17,86 @@ export const size = {
 export const dynamic = 'force-dynamic';
 export const contentType = 'image/png';
 export const maxDuration = 10;
+export const runtime = 'nodejs';
 
 const gardenOgImageCacheControl =
     'public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400';
+const gardenOgImageAssetBaseUrl = 'https://vrt.gredice.com';
+
+type GardenOgStacks = GardenDisplay2DProps['garden']['stacks'];
+
+const spritePngDataUrlBySrc = new Map<string, Promise<string>>();
+
+export function getGardenOgBlockSpriteRequests(stacks: GardenOgStacks) {
+    const requests = new Map<string, string>();
+
+    for (const rows of Object.values(stacks)) {
+        for (const blocks of Object.values(rows)) {
+            for (const block of blocks) {
+                const rotationSuffix = getGardenDisplayRotationSuffix(
+                    block.rotation,
+                );
+                const key = getGardenDisplayBlockImageKey(
+                    block.name,
+                    rotationSuffix,
+                );
+                const src = getBlockImageUrl(block.name, { rotationSuffix });
+                if (src) {
+                    requests.set(key, src);
+                }
+            }
+        }
+    }
+
+    return [...requests].map(([key, src]) => ({ key, src }));
+}
+
+async function getPngDataUrlForSprite(src: string) {
+    const absoluteSrc = new URL(src, gardenOgImageAssetBaseUrl).toString();
+
+    if (!spritePngDataUrlBySrc.has(absoluteSrc)) {
+        spritePngDataUrlBySrc.set(
+            absoluteSrc,
+            (async () => {
+                const response = await fetch(absoluteSrc);
+                if (!response.ok) {
+                    throw new Error(
+                        `Failed to fetch garden OG sprite ${absoluteSrc}: ${response.status.toString()}`,
+                    );
+                }
+
+                const png = await sharp(
+                    Buffer.from(await response.arrayBuffer()),
+                )
+                    .png()
+                    .toBuffer();
+
+                return `data:image/png;base64,${png.toString('base64')}`;
+            })(),
+        );
+    }
+
+    const sprite = spritePngDataUrlBySrc.get(absoluteSrc);
+    if (!sprite) {
+        return absoluteSrc;
+    }
+
+    return sprite.catch((error: unknown) => {
+        console.error(error);
+        return absoluteSrc;
+    });
+}
+
+async function getGardenOgBlockImageSrcByKey(stacks: GardenOgStacks) {
+    return new Map(
+        await Promise.all(
+            getGardenOgBlockSpriteRequests(stacks).map(
+                async ({ key, src }) =>
+                    [key, await getPngDataUrlForSprite(src)] as const,
+            ),
+        ),
+    );
+}
 
 export default async function GardenOgImage({
     params,
@@ -42,6 +126,9 @@ export default async function GardenOgImage({
         console.error(`Block data not found`);
         return null;
     }
+    const blockImageSrcByKey = await getGardenOgBlockImageSrcByKey(
+        garden.stacks,
+    );
 
     return new ImageResponse(
         <div
@@ -73,6 +160,7 @@ export default async function GardenOgImage({
                 <GardenDisplay2D
                     garden={garden}
                     blockData={blockData}
+                    blockImageSrcByKey={blockImageSrcByKey}
                     viewportSize={1200}
                     viewportOffset={{ x: 24, y: 630 / 2 + 24 * 2 + 106 / 2 }}
                     style={{

--- a/apps/garden/components/GardenDisplay2D.tsx
+++ b/apps/garden/components/GardenDisplay2D.tsx
@@ -29,14 +29,28 @@ export type GardenDisplay2DProps = {
      * @default 128
      */
     blockSize?: number;
+    blockImageSrcByKey?: ReadonlyMap<string, string>;
 } & HTMLAttributes<HTMLDivElement>;
 
+export function getGardenDisplayRotationSuffix(rotation?: number | null) {
+    return ((((rotation ?? 0) % 4) + 4) % 4) + 1;
+}
+
+export function getGardenDisplayBlockImageKey(
+    blockName: string,
+    rotationSuffix: number | string,
+) {
+    return `${blockName}:${rotationSuffix.toString()}`;
+}
+
 export function GardenDisplay2D({
+    blockImageSrcByKey,
     garden,
     blockData,
     viewportSize = 600,
     viewportOffset,
     blockSize = 128,
+    style,
     ...rest
 }: GardenDisplay2DProps) {
     // Block snapshots have margins so we need to adjust the size
@@ -124,13 +138,20 @@ export function GardenDisplay2D({
                 ? -((realizedBlockSize - blockSize) / 2)
                 : 0;
 
-            const rotationIndex = (((block.rotation ?? 0) % 4) + 4) % 4;
-            const rotationSuffix = rotationIndex + 1;
+            const rotationSuffix = getGardenDisplayRotationSuffix(
+                block.rotation,
+            );
+            const blockImageKey = getGardenDisplayBlockImageKey(
+                block.name,
+                rotationSuffix,
+            );
 
             return {
                 id: block.id,
                 name: block.name,
-                src: getBlockImageUrl(block.name, { rotationSuffix }),
+                src:
+                    blockImageSrcByKey?.get(blockImageKey) ??
+                    getBlockImageUrl(block.name, { rotationSuffix }),
                 realizedBlockSize,
                 horizontalOffset,
                 underStackHeight: currentUnderStackHeight,
@@ -145,7 +166,7 @@ export function GardenDisplay2D({
     });
 
     return (
-        <div {...rest}>
+        <div {...rest} style={{ position: 'relative', ...style }}>
             {renderedStacks.map((stack) => (
                 <div
                     key={stack.key}

--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -182,10 +182,36 @@
     .operation-page .whitespace-nowrap {
         color: hsl(var(--foreground));
     }
+
+    .public-garden-card-view-transition {
+        contain: layout;
+    }
+}
+
+@supports (view-transition-name: none) {
+    ::view-transition-group(*) {
+        animation-duration: 520ms;
+        animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    ::view-transition-old(*),
+    ::view-transition-new(*) {
+        animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    ::view-transition-group(root) {
+        animation-duration: 220ms;
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {
     .animate-scale-in {
+        animation: none;
+    }
+
+    ::view-transition-group(*),
+    ::view-transition-old(*),
+    ::view-transition-new(*) {
         animation: none;
     }
 }

--- a/apps/www/app/vrtovi/PublicGardenExplorer.tsx
+++ b/apps/www/app/vrtovi/PublicGardenExplorer.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import type { PublicGardenViewerProps } from '@gredice/game';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Close, FullWidth } from '@gredice/ui/icons';
+import { cx } from '@gredice/ui/utils';
+import type { CSSProperties } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { PublicGardenViewerDynamic } from './PublicGardenViewerDynamic';
+
+const transitionDurationMs = 700;
+
+type SceneRect = {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+};
+
+export function PublicGardenExplorer({
+    garden,
+}: {
+    garden: PublicGardenViewerProps['garden'];
+}) {
+    const anchorRef = useRef<HTMLDivElement>(null);
+    const [isMobile, setIsMobile] = useState(false);
+    const [fullscreenMounted, setFullscreenMounted] = useState(false);
+    const [fullscreenVisible, setFullscreenVisible] = useState(false);
+    const [sourceRect, setSourceRect] = useState<SceneRect | null>(null);
+
+    const updateSourceRect = useCallback(() => {
+        const rect = anchorRef.current?.getBoundingClientRect();
+        if (!rect) {
+            return;
+        }
+
+        setSourceRect({
+            top: rect.top,
+            left: rect.left,
+            width: rect.width,
+            height: rect.height,
+        });
+    }, []);
+
+    const closeFullscreen = useCallback(() => {
+        updateSourceRect();
+        setFullscreenVisible(false);
+    }, [updateSourceRect]);
+
+    const openFullscreen = useCallback(() => {
+        updateSourceRect();
+        setFullscreenMounted(true);
+    }, [updateSourceRect]);
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia('(max-width: 768px)');
+        const handleChange = (event: MediaQueryListEvent) =>
+            setIsMobile(event.matches);
+
+        setIsMobile(mediaQuery.matches);
+        mediaQuery.addEventListener('change', handleChange);
+        return () => mediaQuery.removeEventListener('change', handleChange);
+    }, []);
+
+    useEffect(() => {
+        if (!fullscreenMounted) {
+            return;
+        }
+
+        updateSourceRect();
+
+        const animationFrame = window.requestAnimationFrame(() => {
+            setFullscreenVisible(true);
+        });
+
+        return () => window.cancelAnimationFrame(animationFrame);
+    }, [fullscreenMounted, updateSourceRect]);
+
+    useEffect(() => {
+        if (!fullscreenMounted || fullscreenVisible) {
+            return;
+        }
+
+        const timeout = window.setTimeout(() => {
+            setFullscreenMounted(false);
+        }, transitionDurationMs);
+
+        return () => window.clearTimeout(timeout);
+    }, [fullscreenMounted, fullscreenVisible]);
+
+    useEffect(() => {
+        if (!fullscreenMounted) {
+            return;
+        }
+
+        const handleResize = () => {
+            updateSourceRect();
+        };
+
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, [fullscreenMounted, updateSourceRect]);
+
+    useEffect(() => {
+        if (!fullscreenMounted) {
+            return;
+        }
+
+        const previousBodyOverflow = document.body.style.overflow;
+        const previousHtmlOverflow = document.documentElement.style.overflow;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                closeFullscreen();
+            }
+        };
+
+        document.body.style.overflow = 'hidden';
+        document.documentElement.style.overflow = 'hidden';
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.body.style.overflow = previousBodyOverflow;
+            document.documentElement.style.overflow = previousHtmlOverflow;
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [closeFullscreen, fullscreenMounted]);
+
+    const collapsedStyle: CSSProperties | undefined = sourceRect
+        ? {
+              top: sourceRect.top,
+              left: sourceRect.left,
+              width: sourceRect.width,
+              height: sourceRect.height,
+              borderRadius: isMobile ? 16 : 6,
+          }
+        : undefined;
+    const expandedStyle: CSSProperties = {
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        borderRadius: 0,
+    };
+
+    return (
+        <div
+            ref={anchorRef}
+            className="relative h-[min(76vh,760px)] min-h-[520px] overflow-hidden rounded-md border border-black/10 bg-background"
+        >
+            <div
+                className={cx(
+                    fullscreenMounted
+                        ? 'pointer-events-auto fixed z-50 overflow-hidden bg-background transition-[top,left,width,height,border-radius,box-shadow] duration-700 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[top,left,width,height,border-radius]'
+                        : 'absolute inset-0 overflow-hidden',
+                    fullscreenMounted &&
+                        (fullscreenVisible
+                            ? 'shadow-none'
+                            : 'shadow-2xl ring-1 ring-black/10'),
+                )}
+                style={
+                    fullscreenMounted
+                        ? fullscreenVisible
+                            ? expandedStyle
+                            : collapsedStyle
+                        : undefined
+                }
+            >
+                <PublicGardenViewerDynamic
+                    className="size-full"
+                    deferDetails={false}
+                    garden={garden}
+                />
+                <div className="pointer-events-none absolute bottom-4 right-4 z-10 flex max-w-[calc(100%-2rem)] items-center gap-2 transition-[opacity,transform] duration-300 ease-out md:bottom-6 md:right-6">
+                    <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-tertiary border-b-4 bg-background/90 p-1 shadow-lg backdrop-blur-xs">
+                        {fullscreenMounted ? (
+                            <IconButton
+                                title="Zatvori prikaz"
+                                variant="plain"
+                                className="rounded-full"
+                                onClick={closeFullscreen}
+                            >
+                                <Close className="size-4" />
+                            </IconButton>
+                        ) : (
+                            <IconButton
+                                title="Cijeli zaslon"
+                                variant="plain"
+                                className="rounded-full"
+                                onClick={openFullscreen}
+                            >
+                                <FullWidth className="size-4" />
+                            </IconButton>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/www/app/vrtovi/PublicGardenExplorer.tsx
+++ b/apps/www/app/vrtovi/PublicGardenExplorer.tsx
@@ -18,9 +18,15 @@ type SceneRect = {
 };
 
 export function PublicGardenExplorer({
+    className,
+    framed = true,
     garden,
+    size = 'default',
 }: {
+    className?: string;
+    framed?: boolean;
     garden: PublicGardenViewerProps['garden'];
+    size?: 'card' | 'default';
 }) {
     const anchorRef = useRef<HTMLDivElement>(null);
     const [isMobile, setIsMobile] = useState(false);
@@ -145,7 +151,14 @@ export function PublicGardenExplorer({
     return (
         <div
             ref={anchorRef}
-            className="relative h-[min(76vh,760px)] min-h-[520px] overflow-hidden rounded-md border border-black/10 bg-background"
+            className={cx(
+                'relative overflow-hidden bg-background',
+                size === 'card'
+                    ? 'h-[min(58vh,620px)] min-h-[360px]'
+                    : 'h-[min(76vh,760px)] min-h-[520px]',
+                framed && 'rounded-md border border-black/10',
+                className,
+            )}
         >
             <div
                 className={cx(

--- a/apps/www/app/vrtovi/PublicGardenTransitionLink.tsx
+++ b/apps/www/app/vrtovi/PublicGardenTransitionLink.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import type { Route } from 'next';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import type { MouseEvent, ReactNode } from 'react';
+import { startPublicGardenViewTransition } from './PublicGardenViewTransitionProvider';
+
+type PublicGardenTransitionLinkProps = {
+    ariaLabel: string;
+    children: ReactNode;
+    className?: string;
+    href: Route;
+};
+
+function shouldUseViewTransition(event: MouseEvent<HTMLAnchorElement>) {
+    if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.shiftKey
+    ) {
+        return false;
+    }
+
+    const anchor = event.currentTarget;
+    return (
+        anchor.target !== '_blank' && anchor.origin === window.location.origin
+    );
+}
+
+export function PublicGardenTransitionLink({
+    ariaLabel,
+    children,
+    className,
+    href,
+}: PublicGardenTransitionLinkProps) {
+    const router = useRouter();
+
+    function handleClick(event: MouseEvent<HTMLAnchorElement>) {
+        if (!shouldUseViewTransition(event)) {
+            return;
+        }
+
+        event.preventDefault();
+        startPublicGardenViewTransition(() => {
+            router.push(href);
+        });
+    }
+
+    return (
+        <Link
+            aria-label={ariaLabel}
+            className={className}
+            href={href}
+            onClick={handleClick}
+        >
+            {children}
+        </Link>
+    );
+}

--- a/apps/www/app/vrtovi/PublicGardenViewTransitionProvider.tsx
+++ b/apps/www/app/vrtovi/PublicGardenViewTransitionProvider.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+let pendingRouteViewTransitionResolve: (() => void) | null = null;
+
+function resolvePendingRouteViewTransition() {
+    const resolve = pendingRouteViewTransitionResolve;
+    if (!resolve) {
+        return;
+    }
+
+    pendingRouteViewTransitionResolve = null;
+    resolve();
+}
+
+function supportsPublicGardenViewTransition() {
+    return (
+        typeof document !== 'undefined' &&
+        typeof document.startViewTransition === 'function' &&
+        !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    );
+}
+
+export function startPublicGardenViewTransition(navigate: () => void) {
+    if (!supportsPublicGardenViewTransition()) {
+        navigate();
+        return;
+    }
+
+    resolvePendingRouteViewTransition();
+
+    const transition = document.startViewTransition(
+        () =>
+            new Promise<void>((resolve) => {
+                let settled = false;
+                const settle = () => {
+                    if (settled) {
+                        return;
+                    }
+
+                    settled = true;
+                    window.clearTimeout(timeout);
+                    window.requestAnimationFrame(() => resolve());
+                };
+                const timeout = window.setTimeout(settle, 1200);
+
+                pendingRouteViewTransitionResolve = settle;
+                navigate();
+            }),
+    );
+
+    transition.finished.catch(() => {
+        resolvePendingRouteViewTransition();
+    });
+}
+
+export function PublicGardenViewTransitionProvider() {
+    const pathname = usePathname();
+
+    useEffect(() => {
+        if (pathname) {
+            resolvePendingRouteViewTransition();
+        }
+    }, [pathname]);
+
+    return null;
+}

--- a/apps/www/app/vrtovi/[gardenId]/page.tsx
+++ b/apps/www/app/vrtovi/[gardenId]/page.tsx
@@ -1,4 +1,5 @@
-import { PageHeader } from '@gredice/ui/PageHeader';
+import { Card } from '@gredice/ui/Card';
+import { Calendar, Sprout } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
@@ -6,7 +7,13 @@ import { notFound } from 'next/navigation';
 import { KnownPages } from '../../../src/KnownPages';
 import { PublicGardenExplorer } from '../PublicGardenExplorer';
 import { getPublicGardenForWww } from '../publicGardenData';
+import {
+    countActivePlantsFromPublicGarden,
+    formatGardenDate,
+    formatGardenNumber,
+} from '../publicGardenFormatting';
 import { getPublicGardenOgImageUrl } from '../publicGardenUrls';
+import { getPublicGardenCardViewTransitionName } from '../publicGardenViewTransition';
 
 export const dynamic = 'force-dynamic';
 
@@ -76,22 +83,89 @@ export default async function PublicGardenPage({
     }
 
     const garden = await getPublicGardenForWww(gardenId);
+    const activePlantCount = countActivePlantsFromPublicGarden(garden);
 
     return (
-        <Stack spacing={4} className="py-6">
-            <PageHeader
-                header={garden.name}
-                subHeader="Prošetaj među gredicama, biljkama i malim vrtnim detaljima iz ovog zelenog kutka."
-            />
-            <Stack spacing={1}>
-                <PublicGardenExplorer garden={garden} />
-                <Typography
-                    level="body3"
-                    className="px-1 italic text-muted-foreground"
-                >
-                    Prikaz je samo za gledanje.
-                </Typography>
-            </Stack>
+        <Stack spacing={2} className="py-6">
+            <Card
+                className="public-garden-card-view-transition overflow-hidden p-0"
+                style={{
+                    viewTransitionName: getPublicGardenCardViewTransitionName(
+                        garden.id,
+                    ),
+                }}
+            >
+                <PublicGardenExplorer
+                    framed={false}
+                    garden={garden}
+                    size="card"
+                />
+                <div className="border-t bg-card">
+                    <div className="space-y-3 px-4 py-4 sm:px-5">
+                        <div>
+                            <Typography level="h2" component="h1">
+                                {garden.name}
+                            </Typography>
+                            <Typography
+                                level="body2"
+                                secondary
+                                className="mt-2 max-w-2xl text-pretty"
+                            >
+                                Prošetaj među gredicama, biljkama i malim vrtnim
+                                detaljima iz ovog zelenog kutka.
+                            </Typography>
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-2 divide-x border-t bg-card">
+                        <div className="flex items-center gap-2 px-4 py-3 sm:px-5">
+                            <Calendar
+                                aria-hidden
+                                className="size-4 shrink-0 text-primary"
+                            />
+                            <div className="min-w-0">
+                                <Typography
+                                    level="body3"
+                                    className="text-muted-foreground"
+                                >
+                                    Stvoren
+                                </Typography>
+                                <Typography
+                                    level="body2"
+                                    className="truncate font-medium"
+                                >
+                                    {formatGardenDate(garden.createdAt)}
+                                </Typography>
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-2 px-4 py-3 sm:px-5">
+                            <Sprout
+                                aria-hidden
+                                className="size-4 shrink-0 text-primary"
+                            />
+                            <div className="min-w-0">
+                                <Typography
+                                    level="body3"
+                                    className="text-muted-foreground"
+                                >
+                                    Biljaka
+                                </Typography>
+                                <Typography
+                                    level="body2"
+                                    className="truncate font-medium"
+                                >
+                                    {formatGardenNumber(activePlantCount)}
+                                </Typography>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </Card>
+            <Typography
+                level="body3"
+                className="px-1 italic text-muted-foreground"
+            >
+                Prikaz je samo za gledanje.
+            </Typography>
         </Stack>
     );
 }

--- a/apps/www/app/vrtovi/[gardenId]/page.tsx
+++ b/apps/www/app/vrtovi/[gardenId]/page.tsx
@@ -4,8 +4,9 @@ import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { KnownPages } from '../../../src/KnownPages';
-import { PublicGardenViewerDynamic } from '../PublicGardenViewerDynamic';
+import { PublicGardenExplorer } from '../PublicGardenExplorer';
 import { getPublicGardenForWww } from '../publicGardenData';
+import { getPublicGardenOgImageUrl } from '../publicGardenUrls';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,9 +31,10 @@ export async function generateMetadata({
     }
 
     const garden = await getPublicGardenForWww(gardenId);
-    const title = `${garden.name} - javni vrt`;
-    const description = `Readonly prikaz javnog Gredice vrta ${garden.name}.`;
+    const title = garden.name;
+    const description = `Zaviri u Gredice vrt ${garden.name}: prošetaj među gredicama, biljkama i malim vrtnim detaljima.`;
     const path = KnownPages.PublicGarden(garden.id);
+    const ogImageUrl = getPublicGardenOgImageUrl(garden.id);
 
     return {
         title,
@@ -44,6 +46,20 @@ export async function generateMetadata({
             title,
             description,
             url: path,
+            images: [
+                {
+                    url: ogImageUrl,
+                    width: 1200,
+                    height: 630,
+                    alt: `Prikaz vrta ${garden.name}`,
+                },
+            ],
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title,
+            description,
+            images: [ogImageUrl],
         },
     };
 }
@@ -62,18 +78,20 @@ export default async function PublicGardenPage({
     const garden = await getPublicGardenForWww(gardenId);
 
     return (
-        <Stack spacing={6} className="py-8">
+        <Stack spacing={4} className="py-6">
             <PageHeader
-                padded
                 header={garden.name}
-                subHeader="Javni prikaz vrta. Možeš istraživati gredice, biljke i planirane radnje bez uređivanja."
+                subHeader="Prošetaj među gredicama, biljkama i malim vrtnim detaljima iz ovog zelenog kutka."
             />
-            <div className="h-[min(76vh,760px)] min-h-[520px] overflow-hidden rounded-md border border-black/10 bg-background">
-                <PublicGardenViewerDynamic className="h-full" garden={garden} />
-            </div>
-            <Typography level="body2" className="px-2 text-muted-foreground">
-                Prikaz je samo za gledanje.
-            </Typography>
+            <Stack spacing={1}>
+                <PublicGardenExplorer garden={garden} />
+                <Typography
+                    level="body3"
+                    className="px-1 italic text-muted-foreground"
+                >
+                    Prikaz je samo za gledanje.
+                </Typography>
+            </Stack>
         </Stack>
     );
 }

--- a/apps/www/app/vrtovi/layout.tsx
+++ b/apps/www/app/vrtovi/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import { PublicGardenViewTransitionProvider } from './PublicGardenViewTransitionProvider';
+
+export default function PublicGardensLayout({
+    children,
+}: {
+    children: ReactNode;
+}) {
+    return (
+        <>
+            <PublicGardenViewTransitionProvider />
+            {children}
+        </>
+    );
+}

--- a/apps/www/app/vrtovi/page.tsx
+++ b/apps/www/app/vrtovi/page.tsx
@@ -5,10 +5,12 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import Image from 'next/image';
-import Link from 'next/link';
 import { KnownPages } from '../../src/KnownPages';
+import { PublicGardenTransitionLink } from './PublicGardenTransitionLink';
 import { getPublicGardensForWww } from './publicGardenData';
+import { formatGardenDate, formatGardenNumber } from './publicGardenFormatting';
 import { getPublicGardenOgImageUrl } from './publicGardenUrls';
+import { getPublicGardenCardViewTransitionName } from './publicGardenViewTransition';
 
 const pageDescription =
     'Pregledaj Gredice vrtove koje su vlasnici učinili vidljivima i zaviri u biljke, gredice i planirane radnje.';
@@ -28,27 +30,6 @@ export const metadata: Metadata = {
     },
 };
 
-const gardenDateFormatter = new Intl.DateTimeFormat('hr-HR', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-    timeZone: 'Europe/Zagreb',
-});
-
-const gardenNumberFormatter = new Intl.NumberFormat('hr-HR');
-
-function formatGardenDate(value: Date | string) {
-    return gardenDateFormatter.format(new Date(value));
-}
-
-function formatGardenNumber(value: unknown) {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
-        return '—';
-    }
-
-    return gardenNumberFormatter.format(value);
-}
-
 export default async function PublicGardensPage() {
     const gardens = await getPublicGardensForWww();
 
@@ -64,12 +45,18 @@ export default async function PublicGardensPage() {
                     {gardens.items.map((garden, gardenIndex) => (
                         <Card
                             key={garden.id}
-                            className="h-full overflow-hidden p-0 transition-shadow hover:shadow-sm"
+                            className="public-garden-card-view-transition h-full overflow-hidden p-0 transition-shadow hover:shadow-sm"
+                            style={{
+                                viewTransitionName:
+                                    getPublicGardenCardViewTransitionName(
+                                        garden.id,
+                                    ),
+                            }}
                         >
-                            <Link
+                            <PublicGardenTransitionLink
                                 href={KnownPages.PublicGarden(garden.id)}
                                 className="group block h-full text-card-foreground no-underline"
-                                aria-label={`Otvori vrt ${garden.name}`}
+                                ariaLabel={`Otvori vrt ${garden.name}`}
                             >
                                 <div className="overflow-hidden bg-muted">
                                     <Image
@@ -130,7 +117,7 @@ export default async function PublicGardensPage() {
                                         </div>
                                     </div>
                                 </div>
-                            </Link>
+                            </PublicGardenTransitionLink>
                         </Card>
                     ))}
                 </div>

--- a/apps/www/app/vrtovi/page.tsx
+++ b/apps/www/app/vrtovi/page.tsx
@@ -1,4 +1,5 @@
-import { Card, CardContent } from '@gredice/ui/Card';
+import { Card } from '@gredice/ui/Card';
+import { Calendar, Sprout } from '@gredice/ui/icons';
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -7,27 +8,45 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { KnownPages } from '../../src/KnownPages';
 import { getPublicGardensForWww } from './publicGardenData';
+import { getPublicGardenOgImageUrl } from './publicGardenUrls';
 
 const pageDescription =
-    'Pregledaj javne Gredice vrtove i zaviri u biljke, gredice i planirane radnje.';
+    'Pregledaj Gredice vrtove koje su vlasnici učinili vidljivima i zaviri u biljke, gredice i planirane radnje.';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-    title: 'Javni vrtovi',
+    title: 'Vidljivi vrtovi',
     description: pageDescription,
     alternates: {
         canonical: KnownPages.PublicGardens,
     },
     openGraph: {
-        title: 'Javni vrtovi',
+        title: 'Vidljivi vrtovi',
         description: pageDescription,
         url: KnownPages.PublicGardens,
     },
 };
 
-function gardenOgImageUrl(gardenId: number) {
-    return `${KnownPages.GardenApp}${KnownPages.PublicGarden(gardenId)}/opengraph-image`;
+const gardenDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'Europe/Zagreb',
+});
+
+const gardenNumberFormatter = new Intl.NumberFormat('hr-HR');
+
+function formatGardenDate(value: Date | string) {
+    return gardenDateFormatter.format(new Date(value));
+}
+
+function formatGardenNumber(value: unknown) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return '—';
+    }
+
+    return gardenNumberFormatter.format(value);
 }
 
 export default async function PublicGardensPage() {
@@ -37,58 +56,87 @@ export default async function PublicGardensPage() {
         <Stack spacing={8} className="py-8">
             <PageHeader
                 padded
-                header="Javni vrtovi"
+                header="Vidljivi vrtovi"
                 subHeader={pageDescription}
             />
             {gardens.items.length > 0 ? (
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                    {gardens.items.map((garden) => (
+                    {gardens.items.map((garden, gardenIndex) => (
                         <Card
                             key={garden.id}
-                            className="h-full overflow-hidden rounded-md"
+                            className="h-full overflow-hidden p-0 transition-shadow hover:shadow-sm"
                         >
-                            <CardContent noHeader>
-                                <Stack spacing={3}>
-                                    <Link
-                                        href={KnownPages.PublicGarden(
+                            <Link
+                                href={KnownPages.PublicGarden(garden.id)}
+                                className="group block h-full text-card-foreground no-underline"
+                                aria-label={`Otvori vrt ${garden.name}`}
+                            >
+                                <div className="overflow-hidden bg-muted">
+                                    <Image
+                                        src={getPublicGardenOgImageUrl(
                                             garden.id,
                                         )}
-                                        className="block overflow-hidden rounded-sm bg-muted"
-                                    >
-                                        <Image
-                                            src={gardenOgImageUrl(garden.id)}
-                                            alt={`Javni prikaz vrta ${garden.name}`}
-                                            width={1200}
-                                            height={630}
-                                            sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
-                                            className="aspect-[1200/630] w-full object-cover transition-transform duration-300 hover:scale-[1.02]"
+                                        alt={`Prikaz vrta ${garden.name}`}
+                                        width={1200}
+                                        height={630}
+                                        sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                                        priority={gardenIndex === 0}
+                                        className="aspect-[1200/630] w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                                    />
+                                </div>
+                                <div className="grid grid-cols-2 divide-x border-t bg-card">
+                                    <div className="flex items-center gap-2 px-3 py-3">
+                                        <Calendar
+                                            aria-hidden
+                                            className="size-4 shrink-0 text-primary"
                                         />
-                                    </Link>
-                                    <Typography level="h3">
-                                        <Link
-                                            href={KnownPages.PublicGarden(
-                                                garden.id,
-                                            )}
-                                            className="underline-offset-4 hover:underline"
-                                        >
-                                            {garden.name}
-                                        </Link>
-                                    </Typography>
-                                    <Typography
-                                        level="body2"
-                                        className="text-muted-foreground"
-                                    >
-                                        Javni prikaz vrta s biljkama, gredicama
-                                        i aktivnim radnjama.
-                                    </Typography>
-                                </Stack>
-                            </CardContent>
+                                        <div className="min-w-0">
+                                            <Typography
+                                                level="body3"
+                                                className="text-muted-foreground"
+                                            >
+                                                Stvoren
+                                            </Typography>
+                                            <Typography
+                                                level="body2"
+                                                className="truncate font-medium"
+                                            >
+                                                {formatGardenDate(
+                                                    garden.createdAt,
+                                                )}
+                                            </Typography>
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-2 px-3 py-3">
+                                        <Sprout
+                                            aria-hidden
+                                            className="size-4 shrink-0 text-primary"
+                                        />
+                                        <div className="min-w-0">
+                                            <Typography
+                                                level="body3"
+                                                className="text-muted-foreground"
+                                            >
+                                                Biljaka
+                                            </Typography>
+                                            <Typography
+                                                level="body2"
+                                                className="truncate font-medium"
+                                            >
+                                                {formatGardenNumber(
+                                                    garden.activePlantCount,
+                                                )}
+                                            </Typography>
+                                        </div>
+                                    </div>
+                                </div>
+                            </Link>
                         </Card>
                     ))}
                 </div>
             ) : (
                 <Typography level="body1" className="px-2">
-                    Trenutno nema javno objavljenih vrtova.
+                    Trenutno nema vidljivih vrtova.
                 </Typography>
             )}
         </Stack>

--- a/apps/www/app/vrtovi/publicGardenData.ts
+++ b/apps/www/app/vrtovi/publicGardenData.ts
@@ -1,5 +1,28 @@
-import { clientPublic } from '@gredice/client';
+import { clientPublic, type PublicGardenResponse } from '@gredice/client';
 import { notFound } from 'next/navigation';
+
+function countActivePlantsFromPublicGarden(garden: PublicGardenResponse) {
+    return garden.raisedBeds.reduce(
+        (total, raisedBed) =>
+            total +
+            raisedBed.fields.filter(
+                (field) =>
+                    field.active && typeof field.plantSortId === 'number',
+            ).length,
+        0,
+    );
+}
+
+async function getActivePlantCountFallback(gardenId: number) {
+    const response = await clientPublic().api.gardens[':gardenId'].public.$get({
+        param: { gardenId: gardenId.toString() },
+    });
+    if (!response.ok) {
+        return undefined;
+    }
+
+    return countActivePlantsFromPublicGarden(await response.json());
+}
 
 export async function getPublicGardensForWww() {
     const response = await clientPublic().api.gardens.public.$get();
@@ -7,7 +30,33 @@ export async function getPublicGardensForWww() {
         notFound();
     }
 
-    return response.json();
+    const publicGardens = await response.json();
+    const items = await Promise.all(
+        publicGardens.items.map(async (garden) => {
+            if (Number.isFinite(garden.activePlantCount)) {
+                return garden;
+            }
+
+            // Support mixed deployments where www expects the new summary field
+            // before the API serving /gardens/public has been rolled out.
+            const activePlantCount = await getActivePlantCountFallback(
+                garden.id,
+            );
+            if (typeof activePlantCount !== 'number') {
+                return garden;
+            }
+
+            return {
+                ...garden,
+                activePlantCount,
+            };
+        }),
+    );
+
+    return {
+        ...publicGardens,
+        items,
+    };
 }
 
 export async function getPublicGardenForWww(gardenId: number) {

--- a/apps/www/app/vrtovi/publicGardenData.ts
+++ b/apps/www/app/vrtovi/publicGardenData.ts
@@ -1,17 +1,6 @@
-import { clientPublic, type PublicGardenResponse } from '@gredice/client';
+import { clientPublic } from '@gredice/client';
 import { notFound } from 'next/navigation';
-
-function countActivePlantsFromPublicGarden(garden: PublicGardenResponse) {
-    return garden.raisedBeds.reduce(
-        (total, raisedBed) =>
-            total +
-            raisedBed.fields.filter(
-                (field) =>
-                    field.active && typeof field.plantSortId === 'number',
-            ).length,
-        0,
-    );
-}
+import { countActivePlantsFromPublicGarden } from './publicGardenFormatting';
 
 async function getActivePlantCountFallback(gardenId: number) {
     const response = await clientPublic().api.gardens[':gardenId'].public.$get({

--- a/apps/www/app/vrtovi/publicGardenFormatting.ts
+++ b/apps/www/app/vrtovi/publicGardenFormatting.ts
@@ -1,0 +1,36 @@
+import type { PublicGardenResponse } from '@gredice/client';
+
+const gardenDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'Europe/Zagreb',
+});
+
+const gardenNumberFormatter = new Intl.NumberFormat('hr-HR');
+
+export function countActivePlantsFromPublicGarden(
+    garden: PublicGardenResponse,
+) {
+    return garden.raisedBeds.reduce(
+        (total, raisedBed) =>
+            total +
+            raisedBed.fields.filter(
+                (field) =>
+                    field.active && typeof field.plantSortId === 'number',
+            ).length,
+        0,
+    );
+}
+
+export function formatGardenDate(value: Date | string) {
+    return gardenDateFormatter.format(new Date(value));
+}
+
+export function formatGardenNumber(value: unknown) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return '—';
+    }
+
+    return gardenNumberFormatter.format(value);
+}

--- a/apps/www/app/vrtovi/publicGardenUrls.ts
+++ b/apps/www/app/vrtovi/publicGardenUrls.ts
@@ -1,0 +1,5 @@
+import { KnownPages } from '../../src/KnownPages';
+
+export function getPublicGardenOgImageUrl(gardenId: number) {
+    return `${KnownPages.GardenApp}${KnownPages.PublicGarden(gardenId)}/opengraph-image`;
+}

--- a/apps/www/app/vrtovi/publicGardenViewTransition.ts
+++ b/apps/www/app/vrtovi/publicGardenViewTransition.ts
@@ -1,0 +1,3 @@
+export function getPublicGardenCardViewTransitionName(gardenId: number) {
+    return `public-garden-card-${gardenId}`;
+}

--- a/packages/game/src/controls/GameCameraRig.tsx
+++ b/packages/game/src/controls/GameCameraRig.tsx
@@ -158,8 +158,10 @@ function toSnapshot({
 
 export function GameCameraRig({
     controlsEnabled,
+    initialTarget,
 }: {
     controlsEnabled: boolean;
+    initialTarget?: Vector3;
 }) {
     const { camera, gl, size } = useThree();
     const isOrthographicCamera = camera instanceof OrthographicCamera;
@@ -178,7 +180,11 @@ export function GameCameraRig({
     );
     const { data: garden } = useCurrentGarden();
 
-    const targetRef = useRef(new Vector3(...defaultGameCameraTarget));
+    const resolvedInitialTarget = useMemo(
+        () => initialTarget?.clone() ?? new Vector3(...defaultGameCameraTarget),
+        [initialTarget],
+    );
+    const targetRef = useRef(resolvedInitialTarget.clone());
     const animationRef = useRef<CameraAnimation | null>(null);
     const apiRef = useRef<GameCameraRigApi | null>(null);
     const cameraListenersRef = useRef(
@@ -526,7 +532,7 @@ export function GameCameraRig({
             return;
         }
 
-        targetRef.current.set(...defaultGameCameraTarget);
+        targetRef.current.copy(resolvedInitialTarget);
         normalCameraRef.current = {
             position: camera.position.clone(),
             target: targetRef.current.clone(),
@@ -544,6 +550,7 @@ export function GameCameraRig({
         camera,
         flushSnapshot,
         isOrthographicCamera,
+        resolvedInitialTarget,
         setGameCamera,
     ]);
 

--- a/packages/game/src/modals/components/GardenVisibilityCard.tsx
+++ b/packages/game/src/modals/components/GardenVisibilityCard.tsx
@@ -54,10 +54,10 @@ export function GardenVisibilityCard({
                                 className="justify-between gap-4"
                             >
                                 <Typography level="body1" semiBold>
-                                    Javni vrt
+                                    Vidljivost vrta
                                 </Typography>
                                 <Switch
-                                    aria-label={`Javna vidljivost vrta ${gardenName}`}
+                                    aria-label={`Vidljivost vrta ${gardenName}`}
                                     checked={isPublic}
                                     disabled={updateVisibility.isPending}
                                     onCheckedChange={handleVisibilityChange}
@@ -65,8 +65,8 @@ export function GardenVisibilityCard({
                             </Row>
                             <Typography level="body2">
                                 {isPublic
-                                    ? 'Svatko s poveznicom može pregledati vrt bez uređivanja.'
-                                    : 'Vrt je privatan i nije dostupan na javnim stranicama.'}
+                                    ? 'Vrt je vidljiv na popisu i svatko s poveznicom može ga pregledati bez uređivanja.'
+                                    : 'Vrt je privatan i nije vidljiv na popisu vrtova.'}
                             </Typography>
                         </Stack>
                     </Row>
@@ -79,7 +79,7 @@ export function GardenVisibilityCard({
                             size="sm"
                             startDecorator={<ExternalLink className="size-4" />}
                         >
-                            Otvori javni vrt
+                            Otvori prikaz vrta
                         </Button>
                     ) : null}
                     {error ? (

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -810,6 +810,7 @@ export function Environment({
     const hasWeatherOverride = Boolean(gameWeather ?? weather);
     const { data: weatherNow } = useWeatherNow(
         !weatherDisabled && !hasWeatherOverride,
+        garden?.farmId,
     );
     const overrideWeather = weatherDisabled
         ? undefined

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -6,7 +6,6 @@ import {
     isGameBackgroundPaletteKey,
 } from '@gredice/js/gameBackground';
 import { cx } from '@gredice/ui/utils';
-import { OrbitControls } from '@react-three/drei';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
     type HTMLAttributes,
@@ -17,7 +16,8 @@ import {
     useRef,
     useState,
 } from 'react';
-import { MOUSE, Vector3 } from 'three';
+import { Vector3 } from 'three';
+import { GameCameraRig } from '../controls/GameCameraRig';
 import { Bees } from '../entities/bees/Bees';
 import { Birds } from '../entities/birds/Birds';
 import { Cats } from '../entities/cats/Cats';
@@ -242,19 +242,9 @@ function PublicGardenScene({
                                 )}
                             </group>
                         </Suspense>
-                        <OrbitControls
-                            enableDamping
-                            enableRotate={false}
-                            screenSpacePanning={false}
-                            enablePan
-                            minZoom={50}
-                            maxZoom={500}
-                            target={sceneCenter}
-                            mouseButtons={{
-                                LEFT: MOUSE.PAN,
-                                MIDDLE: MOUSE.DOLLY,
-                                RIGHT: MOUSE.PAN,
-                            }}
+                        <GameCameraRig
+                            controlsEnabled
+                            initialTarget={sceneCenter}
                         />
                     </ParticleSystemProvider>
                 </Scene>

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -1,21 +1,40 @@
 'use client';
 
 import type { PublicGardenResponse } from '@gredice/client';
-import { Button } from '@gredice/ui/Button';
-import { Stack as UiStack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
+import {
+    defaultGameBackgroundPaletteKey,
+    isGameBackgroundPaletteKey,
+} from '@gredice/js/gameBackground';
 import { cx } from '@gredice/ui/utils';
 import { OrbitControls } from '@react-three/drei';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { type HTMLAttributes, useMemo, useRef, useState } from 'react';
-import { Vector3 } from 'three';
+import {
+    type HTMLAttributes,
+    type ReactNode,
+    Suspense,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import { MOUSE, Vector3 } from 'three';
+import { Bees } from '../entities/bees/Bees';
+import { Birds } from '../entities/birds/Birds';
+import { Cats } from '../entities/cats/Cats';
+import { Dogs } from '../entities/dogs/Dogs';
 import { EntityFactory } from '../entities/EntityFactory';
 import {
     EntityInstances,
     instancedBlockNames,
 } from '../entities/EntityInstances';
 import { GameSceneDetailContext } from '../GameSceneDetailContext';
+import { useBlockData } from '../hooks/useBlockData';
+import { currentGardenKeys } from '../hooks/useCurrentGarden';
 import { useDeferredSceneDetails } from '../hooks/useDeferredSceneDetails';
+import { useGardensKeys } from '../hooks/useGardens';
+import { ParticleSystemProvider } from '../particles/ParticleSystem';
+import { Environment } from '../scene/Environment';
+import { resolveGameQualityProfile } from '../scene/gameQuality';
 import { Scene } from '../scene/Scene';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
@@ -45,9 +64,11 @@ export type PublicGardenViewerProps = HTMLAttributes<HTMLDivElement> & {
     className?: string;
 };
 
-function normalizeStacks(stacks: PublicGardenStack[]): Stack[] {
+export function normalizePublicGardenStacks(
+    stacks: PublicGardenStack[],
+): Stack[] {
     return stacks.map((stack) => ({
-        position: new Vector3(stack.x, stack.y, 0),
+        position: new Vector3(stack.x, 0, stack.y),
         blocks: stack.blocks,
     }));
 }
@@ -69,142 +90,218 @@ export function publicGardenStacksFromResponse(
     );
 }
 
-function formatDate(value: string | Date | null | undefined) {
-    if (!value) {
-        return null;
+export function getPublicGardenStacksCenter(stacks: Stack[]) {
+    if (stacks.length === 0) {
+        return new Vector3(0, 0, 0);
     }
 
-    return new Intl.DateTimeFormat('hr-HR', {
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric',
-    }).format(new Date(value));
+    const bounds = stacks.reduce(
+        (acc, stack) => ({
+            maxX: Math.max(acc.maxX, stack.position.x),
+            maxZ: Math.max(acc.maxZ, stack.position.z),
+            minX: Math.min(acc.minX, stack.position.x),
+            minZ: Math.min(acc.minZ, stack.position.z),
+        }),
+        {
+            maxX: Number.NEGATIVE_INFINITY,
+            maxZ: Number.NEGATIVE_INFINITY,
+            minX: Number.POSITIVE_INFINITY,
+            minZ: Number.POSITIVE_INFINITY,
+        },
+    );
+
+    return new Vector3(
+        (bounds.minX + bounds.maxX) / 2,
+        0,
+        (bounds.minZ + bounds.maxZ) / 2,
+    );
 }
 
-function statusLabel(status: string | null | undefined) {
-    if (!status) {
-        return 'Bez statusa';
+function normalizePublicGardenBackgroundPalette(value: unknown) {
+    return isGameBackgroundPaletteKey(value)
+        ? value
+        : defaultGameBackgroundPaletteKey;
+}
+
+function getPublicGardenCacheKey(garden: PublicGardenDetail | undefined) {
+    if (!garden) {
+        return 'stacks-only';
     }
 
-    return status;
+    return `${garden.id.toString()}:${garden.updatedAt ?? ''}`;
 }
 
-function PublicGardenDetailsPanel({ garden }: { garden: PublicGardenDetail }) {
-    const [selectedRaisedBedId, setSelectedRaisedBedId] = useState<
-        number | null
-    >(garden.raisedBeds[0]?.id ?? null);
-    const selectedRaisedBed =
-        garden.raisedBeds.find(
-            (raisedBed) => raisedBed.id === selectedRaisedBedId,
-        ) ??
-        garden.raisedBeds[0] ??
-        null;
-    const plantedFields =
-        selectedRaisedBed?.fields.filter(
-            (field) =>
-                typeof field.plantSortId === 'number' && field.active !== false,
-        ) ?? [];
+function publicGardenForGameState(
+    garden: PublicGardenDetail,
+    normalizedStacks: Stack[],
+) {
+    return {
+        id: garden.id,
+        name: garden.name,
+        isSandbox: garden.isSandbox,
+        isPublic: garden.isPublic,
+        backgroundPalette: normalizePublicGardenBackgroundPalette(
+            garden.backgroundPalette,
+        ),
+        farmId: garden.farmId,
+        stacks: normalizedStacks,
+        location: {
+            lat: garden.latitude,
+            lon: garden.longitude,
+        },
+        raisedBeds: garden.raisedBeds,
+    };
+}
+
+function PublicGardenScene({
+    cameraPosition,
+    className,
+    garden,
+    gardenCacheReady,
+    normalizedStacks,
+    renderDetails,
+    sceneCenter,
+}: {
+    cameraPosition: Vector3;
+    className?: string;
+    garden?: ReturnType<typeof publicGardenForGameState>;
+    gardenCacheReady: boolean;
+    normalizedStacks: Stack[];
+    renderDetails: boolean;
+    sceneCenter: Vector3;
+}) {
+    const blockDataQuery = useBlockData();
+    const blockDataLoaded = Boolean(blockDataQuery.data);
+    const qualityProfile = useMemo(() => resolveGameQualityProfile(), []);
+    const renderLivingDetails = renderDetails && gardenCacheReady;
 
     return (
-        <aside className="pointer-events-auto absolute inset-x-3 bottom-3 z-10 max-h-[45%] overflow-auto rounded-md border border-black/10 bg-background/95 p-3 shadow-lg backdrop-blur md:inset-x-auto md:bottom-4 md:right-4 md:top-4 md:max-h-none md:w-80">
-            <UiStack spacing={4}>
-                <UiStack spacing={1}>
-                    <Typography level="body1" semiBold>
-                        {garden.name}
-                    </Typography>
-                    <Typography level="body3" className="text-muted-foreground">
-                        {garden.raisedBeds.length.toString()} gredica ·{' '}
-                        {garden.queuedTasks.length.toString()} aktivnih radnji
-                    </Typography>
-                </UiStack>
-
-                {garden.raisedBeds.length > 0 ? (
-                    <div className="flex gap-2 overflow-x-auto pb-1 md:flex-wrap md:overflow-visible">
-                        {garden.raisedBeds.map((raisedBed) => (
-                            <Button
-                                key={raisedBed.id}
-                                type="button"
-                                size="xs"
-                                variant={
-                                    raisedBed.id === selectedRaisedBed?.id
-                                        ? 'solid'
-                                        : 'outlined'
-                                }
-                                onClick={() =>
-                                    setSelectedRaisedBedId(raisedBed.id)
-                                }
-                            >
-                                {raisedBed.name}
-                            </Button>
-                        ))}
-                    </div>
-                ) : null}
-
-                {selectedRaisedBed ? (
-                    <UiStack spacing={2}>
-                        <Typography level="body2" semiBold>
-                            {selectedRaisedBed.name}
-                        </Typography>
-                        <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-sm">
-                            <dt className="text-muted-foreground">Status</dt>
-                            <dd>{statusLabel(selectedRaisedBed.status)}</dd>
-                            <dt className="text-muted-foreground">Biljke</dt>
-                            <dd>{plantedFields.length.toString()}</dd>
-                            <dt className="text-muted-foreground">Ažurirano</dt>
-                            <dd>{formatDate(selectedRaisedBed.updatedAt)}</dd>
-                        </dl>
-                        <div className="space-y-1">
-                            {plantedFields.length > 0 ? (
-                                plantedFields.slice(0, 12).map((field) => (
-                                    <p
-                                        key={field.id}
-                                        className="rounded-sm bg-muted/60 px-2 py-1 text-xs"
-                                    >
-                                        Polje{' '}
-                                        {(field.positionIndex + 1).toString()} ·
-                                        sorta #{field.plantSortId?.toString()} ·{' '}
-                                        {statusLabel(field.plantStatus)}
-                                    </p>
-                                ))
-                            ) : (
-                                <p className="text-sm text-muted-foreground">
-                                    Nema posađenih biljaka.
-                                </p>
-                            )}
-                        </div>
-                    </UiStack>
-                ) : null}
-
-                <UiStack spacing={2}>
-                    <Typography level="body2" semiBold>
-                        Planirane radnje
-                    </Typography>
-                    {garden.queuedTasks.length > 0 ? (
-                        garden.queuedTasks.slice(0, 6).map((task) => (
-                            <div
-                                key={task.id}
-                                className="rounded-sm border border-border bg-background px-2 py-1.5 text-xs"
-                            >
-                                <div className="font-medium">
-                                    {task.targetLabel}
-                                </div>
-                                <div className="text-muted-foreground">
-                                    {statusLabel(task.status)}
-                                    {task.scheduledDate
-                                        ? ` · ${formatDate(task.scheduledDate)}`
-                                        : ''}
-                                </div>
-                            </div>
-                        ))
-                    ) : (
-                        <p className="text-sm text-muted-foreground">
-                            Nema aktivnih radnji.
-                        </p>
-                    )}
-                </UiStack>
-            </UiStack>
-        </aside>
+        <div className={cx('relative h-full w-full', className)}>
+            {blockDataLoaded && gardenCacheReady ? (
+                <Scene
+                    position={cameraPosition}
+                    quality={qualityProfile}
+                    zoom={90}
+                    className="h-full w-full"
+                >
+                    <ParticleSystemProvider>
+                        <Environment
+                            noSound
+                            quality={qualityProfile}
+                            weather={undefined}
+                        />
+                        <Suspense fallback={null}>
+                            <group name="PublicGardenScene:Entities">
+                                {normalizedStacks.map((stack) =>
+                                    stack.blocks.map((block) => (
+                                        <EntityFactory
+                                            key={`${stack.position.x}|${stack.position.z}|${block.id}-${block.name}`}
+                                            name={block.name}
+                                            stack={stack}
+                                            block={block}
+                                            stacks={normalizedStacks}
+                                            rotation={block.rotation}
+                                            variant={block.variant}
+                                            noRenderInView={instancedBlockNames}
+                                            noControl
+                                        />
+                                    )),
+                                )}
+                                <EntityInstances
+                                    quality={qualityProfile}
+                                    renderGroundDecorations={
+                                        renderLivingDetails
+                                    }
+                                    stacks={normalizedStacks}
+                                    renderDetails={renderLivingDetails}
+                                />
+                                {renderLivingDetails && (
+                                    <Suspense fallback={null}>
+                                        <Birds stacks={normalizedStacks} />
+                                    </Suspense>
+                                )}
+                                {renderLivingDetails && (
+                                    <Suspense fallback={null}>
+                                        <Cats stacks={normalizedStacks} />
+                                    </Suspense>
+                                )}
+                                {renderLivingDetails && (
+                                    <Suspense fallback={null}>
+                                        <Dogs stacks={normalizedStacks} />
+                                    </Suspense>
+                                )}
+                                {renderLivingDetails && garden && (
+                                    <Suspense fallback={null}>
+                                        <Bees
+                                            garden={garden}
+                                            groundDecorationDensity={
+                                                qualityProfile.groundDecorationDensity
+                                            }
+                                        />
+                                    </Suspense>
+                                )}
+                            </group>
+                        </Suspense>
+                        <OrbitControls
+                            enableDamping
+                            enableRotate={false}
+                            screenSpacePanning={false}
+                            enablePan
+                            minZoom={50}
+                            maxZoom={500}
+                            target={sceneCenter}
+                            mouseButtons={{
+                                LEFT: MOUSE.PAN,
+                                MIDDLE: MOUSE.DOLLY,
+                                RIGHT: MOUSE.PAN,
+                            }}
+                        />
+                    </ParticleSystemProvider>
+                </Scene>
+            ) : (
+                <div className="h-full w-full bg-[#d9f2dc]" />
+            )}
+        </div>
     );
+}
+
+function SeedPublicGardenQueryCache({
+    cacheKey,
+    children,
+    client,
+    garden,
+}: {
+    cacheKey: string;
+    children: (gardenCacheReady: boolean) => ReactNode;
+    client: QueryClient;
+    garden?: ReturnType<typeof publicGardenForGameState>;
+}) {
+    const [seededCacheKey, setSeededCacheKey] = useState<string | null>(
+        garden ? null : cacheKey,
+    );
+
+    useEffect(() => {
+        if (!garden) {
+            setSeededCacheKey(cacheKey);
+            return;
+        }
+
+        client.setQueryData(useGardensKeys, [
+            {
+                id: garden.id,
+                name: garden.name,
+                isSandbox: garden.isSandbox,
+                isPublic: garden.isPublic,
+            },
+        ]);
+        client.setQueryData(
+            currentGardenKeys('summer', garden.id, undefined, undefined),
+            garden,
+        );
+        setSeededCacheKey(cacheKey);
+    }, [cacheKey, client, garden]);
+
+    return children(seededCacheKey === cacheKey);
 }
 
 export function PublicGardenViewer({
@@ -223,7 +320,7 @@ export function PublicGardenViewer({
             appBaseUrl: resolvedAppBaseUrl,
             spriteBaseUrl: resolvedSpriteBaseUrl,
             freezeTime: new Date(2024, 5, 21, 12, 0, 0),
-            isMock: true,
+            isMock: false,
             winterMode: 'summer',
         });
     }
@@ -241,61 +338,59 @@ export function PublicGardenViewer({
         [garden, stacks],
     );
     const normalizedStacks = useMemo(
-        () => normalizeStacks(publicStacks),
+        () => normalizePublicGardenStacks(publicStacks),
         [publicStacks],
     );
+    const gameGarden = useMemo(
+        () =>
+            garden
+                ? publicGardenForGameState(garden, normalizedStacks)
+                : undefined,
+        [garden, normalizedStacks],
+    );
+    const sceneCenter = useMemo(
+        () => getPublicGardenStacksCenter(normalizedStacks),
+        [normalizedStacks],
+    );
+    const cameraPosition = useMemo(
+        () =>
+            new Vector3(
+                sceneCenter.x - 100,
+                sceneCenter.y + 100,
+                sceneCenter.z - 100,
+            ),
+        [sceneCenter],
+    );
     const renderDetails = useDeferredSceneDetails(deferDetails);
+    const cacheKey = getPublicGardenCacheKey(garden);
+
+    useEffect(() => {
+        storeRef.current
+            ?.getState()
+            .setBackgroundPaletteKey(gameGarden?.backgroundPalette);
+    }, [gameGarden?.backgroundPalette]);
 
     return (
         <QueryClientProvider client={clientRef.current}>
             <GameStateContext.Provider value={storeRef.current}>
                 <GameSceneDetailContext.Provider value={{ renderDetails }}>
-                    <div className={cx('relative h-full w-full', className)}>
-                        <Scene
-                            position={[-100, 100, -100]}
-                            zoom={90}
-                            className="h-full w-full"
-                        >
-                            <color attach="background" args={['#d9f2dc']} />
-                            <ambientLight intensity={2} />
-                            <hemisphereLight intensity={3} />
-                            <directionalLight
-                                position={[5, 20, 10]}
-                                intensity={2.8}
+                    <SeedPublicGardenQueryCache
+                        cacheKey={cacheKey}
+                        client={clientRef.current}
+                        garden={gameGarden}
+                    >
+                        {(gardenCacheReady) => (
+                            <PublicGardenScene
+                                cameraPosition={cameraPosition}
+                                className={className}
+                                garden={gameGarden}
+                                gardenCacheReady={gardenCacheReady}
+                                normalizedStacks={normalizedStacks}
+                                renderDetails={renderDetails}
+                                sceneCenter={sceneCenter}
                             />
-                            <group>
-                                {normalizedStacks.map((stack) =>
-                                    stack.blocks.map((block) => (
-                                        <EntityFactory
-                                            key={`${stack.position.x}|${stack.position.y}|${block.id}-${block.name}`}
-                                            name={block.name}
-                                            stack={stack}
-                                            block={block}
-                                            stacks={normalizedStacks}
-                                            rotation={block.rotation}
-                                            variant={block.variant}
-                                            noRenderInView={instancedBlockNames}
-                                            noControl
-                                        />
-                                    )),
-                                )}
-                                <EntityInstances
-                                    stacks={normalizedStacks}
-                                    renderDetails={renderDetails}
-                                />
-                            </group>
-                            <OrbitControls
-                                enableRotate={false}
-                                screenSpacePanning={false}
-                                enablePan
-                                minZoom={50}
-                                maxZoom={500}
-                            />
-                        </Scene>
-                        {garden ? (
-                            <PublicGardenDetailsPanel garden={garden} />
-                        ) : null}
-                    </div>
+                        )}
+                    </SeedPublicGardenQueryCache>
                 </GameSceneDetailContext.Provider>
             </GameStateContext.Provider>
         </QueryClientProvider>

--- a/packages/game/src/viewers/PublicGardenViewer.unit.ts
+++ b/packages/game/src/viewers/PublicGardenViewer.unit.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    getPublicGardenStacksCenter,
+    normalizePublicGardenStacks,
+    type PublicGardenStack,
+} from './PublicGardenViewer';
+
+describe('normalizePublicGardenStacks', () => {
+    it('maps public garden rows onto the game z axis', () => {
+        const publicStacks: PublicGardenStack[] = [
+            {
+                x: 2,
+                y: 5,
+                blocks: [
+                    {
+                        id: 'block-1',
+                        name: 'Block_Grass',
+                        rotation: 0,
+                    },
+                ],
+            },
+        ];
+
+        const [stack] = normalizePublicGardenStacks(publicStacks);
+
+        assert.ok(stack);
+        assert.equal(stack.position.x, 2);
+        assert.equal(stack.position.y, 0);
+        assert.equal(stack.position.z, 5);
+    });
+});
+
+describe('getPublicGardenStacksCenter', () => {
+    it('centers the camera target across public garden x and z bounds', () => {
+        const stacks = normalizePublicGardenStacks([
+            { x: 0, y: 4, blocks: [] },
+            { x: 6, y: 10, blocks: [] },
+        ]);
+
+        const center = getPublicGardenStacksCenter(stacks);
+
+        assert.equal(center.x, 3);
+        assert.equal(center.y, 0);
+        assert.equal(center.z, 7);
+    });
+});


### PR DESCRIPTION
## Summary
- Restyle public garden listing/detail cards with real garden facts and shared OG/live scene presentation
- Serve matching garden OG images on www and fix public garden OG rendering
- Make public garden detail scenes interactive, fullscreen-capable, and aligned with in-game camera controls
- Add scoped view transition from `/vrtovi` cards into individual garden detail pages

## Validation
- `corepack pnpm --filter api test:node`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter www typecheck`
- `corepack pnpm --dir apps/www exec biome check ...`
- `git diff --check`
- Playwright smoke for `/vrtovi` -> `/vrtovi/1`, detail card layout, live scene, fullscreen/control behavior