### PR TITLE
[codex] Fix automation AI system prompts

### DIFF
--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -470,7 +470,7 @@ type AnalysisParams = {
     referenceDate?: Date | string | null;
 };
 
-async function buildAnalysisMessages({
+async function buildAnalysisPrompt({
     accountId,
     gardenId,
     raisedBed,
@@ -602,90 +602,89 @@ async function buildAnalysisMessages({
             ? toPositionLabel(positionIndex)
             : null;
 
-    return [
-        {
-            role: 'system' as const,
-            content: [
-                'Ti si stručni agronom za urbane vrtove. Piši ISKLJUČIVO na hrvatskom jeziku i vrati odgovor kao uredno formatiran markdown. Korisnik nema fizički pristup gredici; kada preporuka traži rad na gredici, predloži naručivanje najbliže odgovarajuće operacije iz dostupnog popisa umjesto da korisniku kažeš da to sam ručno napravi.',
-                'Nikada u vidljivom odgovoru ne spominji interne nazive ili JSON ključeve poput `positionIndex`, `positionLabel`, `needsRemoval`, `removalRecommendation`, `plantStatus`, `plantSortId`, `currentLocation`, `sowingLocation`, `availableOperations`, `raisedBedOperationUrl` ili `plantFieldOperationUrlTemplate`. Ne citiraj `key: value` parove iz JSON-a.',
-                'Kad trebaš identificirati lokaciju, napiši samo "polje N" koristeći korisniku vidljivu oznaku polja. Nikada ne dodaj 0-bazirani indeks polja u tekst odgovora.',
-                'Statuse, bool vrijednosti i interne oznake pretvori u normalan hrvatski tekst, npr. "označeno za uklanjanje", "spremno za berbu" ili "u stakleniku".',
-                '',
-                'Raspored polja u gredici:',
-                `- Standardna gredica ima ${RAISED_BED_COLUMNS} stupca i do ${rows} redova (ukupno do ${totalFields} polja).`,
-                '- Polja su numerirana od 1 nadalje, počevši od donjeg desnog kuta slike i čitajući zdesna nalijevo, red po red prema gore.',
-                '- Donji red: 1 (donje desno) → 2 (donje sredina) → 3 (donje lijevo).',
-                '- Gornji red kod 18-poljne gredice: 16 (gornje desno) → 17 (gornja sredina) → 18 (gornje lijevo).',
-                '- U kontekstu koristi korisniku vidljivu oznaku polja. Internu vrijednost polja koristi samo za slaganje URL-a radnje i nikada je ne ispisuj u tekstu.',
-                '- Ponekad su priložene dvije fotografije iste gredice: jedna iz standardne pozicije za gore navedeno numeriranje, a druga s druge strane gredice. Koristi ih kao komplementarne poglede iste gredice; drugi pogled služi za provjeru stanja biljaka, ne kao zasebna gredica ili novi raspored polja.',
-                '- Polja s `currentLocation: "greenhouse"` su presadnice koje trenutno rastu u stakleniku i još nisu presađene u gredicu; polja s `currentLocation: "raisedBed"` su u gredici. `sowingLocation` opisuje gdje je biljka započela.',
-                '- `pastPlantFields` navodi samo nazive biljaka koje su ranije bile u polju; ne sadrži povijest događaja ni datume.',
-                '- `imageDate` je datum fotografija/dnevničkog unosa. Koristi `imageDate`, `analysisReferenceDate` i `weather.historical` za procjenu stanja na fotografijama. `currentDate`, `weather.now` i `weather.forecast` koristi samo za današnje i buduće preporuke za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
-                '- Kada preporučiš konkretnu radnju, napiši je kao markdown poveznicu s apsolutnim URL-om iz konteksta, npr. `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId})`.',
-                '- Za radnje nad pojedinom biljkom/poljem koristi točan URL predložak iz konteksta. Interna vrijednost polja smije postojati samo u URL-u markdown poveznice, nikada u vidljivom tekstu.',
-                '- Koristi samo apsolutne `https://www.gredice.com/radnje/...` URL predloške iz `availableOperations`; ne izmišljaj slugove, ne piši sirovi URL bez markdown oznake i ne dodaj link ako za radnju ne postoji odgovarajući URL predložak.',
-            ].join('\n'),
-        },
-        {
-            role: 'user' as const,
-            content: [
-                {
-                    type: 'text' as const,
-                    text: [
-                        typeof positionIndex === 'number'
-                            ? `Analiziraj sve fotografije vrta i kontekst te napiši objedinjene praktične preporuke za označeno polje ${analyzedPositionLabel} i ostatak gredice.`
-                            : 'Analiziraj sve fotografije gredice i kontekst te napiši objedinjene praktične preporuke za cijelu gredicu.',
-                        'Fotografije su različiti pogledi istog dnevničkog unosa; nemoj ih tretirati kao zasebne zahtjeve.',
-                        'Odgovor MORA imati ove markdown sekcije s točno ovim naslovima:',
-                        '## Sažetak stanja',
-                        '## Najvažnije preporuke',
-                        '## Biljke koje traže najviše pažnje',
-                        '## Plan za sljedeća 3 dana',
-                        'U najvažnijim preporukama napiši 2-4 stavke. U sekciji o biljkama navedi 2-4 biljke; za svaku napiši problem i konkretan idući korak.',
-                        '',
-                        'Kontekst (JSON):',
-                        JSON.stringify(
-                            {
-                                currentDate: nowIso,
-                                imageDate: referenceDateIso,
-                                imageDateSource,
-                                analysisReferenceDate: referenceDateIso,
-                                weather,
-                                raisedBed: {
-                                    orientation,
-                                    columns: RAISED_BED_COLUMNS,
-                                    rows,
-                                    totalFields,
+    return {
+        system: [
+            'Ti si stručni agronom za urbane vrtove. Piši ISKLJUČIVO na hrvatskom jeziku i vrati odgovor kao uredno formatiran markdown. Korisnik nema fizički pristup gredici; kada preporuka traži rad na gredici, predloži naručivanje najbliže odgovarajuće operacije iz dostupnog popisa umjesto da korisniku kažeš da to sam ručno napravi.',
+            'Nikada u vidljivom odgovoru ne spominji interne nazive ili JSON ključeve poput `positionIndex`, `positionLabel`, `needsRemoval`, `removalRecommendation`, `plantStatus`, `plantSortId`, `currentLocation`, `sowingLocation`, `availableOperations`, `raisedBedOperationUrl` ili `plantFieldOperationUrlTemplate`. Ne citiraj `key: value` parove iz JSON-a.',
+            'Kad trebaš identificirati lokaciju, napiši samo "polje N" koristeći korisniku vidljivu oznaku polja. Nikada ne dodaj 0-bazirani indeks polja u tekst odgovora.',
+            'Statuse, bool vrijednosti i interne oznake pretvori u normalan hrvatski tekst, npr. "označeno za uklanjanje", "spremno za berbu" ili "u stakleniku".',
+            '',
+            'Raspored polja u gredici:',
+            `- Standardna gredica ima ${RAISED_BED_COLUMNS} stupca i do ${rows} redova (ukupno do ${totalFields} polja).`,
+            '- Polja su numerirana od 1 nadalje, počevši od donjeg desnog kuta slike i čitajući zdesna nalijevo, red po red prema gore.',
+            '- Donji red: 1 (donje desno) → 2 (donje sredina) → 3 (donje lijevo).',
+            '- Gornji red kod 18-poljne gredice: 16 (gornje desno) → 17 (gornja sredina) → 18 (gornje lijevo).',
+            '- U kontekstu koristi korisniku vidljivu oznaku polja. Internu vrijednost polja koristi samo za slaganje URL-a radnje i nikada je ne ispisuj u tekstu.',
+            '- Ponekad su priložene dvije fotografije iste gredice: jedna iz standardne pozicije za gore navedeno numeriranje, a druga s druge strane gredice. Koristi ih kao komplementarne poglede iste gredice; drugi pogled služi za provjeru stanja biljaka, ne kao zasebna gredica ili novi raspored polja.',
+            '- Polja s `currentLocation: "greenhouse"` su presadnice koje trenutno rastu u stakleniku i još nisu presađene u gredicu; polja s `currentLocation: "raisedBed"` su u gredici. `sowingLocation` opisuje gdje je biljka započela.',
+            '- `pastPlantFields` navodi samo nazive biljaka koje su ranije bile u polju; ne sadrži povijest događaja ni datume.',
+            '- `imageDate` je datum fotografija/dnevničkog unosa. Koristi `imageDate`, `analysisReferenceDate` i `weather.historical` za procjenu stanja na fotografijama. `currentDate`, `weather.now` i `weather.forecast` koristi samo za današnje i buduće preporuke za zalijevanje, zaštitu od mraza, sjetvu i berbu.',
+            '- Kada preporučiš konkretnu radnju, napiši je kao markdown poveznicu s apsolutnim URL-om iz konteksta, npr. `[Naziv radnje](https://www.gredice.com/radnje/{slug}#raisedBedId={raisedBedId})`.',
+            '- Za radnje nad pojedinom biljkom/poljem koristi točan URL predložak iz konteksta. Interna vrijednost polja smije postojati samo u URL-u markdown poveznice, nikada u vidljivom tekstu.',
+            '- Koristi samo apsolutne `https://www.gredice.com/radnje/...` URL predloške iz `availableOperations`; ne izmišljaj slugove, ne piši sirovi URL bez markdown oznake i ne dodaj link ako za radnju ne postoji odgovarajući URL predložak.',
+        ].join('\n'),
+        messages: [
+            {
+                role: 'user' as const,
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: [
+                            typeof positionIndex === 'number'
+                                ? `Analiziraj sve fotografije vrta i kontekst te napiši objedinjene praktične preporuke za označeno polje ${analyzedPositionLabel} i ostatak gredice.`
+                                : 'Analiziraj sve fotografije gredice i kontekst te napiši objedinjene praktične preporuke za cijelu gredicu.',
+                            'Fotografije su različiti pogledi istog dnevničkog unosa; nemoj ih tretirati kao zasebne zahtjeve.',
+                            'Odgovor MORA imati ove markdown sekcije s točno ovim naslovima:',
+                            '## Sažetak stanja',
+                            '## Najvažnije preporuke',
+                            '## Biljke koje traže najviše pažnje',
+                            '## Plan za sljedeća 3 dana',
+                            'U najvažnijim preporukama napiši 2-4 stavke. U sekciji o biljkama navedi 2-4 biljke; za svaku napiši problem i konkretan idući korak.',
+                            '',
+                            'Kontekst (JSON):',
+                            JSON.stringify(
+                                {
+                                    currentDate: nowIso,
+                                    imageDate: referenceDateIso,
+                                    imageDateSource,
+                                    analysisReferenceDate: referenceDateIso,
+                                    weather,
+                                    raisedBed: {
+                                        orientation,
+                                        columns: RAISED_BED_COLUMNS,
+                                        rows,
+                                        totalFields,
+                                    },
+                                    analyzedField:
+                                        typeof positionIndex === 'number'
+                                            ? {
+                                                  positionIndex,
+                                                  positionLabel:
+                                                      analyzedPositionLabel,
+                                              }
+                                            : null,
+                                    imageCount: imageUrls.length,
+                                    plantedFields,
+                                    pastPlantFields:
+                                        pastPlantFields.length > 0
+                                            ? pastPlantFields
+                                            : undefined,
+                                    availableOperations,
+                                    executedOperations,
                                 },
-                                analyzedField:
-                                    typeof positionIndex === 'number'
-                                        ? {
-                                              positionIndex,
-                                              positionLabel:
-                                                  analyzedPositionLabel,
-                                          }
-                                        : null,
-                                imageCount: imageUrls.length,
-                                plantedFields,
-                                pastPlantFields:
-                                    pastPlantFields.length > 0
-                                        ? pastPlantFields
-                                        : undefined,
-                                availableOperations,
-                                executedOperations,
-                            },
-                            null,
-                            2,
-                        ),
-                    ].join('\n'),
-                },
-                ...imageUrls.map((imageUrl) => ({
-                    type: 'image' as const,
-                    image: new URL(imageUrl),
-                })),
-            ],
-        },
-    ];
+                                null,
+                                2,
+                            ),
+                        ].join('\n'),
+                    },
+                    ...imageUrls.map((imageUrl) => ({
+                        type: 'image' as const,
+                        image: new URL(imageUrl),
+                    })),
+                ],
+            },
+        ],
+    };
 }
 
 export async function streamRaisedBedImageAnalysis(
@@ -699,10 +698,11 @@ export async function streamRaisedBedImageAnalysis(
         totalTokens: number;
     }) => void | Promise<void>,
 ) {
-    const messages = await buildAnalysisMessages(params);
+    const { system, messages } = await buildAnalysisPrompt(params);
 
     const result = streamText({
         model: AI_MODEL,
+        system,
         messages,
         onFinish: async ({ text, usage }) => {
             await onFinish({

--- a/packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts
+++ b/packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts
@@ -528,60 +528,59 @@ async function buildReviewContext(input: ReviewInput & { ok: true }) {
     };
 }
 
-function buildReviewMessages({
+function buildReviewPrompt({
     input,
     promptContext,
 }: {
     input: ReviewInput & { ok: true };
     promptContext: AutomationJsonObject;
 }) {
-    return [
-        {
-            role: 'system' as const,
-            content: [
-                'Ti si stručni agronom koji pregledava fotografije Gredice i predlaže ISKLJUČIVO sigurne promjene stanja biljaka.',
-                'Vrati strukturirani rezultat prema shemi. Ne vraćaj markdown.',
-                'U poljima `summary` i `evidence` piši normalne hrvatske rečenice. Ne spominji interne nazive ili JSON ključeve kao `positionIndex`, `needsRemoval`, `plantStatus`, `plantSortId`, `currentLocation` ili `sowingLocation`.',
-                'Predloži promjenu samo kada je vizualni dokaz jasan i gotovo siguran; ne pogađaj na temelju kalendara, očekivanih dana rasta ili mutne/zaklonjene fotografije.',
-                'Za svako polje smiješ predložiti plant-status samo iz `allowedTargetStatuses`; ako nema odgovarajućeg statusa, preskoči plant-status prijedlog za to polje.',
-                'Ako je trenutno stanje `sowed` ili `pendingVerification`, a na slici se jasno vide klice za direktno sijanu biljku, predloži `sprouted`.',
-                'U `weedProposals` predloži field-level status korova (`none`, `light` ili `heavy`) samo kada se korovi ili očišćeno polje jasno vide za pojedino polje.',
-                'Ne predlaži `none` za korove samo zato što korovi nisu vidljivi; predloži `none` samo kada slika jasno pokazuje da je polje čisto, osobito ako postoji trenutačni field ili raised-bed weed state.',
-                '`raisedBed.currentWeedState` je stanje na razini cijele gredice. `field.currentFieldWeedState` i `field.currentFieldWeedLevel` su stanje za pojedino polje; field-level prijedlozi smiju precizirati ili očistiti stanje iz gredice.',
-                'Ako je fotografija close-up i polje nije sigurno prepoznatljivo, koristi `focusField` kada postoji. Ako je fotografija cijele gredice, možeš predložiti više polja.',
-                'Polja s `currentLocation: "greenhouse"` ignoriraj osim ako fotografija jasno pokazuje da se ista biljka nalazi u pripadajućem polju gredice.',
-                'Koristi `expectedPlantCount` kao kontekst za to koliko pojedinačnih biljaka ili klica se očekuje u polju.',
-                '`previousPlantNames` sadrži samo nazive ranijih biljaka u tom polju; ne sadrži povijest događaja, statuse ni datume.',
-                '`imageDate` je datum fotografija ili izvornog dnevničkog unosa; koristi ga za kontekst polja i vrijednosti `daysFrom*`. `currentDate` je trenutak obrade automatizacije i ne smije promijeniti interpretaciju stanja na starijoj fotografiji.',
-                '',
-                'Raspored polja u slici cijele gredice:',
-                '- Polja su numerirana od donjeg desnog kuta slike.',
-                '- Donji red: 1 (donje desno), 2 (donja sredina), 3 (donje lijevo).',
-                '- Kod 18-poljne gredice gornji red je 16 (gornje desno), 17 (gornja sredina), 18 (gornje lijevo).',
-                '- `positionLabel` je 1-bazirana oznaka iz slike; `positionIndex = positionLabel - 1`.',
-            ].join('\n'),
-        },
-        {
-            role: 'user' as const,
-            content: [
-                {
-                    type: 'text' as const,
-                    text: [
-                        'Analiziraj fotografije i kontekst. Vrati samo prijedloge promjena stanja biljaka koje su vizualno sigurne.',
-                        'Vrati i prijedloge statusa korova za pojedinačna polja kada su vizualno sigurni.',
-                        'Ako nema sigurnih promjena, vrati prazne `proposals` i `weedProposals` nizove.',
-                        '',
-                        'Kontekst (JSON):',
-                        JSON.stringify(promptContext, null, 2),
-                    ].join('\n'),
-                },
-                ...input.imageUrls.map((imageUrl) => ({
-                    type: 'image' as const,
-                    image: new URL(imageUrl),
-                })),
-            ],
-        },
-    ];
+    return {
+        system: [
+            'Ti si stručni agronom koji pregledava fotografije Gredice i predlaže ISKLJUČIVO sigurne promjene stanja biljaka.',
+            'Vrati strukturirani rezultat prema shemi. Ne vraćaj markdown.',
+            'U poljima `summary` i `evidence` piši normalne hrvatske rečenice. Ne spominji interne nazive ili JSON ključeve kao `positionIndex`, `needsRemoval`, `plantStatus`, `plantSortId`, `currentLocation` ili `sowingLocation`.',
+            'Predloži promjenu samo kada je vizualni dokaz jasan i gotovo siguran; ne pogađaj na temelju kalendara, očekivanih dana rasta ili mutne/zaklonjene fotografije.',
+            'Za svako polje smiješ predložiti plant-status samo iz `allowedTargetStatuses`; ako nema odgovarajućeg statusa, preskoči plant-status prijedlog za to polje.',
+            'Ako je trenutno stanje `sowed` ili `pendingVerification`, a na slici se jasno vide klice za direktno sijanu biljku, predloži `sprouted`.',
+            'U `weedProposals` predloži field-level status korova (`none`, `light` ili `heavy`) samo kada se korovi ili očišćeno polje jasno vide za pojedino polje.',
+            'Ne predlaži `none` za korove samo zato što korovi nisu vidljivi; predloži `none` samo kada slika jasno pokazuje da je polje čisto, osobito ako postoji trenutačni field ili raised-bed weed state.',
+            '`raisedBed.currentWeedState` je stanje na razini cijele gredice. `field.currentFieldWeedState` i `field.currentFieldWeedLevel` su stanje za pojedino polje; field-level prijedlozi smiju precizirati ili očistiti stanje iz gredice.',
+            'Ako je fotografija close-up i polje nije sigurno prepoznatljivo, koristi `focusField` kada postoji. Ako je fotografija cijele gredice, možeš predložiti više polja.',
+            'Polja s `currentLocation: "greenhouse"` ignoriraj osim ako fotografija jasno pokazuje da se ista biljka nalazi u pripadajućem polju gredice.',
+            'Koristi `expectedPlantCount` kao kontekst za to koliko pojedinačnih biljaka ili klica se očekuje u polju.',
+            '`previousPlantNames` sadrži samo nazive ranijih biljaka u tom polju; ne sadrži povijest događaja, statuse ni datume.',
+            '`imageDate` je datum fotografija ili izvornog dnevničkog unosa; koristi ga za kontekst polja i vrijednosti `daysFrom*`. `currentDate` je trenutak obrade automatizacije i ne smije promijeniti interpretaciju stanja na starijoj fotografiji.',
+            '',
+            'Raspored polja u slici cijele gredice:',
+            '- Polja su numerirana od donjeg desnog kuta slike.',
+            '- Donji red: 1 (donje desno), 2 (donja sredina), 3 (donje lijevo).',
+            '- Kod 18-poljne gredice gornji red je 16 (gornje desno), 17 (gornja sredina), 18 (gornje lijevo).',
+            '- `positionLabel` je 1-bazirana oznaka iz slike; `positionIndex = positionLabel - 1`.',
+        ].join('\n'),
+        messages: [
+            {
+                role: 'user' as const,
+                content: [
+                    {
+                        type: 'text' as const,
+                        text: [
+                            'Analiziraj fotografije i kontekst. Vrati samo prijedloge promjena stanja biljaka koje su vizualno sigurne.',
+                            'Vrati i prijedloge statusa korova za pojedinačna polja kada su vizualno sigurni.',
+                            'Ako nema sigurnih promjena, vrati prazne `proposals` i `weedProposals` nizove.',
+                            '',
+                            'Kontekst (JSON):',
+                            JSON.stringify(promptContext, null, 2),
+                        ].join('\n'),
+                    },
+                    ...input.imageUrls.map((imageUrl) => ({
+                        type: 'image' as const,
+                        image: new URL(imageUrl),
+                    })),
+                ],
+            },
+        ],
+    };
 }
 
 function proposalSkip(
@@ -889,7 +888,7 @@ export async function runRaisedBedImagePlantStatusReview({
         };
     }
 
-    const messages = buildReviewMessages({
+    const { system, messages } = buildReviewPrompt({
         input,
         promptContext: context.promptContext,
     });
@@ -905,6 +904,7 @@ export async function runRaisedBedImagePlantStatusReview({
                             'High-certainty plant status change proposals from raised-bed images.',
                         schema: plantStatusReviewOutputSchema,
                     }),
+                    system,
                     messages,
                 }),
             };


### PR DESCRIPTION
## Summary

Moves raised-bed image AI system instructions out of `messages` and into the AI SDK `system` option for both automation plant-status review and the related raised-bed image analysis stream.

## Root cause

The automation prompt builder sent a `role: "system"` entry inside `messages`. The OpenAI-backed model path rejects system messages in the prompt/messages payload and expects instructions to be passed through the dedicated instruction/system option instead.

## Impact

Automation runs for plant-status review should no longer fail with `Invalid prompt: System messages are not allowed in the prompt or messages fields. Use the instructions option instead.` The user-visible prompts and image/context payloads are otherwise unchanged.

## Validation

- `corepack pnpm --filter @gredice/storage lint`
- `corepack pnpm --filter api lint`
- `corepack pnpm exec tsc --noEmit --pretty false --skipLibCheck --strict --module esnext --moduleResolution bundler --target esnext --lib esnext --esModuleInterop --allowJs --resolveJsonModule --isolatedModules packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts`
- `corepack pnpm exec tsc --noEmit --pretty false --skipLibCheck --strict --module esnext --moduleResolution bundler --target esnext --lib dom,dom.iterable,esnext --esModuleInterop --allowJs --allowImportingTsExtensions --resolveJsonModule --isolatedModules apps/api/lib/garden/raisedBedAiAnalysisService.ts`
- `git diff --check`