### PR TITLE
fix(www): render plant tips as markdown

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantTips.tsx
+++ b/apps/www/app/biljke/[alias]/PlantTips.tsx
@@ -1,6 +1,7 @@
 import type { PlantData } from '@gredice/client';
 import { slug } from '@gredice/js/slug';
 import { Accordion } from '@gredice/ui/Accordion';
+import { Markdown } from '@gredice/ui/Markdown';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
@@ -34,7 +35,7 @@ export function PlantTips({
                             {tip.header}
                         </Typography>
                         <Stack spacing={4}>
-                            <Typography>{tip.content}</Typography>
+                            <Markdown>{tip.content}</Markdown>
                             <FeedbackModal
                                 className="self-end"
                                 topic="www/plants/advice"

--- a/apps/www/tests/PlantTipsHarness.tsx
+++ b/apps/www/tests/PlantTipsHarness.tsx
@@ -1,0 +1,21 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from 'next-themes';
+import { PlantTips } from '../app/biljke/[alias]/PlantTips';
+
+export function PlantTipsHarness(props: Parameters<typeof PlantTips>[0]) {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <ThemeProvider attribute="class">
+                <PlantTips {...props} />
+            </ThemeProvider>
+        </QueryClientProvider>
+    );
+}

--- a/apps/www/tests/plant-tips.spec.tsx
+++ b/apps/www/tests/plant-tips.spec.tsx
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { PlantTipsHarness } from './PlantTipsHarness';
+import '../app/globals.css';
+
+test('renders plant advice content as markdown', async ({ mount, page }) => {
+    await page.route('**/api/gredice/api/auth/current-claims', (route) =>
+        route.fulfill({ status: 401, json: { error: 'Unauthorized' } }),
+    );
+
+    await mount(
+        <PlantTipsHarness
+            plant={{
+                id: 1,
+                information: {
+                    tip: [
+                        {
+                            header: 'Zalijevanje',
+                            content:
+                                'Koristi **malč** za vlagu.\n\n- Provjeri tlo\n\n[Više savjeta](/savjeti)',
+                        },
+                    ],
+                },
+            }}
+        />,
+    );
+
+    await expect(page.getByRole('heading', { name: 'Savjeti' })).toBeVisible();
+    await expect(page.locator('strong', { hasText: 'malč' })).toBeVisible();
+    await expect(page.getByRole('listitem')).toContainText('Provjeri tlo');
+    await expect(
+        page.getByRole('link', { name: 'Više savjeta' }),
+    ).toHaveAttribute('href', '/savjeti');
+});


### PR DESCRIPTION
## Summary
- render plant Savjeti bodies through the shared Markdown renderer
- add a focused Playwright component test covering emphasis, lists, and links
- wrap the test component with the same lightweight React Query/theme providers used by nearby CT harnesses

## Validation
- `corepack pnpm --dir apps/www exec biome check --write 'app/biljke/[alias]/PlantTips.tsx' tests/plant-tips.spec.tsx tests/PlantTipsHarness.tsx`\n- `corepack pnpm --dir apps/www run test:prepare`\n- `corepack pnpm --dir apps/www exec playwright test --config playwright.config.ts --project=chromium tests/plant-tips.spec.tsx`\n- `git diff --check`\n\nCloses #3945