### PR TITLE
[codex] Reduce night scene glow

### DIFF
--- a/packages/game/src/scene/SkyGradientBackground.tsx
+++ b/packages/game/src/scene/SkyGradientBackground.tsx
@@ -69,7 +69,7 @@ const skyGradientFragment = /* glsl */ `
         vec2 p = vUv * 2.0 - 1.0;
         float sunGlow = glowAt(p, uSunPosition, 0.95);
         float sunCore = glowAt(p, uSunPosition, 0.36);
-        float moonGlow = glowAt(p, uMoonPosition, 0.72);
+        float moonGlow = glowAt(p, uMoonPosition, 0.58);
 
         color = mix(color, uSunGlowColor, clamp(sunGlow * uSunGlowIntensity, 0.0, 1.0));
         color = mix(color, vec3(1.0), clamp(sunCore * uSunGlowIntensity * 0.62, 0.0, 1.0));

--- a/packages/game/src/scene/SunMoon.tsx
+++ b/packages/game/src/scene/SunMoon.tsx
@@ -131,7 +131,7 @@ const moonFragment = /* glsl */ `
         // Glow follows the illuminated fraction so a thin crescent doesn't
         // project a full-moon halo.
         float illumFraction = 0.5 * (1.0 - cos(uPhase * TAU));
-        float glow = smoothstep(GLOW_R, DISC_R, d) * 0.18 * illumFraction;
+        float glow = smoothstep(GLOW_R, DISC_R, d) * 0.11 * illumFraction;
 
         float alpha = (lit * discEdge + glow) * uOpacity;
         if (alpha < 0.001) discard;

--- a/packages/game/src/scene/moonlight.ts
+++ b/packages/game/src/scene/moonlight.ts
@@ -3,6 +3,8 @@ import { getVisualNightAmount, smoothstep } from './visualDayNight';
 
 const MOONLESS_NIGHT_LIGHT_SCALE = 0.32;
 const MOONLESS_NIGHT_SKY_SCALE = 0.6;
+const MOONLIT_NIGHT_LIGHT_SCALE = 0.78;
+const MOONLIT_NIGHT_SKY_SCALE = 0.82;
 
 const MOON_HORIZON_FADE = {
     start: -0.05,
@@ -33,10 +35,11 @@ export function resolveMoonlitNightScales({
     const visibleMoonlight = clamp01(moonlight);
     const moonNightLightScale =
         MOONLESS_NIGHT_LIGHT_SCALE +
-        (1 - MOONLESS_NIGHT_LIGHT_SCALE) * visibleMoonlight;
+        (MOONLIT_NIGHT_LIGHT_SCALE - MOONLESS_NIGHT_LIGHT_SCALE) *
+            visibleMoonlight;
     const moonNightSkyScale =
         MOONLESS_NIGHT_SKY_SCALE +
-        (1 - MOONLESS_NIGHT_SKY_SCALE) * visibleMoonlight;
+        (MOONLIT_NIGHT_SKY_SCALE - MOONLESS_NIGHT_SKY_SCALE) * visibleMoonlight;
 
     return {
         lightScale: mix(1, moonNightLightScale, nightAmount),

--- a/packages/game/src/scene/moonlight.unit.ts
+++ b/packages/game/src/scene/moonlight.unit.ts
@@ -18,8 +18,8 @@ test('moonlit night scales darken low-moon nights', () => {
 
     assert.ok(moonless.lightScale < fullMoon.lightScale);
     assert.ok(moonless.skyScale < fullMoon.skyScale);
-    assert.equal(round(fullMoon.lightScale), 1);
-    assert.equal(round(fullMoon.skyScale), 1);
+    assert.equal(round(fullMoon.lightScale), 0.78);
+    assert.equal(round(fullMoon.skyScale), 0.82);
 });
 
 test('moonlit night scales leave daylight unchanged', () => {

--- a/packages/game/src/scene/skyGradient.ts
+++ b/packages/game/src/scene/skyGradient.ts
@@ -329,21 +329,21 @@ export function resolveSkyGradientColors({
         .lerp(colorFromHex('#6f8fb7'), night * visibleMoonlight * 0.08);
 
     const horizon = shiftHsl(base, {
-        lightnessOffset: 0.035 + daylight * 0.035 - nightFloorDarkening * 0.045,
+        lightnessOffset: 0.035 + daylight * 0.035 - nightFloorDarkening * 0.07,
         saturationScale: 1.02 + twilight * 0.2,
     })
         .lerp(
             theme.light,
-            (0.28 + daylight * 0.16) * (1 - nightFloorDarkening * 0.72),
+            (0.28 + daylight * 0.16) * (1 - nightFloorDarkening * 0.82),
         )
         .lerp(colorFromHex(twilightWarmth), twilight * 0.35)
-        .lerp(theme.night, nightFloorDarkening * 0.28 + night * 0.18)
-        .lerp(colorFromHex('#9fb4d4'), night * visibleMoonlight * 0.1);
+        .lerp(theme.night, nightFloorDarkening * 0.34 + night * 0.2)
+        .lerp(colorFromHex('#9fb4d4'), night * visibleMoonlight * 0.05);
 
     const lower = horizon
         .clone()
-        .lerp(theme.night, nightFloorDarkening * 0.5 + night * 0.16)
-        .lerp(zenith, nightFloorDarkening * 0.1);
+        .lerp(theme.night, nightFloorDarkening * 0.62 + night * 0.2)
+        .lerp(zenith, nightFloorDarkening * 0.06);
 
     const weatherTone = {
         cloudy: overcast,
@@ -373,7 +373,7 @@ export function resolveSkyGradientColors({
         moonGlow: applyWeatherTone(moonGlow, weatherTone),
         moonGlowIntensity:
             night *
-            (0.06 + visibleMoonlight * 0.22) *
+            (0.035 + visibleMoonlight * 0.13) *
             (1 - overcast * 0.68) *
             (1 - storm * 0.15),
     };

--- a/packages/game/src/scene/skyGradient.unit.ts
+++ b/packages/game/src/scene/skyGradient.unit.ts
@@ -123,6 +123,7 @@ test('moonlight and cloud cover tune glow strength at night', () => {
     assert.ok(
         moonlitGradient.moonGlowIntensity > moonlessGradient.moonGlowIntensity,
     );
+    assert.ok(moonlitGradient.moonGlowIntensity < 0.16);
     assert.ok(
         overcastGradient.moonGlowIntensity < moonlitGradient.moonGlowIntensity,
     );


### PR DESCRIPTION
## Summary

Reduces night-scene brightness from visible moonlight so moonlit nights no longer lift the sky, horizon, lower backdrop, and ambient lighting back toward daylight. Also tightens the sky-gradient moon glow and the moon billboard halo while keeping the moon disc readable.

## Validation

- `pnpm test --filter @gredice/game`
- `pnpm lint --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- Visual check: `http://localhost:3271/debug/profile/game?mode=night&details=0&quality=high` rendered a nonblank 1280x720 canvas with no Next.js error overlay, no compile toast, and no browser error logs. Screenshot pixel stats: mean luminance 57.65, stdev 14.4.

## Notes

The isolated garden debug route still logs expected backend proxy refusals when only the garden app is running locally; the mock scene rendered successfully.
