### PR TITLE
feat(game): add dynamic sky gradients

### DIFF
--- a/apps/storybook/stories/packages/game/scene/SkyGradient.stories.tsx
+++ b/apps/storybook/stories/packages/game/scene/SkyGradient.stories.tsx
@@ -1,0 +1,422 @@
+import {
+    gameBackgroundPalettes,
+    getGameBackgroundPaletteIndexByKey,
+    resolveEnvironmentSkyBackgroundColors,
+    resolveMoonlitNightScales,
+    resolveSkyBackgroundColor,
+    resolveSkyGradientColors,
+    type SkyGradientWeather,
+} from '@gredice/game';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useMemo } from 'react';
+
+type ColorLike = {
+    b: number;
+    clone: () => ColorLike;
+    convertLinearToSRGB?: () => ColorLike;
+    g: number;
+    r: number;
+};
+
+type SkyGradientStoryProps = {
+    cloudy: number;
+    foggy: number;
+    moonlight: number;
+    moonVisibility: number;
+    moonX: number;
+    moonY: number;
+    paletteKey: string;
+    rainy: number;
+    snowy: number;
+    sunVisibility: number;
+    sunX: number;
+    sunY: number;
+    thundery: number;
+    timeOfDay: number;
+};
+
+function clamp01(value: number) {
+    return Math.min(1, Math.max(0, value));
+}
+
+function colorToRgb(color: ColorLike) {
+    const displayColor = color.clone();
+    displayColor.convertLinearToSRGB?.();
+    return [
+        Math.round(clamp01(displayColor.r) * 255),
+        Math.round(clamp01(displayColor.g) * 255),
+        Math.round(clamp01(displayColor.b) * 255),
+    ];
+}
+
+function colorToCss(color: ColorLike) {
+    const [red, green, blue] = colorToRgb(color);
+    return `rgb(${red} ${green} ${blue})`;
+}
+
+function colorToCssAlpha(color: ColorLike, alpha: number) {
+    const [red, green, blue] = colorToRgb(color);
+    return `rgb(${red} ${green} ${blue} / ${clamp01(alpha).toFixed(3)})`;
+}
+
+function screenPositionToCss(value: number) {
+    return `${((value + 1) / 2) * 100}%`;
+}
+
+function screenPositionYToCss(value: number) {
+    return `${(1 - (value + 1) / 2) * 100}%`;
+}
+
+function formatTimeOfDay(timeOfDay: number) {
+    const totalMinutes = Math.round(timeOfDay * 24 * 60) % (24 * 60);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return `${hours.toString().padStart(2, '0')}:${minutes
+        .toString()
+        .padStart(2, '0')}`;
+}
+
+function useSkyGradientPreview({
+    cloudy,
+    foggy,
+    moonlight,
+    paletteKey,
+    rainy,
+    snowy,
+    thundery,
+    timeOfDay,
+}: Pick<
+    SkyGradientStoryProps,
+    | 'cloudy'
+    | 'foggy'
+    | 'moonlight'
+    | 'paletteKey'
+    | 'rainy'
+    | 'snowy'
+    | 'thundery'
+    | 'timeOfDay'
+>) {
+    return useMemo(() => {
+        const backgroundPaletteIndex =
+            getGameBackgroundPaletteIndexByKey(paletteKey);
+        const weather: SkyGradientWeather = {
+            cloudy,
+            foggy,
+            rainy,
+            snowy,
+            thundery,
+        };
+        const baseColors = resolveEnvironmentSkyBackgroundColors({
+            backgroundPaletteIndex,
+            timeOfDay,
+        });
+        const moonlitNightScales = resolveMoonlitNightScales({
+            moonlight,
+            timeOfDay,
+        });
+        const backgroundColor = resolveSkyBackgroundColor({
+            background: baseColors.background,
+            moonlitSkyScale: moonlitNightScales.skyScale,
+            weather,
+        });
+        const gradient = resolveSkyGradientColors({
+            backgroundColor,
+            backgroundPaletteIndex,
+            moonlight,
+            timeOfDay,
+            weather,
+        });
+
+        return { backgroundColor, gradient };
+    }, [
+        cloudy,
+        foggy,
+        moonlight,
+        paletteKey,
+        rainy,
+        snowy,
+        thundery,
+        timeOfDay,
+    ]);
+}
+
+function buildSkyGradientCss({
+    gradient,
+    moonVisibility,
+    moonX,
+    moonY,
+    sunVisibility,
+    sunX,
+    sunY,
+}: Pick<
+    SkyGradientStoryProps,
+    'moonVisibility' | 'moonX' | 'moonY' | 'sunVisibility' | 'sunX' | 'sunY'
+> & {
+    gradient: ReturnType<typeof useSkyGradientPreview>['gradient'];
+}) {
+    return [
+        `radial-gradient(circle at ${screenPositionToCss(sunX)} ${screenPositionYToCss(sunY)}, rgb(255 255 255 / ${clamp01(
+            gradient.sunGlowIntensity * sunVisibility * 0.62,
+        ).toFixed(3)}) 0%, rgb(255 255 255 / 0) 18%)`,
+        `radial-gradient(circle at ${screenPositionToCss(sunX)} ${screenPositionYToCss(sunY)}, ${colorToCssAlpha(
+            gradient.sunGlow,
+            gradient.sunGlowIntensity * sunVisibility,
+        )} 0%, ${colorToCssAlpha(gradient.sunGlow, 0)} 42%)`,
+        `radial-gradient(circle at ${screenPositionToCss(moonX)} ${screenPositionYToCss(moonY)}, ${colorToCssAlpha(
+            gradient.moonGlow,
+            gradient.moonGlowIntensity * moonVisibility,
+        )} 0%, ${colorToCssAlpha(gradient.moonGlow, 0)} 36%)`,
+        `linear-gradient(180deg, ${colorToCss(gradient.zenith)} 0%, ${colorToCss(
+            gradient.upper,
+        )} 28%, ${colorToCss(gradient.horizon)} 68%, ${colorToCss(
+            gradient.horizon,
+        )} 100%)`,
+    ].join(', ');
+}
+
+function SkyGradientSurface({
+    className,
+    gradient,
+    props,
+}: {
+    className: string;
+    gradient: ReturnType<typeof useSkyGradientPreview>['gradient'];
+    props: SkyGradientStoryProps;
+}) {
+    const {
+        moonVisibility,
+        moonX,
+        moonY,
+        sunVisibility,
+        sunX,
+        sunY,
+        timeOfDay,
+    } = props;
+    const background = buildSkyGradientCss({ gradient, ...props });
+
+    return (
+        <div
+            className={`relative overflow-hidden rounded-md border border-border ${className}`}
+            style={{ background }}
+        >
+            <div
+                className="absolute size-16 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow-[0_0_42px_rgba(255,242,196,0.78)]"
+                style={{
+                    left: screenPositionToCss(sunX),
+                    opacity: clamp01(sunVisibility),
+                    top: screenPositionYToCss(sunY),
+                }}
+            />
+            <div
+                className="absolute size-10 -translate-x-1/2 -translate-y-1/2 rounded-full bg-slate-100 shadow-[0_0_24px_rgba(217,232,255,0.58)]"
+                style={{
+                    left: screenPositionToCss(moonX),
+                    opacity: clamp01(moonVisibility),
+                    top: screenPositionYToCss(moonY),
+                }}
+            />
+            <div className="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-black/10 to-transparent" />
+            <div className="absolute bottom-4 left-4 rounded-md bg-background/80 px-3 py-2 text-sm shadow-sm backdrop-blur">
+                <span className="tabular-nums">
+                    {formatTimeOfDay(timeOfDay)}
+                </span>
+            </div>
+        </div>
+    );
+}
+
+function SkyGradientPreview(props: SkyGradientStoryProps) {
+    const { backgroundColor, gradient } = useSkyGradientPreview(props);
+    const swatches = [
+        ['Zenith', gradient.zenith],
+        ['Upper', gradient.upper],
+        ['Horizon', gradient.horizon],
+        ['Lower', gradient.lower],
+        ['Sun glow', gradient.sunGlow],
+        ['Moon glow', gradient.moonGlow],
+    ] satisfies Array<[string, ColorLike]>;
+
+    return (
+        <div className="min-h-screen bg-background p-4 text-foreground sm:p-6">
+            <div className="grid min-h-[calc(100vh-2rem)] gap-4 lg:grid-cols-[minmax(0,1fr)_18rem]">
+                <SkyGradientSurface
+                    className="min-h-[28rem]"
+                    gradient={gradient}
+                    props={props}
+                />
+                <div className="grid content-start gap-3 rounded-md border border-border bg-background p-4">
+                    <div>
+                        <div className="text-sm font-medium">Base</div>
+                        <div
+                            className="mt-1 h-8 rounded-sm border border-border"
+                            style={{ background: colorToCss(backgroundColor) }}
+                        />
+                    </div>
+                    {swatches.map(([label, color]) => (
+                        <div
+                            className="grid grid-cols-[5rem_1fr] items-center gap-3 text-sm"
+                            key={label}
+                        >
+                            <span className="text-muted-foreground">
+                                {label}
+                            </span>
+                            <span
+                                className="h-8 rounded-sm border border-border"
+                                style={{ background: colorToCss(color) }}
+                            />
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function PaletteTile({
+    args,
+    paletteKey,
+}: {
+    args: SkyGradientStoryProps;
+    paletteKey: string;
+}) {
+    const props = { ...args, paletteKey };
+    const { gradient } = useSkyGradientPreview(props);
+    const palette = gameBackgroundPalettes.find(
+        (backgroundPalette) => backgroundPalette.key === paletteKey,
+    );
+
+    return (
+        <div className="grid overflow-hidden rounded-md border border-border bg-background">
+            <SkyGradientSurface
+                className="aspect-[5/3]"
+                gradient={gradient}
+                props={props}
+            />
+            <div className="border-t border-border px-3 py-2 text-sm font-medium">
+                {palette?.label ?? paletteKey}
+            </div>
+        </div>
+    );
+}
+
+function PaletteSweep(args: SkyGradientStoryProps) {
+    return (
+        <div className="grid min-h-screen gap-4 bg-background p-4 text-foreground sm:grid-cols-2 lg:grid-cols-3">
+            {gameBackgroundPalettes.map((palette) => (
+                <PaletteTile
+                    args={args}
+                    key={palette.key}
+                    paletteKey={palette.key}
+                />
+            ))}
+        </div>
+    );
+}
+
+const meta = {
+    title: 'packages/game/scene/SkyGradient',
+    component: SkyGradientPreview,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Shared sky-gradient resolver used by the garden scene background, with controls for palette, weather, moonlight, and projected sun/moon placement.',
+            },
+        },
+    },
+    argTypes: {
+        paletteKey: {
+            control: 'select',
+            options: gameBackgroundPalettes.map((palette) => palette.key),
+        },
+        timeOfDay: {
+            control: { type: 'range', min: 0, max: 1, step: 0.01 },
+        },
+        cloudy: {
+            control: { type: 'range', min: 0, max: 1, step: 0.01 },
+        },
+        foggy: {
+            control: { type: 'range', min: 0, max: 1, step: 0.01 },
+        },
+        rainy: {
+            control: { type: 'range', min: 0, max: 1, step: 0.01 },
+        },
+        snowy: {
+            control: { type: 'range', min: 0, max: 1, step: 0.01 },
+        },
+        thundery: {
+            control: { type: 'range', min: 0, max: 1, step: 0.01 },
+        },
+        moonlight: {
+            control: { type: 'range', min: 0, max: 1, step: 0.01 },
+        },
+        sunX: {
+            control: { type: 'range', min: -1.4, max: 1.4, step: 0.01 },
+        },
+        sunY: {
+            control: { type: 'range', min: -1.2, max: 1.2, step: 0.01 },
+        },
+        sunVisibility: {
+            control: { type: 'range', min: 0, max: 1, step: 0.01 },
+        },
+        moonX: {
+            control: { type: 'range', min: -1.4, max: 1.4, step: 0.01 },
+        },
+        moonY: {
+            control: { type: 'range', min: -1.2, max: 1.2, step: 0.01 },
+        },
+        moonVisibility: {
+            control: { type: 'range', min: 0, max: 1, step: 0.01 },
+        },
+    },
+    args: {
+        paletteKey: 'current',
+        timeOfDay: 0.72,
+        cloudy: 0,
+        foggy: 0,
+        rainy: 0,
+        snowy: 0,
+        thundery: 0,
+        moonlight: 0.45,
+        sunX: 0.48,
+        sunY: 0.52,
+        sunVisibility: 1,
+        moonX: -0.52,
+        moonY: 0.42,
+        moonVisibility: 0.18,
+    },
+} satisfies Meta<typeof SkyGradientPreview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Tuning: Story = {};
+
+export const NeutralNoon: Story = {
+    args: {
+        paletteKey: 'current',
+        timeOfDay: 0.5,
+        sunX: 0.32,
+        sunY: 0.64,
+        sunVisibility: 1,
+        moonVisibility: 0,
+    },
+};
+
+export const Night: Story = {
+    args: {
+        paletteKey: 'current',
+        timeOfDay: 0.92,
+        moonlight: 0.8,
+        sunVisibility: 0,
+        moonX: -0.16,
+        moonY: 0.62,
+        moonVisibility: 1,
+    },
+};
+
+export const AllPalettes: Story = {
+    render: (args) => <PaletteSweep {...args} />,
+};

--- a/packages/game/src/index.ts
+++ b/packages/game/src/index.ts
@@ -51,7 +51,26 @@ export {
     resolveOperationVisualRewardKind,
     resolveOperationVisualRewards,
 } from './operationVisualRewards';
+export type {
+    GameBackgroundPalette,
+    GameBackgroundPaletteKey,
+} from './scene/backgroundPalettes';
+export {
+    gameBackgroundPalettes,
+    getGameBackgroundPaletteIndexByKey,
+} from './scene/backgroundPalettes';
 export type { GameQualitySetting, GameQualityTier } from './scene/gameQuality';
+export { resolveMoonlitNightScales } from './scene/moonlight';
+export type {
+    SkyBackgroundColors,
+    SkyGradientColors,
+    SkyGradientWeather,
+} from './scene/skyGradient';
+export {
+    resolveEnvironmentSkyBackgroundColors,
+    resolveSkyBackgroundColor,
+    resolveSkyGradientColors,
+} from './scene/skyGradient';
 export { resolveSpriteAtlasAssetPaths } from './sprites/resolveSpriteAtlasAssetPaths';
 export { SpriteAtlasBillboard } from './sprites/SpriteAtlasBillboard';
 export type {

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -10,7 +10,7 @@ import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { useWeatherNow } from '../hooks/useWeatherNow';
 import type { Stack } from '../types/Stack';
 import { type GameState, useGameState } from '../useGameState';
-import { getGameBackgroundPalette } from './backgroundPalettes';
+import { defaultGameBackgroundPaletteIndex } from './backgroundPalettes';
 import { CloudLayer } from './CloudLayer';
 import { updateGameProfileMetadata } from './gameProfileMetadata';
 import {
@@ -21,9 +21,15 @@ import { getMoonlitNightScales } from './moonlight';
 import { Drops } from './Rain/Drops';
 import { useSceneTimeInvalidation } from './SceneTime';
 import { ShadowMapController } from './ShadowMapController';
+import { SkyGradientBackground } from './SkyGradientBackground';
 import Snow from './Snow/Snow';
 import { Stars } from './Stars';
 import { SunMoon } from './SunMoon';
+import {
+    resolveEnvironmentSkyBackgroundColors,
+    resolveSkyBackgroundColor,
+    resolveThemedSkyBackgroundColors,
+} from './skyGradient';
 import { altAzToScenePosition, timeOfDayToDate } from './sunPosition';
 import {
     getVisualDaylightAmount,
@@ -33,27 +39,6 @@ import {
 } from './visualDayNight';
 import { resolveWaterColors } from './waterColors';
 
-const backgroundColorScale = chroma
-    .scale([
-        '#2D3947',
-        '#6f8cac',
-        '#BADDf6',
-        '#E7E2CC',
-        '#E7E2CC',
-        '#f8b195',
-        '#6c5b7b',
-        '#2D3947',
-    ])
-    .domain([
-        visualDayNightTimes.dawnNightEnd,
-        visualDayNightTimes.sunrise,
-        visualDayNightTimes.dayStart - 0.03,
-        visualDayNightTimes.dayStart,
-        visualDayNightTimes.lateDayStart,
-        visualDayNightTimes.sunset,
-        0.84,
-        visualDayNightTimes.nightStart,
-    ]);
 const sunTemperatureScale = chroma
     .scale([
         chroma.temperature(20000),
@@ -71,24 +56,6 @@ const sunTemperatureScale = chroma
         visualDayNightTimes.duskNightStart,
         visualDayNightTimes.nightStart,
     ]);
-const hemisphereSkyColorScale = chroma
-    .scale([
-        chroma.temperature(20000),
-        chroma.temperature(2000),
-        chroma.temperature(20000),
-        chroma.temperature(20000),
-        chroma.temperature(2000),
-        chroma.temperature(20000),
-    ])
-    .domain([
-        visualDayNightTimes.dawnNightEnd,
-        visualDayNightTimes.dawnLightEnd,
-        visualDayNightTimes.dayStart,
-        visualDayNightTimes.lateDayStart,
-        visualDayNightTimes.duskNightStart,
-        visualDayNightTimes.nightStart,
-    ]);
-
 type WeatherBlendConfig = {
     transitionSeconds: number;
 };
@@ -291,41 +258,20 @@ function getSunPosition(
     return altAzToScenePosition(altitude, azimuth);
 }
 
-function resolveThemedBackground({
-    backgroundPaletteIndex,
-    timeOfDay,
-}: {
-    backgroundPaletteIndex: number;
-    timeOfDay: number;
-}) {
-    const palette = getGameBackgroundPalette(backgroundPaletteIndex);
-
-    if (palette.kind === 'current') {
-        return null;
-    }
-
-    const daylight = getVisualDaylightAmount(timeOfDay);
-
-    return {
-        background: chroma
-            .mix(palette.nightColor, palette.dayColor, daylight, 'rgb')
-            .rgb(),
-        hemisphereSkyColor: chroma
-            .mix(palette.nightColor, palette.lightColor, daylight, 'rgb')
-            .rgb(),
-    };
-}
-
 export function environmentState(
     { lat, lon }: { lat: number; lon: number },
     currentTime: Date,
     timeOfDay: number,
 ) {
     const sunPosition = getSunPosition({ lat, lon }, currentTime, timeOfDay);
+    const skyBackgroundColors = resolveEnvironmentSkyBackgroundColors({
+        backgroundPaletteIndex: defaultGameBackgroundPaletteIndex,
+        timeOfDay,
+    });
     const colors = {
-        background: backgroundColorScale(timeOfDay).rgb(),
+        background: skyBackgroundColors.background,
         sunTemperature: sunTemperatureScale(timeOfDay).rgb(),
-        hemisphereSkyColor: hemisphereSkyColorScale(timeOfDay).rgb(),
+        hemisphereSkyColor: skyBackgroundColors.hemisphereSkyColor,
     };
     const intensities = {
         sun: getVisualDaylightAmount(timeOfDay),
@@ -396,7 +342,7 @@ function useEnvironmentElements({
 }) {
     const {
         sunPosition,
-        colors: { background, sunTemperature, hemisphereSkyColor },
+        colors: { sunTemperature },
         intensities: { sun: sunIntensity },
     } = environmentState(location, currentTime, timeOfDay);
     const sceneDate = timeOfDayToDate(currentTime, timeOfDay);
@@ -405,10 +351,16 @@ function useEnvironmentElements({
         location,
         timeOfDay,
     });
-    const themedBackground = resolveThemedBackground({
+    const themedBackground = resolveThemedSkyBackgroundColors({
         backgroundPaletteIndex,
         timeOfDay,
     });
+    const skyBackgroundColors =
+        themedBackground ??
+        resolveEnvironmentSkyBackgroundColors({
+            backgroundPaletteIndex,
+            timeOfDay,
+        });
     const hasThemedBackground = themedBackground !== null;
 
     // Directional light
@@ -442,47 +394,25 @@ function useEnvironmentElements({
         moonlitNightScales.lightScale;
 
     // Background color
-    const effectiveBackground = themedBackground?.background ?? background;
-    const backgroundRed = effectiveBackground[0] / 255;
-    const backgroundGreen = effectiveBackground[1] / 255;
-    const backgroundBlue = effectiveBackground[2] / 255;
-    const cloudy = weather?.cloudy ?? 0;
-    const foggy = weather?.foggy ?? 0;
-    const backgroundColor = useMemo(() => {
-        const color = new Color().setRGB(
-            backgroundRed,
-            backgroundGreen,
+    const effectiveBackground = skyBackgroundColors.background;
+    const backgroundRed = effectiveBackground[0];
+    const backgroundGreen = effectiveBackground[1];
+    const backgroundBlue = effectiveBackground[2];
+    const backgroundColor = useMemo(
+        () =>
+            resolveSkyBackgroundColor({
+                background: [backgroundRed, backgroundGreen, backgroundBlue],
+                moonlitSkyScale: moonlitNightScales.skyScale,
+                weather,
+            }),
+        [
             backgroundBlue,
-            'srgb',
-        );
-        const moonlitBackground = { h: 0, s: 0, l: 0 };
-        color.getHSL(moonlitBackground);
-        color.setHSL(
-            moonlitBackground.h,
-            moonlitBackground.s,
-            moonlitBackground.l * moonlitNightScales.skyScale,
-        );
-
-        // Set background color based on weather
-        if (cloudy > 0 || foggy > 0) {
-            const rainyBackground = { h: 0, s: 0, l: 0 };
-            color.getHSL(rainyBackground);
-            color.setHSL(
-                rainyBackground.h,
-                rainyBackground.s * (1 - Math.min(0.7, cloudy + foggy)), // * (weather.cloudy > 0.5 || weather.foggy > 0.5 ? 0.3 : 0.8),
-                rainyBackground.l * (1 - Math.min(0.1, cloudy + foggy)),
-            ); // * (weather.cloudy > 0.9 ? 0.8 : (weather.cloudy > 0.4 ? 0.9 : 0.95)));
-        }
-
-        return color;
-    }, [
-        backgroundBlue,
-        backgroundGreen,
-        backgroundRed,
-        cloudy,
-        foggy,
-        moonlitNightScales.skyScale,
-    ]);
+            backgroundGreen,
+            backgroundRed,
+            moonlitNightScales.skyScale,
+            weather,
+        ],
+    );
 
     const waterColors = resolveWaterColors({
         skyColor: backgroundColor,
@@ -490,8 +420,7 @@ function useEnvironmentElements({
         weather: weather ?? undefined,
     });
 
-    const effectiveHemisphereSkyColor =
-        themedBackground?.hemisphereSkyColor ?? hemisphereSkyColor;
+    const effectiveHemisphereSkyColor = skyBackgroundColors.hemisphereSkyColor;
     const hemisphereSkyRed = effectiveHemisphereSkyColor[0] / 255;
     const hemisphereSkyGreen = effectiveHemisphereSkyColor[1] / 255;
     const hemisphereSkyBlue = effectiveHemisphereSkyColor[2] / 255;
@@ -544,6 +473,9 @@ function useEnvironmentElements({
             color: directionalLightColor,
             position: directionalLightPosition,
             intensity: directionalLightIntensity,
+        },
+        sky: {
+            moonlight: moonlitNightScales.visibleMoonlight,
         },
         waterColors,
     };
@@ -627,14 +559,20 @@ export function StaticEnvironment({
         (state) => state.backgroundPaletteIndex,
     );
     const setWaterColors = useGameState((state) => state.setWaterColors);
-    const { background, ambient, hemisphere, directionalLight, waterColors } =
-        useEnvironmentElements({
-            backgroundPaletteIndex,
-            location: defaultLocation,
-            currentTime,
-            timeOfDay,
-            weather: undefined,
-        });
+    const {
+        background,
+        ambient,
+        hemisphere,
+        directionalLight,
+        sky,
+        waterColors,
+    } = useEnvironmentElements({
+        backgroundPaletteIndex,
+        location: defaultLocation,
+        currentTime,
+        timeOfDay,
+        weather: undefined,
+    });
     const shadowInvalidationKey = useMemo(
         () =>
             buildLightShadowSignature({
@@ -673,7 +611,18 @@ export function StaticEnvironment({
                 invalidationKey={shadowInvalidationKey}
             />
             {!noBackground && (
-                <SceneBackgroundColor animate={false} color={background} />
+                <>
+                    <SceneBackgroundColor animate={false} color={background} />
+                    <SkyGradientBackground
+                        animate={false}
+                        backgroundColor={background}
+                        backgroundPaletteIndex={backgroundPaletteIndex}
+                        currentTime={currentTime}
+                        location={defaultLocation}
+                        moonlight={sky.moonlight}
+                        timeOfDay={timeOfDay}
+                    />
+                </>
             )}
             <ambientLight intensity={ambient.intensity} />
             <hemisphereLight
@@ -906,14 +855,20 @@ export function Environment({
         blendConfig,
     );
 
-    const { background, ambient, hemisphere, directionalLight, waterColors } =
-        useEnvironmentElements({
-            backgroundPaletteIndex,
-            location,
-            currentTime,
-            timeOfDay,
-            weather: blendedWeather,
-        });
+    const {
+        background,
+        ambient,
+        hemisphere,
+        directionalLight,
+        sky,
+        waterColors,
+    } = useEnvironmentElements({
+        backgroundPaletteIndex,
+        location,
+        currentTime,
+        timeOfDay,
+        weather: blendedWeather,
+    });
     const waterDeep = waterColors.deep;
     const waterFoam = waterColors.foam;
     const waterShallow = waterColors.shallow;
@@ -1151,7 +1106,19 @@ export function Environment({
                 invalidationKey={shadowInvalidationKey}
             />
             {!noBackground && (
-                <SceneBackgroundColor animate color={background} />
+                <>
+                    <SceneBackgroundColor animate color={background} />
+                    <SkyGradientBackground
+                        animate
+                        backgroundColor={background}
+                        backgroundPaletteIndex={backgroundPaletteIndex}
+                        currentTime={currentTime}
+                        location={location}
+                        moonlight={sky.moonlight}
+                        timeOfDay={timeOfDay}
+                        weather={blendedWeather}
+                    />
+                </>
             )}
             <ambientLight
                 name="Environment:AmbientLight"

--- a/packages/game/src/scene/SkyGradientBackground.tsx
+++ b/packages/game/src/scene/SkyGradientBackground.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useFrame, useThree } from '@react-three/fiber';
+import { useEffect, useMemo, useRef } from 'react';
+import * as SunCalc from 'suncalc';
+import { Color, DoubleSide, type Mesh, ShaderMaterial, Vector2 } from 'three';
+import {
+    cloneSkyGradientColors,
+    lerpSkyGradientColors,
+    resolveSkyGradientColors,
+    type SkyGradientColors,
+    type SkyGradientWeather,
+} from './skyGradient';
+import {
+    createSkyViewBasis,
+    getSunViewportTuning,
+    projectSkyDirectionToScreen,
+    SKY_FORWARD_DISTANCE,
+    SUN_SCREEN_OFFSET_MULTIPLIER,
+    updateSkyViewBasis,
+} from './skyProjection';
+import {
+    altAzToScenePosition,
+    degreesToRadians,
+    timeOfDayToDate,
+} from './sunPosition';
+import { smoothstep } from './visualDayNight';
+
+const SKY_GRADIENT_TRANSITION_SECONDS = 0.6;
+const HORIZON_FADE_START = -0.05;
+const HORIZON_FADE_END = 0.18;
+
+const skyGradientVertex = /* glsl */ `
+    varying vec2 vUv;
+
+    void main() {
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+`;
+
+const skyGradientFragment = /* glsl */ `
+    varying vec2 vUv;
+
+    uniform float uAspect;
+    uniform vec3 uZenithColor;
+    uniform vec3 uUpperColor;
+    uniform vec3 uHorizonColor;
+    uniform vec3 uSunGlowColor;
+    uniform vec3 uMoonGlowColor;
+    uniform float uSunGlowIntensity;
+    uniform float uMoonGlowIntensity;
+    uniform vec2 uSunPosition;
+    uniform vec2 uMoonPosition;
+
+    float glowAt(vec2 p, vec2 center, float radius) {
+        vec2 delta = p - center;
+        delta.x *= uAspect;
+        return 1.0 - smoothstep(radius * 0.24, radius, length(delta));
+    }
+
+    void main() {
+        float y = clamp(vUv.y, 0.0, 1.0);
+        vec3 color = uHorizonColor;
+        color = mix(color, uUpperColor, smoothstep(0.38, 0.84, y));
+        color = mix(color, uZenithColor, smoothstep(0.76, 1.0, y));
+
+        vec2 p = vUv * 2.0 - 1.0;
+        float sunGlow = glowAt(p, uSunPosition, 0.95);
+        float sunCore = glowAt(p, uSunPosition, 0.36);
+        float moonGlow = glowAt(p, uMoonPosition, 0.72);
+
+        color = mix(color, uSunGlowColor, clamp(sunGlow * uSunGlowIntensity, 0.0, 1.0));
+        color = mix(color, vec3(1.0), clamp(sunCore * uSunGlowIntensity * 0.62, 0.0, 1.0));
+        color = mix(
+            color,
+            uMoonGlowColor,
+            clamp(moonGlow * uMoonGlowIntensity, 0.0, 1.0)
+        );
+
+        gl_FragColor = vec4(color, 1.0);
+        #include <colorspace_fragment>
+    }
+`;
+
+type SkyGradientBackgroundProps = {
+    animate: boolean;
+    backgroundColor: Color;
+    backgroundPaletteIndex: number;
+    currentTime: Date;
+    location: { lat: number; lon: number };
+    moonlight: number;
+    timeOfDay: number;
+    weather?: SkyGradientWeather | null;
+};
+
+function copyColorUniform(
+    material: ShaderMaterial,
+    name: string,
+    color: Color,
+) {
+    const uniform = material.uniforms[name];
+    if (uniform?.value instanceof Color) {
+        uniform.value.copy(color);
+    }
+}
+
+function copyVectorUniform(
+    material: ShaderMaterial,
+    name: string,
+    vector: Vector2,
+) {
+    const uniform = material.uniforms[name];
+    if (uniform?.value instanceof Vector2) {
+        uniform.value.copy(vector);
+    }
+}
+
+function applyGradientUniforms(
+    material: ShaderMaterial,
+    gradient: SkyGradientColors,
+) {
+    copyColorUniform(material, 'uZenithColor', gradient.zenith);
+    copyColorUniform(material, 'uUpperColor', gradient.upper);
+    copyColorUniform(material, 'uHorizonColor', gradient.horizon);
+    copyColorUniform(material, 'uSunGlowColor', gradient.sunGlow);
+    copyColorUniform(material, 'uMoonGlowColor', gradient.moonGlow);
+    material.uniforms.uSunGlowIntensity.value = gradient.sunGlowIntensity;
+    material.uniforms.uMoonGlowIntensity.value = gradient.moonGlowIntensity;
+}
+
+export function SkyGradientBackground({
+    animate,
+    backgroundColor,
+    backgroundPaletteIndex,
+    currentTime,
+    location,
+    moonlight,
+    timeOfDay,
+    weather,
+}: SkyGradientBackgroundProps) {
+    const camera = useThree((state) => state.camera);
+    const { width: viewportWidth, height: viewportHeight } = useThree(
+        (state) => state.size,
+    );
+    const meshRef = useRef<Mesh>(null);
+    const basisRef = useRef(createSkyViewBasis());
+    const sunScreenRef = useRef(new Vector2(0, 0));
+    const moonScreenRef = useRef(new Vector2(0, 0));
+    const displayedGradientRef = useRef<SkyGradientColors | null>(null);
+    const targetGradientRef = useRef<SkyGradientColors | null>(null);
+    const backgroundRed = backgroundColor.r;
+    const backgroundGreen = backgroundColor.g;
+    const backgroundBlue = backgroundColor.b;
+
+    const material = useMemo(
+        () =>
+            new ShaderMaterial({
+                vertexShader: skyGradientVertex,
+                fragmentShader: skyGradientFragment,
+                depthTest: false,
+                depthWrite: false,
+                side: DoubleSide,
+                uniforms: {
+                    uAspect: { value: 1 },
+                    uZenithColor: { value: new Color('#e6f6ff') },
+                    uUpperColor: { value: new Color('#f1f3ea') },
+                    uHorizonColor: { value: new Color('#fff9ea') },
+                    uSunGlowColor: { value: new Color('#fff1bd') },
+                    uMoonGlowColor: { value: new Color('#d9e8ff') },
+                    uSunGlowIntensity: { value: 0 },
+                    uMoonGlowIntensity: { value: 0 },
+                    uSunPosition: { value: new Vector2(0, 0) },
+                    uMoonPosition: { value: new Vector2(0, 0) },
+                },
+            }),
+        [],
+    );
+
+    const targetGradient = useMemo(
+        () =>
+            resolveSkyGradientColors({
+                backgroundColor: new Color(
+                    backgroundRed,
+                    backgroundGreen,
+                    backgroundBlue,
+                ),
+                backgroundPaletteIndex,
+                moonlight,
+                timeOfDay,
+                weather,
+            }),
+        [
+            backgroundBlue,
+            backgroundGreen,
+            backgroundPaletteIndex,
+            backgroundRed,
+            moonlight,
+            timeOfDay,
+            weather,
+        ],
+    );
+
+    useEffect(() => {
+        targetGradientRef.current = targetGradient;
+
+        if (!displayedGradientRef.current || !animate) {
+            displayedGradientRef.current =
+                cloneSkyGradientColors(targetGradient);
+            applyGradientUniforms(material, displayedGradientRef.current);
+        }
+    }, [animate, material, targetGradient]);
+
+    useFrame((_, delta) => {
+        const mesh = meshRef.current;
+        if (!mesh || !updateSkyViewBasis(camera, basisRef.current)) {
+            return;
+        }
+
+        const basis = basisRef.current;
+        mesh.position
+            .copy(camera.position)
+            .addScaledVector(basis.forward, SKY_FORWARD_DISTANCE);
+        mesh.quaternion.copy(camera.quaternion);
+        mesh.scale.set(basis.halfWidth * 2, basis.halfHeight * 2, 1);
+        material.uniforms.uAspect.value =
+            basis.halfHeight === 0 ? 1 : basis.halfWidth / basis.halfHeight;
+
+        const sceneDate = timeOfDayToDate(currentTime, timeOfDay);
+        const sun = SunCalc.getPosition(sceneDate, location.lat, location.lon);
+        const moon = SunCalc.getMoonPosition(
+            sceneDate,
+            location.lat,
+            location.lon,
+        );
+        const sunTuning = getSunViewportTuning(viewportWidth, viewportHeight);
+        const sunDirection = altAzToScenePosition(
+            sun.altitude,
+            sun.azimuth,
+        ).normalize();
+        const moonDirection = altAzToScenePosition(
+            moon.altitude,
+            moon.azimuth,
+        ).normalize();
+
+        projectSkyDirectionToScreen(
+            sunDirection,
+            basis,
+            {
+                horizontalOffsetMultiplier:
+                    sunTuning.horizontalOffsetMultiplier,
+                screenOffsetMultiplier: SUN_SCREEN_OFFSET_MULTIPLIER,
+                verticalOffsetMultiplier: sunTuning.verticalOffsetMultiplier,
+            },
+            sunScreenRef.current,
+        );
+        projectSkyDirectionToScreen(
+            moonDirection,
+            basis,
+            {},
+            moonScreenRef.current,
+        );
+        copyVectorUniform(material, 'uSunPosition', sunScreenRef.current);
+        copyVectorUniform(material, 'uMoonPosition', moonScreenRef.current);
+
+        const sunOpacity = smoothstep(
+            HORIZON_FADE_START,
+            HORIZON_FADE_END,
+            degreesToRadians(sun.altitude),
+        );
+        const moonOpacity = smoothstep(
+            HORIZON_FADE_START,
+            HORIZON_FADE_END,
+            degreesToRadians(moon.altitude),
+        );
+
+        const displayed = displayedGradientRef.current;
+        const target = targetGradientRef.current;
+        if (displayed && target) {
+            if (animate) {
+                lerpSkyGradientColors(
+                    displayed,
+                    target,
+                    1 -
+                        Math.exp(
+                            -(1 / SKY_GRADIENT_TRANSITION_SECONDS) * delta,
+                        ),
+                );
+            }
+
+            const activeGradient = displayed;
+            applyGradientUniforms(material, activeGradient);
+            material.uniforms.uSunGlowIntensity.value =
+                activeGradient.sunGlowIntensity * sunOpacity;
+            material.uniforms.uMoonGlowIntensity.value =
+                activeGradient.moonGlowIntensity * moonOpacity;
+        }
+    });
+
+    return (
+        <mesh
+            ref={meshRef}
+            frustumCulled={false}
+            material={material}
+            name="Environment:SkyGradientBackground"
+            renderOrder={-1000}
+        >
+            <planeGeometry args={[1, 1]} />
+        </mesh>
+    );
+}

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -9,14 +9,19 @@ import {
     Color,
     DoubleSide,
     type Mesh,
-    type OrthographicCamera,
     ShaderMaterial,
-    Vector3,
 } from 'three';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { useGameState } from '../useGameState';
 import { getMoonVisualPhase } from './moonPhase';
+import {
+    createSkyViewBasis,
+    getSunViewportTuning,
+    SKY_FORWARD_DISTANCE,
+    SUN_SCREEN_OFFSET_MULTIPLIER,
+    updateSkyViewBasis,
+} from './skyProjection';
 import {
     altAzToScenePosition,
     degreesToRadians,
@@ -34,66 +39,11 @@ const MOON_PLANE_SIZE = 0.85;
 const HORIZON_FADE_START = -0.05;
 const HORIZON_FADE_END = 0.18;
 
-// Distance in front of the camera along its forward axis. Large enough that
-// the discs sit deeper than scene geometry, so depthTest lets blocks occlude
-// them naturally.
-const FORWARD_DISTANCE = 500;
-
-// Fraction of the viewport half-height used as the "sky" radius; zenith lands
-// slightly above the top edge, horizon sits near the middle where the ground
-// meets the sky in our isometric view.
-const SKY_SCREEN_FRACTION = 1.05;
-
 // Canvas-pixel size stays constant across zoom levels by counter-scaling the
 // mesh by (REFERENCE_ZOOM / camera.zoom). REFERENCE_ZOOM matches the default
 // game camera zoom so on-screen size matches the plane size at default zoom.
-const REFERENCE_ZOOM = 100;
 const SIZE_MULTIPLIER = 1.5;
 const SUN_SIZE_MULTIPLIER = 0.8;
-const SUN_SCREEN_OFFSET_MULTIPLIER = 0.8;
-
-// Renderer `size` is reported in CSS pixels. These breakpoints map the sun
-// tuning to our mobile/tablet/desktop layout ranges so responsive adjustments
-// stay aligned with the rest of the UI.
-const MOBILE_MAX_WIDTH = 767;
-const TABLET_MAX_WIDTH = 1023;
-
-type SunViewportTuning = {
-    // Multiplies the default billboard scale and camera-space offsets for the
-    // sun so smaller viewports keep it fully visible without affecting the moon.
-    sizeMultiplier: number;
-    horizontalOffsetMultiplier: number;
-    verticalOffsetMultiplier: number;
-};
-
-function getSunViewportTuning(
-    viewportWidth: number,
-    viewportHeight: number,
-): SunViewportTuning {
-    const isPortrait = viewportHeight > viewportWidth;
-
-    if (viewportWidth <= MOBILE_MAX_WIDTH) {
-        return {
-            sizeMultiplier: 0.6,
-            horizontalOffsetMultiplier: isPortrait ? 0.7 : 1,
-            verticalOffsetMultiplier: isPortrait ? 1 : 0.8,
-        };
-    }
-
-    if (viewportWidth <= TABLET_MAX_WIDTH) {
-        return {
-            sizeMultiplier: 0.9,
-            horizontalOffsetMultiplier: isPortrait ? 1 : 0.9,
-            verticalOffsetMultiplier: isPortrait ? 1 : 0.9,
-        };
-    }
-
-    return {
-        sizeMultiplier: 1,
-        horizontalOffsetMultiplier: isPortrait ? 0.9 : 1.6,
-        verticalOffsetMultiplier: isPortrait ? 1.1 : 1,
-    };
-}
 
 const MOON_NIGHT_COLOR = new Color('#c8d8f2');
 const MOON_DAY_COLOR = new Color('#f4f2ec');
@@ -258,28 +208,15 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
         [viewportHeight, viewportWidth],
     );
 
-    const forwardRef = useRef(new Vector3());
-    const rightRef = useRef(new Vector3());
-    const viewUpRef = useRef(new Vector3());
+    const skyBasisRef = useRef(createSkyViewBasis());
 
     const updateSunMoon = useCallback(() => {
         if (!sunMesh.current || !moonMesh.current) return;
 
-        const orthographic = camera as OrthographicCamera;
-        if (!orthographic.isOrthographicCamera) return;
+        if (!updateSkyViewBasis(camera, skyBasisRef.current)) return;
 
-        camera.getWorldDirection(forwardRef.current);
-        rightRef.current
-            .crossVectors(forwardRef.current, camera.up)
-            .normalize();
-        viewUpRef.current
-            .crossVectors(rightRef.current, forwardRef.current)
-            .normalize();
-
-        const halfHeight = orthographic.top / orthographic.zoom;
-        const skyRadius = halfHeight * SKY_SCREEN_FRACTION;
-        const screenScale =
-            (REFERENCE_ZOOM / orthographic.zoom) * SIZE_MULTIPLIER;
+        const basis = skyBasisRef.current;
+        const screenScale = basis.screenScale * SIZE_MULTIPLIER;
         sunMesh.current.scale.setScalar(
             screenScale *
                 SUN_SIZE_MULTIPLIER *
@@ -302,23 +239,23 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
                 sun.altitude,
                 sun.azimuth,
             ).normalize();
-            const sx = sunDir.dot(rightRef.current);
-            const sy = sunDir.dot(viewUpRef.current);
+            const sx = sunDir.dot(basis.right);
+            const sy = sunDir.dot(basis.viewUp);
 
             sunMesh.current.position
                 .copy(camera.position)
-                .addScaledVector(forwardRef.current, FORWARD_DISTANCE)
+                .addScaledVector(basis.forward, SKY_FORWARD_DISTANCE)
                 .addScaledVector(
-                    rightRef.current,
+                    basis.right,
                     sx *
-                        skyRadius *
+                        basis.skyRadius *
                         SUN_SCREEN_OFFSET_MULTIPLIER *
                         sunViewportTuning.horizontalOffsetMultiplier,
                 )
                 .addScaledVector(
-                    viewUpRef.current,
+                    basis.viewUp,
                     sy *
-                        skyRadius *
+                        basis.skyRadius *
                         SUN_SCREEN_OFFSET_MULTIPLIER *
                         sunViewportTuning.verticalOffsetMultiplier,
                 );
@@ -351,14 +288,14 @@ export function SunMoon({ visibility = 1 }: SunMoonProps) {
                 moon.altitude,
                 moon.azimuth,
             ).normalize();
-            const mx = moonDir.dot(rightRef.current);
-            const my = moonDir.dot(viewUpRef.current);
+            const mx = moonDir.dot(basis.right);
+            const my = moonDir.dot(basis.viewUp);
 
             moonMesh.current.position
                 .copy(camera.position)
-                .addScaledVector(forwardRef.current, FORWARD_DISTANCE)
-                .addScaledVector(rightRef.current, mx * skyRadius)
-                .addScaledVector(viewUpRef.current, my * skyRadius);
+                .addScaledVector(basis.forward, SKY_FORWARD_DISTANCE)
+                .addScaledVector(basis.right, mx * basis.skyRadius)
+                .addScaledVector(basis.viewUp, my * basis.skyRadius);
             moonMesh.current.lookAt(camera.position);
 
             moonMaterial.uniforms.uPhase.value = moonVisualPhase.phase;

--- a/packages/game/src/scene/backgroundPalettes.ts
+++ b/packages/game/src/scene/backgroundPalettes.ts
@@ -4,6 +4,7 @@ import {
     isGameBackgroundPaletteKey,
 } from '@gredice/js/gameBackground';
 
+export type { GameBackgroundPaletteKey } from '@gredice/js/gameBackground';
 export { defaultGameBackgroundPaletteKey } from '@gredice/js/gameBackground';
 
 export type GameBackgroundPalette =

--- a/packages/game/src/scene/skyGradient.ts
+++ b/packages/game/src/scene/skyGradient.ts
@@ -1,0 +1,405 @@
+import chroma from 'chroma-js';
+import { Color } from 'three';
+import { getGameBackgroundPalette } from './backgroundPalettes';
+import {
+    getVisualDaylightAmount,
+    getVisualNightAmount,
+    smoothstep,
+    visualDayNightTimes,
+} from './visualDayNight';
+
+const currentBackgroundColorScale = chroma
+    .scale([
+        '#2D3947',
+        '#6f8cac',
+        '#BADDf6',
+        '#F7F1DD',
+        '#FAF4E2',
+        '#f8b195',
+        '#6c5b7b',
+        '#2D3947',
+    ])
+    .domain([
+        visualDayNightTimes.dawnNightEnd,
+        visualDayNightTimes.sunrise,
+        visualDayNightTimes.dayStart - 0.03,
+        visualDayNightTimes.dayStart,
+        visualDayNightTimes.lateDayStart,
+        visualDayNightTimes.sunset,
+        0.84,
+        visualDayNightTimes.nightStart,
+    ]);
+
+const currentHemisphereSkyColorScale = chroma
+    .scale([
+        chroma.temperature(20000),
+        chroma.temperature(2000),
+        chroma.temperature(20000),
+        chroma.temperature(20000),
+        chroma.temperature(2000),
+        chroma.temperature(20000),
+    ])
+    .domain([
+        visualDayNightTimes.dawnNightEnd,
+        visualDayNightTimes.dawnLightEnd,
+        visualDayNightTimes.dayStart,
+        visualDayNightTimes.lateDayStart,
+        visualDayNightTimes.duskNightStart,
+        visualDayNightTimes.nightStart,
+    ]);
+
+const neutralSkyTheme = {
+    dayColor: '#E6F6FF',
+    lightColor: '#FFF9EA',
+    nightColor: '#2D3947',
+};
+
+export type SkyGradientWeather = {
+    cloudy?: number;
+    foggy?: number;
+    rainy?: number;
+    snowy?: number;
+    thundery?: number;
+};
+
+export type SkyBackgroundColors = {
+    background: number[];
+    hemisphereSkyColor: number[];
+};
+
+export type SkyGradientColors = {
+    horizon: Color;
+    lower: Color;
+    moonGlow: Color;
+    moonGlowIntensity: number;
+    sunGlow: Color;
+    sunGlowIntensity: number;
+    upper: Color;
+    zenith: Color;
+};
+
+function clamp01(value: number) {
+    return Math.min(1, Math.max(0, value));
+}
+
+function mix(from: number, to: number, amount: number) {
+    return from + (to - from) * amount;
+}
+
+function colorFromRgb(rgb: number[]) {
+    return new Color().setRGB(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255, 'srgb');
+}
+
+function colorFromHex(hex: string) {
+    return new Color(hex);
+}
+
+function shiftHsl(
+    color: Color,
+    {
+        hueOffset = 0,
+        lightnessOffset = 0,
+        lightnessScale = 1,
+        saturationScale = 1,
+    }: {
+        hueOffset?: number;
+        lightnessOffset?: number;
+        lightnessScale?: number;
+        saturationScale?: number;
+    },
+) {
+    const hsl = { h: 0, l: 0, s: 0 };
+    color.getHSL(hsl);
+    const hue = (hsl.h + hueOffset + 1) % 1;
+    return new Color().setHSL(
+        hue,
+        clamp01(hsl.s * saturationScale),
+        clamp01(hsl.l * lightnessScale + lightnessOffset),
+    );
+}
+
+function applyWeatherTone(color: Color, weather: SkyGradientWeather) {
+    const cloudy = clamp01(weather.cloudy ?? 0);
+    const foggy = clamp01(weather.foggy ?? 0);
+    const rainy = clamp01(weather.rainy ?? 0);
+    const snowy = clamp01(weather.snowy ?? 0);
+    const overcast = clamp01(cloudy + foggy * 0.7 + rainy * 0.25);
+    const hsl = { h: 0, l: 0, s: 0 };
+    color.getHSL(hsl);
+    return new Color().setHSL(
+        hsl.h,
+        clamp01(hsl.s * (1 - overcast * 0.5) * (1 - snowy * 0.22)),
+        clamp01(
+            hsl.l * (1 - overcast * 0.08 - rainy * 0.06) +
+                foggy * 0.045 +
+                snowy * 0.035,
+        ),
+    );
+}
+
+function getTwilightAmount(timeOfDay: number) {
+    const dawn =
+        smoothstep(
+            visualDayNightTimes.dawnNightEnd,
+            visualDayNightTimes.sunrise,
+            timeOfDay,
+        ) *
+        (1 -
+            smoothstep(
+                visualDayNightTimes.dawnLightEnd,
+                visualDayNightTimes.dayStart,
+                timeOfDay,
+            ));
+    const dusk =
+        smoothstep(
+            visualDayNightTimes.lateDayStart,
+            visualDayNightTimes.sunset,
+            timeOfDay,
+        ) *
+        (1 -
+            smoothstep(
+                visualDayNightTimes.duskNightStart,
+                visualDayNightTimes.nightStart,
+                timeOfDay,
+            ));
+
+    return Math.max(dawn, dusk);
+}
+
+function getDuskAmount(timeOfDay: number) {
+    return (
+        smoothstep(
+            visualDayNightTimes.lateDayStart,
+            visualDayNightTimes.sunset,
+            timeOfDay,
+        ) *
+        (1 -
+            smoothstep(
+                visualDayNightTimes.duskNightStart,
+                visualDayNightTimes.nightStart,
+                timeOfDay,
+            ))
+    );
+}
+
+function resolvePaletteTheme(backgroundPaletteIndex: number) {
+    const palette = getGameBackgroundPalette(backgroundPaletteIndex);
+
+    if (palette.kind === 'current') {
+        return {
+            day: colorFromHex(neutralSkyTheme.dayColor),
+            light: colorFromHex(neutralSkyTheme.lightColor),
+            night: colorFromHex(neutralSkyTheme.nightColor),
+            upperDayBlend: 0.18,
+            zenithDayBlend: 0.86,
+        };
+    }
+
+    return {
+        day: colorFromHex(palette.dayColor),
+        light: colorFromHex(palette.lightColor),
+        night: colorFromHex(palette.nightColor),
+        upperDayBlend: 0.12,
+        zenithDayBlend: 0.08,
+    };
+}
+
+export function resolveThemedSkyBackgroundColors({
+    backgroundPaletteIndex,
+    timeOfDay,
+}: {
+    backgroundPaletteIndex: number;
+    timeOfDay: number;
+}): SkyBackgroundColors | null {
+    const palette = getGameBackgroundPalette(backgroundPaletteIndex);
+
+    if (palette.kind === 'current') {
+        return null;
+    }
+
+    const daylight = getVisualDaylightAmount(timeOfDay);
+
+    return {
+        background: chroma
+            .mix(palette.nightColor, palette.dayColor, daylight, 'rgb')
+            .rgb(),
+        hemisphereSkyColor: chroma
+            .mix(palette.nightColor, palette.lightColor, daylight, 'rgb')
+            .rgb(),
+    };
+}
+
+export function resolveEnvironmentSkyBackgroundColors({
+    backgroundPaletteIndex,
+    timeOfDay,
+}: {
+    backgroundPaletteIndex: number;
+    timeOfDay: number;
+}): SkyBackgroundColors {
+    const themedBackground = resolveThemedSkyBackgroundColors({
+        backgroundPaletteIndex,
+        timeOfDay,
+    });
+
+    if (themedBackground) {
+        return themedBackground;
+    }
+
+    return {
+        background: currentBackgroundColorScale(timeOfDay).rgb(),
+        hemisphereSkyColor: currentHemisphereSkyColorScale(timeOfDay).rgb(),
+    };
+}
+
+export function resolveSkyBackgroundColor({
+    background,
+    moonlitSkyScale,
+    weather,
+}: {
+    background: number[];
+    moonlitSkyScale: number;
+    weather?: SkyGradientWeather | null;
+}) {
+    const color = colorFromRgb(background);
+    const moonlitBackground = { h: 0, l: 0, s: 0 };
+    color.getHSL(moonlitBackground);
+    color.setHSL(
+        moonlitBackground.h,
+        moonlitBackground.s,
+        moonlitBackground.l * moonlitSkyScale,
+    );
+
+    if (weather) {
+        return applyWeatherTone(color, weather);
+    }
+
+    return color;
+}
+
+export function resolveSkyGradientColors({
+    backgroundColor,
+    backgroundPaletteIndex,
+    moonlight,
+    timeOfDay,
+    weather,
+}: {
+    backgroundColor: Color;
+    backgroundPaletteIndex: number;
+    moonlight: number;
+    timeOfDay: number;
+    weather?: SkyGradientWeather | null;
+}): SkyGradientColors {
+    const theme = resolvePaletteTheme(backgroundPaletteIndex);
+    const daylight = getVisualDaylightAmount(timeOfDay);
+    const night = getVisualNightAmount(timeOfDay);
+    const twilight = getTwilightAmount(timeOfDay);
+    const dusk = getDuskAmount(timeOfDay);
+    const cloudy = clamp01(weather?.cloudy ?? 0);
+    const foggy = clamp01(weather?.foggy ?? 0);
+    const rainy = clamp01(weather?.rainy ?? 0);
+    const snowy = clamp01(weather?.snowy ?? 0);
+    const storm = clamp01(rainy + (weather?.thundery ?? 0) * 0.35);
+    const overcast = clamp01(cloudy + foggy * 0.7 + rainy * 0.25);
+    const visibleMoonlight = clamp01(moonlight);
+    const twilightWarmth = dusk > 0.5 ? '#ff9f7c' : '#ffd59c';
+
+    const base = backgroundColor.clone();
+    const zenith = shiftHsl(base, {
+        hueOffset: night > 0 ? 0.025 : -0.018 * daylight,
+        lightnessOffset: -0.012 * daylight - 0.04 * night,
+        lightnessScale: 0.96 - twilight * 0.04 - night * 0.08,
+        saturationScale: 0.86 + twilight * 0.22 + night * 0.12,
+    })
+        .lerp(theme.night, night * 0.2)
+        .lerp(theme.day, daylight * theme.zenithDayBlend)
+        .lerp(colorFromHex('#4d5f83'), night * visibleMoonlight * 0.13);
+
+    const upper = base
+        .clone()
+        .lerp(zenith, 0.36)
+        .lerp(theme.day, daylight * theme.upperDayBlend)
+        .lerp(colorFromHex('#6f8fb7'), night * visibleMoonlight * 0.08);
+
+    const horizon = shiftHsl(base, {
+        lightnessOffset: 0.035 + daylight * 0.035,
+        saturationScale: 1.02 + twilight * 0.2,
+    })
+        .lerp(theme.light, 0.28 + daylight * 0.16)
+        .lerp(colorFromHex(twilightWarmth), twilight * 0.35)
+        .lerp(colorFromHex('#9fb4d4'), night * visibleMoonlight * 0.1);
+
+    const lower = horizon.clone();
+
+    const weatherTone = {
+        cloudy: overcast,
+        foggy,
+        rainy: storm,
+        snowy,
+    };
+
+    const sunGlow = colorFromHex('#fff1bd')
+        .lerp(theme.light, daylight * 0.08)
+        .lerp(colorFromHex(twilightWarmth), twilight * 0.34)
+        .lerp(colorFromHex('#e7eefc'), night * 0.24);
+    const moonGlow = colorFromHex('#d9e8ff')
+        .lerp(theme.light, 0.18)
+        .lerp(colorFromHex('#f2f1e9'), daylight * 0.28);
+
+    return {
+        zenith: applyWeatherTone(zenith, weatherTone),
+        upper: applyWeatherTone(upper, weatherTone),
+        horizon: applyWeatherTone(horizon, weatherTone),
+        lower: applyWeatherTone(lower, weatherTone),
+        sunGlow: applyWeatherTone(sunGlow, weatherTone),
+        sunGlowIntensity:
+            (0.26 + daylight * 0.22 + twilight * 0.26) *
+            (1 - overcast * 0.72) *
+            (1 - storm * 0.2),
+        moonGlow: applyWeatherTone(moonGlow, weatherTone),
+        moonGlowIntensity:
+            night *
+            (0.06 + visibleMoonlight * 0.22) *
+            (1 - overcast * 0.68) *
+            (1 - storm * 0.15),
+    };
+}
+
+export function cloneSkyGradientColors(
+    gradient: SkyGradientColors,
+): SkyGradientColors {
+    return {
+        horizon: gradient.horizon.clone(),
+        lower: gradient.lower.clone(),
+        moonGlow: gradient.moonGlow.clone(),
+        moonGlowIntensity: gradient.moonGlowIntensity,
+        sunGlow: gradient.sunGlow.clone(),
+        sunGlowIntensity: gradient.sunGlowIntensity,
+        upper: gradient.upper.clone(),
+        zenith: gradient.zenith.clone(),
+    };
+}
+
+export function lerpSkyGradientColors(
+    current: SkyGradientColors,
+    target: SkyGradientColors,
+    amount: number,
+) {
+    current.zenith.lerp(target.zenith, amount);
+    current.upper.lerp(target.upper, amount);
+    current.horizon.lerp(target.horizon, amount);
+    current.lower.lerp(target.lower, amount);
+    current.sunGlow.lerp(target.sunGlow, amount);
+    current.moonGlow.lerp(target.moonGlow, amount);
+    current.sunGlowIntensity = mix(
+        current.sunGlowIntensity,
+        target.sunGlowIntensity,
+        amount,
+    );
+    current.moonGlowIntensity = mix(
+        current.moonGlowIntensity,
+        target.moonGlowIntensity,
+        amount,
+    );
+
+    return current;
+}

--- a/packages/game/src/scene/skyGradient.unit.ts
+++ b/packages/game/src/scene/skyGradient.unit.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    defaultGameBackgroundPaletteIndex,
+    getGameBackgroundPaletteIndexByKey,
+} from './backgroundPalettes';
+import { resolveMoonlitNightScales } from './moonlight';
+import {
+    resolveEnvironmentSkyBackgroundColors,
+    resolveSkyBackgroundColor,
+    resolveSkyGradientColors,
+} from './skyGradient';
+
+function colorDistance(
+    first: { b: number; g: number; r: number },
+    second: { b: number; g: number; r: number },
+) {
+    return Math.hypot(
+        first.r - second.r,
+        first.g - second.g,
+        first.b - second.b,
+    );
+}
+
+function resolveGradient({
+    moonlight = 0,
+    paletteIndex = defaultGameBackgroundPaletteIndex,
+    timeOfDay,
+    weather,
+}: {
+    moonlight?: number;
+    paletteIndex?: number;
+    timeOfDay: number;
+    weather?: Parameters<typeof resolveSkyGradientColors>[0]['weather'];
+}) {
+    const baseColors = resolveEnvironmentSkyBackgroundColors({
+        backgroundPaletteIndex: paletteIndex,
+        timeOfDay,
+    });
+    const moonlitNightScales = resolveMoonlitNightScales({
+        moonlight,
+        timeOfDay,
+    });
+    const backgroundColor = resolveSkyBackgroundColor({
+        background: baseColors.background,
+        moonlitSkyScale: moonlitNightScales.skyScale,
+        weather,
+    });
+
+    return resolveSkyGradientColors({
+        backgroundColor,
+        backgroundPaletteIndex: paletteIndex,
+        moonlight,
+        timeOfDay,
+        weather,
+    });
+}
+
+test('neutral daytime sky resolves to a visible gradient', () => {
+    const gradient = resolveGradient({ timeOfDay: 0.5 });
+
+    assert.ok(colorDistance(gradient.zenith, gradient.horizon) > 0.025);
+    assert.ok(colorDistance(gradient.upper, gradient.horizon) > 0.015);
+    assert.ok(colorDistance(gradient.lower, gradient.horizon) < 0.001);
+    assert.ok(gradient.sunGlowIntensity > 0.4);
+});
+
+test('background palettes tint the same time of day differently', () => {
+    const blueGradient = resolveGradient({
+        paletteIndex: getGameBackgroundPaletteIndexByKey('light-blue'),
+        timeOfDay: 0.52,
+    });
+    const roseGradient = resolveGradient({
+        paletteIndex: getGameBackgroundPaletteIndexByKey('rose'),
+        timeOfDay: 0.52,
+    });
+
+    assert.ok(colorDistance(blueGradient.horizon, roseGradient.horizon) > 0.1);
+});
+
+test('moonlight and cloud cover tune glow strength at night', () => {
+    const moonlessGradient = resolveGradient({
+        moonlight: 0,
+        timeOfDay: 0.92,
+    });
+    const moonlitGradient = resolveGradient({
+        moonlight: 0.9,
+        timeOfDay: 0.92,
+    });
+    const overcastGradient = resolveGradient({
+        moonlight: 0.9,
+        timeOfDay: 0.92,
+        weather: { cloudy: 0.9 },
+    });
+
+    assert.ok(
+        moonlitGradient.moonGlowIntensity > moonlessGradient.moonGlowIntensity,
+    );
+    assert.ok(
+        overcastGradient.moonGlowIntensity < moonlitGradient.moonGlowIntensity,
+    );
+});

--- a/packages/game/src/scene/skyProjection.ts
+++ b/packages/game/src/scene/skyProjection.ts
@@ -1,0 +1,116 @@
+import { type Camera, OrthographicCamera, Vector2, Vector3 } from 'three';
+
+export const SKY_FORWARD_DISTANCE = 500;
+export const SKY_SCREEN_FRACTION = 1.05;
+export const SKY_REFERENCE_ZOOM = 100;
+export const SUN_SCREEN_OFFSET_MULTIPLIER = 0.8;
+
+const MOBILE_MAX_WIDTH = 767;
+const TABLET_MAX_WIDTH = 1023;
+
+export type SkyViewBasis = {
+    forward: Vector3;
+    halfHeight: number;
+    halfWidth: number;
+    right: Vector3;
+    screenScale: number;
+    skyRadius: number;
+    viewUp: Vector3;
+};
+
+export type SunViewportTuning = {
+    horizontalOffsetMultiplier: number;
+    sizeMultiplier: number;
+    verticalOffsetMultiplier: number;
+};
+
+export function createSkyViewBasis(): SkyViewBasis {
+    return {
+        forward: new Vector3(),
+        halfHeight: 1,
+        halfWidth: 1,
+        right: new Vector3(),
+        screenScale: 1,
+        skyRadius: 1,
+        viewUp: new Vector3(),
+    };
+}
+
+export function updateSkyViewBasis(camera: Camera, basis: SkyViewBasis) {
+    if (!(camera instanceof OrthographicCamera)) {
+        return false;
+    }
+
+    camera.getWorldDirection(basis.forward);
+    basis.right.crossVectors(basis.forward, camera.up).normalize();
+    basis.viewUp.crossVectors(basis.right, basis.forward).normalize();
+    basis.halfWidth = (camera.right - camera.left) / (2 * camera.zoom);
+    basis.halfHeight = (camera.top - camera.bottom) / (2 * camera.zoom);
+    basis.skyRadius = basis.halfHeight * SKY_SCREEN_FRACTION;
+    basis.screenScale = SKY_REFERENCE_ZOOM / camera.zoom;
+
+    return true;
+}
+
+export function getSunViewportTuning(
+    viewportWidth: number,
+    viewportHeight: number,
+): SunViewportTuning {
+    const isPortrait = viewportHeight > viewportWidth;
+
+    if (viewportWidth <= MOBILE_MAX_WIDTH) {
+        return {
+            sizeMultiplier: 0.6,
+            horizontalOffsetMultiplier: isPortrait ? 0.7 : 1,
+            verticalOffsetMultiplier: isPortrait ? 1 : 0.8,
+        };
+    }
+
+    if (viewportWidth <= TABLET_MAX_WIDTH) {
+        return {
+            sizeMultiplier: 0.9,
+            horizontalOffsetMultiplier: isPortrait ? 1 : 0.9,
+            verticalOffsetMultiplier: isPortrait ? 1 : 0.9,
+        };
+    }
+
+    return {
+        sizeMultiplier: 1,
+        horizontalOffsetMultiplier: isPortrait ? 0.9 : 1.6,
+        verticalOffsetMultiplier: isPortrait ? 1.1 : 1,
+    };
+}
+
+export function projectSkyDirectionToScreen(
+    direction: Vector3,
+    basis: SkyViewBasis,
+    {
+        horizontalOffsetMultiplier = 1,
+        screenOffsetMultiplier = 1,
+        verticalOffsetMultiplier = 1,
+    }: {
+        horizontalOffsetMultiplier?: number;
+        screenOffsetMultiplier?: number;
+        verticalOffsetMultiplier?: number;
+    },
+    target = new Vector2(),
+) {
+    const x =
+        basis.halfWidth === 0
+            ? 0
+            : (direction.dot(basis.right) *
+                  basis.skyRadius *
+                  screenOffsetMultiplier *
+                  horizontalOffsetMultiplier) /
+              basis.halfWidth;
+    const y =
+        basis.halfHeight === 0
+            ? 0
+            : (direction.dot(basis.viewUp) *
+                  basis.skyRadius *
+                  screenOffsetMultiplier *
+                  verticalOffsetMultiplier) /
+              basis.halfHeight;
+
+    return target.set(x, y);
+}


### PR DESCRIPTION
## Summary
- add a shader-backed sky gradient that follows the sun and moon positions
- keep neutral daytime bright with a pale-blue upper sky, warm horizon, and strong midday sun glow
- share sky projection/color helpers with SunMoon and add Storybook tuning stories

## Validation
- corepack pnpm --filter @gredice/game lint
- corepack pnpm --filter @gredice/game test
- corepack pnpm --filter @gredice/game typecheck
- corepack pnpm --filter garden typecheck
- corepack pnpm --filter storybook lint
- corepack pnpm --filter storybook typecheck
- corepack pnpm --filter storybook build
- git diff --check

## Visual verification
- verified http://localhost:3301/debug/profile/game?quality=high&details=1&controls=1&debugHud=1 renders the canvas and debug HUD without console errors