### PR TITLE
fix(game): improve pick and place drag performance

### DIFF
--- a/packages/game/src/controls/BlockInteractionRegistry.tsx
+++ b/packages/game/src/controls/BlockInteractionRegistry.tsx
@@ -125,12 +125,87 @@ export function useBlockInteractionTargetRegistration(
     handlers: BlockInteractionHandlers,
 ) {
     const registry = useBlockInteractionRegistry();
+    const targetRef = useRef(target);
+    const handlersRef = useRef(handlers);
+    const hasOnClick = Boolean(handlers.onClick);
+    const hasOnPointerDown = Boolean(handlers.onPointerDown);
+    const hasOnPointerEnter = Boolean(handlers.onPointerEnter);
+    const hasOnPointerLeave = Boolean(handlers.onPointerLeave);
+    const hasOnRotatePointerDown = Boolean(handlers.onRotatePointerDown);
+    const hasOnRotatePointerLeave = Boolean(handlers.onRotatePointerLeave);
+    const hasOnRotatePointerUp = Boolean(handlers.onRotatePointerUp);
+    const hasOnSelectClick = Boolean(handlers.onSelectClick);
+    const hasTarget = Boolean(target);
+    const stableTarget = useMemo<BlockInteractionTarget>(
+        () => ({
+            get block() {
+                return targetRef.current?.block as Block;
+            },
+            get blockIndex() {
+                return targetRef.current?.blockIndex ?? -1;
+            },
+            get stack() {
+                return targetRef.current?.stack as Stack;
+            },
+        }),
+        [],
+    );
+    const stableHandlers = useMemo<BlockInteractionHandlers>(() => {
+        const nextHandlers: BlockInteractionHandlers = {};
+        if (hasOnClick) {
+            nextHandlers.onClick = (event) =>
+                handlersRef.current.onClick?.(event);
+        }
+        if (hasOnPointerDown) {
+            nextHandlers.onPointerDown = (event) =>
+                handlersRef.current.onPointerDown?.(event);
+        }
+        if (hasOnPointerEnter) {
+            nextHandlers.onPointerEnter = (event) =>
+                handlersRef.current.onPointerEnter?.(event);
+        }
+        if (hasOnPointerLeave) {
+            nextHandlers.onPointerLeave = (event) =>
+                handlersRef.current.onPointerLeave?.(event);
+        }
+        if (hasOnRotatePointerDown) {
+            nextHandlers.onRotatePointerDown = (event) =>
+                handlersRef.current.onRotatePointerDown?.(event);
+        }
+        if (hasOnRotatePointerLeave) {
+            nextHandlers.onRotatePointerLeave = (event) =>
+                handlersRef.current.onRotatePointerLeave?.(event);
+        }
+        if (hasOnRotatePointerUp) {
+            nextHandlers.onRotatePointerUp = (event) =>
+                handlersRef.current.onRotatePointerUp?.(event);
+        }
+        if (hasOnSelectClick) {
+            nextHandlers.onSelectClick = (event) =>
+                handlersRef.current.onSelectClick?.(event);
+        }
+        return nextHandlers;
+    }, [
+        hasOnClick,
+        hasOnPointerDown,
+        hasOnPointerEnter,
+        hasOnPointerLeave,
+        hasOnRotatePointerDown,
+        hasOnRotatePointerLeave,
+        hasOnRotatePointerUp,
+        hasOnSelectClick,
+    ]);
 
     useLayoutEffect(() => {
-        if (!key || !target || !registry) {
+        targetRef.current = target;
+        handlersRef.current = handlers;
+    });
+
+    useLayoutEffect(() => {
+        if (!key || !hasTarget || !registry) {
             return;
         }
 
-        return registry.register(key, target, handlers);
-    });
+        return registry.register(key, stableTarget, stableHandlers);
+    }, [key, registry, stableHandlers, stableTarget, hasTarget]);
 }

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -27,7 +27,10 @@ import { useBlockData } from '../hooks/useBlockData';
 import { useBlockDelete } from '../hooks/useBlockDelete';
 import { useBlockMove } from '../hooks/useBlockMove';
 import { useBlockRecycle } from '../hooks/useBlockRecycle';
-import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import {
+    type CurrentGarden,
+    useCurrentGardenCache,
+} from '../hooks/useCurrentGarden';
 import { useGardenBoxStoreBlock } from '../hooks/useGardenBoxStoreBlock';
 import {
     resolveBlockParticleType,
@@ -56,10 +59,12 @@ import {
     suppressBlockInteractions,
 } from './blockInteractionSuppression';
 import {
+    createPickupPlacementPreviewResolver,
     type MovingSegment,
+    type PickupPlacementPreviewResolver,
     type ResolvedPlacementPreview,
-    resolvePickupPlacementPreviewForRelative,
 } from './PickupPlacementResolver';
+import { useHoveredBlockStore } from './useHoveredBlockStore';
 
 const groundPlane = new Plane(new Vector3(0, 1, 0), 0);
 const pickupHintDelayMs = 120;
@@ -146,6 +151,59 @@ function activeDragPreviewAffectsTarget(
     );
 }
 
+const placementPreviewEpsilon = 0.0001;
+
+function placementPreviewNumbersEqual(left: number, right: number) {
+    return Math.abs(left - right) <= placementPreviewEpsilon;
+}
+
+function placementPreviewTargetsEqual(
+    left: ResolvedPlacementPreview['targetOffsets'],
+    right: ResolvedPlacementPreview['targetOffsets'],
+) {
+    if (left.length !== right.length) {
+        return false;
+    }
+
+    return left.every((leftTarget, index) => {
+        const rightTarget = right[index];
+        return (
+            Boolean(rightTarget) &&
+            activeDragPreviewTargetMatches(leftTarget, rightTarget) &&
+            placementPreviewNumbersEqual(
+                leftTarget.hoverHeight,
+                rightTarget?.hoverHeight ?? Number.NaN,
+            )
+        );
+    });
+}
+
+function resolvedPlacementPreviewsEqual(
+    left: ResolvedPlacementPreview | null | undefined,
+    right: ResolvedPlacementPreview | null | undefined,
+) {
+    if (left === right) {
+        return true;
+    }
+    if (!left || !right) {
+        return false;
+    }
+
+    return (
+        placementPreviewNumbersEqual(left.relative.x, right.relative.x) &&
+        placementPreviewNumbersEqual(left.relative.z, right.relative.z) &&
+        placementPreviewNumbersEqual(
+            left.previewHoverHeight,
+            right.previewHoverHeight,
+        ) &&
+        left.hoveredGardenBoxBlockId === right.hoveredGardenBoxBlockId &&
+        left.canStoreInGardenBox === right.canStoreInGardenBox &&
+        left.nextIsOverRecycler === right.nextIsOverRecycler &&
+        left.nextIsBlocked === right.nextIsBlocked &&
+        placementPreviewTargetsEqual(left.targetOffsets, right.targetOffsets)
+    );
+}
+
 export function PickableGroup({
     children,
     interactionTargetKey,
@@ -163,7 +221,7 @@ export function PickableGroup({
         },
     }));
     const { spawn } = useParticles();
-    const { data: garden } = useCurrentGarden();
+    const getCurrentGarden = useCurrentGardenCache();
     const { data: blocksData } = useBlockData();
     const gameStateStore = useContext(GameStateContext);
     const camera = useThree((state) => state.camera);
