### PR TITLE
fix(game): darken sky floor after sunset

### DIFF
--- a/apps/storybook/stories/packages/game/scene/SkyGradient.stories.tsx
+++ b/apps/storybook/stories/packages/game/scene/SkyGradient.stories.tsx
@@ -169,7 +169,7 @@ function buildSkyGradientCss({
         `linear-gradient(180deg, ${colorToCss(gradient.zenith)} 0%, ${colorToCss(
             gradient.upper,
         )} 28%, ${colorToCss(gradient.horizon)} 68%, ${colorToCss(
-            gradient.horizon,
+            gradient.lower,
         )} 100%)`,
     ].join(', ');
 }

--- a/packages/game/src/scene/SkyGradientBackground.tsx
+++ b/packages/game/src/scene/SkyGradientBackground.tsx
@@ -46,6 +46,7 @@ const skyGradientFragment = /* glsl */ `
     uniform vec3 uZenithColor;
     uniform vec3 uUpperColor;
     uniform vec3 uHorizonColor;
+    uniform vec3 uLowerColor;
     uniform vec3 uSunGlowColor;
     uniform vec3 uMoonGlowColor;
     uniform float uSunGlowIntensity;
@@ -61,7 +62,7 @@ const skyGradientFragment = /* glsl */ `
 
     void main() {
         float y = clamp(vUv.y, 0.0, 1.0);
-        vec3 color = uHorizonColor;
+        vec3 color = mix(uLowerColor, uHorizonColor, smoothstep(0.0, 0.42, y));
         color = mix(color, uUpperColor, smoothstep(0.38, 0.84, y));
         color = mix(color, uZenithColor, smoothstep(0.76, 1.0, y));
 
@@ -123,6 +124,7 @@ function applyGradientUniforms(
     copyColorUniform(material, 'uZenithColor', gradient.zenith);
     copyColorUniform(material, 'uUpperColor', gradient.upper);
     copyColorUniform(material, 'uHorizonColor', gradient.horizon);
+    copyColorUniform(material, 'uLowerColor', gradient.lower);
     copyColorUniform(material, 'uSunGlowColor', gradient.sunGlow);
     copyColorUniform(material, 'uMoonGlowColor', gradient.moonGlow);
     material.uniforms.uSunGlowIntensity.value = gradient.sunGlowIntensity;
@@ -166,6 +168,7 @@ export function SkyGradientBackground({
                     uZenithColor: { value: new Color('#e6f6ff') },
                     uUpperColor: { value: new Color('#f1f3ea') },
                     uHorizonColor: { value: new Color('#fff9ea') },
+                    uLowerColor: { value: new Color('#fff9ea') },
                     uSunGlowColor: { value: new Color('#fff1bd') },
                     uMoonGlowColor: { value: new Color('#d9e8ff') },
                     uSunGlowIntensity: { value: 0 },

--- a/packages/game/src/scene/skyGradient.ts
+++ b/packages/game/src/scene/skyGradient.ts
@@ -302,10 +302,13 @@ export function resolveSkyGradientColors({
     const overcast = clamp01(cloudy + foggy * 0.7 + rainy * 0.25);
     const visibleMoonlight = clamp01(moonlight);
     const twilightWarmth = dusk > 0.5 ? '#ff9f7c' : '#ffd59c';
-    const postSunsetDarkening = smoothstep(
-        visualDayNightTimes.sunset,
-        visualDayNightTimes.nightStart,
-        timeOfDay,
+    const nightFloorDarkening = Math.max(
+        night,
+        smoothstep(
+            visualDayNightTimes.sunset,
+            visualDayNightTimes.nightStart,
+            timeOfDay,
+        ),
     );
 
     const base = backgroundColor.clone();
@@ -326,21 +329,21 @@ export function resolveSkyGradientColors({
         .lerp(colorFromHex('#6f8fb7'), night * visibleMoonlight * 0.08);
 
     const horizon = shiftHsl(base, {
-        lightnessOffset: 0.035 + daylight * 0.035 - postSunsetDarkening * 0.045,
+        lightnessOffset: 0.035 + daylight * 0.035 - nightFloorDarkening * 0.045,
         saturationScale: 1.02 + twilight * 0.2,
     })
         .lerp(
             theme.light,
-            (0.28 + daylight * 0.16) * (1 - postSunsetDarkening * 0.72),
+            (0.28 + daylight * 0.16) * (1 - nightFloorDarkening * 0.72),
         )
         .lerp(colorFromHex(twilightWarmth), twilight * 0.35)
-        .lerp(theme.night, postSunsetDarkening * 0.28 + night * 0.18)
+        .lerp(theme.night, nightFloorDarkening * 0.28 + night * 0.18)
         .lerp(colorFromHex('#9fb4d4'), night * visibleMoonlight * 0.1);
 
     const lower = horizon
         .clone()
-        .lerp(theme.night, postSunsetDarkening * 0.5 + night * 0.16)
-        .lerp(zenith, postSunsetDarkening * 0.1);
+        .lerp(theme.night, nightFloorDarkening * 0.5 + night * 0.16)
+        .lerp(zenith, nightFloorDarkening * 0.1);
 
     const weatherTone = {
         cloudy: overcast,

--- a/packages/game/src/scene/skyGradient.ts
+++ b/packages/game/src/scene/skyGradient.ts
@@ -302,6 +302,11 @@ export function resolveSkyGradientColors({
     const overcast = clamp01(cloudy + foggy * 0.7 + rainy * 0.25);
     const visibleMoonlight = clamp01(moonlight);
     const twilightWarmth = dusk > 0.5 ? '#ff9f7c' : '#ffd59c';
+    const postSunsetDarkening = smoothstep(
+        visualDayNightTimes.sunset,
+        visualDayNightTimes.nightStart,
+        timeOfDay,
+    );
 
     const base = backgroundColor.clone();
     const zenith = shiftHsl(base, {
@@ -321,14 +326,21 @@ export function resolveSkyGradientColors({
         .lerp(colorFromHex('#6f8fb7'), night * visibleMoonlight * 0.08);
 
     const horizon = shiftHsl(base, {
-        lightnessOffset: 0.035 + daylight * 0.035,
+        lightnessOffset: 0.035 + daylight * 0.035 - postSunsetDarkening * 0.045,
         saturationScale: 1.02 + twilight * 0.2,
     })
-        .lerp(theme.light, 0.28 + daylight * 0.16)
+        .lerp(
+            theme.light,
+            (0.28 + daylight * 0.16) * (1 - postSunsetDarkening * 0.72),
+        )
         .lerp(colorFromHex(twilightWarmth), twilight * 0.35)
+        .lerp(theme.night, postSunsetDarkening * 0.28 + night * 0.18)
         .lerp(colorFromHex('#9fb4d4'), night * visibleMoonlight * 0.1);
 
-    const lower = horizon.clone();
+    const lower = horizon
+        .clone()
+        .lerp(theme.night, postSunsetDarkening * 0.5 + night * 0.16)
+        .lerp(zenith, postSunsetDarkening * 0.1);
 
     const weatherTone = {
         cloudy: overcast,

--- a/packages/game/src/scene/skyGradient.unit.ts
+++ b/packages/game/src/scene/skyGradient.unit.ts
@@ -82,6 +82,16 @@ test('neutral post-sunset sky darkens the lower background', () => {
     assert.ok(colorLuminance(gradient.lower) < 0.35);
 });
 
+test('neutral after-midnight sky keeps the lower background dark', () => {
+    const gradient = resolveGradient({
+        moonlight: 0.45,
+        timeOfDay: 0.04,
+    });
+
+    assert.ok(colorLuminance(gradient.horizon) < 0.16);
+    assert.ok(colorLuminance(gradient.lower) < 0.12);
+});
+
 test('background palettes tint the same time of day differently', () => {
     const blueGradient = resolveGradient({
         paletteIndex: getGameBackgroundPaletteIndexByKey('light-blue'),

--- a/packages/game/src/scene/skyGradient.unit.ts
+++ b/packages/game/src/scene/skyGradient.unit.ts
@@ -22,6 +22,10 @@ function colorDistance(
     );
 }
 
+function colorLuminance(color: { b: number; g: number; r: number }) {
+    return color.r * 0.2126 + color.g * 0.7152 + color.b * 0.0722;
+}
+
 function resolveGradient({
     moonlight = 0,
     paletteIndex = defaultGameBackgroundPaletteIndex,
@@ -63,6 +67,19 @@ test('neutral daytime sky resolves to a visible gradient', () => {
     assert.ok(colorDistance(gradient.upper, gradient.horizon) > 0.015);
     assert.ok(colorDistance(gradient.lower, gradient.horizon) < 0.001);
     assert.ok(gradient.sunGlowIntensity > 0.4);
+});
+
+test('neutral post-sunset sky darkens the lower background', () => {
+    const gradient = resolveGradient({
+        moonlight: 0.45,
+        timeOfDay: 0.87,
+    });
+
+    assert.ok(
+        colorLuminance(gradient.lower) <
+            colorLuminance(gradient.horizon) - 0.025,
+    );
+    assert.ok(colorLuminance(gradient.lower) < 0.35);
 });
 
 test('background palettes tint the same time of day differently', () => {


### PR DESCRIPTION
## Summary
- Darken the lower sky gradient after sunset so the bottom of the scene no longer stays bright.
- Wire the shared lower gradient stop into the Three.js sky shader.
- Update the SkyGradient Storybook preview and add regression coverage for post-sunset lower-sky brightness.

## Validation
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter storybook typecheck`
- `corepack pnpm --filter @gredice/game exec biome check src/scene/skyGradient.ts src/scene/SkyGradientBackground.tsx src/scene/skyGradient.unit.ts`
- `corepack pnpm --filter storybook exec biome check stories/packages/game/scene/SkyGradient.stories.tsx`
- `git diff --check`
- Browser smoke check on `/debug/profile/game?mode=night&quality=high&details=1&controls=1&debugHud=1` with no console errors