### PR TITLE
feat(game): chunk terrain and improve water rendering

### DIFF
--- a/docs/game-scene-performance.md
+++ b/docs/game-scene-performance.md
@@ -59,6 +59,23 @@ not accidentally based on `next dev`.
   overlay meshes. Instanced block control wrappers are skipped for no-control
   profile scenes and for covered instanced blocks, so stacked scenes no longer
   mount buried grass controls under every top block.
+- The 2026-07-03 terrain/water chunk pass added merged geometry output for
+  stable grass, sand, snow, and dirt terrain chunks while preserving the
+  existing instanced path for animated or interactive blocks. Water tops now
+  batch many foam-edge variants inside chunk meshes with per-vertex foam
+  and shore-depth attributes, and merged water side walls are partitioned by
+  chunk while still checking all water neighbors to avoid chunk-boundary side
+  seams. Water meshes carry sampled depth-map attributes: top surfaces grade by
+  water-column depth plus shaped terrain angle/corner depth under the surface,
+  then smooth those samples across adjacent top surfaces so flat stepped
+  columns shade as a continuous depth field instead of abrupt per-block bands.
+  Shore-distance color also uses smoothed per-vertex samples so flat water near
+  banks, islands, and garden edges fades toward deeper color gradually. Side
+  faces receive the same smoothed top-edge depth and shore samples, matching the
+  top color at the bend before easing darker down the wall. Shore foam still
+  follows exposed edges, and color/opacity ease continuously with depth instead
+  of snapping at a fixed block threshold. Production profile runs should be used
+  for before/after budget decisions.
 - Snow and rain overlays are optimized for repeated instanced blocks, but many
   non-instanced entities can still mount per-block `SnowOverlay` or
   `RainWetOverlay` meshes when weather makes them visible, so snow/rain profiles

--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -26,6 +26,10 @@ import { useGameGLTF } from '../utils/useGameGLTF';
 import { useWaterBlockMaterial } from './BlockWater';
 import { getCactusVariantConfig } from './Cactus';
 import {
+    chunkMeshInstances,
+    type MeshInstanceChunk,
+} from './chunkedMeshGeometry';
+import {
     type EntityBlockInstance,
     EntityInstancesBlock,
     type EntityInstancesBlockBaseProps,
@@ -47,18 +51,30 @@ import {
     resolveRaisedBedWateringVisualRewards,
 } from './raisedBed/raisedBedSoilWetPatches';
 import {
+    getWaterBlockColumnSurfaceY,
+    getWaterBlockDepthSamples,
+    type WaterBlockDepthSamples,
+} from './waterBlockDepth';
+import {
     resolveWaterFoamCorners,
     resolveWaterFoamEdges,
 } from './waterBlockFoam';
-import {
-    createMergedWaterSideGeometry,
-    createWaterBlockGeometry,
-} from './waterBlockGeometry';
+import { createMergedWaterSideGeometry } from './waterBlockGeometry';
 import {
     getWaterBlockCenterY,
     getWaterBlockVisualHeight,
 } from './waterBlockHeight';
 import { isWaterBlockTopSurfaceVisible } from './waterBlockSurface';
+import {
+    chunkWaterTopInstances,
+    createWaterTopChunkGeometry,
+    type WaterTopChunkInstance,
+} from './waterChunkGeometry';
+import { smoothWaterTopDepthSamples } from './waterDepthSmoothing';
+import {
+    resolveWaterShoreDepthSamples,
+    resolveWaterShoreDepths,
+} from './waterShoreDepth';
 
 type CommonWeatherProps = Pick<
     EntityInstancesBlockBaseProps,
@@ -95,8 +111,14 @@ type LoadedAssetBlockMaterialProps = Omit<
     material: (gltf: GLTFResult) => Material | Material[];
 };
 type WaterBlockInstance = EntityBlockInstance & {
+    depth: number;
+    depthSamples: WaterBlockDepthSamples;
+    shoreDepthSamples?: WaterBlockDepthSamples;
+    surfaceY: number;
     waterHeight: number;
 };
+
+const emptyWaterDepthSamples: WaterBlockDepthSamples = [0, 0, 0, 0];
 
 const gardenBoxTooltipDurationMs = 3600;
 const gardenBoxTooltipYOffset = 1.25;
@@ -386,6 +408,7 @@ function BlockGroundInstances({
                     slopeExponent: 3.2,
                     noiseScale: 1.7,
                 }}
+                renderStableChunksAsMergedGeometry
                 {...commonSnowProps}
             />
             <EntityInstancesGeometry
@@ -398,6 +421,7 @@ function BlockGroundInstances({
                     slopeExponent: 3.2,
                     noiseScale: 1.7,
                 }}
+                renderStableChunksAsMergedGeometry
                 {...commonSnowProps}
             />
         </>
