### PR TITLE
feat(public): add native content view transitions

### DIFF
--- a/apps/news/app/[slug]/page.tsx
+++ b/apps/news/app/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { NewsDetail } from '../../components/NewsDetail';
 import { getBlogPost } from '../../lib/news';
+import { getNewsArticleViewTransitionName } from '../../lib/viewTransitions';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,7 +17,12 @@ export default async function BlogPostPage({
         notFound();
     }
 
-    return <NewsDetail entry={entry} />;
+    return (
+        <NewsDetail
+            entry={entry}
+            viewTransitionName={getNewsArticleViewTransitionName('blog', slug)}
+        />
+    );
 }
 
 export async function generateMetadata({

--- a/apps/news/app/globals.css
+++ b/apps/news/app/globals.css
@@ -175,10 +175,36 @@ svg.lucide {
     .site-footer .text-tertiary-foreground {
         color: hsl(var(--foreground));
     }
+
+    .news-card-view-transition {
+        contain: layout;
+    }
+}
+
+@supports (view-transition-name: none) {
+    ::view-transition-group(*) {
+        animation-duration: 520ms;
+        animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    ::view-transition-old(*),
+    ::view-transition-new(*) {
+        animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    ::view-transition-group(root) {
+        animation-duration: 220ms;
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {
     .animate-scale-in {
+        animation: none;
+    }
+
+    ::view-transition-group(*),
+    ::view-transition-old(*),
+    ::view-transition-new(*) {
         animation: none;
     }
 }

--- a/apps/news/app/layout.tsx
+++ b/apps/news/app/layout.tsx
@@ -44,6 +44,7 @@ export default function RootLayout({
     return (
         <html lang="hr" translate="no" suppressHydrationWarning>
             <body className={`${montserrat.variable} min-h-dvh antialiased`}>
+                <style>{'@view-transition { navigation: auto; }'}</style>
                 <PublicChromeProvider apiBasePath="/novosti/api/gredice">
                     <div className="flex min-h-dvh flex-col">
                         <PublicHeader

--- a/apps/news/app/page.tsx
+++ b/apps/news/app/page.tsx
@@ -15,6 +15,7 @@ import {
     getPrimaryNewsTags,
     uniqueNewsValues,
 } from '../lib/news';
+import { getNewsArticleViewTransitionName } from '../lib/viewTransitions';
 
 export const dynamic = 'force-dynamic';
 
@@ -161,6 +162,10 @@ export default async function NewsHomePage({
                             entry={item.entry}
                             href={item.href}
                             kind={item.kind}
+                            viewTransitionName={getNewsArticleViewTransitionName(
+                                item.kind,
+                                item.entry.slug,
+                            )}
                         />
                     ))}
                 </section>

--- a/apps/news/app/sto-je-novo/[slug]/page.tsx
+++ b/apps/news/app/sto-je-novo/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { NewsDetail } from '../../../components/NewsDetail';
 import { getChangelogEntry } from '../../../lib/news';
+import { getNewsArticleViewTransitionName } from '../../../lib/viewTransitions';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,7 +17,15 @@ export default async function ChangelogEntryPage({
         notFound();
     }
 
-    return <NewsDetail entry={entry} />;
+    return (
+        <NewsDetail
+            entry={entry}
+            viewTransitionName={getNewsArticleViewTransitionName(
+                'changelog',
+                slug,
+            )}
+        />
+    );
 }
 
 export async function generateMetadata({

--- a/apps/news/app/sto-je-novo/page.tsx
+++ b/apps/news/app/sto-je-novo/page.tsx
@@ -10,6 +10,7 @@ import {
     getPrimaryNewsTags,
     uniqueNewsValues,
 } from '../../lib/news';
+import { getNewsArticleViewTransitionName } from '../../lib/viewTransitions';
 
 export const dynamic = 'force-dynamic';
 
@@ -148,6 +149,10 @@ export default async function WhatsNewPage({
                                             kind="changelog"
                                             showDate={false}
                                             showKindLabel={false}
+                                            viewTransitionName={getNewsArticleViewTransitionName(
+                                                'changelog',
+                                                entry.slug,
+                                            )}
                                         />
                                     </TimelineEntry>
                                 );

--- a/apps/news/components/NewsCard.tsx
+++ b/apps/news/components/NewsCard.tsx
@@ -1,5 +1,4 @@
 import type { Route } from 'next';
-import Link from 'next/link';
 import { formatNewsDate } from '../lib/news';
 
 export type NewsCardKind = 'blog' | 'changelog';
@@ -42,7 +41,7 @@ export function NewsCard({
 
     return (
         <article className="w-full">
-            <Link
+            <a
                 className={`news-card-view-transition grid overflow-hidden rounded-md border bg-card shadow-xs transition-colors hover:bg-muted/20 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ${
                     entry.metaImageUrl
                         ? 'md:grid-cols-[minmax(0,1fr)_10rem]'
@@ -98,7 +97,7 @@ export function NewsCard({
                         />
                     </div>
                 ) : null}
-            </Link>
+            </a>
         </article>
     );
 }

--- a/apps/news/components/NewsCard.tsx
+++ b/apps/news/components/NewsCard.tsx
@@ -9,6 +9,7 @@ export type NewsCardEntry = {
     excerpt?: string | null;
     metaImageUrl?: string | null;
     publishedAt?: string | null;
+    slug: string;
     tags: string[];
     title: string;
 };
@@ -24,12 +25,14 @@ export function NewsCard({
     kind,
     showDate = true,
     showKindLabel = true,
+    viewTransitionName,
 }: {
     entry: NewsCardEntry;
     href: Route;
     kind: NewsCardKind;
     showDate?: boolean;
     showKindLabel?: boolean;
+    viewTransitionName?: string;
 }) {
     const dateLabel =
         showDate && entry.publishedAt
@@ -40,12 +43,13 @@ export function NewsCard({
     return (
         <article className="w-full">
             <Link
-                className={`grid overflow-hidden rounded-md border bg-card shadow-xs transition-colors hover:bg-muted/20 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ${
+                className={`news-card-view-transition grid overflow-hidden rounded-md border bg-card shadow-xs transition-colors hover:bg-muted/20 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ${
                     entry.metaImageUrl
                         ? 'md:grid-cols-[minmax(0,1fr)_10rem]'
                         : ''
                 }`}
                 href={href}
+                style={viewTransitionName ? { viewTransitionName } : undefined}
             >
                 <div className="grid content-start gap-3 p-5">
                     {entry.tags.length > 0 ? (

--- a/apps/news/components/NewsDetail.tsx
+++ b/apps/news/components/NewsDetail.tsx
@@ -3,10 +3,19 @@ import type { NewsDetail as NewsDetailEntry } from '../lib/news';
 import { formatNewsDate } from '../lib/news';
 import { sectionsComponentRegistry } from './shared/sectionsComponentRegistry';
 
-export function NewsDetail({ entry }: { entry: NewsDetailEntry }) {
+export function NewsDetail({
+    entry,
+    viewTransitionName,
+}: {
+    entry: NewsDetailEntry;
+    viewTransitionName?: string;
+}) {
     return (
         <article className="grid gap-8">
-            <header className="mx-auto grid w-full max-w-4xl gap-4 px-4 pt-10 sm:px-6 lg:px-8">
+            <header
+                className="news-card-view-transition mx-auto grid w-full max-w-4xl gap-4 px-4 pt-10 sm:px-6 lg:px-8"
+                style={viewTransitionName ? { viewTransitionName } : undefined}
+            >
                 <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
                     {entry.category ? <span>{entry.category}</span> : null}
                     {entry.publishedAt ? (

--- a/apps/news/lib/viewTransitions.ts
+++ b/apps/news/lib/viewTransitions.ts
@@ -1,0 +1,13 @@
+const invalidViewTransitionNameCharacters = /[^a-zA-Z0-9_-]+/g;
+
+export function getNewsArticleViewTransitionName(
+    kind: 'blog' | 'changelog',
+    slug: string,
+) {
+    const normalizedSlug =
+        slug
+            .replace(invalidViewTransitionNameCharacters, '-')
+            .replace(/^-+|-+$/g, '') || 'article';
+
+    return `news-${kind}-${normalizedSlug}`;
+}

--- a/apps/www/app/PlantsShowcase.tsx
+++ b/apps/www/app/PlantsShowcase.tsx
@@ -34,6 +34,7 @@ export async function PlantsShowcase() {
                     >
                         <PlantsGalleryItem
                             key={plant.information.name}
+                            id={plant.id.toString()}
                             information={plant.information}
                             attributes={plant.attributes}
                             image={plant.image}

--- a/apps/www/app/biljke/PlantsGalleryItem.tsx
+++ b/apps/www/app/biljke/PlantsGalleryItem.tsx
@@ -9,12 +9,14 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { ItemCard } from '../../components/shared/ItemCard';
 import { KnownPages } from '../../src/KnownPages';
+import { getPlantImageViewTransitionName } from './plantViewTransition';
 
 export type PlantsGalleryItemProps = Pick<
     PlantData,
     'information' | 'attributes' | 'image'
 > &
     Partial<Pick<PlantData, 'prices'>> & {
+        id: string;
         isRecommended?: boolean;
         matchingAlternativeName?: string;
         matchingSortName?: string;
@@ -22,6 +24,7 @@ export type PlantsGalleryItemProps = Pick<
 
 export function PlantsGalleryItem(props: PlantsGalleryItemProps) {
     const {
+        id,
         information,
         prices,
         attributes,
@@ -62,6 +65,7 @@ export function PlantsGalleryItem(props: PlantsGalleryItemProps) {
                 </Stack>
             }
             href={KnownPages.Plant(information.name)}
+            mediaViewTransitionName={getPlantImageViewTransitionName(id)}
         >
             <PlantOrSortImage
                 plant={props}

--- a/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
+++ b/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
@@ -15,6 +15,7 @@ import { AttributeCard } from '../../../components/attributes/DetailCard';
 import { CommunityEditButton } from '../../../components/community-edits/CommunityEditButton';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { KnownPages } from '../../../src/KnownPages';
+import { getPlantImageViewTransitionName } from '../plantViewTransition';
 import { getPlantInforationSections } from './getPlantInforationSections';
 import { PlantCalendarPicker } from './PlantCalendarPicker';
 import { hasPlantHealth } from './PlantHealthSection';
@@ -119,19 +120,37 @@ export function PlantPageHeader({
         <PageHeader
             visual={
                 sort ? (
-                    <PlantOrSortImage
-                        plantSort={sort}
-                        preload
-                        width={192}
-                        height={192}
-                    />
+                    <span
+                        className="public-content-card-view-transition inline-flex size-48 items-center justify-center overflow-hidden"
+                        style={{
+                            viewTransitionName: getPlantImageViewTransitionName(
+                                plant.id,
+                            ),
+                        }}
+                    >
+                        <PlantOrSortImage
+                            plantSort={sort}
+                            preload
+                            width={192}
+                            height={192}
+                        />
+                    </span>
                 ) : (
-                    <PlantOrSortImage
-                        plant={plant}
-                        preload
-                        width={192}
-                        height={192}
-                    />
+                    <span
+                        className="public-content-card-view-transition inline-flex size-48 items-center justify-center overflow-hidden"
+                        style={{
+                            viewTransitionName: getPlantImageViewTransitionName(
+                                plant.id,
+                            ),
+                        }}
+                    >
+                        <PlantOrSortImage
+                            plant={plant}
+                            preload
+                            width={192}
+                            height={192}
+                        />
+                    </span>
                 )
             }
             header={sort?.information?.name ?? plant.information.name}

--- a/apps/www/app/biljke/layout.tsx
+++ b/apps/www/app/biljke/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+
+export default function PlantsLayout({ children }: { children: ReactNode }) {
+    return (
+        <>
+            <style>{'@view-transition { navigation: auto; }'}</style>
+            {children}
+        </>
+    );
+}

--- a/apps/www/app/biljke/plantViewTransition.ts
+++ b/apps/www/app/biljke/plantViewTransition.ts
@@ -1,0 +1,3 @@
+export function getPlantImageViewTransitionName(plantId: string | number) {
+    return `plant-image-${plantId}`;
+}

--- a/apps/www/app/globals.css
+++ b/apps/www/app/globals.css
@@ -183,7 +183,8 @@
         color: hsl(var(--foreground));
     }
 
-    .public-garden-card-view-transition {
+    .public-garden-card-view-transition,
+    .public-content-card-view-transition {
         contain: layout;
     }
 }

--- a/apps/www/app/radnje/OperationCard.tsx
+++ b/apps/www/app/radnje/OperationCard.tsx
@@ -5,11 +5,13 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
+import Link from 'next/link';
 import { KnownPages } from '../../src/KnownPages';
+import { getOperationImageViewTransitionName } from './operationViewTransition';
 
 type OperationCardData = Pick<
     OperationData,
-    'attributes' | 'image' | 'information' | 'prices'
+    'attributes' | 'id' | 'image' | 'information' | 'prices'
 >;
 
 export function OperationCard({
@@ -22,37 +24,57 @@ export function OperationCard({
     const compact = variant === 'compact';
 
     return (
-        <Card
+        <Link
+            className="group block h-full rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             href={KnownPages.Operation(operation.information.label)}
-            className={cx('border-tertiary border-b-4', compact && 'p-1')}
         >
-            <CardContent noHeader className={cx(compact && 'px-2 py-1')}>
-                <Row justifyContent="space-between" spacing={2}>
-                    <Row spacing={compact ? 3 : 4} className="min-w-0 flex-1">
-                        <OperationImage
-                            operation={operation}
-                            size={compact ? 48 : 72}
-                        />
-                        <Stack className="min-w-0">
-                            <Typography semiBold>
-                                {operation.information.label}
-                            </Typography>
-                            <Typography
-                                level="body2"
-                                className={cx(
-                                    'text-pretty',
-                                    compact && 'leading-snug',
-                                )}
+            <Card
+                className={cx(
+                    'h-full border-tertiary border-b-4 transition-colors group-hover:bg-accent group-hover:text-accent-foreground',
+                    compact && 'p-1',
+                )}
+            >
+                <CardContent noHeader className={cx(compact && 'px-2 py-1')}>
+                    <Row justifyContent="space-between" spacing={2}>
+                        <Row
+                            spacing={compact ? 3 : 4}
+                            className="min-w-0 flex-1"
+                        >
+                            <span
+                                className="public-content-card-view-transition inline-flex shrink-0"
+                                style={{
+                                    viewTransitionName:
+                                        getOperationImageViewTransitionName(
+                                            operation.id,
+                                        ),
+                                }}
                             >
-                                {operation.information.shortDescription}
-                            </Typography>
-                        </Stack>
+                                <OperationImage
+                                    operation={operation}
+                                    size={compact ? 48 : 72}
+                                />
+                            </span>
+                            <Stack className="min-w-0">
+                                <Typography semiBold>
+                                    {operation.information.label}
+                                </Typography>
+                                <Typography
+                                    level="body2"
+                                    className={cx(
+                                        'text-pretty',
+                                        compact && 'leading-snug',
+                                    )}
+                                >
+                                    {operation.information.shortDescription}
+                                </Typography>
+                            </Stack>
+                        </Row>
+                        <Typography>
+                            {operation.prices.perOperation.toFixed(2)}€
+                        </Typography>
                     </Row>
-                    <Typography>
-                        {operation.prices.perOperation.toFixed(2)}€
-                    </Typography>
-                </Row>
-            </CardContent>
-        </Card>
+                </CardContent>
+            </Card>
+        </Link>
     );
 }

--- a/apps/www/app/radnje/OperationCard.tsx
+++ b/apps/www/app/radnje/OperationCard.tsx
@@ -5,7 +5,6 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import Link from 'next/link';
 import { KnownPages } from '../../src/KnownPages';
 import { getOperationImageViewTransitionName } from './operationViewTransition';
 
@@ -24,7 +23,7 @@ export function OperationCard({
     const compact = variant === 'compact';
 
     return (
-        <Link
+        <a
             className="group block h-full rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             href={KnownPages.Operation(operation.information.label)}
         >
@@ -75,6 +74,6 @@ export function OperationCard({
                     </Row>
                 </CardContent>
             </Card>
-        </Link>
+        </a>
     );
 }

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -19,6 +19,7 @@ import { getOperationsData } from '../../../lib/plants/getOperationsData';
 import { KnownPages } from '../../../src/KnownPages';
 import { merchantReturnPolicy } from '../../../src/merchantReturnPolicy';
 import { matchesPageAlias, toPageAlias } from '../../../src/pageAliases';
+import { getOperationImageViewTransitionName } from '../operationViewTransition';
 import { OperationApplicationsList } from './OperationApplicationsList';
 import { OperationAttributesCards } from './OperationAttributesCards';
 
@@ -110,7 +111,19 @@ export default async function OperationPage(
                     ]}
                 />
                 <PageHeader
-                    visual={<OperationImage operation={operation} size={192} />}
+                    visual={
+                        <span
+                            className="public-content-card-view-transition inline-flex size-48 items-center justify-center overflow-hidden"
+                            style={{
+                                viewTransitionName:
+                                    getOperationImageViewTransitionName(
+                                        operation.id,
+                                    ),
+                            }}
+                        >
+                            <OperationImage operation={operation} size={192} />
+                        </span>
+                    }
                     header={operation.information.label}
                     subHeader={operation.information.shortDescription}
                 >

--- a/apps/www/app/radnje/layout.tsx
+++ b/apps/www/app/radnje/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+
+export default function OperationsLayout({
+    children,
+}: {
+    children: ReactNode;
+}) {
+    return (
+        <>
+            <style>{'@view-transition { navigation: auto; }'}</style>
+            {children}
+        </>
+    );
+}

--- a/apps/www/app/radnje/operationViewTransition.ts
+++ b/apps/www/app/radnje/operationViewTransition.ts
@@ -1,0 +1,5 @@
+export function getOperationImageViewTransitionName(
+    operationId: string | number,
+) {
+    return `operation-image-${operationId}`;
+}

--- a/apps/www/components/shared/ItemCard.tsx
+++ b/apps/www/components/shared/ItemCard.tsx
@@ -1,6 +1,5 @@
 import { Card, CardHeader, CardOverflow } from '@gredice/ui/Card';
 import type { Route } from 'next';
-import Link from 'next/link';
 import type { PropsWithChildren, ReactElement } from 'react';
 
 export function ItemCard({
@@ -14,7 +13,7 @@ export function ItemCard({
     mediaViewTransitionName?: string;
 }>) {
     return (
-        <Link
+        <a
             className="group block h-full rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             href={href}
         >
@@ -33,6 +32,6 @@ export function ItemCard({
                     {label}
                 </CardHeader>
             </Card>
-        </Link>
+        </a>
     );
 }

--- a/apps/www/components/shared/ItemCard.tsx
+++ b/apps/www/components/shared/ItemCard.tsx
@@ -1,23 +1,38 @@
 import { Card, CardHeader, CardOverflow } from '@gredice/ui/Card';
 import type { Route } from 'next';
+import Link from 'next/link';
 import type { PropsWithChildren, ReactElement } from 'react';
 
 export function ItemCard({
     children,
     label,
     href,
-}: PropsWithChildren<{ label: string | ReactElement; href: Route | URL }>) {
+    mediaViewTransitionName,
+}: PropsWithChildren<{
+    label: string | ReactElement;
+    href: Route;
+    mediaViewTransitionName?: string;
+}>) {
     return (
-        <Card
-            className="overflow-hidden hover:shadow-xl transition-all group border-tertiary border-b-4"
-            href={href as string}
+        <Link
+            className="group block h-full rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            href={href}
         >
-            <CardOverflow className="p-0 aspect-square overflow-hidden mb-2">
-                <div className="relative size-full">{children}</div>
-            </CardOverflow>
-            <CardHeader className="bg-muted/60 border-t -m-2 py-2 px-3 group-hover:bg-muted transition-all h-full">
-                {label}
-            </CardHeader>
-        </Card>
+            <Card className="h-full overflow-hidden border-tertiary border-b-4 transition-all group-hover:bg-accent group-hover:text-accent-foreground group-hover:shadow-xl">
+                <CardOverflow
+                    className="public-content-card-view-transition mb-2 aspect-square overflow-hidden p-0"
+                    style={
+                        mediaViewTransitionName
+                            ? { viewTransitionName: mediaViewTransitionName }
+                            : undefined
+                    }
+                >
+                    <div className="relative size-full">{children}</div>
+                </CardOverflow>
+                <CardHeader className="-m-2 h-full border-t bg-muted/60 px-3 py-2 transition-all group-hover:bg-muted">
+                    {label}
+                </CardHeader>
+            </Card>
+        </Link>
     );
 }


### PR DESCRIPTION
## Summary
- Adds native browser view-transition opt-in for the public plants and operations routes.
- Names matching plant and operation preview visuals from list cards to detail pages.
- Adds the same native transition treatment to the news app cards and article detail headers.

## Validation
- `corepack pnpm --filter www lint`
- `corepack pnpm --filter news lint`
- `corepack pnpm --filter www typecheck`
- `corepack pnpm --filter news typecheck`
- `git diff --check`
- Local smoke: `/biljke` and `/radnje` render transition opt-in and named visuals on `localhost:3380`.
- Local smoke: `apps/news` rendered list/detail transition markers on `localhost:3387` with `GREDICE_API_HOST=https://api.gredice.com`.