### PR TITLE
fix(garden): show mulch blocks in items HUD

### DIFF
--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -25,24 +25,69 @@ import {
 
 const now = '2026-05-13T00:00:00.000Z';
 
+const mulchBlockFixtures: Record<
+    string,
+    {
+        label: string;
+        shortDescription: string;
+        sunflowers: number;
+        height: number;
+        stackable: boolean;
+    }
+> = {
+    MulchWood: {
+        label: 'Malč - kora drveta',
+        shortDescription:
+            'Malč od kore drveta koristi se za zadržavanje vlage, zaštitu tla i smanjenje rasta korova.',
+        sunflowers: 20,
+        height: 0.01,
+        stackable: true,
+    },
+    MulchCoconut: {
+        label: 'Malč - kokosova kora',
+        shortDescription:
+            'Malč od kokosove kore koristi se za zaštitu tla, očuvanje vlage i dekorativni izgled gredice.',
+        sunflowers: 20,
+        height: 0.01,
+        stackable: true,
+    },
+    MulchHey: {
+        label: 'Malč - slama',
+        shortDescription:
+            'Malč od slame koristi se za zaštitu tla, zadržavanje vlage i sprječavanje rasta korova.',
+        sunflowers: 20,
+        height: 0.01,
+        stackable: true,
+    },
+};
+
 function createBlockData(name: string, index: number) {
+    const mulchFixture = mulchBlockFixtures[name];
+
     return {
         id: index + 1,
         entityType: { id: 8, name: 'block', label: 'Blok' },
         slug: name.toLowerCase().replaceAll('_', '-'),
         information: {
             name,
-            label: name.replaceAll('_', ' '),
-            shortDescription: 'Mock block for HUD layout tests.',
-            fullDescription: 'Mock block for HUD layout tests.',
+            label: mulchFixture?.label ?? name.replaceAll('_', ' '),
+            shortDescription:
+                mulchFixture?.shortDescription ??
+                'Mock block for HUD layout tests.',
+            fullDescription:
+                mulchFixture?.shortDescription ??
+                'Mock block for HUD layout tests.',
         },
         attributes: {
-            height: 1,
+            height: mulchFixture?.height ?? 1,
             nightOnlyPurchase: name === 'FireflyJar',
-            stackable: true,
+            stackable: mulchFixture?.stackable ?? true,
             type: name === 'Raised_Bed' ? 'raisedBed' : 'decoration',
         },
-        prices: { sunflowers: name === 'PaintRoller' ? 100 : 10 },
+        prices: {
+            sunflowers:
+                mulchFixture?.sunflowers ?? (name === 'PaintRoller' ? 100 : 10),
+        },
         functions: {
             recycler: false,
             raisedBed: name === 'Raised_Bed',
@@ -97,6 +142,9 @@ const blockNames = [
     'StoneSmall',
     'StoneMedium',
     'StoneLarge',
+    'MulchWood',
+    'MulchCoconut',
+    'MulchHey',
     'WaterWell',
     'LemonadeStand',
     'IceCreamCart',

--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -188,7 +188,7 @@ test('sandbox trash target appears centered above item picker while dragging', a
     await expect(trashTarget).toHaveClass(/bg-red-600/u);
 });
 
-test('pots are listed under the decoration picker without mulch blocks', async ({
+test('pots and mulch are listed under the decoration picker', async ({
     mount,
     page,
 }) => {
@@ -213,7 +213,7 @@ test('pots are listed under the decoration picker without mulch blocks', async (
         page
             .locator('[data-items-picker-group-label]')
             .filter({ hasText: 'Malč' }),
-    ).toHaveCount(0);
+    ).toBeVisible();
 
     await page.getByRole('button', { name: 'Posude' }).click();
 
@@ -222,6 +222,34 @@ test('pots are listed under the decoration picker without mulch blocks', async (
     ).toBeVisible();
     await expect(
         page.getByRole('button', { name: 'PotWideLippedCup' }),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Natrag' }).click();
+    await page.getByRole('button', { name: 'Malč' }).click();
+
+    await expect(
+        page.getByRole('button', { name: 'Malč - kora drveta' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Malč - kokosova kora' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Malč - slama' }),
+    ).toBeVisible();
+
+    await expect(
+        page.getByRole('img', { name: 'Malč - kora drveta' }).first(),
+    ).toHaveAttribute('src', /MulchWood\.webp/u);
+
+    await page.getByRole('button', { name: 'Malč - kora drveta' }).click();
+
+    await expect(
+        page.getByText(
+            'Malč od kore drveta koristi se za zadržavanje vlage, zaštitu tla i smanjenje rasta korova.',
+        ),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: /Postavi.*20/u }),
     ).toBeVisible();
 });
 
@@ -344,7 +372,7 @@ test('sandbox decoration picker includes special blocks', async ({
     ).toBeVisible();
 });
 
-test('local sandbox decoration picker includes sunflower', async ({
+test('local sandbox decoration picker includes sunflower and mulch', async ({
     mount,
     page,
 }) => {
@@ -354,6 +382,15 @@ test('local sandbox decoration picker includes sunflower', async ({
     await page.getByRole('button', { name: 'Dekoracija' }).click();
 
     await expect(page.getByRole('button', { name: 'Sunflower' })).toBeVisible();
+    await expect(
+        page
+            .locator('[data-items-picker-group-label]')
+            .filter({ hasText: 'Malč' }),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Malč' }).click();
+
+    await expect(page.getByRole('button', { name: 'MulchWood' })).toBeVisible();
 });
 
 test('item picker price buttons use the soft surface', async ({

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -57,6 +57,12 @@ const rockItems: HudItemEntity[] = [
     { type: 'entity', name: 'DesertStoneLarge' },
 ];
 
+const mulchItems: HudItemEntity[] = [
+    { type: 'entity', name: 'MulchWood' },
+    { type: 'entity', name: 'MulchCoconut' },
+    { type: 'entity', name: 'MulchHey' },
+];
+
 const treeItems: HudItemEntity[] = [
     { type: 'entity', name: 'PalmTree' },
     { type: 'entity', name: 'Tree' },
@@ -115,6 +121,13 @@ const items: HudItem[] = [
                 imageSrc:
                     'https://www.gredice.com/assets/blocks/StoneMedium.webp',
                 items: rockItems,
+            },
+            {
+                type: 'picker',
+                label: 'Malč',
+                imageSrc:
+                    'https://www.gredice.com/assets/blocks/MulchWood.webp',
+                items: mulchItems,
             },
             {
                 type: 'picker',

--- a/packages/game/src/localSandboxBlockData.ts
+++ b/packages/game/src/localSandboxBlockData.ts
@@ -24,6 +24,9 @@ export const localSandboxBlockNames = [
     'DesertStoneSmall',
     'DesertStoneMedium',
     'DesertStoneLarge',
+    'MulchWood',
+    'MulchCoconut',
+    'MulchHey',
     'GiftBox_RedWhite',
     'GiftBox_GreenGold',
     'GiftBox_BlueWhite',
@@ -110,6 +113,9 @@ const localSandboxStackHeights: Partial<Record<LocalSandboxBlockName, number>> =
         GiftBox_PurpleSilver: 0.62,
         GiftBox_RedWhite: 0.62,
         GiftBox_WhiteGreen: 0.62,
+        MulchCoconut: 0.01,
+        MulchHey: 0.01,
+        MulchWood: 0.01,
         PaintRoller: 0.9,
         BeachUmbrella: 1.8,
         LemonadeStand: 1.9,
@@ -138,6 +144,21 @@ type LocalSandboxHitboxAttributes = Partial<
 >;
 
 const localSandboxHitboxAttributes: LocalSandboxHitboxAttributes = {
+    MulchCoconut: {
+        hitboxDepth: 0.96,
+        hitboxHeight: 0.08,
+        hitboxWidth: 0.96,
+    },
+    MulchHey: {
+        hitboxDepth: 0.96,
+        hitboxHeight: 0.08,
+        hitboxWidth: 0.96,
+    },
+    MulchWood: {
+        hitboxDepth: 0.96,
+        hitboxHeight: 0.08,
+        hitboxWidth: 0.96,
+    },
     SummerHat: {
         hitboxDepth: 0.64,
         hitboxHeight: 0.2,

--- a/packages/game/src/localSandboxBlockData.unit.ts
+++ b/packages/game/src/localSandboxBlockData.unit.ts
@@ -84,14 +84,23 @@ test('local sandbox exposes flower decorations used by the item HUD', () => {
     assert.equal(sunflower?.attributes.height, 1);
 });
 
-test('local sandbox does not expose mulch as placeable blocks', () => {
+test('local sandbox exposes mulch blocks used by the item HUD', () => {
     const blockData = getLocalSandboxBlockData();
     const blockNames = new Set(
         blockData.map((block) => block.information.name),
     );
 
     assert.equal(blockNames.has('BaleHey'), false);
-    assert.equal(blockNames.has('MulchHey'), false);
-    assert.equal(blockNames.has('MulchCoconut'), false);
-    assert.equal(blockNames.has('MulchWood'), false);
+    for (const blockName of ['MulchHey', 'MulchCoconut', 'MulchWood']) {
+        const block = blockData.find(
+            (item) => item.information.name === blockName,
+        );
+
+        assert.ok(block);
+        assert.equal(block.prices.sunflowers, 0);
+        assert.equal(block.attributes.height, 0.01);
+        assert.equal(block.attributes.hitboxDepth, 0.96);
+        assert.equal(block.attributes.hitboxHeight, 0.08);
+        assert.equal(block.attributes.hitboxWidth, 0.96);
+    }
 });


### PR DESCRIPTION
## Summary
- Add the purchasable mulch variants to the Garden Items HUD under a dedicated `Malč` decoration picker.
- Add mulch fixtures to the Items HUD tests so labels, descriptions, images, and sunflower pricing resolve from block data.
- Expose mulch in local sandbox block data with explicit placement height and hitbox metadata, while keeping `BaleHey` out of placeable sandbox blocks.

Closes #3932

## Validation
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter garden lint`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden test:prepare`
- `pnpm --filter garden exec playwright test tests/items-hud.spec.tsx`