@@ -212,37 +270,6 @@ export function PickableGroup({
     const recycleBlock = useBlockRecycle();
     const storeBlockInGardenBox = useGardenBoxStoreBlock();
 
-    const raisedBed = findRaisedBedByBlockId(garden, block.id);
-    const canRecycleRaisedBed = (raisedBed?.status ?? 'new') === 'new';
-    const canRecycle = canRecycleRaisedBed;
-
-    const attachedRaisedBedBlockId =
-        block.name === 'Raised_Bed' && garden
-            ? findAttachedRaisedBedBlockId(garden.stacks, block.id)
-            : null;
-    const attachedPlacement = attachedRaisedBedBlockId
-        ? garden?.stacks
-              .flatMap((candidateStack) =>
-                  candidateStack.blocks.map(
-                      (candidateBlock, candidateBlockIndex) => ({
-                          candidateStack,
-                          candidateBlock,
-                          candidateBlockIndex,
-                      }),
-                  ),
-              )
-              .find(
-                  (candidate) =>
-                      candidate.candidateBlock.id === attachedRaisedBedBlockId,
-              )
-        : null;
-    const attachedCurrentStackHeight = attachedPlacement
-        ? getStackHeight(
-              blocksData,
-              attachedPlacement.candidateStack,
-              attachedPlacement.candidateBlock,
-          )
-        : 0;
     const blockIndex = stack.blocks.indexOf(block);
     const activePreviewTarget = useMemo(
         () =>
@@ -375,7 +402,38 @@ export function PickableGroup({
         };
     }, [stopDragAutopan]);
 
-    function getMovingSegments(): MovingSegment[] {
+    function getAttachedPlacement(garden: CurrentGarden | null | undefined) {
+        if (block.name !== 'Raised_Bed' || !garden) {
+            return null;
+        }
+
+        const attachedRaisedBedBlockId = findAttachedRaisedBedBlockId(
+            garden.stacks,
+            block.id,
+        );
+
+        return attachedRaisedBedBlockId
+            ? (garden.stacks
+                  .flatMap((candidateStack) =>
+                      candidateStack.blocks.map(
+                          (candidateBlock, candidateBlockIndex) => ({
+                              candidateStack,
+                              candidateBlock,
+                              candidateBlockIndex,
+                          }),
+                      ),
+                  )
+                  .find(
+                      (candidate) =>
+                          candidate.candidateBlock.id ===
+                          attachedRaisedBedBlockId,
+                  ) ?? null)
+            : null;
+    }
+
+    function getMovingSegments(
+        garden: CurrentGarden | null | undefined = getCurrentGarden(),
+    ): MovingSegment[] {
         if (blockIndex < 0) {
             return [];
         }
@@ -385,6 +443,18 @@ export function PickableGroup({
             return [];
         }
 
+        const raisedBed = findRaisedBedByBlockId(garden, block.id);
+        const canRecycle = garden
+            ? (raisedBed?.status ?? 'new') === 'new'
+            : false;
+        const attachedPlacement = getAttachedPlacement(garden);
+        const attachedCurrentStackHeight = attachedPlacement
+            ? getStackHeight(
+                  blocksData,
+                  attachedPlacement.candidateStack,
+                  attachedPlacement.candidateBlock,
+              )
+            : 0;
         const attachedBlocks = attachedPlacement
             ? attachedPlacement.candidateStack.blocks.slice(
                   attachedPlacement.candidateBlockIndex,
@@ -418,21 +488,22 @@ export function PickableGroup({
         ];
     }
 
-    function resolvePlacementPreviewForRelative(relative: Vector3) {
+    function createPlacementPreviewResolver(
+        garden: CurrentGarden | null | undefined = getCurrentGarden(),
+    ) {
         if (!garden || !blocksData || blockIndex < 0) {
             return null;
         }
 
-        const movingSegments = getMovingSegments();
+        const movingSegments = getMovingSegments(garden);
         if (movingSegments.length === 0) {
             return null;
         }
-        return resolvePickupPlacementPreviewForRelative({
+        return createPickupPlacementPreviewResolver({
             blockData: blocksData,
             gardenIsSandbox: garden.isSandbox,
             localSandboxStorageKey,
             movingSegments,
-            relative,
             stacks: garden.stacks,
         });
     }
@@ -492,17 +563,24 @@ export function PickableGroup({
         return (screenX - clientX) ** 2 + (screenY - clientY) ** 2;
     }
 
-    function resolvePlacementPreviewAtDestination(destination: {
-        x: number;
-        z: number;
-    }) {
+    function resolvePlacementPreviewAtDestination(
+        destination: {
+            x: number;
+            z: number;
+        },
+        resolver?: PickupPlacementPreviewResolver | null,
+    ) {
         const { relative } = dragState.current;
         relative.set(
             destination.x - stack.position.x,
             0,
             destination.z - stack.position.z,
         );
-        return resolvePlacementPreviewForRelative(relative);
+        return (
+            (resolver ?? createPlacementPreviewResolver())?.resolveForRelative(
+                relative,
+            ) ?? null
+        );
     }
 
     function resolvePlacementPreview(
@@ -510,12 +588,17 @@ export function PickableGroup({
         clientY: number,
         pickupAnchorOffset: PickupAnchorOffset,
     ): ResolvedPlacementPreview | null {
+        const garden = getCurrentGarden();
         if (!garden || !blocksData || blockIndex < 0) {
             return null;
         }
 
         const rect = domElement.getBoundingClientRect();
         if (rect.width <= 0 || rect.height <= 0) {
+            return null;
+        }
+        const resolver = createPlacementPreviewResolver(garden);
+        if (!resolver) {
             return null;
         }
 
@@ -549,8 +632,10 @@ export function PickableGroup({
             x: dest.x,
             z: dest.z,
         })) {
-            const preview =
-                resolvePlacementPreviewAtDestination(candidateDestination);
+            const preview = resolvePlacementPreviewAtDestination(
+                candidateDestination,
+                resolver,
+            );
             if (!preview) {
                 continue;
             }
@@ -608,7 +693,7 @@ export function PickableGroup({
 
     function isPointerOverSandboxTrash(clientX: number, clientY: number) {
         return (
-            Boolean(garden?.isSandbox) &&
+            Boolean(getCurrentGarden()?.isSandbox) &&
             isPointOverSandboxBlockTrashDropTarget(clientX, clientY)
         );
     }
@@ -678,6 +763,10 @@ export function PickableGroup({
             session.pickupAnchorOffset,
         );
         if (!preview) {
+            return;
+        }
+
+        if (resolvedPlacementPreviewsEqual(session.latestPreview, preview)) {
             return;
         }
 
@@ -779,6 +868,7 @@ export function PickableGroup({
         setIsDragging(false);
         setPickupOutlineVisible(true);
         setPickupBlock(block);
+        useHoveredBlockStore.getState().setHoveredBlock(null);
         disturbAnimals({
             sourceBlockId: block.id,
             sourceBlockName: block.name,
@@ -803,8 +893,11 @@ export function PickableGroup({
         preview: ResolvedPlacementPreview | null,
         deleteRequested: boolean,
     ) {
+        const garden = getCurrentGarden();
+        const attachedPlacement = getAttachedPlacement(garden);
+        const raisedBed = findRaisedBedByBlockId(garden, block.id);
         const blockIdsToDelete = deleteRequested
-            ? getMovingSegments().flatMap((segment) =>
+            ? getMovingSegments(garden).flatMap((segment) =>
                   segment.blocks.map((segmentBlock) => segmentBlock.id),
               )
             : [];
@@ -937,7 +1030,7 @@ export function PickableGroup({
             return;
         }
 
-        const moveRequests = getMovingSegments().flatMap((segment) =>
+        const moveRequests = getMovingSegments(garden).flatMap((segment) =>
             segment.blocks.map((segmentBlock) => ({
                 sourcePosition: {
                     x: segment.sourceStack.position.x,
@@ -1078,7 +1171,7 @@ export function PickableGroup({
             event.button !== 0 ||
             pointerSession.current ||
             areBlockInteractionsSuppressed() ||
-            !garden ||
+            !getCurrentGarden() ||
             !blocksData ||
             blockIndex < 0
         ) {

--- a/packages/game/src/controls/PickupPlacementResolver.ts
+++ b/packages/game/src/controls/PickupPlacementResolver.ts
@@ -49,6 +49,10 @@ export type ResolvedPlacementPreview = {
     targetOffsets: ActiveDragPreviewTargetOffset[];
 };
 
+export type PickupPlacementPreviewResolver = {
+    resolveForRelative: (relative: Vector3) => ResolvedPlacementPreview | null;
+};
+
 function getStack(
     stacks: Stack[] | undefined,
     destination: { x: number; z: number },
@@ -159,6 +163,11 @@ function getSegmentFootprintOffsets(
 
     return Array.from(offsetsByKey.values());
 }
+
+type PreparedMovingSegment = {
+    footprintOffsets: { x: number; y: number }[];
+    segment: MovingSegment;
+};
 
 function createTargetOffsets(
     placementPreviews: PlacementPreview[],
@@ -341,6 +350,30 @@ export function resolvePickupPlacementPreviewForRelative({
     relative: Vector3;
     stacks: Stack[] | undefined;
 }): ResolvedPlacementPreview | null {
+    return (
+        createPickupPlacementPreviewResolver({
+            blockData,
+            gardenIsSandbox,
+            localSandboxStorageKey,
+            movingSegments,
+            stacks,
+        })?.resolveForRelative(relative) ?? null
+    );
+}
+
+export function createPickupPlacementPreviewResolver({
+    blockData,
+    gardenIsSandbox,
+    localSandboxStorageKey,
+    movingSegments,
+    stacks,
+}: {
+    blockData: BlockData[] | null | undefined;
+    gardenIsSandbox: boolean;
+    localSandboxStorageKey: string | null;
+    movingSegments: MovingSegment[];
+    stacks: Stack[] | undefined;
+}): PickupPlacementPreviewResolver | null {
     if (!blockData || movingSegments.length === 0) {
         return null;
     }
@@ -355,9 +388,49 @@ export function resolvePickupPlacementPreviewForRelative({
         movingBlockIds,
         stacks,
     });
+    const preparedMovingSegments: PreparedMovingSegment[] = movingSegments.map(
+        (segment) => ({
+            footprintOffsets: getSegmentFootprintOffsets(blockData, segment),
+            segment,
+        }),
+    );
 
-    const placementPreviews: PlacementPreview[] = movingSegments.flatMap(
-        (segment) => {
+    return {
+        resolveForRelative: (relative) =>
+            resolvePickupPlacementPreviewFromPreparedState({
+                blockData,
+                gardenIsSandbox,
+                localSandboxStorageKey,
+                movingBlockIds,
+                occupiedCells,
+                preparedMovingSegments,
+                relative,
+                stacks,
+            }),
+    };
+}
+
+function resolvePickupPlacementPreviewFromPreparedState({
+    blockData,
+    gardenIsSandbox,
+    localSandboxStorageKey,
+    movingBlockIds,
+    occupiedCells,
+    preparedMovingSegments,
+    relative,
+    stacks,
+}: {
+    blockData: BlockData[];
+    gardenIsSandbox: boolean;
+    localSandboxStorageKey: string | null;
+    movingBlockIds: Set<string>;
+    occupiedCells: Map<string, OccupiedCell[]>;
+    preparedMovingSegments: PreparedMovingSegment[];
+    relative: Vector3;
+    stacks: Stack[] | undefined;
+}): ResolvedPlacementPreview | null {
+    const placementPreviews: PlacementPreview[] =
+        preparedMovingSegments.flatMap(({ footprintOffsets, segment }) => {
             if (!segment.blocks[0]) {
                 return [];
             }
@@ -366,10 +439,6 @@ export function resolvePickupPlacementPreviewForRelative({
                 x: segment.sourceStack.position.x + relative.x,
                 z: segment.sourceStack.position.z + relative.z,
             };
-            const footprintOffsets = getSegmentFootprintOffsets(
-                blockData,
-                segment,
-            );
             const anchorOccupiedCell = getTopOccupiedCell(
                 occupiedCells,
                 destination,
@@ -458,8 +527,7 @@ export function resolvePickupPlacementPreviewForRelative({
                     segment,
                 },
             ];
-        },
-    );
+        });
 
     const movedRaisedBedPreviews = placementPreviews.filter((preview) =>
         preview.segment.blocks.some(

--- a/packages/game/src/controls/PickupPlacementResolver.unit.ts
+++ b/packages/game/src/controls/PickupPlacementResolver.unit.ts
@@ -5,6 +5,7 @@ import { Vector3 } from 'three';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
 import {
+    createPickupPlacementPreviewResolver,
     type MovingSegment,
     resolvePickupPlacementPreviewForRelative,
 } from './PickupPlacementResolver';
@@ -354,5 +355,56 @@ describe('resolvePickupPlacementPreviewForRelative', () => {
         });
 
         assert.equal(preview?.nextIsBlocked, false);
+    });
+
+    it('matches the single-resolution path when reusing prepared placement state', () => {
+        const stand = createBlock('LemonadeStand', 'stand');
+        const sourceStack = createStack(0, 0, [stand]);
+        const supportStack = createStack(1, 0, [createBlock('Tree', 'tree')]);
+        const blockedStack = createStack(2, 0, [
+            createBlock('WaterWell', 'water-well'),
+        ]);
+        const movingSegments = [
+            createMovingSegment({ block: stand, sourceStack }),
+        ];
+        const resolver = createPickupPlacementPreviewResolver({
+            blockData,
+            gardenIsSandbox: false,
+            localSandboxStorageKey: null,
+            movingSegments,
+            stacks: [sourceStack, supportStack, blockedStack],
+        });
+        if (!resolver) {
+            throw new Error('Expected placement resolver');
+        }
+
+        const relative = new Vector3(1, 0, 0);
+        const preparedPreview = resolver.resolveForRelative(relative);
+        const directPreview = resolvePickupPlacementPreviewForRelative({
+            blockData,
+            gardenIsSandbox: false,
+            localSandboxStorageKey: null,
+            movingSegments,
+            relative,
+            stacks: [sourceStack, supportStack, blockedStack],
+        });
+
+        assert.deepEqual(
+            {
+                hoveredGardenBoxBlockId:
+                    preparedPreview?.hoveredGardenBoxBlockId,
+                nextIsBlocked: preparedPreview?.nextIsBlocked,
+                nextIsOverRecycler: preparedPreview?.nextIsOverRecycler,
+                previewHoverHeight: preparedPreview?.previewHoverHeight,
+                targetOffsets: preparedPreview?.targetOffsets,
+            },
+            {
+                hoveredGardenBoxBlockId: directPreview?.hoveredGardenBoxBlockId,
+                nextIsBlocked: directPreview?.nextIsBlocked,
+                nextIsOverRecycler: directPreview?.nextIsOverRecycler,
+                previewHoverHeight: directPreview?.previewHoverHeight,
+                targetOffsets: directPreview?.targetOffsets,
+            },
+        );
     });
 });

--- a/packages/game/src/controls/RotatableGroup.tsx
+++ b/packages/game/src/controls/RotatableGroup.tsx
@@ -1,11 +1,11 @@
 import type { ThreeEvent } from '@react-three/fiber';
-import { type PropsWithChildren, useRef } from 'react';
+import { type PropsWithChildren, useContext, useRef } from 'react';
 import type { Vector3 } from 'three';
 import { useBlockRotate } from '../hooks/useBlockRotate';
-import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useCurrentGardenCache } from '../hooks/useCurrentGarden';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
-import { useGameState } from '../useGameState';
+import { GameStateContext, useGameState } from '../useGameState';
 import { findAttachedRaisedBedBlockId } from '../utils/raisedBedBlocks';
 import { useBlockInteractionTargetRegistration } from './BlockInteractionRegistry';
 
@@ -25,10 +25,9 @@ export function RotatableGroup({
     stack?: Stack;
 }>) {
     const blockRotate = useBlockRotate();
-    const { data: garden } = useCurrentGarden();
+    const getCurrentGarden = useCurrentGardenCache();
+    const gameStateStore = useContext(GameStateContext);
     const effectsAudioMixer = useGameState((state) => state.audio.effects);
-    const isDragging = useGameState((state) => state.isDragging);
-    const pickupBlock = useGameState((state) => state.pickupBlock);
     const swipeSound = effectsAudioMixer.useSoundEffect(
         'https://cdn.gredice.com/sounds/effects/Swipe Generic 01.mp3',
     );
@@ -37,8 +36,10 @@ export function RotatableGroup({
     const firstTapTimeStamp = useRef(0);
 
     function doRotate() {
-        if (isDragging || pickupBlock) return false;
+        const gameState = gameStateStore?.getState();
+        if (gameState?.isDragging || gameState?.pickupBlock) return false;
 
+        const garden = getCurrentGarden();
         const attachedRaisedBedBlockId =
             block.name === 'Raised_Bed' && garden
                 ? findAttachedRaisedBedBlockId(garden.stacks, block.id)

--- a/packages/game/src/entities/EntityFactory.tsx
+++ b/packages/game/src/entities/EntityFactory.tsx
@@ -1,6 +1,11 @@
 import { Edges } from '@react-three/drei';
 import type { ThreeEvent } from '@react-three/fiber';
-import { type ComponentType, type PropsWithChildren, useEffect } from 'react';
+import {
+    type ComponentType,
+    memo,
+    type PropsWithChildren,
+    useContext,
+} from 'react';
 import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import {
     createBlockInteractionTargetKey,
@@ -12,16 +17,14 @@ import { SelectableGroup } from '../controls/SelectableGroup';
 import { useDeferredSingleClick } from '../controls/useDeferredSingleClick';
 import { useHoveredBlockStore } from '../controls/useHoveredBlockStore';
 import { useBlockData } from '../hooks/useBlockData';
-import {
-    useCurrentGarden,
-    useIsSandboxGarden,
-} from '../hooks/useCurrentGarden';
+import { useCurrentGardenCache } from '../hooks/useCurrentGarden';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
-import { useGameState } from '../useGameState';
+import { GameStateContext, useGameState } from '../useGameState';
 import { useSetRaisedBedCloseupParam } from '../useRaisedBedCloseup';
 import { useGiftBoxParam } from '../useUrlState';
 import { useStackHeight } from '../utils/getStackHeight';
 import { findRaisedBedByBlockId } from '../utils/raisedBedBlocks';
+import { areEntityFactoryPropsEqual } from './entityFactoryMemo';
 import { entityNameMap } from './entityNameMap';
 import { QueuedPlacementDropAnimation } from './helpers/PlacementDropAnimation';
 import { UnknownEntityPlaceholder } from './UnknownEntityPlaceholder';
@@ -31,6 +34,8 @@ export type EntityFactoryProps = {
     noControl?: boolean;
     noRenderInView?: string[];
 };
+
+type EntityFactoryComponentProps = EntityFactoryProps & EntityInstanceProps;
 
 const instancedRenderModeDebugColor = '#22c55e';
 const componentRenderModeDebugColor = '#f59e0b';
@@ -115,49 +120,41 @@ function InstancedEntitySelectionRegistration({
     blockIndex: number;
     interactionTargetKey: string | undefined;
 }) {
-    const { data: garden } = useCurrentGarden();
+    const getCurrentGarden = useCurrentGardenCache();
+    const gameStateStore = useContext(GameStateContext);
     const { track } = useGameAnalytics();
-    const hoveredBlock = useHoveredBlockStore((state) => state.hoveredBlock);
     const setHoveredBlock = useHoveredBlockStore(
         (state) => state.setHoveredBlock,
-    );
-    const isSandbox = useIsSandboxGarden();
-    const hasActiveDragPreview = useGameState((state) =>
-        Boolean(state.activeDragPreview),
     );
     const setOpenGardenBoxBlockId = useGameState(
         (state) => state.setOpenGardenBoxBlockId,
     );
     const { mutate: setRaisedBedCloseupParam } = useSetRaisedBedCloseupParam();
     const [, setGiftBoxParam] = useGiftBoxParam();
-    const raisedBed =
-        block.name === 'Raised_Bed'
-            ? findRaisedBedByBlockId(garden, block.id)
-            : null;
     const selectable =
         block.name === 'GardenBox' ||
         block.name.startsWith('GiftBox_') ||
-        Boolean(raisedBed);
-    const selectionHoverEnabled = selectable && !hasActiveDragPreview;
-
-    useEffect(() => {
-        if (hasActiveDragPreview && hoveredBlock === block) {
-            setHoveredBlock(null);
-        }
-    }, [block, hasActiveDragPreview, hoveredBlock, setHoveredBlock]);
+        block.name === 'Raised_Bed';
+    const hasActiveDragPreview = () =>
+        Boolean(gameStateStore?.getState().activeDragPreview);
 
     const handleSelected = useDeferredSingleClick(() => {
-        if (hasActiveDragPreview) {
+        if (hasActiveDragPreview()) {
             return;
         }
 
         if (block.name === 'GardenBox') {
-            if (!isSandbox) {
+            if (!getCurrentGarden()?.isSandbox) {
                 setOpenGardenBoxBlockId(block.id);
             }
             return;
         }
 
+        const garden = getCurrentGarden();
+        const raisedBed =
+            block.name === 'Raised_Bed'
+                ? findRaisedBedByBlockId(garden, block.id)
+                : null;
         if (block.name === 'Raised_Bed' && raisedBed) {
             track('game_raised_bed_opened', {
                 block_id: block.id,
@@ -188,18 +185,19 @@ function InstancedEntitySelectionRegistration({
             },
             ...(selectable
                 ? {
-                      ...(selectionHoverEnabled
-                          ? {
-                                onPointerEnter: (
-                                    event: ThreeEvent<PointerEvent>,
-                                ) => {
-                                    event.stopPropagation();
-                                    setHoveredBlock(block);
-                                },
-                            }
-                          : {}),
+                      onPointerEnter: (event: ThreeEvent<PointerEvent>) => {
+                          if (hasActiveDragPreview()) {
+                              return;
+                          }
+
+                          event.stopPropagation();
+                          setHoveredBlock(block);
+                      },
                       onPointerLeave: (event: ThreeEvent<PointerEvent>) => {
-                          if (hoveredBlock === block) {
+                          if (
+                              useHoveredBlockStore.getState().hoveredBlock ===
+                              block
+                          ) {
                               event.stopPropagation();
                               setHoveredBlock(null);
                           }
@@ -212,14 +210,14 @@ function InstancedEntitySelectionRegistration({
     return null;
 }
 
-export function EntityFactory({
+function EntityFactoryComponent({
     name,
     stack,
     block,
     noControl,
     noRenderInView,
     ...rest
-}: EntityFactoryProps & EntityInstanceProps) {
+}: EntityFactoryComponentProps) {
     const EntityComponent = entityComponents[name];
     const view = useGameState((state) => state.view);
     const isInstancedInView = noRenderInView?.includes(name) ?? false;
@@ -319,3 +317,8 @@ export function EntityFactory({
         </SelectableGroup>
     );
 }
+
+export const EntityFactory = memo(
+    EntityFactoryComponent,
+    areEntityFactoryPropsEqual,
+);

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -119,6 +119,94 @@ function chunkInstances(instances: EntityBlockInstance[]) {
         );
 }
 
+function numbersEqual(left: number, right: number) {
+    return Math.abs(left - right) <= 0.0001;
+}
+
+function tuplesEqual(
+    left: [number, number, number],
+    right: [number, number, number],
+) {
+    return (
+        numbersEqual(left[0], right[0]) &&
+        numbersEqual(left[1], right[1]) &&
+        numbersEqual(left[2], right[2])
+    );
+}
+
+function scalesEqual(
+    left: EntityInstancesBlockBaseProps['scale'],
+    right: EntityInstancesBlockBaseProps['scale'],
+) {
+    if (left === right) {
+        return true;
+    }
+    if (Array.isArray(left) && Array.isArray(right)) {
+        return tuplesEqual(left, right);
+    }
+    return false;
+}
+
+function entityBlockInstancesEqual(
+    left: EntityBlockInstance[] | undefined,
+    right: EntityBlockInstance[] | undefined,
+) {
+    if (left === right) {
+        return true;
+    }
+    if (!left || !right || left.length !== right.length) {
+        return false;
+    }
+
+    return left.every((leftInstance, index) => {
+        const rightInstance = right[index];
+        return (
+            Boolean(rightInstance) &&
+            leftInstance.block === rightInstance.block &&
+            leftInstance.blockIndex === rightInstance.blockIndex &&
+            leftInstance.id === rightInstance.id &&
+            leftInstance.pickupOutlineVisible ===
+                rightInstance.pickupOutlineVisible &&
+            tuplesEqual(leftInstance.position, rightInstance.position) &&
+            numbersEqual(leftInstance.rotation, rightInstance.rotation) &&
+            leftInstance.stack === rightInstance.stack &&
+            numbersEqual(leftInstance.stackHeight, rightInstance.stackHeight)
+        );
+    });
+}
+
+function useStableEntityBlockInstances(
+    instances: EntityBlockInstance[] | undefined,
+) {
+    const previous = useRef<EntityBlockInstance[] | undefined>(undefined);
+
+    if (!entityBlockInstancesEqual(previous.current, instances)) {
+        previous.current = instances;
+    }
+
+    return previous.current;
+}
+
+function useStableTuple(tuple: [number, number, number]) {
+    const previous = useRef(tuple);
+
+    if (!tuplesEqual(previous.current, tuple)) {
+        previous.current = tuple;
+    }
+
+    return previous.current;
+}
+
+function useStableScale(scale: EntityInstancesBlockBaseProps['scale']) {
+    const previous = useRef(scale);
+
+    if (!scalesEqual(previous.current, scale)) {
+        previous.current = scale;
+    }
+
+    return previous.current;
+}
+
 function createInstanceMatrix(
     instance: EntityBlockInstance,
     localTransform: {
@@ -264,7 +352,7 @@ export function useEntityBlockInstances({
             : null,
     );
 
-    return stacks
+    const instances = stacks
         ?.filter((stack) =>
             stack.blocks.some((block) =>
                 blockNameMatches(block.name, name, names),
@@ -314,6 +402,8 @@ export function useEntityBlockInstances({
                     };
                 }),
         );
+
+    return useStableEntityBlockInstances(instances);
 }
 
 export function EntityInstancesBlock(
@@ -403,25 +493,49 @@ export function EntityInstancesGeometry(
         (state) => state.blockPlacementDropAnimations,
     );
 
-    if (!instances?.length) {
-        return null;
-    }
-
-    const localTransform = {
-        position: localPosition ?? defaultLocalPosition,
-        rotation: localRotation ?? defaultLocalRotation,
-    };
-    const animatedBlockIds = new Set(Object.keys(placementDropAnimations));
-    const stableInstances = instances.filter(
-        (data) => !animatedBlockIds.has(data.block.id),
+    const stableLocalPosition = useStableTuple(
+        localPosition ?? defaultLocalPosition,
     );
-    const animatedInstances = instances.filter((data) =>
-        animatedBlockIds.has(data.block.id),
+    const stableLocalRotation = useStableTuple(
+        localRotation ?? defaultLocalRotation,
     );
-    const stableChunks = chunkInstances(stableInstances);
+    const stableScale = useStableScale(scale);
+    const localTransform = useMemo(
+        () => ({
+            position: stableLocalPosition,
+            rotation: stableLocalRotation,
+        }),
+        [stableLocalPosition, stableLocalRotation],
+    );
+    const animatedBlockIds = useMemo(
+        () => new Set(Object.keys(placementDropAnimations)),
+        [placementDropAnimations],
+    );
+    const stableInstances = useMemo(
+        () =>
+            (instances ?? []).filter(
+                (data) => !animatedBlockIds.has(data.block.id),
+            ),
+        [animatedBlockIds, instances],
+    );
+    const animatedInstances = useMemo(
+        () =>
+            (instances ?? []).filter((data) =>
+                animatedBlockIds.has(data.block.id),
+            ),
+        [animatedBlockIds, instances],
+    );
+    const stableChunks = useMemo(
+        () => chunkInstances(stableInstances),
+        [stableInstances],
+    );
 
     const material = 'material' in props ? props.material : undefined;
     const materialNode = 'materialNode' in props ? props.materialNode : null;
+
+    if (!instances?.length) {
+        return null;
+    }
 
     const renderAnimatedInstances = (suffix: string) =>
         animatedInstances.map((data) => (
@@ -442,7 +556,7 @@ export function EntityInstancesGeometry(
                         material={material}
                         position={localTransform.position}
                         rotation={localTransform.rotation}
-                        scale={scale}
+                        scale={stableScale}
                         receiveShadow={receiveShadow}
                         castShadow={castShadow}
                         renderOrder={renderOrder}
@@ -476,7 +590,7 @@ export function EntityInstancesGeometry(
                           <group
                               position={localTransform.position}
                               rotation={localTransform.rotation}
-                              scale={scale}
+                              scale={stableScale}
                           >
                               <SnowOverlay
                                   geometry={geometry}
@@ -507,7 +621,7 @@ export function EntityInstancesGeometry(
                           <group
                               position={localTransform.position}
                               rotation={localTransform.rotation}
-                              scale={scale}
+                              scale={stableScale}
                           >
                               <RainWetOverlay geometry={geometry} />
                           </group>
@@ -529,7 +643,7 @@ export function EntityInstancesGeometry(
                     materialNode={materialNode}
                     receiveShadow={receiveShadow}
                     renderOrder={renderOrder}
-                    scale={scale}
+                    scale={stableScale}
                 />
             ))}
             {renderAnimatedInstances('base')}
@@ -548,7 +662,7 @@ export function EntityInstancesGeometry(
                                 geometry={geometry}
                                 position={localTransform.position}
                                 rotation={localTransform.rotation}
-                                scale={scale}
+                                scale={stableScale}
                                 raycast={() => null}
                             >
                                 <meshBasicMaterial visible={false} />
@@ -562,7 +676,7 @@ export function EntityInstancesGeometry(
                     chunks={stableChunks}
                     geometry={geometry}
                     localTransform={localTransform}
-                    scale={scale}
+                    scale={stableScale}
                 />
             )}
             {snow && renderSnow && (
@@ -570,7 +684,7 @@ export function EntityInstancesGeometry(
                     chunks={stableChunks}
                     geometry={geometry}
                     localTransform={localTransform}
-                    scale={scale}
+                    scale={stableScale}
                     snow={snow}
                     snowLift={snowLift}
                     snowOverlayMinCoverage={snowOverlayMinCoverage}

--- a/packages/game/src/entities/entityFactoryMemo.ts
+++ b/packages/game/src/entities/entityFactoryMemo.ts
@@ -1,0 +1,84 @@
+import type { Block } from '../types/Block';
+import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
+import type { Stack } from '../types/Stack';
+import type { EntityFactoryProps } from './EntityFactory';
+
+type EntityFactoryMemoProps = EntityFactoryProps & EntityInstanceProps;
+
+function isInstancedEntityFactoryProps(props: EntityFactoryMemoProps) {
+    return props.noRenderInView?.includes(props.name) ?? false;
+}
+
+function areBlocksEqual(left: Block, right: Block) {
+    return (
+        left === right ||
+        (left.id === right.id &&
+            left.name === right.name &&
+            left.rotation === right.rotation &&
+            left.variant === right.variant)
+    );
+}
+
+function areStackPositionsEqual(left: Stack, right: Stack) {
+    return (
+        left.position === right.position ||
+        (left.position.x === right.position.x &&
+            left.position.y === right.position.y &&
+            left.position.z === right.position.z)
+    );
+}
+
+function areStackBlocksEqual(left: Block[], right: Block[]) {
+    if (left === right) {
+        return true;
+    }
+
+    if (left.length !== right.length) {
+        return false;
+    }
+
+    return left.every((leftBlock, index) => {
+        const rightBlock = right[index];
+        return Boolean(rightBlock) && areBlocksEqual(leftBlock, rightBlock);
+    });
+}
+
+function areInstancedStacksEqual(left: Stack, right: Stack) {
+    return (
+        left === right ||
+        (areStackPositionsEqual(left, right) &&
+            areStackBlocksEqual(left.blocks, right.blocks))
+    );
+}
+
+export function areEntityFactoryPropsEqual(
+    previous: EntityFactoryMemoProps,
+    next: EntityFactoryMemoProps,
+) {
+    const previousInstanced = isInstancedEntityFactoryProps(previous);
+    const nextInstanced = isInstancedEntityFactoryProps(next);
+
+    if (
+        previous.name !== next.name ||
+        previous.rotation !== next.rotation ||
+        previous.variant !== next.variant ||
+        previous.noControl !== next.noControl ||
+        previous.noRenderInView !== next.noRenderInView ||
+        previousInstanced !== nextInstanced
+    ) {
+        return false;
+    }
+
+    if (previousInstanced && nextInstanced) {
+        return (
+            areBlocksEqual(previous.block, next.block) &&
+            areInstancedStacksEqual(previous.stack, next.stack)
+        );
+    }
+
+    return (
+        previous.block === next.block &&
+        previous.stack === next.stack &&
+        previous.stacks === next.stacks
+    );
+}

--- a/packages/game/src/entities/entityFactoryMemo.unit.ts
+++ b/packages/game/src/entities/entityFactoryMemo.unit.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { areEntityFactoryPropsEqual } from './entityFactoryMemo';
+
+type EntityFactoryMemoProps = Parameters<typeof areEntityFactoryPropsEqual>[0];
+
+const instancedNames = ['Block_Grass'];
+
+function createBlock(overrides: Partial<Block> = {}): Block {
+    return {
+        id: 'block-1',
+        name: 'Block_Grass',
+        rotation: 0,
+        ...overrides,
+    };
+}
+
+function createStack({
+    blocks = [createBlock()],
+    x = 1,
+    y = 0,
+    z = 2,
+}: {
+    blocks?: Block[];
+    x?: number;
+    y?: number;
+    z?: number;
+} = {}): Stack {
+    return {
+        position: new Vector3(x, y, z),
+        blocks,
+    };
+}
+
+function createProps(
+    overrides: Partial<EntityFactoryMemoProps> = {},
+): EntityFactoryMemoProps {
+    const block = overrides.block ?? createBlock();
+    const stack = overrides.stack ?? createStack({ blocks: [block] });
+    return {
+        name: block.name,
+        stack,
+        block,
+        stacks: [stack],
+        rotation: block.rotation,
+        variant: block.variant,
+        noRenderInView: instancedNames,
+        ...overrides,
+    };
+}
+
+describe('areEntityFactoryPropsEqual', () => {
+    it('keeps equivalent instanced stacks stable when only Vector3 references change', () => {
+        const previousBlock = createBlock();
+        const nextBlock = createBlock();
+        const previous = createProps({
+            block: previousBlock,
+            stack: createStack({ blocks: [previousBlock] }),
+        });
+        const next = createProps({
+            block: nextBlock,
+            stack: createStack({ blocks: [nextBlock] }),
+        });
+
+        assert.equal(areEntityFactoryPropsEqual(previous, next), true);
+    });
+
+    it('rerenders instanced blocks when their stack contents change', () => {
+        const block = createBlock();
+        const previous = createProps({
+            block,
+            stack: createStack({ blocks: [block] }),
+        });
+        const next = createProps({
+            block,
+            stack: createStack({
+                blocks: [block, createBlock({ id: 'block-2' })],
+            }),
+        });
+
+        assert.equal(areEntityFactoryPropsEqual(previous, next), false);
+    });
+
+    it('keeps non-instanced entities on strict stack identity', () => {
+        const previousBlock = createBlock({ name: 'Tree' });
+        const nextBlock = createBlock({ name: 'Tree' });
+        const previous = createProps({
+            name: 'Tree',
+            block: previousBlock,
+            stack: createStack({ blocks: [previousBlock] }),
+            noRenderInView: instancedNames,
+        });
+        const next = createProps({
+            name: 'Tree',
+            block: nextBlock,
+            stack: createStack({ blocks: [nextBlock] }),
+            noRenderInView: instancedNames,
+        });
+
+        assert.equal(areEntityFactoryPropsEqual(previous, next), false);
+    });
+});

--- a/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     type ActiveDragPreviewTarget,
     createActiveDragPreviewTarget,
@@ -27,6 +27,56 @@ type GroundBlockDecorationsProps = {
 
 function activeDragTargetKey(target: ActiveDragPreviewTarget) {
     return `${target.stackPosition.x}|${target.stackPosition.z}|${target.blockId}|${target.blockIndex}`;
+}
+
+function numbersEqual(left: number, right: number) {
+    return Math.abs(left - right) <= 0.0001;
+}
+
+function decorationInstancesEqual(
+    left: GroundDecorationInstance[] | undefined,
+    right: GroundDecorationInstance[],
+) {
+    if (left === right) {
+        return true;
+    }
+    if (!left || left.length !== right.length) {
+        return false;
+    }
+
+    return left.every((leftInstance, index) => {
+        const rightInstance = right[index];
+        return (
+            Boolean(rightInstance) &&
+            numbersEqual(leftInstance.alphaTest, rightInstance.alphaTest) &&
+            numbersEqual(leftInstance.height, rightInstance.height) &&
+            numbersEqual(leftInstance.opacity, rightInstance.opacity) &&
+            numbersEqual(
+                leftInstance.position[0],
+                rightInstance?.position[0] ?? Number.NaN,
+            ) &&
+            numbersEqual(
+                leftInstance.position[1],
+                rightInstance?.position[1] ?? Number.NaN,
+            ) &&
+            numbersEqual(
+                leftInstance.position[2],
+                rightInstance?.position[2] ?? Number.NaN,
+            ) &&
+            numbersEqual(leftInstance.rotationZ, rightInstance.rotationZ) &&
+            leftInstance.spriteName === rightInstance.spriteName
+        );
+    });
+}
+
+function useStableDecorationInstances(instances: GroundDecorationInstance[]) {
+    const previous = useRef<GroundDecorationInstance[] | undefined>(undefined);
+
+    if (!decorationInstancesEqual(previous.current, instances)) {
+        previous.current = instances;
+    }
+
+    return previous.current ?? instances;
 }
 
 export function GroundBlockDecorations({
@@ -102,7 +152,7 @@ export function GroundBlockDecorations({
         (sum, block) => sum + block.placements.length,
         0,
     );
-    const decorationInstances = useMemo(() => {
+    const computedDecorationInstances = useMemo(() => {
         const instances: GroundDecorationInstance[] = [];
 
         for (const {
@@ -157,6 +207,9 @@ export function GroundBlockDecorations({
 
         return instances;
     }, [activeDragPreview, blockData, decorationBlocks]);
+    const decorationInstances = useStableDecorationInstances(
+        computedDecorationInstances,
+    );
 
     useEffect(() => {
         updateGameProfileMetadata({

--- a/packages/game/src/hooks/currentGardenStructuralSharing.ts
+++ b/packages/game/src/hooks/currentGardenStructuralSharing.ts
@@ -1,0 +1,210 @@
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import type { CurrentGarden } from './useCurrentGarden';
+
+function blockVariantsEqual(left: Block, right: Block) {
+    return (left.variant ?? null) === (right.variant ?? null);
+}
+
+function blocksEqual(left: Block, right: Block) {
+    return (
+        left === right ||
+        (left.id === right.id &&
+            left.name === right.name &&
+            left.rotation === right.rotation &&
+            blockVariantsEqual(left, right))
+    );
+}
+
+function stackPositionsEqual(left: Stack, right: Stack) {
+    return (
+        left.position === right.position ||
+        (left.position.x === right.position.x &&
+            left.position.y === right.position.y &&
+            left.position.z === right.position.z)
+    );
+}
+
+function stackKey(stack: Stack) {
+    return `${stack.position.x}|${stack.position.y}|${stack.position.z}`;
+}
+
+function shareBlocks(previousBlocks: Block[], nextBlocks: Block[]) {
+    if (previousBlocks === nextBlocks) {
+        return previousBlocks;
+    }
+
+    let changed = previousBlocks.length !== nextBlocks.length;
+    const blocks = nextBlocks.map((nextBlock, index) => {
+        const previousBlock = previousBlocks[index];
+        if (previousBlock && blocksEqual(previousBlock, nextBlock)) {
+            return previousBlock;
+        }
+
+        changed = true;
+        return nextBlock;
+    });
+
+    return changed ? blocks : previousBlocks;
+}
+
+function shareStack(previousStack: Stack | undefined, nextStack: Stack) {
+    if (!previousStack || !stackPositionsEqual(previousStack, nextStack)) {
+        return nextStack;
+    }
+
+    const blocks = shareBlocks(previousStack.blocks, nextStack.blocks);
+    if (blocks === previousStack.blocks) {
+        return previousStack;
+    }
+
+    return {
+        ...nextStack,
+        position: previousStack.position,
+        blocks,
+    };
+}
+
+function shareStacks(previousStacks: Stack[], nextStacks: Stack[]) {
+    if (previousStacks === nextStacks) {
+        return previousStacks;
+    }
+
+    const previousStackByKey = new Map(
+        previousStacks.map((stack) => [stackKey(stack), stack]),
+    );
+    let changed = previousStacks.length !== nextStacks.length;
+    const stacks = nextStacks.map((nextStack, index) => {
+        const sharedStack = shareStack(
+            previousStackByKey.get(stackKey(nextStack)),
+            nextStack,
+        );
+        if (sharedStack !== previousStacks[index]) {
+            changed = true;
+        }
+        return sharedStack;
+    });
+
+    return changed ? stacks : previousStacks;
+}
+
+function jsonValuesEqual(left: unknown, right: unknown): boolean {
+    if (left === right) {
+        return true;
+    }
+
+    if (Array.isArray(left) && Array.isArray(right)) {
+        return (
+            left.length === right.length &&
+            left.every((leftValue, index) =>
+                jsonValuesEqual(leftValue, right[index]),
+            )
+        );
+    }
+
+    if (
+        !left ||
+        !right ||
+        typeof left !== 'object' ||
+        typeof right !== 'object'
+    ) {
+        return false;
+    }
+
+    const leftRecord = left as Record<string, unknown>;
+    const rightRecord = right as Record<string, unknown>;
+    const leftKeys = Object.keys(leftRecord);
+    const rightKeys = Object.keys(rightRecord);
+    return (
+        leftKeys.length === rightKeys.length &&
+        leftKeys.every(
+            (key) =>
+                Object.hasOwn(rightRecord, key) &&
+                jsonValuesEqual(leftRecord[key], rightRecord[key]),
+        )
+    );
+}
+
+function shareJsonValue<T>(previousValue: T, nextValue: T) {
+    return jsonValuesEqual(previousValue, nextValue)
+        ? previousValue
+        : nextValue;
+}
+
+function shareLocation(
+    previousLocation: CurrentGarden['location'],
+    nextLocation: CurrentGarden['location'],
+) {
+    return previousLocation.lat === nextLocation.lat &&
+        previousLocation.lon === nextLocation.lon
+        ? previousLocation
+        : nextLocation;
+}
+
+export function shareCurrentGardenData(
+    previousGarden: CurrentGarden | null | undefined,
+    nextGarden: CurrentGarden | null,
+) {
+    if (!previousGarden || !nextGarden) {
+        return nextGarden;
+    }
+
+    if (
+        previousGarden.id !== nextGarden.id ||
+        previousGarden.name !== nextGarden.name ||
+        previousGarden.isSandbox !== nextGarden.isSandbox ||
+        previousGarden.isPublic !== nextGarden.isPublic ||
+        previousGarden.backgroundPalette !== nextGarden.backgroundPalette ||
+        previousGarden.farmId !== nextGarden.farmId
+    ) {
+        return nextGarden;
+    }
+
+    const stacks = shareStacks(previousGarden.stacks, nextGarden.stacks);
+    const location = shareLocation(
+        previousGarden.location,
+        nextGarden.location,
+    );
+    const raisedBeds = shareJsonValue(
+        previousGarden.raisedBeds,
+        nextGarden.raisedBeds,
+    );
+
+    if (
+        stacks === previousGarden.stacks &&
+        location === previousGarden.location &&
+        raisedBeds === previousGarden.raisedBeds
+    ) {
+        return previousGarden;
+    }
+
+    return {
+        ...nextGarden,
+        stacks,
+        location,
+        raisedBeds,
+    };
+}
+
+export function shareCurrentGardenQueryData(
+    previousGarden: unknown,
+    nextGarden: unknown,
+) {
+    if (nextGarden === null || isCurrentGarden(nextGarden)) {
+        return shareCurrentGardenData(
+            isCurrentGarden(previousGarden) ? previousGarden : null,
+            nextGarden,
+        );
+    }
+
+    return nextGarden;
+}
+
+function isCurrentGarden(value: unknown): value is CurrentGarden {
+    return (
+        Boolean(value) &&
+        typeof value === 'object' &&
+        Array.isArray((value as CurrentGarden).stacks) &&
+        Array.isArray((value as CurrentGarden).raisedBeds)
+    );
+}

--- a/packages/game/src/hooks/currentGardenStructuralSharing.unit.ts
+++ b/packages/game/src/hooks/currentGardenStructuralSharing.unit.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { shareCurrentGardenData } from './currentGardenStructuralSharing';
+import type { CurrentGarden } from './useCurrentGarden';
+
+function createBlock(overrides: Partial<Block> = {}): Block {
+    return {
+        id: 'block-1',
+        name: 'Block_Grass',
+        rotation: 0,
+        ...overrides,
+    };
+}
+
+function createStack(
+    x: number,
+    z: number,
+    blocks: Block[] = [createBlock()],
+): Stack {
+    return {
+        position: new Vector3(x, 0, z),
+        blocks,
+    };
+}
+
+function createGarden(overrides: Partial<CurrentGarden> = {}): CurrentGarden {
+    return {
+        id: 1,
+        name: 'Garden',
+        isSandbox: false,
+        isPublic: false,
+        backgroundPalette: 'current',
+        farmId: 1,
+        stacks: [createStack(0, 0)],
+        location: {
+            lat: 45,
+            lon: 16,
+        },
+        raisedBeds: [],
+        ...overrides,
+    };
+}
+
+describe('shareCurrentGardenData', () => {
+    it('keeps the optimistic garden when a refetch rebuilds equivalent stack objects', () => {
+        const previousStack = createStack(0, 0, [
+            createBlock({ id: 'backend-block' }),
+        ]);
+        const previousGarden = createGarden({
+            stacks: [previousStack],
+        });
+        const nextGarden = createGarden({
+            stacks: [
+                createStack(0, 0, [
+                    createBlock({
+                        id: 'backend-block',
+                        variant: null,
+                    }),
+                ]),
+            ],
+        });
+
+        assert.equal(
+            shareCurrentGardenData(previousGarden, nextGarden),
+            previousGarden,
+        );
+    });
+
+    it('keeps unchanged stack references when another stack changes', () => {
+        const unchangedStack = createStack(0, 0, [
+            createBlock({ id: 'unchanged' }),
+        ]);
+        const changedStack = createStack(1, 0, [createBlock({ id: 'old' })]);
+        const previousGarden = createGarden({
+            stacks: [unchangedStack, changedStack],
+        });
+        const nextChangedStack = createStack(1, 0, [
+            createBlock({ id: 'old' }),
+            createBlock({ id: 'new' }),
+        ]);
+        const nextGarden = createGarden({
+            stacks: [
+                createStack(0, 0, [createBlock({ id: 'unchanged' })]),
+                nextChangedStack,
+            ],
+        });
+
+        const sharedGarden = shareCurrentGardenData(previousGarden, nextGarden);
+
+        assert.notEqual(sharedGarden, previousGarden);
+        assert.equal(sharedGarden?.stacks[0], unchangedStack);
+        assert.notEqual(sharedGarden?.stacks[1], changedStack);
+        assert.equal(sharedGarden?.stacks[1]?.position, changedStack.position);
+        assert.equal(
+            sharedGarden?.stacks[1]?.blocks[0],
+            changedStack.blocks[0],
+        );
+        assert.equal(
+            sharedGarden?.stacks[1]?.blocks[1],
+            nextChangedStack.blocks[1],
+        );
+    });
+
+    it('returns new data when garden metadata changes', () => {
+        const previousGarden = createGarden();
+        const nextGarden = createGarden({ name: 'Renamed garden' });
+
+        assert.equal(
+            shareCurrentGardenData(previousGarden, nextGarden),
+            nextGarden,
+        );
+    });
+});

--- a/packages/game/src/hooks/optimisticBlockPlacement.ts
+++ b/packages/game/src/hooks/optimisticBlockPlacement.ts
@@ -117,19 +117,39 @@ export function replaceOptimisticBlockId<TGarden extends GardenWithStacks>(
     optimisticBlockId: string,
     blockId: string,
 ): TGarden {
+    let changed = false;
+    const stacks = garden.stacks.map((stack) => {
+        let stackChanged = false;
+        const blocks = stack.blocks.map((block) => {
+            if (block.id !== optimisticBlockId) {
+                return block;
+            }
+
+            stackChanged = true;
+            return {
+                ...block,
+                id: blockId,
+            };
+        });
+
+        if (!stackChanged) {
+            return stack;
+        }
+
+        changed = true;
+        return {
+            ...stack,
+            blocks,
+        };
+    });
+
+    if (!changed) {
+        return garden;
+    }
+
     return {
         ...garden,
-        stacks: garden.stacks.map((stack) => ({
-            ...stack,
-            blocks: stack.blocks.map((block) =>
-                block.id === optimisticBlockId
-                    ? {
-                          ...block,
-                          id: blockId,
-                      }
-                    : block,
-            ),
-        })),
+        stacks,
     };
 }
 

--- a/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
+++ b/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
@@ -244,6 +244,67 @@ describe('replaceOptimisticBlockId', () => {
             },
         );
     });
+
+    it('preserves stacks that do not contain the optimistic block', () => {
+        const targetBlock = {
+            id: 'optimistic-shade',
+            name: 'Shade',
+            rotation: 0,
+        };
+        const untouchedBlock = {
+            id: 'grass-a',
+            name: 'Block_Grass',
+            rotation: 0,
+        };
+        const targetStack = {
+            position: new Vector3(0, 0, 0),
+            blocks: [targetBlock],
+        };
+        const untouchedStack = {
+            position: new Vector3(1, 0, 0),
+            blocks: [untouchedBlock],
+        };
+        const garden = {
+            stacks: [targetStack, untouchedStack],
+        };
+
+        const updatedGarden = replaceOptimisticBlockId(
+            garden,
+            'optimistic-shade',
+            'shade-1',
+        );
+
+        assert.notEqual(updatedGarden, garden);
+        assert.notEqual(updatedGarden.stacks, garden.stacks);
+        assert.notEqual(updatedGarden.stacks[0], targetStack);
+        assert.notEqual(updatedGarden.stacks[0]?.blocks, targetStack.blocks);
+        assert.equal(updatedGarden.stacks[0]?.blocks[0]?.id, 'shade-1');
+        assert.equal(updatedGarden.stacks[1], untouchedStack);
+        assert.equal(updatedGarden.stacks[1]?.blocks, untouchedStack.blocks);
+        assert.equal(updatedGarden.stacks[1]?.blocks[0], untouchedBlock);
+    });
+
+    it('returns the original garden when the optimistic block is missing', () => {
+        const garden = {
+            stacks: [
+                {
+                    position: new Vector3(0, 0, 0),
+                    blocks: [
+                        {
+                            id: 'shade-1',
+                            name: 'Shade',
+                            rotation: 0,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        assert.equal(
+            replaceOptimisticBlockId(garden, 'optimistic-shade', 'shade-1'),
+            garden,
+        );
+    });
 });
 
 describe('removeOptimisticBlockId', () => {

--- a/packages/game/src/hooks/optimisticStackUpdates.ts
+++ b/packages/game/src/hooks/optimisticStackUpdates.ts
@@ -1,0 +1,47 @@
+import type { Stack } from '../types/Stack';
+
+export function rotateBlocksInStacks({
+    blockIds,
+    rotation,
+    stacks,
+}: {
+    blockIds: Iterable<string>;
+    rotation: number;
+    stacks: Stack[];
+}) {
+    const blockIdSet = new Set(blockIds);
+    if (blockIdSet.size === 0) {
+        return stacks;
+    }
+
+    let changed = false;
+    const nextStacks = stacks.map((stack) => {
+        let stackChanged = false;
+        const nextBlocks = stack.blocks.map((block) => {
+            if (!blockIdSet.has(block.id)) {
+                return block;
+            }
+            if (block.rotation === rotation) {
+                return block;
+            }
+
+            stackChanged = true;
+            return {
+                ...block,
+                rotation,
+            };
+        });
+
+        if (!stackChanged) {
+            return stack;
+        }
+
+        changed = true;
+        return {
+            ...stack,
+            blocks: nextBlocks,
+        };
+    });
+
+    return changed ? nextStacks : stacks;
+}

--- a/packages/game/src/hooks/optimisticStackUpdates.unit.ts
+++ b/packages/game/src/hooks/optimisticStackUpdates.unit.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Vector3 } from 'three';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { rotateBlocksInStacks } from './optimisticStackUpdates';
+
+function createBlock(id: string, rotation = 0): Block {
+    return {
+        id,
+        name: 'Tree',
+        rotation,
+    };
+}
+
+function createStack(x: number, blocks: Block[]): Stack {
+    return {
+        position: new Vector3(x, 0, 0),
+        blocks,
+    };
+}
+
+test('rotateBlocksInStacks preserves stacks that do not contain target blocks', () => {
+    const targetBlock = createBlock('target');
+    const untouchedBlock = createBlock('untouched');
+    const targetStack = createStack(0, [targetBlock]);
+    const untouchedStack = createStack(1, [untouchedBlock]);
+    const stacks = [targetStack, untouchedStack];
+
+    const rotatedStacks = rotateBlocksInStacks({
+        blockIds: ['target'],
+        rotation: 1,
+        stacks,
+    });
+
+    assert.notEqual(rotatedStacks, stacks);
+    assert.notEqual(rotatedStacks[0], targetStack);
+    assert.notEqual(rotatedStacks[0]?.blocks, targetStack.blocks);
+    assert.equal(rotatedStacks[0]?.blocks[0]?.rotation, 1);
+    assert.equal(rotatedStacks[1], untouchedStack);
+    assert.equal(rotatedStacks[1]?.blocks, untouchedStack.blocks);
+    assert.equal(rotatedStacks[1]?.blocks[0], untouchedBlock);
+});
+
+test('rotateBlocksInStacks returns the original stack array when no rotation changes', () => {
+    const targetBlock = createBlock('target', 2);
+    const targetStack = createStack(0, [targetBlock]);
+    const stacks = [targetStack];
+
+    assert.equal(
+        rotateBlocksInStacks({
+            blockIds: ['target'],
+            rotation: 2,
+            stacks,
+        }),
+        stacks,
+    );
+});

--- a/packages/game/src/hooks/useBlockRotate.ts
+++ b/packages/game/src/hooks/useBlockRotate.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { handleOptimisticUpdate } from '../helpers/queryHelpers';
 import { persistLocalSandboxGarden } from '../localSandboxGarden';
 import { useGameState } from '../useGameState';
+import { rotateBlocksInStacks } from './optimisticStackUpdates';
 import { currentGardenKeys, useCurrentGarden } from './useCurrentGarden';
 
 const mutationKey = ['gardens', 'current', 'blockRotate'];
@@ -67,20 +68,10 @@ export function useBlockRotate() {
             const targetBlockIds = new Set(
                 blockIds?.length ? blockIds : [blockId],
             );
-            const updatedStacks = currentGarden.stacks.map((stack) => {
-                const updatedBlocks = stack.blocks.map((candidate) => {
-                    if (targetBlockIds.has(candidate.id)) {
-                        return {
-                            ...candidate,
-                            rotation: rotation,
-                        };
-                    }
-                    return candidate;
-                });
-                return {
-                    ...stack,
-                    blocks: updatedBlocks,
-                };
+            const updatedStacks = rotateBlocksInStacks({
+                blockIds: targetBlockIds,
+                rotation,
+                stacks: currentGarden.stacks,
             });
 
             const previousItem = await handleOptimisticUpdate(

--- a/packages/game/src/hooks/useCurrentGarden.ts
+++ b/packages/game/src/hooks/useCurrentGarden.ts
@@ -4,7 +4,12 @@ import {
     type GameBackgroundPaletteKey,
     isGameBackgroundPaletteKey,
 } from '@gredice/js/gameBackground';
-import { type UseQueryResult, useQuery } from '@tanstack/react-query';
+import {
+    type UseQueryResult,
+    useQuery,
+    useQueryClient,
+} from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
 import { Vector3 } from 'three';
 import {
     loadLocalSandboxGarden,
@@ -27,6 +32,7 @@ import {
     type WinterMode,
 } from '../useGameState';
 import { useCurrentGardenIdParam } from '../useUrlState';
+import { shareCurrentGardenQueryData } from './currentGardenStructuralSharing';
 import { useGardens, useGardensKeys } from './useGardens';
 
 const GARDEN_POSITION_X_OFFSET = -1;
@@ -66,6 +72,8 @@ type useCurrentGardenResponse = Omit<
         lon: number;
     };
 };
+
+export type CurrentGarden = useCurrentGardenResponse;
 
 type MockRaisedBed = useCurrentGardenResponse['raisedBeds'][number];
 type MockRaisedBedField = MockRaisedBed['fields'][number];
@@ -1268,10 +1276,56 @@ export function useCurrentGarden(): UseQueryResult<useCurrentGardenResponse | nu
                 raisedBeds: garden.raisedBeds,
             };
         },
+        structuralSharing: shareCurrentGardenQueryData,
         retry: false,
         staleTime: 1000 * 60, // 1m
         enabled: isLocalSandbox || isMock || Boolean(gardens),
     });
+}
+
+export function useCurrentGardenCache() {
+    const queryClient = useQueryClient();
+    const isMock = useGameState((state) => state.isMock);
+    const localSandboxStorageKey = useGameState(
+        (state) => state.localSandboxStorageKey,
+    );
+    const mockGardenProfile = useGameState((state) => state.mockGardenProfile);
+    const winterMode = useGameState((state) => state.winterMode);
+    const isLocalSandbox = localSandboxStorageKey !== null;
+    const { data: gardens } = useGardens(isMock || isLocalSandbox);
+    let selectedGardenId: number | null = null;
+    if (!isMock && !isLocalSandbox) {
+        // biome-ignore lint/correctness/useHookAtTopLevel: store mode is fixed when the game state is created.
+        const [gardenId] = useCurrentGardenIdParam();
+        selectedGardenId = gardenId;
+    }
+    const currentGardenId =
+        (isLocalSandbox ? localSandboxGardenId : selectedGardenId) ??
+        (gardens && gardens.length > 0 ? gardens[0].id : null);
+    const gardenQueryKey = useMemo(
+        () =>
+            currentGardenKeys(
+                winterMode,
+                currentGardenId,
+                isMock ? mockGardenProfile : undefined,
+                localSandboxStorageKey,
+            ),
+        [
+            currentGardenId,
+            isMock,
+            localSandboxStorageKey,
+            mockGardenProfile,
+            winterMode,
+        ],
+    );
+
+    return useCallback(
+        () =>
+            queryClient.getQueryData<useCurrentGardenResponse | null>(
+                gardenQueryKey,
+            ) ?? null,
+        [gardenQueryKey, queryClient],
+    );
 }
 
 /**

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -15,6 +15,7 @@ import type {
     ActiveDragPreviewTarget,
     ActiveDragPreviewTargetOffset,
 } from './dragPreviewIdentity';
+import { activeDragPreviewTargetMatches } from './dragPreviewIdentity';
 import {
     getGameBackgroundPaletteIndexByKey,
     getGameBackgroundPaletteKey,
@@ -66,6 +67,61 @@ export type ActiveDragPreview = {
     isBlocked: boolean;
     isOverRecycler: boolean;
 };
+
+const activeDragPreviewEpsilon = 0.0001;
+
+function activeDragPreviewNumbersEqual(left: number, right: number) {
+    return Math.abs(left - right) <= activeDragPreviewEpsilon;
+}
+
+function activeDragPreviewTargetOffsetsEqual(
+    left: ActiveDragPreviewTargetOffset,
+    right: ActiveDragPreviewTargetOffset,
+) {
+    return (
+        activeDragPreviewTargetMatches(left, right) &&
+        activeDragPreviewNumbersEqual(left.hoverHeight, right.hoverHeight)
+    );
+}
+
+function activeDragPreviewTargetOffsetListsEqual(
+    left: ActiveDragPreviewTargetOffset[],
+    right: ActiveDragPreviewTargetOffset[],
+) {
+    if (left.length !== right.length) {
+        return false;
+    }
+
+    return left.every((leftTarget, index) => {
+        const rightTarget = right[index];
+        return (
+            Boolean(rightTarget) &&
+            activeDragPreviewTargetOffsetsEqual(leftTarget, rightTarget)
+        );
+    });
+}
+
+export function activeDragPreviewsEqual(
+    left: ActiveDragPreview | null,
+    right: ActiveDragPreview | null,
+) {
+    if (left === right) {
+        return true;
+    }
+    if (!left || !right) {
+        return false;
+    }
+
+    return (
+        activeDragPreviewTargetMatches(left.source, right.source) &&
+        activeDragPreviewTargetOffsetListsEqual(left.targets, right.targets) &&
+        left.hoveredGardenBoxBlockId === right.hoveredGardenBoxBlockId &&
+        activeDragPreviewNumbersEqual(left.relative.x, right.relative.x) &&
+        activeDragPreviewNumbersEqual(left.relative.z, right.relative.z) &&
+        left.isBlocked === right.isBlocked &&
+        left.isOverRecycler === right.isOverRecycler
+    );
+}
 
 export type GardenBoxTooltip = {
     blockId: string;
@@ -451,9 +507,23 @@ export function createGameState({
         sandboxBlockTrashDropTargetActive: false,
         setSandboxBlockTrashDropTargetActive: (
             sandboxBlockTrashDropTargetActive,
-        ) => set({ sandboxBlockTrashDropTargetActive }),
+        ) =>
+            set((state) =>
+                state.sandboxBlockTrashDropTargetActive ===
+                sandboxBlockTrashDropTargetActive
+                    ? state
+                    : { sandboxBlockTrashDropTargetActive },
+            ),
         activeDragPreview: null,
-        setActiveDragPreview: (activeDragPreview) => set({ activeDragPreview }),
+        setActiveDragPreview: (activeDragPreview) =>
+            set((state) =>
+                activeDragPreviewsEqual(
+                    state.activeDragPreview,
+                    activeDragPreview,
+                )
+                    ? state
+                    : { activeDragPreview },
+            ),
         openGardenBoxBlockId: null,
         setOpenGardenBoxBlockId: (openGardenBoxBlockId) =>
             set({ openGardenBoxBlockId }),

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { ActiveDragPreview } from './useGameState';
+import { activeDragPreviewsEqual, createGameState } from './useGameState';
+
+function createPreview(): ActiveDragPreview {
+    return {
+        source: {
+            blockId: 'source',
+            blockIndex: 0,
+            stackPosition: { x: 0, z: 0 },
+        },
+        targets: [
+            {
+                blockId: 'source',
+                blockIndex: 0,
+                stackPosition: { x: 0, z: 0 },
+                hoverHeight: 0,
+            },
+        ],
+        hoveredGardenBoxBlockId: null,
+        relative: { x: 0, z: 0 },
+        isBlocked: false,
+        isOverRecycler: false,
+    };
+}
+
+test('activeDragPreviewsEqual matches equivalent preview values', () => {
+    const preview = createPreview();
+
+    assert.equal(
+        activeDragPreviewsEqual(preview, {
+            ...preview,
+            source: {
+                blockId: 'source',
+                blockIndex: 0,
+                stackPosition: { x: 0, z: 0 },
+            },
+            targets: [
+                {
+                    blockId: 'source',
+                    blockIndex: 0,
+                    stackPosition: { x: 0, z: 0 },
+                    hoverHeight: 0,
+                },
+            ],
+            relative: { x: 0, z: 0 },
+        }),
+        true,
+    );
+});
+
+test('setActiveDragPreview skips equivalent drag preview updates', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+    let updateCount = 0;
+    const unsubscribe = store.subscribe(() => {
+        updateCount += 1;
+    });
+    const preview = createPreview();
+
+    try {
+        store.getState().setActiveDragPreview(preview);
+        assert.equal(updateCount, 1);
+
+        store.getState().setActiveDragPreview({
+            ...preview,
+            source: {
+                blockId: 'source',
+                blockIndex: 0,
+                stackPosition: { x: 0, z: 0 },
+            },
+            targets: [
+                {
+                    blockId: 'source',
+                    blockIndex: 0,
+                    stackPosition: { x: 0, z: 0 },
+                    hoverHeight: 0,
+                },
+            ],
+            relative: { x: 0, z: 0 },
+        });
+        assert.equal(updateCount, 1);
+
+        store.getState().setActiveDragPreview({
+            ...preview,
+            relative: { x: 1, z: 0 },
+        });
+        assert.equal(updateCount, 2);
+    } finally {
+        unsubscribe();
+        store.getState().audio.dispose();
+    }
+});


### PR DESCRIPTION
## Summary

- Precompute pickup placement resolver state once per pointer sample instead of rebuilding occupied-cell and footprint data for every snap candidate.
- Skip repeated identical placement previews before updating drag springs, trash-target state, or shared `activeDragPreview` state.
- Preserve stack/block references for rotate and optimistic placement id replacement so one block update does not invalidate the whole garden scene.
- Structurally share current-garden query results so settled store-add refetches keep the optimistic garden and unchanged stack references instead of rebuilding the whole scene.
- Stabilize block instance and ground decoration inputs so unchanged instanced render batches avoid redundant matrix/bounds work.
- Keep transient pickup/preview state out of per-entity control subscriptions and keep block interaction registry registrations stable across renders.
- Memoize `EntityFactory` for unchanged instanced blocks so moving one block does not re-render every unchanged pick/rotate/selection control wrapper.
- Read current garden data from the React Query cache inside pick, rotate, and selection handlers instead of subscribing every registered control wrapper to the full garden query.
- Keep instanced `EntityFactory` children memoized when a mutation/refetch rebuilds equivalent stack and `Vector3` objects, while still rerendering for real stack-content or block changes.

## Root Cause

The drops were not caused by edit/mode rendering. They came from object churn, broad transient-state subscriptions, and un-memoized per-entity control wrappers around pick/place, rotate, and store-add operations:

- Drag preview resolution scanned the garden repeatedly across the 11x11 snap grid for each pointer sample, then published fresh preview objects even when the resolved destination did not change.
- Rotating one block cloned every stack and every block array in the garden during the optimistic update.
- Placing a new block preserved references for the initial optimistic insert, but replacing the optimistic id with the backend id cloned every stack again.
- Store-add placement used an optimistic garden update, but the settled invalidation/refetch rebuilt every `Stack`, block object, and `Vector3` in `useCurrentGarden`, so React saw the whole instanced scene as changed even when the server response matched the optimistic state.
- The instanced block and ground-decoration render paths rebuilt arrays from those fresh references, so unchanged meshes could still re-run matrix and bounds updates.
- The first follow-up trace for lifting and dropping one entity back onto the same place showed renderer-main React work dominated by per-entity controls: about 695ms total `PickableGroup`, 315ms `RotatableGroup`, 301ms `InstancedEntitySelectionRegistration`, plus 643ms of scheduler remaining effects. Those controls were subscribing every registered entity to pickup/active-preview/hover state and the registry hook re-registered handlers after every render.
- The second follow-up trace for moving an entity to another stack still showed ~800ms and ~1046ms React scheduler tasks. Pickup activation had improved, but the moved-stack commit remapped the scene and rendered unchanged instanced control wrappers because `EntityFactory` received a new `stacks` array even when each unchanged instanced block still had the same `stack` and `block` references.
- The third follow-up trace, captured after the `EntityFactory` memo, showed the parent memo was working for one commit: `EntityFactoryComponent` rendered once in the main commit. The remaining scheduler cost came from child wrappers still subscribing directly to `useCurrentGarden`: `PickableGroup` was ~826ms / 2394 renders, `RotatableGroup` ~202ms / 1745 renders, and `InstancedEntitySelectionRegistration` ~198ms / 1847 renders across the two long scheduler tasks.
- The fourth follow-up trace, captured after moving current-garden reads to cache lookups, showed another invalidation layer: after the backend/refetch commit, DevTools reported `stack.position` as referentially unequal but deeply equal. That rebuilt equivalent stack object still defeated the memo comparator and caused bulk instanced rerenders.
- The store-add traces showed the per-control explosion was fixed, but repeated ~580-690ms scheduler tasks were dominated by `EntityInstances`, `AdditionalEntityInstances`, and `EntityInstancesBlock`; DevTools changed-prop reasons were `stack` because the settled refetch rebuilt logically equivalent stacks and positions.

## Impact

The placement search keeps the same behavior but reuses prepared resolver state across all candidate cells for a pointer sample. Repeated pointer events inside the same resolved destination become no-ops, and single-block rotate/place updates keep untouched stack references intact. Unchanged entity and decoration batches retain stable inputs. Registered instanced controls now check transient drag state and current garden data imperatively only when an interaction happens. Unchanged instanced `EntityFactory` children are skipped across moved-stack garden updates and across refetches that rebuild equivalent stack/position objects.

For store-add flows, the optimistic placement remains visible while the refetch runs. When server data matches the optimistic state, React Query keeps the existing garden, stack, block, and position references, so the expensive scene rebuild is skipped instead of being pushed to the foreground interaction path.

Synthetic resolver benchmark on a 25x25 stack grid, 50 pointer samples x 121 snap candidates:

- Before-shape (`resolvePickupPlacementPreviewForRelative` per candidate): `445.1ms`
- New shape (one prepared resolver per sample): `17.5ms`

Trace follow-up from `Trace-20260703T150836.json.gz`:

- `pointerup`: ~95ms task
- React scheduler tasks after drop: ~214ms and ~651ms
- Top React component tracks in the capture: `PickableGroup`, `RotatableGroup`, `InstancedEntitySelectionRegistration`

Trace follow-up from `Trace-20260703T151614.json.gz`:

- `pointerup`: ~111ms task
- React scheduler tasks after moved-stack drop: ~800ms and ~1046ms
- Top React component tracks in the moved-stack commit: `PickableGroup`, `InstancedEntitySelectionRegistration`, `RotatableGroup`

Trace follow-up from `Trace-20260703T152057.json.gz`:

- Initial ~1179ms task was DevTools CPU profiler startup overhead and not part of the in-game interaction.
- Interaction still had `pointerup` at ~102ms, then React scheduler tasks at ~760ms and ~1011ms.
- `EntityFactoryComponent` was no longer the problem after the memo, but `PickableGroup`, `RotatableGroup`, and `InstancedEntitySelectionRegistration` still rendered in bulk because they subscribed to the whole current garden query.

Trace follow-up from `Trace-20260703T153210.json.gz`:

- Initial ~681ms task was DevTools CPU profiler startup overhead and not part of the in-game interaction.
- Interaction had `pointerup` at ~71ms, then React scheduler tasks at ~572ms and ~869ms.
- In the later scheduler task, paired React timings still showed `EntityFactoryComponent` ~189ms / 516 renders, `PickableGroup` ~144ms / 516 renders, `RotatableGroup` ~55ms, and `InstancedEntitySelectionRegistration` ~24ms.
- DevTools attributed those renders to rebuilt-but-equivalent `stack.position` props. The comparator now treats equivalent instanced stack positions and block lists as stable, but still rerenders when stack contents, block values, rotation, variant, controls, or render mode actually change.

Trace follow-up from `Trace-20260703T153834.json.gz` and `Trace-20260703T153905.json.gz`:

- Initial ~704ms and ~804ms tasks were DevTools CPU profiler startup overhead and not part of the in-game interaction.
- Store-add interactions had pointer/click tasks around ~66-70ms, followed by repeated React scheduler tasks around ~581-691ms.
- Top remaining direct React work moved to instanced scene rebuild paths: `EntityInstances` ~50-63ms, `AdditionalEntityInstances` ~41-49ms, and `EntityInstancesBlock` ~12-20ms; changed-prop reasons were `stack` and rebuilt stack positions.

## Validation

- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter www`
- `git diff --check`
- `git diff --cached --check`