@@ -421,8 +445,21 @@ function WaterBlockInstances({ stacks }: { stacks: Stack[] | undefined }) {
                 const previewYOffset =
                     instance.position[1] - instance.stackHeight;
 
+                const depthSamples = getWaterBlockDepthSamples({
+                    block: instance.block,
+                    blockData,
+                    stack: instance.stack,
+                });
+
                 return {
                     ...instance,
+                    depth: Math.max(...depthSamples),
+                    depthSamples,
+                    surfaceY: getWaterBlockColumnSurfaceY({
+                        block: instance.block,
+                        blockData,
+                        stack: instance.stack,
+                    }),
                     position: [
                         instance.position[0],
                         getWaterBlockCenterY({
@@ -437,162 +474,200 @@ function WaterBlockInstances({ stacks }: { stacks: Stack[] | undefined }) {
             }),
         [baseWaterInstances, blockData],
     );
+    const topSurfaceInstances = useMemo(() => {
+        const topInstances =
+            waterInstances
+                ?.filter(isWaterBlockTopSurfaceVisible)
+                .map((instance): WaterTopChunkInstance => {
+                    const foamEdges = resolveWaterFoamEdges({
+                        block: instance.block,
+                        blockData,
+                        stack: instance.stack,
+                        stacks,
+                    });
+                    const foamCorners = resolveWaterFoamCorners({
+                        block: instance.block,
+                        blockData,
+                        stack: instance.stack,
+                        stacks,
+                    });
+
+                    return {
+                        foamCorners,
+                        foamEdges,
+                        depthSamples: instance.depthSamples,
+                        position: instance.position,
+                        rotation: 0,
+                        shoreDepth: 0,
+                        surfaceY: instance.surfaceY,
+                        waterHeight: instance.waterHeight,
+                    };
+                }) ?? [];
+        const shoreDepths = resolveWaterShoreDepths(topInstances);
+        const smoothedTopInstances = smoothWaterTopDepthSamples(
+            topInstances.map((instance, index) => ({
+                ...instance,
+                shoreDepth: shoreDepths[index] ?? 0,
+            })),
+        );
+        const shoreDepthSamples =
+            resolveWaterShoreDepthSamples(smoothedTopInstances);
+
+        return smoothedTopInstances.map((instance, index) => ({
+            ...instance,
+            shoreDepthSamples:
+                shoreDepthSamples[index] ?? emptyWaterDepthSamples,
+        }));
+    }, [blockData, stacks, waterInstances]);
+    const sideSurfaceInstances = useMemo(() => {
+        const samplesByColumn = new Map<string, WaterTopChunkInstance>();
+
+        for (const instance of topSurfaceInstances) {
+            samplesByColumn.set(waterColumnSampleKey(instance), instance);
+        }
+
+        return (
+            waterInstances?.map((instance): WaterBlockInstance => {
+                const sampledSurface = samplesByColumn.get(
+                    waterColumnSampleKey(instance),
+                );
+
+                return sampledSurface
+                    ? {
+                          ...instance,
+                          depthSamples: sampledSurface.depthSamples,
+                          shoreDepthSamples: sampledSurface.shoreDepthSamples,
+                      }
+                    : instance;
+            }) ?? []
+        );
+    }, [topSurfaceInstances, waterInstances]);
 
     if (!waterInstances?.length) {
         return null;
     }
 
-    const topSurfaceInstances = waterInstances.filter(
-        isWaterBlockTopSurfaceVisible,
-    );
-    const groupedInstances = resolveWaterBlockInstanceGroups({
-        blockData,
-        instances: topSurfaceInstances,
-        stacks,
-    });
-
     return (
         <>
-            {groupedInstances.map((mask) => (
-                <WaterBlockMaskInstances
-                    key={`Block_Water-${mask.key}`}
-                    foamCorners={mask.foamCorners}
-                    foamEdges={mask.foamEdges}
-                    instances={mask.instances}
-                    maskKey={mask.key}
-                    waterHeight={mask.waterHeight}
-                />
-            ))}
-            <WaterBlockMergedSides instances={waterInstances} />
+            <WaterBlockTopChunks instances={topSurfaceInstances} />
+            <WaterBlockMergedSides instances={sideSurfaceInstances} />
         </>
     );
 }
 
-function foamEdgeKey(foamEdges: Vector4) {
-    return `${foamEdges.x}${foamEdges.y}${foamEdges.z}${foamEdges.w}`;
+function waterColumnSampleKey({
+    position,
+    surfaceY,
+}: Pick<WaterTopChunkInstance, 'position' | 'surfaceY'>) {
+    return `${position[0]}|${position[2]}|${surfaceY.toFixed(6)}`;
 }
 
-function waterFoamMaskKey({
-    foamCorners,
-    foamEdges,
-    waterHeight,
-}: {
-    foamCorners: Vector4;
-    foamEdges: Vector4;
-    waterHeight: number;
-}) {
-    return `${foamEdgeKey(foamEdges)}-${foamEdgeKey(foamCorners)}-${waterHeight}`;
-}
+const mergedWaterSideFoamEdges = new Vector4(0, 0, 0, 0);
+const mergedWaterTopFoamEdges = new Vector4(0, 0, 0, 0);
+const mergedWaterTopFoamCorners = new Vector4(0, 0, 0, 0);
 
-function resolveWaterBlockInstanceGroups({
-    blockData,
+function WaterBlockTopChunks({
     instances,
-    stacks,
 }: {
-    blockData: Parameters<typeof resolveWaterFoamEdges>[0]['blockData'];
-    instances: WaterBlockInstance[];
-    stacks: Stack[] | undefined;
+    instances: WaterTopChunkInstance[];
 }) {
-    const groupedInstances = new Map<
-        string,
+    const chunks = useMemo(
+        () => chunkWaterTopInstances(instances),
+        [instances],
+    );
+    const material = useWaterBlockMaterial(
+        mergedWaterTopFoamEdges,
+        false,
+        mergedWaterTopFoamCorners,
         {
-            foamCorners: Vector4;
-            foamEdges: Vector4;
-            instances: WaterBlockInstance[];
-            key: string;
-            waterHeight: number;
-        }
-    >();
+            useFoamAttributes: true,
+            useWaterDepthAttribute: true,
+            useShoreDepthAttribute: true,
+            useLocalPositionAttribute: true,
+        },
+    );
 
-    for (const instance of instances) {
-        const { waterHeight } = instance;
-        const foamEdges = resolveWaterFoamEdges({
-            block: instance.block,
-            blockData,
-            stack: instance.stack,
-            stacks,
-        });
-        const foamCorners = resolveWaterFoamCorners({
-            block: instance.block,
-            blockData,
-            stack: instance.stack,
-            stacks,
-        });
-        const key = waterFoamMaskKey({
-            foamCorners,
-            foamEdges,
-            waterHeight,
-        });
-        const group = groupedInstances.get(key);
-
-        if (group) {
-            group.instances.push(instance);
-        } else {
-            groupedInstances.set(key, {
-                foamCorners,
-                foamEdges,
-                instances: [instance],
-                key,
-                waterHeight,
-            });
-        }
-    }
-
-    return [...groupedInstances.values()];
+    return chunks.map((chunk) => (
+        <WaterBlockTopChunk
+            key={`Block_Water_Top:${chunk.key}`}
+            chunk={chunk}
+            material={material}
+        />
+    ));
 }
 
-function WaterBlockMaskInstances({
-    foamCorners,
-    foamEdges,
-    instances,
-    maskKey,
-    waterHeight,
+function WaterBlockTopChunk({
+    chunk,
+    material,
 }: {
-    foamCorners: Vector4;
-    foamEdges: Vector4;
-    instances: WaterBlockInstance[];
-    maskKey: string;
-    waterHeight: number;
+    chunk: MeshInstanceChunk<WaterTopChunkInstance>;
+    material: ReturnType<typeof useWaterBlockMaterial>;
 }) {
-    const material = useWaterBlockMaterial(foamEdges, true, foamCorners);
     const geometry = useMemo(
-        () =>
-            createWaterBlockGeometry(foamEdges, {
-                height: waterHeight,
-                includeSides: false,
-            }),
-        [foamEdges, waterHeight],
+        () => createWaterTopChunkGeometry(chunk.instances),
+        [chunk.instances],
     );
 
     useEffect(() => () => geometry.dispose(), [geometry]);
 
-    if (instances.length === 0) {
+    if ((geometry.getIndex()?.count ?? 0) === 0) {
         return null;
     }
 
     return (
-        <EntityInstancesGeometry
-            instanceKey={`Block_Water-${maskKey}`}
-            instances={instances}
+        <mesh
+            castShadow={false}
+            receiveShadow
             geometry={geometry}
             material={material}
-            castShadow={false}
+            name={`WaterTopChunk:${chunk.key}:count:${chunk.instances.length}`}
             renderOrder={1}
+            raycast={() => null}
         />
     );
 }
-
-const mergedWaterSideFoamEdges = new Vector4(0, 0, 0, 0);
 
 function WaterBlockMergedSides({
     instances,
 }: {
     instances: WaterBlockInstance[];
 }) {
-    const material = useWaterBlockMaterial(mergedWaterSideFoamEdges, false);
+    const material = useWaterBlockMaterial(
+        mergedWaterSideFoamEdges,
+        false,
+        undefined,
+        {
+            useWaterDepthAttribute: true,
+            useShoreDepthAttribute: true,
+        },
+    );
+    const chunks = useMemo(() => chunkMeshInstances(instances), [instances]);
+
+    return chunks.map((chunk) => (
+        <WaterBlockMergedSideChunk
+            key={`Block_Water_Sides:${chunk.key}`}
+            allInstances={instances}
+            chunk={chunk}
+            material={material}
+        />
+    ));
+}
+
+function WaterBlockMergedSideChunk({
+    allInstances,
+    chunk,
+    material,
+}: {
+    allInstances: WaterBlockInstance[];
+    chunk: MeshInstanceChunk<WaterBlockInstance>;
+    material: ReturnType<typeof useWaterBlockMaterial>;
+}) {
     const geometry = useMemo(
-        () => createMergedWaterSideGeometry(instances),
-        [instances],
+        () =>
+            createMergedWaterSideGeometry(chunk.instances, {
+                neighborInstances: allInstances,
+            }),
+        [allInstances, chunk.instances],
     );
     const hasSideFaces = (geometry.getIndex()?.count ?? 0) > 0;
 
@@ -608,6 +683,7 @@ function WaterBlockMergedSides({
             receiveShadow={false}
             geometry={geometry}
             material={material}
+            name={`WaterSideChunk:${chunk.key}:count:${chunk.instances.length}`}
             renderOrder={1}
             raycast={() => null}
         />
@@ -2336,6 +2412,7 @@ function SimpleAdditionalInstances({
                     slopeExponent: 2.2,
                     noiseScale: 1.8,
                 }}
+                renderStableChunksAsMergedGeometry
                 {...commonSnowProps}
             />
             <AssetBlock
@@ -2351,6 +2428,7 @@ function SimpleAdditionalInstances({
                     slopeExponent: 2.2,
                     noiseScale: 1.8,
                 }}
+                renderStableChunksAsMergedGeometry
                 {...commonSnowProps}
             />
             <AssetBlock
@@ -2370,6 +2448,7 @@ function SimpleAdditionalInstances({
                     slopeExponent: 2.2,
                     noiseScale: 1.8,
                 }}
+                renderStableChunksAsMergedGeometry
                 {...commonSnowProps}
             />
             <AssetBlock

--- a/packages/game/src/entities/BlockWater.tsx
+++ b/packages/game/src/entities/BlockWater.tsx
@@ -201,7 +201,7 @@ void main() {
 
     // Edge foam follows the global shore-distance field on chunked water, so
     // the pattern can cross tile boundaries and softly fade away from banks.
-    float edgeWidth = mix(0.5, 0.32, smoothstep(0.12, 1.45, shoreDepth));
+    float edgeWidth = mix(0.34, 0.22, smoothstep(0.08, 0.9, shoreDepth));
     float negXBand = 1.0 - smoothstep(0.0, edgeWidth, vLocalPosition.x + 0.5);
     float posXBand = 1.0 - smoothstep(0.0, edgeWidth, 0.5 - vLocalPosition.x);
     float negZBand = 1.0 - smoothstep(0.0, edgeWidth, vLocalPosition.z + 0.5);
@@ -222,8 +222,8 @@ void main() {
     float shoreFoamFade = max(localEdgeBand, localCornerBand);
     float shoreFoamCore = shoreFoamFade;
 #ifdef USE_WATER_SHORE_DEPTH_ATTRIBUTE
-    shoreFoamFade = 1.0 - smoothstep(0.08, 1.05, shoreDepth);
-    shoreFoamCore = 1.0 - smoothstep(0.0, 0.34, shoreDepth);
+    shoreFoamFade = 1.0 - smoothstep(0.03, 0.62, shoreDepth);
+    shoreFoamCore = 1.0 - smoothstep(0.0, 0.22, shoreDepth);
 #endif
     float globalFoam = max(
         foamMotion(topUv, 0.0),

--- a/packages/game/src/entities/BlockWater.tsx
+++ b/packages/game/src/entities/BlockWater.tsx
@@ -6,6 +6,7 @@ import { useSceneTimeUniform } from '../scene/SceneTime';
 import { defaultWaterColors } from '../scene/waterColors';
 import type { EntityInstanceProps } from '../types/runtime/EntityInstanceProps';
 import { useGameState } from '../useGameState';
+import { getWaterBlockDepthSamples } from './waterBlockDepth';
 import {
     resolveWaterFoamCorners,
     resolveWaterFoamEdges,
@@ -18,11 +19,32 @@ import {
 import { isWaterBlockTopSurfaceVisible } from './waterBlockSurface';
 
 const waterVertexShader = `
+uniform float uWaterDepth;
+
 varying vec3 vLocalPosition;
 varying vec3 vLocalNormal;
 varying vec3 vWorldPosition;
 varying vec3 vWorldNormal;
 varying float vTopness;
+varying float vWaterDepth;
+varying float vWaterSurfaceY;
+varying float vWaterShoreDepth;
+#ifdef USE_WATER_LOCAL_POSITION_ATTRIBUTE
+attribute vec3 waterLocalPosition;
+#endif
+#ifdef USE_WATER_DEPTH_ATTRIBUTE
+attribute float waterDepth;
+attribute float waterSurfaceY;
+#endif
+#ifdef USE_WATER_SHORE_DEPTH_ATTRIBUTE
+attribute float waterShoreDepth;
+#endif
+#ifdef USE_WATER_FOAM_ATTRIBUTES
+attribute vec4 waterFoamEdges;
+attribute vec4 waterFoamCorners;
+varying vec4 vFoamEdges;
+varying vec4 vFoamCorners;
+#endif
 
 void main() {
     vec4 worldPosition = vec4(position, 1.0);
@@ -37,10 +59,27 @@ void main() {
     #endif
 
     vLocalPosition = position;
+#ifdef USE_WATER_LOCAL_POSITION_ATTRIBUTE
+    vLocalPosition = waterLocalPosition;
+#endif
     vLocalNormal = normal;
     vWorldPosition = worldPosition.xyz;
     vWorldNormal = normalize(mat3(modelMatrix) * objectNormal);
     vTopness = smoothstep(0.5, 0.95, normal.y);
+    vWaterDepth = uWaterDepth;
+    vWaterSurfaceY = worldPosition.y;
+#ifdef USE_WATER_DEPTH_ATTRIBUTE
+    vWaterDepth = waterDepth;
+    vWaterSurfaceY = waterSurfaceY;
+#endif
+    vWaterShoreDepth = 0.0;
+#ifdef USE_WATER_SHORE_DEPTH_ATTRIBUTE
+    vWaterShoreDepth = waterShoreDepth;
+#endif
+#ifdef USE_WATER_FOAM_ATTRIBUTES
+    vFoamEdges = waterFoamEdges;
+    vFoamCorners = waterFoamCorners;
+#endif
 
     gl_Position = projectionMatrix * viewMatrix * worldPosition;
 }
@@ -60,6 +99,13 @@ varying vec3 vLocalNormal;
 varying vec3 vWorldPosition;
 varying vec3 vWorldNormal;
 varying float vTopness;
+varying float vWaterDepth;
+varying float vWaterSurfaceY;
+varying float vWaterShoreDepth;
+#ifdef USE_WATER_FOAM_ATTRIBUTES
+varying vec4 vFoamEdges;
+varying vec4 vFoamCorners;
+#endif
 
 float hash21(vec2 p) {
     return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
@@ -76,24 +122,62 @@ float valueNoise(vec2 p) {
     return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
 }
 
-float foamMotion(float along, float seed) {
-    float wave = sin(along * 5.2 + uTime * 2.15 + seed) * 0.5 + 0.5;
-    float broken = valueNoise(vec2(along * 1.25 + seed, uTime * 0.72));
-    return smoothstep(0.24, 0.82, mix(wave, broken, 0.28));
+float foamMotion(vec2 p, float seed) {
+    float foamTime = uTime * 1.7;
+    vec2 driftA = vec2(foamTime * 0.045, -foamTime * 0.035);
+    vec2 driftB = vec2(-foamTime * 0.028, foamTime * 0.032);
+    float broad = valueNoise(p * 1.85 + driftA + vec2(seed, seed * 0.37));
+    float broken = valueNoise(p * 4.9 + driftB + vec2(seed * 1.91, -seed * 0.73));
+    float flecks = valueNoise(p * 9.2 - driftA * 1.35 + vec2(seed * 3.4, seed * 1.2));
+    float thresholdDrift = valueNoise(vec2(seed * 2.17, foamTime * 0.075)) * 0.08;
+    float field = broad * 0.52 + broken * 0.34 + flecks * 0.14;
+    return smoothstep(0.34 + thresholdDrift, 0.66 + thresholdDrift, field);
 }
 
 void main() {
+    vec4 foamEdges = uFoamEdges;
+    vec4 foamCorners = uFoamCorners;
+#ifdef USE_WATER_FOAM_ATTRIBUTES
+    foamEdges = vFoamEdges;
+    foamCorners = vFoamCorners;
+#endif
+
     // Hide inner walls that face an adjacent water block — keeps the
     // tiled surface continuous instead of revealing internal partitions.
     if (uDiscardInnerEdges > 0.5) {
-        if (vLocalNormal.x < -0.7 && uFoamEdges.x < 0.5) discard;
-        if (vLocalNormal.x > 0.7 && uFoamEdges.y < 0.5) discard;
-        if (vLocalNormal.z < -0.7 && uFoamEdges.z < 0.5) discard;
-        if (vLocalNormal.z > 0.7 && uFoamEdges.w < 0.5) discard;
+        if (vLocalNormal.x < -0.7 && foamEdges.x < 0.5) discard;
+        if (vLocalNormal.x > 0.7 && foamEdges.y < 0.5) discard;
+        if (vLocalNormal.z < -0.7 && foamEdges.z < 0.5) discard;
+        if (vLocalNormal.z > 0.7 && foamEdges.w < 0.5) discard;
     }
 
     float topness = clamp(vTopness, 0.0, 1.0);
     float sideness = 1.0 - topness;
+    float columnDepth = max(vWaterDepth, 0.0);
+    float fragmentDepth = max((vWaterSurfaceY - vWorldPosition.y) / 0.4, 0.0);
+    float shoreDepth = max(vWaterShoreDepth, 0.0);
+    float columnDepth01 = smoothstep(0.02, 2.35, columnDepth);
+    float volumeDepth01 = smoothstep(0.02, 2.35, fragmentDepth);
+    float sideVertical01 = smoothstep(0.0, 1.35, fragmentDepth);
+    float sideDepth01 = clamp(
+        max(columnDepth01, volumeDepth01 * 0.72) +
+            sideVertical01 * mix(0.16, 0.08, columnDepth01),
+        0.0,
+        1.0
+    );
+    float depthMap01 = mix(sideDepth01, columnDepth01, topness);
+    float shoreInfluence = 1.0 - smoothstep(0.0, 0.95, shoreDepth);
+    float coastDepthLift = smoothstep(0.28, 1.1, shoreDepth) * (1.0 - depthMap01) * 0.06;
+    float depth01 = clamp(depthMap01 + coastDepthLift, 0.0, 1.0);
+    depth01 = mix(
+        depth01,
+        min(depth01, 0.06 + columnDepth01 * 0.2),
+        shoreInfluence * topness
+    );
+    float deepInfluence = max(
+        smoothstep(1.05, 2.6, shoreDepth) * 0.12,
+        smoothstep(0.18, 0.88, depth01)
+    );
     vec2 topUv = vWorldPosition.xz;
 
     // Broad, low-detail surface patches drift over the top face only.
@@ -103,51 +187,67 @@ void main() {
     float surfaceB = valueNoise(topUv * 1.35 + surfaceFlowB);
     float toonLight = smoothstep(0.46, 0.74, surfaceA);
     float toonDark = smoothstep(0.54, 0.82, 1.0 - surfaceB);
-    float surfacePattern = (toonLight * 0.18 - toonDark * 0.12) * topness;
+    float causticLines = smoothstep(
+        0.86,
+        0.995,
+        sin((topUv.x + topUv.y * 0.56) * 7.2 + uTime * 0.75 + surfaceA * 2.1) * 0.5 + 0.5
+    );
+    float shallowCaustics = causticLines * shoreInfluence * topness * 0.1;
+    float surfacePattern =
+        (toonLight * 0.18 - toonDark * 0.12 + shallowCaustics) *
+        topness *
+        mix(1.1, 0.7, depth01);
     float tonalShift = surfacePattern;
 
     // Edge foam — only on edges facing non-water neighbours, animated
     // along the edge so it looks like the water is breaking against the bank.
-    float edgeWidth = 0.22;
+    float edgeWidth = mix(0.5, 0.32, smoothstep(0.12, 1.45, shoreDepth));
     float negXBand = 1.0 - smoothstep(0.0, edgeWidth, vLocalPosition.x + 0.5);
     float posXBand = 1.0 - smoothstep(0.0, edgeWidth, 0.5 - vLocalPosition.x);
     float negZBand = 1.0 - smoothstep(0.0, edgeWidth, vLocalPosition.z + 0.5);
     float posZBand = 1.0 - smoothstep(0.0, edgeWidth, 0.5 - vLocalPosition.z);
-    float cornerWidth = edgeWidth * 1.6;
+    float cornerWidth = edgeWidth * 1.9;
     float negXCornerBand = 1.0 - smoothstep(0.0, cornerWidth, vLocalPosition.x + 0.5);
     float posXCornerBand = 1.0 - smoothstep(0.0, cornerWidth, 0.5 - vLocalPosition.x);
     float negZCornerBand = 1.0 - smoothstep(0.0, cornerWidth, vLocalPosition.z + 0.5);
     float posZCornerBand = 1.0 - smoothstep(0.0, cornerWidth, 0.5 - vLocalPosition.z);
-    float negXEdge = negXBand * uFoamEdges.x * foamMotion(vWorldPosition.z, 0.0);
-    float posXEdge = posXBand * uFoamEdges.y * foamMotion(vWorldPosition.z, 1.7);
-    float negZEdge = negZBand * uFoamEdges.z * foamMotion(vWorldPosition.x, 3.4);
-    float posZEdge = posZBand * uFoamEdges.w * foamMotion(vWorldPosition.x, 5.1);
+    float negXEdge = negXBand * foamEdges.x * foamMotion(topUv + vec2(-1.3, 0.2), 0.0);
+    float posXEdge = posXBand * foamEdges.y * foamMotion(topUv + vec2(1.1, -0.4), 1.7);
+    float negZEdge = negZBand * foamEdges.z * foamMotion(topUv + vec2(0.4, -1.2), 3.4);
+    float posZEdge = posZBand * foamEdges.w * foamMotion(topUv + vec2(-0.2, 1.4), 5.1);
     float edgeFoam = max(max(negXEdge, posXEdge), max(negZEdge, posZEdge));
 
-    float negXNegZCorner = negXCornerBand * negZCornerBand * uFoamCorners.x * foamMotion(vWorldPosition.x + vWorldPosition.z, 6.8);
-    float posXNegZCorner = posXCornerBand * negZCornerBand * uFoamCorners.y * foamMotion(vWorldPosition.x - vWorldPosition.z, 8.5);
-    float negXPosZCorner = negXCornerBand * posZCornerBand * uFoamCorners.z * foamMotion(vWorldPosition.z - vWorldPosition.x, 10.2);
-    float posXPosZCorner = posXCornerBand * posZCornerBand * uFoamCorners.w * foamMotion(vWorldPosition.x + vWorldPosition.z, 11.9);
+    float negXNegZCorner = negXCornerBand * negZCornerBand * foamCorners.x * foamMotion(topUv + vec2(-1.0, -1.0), 6.8);
+    float posXNegZCorner = posXCornerBand * negZCornerBand * foamCorners.y * foamMotion(topUv + vec2(1.0, -1.0), 8.5);
+    float negXPosZCorner = negXCornerBand * posZCornerBand * foamCorners.z * foamMotion(topUv + vec2(-1.0, 1.0), 10.2);
+    float posXPosZCorner = posXCornerBand * posZCornerBand * foamCorners.w * foamMotion(topUv + vec2(1.0, 1.0), 11.9);
     float cornerFoam = max(max(negXNegZCorner, posXNegZCorner), max(negXPosZCorner, posXPosZCorner));
-    float foamNoise = valueNoise(topUv * 3.2 + vec2(uTime * 0.34, -uTime * 0.26));
-    edgeFoam = max(edgeFoam, cornerFoam * 0.95) * (0.78 + 0.22 * smoothstep(0.18, 0.82, foamNoise));
+    float foamNoise = valueNoise(topUv * 3.2 + vec2(uTime * 0.119, -uTime * 0.085));
+    float shoreFoamBreakup = 0.96 + 0.28 * smoothstep(0.12, 0.66, foamNoise);
+    edgeFoam =
+        max(edgeFoam, cornerFoam * 1.18) *
+        shoreFoamBreakup *
+        (1.18 + shoreInfluence * 1.35);
 
-    float topFoam = edgeFoam * topness * 0.9;
-    float fallingFoam = edgeFoam * sideness * 0.12;
+    float topFoam = smoothstep(0.06, 0.42, edgeFoam) * topness * mix(1.1, 1.75, shoreInfluence);
+    float fallingFoam = edgeFoam * sideness * 0.18;
     float foam = clamp(max(topFoam, fallingFoam), 0.0, 1.0);
 
-    float depth = clamp(0.34 + tonalShift + topness * 0.06, 0.0, 1.0);
-    vec3 water = mix(uDeepColor, uShallowColor, depth);
+    vec3 shallowWater = mix(uShallowColor, uFoamColor, shoreInfluence * topness * 0.08);
+    vec3 deepWater = mix(uDeepColor, uDeepColor * vec3(0.52, 0.72, 1.14), deepInfluence * 0.52);
+    vec3 water = mix(shallowWater, deepWater, smoothstep(0.02, 0.84, depth01));
 
     float light = clamp(dot(normalize(vWorldNormal), normalize(vec3(-0.35, 0.9, 0.25))), 0.0, 1.0);
     water *= 0.86 + light * 0.16 + topness * 0.05;
     water *= 1.0 + surfacePattern * 0.38;
+    water = mix(water, uDeepColor * vec3(0.56, 0.68, 1.08), depth01 * topness * 0.22);
 
-    float foamBlend = foam * mix(0.18, 0.85, topness);
+    float foamBlend = foam * mix(0.22, 1.0, topness) * (1.0 + shoreInfluence * 0.18);
     vec3 color = mix(water, uFoamColor, foamBlend);
-    float baseAlpha = mix(0.47, 0.42, topness);
+    float topAlpha = mix(0.48, 1.0, smoothstep(0.06, 0.72, depth01));
+    float baseAlpha = mix(0.58, topAlpha, topness);
     float surfaceAlpha = surfacePattern * 0.008;
-    float alpha = clamp(baseAlpha + surfaceAlpha + foam * 0.055 + sideness * 0.04, 0.3, 0.58);
+    float alpha = clamp(baseAlpha + surfaceAlpha + foam * 0.055 + sideness * 0.04, 0.36, 1.0);
 
     gl_FragColor = vec4(color, alpha);
     #include <colorspace_fragment>
@@ -156,17 +256,44 @@ void main() {
 
 const emptyWaterFoamCorners = new Vector4(0, 0, 0, 0);
 
+type WaterBlockMaterialOptions = {
+    useFoamAttributes?: boolean;
+    useLocalPositionAttribute?: boolean;
+    useWaterDepthAttribute?: boolean;
+    useShoreDepthAttribute?: boolean;
+    waterDepth?: number;
+};
+
 export function useWaterBlockMaterial(
     foamEdges: Vector4,
     discardInnerEdges = true,
     foamCorners: Vector4 = emptyWaterFoamCorners,
+    options: WaterBlockMaterialOptions = {},
 ) {
     const waterColors = useGameState((state) => state.waterColors);
     const timeUniform = useSceneTimeUniform();
+    const useFoamAttributes = options.useFoamAttributes === true;
+    const useLocalPositionAttribute =
+        options.useLocalPositionAttribute === true;
+    const useWaterDepthAttribute = options.useWaterDepthAttribute === true;
+    const useShoreDepthAttribute = options.useShoreDepthAttribute === true;
+    const waterDepth = options.waterDepth ?? 0;
     const material = useMemo(() => {
         const waterMaterial = new ShaderMaterial({
             vertexShader: waterVertexShader,
             fragmentShader: waterFragmentShader,
+            defines: {
+                ...(useFoamAttributes ? { USE_WATER_FOAM_ATTRIBUTES: '' } : {}),
+                ...(useLocalPositionAttribute
+                    ? { USE_WATER_LOCAL_POSITION_ATTRIBUTE: '' }
+                    : {}),
+                ...(useWaterDepthAttribute
+                    ? { USE_WATER_DEPTH_ATTRIBUTE: '' }
+                    : {}),
+                ...(useShoreDepthAttribute
+                    ? { USE_WATER_SHORE_DEPTH_ATTRIBUTE: '' }
+                    : {}),
+            },
             transparent: true,
             depthWrite: false,
             depthTest: true,
@@ -181,19 +308,31 @@ export function useWaterBlockMaterial(
                 uFoamEdges: { value: foamEdges.clone() },
                 uFoamCorners: { value: foamCorners.clone() },
                 uDiscardInnerEdges: { value: discardInnerEdges ? 1 : 0 },
+                uWaterDepth: { value: waterDepth },
             },
         });
         waterMaterial.polygonOffset = true;
         waterMaterial.polygonOffsetFactor = -0.5;
         waterMaterial.polygonOffsetUnits = -0.5;
         return waterMaterial;
-    }, [discardInnerEdges, foamCorners, foamEdges, timeUniform]);
+    }, [
+        discardInnerEdges,
+        foamCorners,
+        foamEdges,
+        timeUniform,
+        useFoamAttributes,
+        useLocalPositionAttribute,
+        useWaterDepthAttribute,
+        useShoreDepthAttribute,
+        waterDepth,
+    ]);
 
     useEffect(() => {
         material.uniforms.uFoamEdges.value.copy(foamEdges);
         material.uniforms.uFoamCorners.value.copy(foamCorners);
         material.uniforms.uDiscardInnerEdges.value = discardInnerEdges ? 1 : 0;
-    }, [discardInnerEdges, foamCorners, foamEdges, material]);
+        material.uniforms.uWaterDepth.value = waterDepth;
+    }, [discardInnerEdges, foamCorners, foamEdges, material, waterDepth]);
 
     useEffect(() => {
         material.uniforms.uDeepColor.value.set(waterColors.deep);
@@ -227,6 +366,9 @@ export function BlockWater({ stack, block, stacks }: EntityInstanceProps) {
         [block, blockData, stack, stacks],
     );
     const includeTop = isWaterBlockTopSurfaceVisible({ block, stack });
+    const waterDepth = Math.max(
+        ...getWaterBlockDepthSamples({ block, blockData, stack }),
+    );
     const geometry = useMemo(
         () =>
             createWaterBlockGeometry(foamEdges, {
@@ -235,7 +377,9 @@ export function BlockWater({ stack, block, stacks }: EntityInstanceProps) {
             }),
         [foamEdges, includeTop, waterHeight],
     );
-    const material = useWaterBlockMaterial(foamEdges, true, foamCorners);
+    const material = useWaterBlockMaterial(foamEdges, true, foamCorners, {
+        waterDepth,
+    });
 
     useEffect(() => () => geometry.dispose(), [geometry]);
 

--- a/packages/game/src/entities/BlockWater.tsx
+++ b/packages/game/src/entities/BlockWater.tsx
@@ -199,8 +199,8 @@ void main() {
         mix(1.1, 0.7, depth01);
     float tonalShift = surfacePattern;
 
-    // Edge foam — only on edges facing non-water neighbours, animated
-    // along the edge so it looks like the water is breaking against the bank.
+    // Edge foam follows the global shore-distance field on chunked water, so
+    // the pattern can cross tile boundaries and softly fade away from banks.
     float edgeWidth = mix(0.5, 0.32, smoothstep(0.12, 1.45, shoreDepth));
     float negXBand = 1.0 - smoothstep(0.0, edgeWidth, vLocalPosition.x + 0.5);
     float posXBand = 1.0 - smoothstep(0.0, edgeWidth, 0.5 - vLocalPosition.x);
@@ -211,26 +211,33 @@ void main() {
     float posXCornerBand = 1.0 - smoothstep(0.0, cornerWidth, 0.5 - vLocalPosition.x);
     float negZCornerBand = 1.0 - smoothstep(0.0, cornerWidth, vLocalPosition.z + 0.5);
     float posZCornerBand = 1.0 - smoothstep(0.0, cornerWidth, 0.5 - vLocalPosition.z);
-    float negXEdge = negXBand * foamEdges.x * foamMotion(topUv + vec2(-1.3, 0.2), 0.0);
-    float posXEdge = posXBand * foamEdges.y * foamMotion(topUv + vec2(1.1, -0.4), 1.7);
-    float negZEdge = negZBand * foamEdges.z * foamMotion(topUv + vec2(0.4, -1.2), 3.4);
-    float posZEdge = posZBand * foamEdges.w * foamMotion(topUv + vec2(-0.2, 1.4), 5.1);
-    float edgeFoam = max(max(negXEdge, posXEdge), max(negZEdge, posZEdge));
-
-    float negXNegZCorner = negXCornerBand * negZCornerBand * foamCorners.x * foamMotion(topUv + vec2(-1.0, -1.0), 6.8);
-    float posXNegZCorner = posXCornerBand * negZCornerBand * foamCorners.y * foamMotion(topUv + vec2(1.0, -1.0), 8.5);
-    float negXPosZCorner = negXCornerBand * posZCornerBand * foamCorners.z * foamMotion(topUv + vec2(-1.0, 1.0), 10.2);
-    float posXPosZCorner = posXCornerBand * posZCornerBand * foamCorners.w * foamMotion(topUv + vec2(1.0, 1.0), 11.9);
-    float cornerFoam = max(max(negXNegZCorner, posXNegZCorner), max(negXPosZCorner, posXPosZCorner));
+    float localEdgeBand = max(
+        max(negXBand * foamEdges.x, posXBand * foamEdges.y),
+        max(negZBand * foamEdges.z, posZBand * foamEdges.w)
+    );
+    float localCornerBand = max(
+        max(negXCornerBand * negZCornerBand * foamCorners.x, posXCornerBand * negZCornerBand * foamCorners.y),
+        max(negXCornerBand * posZCornerBand * foamCorners.z, posXCornerBand * posZCornerBand * foamCorners.w)
+    );
+    float shoreFoamFade = max(localEdgeBand, localCornerBand);
+    float shoreFoamCore = shoreFoamFade;
+#ifdef USE_WATER_SHORE_DEPTH_ATTRIBUTE
+    shoreFoamFade = 1.0 - smoothstep(0.08, 1.05, shoreDepth);
+    shoreFoamCore = 1.0 - smoothstep(0.0, 0.34, shoreDepth);
+#endif
+    float globalFoam = max(
+        foamMotion(topUv, 0.0),
+        foamMotion(topUv + vec2(3.7, -2.4), 4.2) * 0.82
+    );
     float foamNoise = valueNoise(topUv * 3.2 + vec2(uTime * 0.119, -uTime * 0.085));
     float shoreFoamBreakup = 0.96 + 0.28 * smoothstep(0.12, 0.66, foamNoise);
-    edgeFoam =
-        max(edgeFoam, cornerFoam * 1.18) *
-        shoreFoamBreakup *
-        (1.18 + shoreInfluence * 1.35);
+    float shoreFoamField =
+        max(globalFoam, shoreFoamCore * 0.58) *
+        shoreFoamFade *
+        shoreFoamBreakup;
 
-    float topFoam = smoothstep(0.06, 0.42, edgeFoam) * topness * mix(1.1, 1.75, shoreInfluence);
-    float fallingFoam = edgeFoam * sideness * 0.18;
+    float topFoam = smoothstep(0.08, 0.4, shoreFoamField) * topness * mix(0.95, 1.55, shoreFoamCore);
+    float fallingFoam = smoothstep(0.1, 0.55, shoreFoamField) * sideness * 0.16;
     float foam = clamp(max(topFoam, fallingFoam), 0.0, 1.0);
 
     vec3 shallowWater = mix(uShallowColor, uFoamColor, shoreInfluence * topness * 0.08);

--- a/packages/game/src/entities/BlockWater.tsx
+++ b/packages/game/src/entities/BlockWater.tsx
@@ -222,21 +222,21 @@ void main() {
     float shoreFoamFade = max(localEdgeBand, localCornerBand);
     float shoreFoamCore = shoreFoamFade;
 #ifdef USE_WATER_SHORE_DEPTH_ATTRIBUTE
-    shoreFoamFade = 1.0 - smoothstep(0.03, 0.62, shoreDepth);
-    shoreFoamCore = 1.0 - smoothstep(0.0, 0.22, shoreDepth);
+    shoreFoamFade = 1.0 - smoothstep(0.02, 0.5, shoreDepth);
+    shoreFoamCore = 1.0 - smoothstep(0.0, 0.16, shoreDepth);
 #endif
     float globalFoam = max(
         foamMotion(topUv, 0.0),
         foamMotion(topUv + vec2(3.7, -2.4), 4.2) * 0.82
     );
     float foamNoise = valueNoise(topUv * 3.2 + vec2(uTime * 0.119, -uTime * 0.085));
-    float shoreFoamBreakup = 0.96 + 0.28 * smoothstep(0.12, 0.66, foamNoise);
+    float shoreFoamBreakup = 0.84 + 0.34 * smoothstep(0.22, 0.74, foamNoise);
     float shoreFoamField =
-        max(globalFoam, shoreFoamCore * 0.58) *
+        max(globalFoam, shoreFoamCore * 0.42) *
         shoreFoamFade *
         shoreFoamBreakup;
 
-    float topFoam = smoothstep(0.08, 0.4, shoreFoamField) * topness * mix(0.95, 1.55, shoreFoamCore);
+    float topFoam = smoothstep(0.14, 0.46, shoreFoamField) * topness * mix(0.86, 1.28, shoreFoamCore);
     float fallingFoam = smoothstep(0.1, 0.55, shoreFoamField) * sideness * 0.16;
     float foam = clamp(max(topFoam, fallingFoam), 0.0, 1.0);
 

--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -278,6 +278,9 @@ export function EntityInstances({
         renderSnow: snowOverlaysVisible,
         snowOverlayMinCoverage: qualityProfile.snowOverlayMinCoverage,
     };
+    const mergedTerrainChunkProps = {
+        renderStableChunksAsMergedGeometry: true,
+    };
 
     return (
         <>
@@ -292,6 +295,7 @@ export function EntityInstances({
                 material={(gltf) => gltf.nodes.Block_Grass_1_2.material}
                 snow={snowPresets.grassFlat}
                 snowLift={0.01}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -305,6 +309,7 @@ export function EntityInstances({
                 material={(gltf) => gltf.nodes.Block_Grass_Angle_1_2.material}
                 snow={snowPresets.grassAngle}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -315,6 +320,7 @@ export function EntityInstances({
                 yOffset={0.2}
                 geometry={(gltf) => gltf.nodes.Block_Grass_Corner_1_1.geometry}
                 material={(gltf) => gltf.nodes.Block_Grass_Corner_1_2.material}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -328,6 +334,7 @@ export function EntityInstances({
                 material={(gltf) => gltf.nodes.Block_Grass_Corner_1_2.material}
                 snow={snowPresets.grassCorner}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -342,6 +349,7 @@ export function EntityInstances({
                 material={(gltf) =>
                     gltf.nodes.Block_Grass_Reverse_Corner_1_2.material
                 }
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -359,6 +367,7 @@ export function EntityInstances({
                 }
                 snow={snowPresets.grassReverseCorner}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -372,6 +381,7 @@ export function EntityInstances({
                 material={(gltf) => gltf.nodes.Block_Sand_1.material}
                 snow={snowPresets.sand}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -385,6 +395,7 @@ export function EntityInstances({
                 material={(gltf) => gltf.nodes.Block_Sand_Angle_1.material}
                 snow={snowPresets.sandAngle}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -398,6 +409,7 @@ export function EntityInstances({
                 material={(gltf) => gltf.nodes.Block_Sand_Corner_1.material}
                 snow={snowPresets.sandCorner}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -415,6 +427,7 @@ export function EntityInstances({
                 }
                 snow={snowPresets.sandReverseCorner}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -427,6 +440,7 @@ export function EntityInstances({
                 material={() => snowMaterial}
                 snow={snowPresets.snow}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -439,6 +453,7 @@ export function EntityInstances({
                 material={() => snowMaterial}
                 snow={snowPresets.snowAngle}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -451,6 +466,7 @@ export function EntityInstances({
                 material={() => snowMaterial}
                 snow={snowPresets.snowCorner}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             <EntityInstancesAssetBlock
@@ -465,6 +481,7 @@ export function EntityInstances({
                 material={() => snowMaterial}
                 snow={snowPresets.snowReverseCorner}
                 snowLift={0.003}
+                {...mergedTerrainChunkProps}
                 {...commonSnowProps}
             />
             {shouldRenderGroundDecorations && (

--- a/packages/game/src/entities/EntityInstancesBlock.tsx
+++ b/packages/game/src/entities/EntityInstancesBlock.tsx
@@ -2,18 +2,12 @@ import {
     cloneElement,
     isValidElement,
     type ReactNode,
+    useEffect,
     useLayoutEffect,
     useMemo,
     useRef,
 } from 'react';
-import {
-    Euler,
-    type InstancedMesh,
-    type Material,
-    Matrix4,
-    Quaternion,
-    Vector3,
-} from 'three';
+import type { InstancedMesh, Material } from 'three';
 import type { BufferGeometry } from 'three/src/Three.Core.js';
 import {
     type ActiveDragPreviewTarget,
@@ -38,13 +32,19 @@ import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
 import { type ActiveDragPreview, useGameState } from '../useGameState';
 import { getStackHeight } from '../utils/getStackHeight';
+import {
+    chunkMeshInstances,
+    createMergedChunkGeometry,
+    createMeshInstanceMatrix,
+    type MeshInstanceChunk,
+    type MeshInstanceLocalTransform,
+} from './chunkedMeshGeometry';
 import { blockPickupOutlineStyle } from './helpers/blockPickupOutlineStyle';
 import { HoverOutline } from './helpers/HoverOutline';
 import { PlacementDropAnimation } from './helpers/PlacementDropAnimation';
 
 const defaultLocalPosition: [number, number, number] = [0, 0, 0];
 const defaultLocalRotation: [number, number, number] = [0, 0, 0];
-const instanceChunkSize = 8;
 
 export type EntityInstancesBlockBaseProps = {
     stacks: Stack[] | undefined;
@@ -59,6 +59,7 @@ export type EntityInstancesBlockBaseProps = {
     geometry: BufferGeometry;
     snow?: SnowMaterialOptions;
     renderRainWetOverlay?: boolean;
+    renderStableChunksAsMergedGeometry?: boolean;
     castShadow?: boolean;
     receiveShadow?: boolean;
     renderOrder?: number;
@@ -84,40 +85,6 @@ export type EntityBlockInstance = {
     stack: Stack;
     stackHeight: number;
 };
-
-type InstanceChunk = {
-    key: string;
-    instances: EntityBlockInstance[];
-};
-
-function chunkInstanceKey(position: [number, number, number]) {
-    return `${Math.floor(position[0] / instanceChunkSize)}:${Math.floor(
-        position[2] / instanceChunkSize,
-    )}`;
-}
-
-function chunkInstances(instances: EntityBlockInstance[]) {
-    const chunkByKey = new Map<string, EntityBlockInstance[]>();
-
-    for (const instance of instances) {
-        const key = chunkInstanceKey(instance.position);
-        const chunk = chunkByKey.get(key);
-        if (chunk) {
-            chunk.push(instance);
-            continue;
-        }
-        chunkByKey.set(key, [instance]);
-    }
-
-    return [...chunkByKey.entries()]
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(
-            ([key, chunk]): InstanceChunk => ({
-                key,
-                instances: chunk,
-            }),
-        );
-}
 
 function numbersEqual(left: number, right: number) {
     return Math.abs(left - right) <= 0.0001;
@@ -205,41 +172,6 @@ function useStableScale(scale: EntityInstancesBlockBaseProps['scale']) {
     }
 
     return previous.current;
-}
-
-function createInstanceMatrix(
-    instance: EntityBlockInstance,
-    localTransform: {
-        position: [number, number, number];
-        rotation: [number, number, number];
-    },
-    scale: EntityInstancesBlockBaseProps['scale'],
-) {
-    const rootPosition = new Vector3(...instance.position);
-    const rootQuaternion = new Quaternion().setFromAxisAngle(
-        new Vector3(0, 1, 0),
-        instance.rotation * (Math.PI / 2),
-    );
-    const rootScale = new Vector3(1, 1, 1);
-    const rootMatrix = new Matrix4().compose(
-        rootPosition,
-        rootQuaternion,
-        rootScale,
-    );
-    const localPosition = new Vector3(...localTransform.position);
-    const localQuaternion = new Quaternion().setFromEuler(
-        new Euler(...localTransform.rotation),
-    );
-    const localScale = Array.isArray(scale)
-        ? new Vector3(scale[0], scale[1], scale[2])
-        : new Vector3(scale ?? 1, scale ?? 1, scale ?? 1);
-    const localMatrix = new Matrix4().compose(
-        localPosition,
-        localQuaternion,
-        localScale,
-    );
-
-    return rootMatrix.multiply(localMatrix);
 }
 
 function cloneMaterialNode(materialNode: ReactNode) {
@@ -422,6 +354,7 @@ export function EntityInstancesBlock(
         geometry,
         snow,
         renderRainWetOverlay = false,
+        renderStableChunksAsMergedGeometry,
         castShadow = true,
         receiveShadow = true,
         renderOrder,
@@ -442,6 +375,7 @@ export function EntityInstancesBlock(
         receiveShadow,
         renderOrder,
         renderRainWetOverlay,
+        renderStableChunksAsMergedGeometry,
         renderSnow,
         scale,
         snow,
@@ -485,6 +419,7 @@ export function EntityInstancesGeometry(
         snowLift = 0,
         snowOverlayMinCoverage,
         renderRainWetOverlay = false,
+        renderStableChunksAsMergedGeometry = false,
         castShadow = true,
         receiveShadow = true,
         renderOrder,
@@ -526,7 +461,7 @@ export function EntityInstancesGeometry(
         [animatedBlockIds, instances],
     );
     const stableChunks = useMemo(
-        () => chunkInstances(stableInstances),
+        () => chunkMeshInstances(stableInstances),
         [stableInstances],
     );
 
@@ -631,21 +566,37 @@ export function EntityInstancesGeometry(
 
     return (
         <>
-            {stableChunks.map((chunk) => (
-                <ChunkedInstancedMesh
-                    key={`${instanceKey}:${chunk.key}`}
-                    castShadow={castShadow}
-                    chunk={chunk}
-                    debugName={`BlockInstances:${instanceKey}:chunk:${chunk.key}:count:${chunk.instances.length}`}
-                    geometry={geometry}
-                    localTransform={localTransform}
-                    material={material}
-                    materialNode={materialNode}
-                    receiveShadow={receiveShadow}
-                    renderOrder={renderOrder}
-                    scale={stableScale}
-                />
-            ))}
+            {stableChunks.map((chunk) =>
+                renderStableChunksAsMergedGeometry ? (
+                    <ChunkedMergedMesh
+                        key={`${instanceKey}:${chunk.key}`}
+                        castShadow={castShadow}
+                        chunk={chunk}
+                        debugName={`MergedBlockChunk:${instanceKey}:chunk:${chunk.key}:count:${chunk.instances.length}`}
+                        geometry={geometry}
+                        localTransform={localTransform}
+                        material={material}
+                        materialNode={materialNode}
+                        receiveShadow={receiveShadow}
+                        renderOrder={renderOrder}
+                        scale={stableScale}
+                    />
+                ) : (
+                    <ChunkedInstancedMesh
+                        key={`${instanceKey}:${chunk.key}`}
+                        castShadow={castShadow}
+                        chunk={chunk}
+                        debugName={`BlockInstances:${instanceKey}:chunk:${chunk.key}:count:${chunk.instances.length}`}
+                        geometry={geometry}
+                        localTransform={localTransform}
+                        material={material}
+                        materialNode={materialNode}
+                        receiveShadow={receiveShadow}
+                        renderOrder={renderOrder}
+                        scale={stableScale}
+                    />
+                ),
+            )}
             {renderAnimatedInstances('base')}
             {(instances ?? []).map((data) =>
                 data.pickupOutlineVisible ? (
@@ -709,13 +660,10 @@ function ChunkedInstancedMesh({
     scale,
 }: {
     castShadow: boolean;
-    chunk: InstanceChunk;
+    chunk: MeshInstanceChunk<EntityBlockInstance>;
     debugName: string;
     geometry: BufferGeometry;
-    localTransform: {
-        position: [number, number, number];
-        rotation: [number, number, number];
-    };
+    localTransform: MeshInstanceLocalTransform;
     material: Material | Material[] | undefined;
     materialNode: ReactNode;
     receiveShadow: boolean;
@@ -733,7 +681,7 @@ function ChunkedInstancedMesh({
         chunk.instances.forEach((instance, index) => {
             mesh.setMatrixAt(
                 index,
-                createInstanceMatrix(instance, localTransform, scale),
+                createMeshInstanceMatrix(instance, localTransform, scale),
             );
         });
         mesh.count = chunk.instances.length;
@@ -756,6 +704,60 @@ function ChunkedInstancedMesh({
     );
 }
 
+function ChunkedMergedMesh({
+    castShadow,
+    chunk,
+    debugName,
+    geometry,
+    localTransform,
+    material,
+    materialNode,
+    receiveShadow,
+    renderOrder,
+    scale,
+}: {
+    castShadow: boolean;
+    chunk: MeshInstanceChunk<EntityBlockInstance>;
+    debugName: string;
+    geometry: BufferGeometry;
+    localTransform: MeshInstanceLocalTransform;
+    material: Material | Material[] | undefined;
+    materialNode: ReactNode;
+    receiveShadow: boolean;
+    renderOrder?: number;
+    scale: EntityInstancesBlockBaseProps['scale'];
+}) {
+    const mergedGeometry = useMemo(
+        () =>
+            createMergedChunkGeometry({
+                geometry,
+                instances: chunk.instances,
+                localTransform,
+                scale,
+            }),
+        [chunk.instances, geometry, localTransform, scale],
+    );
+
+    useEffect(() => () => mergedGeometry.dispose(), [mergedGeometry]);
+
+    if (!mergedGeometry.getAttribute('position')) {
+        return null;
+    }
+
+    return (
+        <mesh
+            name={debugName}
+            castShadow={castShadow}
+            receiveShadow={receiveShadow}
+            renderOrder={renderOrder}
+            geometry={mergedGeometry}
+            material={material}
+        >
+            {cloneMaterialNode(materialNode)}
+        </mesh>
+    );
+}
+
 function InstancedSnowOverlays({
     chunks,
     geometry,
@@ -765,12 +767,9 @@ function InstancedSnowOverlays({
     snowLift,
     snowOverlayMinCoverage,
 }: {
-    chunks: InstanceChunk[];
+    chunks: MeshInstanceChunk<EntityBlockInstance>[];
     geometry: BufferGeometry;
-    localTransform: {
-        position: [number, number, number];
-        rotation: [number, number, number];
-    };
+    localTransform: MeshInstanceLocalTransform;
     scale: EntityInstancesBlockBaseProps['scale'];
     snow: SnowMaterialOptions;
     snowLift: number;
@@ -840,12 +839,9 @@ function InstancedRainWetOverlays({
     localTransform,
     scale,
 }: {
-    chunks: InstanceChunk[];
+    chunks: MeshInstanceChunk<EntityBlockInstance>[];
     geometry: BufferGeometry;
-    localTransform: {
-        position: [number, number, number];
-        rotation: [number, number, number];
-    };
+    localTransform: MeshInstanceLocalTransform;
     scale: EntityInstancesBlockBaseProps['scale'];
 }) {
     const visible = useRainWetOverlayVisible();

--- a/packages/game/src/entities/chunkedMeshGeometry.ts
+++ b/packages/game/src/entities/chunkedMeshGeometry.ts
@@ -1,0 +1,122 @@
+import { BufferGeometry, Euler, Matrix4, Quaternion, Vector3 } from 'three';
+import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+
+export const meshChunkSize = 8;
+
+export type ChunkedMeshInstance = {
+    position: [number, number, number];
+    rotation: number;
+};
+
+export type MeshInstanceChunk<T extends ChunkedMeshInstance> = {
+    key: string;
+    instances: T[];
+};
+
+export type MeshInstanceLocalTransform = {
+    position: [number, number, number];
+    rotation: [number, number, number];
+};
+
+export type MeshInstanceScale = number | [number, number, number] | undefined;
+
+function chunkInstanceKey(
+    position: [number, number, number],
+    chunkSize = meshChunkSize,
+) {
+    return `${Math.floor(position[0] / chunkSize)}:${Math.floor(
+        position[2] / chunkSize,
+    )}`;
+}
+
+export function chunkMeshInstances<T extends ChunkedMeshInstance>(
+    instances: T[],
+    chunkSize = meshChunkSize,
+) {
+    const chunkByKey = new Map<string, T[]>();
+
+    for (const instance of instances) {
+        const key = chunkInstanceKey(instance.position, chunkSize);
+        const chunk = chunkByKey.get(key);
+        if (chunk) {
+            chunk.push(instance);
+            continue;
+        }
+        chunkByKey.set(key, [instance]);
+    }
+
+    return [...chunkByKey.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(
+            ([key, chunk]): MeshInstanceChunk<T> => ({
+                key,
+                instances: chunk,
+            }),
+        );
+}
+
+export function createMeshInstanceMatrix(
+    instance: ChunkedMeshInstance,
+    localTransform: MeshInstanceLocalTransform,
+    scale: MeshInstanceScale,
+) {
+    const rootPosition = new Vector3(...instance.position);
+    const rootQuaternion = new Quaternion().setFromAxisAngle(
+        new Vector3(0, 1, 0),
+        instance.rotation * (Math.PI / 2),
+    );
+    const rootMatrix = new Matrix4().compose(
+        rootPosition,
+        rootQuaternion,
+        new Vector3(1, 1, 1),
+    );
+    const localPosition = new Vector3(...localTransform.position);
+    const localQuaternion = new Quaternion().setFromEuler(
+        new Euler(...localTransform.rotation),
+    );
+    const localScale = Array.isArray(scale)
+        ? new Vector3(scale[0], scale[1], scale[2])
+        : new Vector3(scale ?? 1, scale ?? 1, scale ?? 1);
+    const localMatrix = new Matrix4().compose(
+        localPosition,
+        localQuaternion,
+        localScale,
+    );
+
+    return rootMatrix.multiply(localMatrix);
+}
+
+export function createMergedChunkGeometry<T extends ChunkedMeshInstance>({
+    geometry,
+    instances,
+    localTransform,
+    scale,
+}: {
+    geometry: BufferGeometry;
+    instances: T[];
+    localTransform: MeshInstanceLocalTransform;
+    scale: MeshInstanceScale;
+}) {
+    if (instances.length === 0) {
+        return new BufferGeometry();
+    }
+
+    const transformedGeometries = instances.map((instance) => {
+        const transformedGeometry = geometry.clone();
+        transformedGeometry.applyMatrix4(
+            createMeshInstanceMatrix(instance, localTransform, scale),
+        );
+        return transformedGeometry;
+    });
+    const mergedGeometry =
+        mergeGeometries(transformedGeometries, false) ?? new BufferGeometry();
+
+    for (const transformedGeometry of transformedGeometries) {
+        transformedGeometry.dispose();
+    }
+
+    mergedGeometry.computeBoundingBox();
+    mergedGeometry.computeBoundingSphere();
+
+    return mergedGeometry;
+}

--- a/packages/game/src/entities/chunkedMeshGeometry.unit.ts
+++ b/packages/game/src/entities/chunkedMeshGeometry.unit.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { BufferGeometry, Float32BufferAttribute } from 'three';
+import {
+    type ChunkedMeshInstance,
+    chunkMeshInstances,
+    createMergedChunkGeometry,
+    createMeshInstanceMatrix,
+} from './chunkedMeshGeometry';
+
+function createPointGeometry() {
+    const geometry = new BufferGeometry();
+    geometry.setAttribute('position', new Float32BufferAttribute([0, 0, 0], 3));
+    return geometry;
+}
+
+function geometryPositions(geometry: BufferGeometry) {
+    const position = geometry.getAttribute('position');
+    const positions: number[][] = [];
+
+    for (let index = 0; index < position.count; index += 1) {
+        positions.push([
+            Number(position.getX(index).toFixed(6)),
+            Number(position.getY(index).toFixed(6)),
+            Number(position.getZ(index).toFixed(6)),
+        ]);
+    }
+
+    return positions;
+}
+
+describe('chunkMeshInstances', () => {
+    it('partitions instances into stable world-space chunk keys', () => {
+        const chunks = chunkMeshInstances(
+            [
+                { position: [0, 0, 0], rotation: 0 },
+                { position: [7.9, 0, 0], rotation: 0 },
+                { position: [8, 0, 0], rotation: 0 },
+                { position: [-0.1, 0, -8.1], rotation: 0 },
+            ],
+            8,
+        );
+
+        assert.deepEqual(
+            chunks.map((chunk) => [chunk.key, chunk.instances.length]),
+            [
+                ['-1:-2', 1],
+                ['0:0', 2],
+                ['1:0', 1],
+            ],
+        );
+    });
+});
+
+describe('createMeshInstanceMatrix', () => {
+    it('combines root and local transforms', () => {
+        const matrix = createMeshInstanceMatrix(
+            { position: [2, 3, 4], rotation: 0 },
+            { position: [0, 0.5, 0], rotation: [0, 0, 0] },
+            [2, 1, 2],
+        );
+        const point = createPointGeometry();
+        point.applyMatrix4(matrix);
+
+        assert.deepEqual(geometryPositions(point), [[2, 3.5, 4]]);
+
+        point.dispose();
+    });
+});
+
+describe('createMergedChunkGeometry', () => {
+    it('applies instance transforms and merges clones into one geometry', () => {
+        const source = createPointGeometry();
+        const instances: ChunkedMeshInstance[] = [
+            { position: [1, 0, 0], rotation: 0 },
+            { position: [3, 0, 0], rotation: 0 },
+        ];
+        const merged = createMergedChunkGeometry({
+            geometry: source,
+            instances,
+            localTransform: { position: [0, 1, 0], rotation: [0, 0, 0] },
+            scale: undefined,
+        });
+
+        assert.deepEqual(geometryPositions(merged), [
+            [1, 1, 0],
+            [3, 1, 0],
+        ]);
+
+        source.dispose();
+        merged.dispose();
+    });
+});

--- a/packages/game/src/entities/waterBlockDepth.ts
+++ b/packages/game/src/entities/waterBlockDepth.ts
@@ -1,0 +1,251 @@
+import type { BlockData } from '@gredice/client';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import {
+    getBlockDataByName,
+    getStackHeight,
+    isEdgeOrCornerTerrainBlockName,
+} from '../utils/stackHeightCore';
+import { waterBlockName } from './waterBlockFoam';
+import {
+    defaultWaterBlockVisualHeight,
+    waterBlockBottomOverlap,
+} from './waterBlockGeometry';
+import { getWaterBlockVerticalRange } from './waterBlockHeight';
+
+export type WaterBlockDepthSamples = [number, number, number, number];
+
+const waterDepthSamplePositions = [
+    [-0.5, -0.5],
+    [-0.5, 0.5],
+    [0.5, 0.5],
+    [0.5, -0.5],
+] as const;
+
+function getWaterBlockColumnBounds({
+    block,
+    stack,
+}: {
+    block: Block;
+    stack: Stack;
+}) {
+    if (block.name !== waterBlockName) {
+        return null;
+    }
+
+    const waterBlockIndex = stack.blocks.indexOf(block);
+
+    if (waterBlockIndex < 0) {
+        return null;
+    }
+
+    let bottomIndex = waterBlockIndex;
+    let topIndex = waterBlockIndex;
+
+    while (stack.blocks[bottomIndex - 1]?.name === waterBlockName) {
+        bottomIndex -= 1;
+    }
+
+    while (stack.blocks[topIndex + 1]?.name === waterBlockName) {
+        topIndex += 1;
+    }
+
+    return { bottomIndex, topIndex };
+}
+
+function clamp01(value: number) {
+    return Math.min(Math.max(value, 0), 1);
+}
+
+function rotateLocalPointIntoBlockSpace({
+    localX,
+    localZ,
+    rotation,
+}: {
+    localX: number;
+    localZ: number;
+    rotation: number | undefined;
+}) {
+    const angle = -(((Math.round(rotation ?? 0) % 4) + 4) % 4) * (Math.PI / 2);
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+
+    return {
+        x: localX * cos + localZ * sin,
+        z: -localX * sin + localZ * cos,
+    };
+}
+
+function getShapedTerrainSurfaceRatio({
+    block,
+    localX,
+    localZ,
+}: {
+    block: Block;
+    localX: number;
+    localZ: number;
+}) {
+    const rotated = rotateLocalPointIntoBlockSpace({
+        localX,
+        localZ,
+        rotation: block.rotation,
+    });
+    const x = clamp01(rotated.x + 0.5);
+    const z = clamp01(rotated.z + 0.5);
+
+    if (block.name.endsWith('_Reverse_Corner')) {
+        return Math.max(x, z);
+    }
+
+    if (block.name.endsWith('_Corner')) {
+        return Math.min(x, z);
+    }
+
+    if (block.name.endsWith('_Angle')) {
+        return x;
+    }
+
+    return 1;
+}
+
+function getWaterColumnBottomSurfaceY({
+    block,
+    blockData,
+    localX,
+    localZ,
+    stack,
+}: {
+    block: Block;
+    blockData: BlockData[] | null | undefined;
+    localX: number;
+    localZ: number;
+    stack: Stack;
+}) {
+    const bounds = getWaterBlockColumnBounds({ block, stack });
+    if (!bounds) {
+        return 0;
+    }
+
+    const supportBlock = stack.blocks[bounds.bottomIndex - 1];
+    if (!supportBlock) {
+        return 0;
+    }
+
+    const supportBaseY = getStackHeight(blockData, stack, supportBlock);
+    const supportHeight =
+        getBlockDataByName(blockData, supportBlock.name)?.attributes.height ??
+        defaultWaterBlockVisualHeight;
+
+    if (!isEdgeOrCornerTerrainBlockName(supportBlock.name)) {
+        return supportBaseY + supportHeight;
+    }
+
+    return (
+        supportBaseY +
+        supportHeight *
+            getShapedTerrainSurfaceRatio({
+                block: supportBlock,
+                localX,
+                localZ,
+            })
+    );
+}
+
+export function getWaterBlockColumnDepth({
+    block,
+    stack,
+}: {
+    block: Block;
+    stack: Stack;
+}) {
+    if (block.name !== waterBlockName) {
+        return 0;
+    }
+
+    const bounds = getWaterBlockColumnBounds({ block, stack });
+
+    if (!bounds) {
+        return 1;
+    }
+
+    return bounds.topIndex - bounds.bottomIndex + 1;
+}
+
+export function getWaterBlockColumnSurfaceY({
+    block,
+    blockData,
+    stack,
+}: {
+    block: Block;
+    blockData: BlockData[] | null | undefined;
+    stack: Stack;
+}) {
+    const bounds = getWaterBlockColumnBounds({ block, stack });
+    const topWaterBlock =
+        bounds === null ? block : stack.blocks[bounds.topIndex];
+
+    if (!topWaterBlock) {
+        return 0;
+    }
+
+    return (
+        getWaterBlockVerticalRange({
+            block: topWaterBlock,
+            blockData,
+            stack,
+        })?.max ?? 0
+    );
+}
+
+export function getWaterBlockDepthAtLocalPosition({
+    block,
+    blockData,
+    localX,
+    localZ,
+    stack,
+}: {
+    block: Block;
+    blockData: BlockData[] | null | undefined;
+    localX: number;
+    localZ: number;
+    stack: Stack;
+}) {
+    const surfaceY = getWaterBlockColumnSurfaceY({
+        block,
+        blockData,
+        stack,
+    });
+    const bottomSurfaceY = getWaterColumnBottomSurfaceY({
+        block,
+        blockData,
+        localX,
+        localZ,
+        stack,
+    });
+
+    return Math.max(
+        (surfaceY - bottomSurfaceY + waterBlockBottomOverlap) /
+            defaultWaterBlockVisualHeight,
+        0,
+    );
+}
+
+export function getWaterBlockDepthSamples({
+    block,
+    blockData,
+    stack,
+}: {
+    block: Block;
+    blockData: BlockData[] | null | undefined;
+    stack: Stack;
+}): WaterBlockDepthSamples {
+    return waterDepthSamplePositions.map(([localX, localZ]) =>
+        getWaterBlockDepthAtLocalPosition({
+            block,
+            blockData,
+            localX,
+            localZ,
+            stack,
+        }),
+    ) as WaterBlockDepthSamples;
+}

--- a/packages/game/src/entities/waterBlockDepth.unit.ts
+++ b/packages/game/src/entities/waterBlockDepth.unit.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import { getLocalSandboxBlockData } from '../localSandboxBlockData';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import {
+    getWaterBlockColumnDepth,
+    getWaterBlockColumnSurfaceY,
+    getWaterBlockDepthSamples,
+} from './waterBlockDepth';
+
+function block(id: string, name: string): Block {
+    return { id, name, rotation: 0 };
+}
+
+function stack(blocks: Block[]): Stack {
+    return {
+        blocks,
+        position: new Vector3(0, 0, 0),
+    };
+}
+
+function rounded(values: number[]) {
+    return values.map((value) => Number(value.toFixed(6)));
+}
+
+describe('getWaterBlockColumnDepth', () => {
+    it('counts contiguous water blocks below the visible water surface', () => {
+        const shallowWater = block('water-a', 'Block_Water');
+        const middleWater = block('water-b', 'Block_Water');
+        const deepWater = block('water-c', 'Block_Water');
+        const currentStack = stack([shallowWater, middleWater, deepWater]);
+
+        assert.equal(
+            getWaterBlockColumnDepth({
+                block: deepWater,
+                stack: currentStack,
+            }),
+            3,
+        );
+        assert.equal(
+            getWaterBlockColumnDepth({
+                block: shallowWater,
+                stack: currentStack,
+            }),
+            3,
+        );
+    });
+
+    it('stops counting at non-water support blocks', () => {
+        const water = block('water-a', 'Block_Water');
+        const currentStack = stack([block('grass-a', 'Block_Grass'), water]);
+
+        assert.equal(
+            getWaterBlockColumnDepth({
+                block: water,
+                stack: currentStack,
+            }),
+            1,
+        );
+    });
+
+    it('does not count separated water below another block', () => {
+        const lowerWater = block('water-a', 'Block_Water');
+        const upperWater = block('water-b', 'Block_Water');
+        const currentStack = stack([
+            lowerWater,
+            block('grass-a', 'Block_Grass'),
+            upperWater,
+        ]);
+
+        assert.equal(
+            getWaterBlockColumnDepth({
+                block: upperWater,
+                stack: currentStack,
+            }),
+            1,
+        );
+    });
+
+    it('resolves the top surface y for the full contiguous water column', () => {
+        const shallowWater = block('water-a', 'Block_Water');
+        const deepWater = block('water-b', 'Block_Water');
+        const currentStack = stack([shallowWater, deepWater]);
+
+        assert.equal(
+            Number(
+                getWaterBlockColumnSurfaceY({
+                    block: shallowWater,
+                    blockData: getLocalSandboxBlockData(),
+                    stack: currentStack,
+                }).toFixed(6),
+            ),
+            0.74,
+        );
+    });
+
+    it('samples one flat water block as one block deep', () => {
+        const water = block('water-a', 'Block_Water');
+        const currentStack = stack([block('grass-a', 'Block_Grass'), water]);
+
+        assert.deepEqual(
+            rounded(
+                getWaterBlockDepthSamples({
+                    block: water,
+                    blockData: getLocalSandboxBlockData(),
+                    stack: currentStack,
+                }),
+            ),
+            [1, 1, 1, 1],
+        );
+    });
+
+    it('samples water over angled terrain from deep edge to shallow edge', () => {
+        const water = block('water-a', 'Block_Water');
+        const currentStack = stack([
+            block('angle-a', 'Block_Sand_Angle'),
+            water,
+        ]);
+
+        assert.deepEqual(
+            rounded(
+                getWaterBlockDepthSamples({
+                    block: water,
+                    blockData: getLocalSandboxBlockData(),
+                    stack: currentStack,
+                }),
+            ),
+            [1, 1, 0, 0],
+        );
+    });
+
+    it('includes upper water blocks when sampling angled terrain depth', () => {
+        const lowerWater = block('water-a', 'Block_Water');
+        const upperWater = block('water-b', 'Block_Water');
+        const currentStack = stack([
+            block('angle-a', 'Block_Sand_Angle'),
+            lowerWater,
+            upperWater,
+        ]);
+
+        assert.deepEqual(
+            rounded(
+                getWaterBlockDepthSamples({
+                    block: upperWater,
+                    blockData: getLocalSandboxBlockData(),
+                    stack: currentStack,
+                }),
+            ),
+            [2, 2, 1, 1],
+        );
+    });
+});

--- a/packages/game/src/entities/waterBlockGeometry.ts
+++ b/packages/game/src/entities/waterBlockGeometry.ts
@@ -4,6 +4,7 @@ import {
     Uint16BufferAttribute,
     type Vector4,
 } from 'three';
+import type { WaterBlockDepthSamples } from './waterBlockDepth';
 
 const waterBlockHalfSize = 0.5;
 export const defaultWaterBlockVisualHeight = 0.4;
@@ -13,7 +14,11 @@ const segmentMergeEpsilon = 1e-6;
 type WaterFoamEdge = 'x' | 'y' | 'z' | 'w';
 
 type WaterFace = {
+    depth?: number;
+    depths?: WaterBlockDepthSamples;
     normal: [number, number, number];
+    shoreDepths?: WaterBlockDepthSamples;
+    surfaceY?: number;
     vertices: [
         [number, number, number],
         [number, number, number],
@@ -29,7 +34,11 @@ type WaterBlockGeometryOptions = {
 };
 
 type WaterSideInstance = {
+    depth?: number;
+    depthSamples?: WaterBlockDepthSamples;
     position: [number, number, number];
+    shoreDepthSamples?: WaterBlockDepthSamples;
+    surfaceY?: number;
     waterHeight?: number;
 };
 
@@ -40,10 +49,18 @@ type WaterSideInstanceRange = {
 
 type WaterSideSegment = {
     axis: 'x' | 'z';
+    depth: number;
+    depthEnd: number;
+    depthStart: number;
+    hasDepthMap: boolean;
+    hasShoreDepthMap: boolean;
     line: number;
     normal: [number, number, number];
+    shoreDepthEnd: number;
+    shoreDepthStart: number;
     start: number;
     end: number;
+    surfaceY: number;
     yMax: number;
     yMin: number;
 };
@@ -127,17 +144,26 @@ function pushFace({
     indices,
     normals,
     positions,
+    waterDepths,
+    waterShoreDepths,
+    waterSurfaceYs,
 }: {
     face: WaterFace;
     indices: number[];
     normals: number[];
     positions: number[];
+    waterDepths?: number[];
+    waterShoreDepths?: number[];
+    waterSurfaceYs?: number[];
 }) {
     const startIndex = positions.length / 3;
 
-    for (const vertex of face.vertices) {
+    for (const [vertexIndex, vertex] of face.vertices.entries()) {
         positions.push(...vertex);
         normals.push(...face.normal);
+        waterDepths?.push(face.depths?.[vertexIndex] ?? face.depth ?? 0);
+        waterShoreDepths?.push(face.shoreDepths?.[vertexIndex] ?? 0);
+        waterSurfaceYs?.push(face.surfaceY ?? vertex[1]);
     }
 
     indices.push(
@@ -153,15 +179,51 @@ function pushFace({
 function createGeometryFromFaces(faces: WaterFace[]) {
     const positions: number[] = [];
     const normals: number[] = [];
+    const waterDepths: number[] = [];
+    const waterShoreDepths: number[] = [];
+    const waterSurfaceYs: number[] = [];
     const indices: number[] = [];
+    const hasDepthMap = faces.some(
+        (face) =>
+            face.depth !== undefined ||
+            face.depths !== undefined ||
+            face.surfaceY !== undefined,
+    );
+    const hasShoreDepthMap = faces.some(
+        (face) => face.shoreDepths !== undefined,
+    );
 
     for (const face of faces) {
-        pushFace({ face, positions, normals, indices });
+        pushFace({
+            face,
+            positions,
+            normals,
+            indices,
+            waterDepths: hasDepthMap ? waterDepths : undefined,
+            waterShoreDepths: hasShoreDepthMap ? waterShoreDepths : undefined,
+            waterSurfaceYs: hasDepthMap ? waterSurfaceYs : undefined,
+        });
     }
 
     const geometry = new BufferGeometry();
     geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
     geometry.setAttribute('normal', new Float32BufferAttribute(normals, 3));
+    if (hasDepthMap) {
+        geometry.setAttribute(
+            'waterDepth',
+            new Float32BufferAttribute(waterDepths, 1),
+        );
+        geometry.setAttribute(
+            'waterSurfaceY',
+            new Float32BufferAttribute(waterSurfaceYs, 1),
+        );
+    }
+    if (hasShoreDepthMap) {
+        geometry.setAttribute(
+            'waterShoreDepth',
+            new Float32BufferAttribute(waterShoreDepths, 1),
+        );
+    }
     geometry.setIndex(new Uint16BufferAttribute(indices, 1));
     geometry.computeBoundingBox();
     geometry.computeBoundingSphere();
@@ -199,6 +261,13 @@ function segmentGroupKey(segment: WaterSideSegment) {
         segment.axis,
         segment.line,
         segment.normal.join(','),
+        segment.hasDepthMap,
+        segment.depthStart,
+        segment.depthEnd,
+        segment.hasShoreDepthMap,
+        segment.shoreDepthStart,
+        segment.shoreDepthEnd,
+        segment.surfaceY,
         segment.yMin,
         segment.yMax,
     ].join('|');
@@ -209,6 +278,13 @@ function verticalSegmentGroupKey(segment: WaterSideSegment) {
         segment.axis,
         segment.line,
         segment.normal.join(','),
+        segment.hasDepthMap,
+        segment.depthStart,
+        segment.depthEnd,
+        segment.hasShoreDepthMap,
+        segment.shoreDepthStart,
+        segment.shoreDepthEnd,
+        segment.surfaceY,
         segment.start,
         segment.end,
     ].join('|');
@@ -265,6 +341,18 @@ function mergeVerticalSideSegments(segments: WaterSideSegment[]) {
     return mergedSegments;
 }
 
+function sideSegmentSamplesConnect(
+    currentSegment: WaterSideSegment,
+    nextSegment: WaterSideSegment,
+) {
+    return (
+        Math.abs(currentSegment.depthEnd - nextSegment.depthStart) <=
+            segmentMergeEpsilon &&
+        Math.abs(currentSegment.shoreDepthEnd - nextSegment.shoreDepthStart) <=
+            segmentMergeEpsilon
+    );
+}
+
 function mergeHorizontalSideSegments(segments: WaterSideSegment[]) {
     const segmentGroups = new Map<string, WaterSideSegment[]>();
 
@@ -293,9 +381,12 @@ function mergeHorizontalSideSegments(segments: WaterSideSegment[]) {
         for (const segment of sortedGroup.slice(1)) {
             if (
                 currentSegment &&
-                segment.start <= currentSegment.end + segmentMergeEpsilon
+                segment.start <= currentSegment.end + segmentMergeEpsilon &&
+                sideSegmentSamplesConnect(currentSegment, segment)
             ) {
                 currentSegment.end = Math.max(currentSegment.end, segment.end);
+                currentSegment.depthEnd = segment.depthEnd;
+                currentSegment.shoreDepthEnd = segment.shoreDepthEnd;
                 continue;
             }
 
@@ -317,12 +408,67 @@ function mergeSideSegments(segments: WaterSideSegment[]) {
     return mergeHorizontalSideSegments(mergeVerticalSideSegments(segments));
 }
 
+function segmentDepthsForFace(
+    segment: Pick<
+        WaterSideSegment,
+        | 'depthEnd'
+        | 'depthStart'
+        | 'hasDepthMap'
+        | 'hasShoreDepthMap'
+        | 'shoreDepthEnd'
+        | 'shoreDepthStart'
+    >,
+    order: 'start-first' | 'end-first',
+) {
+    const firstDepth =
+        order === 'start-first' ? segment.depthStart : segment.depthEnd;
+    const secondDepth =
+        order === 'start-first' ? segment.depthEnd : segment.depthStart;
+    const firstShoreDepth =
+        order === 'start-first'
+            ? segment.shoreDepthStart
+            : segment.shoreDepthEnd;
+    const secondShoreDepth =
+        order === 'start-first'
+            ? segment.shoreDepthEnd
+            : segment.shoreDepthStart;
+
+    return {
+        ...(segment.hasDepthMap
+            ? {
+                  depths: [
+                      firstDepth,
+                      firstDepth,
+                      secondDepth,
+                      secondDepth,
+                  ] satisfies WaterBlockDepthSamples,
+              }
+            : {}),
+        ...(segment.hasShoreDepthMap
+            ? {
+                  shoreDepths: [
+                      firstShoreDepth,
+                      firstShoreDepth,
+                      secondShoreDepth,
+                      secondShoreDepth,
+                  ] satisfies WaterBlockDepthSamples,
+              }
+            : {}),
+    };
+}
+
 function waterSideSegmentToFace(segment: WaterSideSegment): WaterFace {
     const { end, line, normal, start, yMax, yMin } = segment;
 
     if (segment.axis === 'z') {
         return {
+            ...(segment.hasDepthMap ? { depth: segment.depth } : {}),
+            ...segmentDepthsForFace(
+                segment,
+                normal[2] < 0 ? 'end-first' : 'start-first',
+            ),
             normal,
+            ...(segment.hasDepthMap ? { surfaceY: segment.surfaceY } : {}),
             vertices:
                 normal[2] < 0
                     ? [
@@ -341,7 +487,13 @@ function waterSideSegmentToFace(segment: WaterSideSegment): WaterFace {
     }
 
     return {
+        ...(segment.hasDepthMap ? { depth: segment.depth } : {}),
+        ...segmentDepthsForFace(
+            segment,
+            normal[0] < 0 ? 'end-first' : 'start-first',
+        ),
         normal,
+        ...(segment.hasDepthMap ? { surfaceY: segment.surfaceY } : {}),
         vertices:
             normal[0] < 0
                 ? [
@@ -361,6 +513,20 @@ function waterSideSegmentToFace(segment: WaterSideSegment): WaterFace {
 
 function getWaterSideInstanceHeight(instance: WaterSideInstance) {
     return instance.waterHeight ?? defaultWaterBlockVisualHeight;
+}
+
+function getWaterSideInstanceDepth(instance: WaterSideInstance) {
+    return instance.depth ?? 1;
+}
+
+function getWaterSideInstanceDepthSamples(instance: WaterSideInstance) {
+    const depth = getWaterSideInstanceDepth(instance);
+
+    return instance.depthSamples ?? [depth, depth, depth, depth];
+}
+
+function getWaterSideInstanceShoreDepthSamples(instance: WaterSideInstance) {
+    return instance.shoreDepthSamples ?? [0, 0, 0, 0];
 }
 
 function getWaterSideInstanceRange(instance: WaterSideInstance) {
@@ -456,24 +622,40 @@ function getVisibleWaterSideRanges({
 
 function pushVisibleWaterSideSegments({
     axis,
+    depth,
+    depthEnd,
+    depthStart,
     end,
+    hasDepthMap,
+    hasShoreDepthMap,
     line,
     normal,
     range,
     sideSegments,
+    shoreDepthEnd,
+    shoreDepthStart,
     stackGroups,
     start,
+    surfaceY,
     x,
     z,
 }: {
     axis: 'x' | 'z';
+    depth: number;
+    depthEnd: number;
+    depthStart: number;
     end: number;
+    hasDepthMap: boolean;
+    hasShoreDepthMap: boolean;
     line: number;
     normal: [number, number, number];
     range: WaterSideInstanceRange;
     sideSegments: WaterSideSegment[];
+    shoreDepthEnd: number;
+    shoreDepthStart: number;
     stackGroups: Map<string, WaterSideInstance[]>;
     start: number;
+    surfaceY: number;
     x: number;
     z: number;
 }) {
@@ -485,18 +667,31 @@ function pushVisibleWaterSideSegments({
     })) {
         sideSegments.push({
             axis,
+            depth,
+            depthEnd,
+            depthStart,
+            hasDepthMap,
+            hasShoreDepthMap,
             line,
             normal,
+            shoreDepthEnd,
+            shoreDepthStart,
             start,
             end,
+            surfaceY,
             yMin: visibleRange.min,
             yMax: visibleRange.max,
         });
     }
 }
 
-export function createMergedWaterSideGeometry(instances: WaterSideInstance[]) {
-    const stackGroups = groupWaterSideInstancesByStackPosition(instances);
+export function createMergedWaterSideGeometry(
+    instances: WaterSideInstance[],
+    options: { neighborInstances?: WaterSideInstance[] } = {},
+) {
+    const stackGroups = groupWaterSideInstancesByStackPosition(
+        options.neighborInstances ?? instances,
+    );
     const sideSegments: WaterSideSegment[] = [];
 
     for (const instance of instances) {
@@ -505,55 +700,97 @@ export function createMergedWaterSideGeometry(instances: WaterSideInstance[]) {
         const yMin = y + waterBlockMinY(height);
         const yMax = y + waterBlockMaxY(height);
         const range = { min: yMin, max: yMax };
+        const hasDepthMap =
+            instance.depth !== undefined ||
+            instance.depthSamples !== undefined ||
+            instance.surfaceY !== undefined;
+        const hasShoreDepthMap = instance.shoreDepthSamples !== undefined;
+        const depth = hasDepthMap ? getWaterSideInstanceDepth(instance) : 1;
+        const depthSamples = getWaterSideInstanceDepthSamples(instance);
+        const shoreDepthSamples =
+            getWaterSideInstanceShoreDepthSamples(instance);
+        const surfaceY = hasDepthMap ? (instance.surfaceY ?? yMax) : 0;
 
         pushVisibleWaterSideSegments({
             axis: 'x',
+            depth,
+            depthStart: depthSamples[0],
+            depthEnd: depthSamples[1],
+            hasDepthMap,
+            hasShoreDepthMap,
             line: x - waterBlockHalfSize,
             normal: [-1, 0, 0],
             start: z - waterBlockHalfSize,
             end: z + waterBlockHalfSize,
             range,
             sideSegments,
+            shoreDepthStart: shoreDepthSamples[0],
+            shoreDepthEnd: shoreDepthSamples[1],
             stackGroups,
+            surfaceY,
             x: x - 1,
             z,
         });
 
         pushVisibleWaterSideSegments({
             axis: 'x',
+            depth,
+            depthStart: depthSamples[3],
+            depthEnd: depthSamples[2],
+            hasDepthMap,
+            hasShoreDepthMap,
             line: x + waterBlockHalfSize,
             normal: [1, 0, 0],
             start: z - waterBlockHalfSize,
             end: z + waterBlockHalfSize,
             range,
             sideSegments,
+            shoreDepthStart: shoreDepthSamples[3],
+            shoreDepthEnd: shoreDepthSamples[2],
             stackGroups,
+            surfaceY,
             x: x + 1,
             z,
         });
 
         pushVisibleWaterSideSegments({
             axis: 'z',
+            depth,
+            depthStart: depthSamples[0],
+            depthEnd: depthSamples[3],
+            hasDepthMap,
+            hasShoreDepthMap,
             line: z - waterBlockHalfSize,
             normal: [0, 0, -1],
             start: x - waterBlockHalfSize,
             end: x + waterBlockHalfSize,
             range,
             sideSegments,
+            shoreDepthStart: shoreDepthSamples[0],
+            shoreDepthEnd: shoreDepthSamples[3],
             stackGroups,
+            surfaceY,
             x,
             z: z - 1,
         });
 
         pushVisibleWaterSideSegments({
             axis: 'z',
+            depth,
+            depthStart: depthSamples[1],
+            depthEnd: depthSamples[2],
+            hasDepthMap,
+            hasShoreDepthMap,
             line: z + waterBlockHalfSize,
             normal: [0, 0, 1],
             start: x - waterBlockHalfSize,
             end: x + waterBlockHalfSize,
             range,
             sideSegments,
+            shoreDepthStart: shoreDepthSamples[1],
+            shoreDepthEnd: shoreDepthSamples[2],
             stackGroups,
+            surfaceY,
             x,
             z: z + 1,
         });

--- a/packages/game/src/entities/waterBlockGeometry.unit.ts
+++ b/packages/game/src/entities/waterBlockGeometry.unit.ts
@@ -107,6 +107,25 @@ describe('createMergedWaterSideGeometry', () => {
         geometry.dispose();
     });
 
+    it('uses neighbor instances to hide side walls across chunk boundaries', () => {
+        const geometry = createMergedWaterSideGeometry(
+            [{ position: [0, 0, 0] }],
+            {
+                neighborInstances: [
+                    { position: [0, 0, 0] },
+                    { position: [1, 0, 0] },
+                ],
+            },
+        );
+        const positionAttribute = geometry.getAttribute('position');
+        const indexAttribute = geometry.getIndex();
+
+        assert.equal(positionAttribute.count, 12);
+        assert.equal(indexAttribute?.count, 18);
+
+        geometry.dispose();
+    });
+
     it('keeps side walls when adjacent water blocks are on different levels', () => {
         const geometry = createMergedWaterSideGeometry([
             { position: [0, 0, 0] },
@@ -165,6 +184,61 @@ describe('createMergedWaterSideGeometry', () => {
         ]);
 
         assert.deepEqual(geometryYExtents(geometry), [-0.06, 0.19]);
+
+        geometry.dispose();
+    });
+
+    it('stores depth-map attributes for merged side walls', () => {
+        const geometry = createMergedWaterSideGeometry([
+            {
+                depth: 3,
+                position: [0, getWaterBlockYOffset(0.4), 0],
+                surfaceY: 1.2,
+                waterHeight: 0.4,
+            },
+        ]);
+        const position = geometry.getAttribute('position');
+        const waterDepth = geometry.getAttribute('waterDepth');
+        const waterSurfaceY = geometry.getAttribute('waterSurfaceY');
+
+        assert.equal(waterDepth.count, position.count);
+        assert.equal(waterSurfaceY.count, position.count);
+        assert.equal(waterDepth.getX(0), 3);
+        assert.equal(Number(waterSurfaceY.getX(0).toFixed(6)), 1.2);
+
+        geometry.dispose();
+    });
+
+    it('stores per-edge top depth and shore samples for merged side walls', () => {
+        const geometry = createMergedWaterSideGeometry([
+            {
+                depth: 4,
+                depthSamples: [1, 2, 3, 4],
+                position: [0, getWaterBlockYOffset(0.4), 0],
+                shoreDepthSamples: [0, 1, 2, 3],
+                surfaceY: 1.2,
+                waterHeight: 0.4,
+            },
+        ]);
+        const normal = geometry.getAttribute('normal');
+        const waterDepth = geometry.getAttribute('waterDepth');
+        const waterShoreDepth = geometry.getAttribute('waterShoreDepth');
+        const negativeXDepths: number[] = [];
+        const negativeXShoreDepths: number[] = [];
+
+        for (let index = 0; index < normal.count; index += 1) {
+            if (
+                normal.getX(index) === -1 &&
+                normal.getY(index) === 0 &&
+                normal.getZ(index) === 0
+            ) {
+                negativeXDepths.push(waterDepth.getX(index));
+                negativeXShoreDepths.push(waterShoreDepth.getX(index));
+            }
+        }
+
+        assert.deepEqual(negativeXDepths, [2, 2, 1, 1]);
+        assert.deepEqual(negativeXShoreDepths, [1, 1, 0, 0]);
 
         geometry.dispose();
     });

--- a/packages/game/src/entities/waterChunkGeometry.ts
+++ b/packages/game/src/entities/waterChunkGeometry.ts
@@ -1,0 +1,131 @@
+import {
+    BufferGeometry,
+    Float32BufferAttribute,
+    Uint16BufferAttribute,
+    type Vector4,
+} from 'three';
+import {
+    type ChunkedMeshInstance,
+    chunkMeshInstances,
+    type MeshInstanceChunk,
+} from './chunkedMeshGeometry';
+import type { WaterBlockDepthSamples } from './waterBlockDepth';
+
+export type WaterTopChunkInstance = ChunkedMeshInstance & {
+    depthSamples: WaterBlockDepthSamples;
+    foamCorners: Vector4;
+    foamEdges: Vector4;
+    shoreDepth: number;
+    shoreDepthSamples?: WaterBlockDepthSamples;
+    surfaceY: number;
+    waterHeight: number;
+};
+
+const waterBlockHalfSize = 0.5;
+
+export function chunkWaterTopInstances(
+    instances: WaterTopChunkInstance[],
+): MeshInstanceChunk<WaterTopChunkInstance>[] {
+    return chunkMeshInstances(instances);
+}
+
+export function createWaterTopChunkGeometry(
+    instances: WaterTopChunkInstance[],
+) {
+    const positions: number[] = [];
+    const normals: number[] = [];
+    const localPositions: number[] = [];
+    const foamEdges: number[] = [];
+    const foamCorners: number[] = [];
+    const depths: number[] = [];
+    const shoreDepths: number[] = [];
+    const surfaceYs: number[] = [];
+    const indices: number[] = [];
+
+    instances.forEach((instance, instanceIndex) => {
+        const [x, y, z] = instance.position;
+        const topY = y + instance.waterHeight / 2;
+        const localY = instance.waterHeight / 2;
+        const vertexOffset = instanceIndex * 4;
+        const worldVertices = [
+            [x - waterBlockHalfSize, topY, z - waterBlockHalfSize],
+            [x - waterBlockHalfSize, topY, z + waterBlockHalfSize],
+            [x + waterBlockHalfSize, topY, z + waterBlockHalfSize],
+            [x + waterBlockHalfSize, topY, z - waterBlockHalfSize],
+        ];
+        const localVertices = [
+            [-waterBlockHalfSize, localY, -waterBlockHalfSize],
+            [-waterBlockHalfSize, localY, waterBlockHalfSize],
+            [waterBlockHalfSize, localY, waterBlockHalfSize],
+            [waterBlockHalfSize, localY, -waterBlockHalfSize],
+        ];
+
+        for (let vertexIndex = 0; vertexIndex < 4; vertexIndex += 1) {
+            const worldVertex = worldVertices[vertexIndex];
+            const localVertex = localVertices[vertexIndex];
+
+            if (worldVertex && localVertex) {
+                positions.push(...worldVertex);
+                normals.push(0, 1, 0);
+                localPositions.push(...localVertex);
+                foamEdges.push(
+                    instance.foamEdges.x,
+                    instance.foamEdges.y,
+                    instance.foamEdges.z,
+                    instance.foamEdges.w,
+                );
+                foamCorners.push(
+                    instance.foamCorners.x,
+                    instance.foamCorners.y,
+                    instance.foamCorners.z,
+                    instance.foamCorners.w,
+                );
+                depths.push(instance.depthSamples[vertexIndex] ?? 0);
+                shoreDepths.push(
+                    instance.shoreDepthSamples?.[vertexIndex] ??
+                        instance.shoreDepth,
+                );
+                surfaceYs.push(instance.surfaceY);
+            }
+        }
+
+        indices.push(
+            vertexOffset,
+            vertexOffset + 1,
+            vertexOffset + 2,
+            vertexOffset,
+            vertexOffset + 2,
+            vertexOffset + 3,
+        );
+    });
+
+    const geometry = new BufferGeometry();
+    geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
+    geometry.setAttribute('normal', new Float32BufferAttribute(normals, 3));
+    geometry.setAttribute(
+        'waterLocalPosition',
+        new Float32BufferAttribute(localPositions, 3),
+    );
+    geometry.setAttribute(
+        'waterFoamEdges',
+        new Float32BufferAttribute(foamEdges, 4),
+    );
+    geometry.setAttribute(
+        'waterFoamCorners',
+        new Float32BufferAttribute(foamCorners, 4),
+    );
+    geometry.setAttribute('waterDepth', new Float32BufferAttribute(depths, 1));
+    geometry.setAttribute(
+        'waterShoreDepth',
+        new Float32BufferAttribute(shoreDepths, 1),
+    );
+    geometry.setAttribute(
+        'waterSurfaceY',
+        new Float32BufferAttribute(surfaceYs, 1),
+    );
+    geometry.setIndex(new Uint16BufferAttribute(indices, 1));
+    geometry.computeBoundingBox();
+    geometry.computeBoundingSphere();
+
+    return geometry;
+}

--- a/packages/game/src/entities/waterChunkGeometry.unit.ts
+++ b/packages/game/src/entities/waterChunkGeometry.unit.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector4 } from 'three';
+import {
+    chunkWaterTopInstances,
+    createWaterTopChunkGeometry,
+    type WaterTopChunkInstance,
+} from './waterChunkGeometry';
+
+function waterTopInstance(
+    position: [number, number, number],
+    foamEdges = new Vector4(1, 0, 1, 0),
+    foamCorners = new Vector4(0, 1, 0, 1),
+): WaterTopChunkInstance {
+    return {
+        depthSamples: [1, 2, 3, 4],
+        foamCorners,
+        foamEdges,
+        position,
+        rotation: 0,
+        shoreDepth: 2,
+        surfaceY: position[1] + 0.2,
+        waterHeight: 0.4,
+    };
+}
+
+function waterTopInstanceWithShoreSamples(
+    position: [number, number, number],
+): WaterTopChunkInstance {
+    return {
+        ...waterTopInstance(position),
+        shoreDepth: 2,
+        shoreDepthSamples: [0, 1, 2, 3],
+    };
+}
+
+describe('chunkWaterTopInstances', () => {
+    it('partitions water top surfaces by world chunk', () => {
+        const chunks = chunkWaterTopInstances([
+            waterTopInstance([0, 0, 0]),
+            waterTopInstance([8, 0, 0]),
+        ]);
+
+        assert.deepEqual(
+            chunks.map((chunk) => [chunk.key, chunk.instances.length]),
+            [
+                ['0:0', 1],
+                ['1:0', 1],
+            ],
+        );
+    });
+});
+
+describe('createWaterTopChunkGeometry', () => {
+    it('stores world positions, local positions, and foam masks', () => {
+        const geometry = createWaterTopChunkGeometry([
+            waterTopInstance(
+                [2, 1, 3],
+                new Vector4(1, 0, 0, 1),
+                new Vector4(0, 1, 1, 0),
+            ),
+        ]);
+        const position = geometry.getAttribute('position');
+        const localPosition = geometry.getAttribute('waterLocalPosition');
+        const foamEdges = geometry.getAttribute('waterFoamEdges');
+        const foamCorners = geometry.getAttribute('waterFoamCorners');
+        const waterDepth = geometry.getAttribute('waterDepth');
+        const shoreDepth = geometry.getAttribute('waterShoreDepth');
+        const surfaceY = geometry.getAttribute('waterSurfaceY');
+
+        assert.equal(position.count, 4);
+        assert.equal(geometry.getIndex()?.count, 6);
+        assert.deepEqual(
+            [position.getX(0), position.getY(0), position.getZ(0)].map(
+                (value) => Number(value.toFixed(6)),
+            ),
+            [1.5, 1.2, 2.5],
+        );
+        assert.deepEqual(
+            [
+                localPosition.getX(0),
+                localPosition.getY(0),
+                localPosition.getZ(0),
+            ].map((value) => Number(value.toFixed(6))),
+            [-0.5, 0.2, -0.5],
+        );
+        assert.deepEqual(
+            [
+                foamEdges.getX(0),
+                foamEdges.getY(0),
+                foamEdges.getZ(0),
+                foamEdges.getW(0),
+            ],
+            [1, 0, 0, 1],
+        );
+        assert.deepEqual(
+            [
+                foamCorners.getX(0),
+                foamCorners.getY(0),
+                foamCorners.getZ(0),
+                foamCorners.getW(0),
+            ],
+            [0, 1, 1, 0],
+        );
+        assert.deepEqual(
+            [
+                waterDepth.getX(0),
+                waterDepth.getX(1),
+                waterDepth.getX(2),
+                waterDepth.getX(3),
+            ],
+            [1, 2, 3, 4],
+        );
+        assert.equal(shoreDepth.getX(0), 2);
+        assert.equal(Number(surfaceY.getX(0).toFixed(6)), 1.2);
+
+        geometry.dispose();
+    });
+
+    it('stores per-vertex shore depth samples when present', () => {
+        const geometry = createWaterTopChunkGeometry([
+            waterTopInstanceWithShoreSamples([0, 0, 0]),
+        ]);
+        const shoreDepth = geometry.getAttribute('waterShoreDepth');
+
+        assert.deepEqual(
+            [
+                shoreDepth.getX(0),
+                shoreDepth.getX(1),
+                shoreDepth.getX(2),
+                shoreDepth.getX(3),
+            ],
+            [0, 1, 2, 3],
+        );
+
+        geometry.dispose();
+    });
+});

--- a/packages/game/src/entities/waterDepthSmoothing.ts
+++ b/packages/game/src/entities/waterDepthSmoothing.ts
@@ -1,0 +1,295 @@
+import type { WaterBlockDepthSamples } from './waterBlockDepth';
+import { defaultWaterBlockVisualHeight } from './waterBlockGeometry';
+import type { WaterTopChunkInstance } from './waterChunkGeometry';
+
+const waterBlockHalfSize = 0.5;
+const waterTopDepthSmoothingRadius = 0.95;
+const maxSurfaceDelta = defaultWaterBlockVisualHeight * 3.25;
+
+const waterDepthSamplePositions: [
+    [number, number],
+    [number, number],
+    [number, number],
+    [number, number],
+] = [
+    [-waterBlockHalfSize, -waterBlockHalfSize],
+    [-waterBlockHalfSize, waterBlockHalfSize],
+    [waterBlockHalfSize, waterBlockHalfSize],
+    [waterBlockHalfSize, -waterBlockHalfSize],
+];
+
+function stackPositionKey(x: number, z: number) {
+    return `${x}|${z}`;
+}
+
+function groupInstancesByPosition(instances: WaterTopChunkInstance[]) {
+    const groups = new Map<string, WaterTopChunkInstance[]>();
+
+    for (const instance of instances) {
+        const [x, , z] = instance.position;
+        const key = stackPositionKey(x, z);
+        const group = groups.get(key);
+
+        if (group) {
+            group.push(instance);
+        } else {
+            groups.set(key, [instance]);
+        }
+    }
+
+    return groups;
+}
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function clamp01(value: number) {
+    return clamp(value, 0, 1);
+}
+
+function lerp(start: number, end: number, value: number) {
+    return start + (end - start) * value;
+}
+
+function sampleDepthAtLocalPosition({
+    depthSamples,
+    localX,
+    localZ,
+}: {
+    depthSamples: WaterBlockDepthSamples;
+    localX: number;
+    localZ: number;
+}) {
+    const u = clamp01(localX + waterBlockHalfSize);
+    const v = clamp01(localZ + waterBlockHalfSize);
+    const negativeZ = lerp(depthSamples[0], depthSamples[3], u);
+    const positiveZ = lerp(depthSamples[1], depthSamples[2], u);
+
+    return lerp(negativeZ, positiveZ, v);
+}
+
+function sampleDepthAtWorldPosition({
+    instance,
+    x,
+    z,
+}: {
+    instance: WaterTopChunkInstance;
+    x: number;
+    z: number;
+}) {
+    return sampleDepthAtLocalPosition({
+        depthSamples: instance.depthSamples,
+        localX: x - instance.position[0],
+        localZ: z - instance.position[2],
+    });
+}
+
+function distanceToInstanceFootprint({
+    instance,
+    x,
+    z,
+}: {
+    instance: WaterTopChunkInstance;
+    x: number;
+    z: number;
+}) {
+    const [instanceX, , instanceZ] = instance.position;
+    const nearestX = clamp(
+        x,
+        instanceX - waterBlockHalfSize,
+        instanceX + waterBlockHalfSize,
+    );
+    const nearestZ = clamp(
+        z,
+        instanceZ - waterBlockHalfSize,
+        instanceZ + waterBlockHalfSize,
+    );
+
+    return Math.hypot(x - nearestX, z - nearestZ);
+}
+
+function getSmoothingCandidates({
+    instancesByPosition,
+    x,
+    z,
+}: {
+    instancesByPosition: Map<string, WaterTopChunkInstance[]>;
+    x: number;
+    z: number;
+}) {
+    const candidates: WaterTopChunkInstance[] = [];
+    const searchMinX = Math.floor(
+        x - waterBlockHalfSize - waterTopDepthSmoothingRadius,
+    );
+    const searchMaxX = Math.ceil(
+        x + waterBlockHalfSize + waterTopDepthSmoothingRadius,
+    );
+    const searchMinZ = Math.floor(
+        z - waterBlockHalfSize - waterTopDepthSmoothingRadius,
+    );
+    const searchMaxZ = Math.ceil(
+        z + waterBlockHalfSize + waterTopDepthSmoothingRadius,
+    );
+
+    for (
+        let candidateX = searchMinX;
+        candidateX <= searchMaxX;
+        candidateX += 1
+    ) {
+        for (
+            let candidateZ = searchMinZ;
+            candidateZ <= searchMaxZ;
+            candidateZ += 1
+        ) {
+            candidates.push(
+                ...(instancesByPosition.get(
+                    stackPositionKey(candidateX, candidateZ),
+                ) ?? []),
+            );
+        }
+    }
+
+    return candidates;
+}
+
+function depthSmoothingWeight({
+    candidate,
+    distance,
+    instance,
+}: {
+    candidate: WaterTopChunkInstance;
+    distance: number;
+    instance: WaterTopChunkInstance;
+}) {
+    if (distance > waterTopDepthSmoothingRadius) {
+        return 0;
+    }
+
+    const surfaceDelta = Math.abs(candidate.surfaceY - instance.surfaceY);
+    if (surfaceDelta > maxSurfaceDelta) {
+        return 0;
+    }
+
+    const distanceFactor = 1 - distance / waterTopDepthSmoothingRadius;
+    const verticalFactor =
+        1 - Math.min(surfaceDelta / maxSurfaceDelta, 1) * 0.35;
+
+    return distanceFactor * distanceFactor * verticalFactor;
+}
+
+function smoothValueAtWorldPosition({
+    instancesByPosition,
+    instance,
+    sampleValue,
+    x,
+    z,
+}: {
+    instancesByPosition: Map<string, WaterTopChunkInstance[]>;
+    instance: WaterTopChunkInstance;
+    sampleValue: (input: {
+        instance: WaterTopChunkInstance;
+        x: number;
+        z: number;
+    }) => number;
+    x: number;
+    z: number;
+}) {
+    let weightedValue = 0;
+    let totalWeight = 0;
+
+    for (const candidate of getSmoothingCandidates({
+        instancesByPosition,
+        x,
+        z,
+    })) {
+        const distance = distanceToInstanceFootprint({
+            instance: candidate,
+            x,
+            z,
+        });
+        const weight = depthSmoothingWeight({
+            candidate,
+            distance,
+            instance,
+        });
+
+        if (weight <= 0) {
+            continue;
+        }
+
+        weightedValue +=
+            sampleValue({
+                instance: candidate,
+                x,
+                z,
+            }) * weight;
+        totalWeight += weight;
+    }
+
+    if (totalWeight <= 0) {
+        return sampleValue({ instance, x, z });
+    }
+
+    return weightedValue / totalWeight;
+}
+
+function smoothSamplesForInstance({
+    instancesByPosition,
+    instance,
+    sampleValue,
+}: {
+    instancesByPosition: Map<string, WaterTopChunkInstance[]>;
+    instance: WaterTopChunkInstance;
+    sampleValue: (input: {
+        instance: WaterTopChunkInstance;
+        x: number;
+        z: number;
+    }) => number;
+}): WaterBlockDepthSamples {
+    const [x, , z] = instance.position;
+
+    return [
+        smoothValueAtWorldPosition({
+            instancesByPosition,
+            instance,
+            sampleValue,
+            x: x + waterDepthSamplePositions[0][0],
+            z: z + waterDepthSamplePositions[0][1],
+        }),
+        smoothValueAtWorldPosition({
+            instancesByPosition,
+            instance,
+            sampleValue,
+            x: x + waterDepthSamplePositions[1][0],
+            z: z + waterDepthSamplePositions[1][1],
+        }),
+        smoothValueAtWorldPosition({
+            instancesByPosition,
+            instance,
+            sampleValue,
+            x: x + waterDepthSamplePositions[2][0],
+            z: z + waterDepthSamplePositions[2][1],
+        }),
+        smoothValueAtWorldPosition({
+            instancesByPosition,
+            instance,
+            sampleValue,
+            x: x + waterDepthSamplePositions[3][0],
+            z: z + waterDepthSamplePositions[3][1],
+        }),
+    ];
+}
+
+export function smoothWaterTopDepthSamples(instances: WaterTopChunkInstance[]) {
+    const instancesByPosition = groupInstancesByPosition(instances);
+
+    return instances.map((instance) => ({
+        ...instance,
+        depthSamples: smoothSamplesForInstance({
+            instancesByPosition,
+            instance,
+            sampleValue: sampleDepthAtWorldPosition,
+        }),
+    }));
+}

--- a/packages/game/src/entities/waterDepthSmoothing.unit.ts
+++ b/packages/game/src/entities/waterDepthSmoothing.unit.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector4 } from 'three';
+import type { WaterBlockDepthSamples } from './waterBlockDepth';
+import type { WaterTopChunkInstance } from './waterChunkGeometry';
+import { smoothWaterTopDepthSamples } from './waterDepthSmoothing';
+
+const noFoam = new Vector4(0, 0, 0, 0);
+
+function waterTop(
+    position: [number, number, number],
+    depthSamples: WaterBlockDepthSamples,
+    shoreDepth = 0,
+): WaterTopChunkInstance {
+    return {
+        depthSamples,
+        foamCorners: noFoam,
+        foamEdges: noFoam,
+        position,
+        rotation: 0,
+        shoreDepth,
+        surfaceY: position[1] + 0.2,
+        waterHeight: 0.4,
+    };
+}
+
+function rounded(values: number[]) {
+    return values.map((value) => Number(value.toFixed(6)));
+}
+
+describe('smoothWaterTopDepthSamples', () => {
+    it('smooths flat water depth across shared borders', () => {
+        const [shallow, deep] = smoothWaterTopDepthSamples([
+            waterTop([0, 0, 0], [1, 1, 1, 1]),
+            waterTop([1, 0, 0], [3, 3, 3, 3]),
+        ]);
+
+        assert.ok(shallow);
+        assert.ok(deep);
+        assert.deepEqual(
+            rounded([shallow.depthSamples[2], shallow.depthSamples[3]]),
+            [2, 2],
+        );
+        assert.deepEqual(
+            rounded([deep.depthSamples[0], deep.depthSamples[1]]),
+            [2, 2],
+        );
+        assert.ok(shallow.depthSamples[0] < shallow.depthSamples[2]);
+        assert.ok(deep.depthSamples[2] > deep.depthSamples[0]);
+    });
+
+    it('keeps separated water surfaces unchanged', () => {
+        const smoothed = smoothWaterTopDepthSamples([
+            waterTop([0, 0, 0], [1, 1, 1, 1]),
+            waterTop([2, 0, 0], [3, 3, 3, 3]),
+        ]);
+
+        assert.deepEqual(smoothed[0]?.depthSamples, [1, 1, 1, 1]);
+        assert.deepEqual(smoothed[1]?.depthSamples, [3, 3, 3, 3]);
+    });
+
+    it('preserves shaped terrain depth when there are no neighbors', () => {
+        const smoothed = smoothWaterTopDepthSamples([
+            waterTop([0, 0, 0], [1, 1, 0, 0]),
+        ]);
+
+        assert.deepEqual(smoothed[0]?.depthSamples, [1, 1, 0, 0]);
+    });
+
+    it('does not smooth unrelated vertical water surfaces', () => {
+        const smoothed = smoothWaterTopDepthSamples([
+            waterTop([0, 0, 0], [1, 1, 1, 1]),
+            waterTop([1, 3, 0], [3, 3, 3, 3]),
+        ]);
+
+        assert.deepEqual(smoothed[0]?.depthSamples, [1, 1, 1, 1]);
+        assert.deepEqual(smoothed[1]?.depthSamples, [3, 3, 3, 3]);
+    });
+});

--- a/packages/game/src/entities/waterShoreDepth.ts
+++ b/packages/game/src/entities/waterShoreDepth.ts
@@ -1,0 +1,319 @@
+import type { Vector4 } from 'three';
+import type { WaterBlockDepthSamples } from './waterBlockDepth';
+
+export type WaterShoreDepthInstance = {
+    foamEdges: Vector4;
+    position: [number, number, number];
+    waterHeight: number;
+};
+
+const waterRangeOverlapEpsilon = 1e-6;
+const waterBlockHalfSize = 0.5;
+const shoreDepthDirections = [
+    [-1, 0],
+    [1, 0],
+    [0, -1],
+    [0, 1],
+] as const;
+const waterShoreDepthSamplePositions = [
+    [-waterBlockHalfSize, -waterBlockHalfSize],
+    [-waterBlockHalfSize, waterBlockHalfSize],
+    [waterBlockHalfSize, waterBlockHalfSize],
+    [waterBlockHalfSize, -waterBlockHalfSize],
+] as const;
+const emptyWaterShoreDepthSamples: WaterBlockDepthSamples = [0, 0, 0, 0];
+
+type ShoreSegment = {
+    endX: number;
+    endZ: number;
+    startX: number;
+    startZ: number;
+};
+
+function stackPositionKey(x: number, z: number) {
+    return `${x}|${z}`;
+}
+
+function waterRange(instance: WaterShoreDepthInstance) {
+    const [, y] = instance.position;
+    const halfHeight = instance.waterHeight / 2;
+
+    return {
+        min: y - halfHeight,
+        max: y + halfHeight,
+    };
+}
+
+function waterRangesOverlap(
+    left: WaterShoreDepthInstance,
+    right: WaterShoreDepthInstance,
+) {
+    const leftRange = waterRange(left);
+    const rightRange = waterRange(right);
+
+    return (
+        Math.min(leftRange.max, rightRange.max) -
+            Math.max(leftRange.min, rightRange.min) >
+        waterRangeOverlapEpsilon
+    );
+}
+
+function hasShoreEdge({ foamEdges }: WaterShoreDepthInstance) {
+    return (
+        foamEdges.x > 0.5 ||
+        foamEdges.y > 0.5 ||
+        foamEdges.z > 0.5 ||
+        foamEdges.w > 0.5
+    );
+}
+
+function groupInstancesByPosition(instances: WaterShoreDepthInstance[]) {
+    const groups = new Map<string, WaterShoreDepthInstance[]>();
+
+    for (const instance of instances) {
+        const [x, , z] = instance.position;
+        const key = stackPositionKey(x, z);
+        const group = groups.get(key);
+
+        if (group) {
+            group.push(instance);
+        } else {
+            groups.set(key, [instance]);
+        }
+    }
+
+    return groups;
+}
+
+function getConnectedWaterNeighbors({
+    instance,
+    instancesByPosition,
+}: {
+    instance: WaterShoreDepthInstance;
+    instancesByPosition: Map<string, WaterShoreDepthInstance[]>;
+}) {
+    const [x, , z] = instance.position;
+    const neighbors: WaterShoreDepthInstance[] = [];
+
+    for (const [xOffset, zOffset] of shoreDepthDirections) {
+        const candidates =
+            instancesByPosition.get(
+                stackPositionKey(x + xOffset, z + zOffset),
+            ) ?? [];
+
+        for (const candidate of candidates) {
+            if (waterRangesOverlap(instance, candidate)) {
+                neighbors.push(candidate);
+            }
+        }
+    }
+
+    return neighbors;
+}
+
+function resolveConnectedWaterComponents(instances: WaterShoreDepthInstance[]) {
+    const instancesByPosition = groupInstancesByPosition(instances);
+    const visited = new Set<WaterShoreDepthInstance>();
+    const components: WaterShoreDepthInstance[][] = [];
+
+    for (const instance of instances) {
+        if (visited.has(instance)) {
+            continue;
+        }
+
+        const component: WaterShoreDepthInstance[] = [];
+        const queue = [instance];
+        visited.add(instance);
+
+        for (let queueIndex = 0; queueIndex < queue.length; queueIndex += 1) {
+            const current = queue[queueIndex];
+            if (!current) {
+                continue;
+            }
+
+            component.push(current);
+
+            for (const neighbor of getConnectedWaterNeighbors({
+                instance: current,
+                instancesByPosition,
+            })) {
+                if (visited.has(neighbor)) {
+                    continue;
+                }
+
+                visited.add(neighbor);
+                queue.push(neighbor);
+            }
+        }
+
+        components.push(component);
+    }
+
+    return components;
+}
+
+function collectShoreSegments(instance: WaterShoreDepthInstance) {
+    const [x, , z] = instance.position;
+    const segments: ShoreSegment[] = [];
+
+    if (instance.foamEdges.x > 0.5) {
+        segments.push({
+            startX: x - waterBlockHalfSize,
+            startZ: z - waterBlockHalfSize,
+            endX: x - waterBlockHalfSize,
+            endZ: z + waterBlockHalfSize,
+        });
+    }
+
+    if (instance.foamEdges.y > 0.5) {
+        segments.push({
+            startX: x + waterBlockHalfSize,
+            startZ: z - waterBlockHalfSize,
+            endX: x + waterBlockHalfSize,
+            endZ: z + waterBlockHalfSize,
+        });
+    }
+
+    if (instance.foamEdges.z > 0.5) {
+        segments.push({
+            startX: x - waterBlockHalfSize,
+            startZ: z - waterBlockHalfSize,
+            endX: x + waterBlockHalfSize,
+            endZ: z - waterBlockHalfSize,
+        });
+    }
+
+    if (instance.foamEdges.w > 0.5) {
+        segments.push({
+            startX: x - waterBlockHalfSize,
+            startZ: z + waterBlockHalfSize,
+            endX: x + waterBlockHalfSize,
+            endZ: z + waterBlockHalfSize,
+        });
+    }
+
+    return segments;
+}
+
+function distanceToShoreSegment({
+    segment,
+    x,
+    z,
+}: {
+    segment: ShoreSegment;
+    x: number;
+    z: number;
+}) {
+    const dx = segment.endX - segment.startX;
+    const dz = segment.endZ - segment.startZ;
+    const lengthSquared = dx * dx + dz * dz;
+    const segmentOffset =
+        lengthSquared > 0
+            ? Math.min(
+                  Math.max(
+                      ((x - segment.startX) * dx + (z - segment.startZ) * dz) /
+                          lengthSquared,
+                      0,
+                  ),
+                  1,
+              )
+            : 0;
+    const nearestX = segment.startX + dx * segmentOffset;
+    const nearestZ = segment.startZ + dz * segmentOffset;
+
+    return Math.hypot(x - nearestX, z - nearestZ);
+}
+
+function distanceToShoreSegments({
+    segments,
+    x,
+    z,
+}: {
+    segments: ShoreSegment[];
+    x: number;
+    z: number;
+}) {
+    let distance = Number.POSITIVE_INFINITY;
+
+    for (const segment of segments) {
+        distance = Math.min(
+            distance,
+            distanceToShoreSegment({ segment, x, z }),
+        );
+    }
+
+    return Number.isFinite(distance) ? distance : 0;
+}
+
+export function resolveWaterShoreDepths(instances: WaterShoreDepthInstance[]) {
+    const instancesByPosition = groupInstancesByPosition(instances);
+    const depths = new Map<WaterShoreDepthInstance, number>();
+    const queue: WaterShoreDepthInstance[] = [];
+
+    for (const instance of instances) {
+        if (hasShoreEdge(instance)) {
+            depths.set(instance, 0);
+            queue.push(instance);
+        }
+    }
+
+    for (let queueIndex = 0; queueIndex < queue.length; queueIndex += 1) {
+        const instance = queue[queueIndex];
+        if (!instance) {
+            continue;
+        }
+
+        const depth = depths.get(instance);
+        if (depth === undefined) {
+            continue;
+        }
+
+        for (const neighbor of getConnectedWaterNeighbors({
+            instance,
+            instancesByPosition,
+        })) {
+            const nextDepth = depth + 1;
+            const currentDepth = depths.get(neighbor);
+
+            if (currentDepth !== undefined && currentDepth <= nextDepth) {
+                continue;
+            }
+
+            depths.set(neighbor, nextDepth);
+            queue.push(neighbor);
+        }
+    }
+
+    return instances.map((instance) => depths.get(instance) ?? 0);
+}
+
+export function resolveWaterShoreDepthSamples(
+    instances: WaterShoreDepthInstance[],
+): WaterBlockDepthSamples[] {
+    const sampleMap = new Map<
+        WaterShoreDepthInstance,
+        WaterBlockDepthSamples
+    >();
+
+    for (const component of resolveConnectedWaterComponents(instances)) {
+        const shoreSegments = component.flatMap(collectShoreSegments);
+
+        for (const instance of component) {
+            const [x, , z] = instance.position;
+            const samples = waterShoreDepthSamplePositions.map(
+                ([xOffset, zOffset]) =>
+                    distanceToShoreSegments({
+                        segments: shoreSegments,
+                        x: x + xOffset,
+                        z: z + zOffset,
+                    }),
+            ) as WaterBlockDepthSamples;
+
+            sampleMap.set(instance, samples);
+        }
+    }
+
+    return instances.map(
+        (instance) => sampleMap.get(instance) ?? emptyWaterShoreDepthSamples,
+    );
+}

--- a/packages/game/src/entities/waterShoreDepth.unit.ts
+++ b/packages/game/src/entities/waterShoreDepth.unit.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector4 } from 'three';
+import {
+    resolveWaterShoreDepthSamples,
+    resolveWaterShoreDepths,
+    type WaterShoreDepthInstance,
+} from './waterShoreDepth';
+
+const noFoamEdges = new Vector4(0, 0, 0, 0);
+
+function water(
+    x: number,
+    z: number,
+    foamEdges = noFoamEdges,
+    y = 0,
+): WaterShoreDepthInstance {
+    return {
+        foamEdges,
+        position: [x, y, z],
+        waterHeight: 0.4,
+    };
+}
+
+function gridWater(size: number) {
+    const instances: WaterShoreDepthInstance[] = [];
+
+    for (let x = 0; x < size; x += 1) {
+        for (let z = 0; z < size; z += 1) {
+            instances.push(
+                water(
+                    x,
+                    z,
+                    new Vector4(
+                        x === 0 ? 1 : 0,
+                        x === size - 1 ? 1 : 0,
+                        z === 0 ? 1 : 0,
+                        z === size - 1 ? 1 : 0,
+                    ),
+                ),
+            );
+        }
+    }
+
+    return instances;
+}
+
+function depthAt(
+    instances: WaterShoreDepthInstance[],
+    depths: number[],
+    x: number,
+    z: number,
+) {
+    const index = instances.findIndex(
+        (instance) => instance.position[0] === x && instance.position[2] === z,
+    );
+
+    return depths[index];
+}
+
+function rounded(values: number[]) {
+    return values.map((value) => Number(value.toFixed(6)));
+}
+
+describe('resolveWaterShoreDepths', () => {
+    it('starts shoreline water at depth zero', () => {
+        assert.deepEqual(
+            resolveWaterShoreDepths([water(0, 0, new Vector4(1, 0, 0, 0))]),
+            [0],
+        );
+    });
+
+    it('increments depth by tile distance from exposed shore water', () => {
+        const instances = gridWater(5);
+        const depths = resolveWaterShoreDepths(instances);
+
+        assert.equal(depthAt(instances, depths, 0, 2), 0);
+        assert.equal(depthAt(instances, depths, 1, 2), 1);
+        assert.equal(depthAt(instances, depths, 2, 2), 2);
+    });
+
+    it('does not connect water surfaces at separate vertical ranges', () => {
+        const lower = water(0, 0, new Vector4(1, 0, 0, 0), 0);
+        const upper = water(1, 0, noFoamEdges, 1);
+
+        assert.deepEqual(resolveWaterShoreDepths([lower, upper]), [0, 0]);
+    });
+});
+
+describe('resolveWaterShoreDepthSamples', () => {
+    it('samples continuous distance from exposed shore edges', () => {
+        const instances = [
+            water(0, 0, new Vector4(1, 0, 0, 0)),
+            water(1, 0),
+            water(2, 0),
+        ];
+        const samples = resolveWaterShoreDepthSamples(instances);
+
+        assert.deepEqual(rounded(samples[0] ?? []), [0, 0, 1, 1]);
+        assert.deepEqual(rounded(samples[1] ?? []), [1, 1, 2, 2]);
+        assert.deepEqual(rounded(samples[2] ?? []), [2, 2, 3, 3]);
+    });
+
+    it('uses Euclidean point-to-segment distance for diagonal samples', () => {
+        const instances = [
+            water(0, 0, new Vector4(1, 0, 0, 0)),
+            water(1, 0),
+            water(1, 1),
+        ];
+        const samples = resolveWaterShoreDepthSamples(instances);
+        const expected = [1, Math.SQRT2, Math.sqrt(5), 2].map((value) =>
+            Number(value.toFixed(6)),
+        );
+
+        assert.deepEqual(rounded(samples[2] ?? []), expected);
+    });
+
+    it('keeps separate vertical water ranges isolated', () => {
+        const lower = water(0, 0, new Vector4(1, 0, 0, 0), 0);
+        const upper = water(1, 0, noFoamEdges, 1);
+
+        assert.deepEqual(resolveWaterShoreDepthSamples([lower, upper]), [
+            [0, 0, 1, 1],
+            [0, 0, 0, 0],
+        ]);
+    });
+});

--- a/packages/game/src/scene/waterColors.ts
+++ b/packages/game/src/scene/waterColors.ts
@@ -15,9 +15,9 @@ export type WaterColors = {
 };
 
 export const defaultWaterColors: WaterColors = {
-    deep: '#8fcfc4',
-    shallow: '#d6eee3',
-    foam: '#f8fff8',
+    deep: '#1f6ea7',
+    shallow: '#8eddd3',
+    foam: '#fbfffb',
 };
 
 function clamp01(value: number) {


### PR DESCRIPTION
## Summary
- Render stable ground and water surfaces through chunked/merged mesh geometry instead of many per-block entity models.
- Add merged water top/side geometry with per-vertex depth, shore-distance, foam, and local-position attributes.
- Improve stylized water rendering with depth-based color, smoother shore gradients, stronger/wider foam, and slower/noise-like foam breakup.
- Document the updated scene performance/rendering approach and cover chunk/water geometry behavior with unit tests.

## Validation
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter www typecheck`
- `git diff --check`
- Browser smoke on `/debug/profile/game?profile=dense&quality=medium&details=1&debugHud=1&hud=0` with full canvas and no WebGL/shader errors.
