### PR TITLE
feat(www): add public garden breadcrumbs

### DIFF
--- a/apps/www/app/vrtovi/[gardenId]/page.tsx
+++ b/apps/www/app/vrtovi/[gardenId]/page.tsx
@@ -1,3 +1,4 @@
+import { Breadcrumbs } from '@gredice/ui/Breadcrumbs';
 import { Card } from '@gredice/ui/Card';
 import { Calendar, Sprout } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
@@ -88,6 +89,13 @@ export default async function PublicGardenPage({
 
     return (
         <Stack spacing={2} className="py-6">
+            <Breadcrumbs
+                className="px-1"
+                items={[
+                    { label: 'Vrtovi', href: KnownPages.PublicGardens },
+                    { label: garden.name },
+                ]}
+            />
             <Card
                 className="public-garden-card-view-transition overflow-hidden p-0"
                 style={{


### PR DESCRIPTION
## Summary
- add breadcrumbs above public garden detail pages
- link the parent crumb back to the public gardens list

## Validation
- corepack pnpm lint --filter www
- corepack pnpm typecheck --filter www
- corepack pnpm build --filter www
- git diff --check
- Playwright smoke for /vrtovi/1 at desktop and mobile widths