### PR TITLE
feat(game): add debug wireframe view toggle

### DIFF
--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -14,6 +14,7 @@ import {
     Ghost,
     Graph,
     Layers,
+    LayoutGrid,
     Lightning,
     MapPin,
     Moon,
@@ -28,6 +29,7 @@ import {
 import { Row } from '@gredice/ui/Row';
 import { Slider } from '@gredice/ui/Slider';
 import { Stack } from '@gredice/ui/Stack';
+import { Switch } from '@gredice/ui/Switch';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import type {
@@ -300,6 +302,10 @@ export function DebugHud() {
     );
     const setEntityRenderModeDebugVisible = useGameState(
         (s) => s.setEntityRenderModeDebugVisible,
+    );
+    const wireframeDebugVisible = useGameState((s) => s.wireframeDebugVisible);
+    const setWireframeDebugVisible = useGameState(
+        (s) => s.setWireframeDebugVisible,
     );
     const animalPathfindingDebugVisible = useGameState(
         (s) => s.animalPathfindingDebugVisible,
@@ -1057,6 +1063,20 @@ export function DebugHud() {
                             )}
                         </DebugPanelSection>
                         <DebugPanelSection title="Scene" icon={Layers}>
+                            <div className="flex items-center justify-between gap-2 rounded-md border border-border/50 bg-card/60 px-2 py-1.5">
+                                <span className="inline-flex min-w-0 items-center gap-1.5 text-xs">
+                                    <LayoutGrid className="size-3.5 shrink-0 text-muted-foreground" />
+                                    <span className="truncate">
+                                        Wireframe view
+                                    </span>
+                                </span>
+                                <Switch
+                                    aria-label="Wireframe view"
+                                    checked={wireframeDebugVisible}
+                                    onCheckedChange={setWireframeDebugVisible}
+                                    size="sm"
+                                />
+                            </div>
                             <Row spacing={1} className="flex-wrap">
                                 <Button
                                     size="xs"

--- a/packages/game/src/scene/Scene.tsx
+++ b/packages/game/src/scene/Scene.tsx
@@ -9,14 +9,16 @@ import {
 import {
     type HTMLAttributes,
     type PropsWithChildren,
+    useCallback,
     useEffect,
     useRef,
 } from 'react';
-import { PCFShadowMap } from 'three';
+import { Material, type Object3D, PCFShadowMap } from 'three';
 import {
     HoverOutlineEffect,
     HoverOutlineProvider,
 } from '../entities/helpers/HoverOutline';
+import { useOptionalGameState } from '../useGameState';
 import { updateGameProfileMetadata } from './gameProfileMetadata';
 import {
     type GameQualityProfile,
@@ -33,6 +35,74 @@ export type SceneProps = HTMLAttributes<HTMLDivElement> &
     }>;
 
 const rendererStatsUpdateMs = 500;
+const wireframeOverrideRefreshMs = 250;
+
+type WireframeMaterial = Material & { wireframe: boolean };
+type WireframeMaterialState = {
+    material: WireframeMaterial;
+    wireframe: boolean;
+};
+
+function isMaterial(value: unknown): value is Material {
+    return value instanceof Material;
+}
+
+function isWireframeMaterial(
+    material: Material,
+): material is WireframeMaterial {
+    return 'wireframe' in material && typeof material.wireframe === 'boolean';
+}
+
+function getObjectMaterials(object: Object3D) {
+    if (!('material' in object)) {
+        return [];
+    }
+
+    const { material } = object;
+    if (Array.isArray(material)) {
+        return material.filter(isMaterial);
+    }
+
+    return isMaterial(material) ? [material] : [];
+}
+
+function applyWireframeOverride(
+    scene: Object3D,
+    previousStates: Map<string, WireframeMaterialState>,
+) {
+    scene.traverse((object) => {
+        for (const material of getObjectMaterials(object)) {
+            if (!isWireframeMaterial(material)) {
+                continue;
+            }
+
+            if (!previousStates.has(material.uuid)) {
+                previousStates.set(material.uuid, {
+                    material,
+                    wireframe: material.wireframe,
+                });
+            }
+
+            if (!material.wireframe) {
+                material.wireframe = true;
+                material.needsUpdate = true;
+            }
+        }
+    });
+}
+
+function restoreWireframeOverride(
+    previousStates: Map<string, WireframeMaterialState>,
+) {
+    for (const { material, wireframe } of previousStates.values()) {
+        if (material.wireframe !== wireframe) {
+            material.wireframe = wireframe;
+            material.needsUpdate = true;
+        }
+    }
+
+    previousStates.clear();
+}
 
 function RendererStatsReporter() {
     const lastUpdateRef = useRef(0);
@@ -58,6 +128,42 @@ function RendererStatsReporter() {
     return null;
 }
 
+function SceneWireframeMode({ enabled }: { enabled: boolean }) {
+    const scene = useThree((state) => state.scene);
+    const previousStatesRef = useRef(new Map<string, WireframeMaterialState>());
+    const lastApplyRef = useRef(0);
+
+    const applyOverride = useCallback(() => {
+        applyWireframeOverride(scene, previousStatesRef.current);
+    }, [scene]);
+
+    useEffect(() => {
+        const previousStates = previousStatesRef.current;
+
+        if (!enabled) {
+            restoreWireframeOverride(previousStates);
+            return;
+        }
+
+        applyOverride();
+        return () => restoreWireframeOverride(previousStates);
+    }, [applyOverride, enabled]);
+
+    useFrame(() => {
+        if (enabled) {
+            const now = performance.now();
+            if (now - lastApplyRef.current < wireframeOverrideRefreshMs) {
+                return;
+            }
+
+            lastApplyRef.current = now;
+            applyOverride();
+        }
+    });
+
+    return null;
+}
+
 function SceneDebugName() {
     const scene = useThree((state) => state.scene);
 
@@ -77,6 +183,10 @@ export function Scene({
     ...rest
 }: SceneProps) {
     const qualityProfile = quality ?? resolveGameQualityProfile();
+    const wireframeDebugVisible = useOptionalGameState(
+        (state) => state.wireframeDebugVisible,
+        false,
+    );
 
     useEffect(() => {
         updateGameProfileMetadata({
@@ -113,6 +223,9 @@ export function Scene({
                 <HoverOutlineProvider>
                     <SceneDebugName />
                     {debugStats && <RendererStatsReporter />}
+                    <SceneWireframeMode
+                        enabled={Boolean(debugStats && wireframeDebugVisible)}
+                    />
                     {children}
                     <HoverOutlineEffect />
                 </HoverOutlineProvider>

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -329,6 +329,8 @@ export type GameState = {
     setEditHitboxDebugVisible: (visible: boolean) => void;
     entityRenderModeDebugVisible: boolean;
     setEntityRenderModeDebugVisible: (visible: boolean) => void;
+    wireframeDebugVisible: boolean;
+    setWireframeDebugVisible: (visible: boolean) => void;
     animalPathfindingDebugVisible: boolean;
     setAnimalPathfindingDebugVisible: (visible: boolean) => void;
     animalTargetsDebugVisible: boolean;
@@ -731,6 +733,9 @@ export function createGameState({
         entityRenderModeDebugVisible: false,
         setEntityRenderModeDebugVisible: (entityRenderModeDebugVisible) =>
             set({ entityRenderModeDebugVisible }),
+        wireframeDebugVisible: false,
+        setWireframeDebugVisible: (wireframeDebugVisible) =>
+            set({ wireframeDebugVisible }),
         animalPathfindingDebugVisible: false,
         setAnimalPathfindingDebugVisible: (animalPathfindingDebugVisible) =>
             set({ animalPathfindingDebugVisible }),


### PR DESCRIPTION
## Summary
- Add a Wireframe view switch to the garden Debug HUD scene controls.
- Store the wireframe debug flag in game state and apply it from the shared Scene wrapper while debug stats are enabled.
- Restore each material's previous wireframe state when the toggle is disabled, with a throttled scan for lazy-loaded materials.

## Validation
- `corepack pnpm lint --filter @gredice/game`
- `corepack pnpm typecheck --filter @gredice/game --filter garden --filter www`
- Playwright runtime probe on `http://localhost:4841/debug/profile/game?debugHud=1&details=0&quality=medium&profile=dense`: switch visible, canvas stayed nonblank, screenshot changed after toggling. The only failed responses were existing local API proxy calls because the API dev app was not running beside the garden dev app.