### PR TITLE
feat(game): place store blocks near camera target

### DIFF
--- a/apps/api/lib/garden/blockPlacementService.node.spec.ts
+++ b/apps/api/lib/garden/blockPlacementService.node.spec.ts
@@ -93,6 +93,46 @@ describe('resolveGardenBlockPlacement', () => {
         });
     });
 
+    it('starts automatic placement near the preferred position', () => {
+        const placement = resolveGardenBlockPlacement({
+            blockName: 'Shade',
+            preferredPosition: { x: 12.4, y: -7.6 },
+            stacks: [],
+            blockNameById: new Map(),
+            blockDataByName,
+        });
+
+        assert.deepStrictEqual(placement, {
+            valid: true,
+            placement: {
+                x: 12,
+                y: -8,
+                index: 0,
+                existingBlocks: [],
+            },
+        });
+    });
+
+    it('searches outward from the preferred position when that cell is blocked', () => {
+        const placement = resolveGardenBlockPlacement({
+            blockName: 'Shade',
+            preferredPosition: { x: 12, y: -8 },
+            stacks: [{ positionX: 12, positionY: -8, blocks: ['shade-a'] }],
+            blockNameById: new Map([['shade-a', 'Shade']]),
+            blockDataByName,
+        });
+
+        assert.deepStrictEqual(placement, {
+            valid: true,
+            placement: {
+                x: 12,
+                y: -9,
+                index: 0,
+                existingBlocks: [],
+            },
+        });
+    });
+
     it('rejects explicitly requested raised-bed positions that the backend would not allow', () => {
         const placement = resolveGardenBlockPlacement({
             blockName: 'Raised_Bed',

--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -130,6 +130,7 @@ const blockNames = [
 
 type ItemsHudStoryOptions = {
     accountSunflowers?: number;
+    cameraTarget?: [x: number, y: number, z: number];
     closeup?: boolean;
     isSandbox?: boolean;
     localSandboxStorageKey?: string;
@@ -173,6 +174,7 @@ function createItemsHudQueryClient({
 function ItemsHudTestProviders({
     children,
     accountSunflowers,
+    cameraTarget,
     isSandbox = false,
     localSandboxStorageKey,
     closeup = false,
@@ -204,8 +206,24 @@ function ItemsHudTestProviders({
         if (closeup) {
             store.setState({ view: 'closeup' });
         }
+        if (cameraTarget) {
+            store.setState({
+                gameCameraSnapshot: {
+                    position: [cameraTarget[0] - 10, 10, cameraTarget[2] - 10],
+                    target: cameraTarget,
+                    version: 1,
+                    zoom: 100,
+                },
+            });
+        }
         return store;
-    }, [closeup, localSandboxStorageKey, pickupBlock, trashTargetActive]);
+    }, [
+        cameraTarget,
+        closeup,
+        localSandboxStorageKey,
+        pickupBlock,
+        trashTargetActive,
+    ]);
 
     return (
         <NuqsTestingAdapter>
@@ -253,6 +271,22 @@ function ItemsHudTestFrame({ closeup = false }: { closeup?: boolean }) {
 export function ItemsHudAlignmentStory() {
     return (
         <ItemsHudTestProviders>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <BottomControlsTestFrame />
+                    <ItemsHudTestFrame />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}
+
+export function ItemsHudCameraTargetStory() {
+    return (
+        <ItemsHudTestProviders cameraTarget={[12.4, 0, -7.6]}>
             <div className="relative h-screen w-screen overflow-hidden">
                 <div
                     data-testid="bottom-hud"

--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -3,6 +3,10 @@ import { cx } from '@gredice/ui/utils';
 import * as ReactQuery from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { type PropsWithChildren, useMemo } from 'react';
+import type {
+    GameCameraRigApi,
+    GameCameraSnapshot,
+} from '../../../packages/game/src/controls/GameCameraRigApi';
 import {
     gameHudBottomBarClassName,
     gameHudBottomControlsClassName,
@@ -46,6 +50,27 @@ function createBlockData(name: string, index: number) {
         createdAt: now,
         updatedAt: now,
     } satisfies BlockData;
+}
+
+function createMockGameCamera(
+    target: [x: number, y: number, z: number],
+): GameCameraRigApi {
+    const snapshot: GameCameraSnapshot = {
+        position: [target[0] - 10, 10, target[2] - 10],
+        target,
+        version: 1,
+        zoom: 100,
+    };
+
+    return {
+        focus: () => undefined,
+        getCamera: () => null,
+        getDomElement: () => null,
+        getSnapshot: () => snapshot,
+        panByDragEdge: () => false,
+        projectToScreen: () => null,
+        subscribe: () => () => undefined,
+    };
 }
 
 const blockNames = [
@@ -208,12 +233,7 @@ function ItemsHudTestProviders({
         }
         if (cameraTarget) {
             store.setState({
-                gameCameraSnapshot: {
-                    position: [cameraTarget[0] - 10, 10, cameraTarget[2] - 10],
-                    target: cameraTarget,
-                    version: 1,
-                    zoom: 100,
-                },
+                gameCamera: createMockGameCamera(cameraTarget),
             });
         }
         return store;

--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import {
     CloseupBottomHudStory,
     ItemsHudAlignmentStory,
+    ItemsHudCameraTargetStory,
     ItemsHudControlsTooltipStory,
     LocalSandboxItemsHudStory,
     LowSunflowerBalanceItemsHudStory,
@@ -412,6 +413,43 @@ test('item details place button keeps the soft color treatment', async ({
 
     const pricePill = placeButton.locator('div').filter({ hasText: '10' });
     await expect(pricePill).toHaveClass(/bg-primary\/15/u);
+});
+
+test('item placement starts near the current camera target', async ({
+    mount,
+    page,
+}) => {
+    const placeRequestPositions: Array<{ x: number; y: number }> = [];
+
+    await page.route(
+        /\/api(?:\/gredice)?\/gardens\/1\/blocks$/u,
+        async (route) => {
+            const position = getPlacementRequestPosition(
+                route.request().postDataJSON(),
+            );
+            if (position) {
+                placeRequestPositions.push(position);
+            }
+
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    id: 'placed-block-1',
+                    position: { x: 12, y: -8 },
+                }),
+            });
+        },
+    );
+
+    await mount(<ItemsHudCameraTargetStory />);
+
+    await page.getByRole('button', { name: 'Dekoracija' }).click();
+    await page.getByRole('button', { name: 'Stool' }).click();
+    await page.getByRole('button', { name: /Postavi.*10/u }).click();
+
+    await expect.poll(() => placeRequestPositions.length).toBe(1);
+    expect(placeRequestPositions).toEqual([{ x: 12, y: -8 }]);
 });
 
 test('item placement reserves local positions while requests are pending', async ({

--- a/packages/game/src/hooks/optimisticBlockPlacement.ts
+++ b/packages/game/src/hooks/optimisticBlockPlacement.ts
@@ -16,6 +16,30 @@ type GardenWithStacks = {
     stacks: Stack[];
 };
 
+export type BlockPlacementPosition = {
+    x: number;
+    y: number;
+};
+
+type CameraSnapshotLike = {
+    target: [x: number, y: number, z: number];
+};
+
+export function getPreferredBlockPlacementPosition(
+    snapshot: CameraSnapshotLike | null | undefined,
+): BlockPlacementPosition | undefined {
+    if (!snapshot) {
+        return undefined;
+    }
+
+    const [x, , z] = snapshot.target;
+    if (!Number.isFinite(x) || !Number.isFinite(z)) {
+        return undefined;
+    }
+
+    return { x, y: z };
+}
+
 function createBlockDataByName(blockData: PlacementBlockData[]) {
     const blockDataByName = new Map<string, GardenBlockDataLike>();
     for (const block of blockData) {
@@ -62,6 +86,9 @@ export function createOptimisticBlockPlacement<
     blockData: PlacementBlockData[] | null | undefined,
     blockName: string,
     blockId: string,
+    options: {
+        preferredPosition?: BlockPlacementPosition | null;
+    } = {},
 ) {
     if (!blockData) {
         return null;
@@ -73,6 +100,7 @@ export function createOptimisticBlockPlacement<
         blockNameById: createBlockNameById(garden.stacks),
         blockRotationById: createBlockRotationById(garden.stacks),
         blockDataByName: createBlockDataByName(blockData),
+        preferredPosition: options.preferredPosition ?? undefined,
     });
     if (!placement.valid) {
         return null;

--- a/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
+++ b/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import { Vector3 } from 'three';
 import {
     createOptimisticBlockPlacement,
+    getPreferredBlockPlacementPosition,
     type PlacementBlockData,
     removeOptimisticBlockId,
     replaceOptimisticBlockId,
@@ -206,6 +207,37 @@ describe('createOptimisticBlockPlacement', () => {
                 },
             ],
         });
+    });
+
+    it('uses the preferred position when placing a new block', () => {
+        const placement = createOptimisticBlockPlacement(
+            {
+                stacks: [],
+            },
+            blockData,
+            'Shade',
+            'optimistic-shade',
+            {
+                preferredPosition: getPreferredBlockPlacementPosition({
+                    target: [12.4, 0, -7.6],
+                }),
+            },
+        );
+
+        assert.ok(placement);
+        assert.deepStrictEqual(placement.position, new Vector3(12, 0, -8));
+        assert.deepStrictEqual(placement.stacks, [
+            {
+                position: new Vector3(12, 0, -8),
+                blocks: [
+                    {
+                        id: 'optimistic-shade',
+                        name: 'Shade',
+                        rotation: 0,
+                    },
+                ],
+            },
+        ]);
     });
 });
 

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -7,6 +7,7 @@ import {
 import { useGameState } from '../useGameState';
 import {
     createOptimisticBlockPlacement,
+    getPreferredBlockPlacementPosition,
     removeOptimisticBlockId,
     replaceOptimisticBlockId,
 } from './optimisticBlockPlacement';
@@ -115,6 +116,10 @@ export function useBlockPlace() {
     const queryClient = useQueryClient();
     const { data: garden } = useCurrentGarden();
     const { data: blockData } = useBlockData();
+    const gameCamera = useGameState((state) => state.gameCamera);
+    const gameCameraSnapshot = useGameState(
+        (state) => state.gameCameraSnapshot,
+    );
     const localSandboxStorageKey = useGameState(
         (state) => state.localSandboxStorageKey,
     );
@@ -201,6 +206,13 @@ export function useBlockPlace() {
                         blockData,
                         variables.blockName,
                         optimisticBlockId,
+                        {
+                            preferredPosition:
+                                getPreferredBlockPlacementPosition(
+                                    gameCameraSnapshot ??
+                                        gameCamera?.getSnapshot(),
+                                ),
+                        },
                     );
                     if (!optimisticPlacement) {
                         return;

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -117,9 +117,6 @@ export function useBlockPlace() {
     const { data: garden } = useCurrentGarden();
     const { data: blockData } = useBlockData();
     const gameCamera = useGameState((state) => state.gameCamera);
-    const gameCameraSnapshot = useGameState(
-        (state) => state.gameCameraSnapshot,
-    );
     const localSandboxStorageKey = useGameState(
         (state) => state.localSandboxStorageKey,
     );
@@ -209,8 +206,7 @@ export function useBlockPlace() {
                         {
                             preferredPosition:
                                 getPreferredBlockPlacementPosition(
-                                    gameCameraSnapshot ??
-                                        gameCamera?.getSnapshot(),
+                                    gameCamera?.getSnapshot(),
                                 ),
                         },
                     );

--- a/packages/js/src/gardenBlocks/index.ts
+++ b/packages/js/src/gardenBlocks/index.ts
@@ -114,6 +114,20 @@ function spiral(step: number): Position {
     }
 }
 
+function addPositions(left: Position, right: Position): Position {
+    return {
+        x: left.x + right.x,
+        y: left.y + right.y,
+    };
+}
+
+function toGridPosition(position: Position): Position {
+    return {
+        x: Math.round(position.x),
+        y: Math.round(position.y),
+    };
+}
+
 function findStackAtPosition(stacks: GardenBlockStack[], position: Position) {
     return stacks.find(
         (stack) =>
@@ -543,12 +557,86 @@ function validatePlacementAtPosition(params: {
     };
 }
 
+function resolveAutomaticGardenBlockPlacement(params: {
+    blockName: string;
+    occupiedCells: Map<string, OccupiedCell[]>;
+    searchOrigin: Position;
+    stacks: GardenBlockStack[];
+    blockNameById: Map<string, string>;
+    blockDataByName: Map<string, GardenBlockDataLike>;
+}): GardenBlockPlacementResult {
+    const {
+        blockName,
+        occupiedCells,
+        searchOrigin,
+        stacks,
+        blockNameById,
+        blockDataByName,
+    } = params;
+    let waterPlacementFallback: GardenBlockPlacementResult | null = null;
+
+    const validateCandidate = (
+        candidatePosition: Position,
+    ): GardenBlockPlacementResult | null => {
+        const placement = validatePlacementAtPosition({
+            blockName,
+            occupiedCells,
+            position: candidatePosition,
+            stacks,
+            blockNameById,
+            blockDataByName,
+        });
+        if (!placement.valid) {
+            return null;
+        }
+
+        if (
+            isWaterPlacement({
+                blockName,
+                placement: placement.placement,
+                stacks,
+                blockNameById,
+                blockDataByName,
+            })
+        ) {
+            waterPlacementFallback ??= placement;
+            return null;
+        }
+
+        return placement;
+    };
+
+    const searchOriginPlacement = validateCandidate(searchOrigin);
+    if (searchOriginPlacement) {
+        return searchOriginPlacement;
+    }
+
+    for (let step = 0; step < MAX_SPIRAL_STEPS; step++) {
+        const placement = validateCandidate(
+            addPositions(searchOrigin, spiral(step)),
+        );
+        if (placement) {
+            return placement;
+        }
+    }
+
+    if (waterPlacementFallback) {
+        return waterPlacementFallback;
+    }
+
+    return {
+        valid: false,
+        error: 'No valid placement position found',
+    };
+}
+
 export function resolveGardenBlockPlacement(params: {
     blockName: string;
     stacks: GardenBlockStack[];
     blockNameById: Map<string, string>;
     blockDataByName: Map<string, GardenBlockDataLike>;
     blockRotationById?: Map<string, number | null | undefined>;
+    preferredPosition?: Position;
     requestedPosition?: Position;
 }): GardenBlockPlacementResult {
     const {
@@ -557,6 +645,7 @@ export function resolveGardenBlockPlacement(params: {
         blockNameById,
         blockDataByName,
         blockRotationById,
+        preferredPosition,
         requestedPosition,
     } = params;
     const occupiedCells = createOccupiedCells({
@@ -577,68 +666,14 @@ export function resolveGardenBlockPlacement(params: {
         });
     }
 
-    let waterPlacementFallback: GardenBlockPlacementResult | null = null;
-
-    const originPlacement = validatePlacementAtPosition({
+    return resolveAutomaticGardenBlockPlacement({
         blockName,
         occupiedCells,
-        position: { x: 0, y: 0 },
         stacks,
         blockNameById,
         blockDataByName,
+        searchOrigin: preferredPosition
+            ? toGridPosition(preferredPosition)
+            : { x: 0, y: 0 },
     });
-    if (originPlacement.valid) {
-        if (
-            isWaterPlacement({
-                blockName,
-                placement: originPlacement.placement,
-                stacks,
-                blockNameById,
-                blockDataByName,
-            })
-        ) {
-            waterPlacementFallback = originPlacement;
-        } else {
-            return originPlacement;
-        }
-    }
-
-    for (let step = 0; step < MAX_SPIRAL_STEPS; step++) {
-        const candidatePosition = spiral(step);
-        const placement = validatePlacementAtPosition({
-            blockName,
-            occupiedCells,
-            position: candidatePosition,
-            stacks,
-            blockNameById,
-            blockDataByName,
-        });
-        if (!placement.valid) {
-            continue;
-        }
-
-        if (
-            isWaterPlacement({
-                blockName,
-                placement: placement.placement,
-                stacks,
-                blockNameById,
-                blockDataByName,
-            })
-        ) {
-            waterPlacementFallback ??= placement;
-            continue;
-        }
-
-        return placement;
-    }
-
-    if (waterPlacementFallback) {
-        return waterPlacementFallback;
-    }
-
-    return {
-        valid: false,
-        error: 'No valid placement position found',
-    };
 }


### PR DESCRIPTION
## Summary
- Start automatic block placement searches from a preferred grid position instead of always from world origin.
- Seed item-store block placement from the current game camera target so new store blocks appear near the user's current pan position.
- Cover preferred placement in resolver, optimistic placement, and Items HUD component tests.

## Validation
- corepack pnpm --filter @gredice/game test -- --test-name-pattern "createOptimisticBlockPlacement|resolvePickupPlacementPreviewForRelative"
- corepack pnpm --dir apps/api test:node -- --test-name-pattern resolveGardenBlockPlacement
- corepack pnpm --filter @gredice/js lint
- corepack pnpm --filter @gredice/game lint
- corepack pnpm --filter garden lint
- corepack pnpm --filter api lint
- corepack pnpm --filter @gredice/game typecheck
- corepack pnpm --filter garden typecheck
- corepack pnpm --filter garden test:prepare
- corepack pnpm --filter garden test:run -- items-hud.spec.tsx --grep "item placement starts near the current camera target"
- git diff --check

Note: direct tsc for packages/js and apps/api is not part of their package scripts and currently reports unrelated existing tsconfig/spec errors.