### PR TITLE
chore(garden): move sharp to app dependencies

### DIFF
--- a/apps/garden/package.json
+++ b/apps/garden/package.json
@@ -38,7 +38,8 @@
         "next-themes": "0.4.6",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "server-only": "0.0.1"
+        "server-only": "0.0.1",
+        "sharp": "0.35.2"
     },
     "devDependencies": {
         "@biomejs/biome": "2.5.1",
@@ -59,7 +60,6 @@
         "nuqs": "2.9.0",
         "postcss": "8.5.16",
         "sass": "1.101.0",
-        "sharp": "0.35.2",
         "tailwindcss": "4.3.2",
         "typescript": "6.0.3"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,6 +548,9 @@ importers:
       server-only:
         specifier: 0.0.1
         version: 0.0.1
+      sharp:
+        specifier: 0.35.2
+        version: 0.35.2
     devDependencies:
       '@biomejs/biome':
         specifier: 2.5.1
@@ -603,9 +606,6 @@ importers:
       sass:
         specifier: 1.101.0
         version: 1.101.0
-      sharp:
-        specifier: 0.35.2
-        version: 0.35.2
       tailwindcss:
         specifier: 4.3.2
         version: 4.3.2


### PR DESCRIPTION
## Summary
- Move `sharp` from `devDependencies` to runtime dependencies in `apps/garden`
- Update the lockfile to match the package manifest

## Testing
- Not run (not requested)