### PR TITLE
feat(game): add shift multi-select pickup

### DIFF
--- a/packages/game/src/controls/BlockInteractionLayer.tsx
+++ b/packages/game/src/controls/BlockInteractionLayer.tsx
@@ -204,6 +204,10 @@ export function BlockInteractionLayer({
 
         clearHoveredTarget(event, resolved?.event);
         hoveredTargetKeyRef.current = nextTargetKey;
+        resolved?.target.handlers.onPickupPointerEnter?.(resolved.event);
+        if (resolved && hasStopped(resolved.event)) {
+            return;
+        }
         resolved?.target.handlers.onPointerEnter?.(resolved.event);
     }
 

--- a/packages/game/src/controls/BlockInteractionRegistry.tsx
+++ b/packages/game/src/controls/BlockInteractionRegistry.tsx
@@ -20,6 +20,7 @@ export type BlockInteractionTarget = {
 
 export type BlockInteractionHandlers = {
     onClick?: (event: ThreeEvent<MouseEvent>) => void;
+    onPickupPointerEnter?: (event: ThreeEvent<PointerEvent>) => void;
     onPointerDown?: (event: ThreeEvent<PointerEvent>) => void;
     onPointerEnter?: (event: ThreeEvent<PointerEvent>) => void;
     onPointerLeave?: (event: ThreeEvent<PointerEvent>) => void;

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -45,7 +45,11 @@ import {
     getStackHeight,
     useStackHeight,
 } from '../utils/getStackHeight';
-import { triggerPickHaptic, triggerPlaceHaptic } from '../utils/haptics';
+import {
+    triggerPickHaptic,
+    triggerPlaceHaptic,
+    triggerSelectionHaptic,
+} from '../utils/haptics';
 import {
     findAttachedRaisedBedBlockId,
     findRaisedBedByBlockId,
@@ -60,6 +64,7 @@ import {
     type ResolvedPlacementPreview,
     resolvePickupPlacementPreviewForRelative,
 } from './PickupPlacementResolver';
+import { createPickupSelectionMovingSegments } from './pickupSelection';
 
 const groundPlane = new Plane(new Vector3(0, 1, 0), 0);
 const pickupHintDelayMs = 120;
@@ -190,6 +195,12 @@ export function PickableGroup({
     );
 
     const setPickupBlock = useGameState((state) => state.setPickupBlock);
+    const setPickupSelectionTargets = useGameState(
+        (state) => state.setPickupSelectionTargets,
+    );
+    const clearPickupSelectionTargets = useGameState(
+        (state) => state.clearPickupSelectionTargets,
+    );
     const disturbAnimals = useGameState((state) => state.disturbAnimals);
     const setActiveDragPreview = useGameState(
         (state) => state.setActiveDragPreview,
@@ -268,6 +279,9 @@ export function PickableGroup({
         activeDragPreview?.source,
         activePreviewTarget,
     );
+    const sourcePickupSelectionTargets = useGameState((state) =>
+        isPreviewSource ? state.pickupSelectionTargets : null,
+    );
     const activePreviewTargetOffset = findActiveDragPreviewTargetOffset(
         activeDragPreview?.targets,
         activePreviewTarget,
@@ -281,6 +295,9 @@ export function PickableGroup({
     });
     const pointerSession = useRef<PointerSession | null>(null);
     const pointerSessionCleanup = useRef<(() => void) | null>(null);
+    const refreshPlacementPreviewFromSessionRef = useRef<
+        ((session: PointerSession) => void) | null
+    >(null);
 
     const stopDragAutopan = useCallback((session: PointerSession) => {
         if (session.dragAutopanFrame !== null) {
@@ -376,15 +393,11 @@ export function PickableGroup({
     }, [stopDragAutopan]);
 
     function getMovingSegments(): MovingSegment[] {
-        if (blockIndex < 0) {
+        if (!garden || blockIndex < 0) {
             return [];
         }
 
         const sourceBlocks = stack.blocks.slice(blockIndex);
-        if (sourceBlocks.length === 0) {
-            return [];
-        }
-
         const attachedBlocks = attachedPlacement
             ? attachedPlacement.candidateStack.blocks.slice(
                   attachedPlacement.candidateBlockIndex,
@@ -395,27 +408,24 @@ export function PickableGroup({
             sourceBlocks.length === 1 &&
             (!attachedPlacement || attachedBlocks.length === 1);
 
-        return [
-            {
-                sourceStack: stack,
-                sourceStartIndex: blockIndex,
-                blocks: sourceBlocks,
-                baseHeight: currentStackHeight ?? 0,
-                canRecycle: canRecycleSelection,
-            },
-            ...(attachedPlacement && attachedBlocks.length > 0
-                ? [
-                      {
+        return createPickupSelectionMovingSegments({
+            attachedSegment:
+                attachedPlacement && attachedBlocks.length > 0
+                    ? {
                           sourceStack: attachedPlacement.candidateStack,
                           sourceStartIndex:
                               attachedPlacement.candidateBlockIndex,
                           blocks: attachedBlocks,
                           baseHeight: attachedCurrentStackHeight,
-                          canRecycle: false,
-                      },
-                  ]
-                : []),
-        ];
+                      }
+                    : null,
+            blockData: blocksData,
+            canRecyclePrimarySegment: canRecycleSelection,
+            primaryTarget: activePreviewTarget,
+            selectedTargets:
+                gameStateStore?.getState().pickupSelectionTargets ?? [],
+            stacks: garden.stacks,
+        });
     }
 
     function resolvePlacementPreviewForRelative(relative: Vector3) {
@@ -603,6 +613,7 @@ export function PickableGroup({
         setIsOverRecycler(false);
         setPickupOutlineVisible(false);
         setPickupBlock(null);
+        clearPickupSelectionTargets();
         setSandboxBlockTrashDropTargetActive(false);
     }
 
@@ -684,6 +695,17 @@ export function PickableGroup({
         session.latestPreview = preview;
         applyActivePreview(preview);
     }
+    refreshPlacementPreviewFromSessionRef.current =
+        refreshPlacementPreviewFromSession;
+
+    useEffect(() => {
+        const session = pointerSession.current;
+        if (!isPreviewSource || !sourcePickupSelectionTargets || !session) {
+            return;
+        }
+
+        refreshPlacementPreviewFromSessionRef.current?.(session);
+    }, [isPreviewSource, sourcePickupSelectionTargets]);
 
     function startDragAutopan(session: PointerSession) {
         if (session.dragAutopanFrame !== null || !gameCamera) {
@@ -779,6 +801,7 @@ export function PickableGroup({
         setIsDragging(false);
         setPickupOutlineVisible(true);
         setPickupBlock(block);
+        setPickupSelectionTargets([activePreviewTarget]);
         disturbAnimals({
             sourceBlockId: block.id,
             sourceBlockName: block.name,
@@ -1050,12 +1073,11 @@ export function PickableGroup({
         event.preventDefault();
         suppressBlockInteractions(suppressClickAfterDragMs);
         const preview =
-            session.latestPreview ??
             resolvePlacementPreview(
                 session.lastClientX,
                 session.lastClientY,
                 session.pickupAnchorOffset,
-            );
+            ) ?? session.latestPreview;
         void finishPickup(
             preview,
             isPointerOverSandboxTrash(session.lastClientX, session.lastClientY),
@@ -1073,7 +1095,35 @@ export function PickableGroup({
         cancelPointerSession(true);
     }
 
+    function handlePickupPointerEnter(event: ThreeEvent<PointerEvent>) {
+        if (blockIndex < 0 || !event.nativeEvent.shiftKey || !gameStateStore) {
+            return false;
+        }
+
+        const gameState = gameStateStore.getState();
+        const preview = gameState.activeDragPreview;
+        if (
+            !preview ||
+            activeDragPreviewAffectsTarget(preview, activePreviewTarget)
+        ) {
+            return false;
+        }
+
+        const added = gameState.addPickupSelectionTarget(activePreviewTarget);
+        if (!added) {
+            return false;
+        }
+
+        event.stopPropagation();
+        triggerSelectionHaptic();
+        return true;
+    }
+
     function handlePointerDown(event: ThreeEvent<PointerEvent>) {
+        if (event.button === 0 && handlePickupPointerEnter(event)) {
+            return;
+        }
+
         if (
             event.button !== 0 ||
             pointerSession.current ||
@@ -1168,6 +1218,7 @@ export function PickableGroup({
         },
         {
             onClick: handleClick,
+            onPickupPointerEnter: handlePickupPointerEnter,
             onPointerDown: handlePointerDown,
         },
     );
@@ -1247,6 +1298,7 @@ export function PickableGroup({
         <animated.group
             position={dragPosition}
             scale={dragSprings.scale}
+            onPointerEnter={handlePickupPointerEnter}
             onPointerDown={handlePointerDown}
             onClick={handleClick}
         >

--- a/packages/game/src/controls/pickupSelection.ts
+++ b/packages/game/src/controls/pickupSelection.ts
@@ -1,0 +1,170 @@
+import type { BlockData } from '@gredice/client';
+import {
+    type ActiveDragPreviewTarget,
+    activeDragPreviewTargetMatches,
+} from '../dragPreviewIdentity';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { getStackHeight } from '../utils/stackHeightCore';
+import type { MovingSegment } from './PickupPlacementResolver';
+
+export type AttachedPickupSegment = {
+    sourceStack: Stack;
+    sourceStartIndex: number;
+    blocks: Block[];
+    baseHeight: number;
+};
+
+type SelectedSegmentCandidate = {
+    target: ActiveDragPreviewTarget;
+    sourceStack: Stack;
+    sourceStartIndex: number;
+    block: Block;
+};
+
+function stackPositionMatches(stack: Stack, target: ActiveDragPreviewTarget) {
+    return (
+        stack.position.x === target.stackPosition.x &&
+        stack.position.z === target.stackPosition.z
+    );
+}
+
+function stackKey(stack: Stack) {
+    return `${stack.position.x}|${stack.position.z}`;
+}
+
+function findSelectedSegmentCandidate(
+    stacks: Stack[] | undefined,
+    target: ActiveDragPreviewTarget,
+): SelectedSegmentCandidate | null {
+    const sourceStack = stacks?.find((stack) =>
+        stackPositionMatches(stack, target),
+    );
+    if (!sourceStack) {
+        return null;
+    }
+
+    const sourceStartIndex = sourceStack.blocks.findIndex(
+        (candidate) => candidate.id === target.blockId,
+    );
+    const block = sourceStack.blocks[sourceStartIndex];
+    if (sourceStartIndex < 0 || !block) {
+        return null;
+    }
+
+    return {
+        target,
+        sourceStack,
+        sourceStartIndex,
+        block,
+    };
+}
+
+function selectionTargetsInclude(
+    targets: ActiveDragPreviewTarget[],
+    target: ActiveDragPreviewTarget,
+) {
+    return targets.some((candidate) =>
+        activeDragPreviewTargetMatches(candidate, target),
+    );
+}
+
+function getSelectedSegmentCandidates({
+    primaryTarget,
+    selectedTargets,
+    stacks,
+}: {
+    primaryTarget: ActiveDragPreviewTarget;
+    selectedTargets: ActiveDragPreviewTarget[];
+    stacks: Stack[] | undefined;
+}) {
+    const targets = selectionTargetsInclude(selectedTargets, primaryTarget)
+        ? selectedTargets
+        : [primaryTarget, ...selectedTargets];
+    const candidateByStackKey = new Map<string, SelectedSegmentCandidate>();
+
+    for (const target of targets) {
+        const candidate = findSelectedSegmentCandidate(stacks, target);
+        if (!candidate) {
+            continue;
+        }
+
+        const key = stackKey(candidate.sourceStack);
+        const existing = candidateByStackKey.get(key);
+        if (
+            !existing ||
+            candidate.sourceStartIndex < existing.sourceStartIndex
+        ) {
+            candidateByStackKey.set(key, candidate);
+        }
+    }
+
+    return Array.from(candidateByStackKey.values());
+}
+
+function attachedSegmentIsAlreadySelected(
+    attachedSegment: AttachedPickupSegment,
+    selectedCandidates: SelectedSegmentCandidate[],
+) {
+    return selectedCandidates.some(
+        (candidate) =>
+            candidate.sourceStack === attachedSegment.sourceStack &&
+            candidate.sourceStartIndex <= attachedSegment.sourceStartIndex,
+    );
+}
+
+export function createPickupSelectionMovingSegments({
+    attachedSegment,
+    blockData,
+    canRecyclePrimarySegment,
+    primaryTarget,
+    selectedTargets,
+    stacks,
+}: {
+    attachedSegment?: AttachedPickupSegment | null;
+    blockData: BlockData[] | null | undefined;
+    canRecyclePrimarySegment: boolean;
+    primaryTarget: ActiveDragPreviewTarget;
+    selectedTargets: ActiveDragPreviewTarget[];
+    stacks: Stack[] | undefined;
+}): MovingSegment[] {
+    const selectedCandidates = getSelectedSegmentCandidates({
+        primaryTarget,
+        selectedTargets,
+        stacks,
+    });
+    const hasExtraSelectedSegment = selectedCandidates.some(
+        (candidate) =>
+            !activeDragPreviewTargetMatches(candidate.target, primaryTarget),
+    );
+    const selectedSegments = selectedCandidates.map((candidate) => ({
+        sourceStack: candidate.sourceStack,
+        sourceStartIndex: candidate.sourceStartIndex,
+        blocks: candidate.sourceStack.blocks.slice(candidate.sourceStartIndex),
+        baseHeight: getStackHeight(
+            blockData,
+            candidate.sourceStack,
+            candidate.block,
+        ),
+        canRecycle:
+            canRecyclePrimarySegment &&
+            !hasExtraSelectedSegment &&
+            activeDragPreviewTargetMatches(candidate.target, primaryTarget),
+    }));
+
+    if (
+        !attachedSegment ||
+        attachedSegment.blocks.length === 0 ||
+        attachedSegmentIsAlreadySelected(attachedSegment, selectedCandidates)
+    ) {
+        return selectedSegments;
+    }
+
+    return [
+        ...selectedSegments,
+        {
+            ...attachedSegment,
+            canRecycle: false,
+        },
+    ];
+}

--- a/packages/game/src/controls/pickupSelection.unit.ts
+++ b/packages/game/src/controls/pickupSelection.unit.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { BlockData } from '@gredice/client';
+import { Vector3 } from 'three';
+import { createActiveDragPreviewTarget } from '../dragPreviewIdentity';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { createPickupSelectionMovingSegments } from './pickupSelection';
+
+function createBlock(name: string, id = name): Block {
+    return {
+        id,
+        name,
+        rotation: 0,
+    };
+}
+
+function createStack(x: number, z: number, blocks: Block[]): Stack {
+    return {
+        position: new Vector3(x, 0, z),
+        blocks,
+    };
+}
+
+function createBlockData(name: string, id: number, height = 1): BlockData {
+    return {
+        id,
+        entityType: {
+            id: 8,
+            name: 'block',
+            label: 'Blok',
+        },
+        slug: name,
+        information: {
+            name,
+            shortDescription: name,
+            fullDescription: name,
+            label: name,
+        },
+        attributes: {
+            height,
+            stackable: true,
+            type: 'decoration',
+            nightOnlyPurchase: false,
+        },
+        prices: {
+            sunflowers: 0,
+        },
+        functions: {
+            recycler: false,
+            raisedBed: name === 'Raised_Bed',
+        },
+        createdAt: '2026-06-01T00:00:00.000Z',
+        updatedAt: '2026-06-01T00:00:00.000Z',
+    };
+}
+
+const blockData = [
+    createBlockData('Block_Grass', 1, 0.2),
+    createBlockData('Raised_Bed', 2),
+    createBlockData('Tree', 3),
+];
+
+describe('createPickupSelectionMovingSegments', () => {
+    it('uses the primary target when selection state has not been seeded yet', () => {
+        const grass = createBlock('Block_Grass', 'grass');
+        const tree = createBlock('Tree', 'tree');
+        const sourceStack = createStack(0, 0, [grass, tree]);
+        const primaryTarget = createActiveDragPreviewTarget({
+            blockId: tree.id,
+            blockIndex: 1,
+            stackPosition: sourceStack.position,
+        });
+
+        const segments = createPickupSelectionMovingSegments({
+            blockData,
+            canRecyclePrimarySegment: true,
+            primaryTarget,
+            selectedTargets: [],
+            stacks: [sourceStack],
+        });
+
+        assert.equal(segments.length, 1);
+        assert.deepEqual(segments[0]?.blocks, [tree]);
+        assert.equal(segments[0]?.baseHeight, 0.2);
+        assert.equal(segments[0]?.canRecycle, true);
+    });
+
+    it('moves selected blocks from multiple stacks together', () => {
+        const primaryBlock = createBlock('Tree', 'primary');
+        const extraBlock = createBlock('Raised_Bed', 'extra');
+        const primaryStack = createStack(0, 0, [primaryBlock]);
+        const extraStack = createStack(2, 0, [extraBlock]);
+        const primaryTarget = createActiveDragPreviewTarget({
+            blockId: primaryBlock.id,
+            blockIndex: 0,
+            stackPosition: primaryStack.position,
+        });
+        const extraTarget = createActiveDragPreviewTarget({
+            blockId: extraBlock.id,
+            blockIndex: 0,
+            stackPosition: extraStack.position,
+        });
+
+        const segments = createPickupSelectionMovingSegments({
+            blockData,
+            canRecyclePrimarySegment: true,
+            primaryTarget,
+            selectedTargets: [primaryTarget, extraTarget],
+            stacks: [primaryStack, extraStack],
+        });
+
+        assert.equal(segments.length, 2);
+        assert.deepEqual(
+            segments.map((segment) => segment.blocks[0]?.id),
+            ['primary', 'extra'],
+        );
+        assert.equal(segments[0]?.canRecycle, false);
+        assert.equal(segments[1]?.canRecycle, false);
+    });
+
+    it('dedupes one stack by the lowest selected block', () => {
+        const lowerBlock = createBlock('Tree', 'lower');
+        const upperBlock = createBlock('Raised_Bed', 'upper');
+        const sourceStack = createStack(0, 0, [lowerBlock, upperBlock]);
+        const primaryTarget = createActiveDragPreviewTarget({
+            blockId: upperBlock.id,
+            blockIndex: 1,
+            stackPosition: sourceStack.position,
+        });
+        const lowerTarget = createActiveDragPreviewTarget({
+            blockId: lowerBlock.id,
+            blockIndex: 0,
+            stackPosition: sourceStack.position,
+        });
+
+        const segments = createPickupSelectionMovingSegments({
+            blockData,
+            canRecyclePrimarySegment: true,
+            primaryTarget,
+            selectedTargets: [primaryTarget, lowerTarget],
+            stacks: [sourceStack],
+        });
+
+        assert.equal(segments.length, 1);
+        assert.equal(segments[0]?.sourceStartIndex, 0);
+        assert.deepEqual(segments[0]?.blocks, [lowerBlock, upperBlock]);
+    });
+
+    it('does not add an attached segment already covered by a selected stack slice', () => {
+        const raisedBed = createBlock('Raised_Bed', 'raised-bed');
+        const attachedBlock = createBlock('Block_Grass', 'attached');
+        const sourceStack = createStack(0, 0, [raisedBed, attachedBlock]);
+        const primaryTarget = createActiveDragPreviewTarget({
+            blockId: raisedBed.id,
+            blockIndex: 0,
+            stackPosition: sourceStack.position,
+        });
+
+        const segments = createPickupSelectionMovingSegments({
+            attachedSegment: {
+                sourceStack,
+                sourceStartIndex: 1,
+                blocks: [attachedBlock],
+                baseHeight: 1,
+            },
+            blockData,
+            canRecyclePrimarySegment: false,
+            primaryTarget,
+            selectedTargets: [primaryTarget],
+            stacks: [sourceStack],
+        });
+
+        assert.equal(segments.length, 1);
+        assert.deepEqual(segments[0]?.blocks, [raisedBed, attachedBlock]);
+    });
+});

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -11,9 +11,10 @@ import type {
     GameCameraRigApi,
     GameCameraSnapshot,
 } from './controls/GameCameraRigApi';
-import type {
-    ActiveDragPreviewTarget,
-    ActiveDragPreviewTargetOffset,
+import {
+    type ActiveDragPreviewTarget,
+    type ActiveDragPreviewTargetOffset,
+    activeDragPreviewTargetMatches,
 } from './dragPreviewIdentity';
 import {
     getGameBackgroundPaletteIndexByKey,
@@ -214,6 +215,10 @@ export type GameState = {
     // Pickup system
     pickupBlock: Block | null;
     setPickupBlock: (block: Block | null) => void;
+    pickupSelectionTargets: ActiveDragPreviewTarget[];
+    setPickupSelectionTargets: (targets: ActiveDragPreviewTarget[]) => void;
+    addPickupSelectionTarget: (target: ActiveDragPreviewTarget) => boolean;
+    clearPickupSelectionTargets: () => void;
     stationaryPickupOutlineTarget: ActiveDragPreviewTarget | null;
     setStationaryPickupOutlineTarget: (
         target: ActiveDragPreviewTarget | null,
@@ -442,9 +447,28 @@ export function createGameState({
         sunriseTime: sunrise,
         sunsetTime: sunset,
 
-        // Pickaup system
+        // Pickup system
         pickupBlock: null,
         setPickupBlock: (block: Block | null) => set({ pickupBlock: block }),
+        pickupSelectionTargets: [],
+        setPickupSelectionTargets: (pickupSelectionTargets) =>
+            set({ pickupSelectionTargets }),
+        addPickupSelectionTarget: (target) => {
+            const pickupSelectionTargets = get().pickupSelectionTargets;
+            if (
+                pickupSelectionTargets.some((candidate) =>
+                    activeDragPreviewTargetMatches(candidate, target),
+                )
+            ) {
+                return false;
+            }
+
+            set({
+                pickupSelectionTargets: [...pickupSelectionTargets, target],
+            });
+            return true;
+        },
+        clearPickupSelectionTargets: () => set({ pickupSelectionTargets: [] }),
         stationaryPickupOutlineTarget: null,
         setStationaryPickupOutlineTarget: (stationaryPickupOutlineTarget) =>
             set({ stationaryPickupOutlineTarget }),


### PR DESCRIPTION
## Summary

- Add active pickup selection state so a picked block can carry additional selected blocks.
- Allow holding Shift while an active pickup is in progress to add another hovered pickable block to the moving selection.
- Reuse the existing multi-segment placement resolver and move mutation path so selected blocks keep their relative offsets and move together.
- Add unit coverage for selection segment construction, same-stack deduping, attached segment handling, and recycler disabling for multi-selection.

## Behavior

Once a block is picked up, holding Shift while hovering another pickable block adds that block's stack slice to the active pickup. Selected blocks receive the same pickup preview outline and are included in the final move/drop calculation. Existing single-block pick/place, raised-bed attachment handling, GardenBox storage, and recycler behavior remain unchanged for normal pickup.

## Validation

- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter www`
- `git diff --check`
- `git diff --cached --check`