### PR TITLE
fix(www): use pnpm install for vercel

### DIFF
--- a/.github/workflows/nextjs_ci_reusable.yml
+++ b/.github/workflows/nextjs_ci_reusable.yml
@@ -154,7 +154,12 @@ jobs:
 
       - name: 📦️ Install playwright browsers
         if: steps.playwright.outputs.enabled == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
+        run: |
+          mapfile -t microsoft_sources < <(grep -rl 'packages.microsoft.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null || true)
+          if [ "${#microsoft_sources[@]}" -gt 0 ]; then
+            sudo rm -f "${microsoft_sources[@]}"
+          fi
+          pnpm exec playwright install --with-deps chromium
         working-directory: ${{ inputs.path }}/
 
       - name: ⚒️ Test app

--- a/apps/www/vercel.json
+++ b/apps/www/vercel.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "installCommand": "pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
## Summary
- add a www Vercel config so preview builds run `pnpm install --frozen-lockfile`
- make Playwright browser setup ignore broken `packages.microsoft.com` apt sources before installing system deps

## Validation
- `node -e "JSON.parse(require('node:fs').readFileSync('apps/www/vercel.json','utf8'))"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/nextjs_ci_reusable.yml'); puts 'ok'"`
- `git diff --check`

## Context
The red check on #3921 was the external `Vercel – www` preview. Its log failed with `NEXT_NO_VERSION` after Vercel ran `npm install --prefix=../..` and missed app dependencies when no cache was available. The first #3922 run confirmed the Vercel fix by running `pnpm install --frozen-lockfile` and detecting Next.js, then exposed an unrelated GitHub Actions failure where `playwright install --with-deps chromium` failed on 403s from `packages.microsoft.com`.