### PR TITLE
fix(garden): restore shift multi-block pickup selection

### DIFF
--- a/packages/game/src/controls/BlockInteractionRegistry.tsx
+++ b/packages/game/src/controls/BlockInteractionRegistry.tsx
@@ -30,6 +30,22 @@ export type BlockInteractionHandlers = {
     onSelectClick?: (event: ThreeEvent<MouseEvent>) => void;
 };
 
+export type BlockInteractionHandlersRef = {
+    current: BlockInteractionHandlers;
+};
+
+export type BlockInteractionHandlerPresence = {
+    hasOnClick: boolean;
+    hasOnPickupPointerEnter: boolean;
+    hasOnPointerDown: boolean;
+    hasOnPointerEnter: boolean;
+    hasOnPointerLeave: boolean;
+    hasOnRotatePointerDown: boolean;
+    hasOnRotatePointerLeave: boolean;
+    hasOnRotatePointerUp: boolean;
+    hasOnSelectClick: boolean;
+};
+
 type RegisteredBlockInteractionTarget = BlockInteractionTarget & {
     handlers: BlockInteractionHandlers;
 };
@@ -120,6 +136,51 @@ export function useBlockInteractionRegistry() {
     return useContext(BlockInteractionRegistryContext);
 }
 
+export function createStableBlockInteractionHandlers(
+    handlersRef: BlockInteractionHandlersRef,
+    presence: BlockInteractionHandlerPresence,
+): BlockInteractionHandlers {
+    const nextHandlers: BlockInteractionHandlers = {};
+
+    if (presence.hasOnClick) {
+        nextHandlers.onClick = (event) => handlersRef.current.onClick?.(event);
+    }
+    if (presence.hasOnPickupPointerEnter) {
+        nextHandlers.onPickupPointerEnter = (event) =>
+            handlersRef.current.onPickupPointerEnter?.(event);
+    }
+    if (presence.hasOnPointerDown) {
+        nextHandlers.onPointerDown = (event) =>
+            handlersRef.current.onPointerDown?.(event);
+    }
+    if (presence.hasOnPointerEnter) {
+        nextHandlers.onPointerEnter = (event) =>
+            handlersRef.current.onPointerEnter?.(event);
+    }
+    if (presence.hasOnPointerLeave) {
+        nextHandlers.onPointerLeave = (event) =>
+            handlersRef.current.onPointerLeave?.(event);
+    }
+    if (presence.hasOnRotatePointerDown) {
+        nextHandlers.onRotatePointerDown = (event) =>
+            handlersRef.current.onRotatePointerDown?.(event);
+    }
+    if (presence.hasOnRotatePointerLeave) {
+        nextHandlers.onRotatePointerLeave = (event) =>
+            handlersRef.current.onRotatePointerLeave?.(event);
+    }
+    if (presence.hasOnRotatePointerUp) {
+        nextHandlers.onRotatePointerUp = (event) =>
+            handlersRef.current.onRotatePointerUp?.(event);
+    }
+    if (presence.hasOnSelectClick) {
+        nextHandlers.onSelectClick = (event) =>
+            handlersRef.current.onSelectClick?.(event);
+    }
+
+    return nextHandlers;
+}
+
 export function useBlockInteractionTargetRegistration(
     key: string | undefined,
     target: BlockInteractionTarget | undefined,
@@ -129,6 +190,7 @@ export function useBlockInteractionTargetRegistration(
     const targetRef = useRef(target);
     const handlersRef = useRef(handlers);
     const hasOnClick = Boolean(handlers.onClick);
+    const hasOnPickupPointerEnter = Boolean(handlers.onPickupPointerEnter);
     const hasOnPointerDown = Boolean(handlers.onPointerDown);
     const hasOnPointerEnter = Boolean(handlers.onPointerEnter);
     const hasOnPointerLeave = Boolean(handlers.onPointerLeave);
@@ -151,51 +213,31 @@ export function useBlockInteractionTargetRegistration(
         }),
         [],
     );
-    const stableHandlers = useMemo<BlockInteractionHandlers>(() => {
-        const nextHandlers: BlockInteractionHandlers = {};
-        if (hasOnClick) {
-            nextHandlers.onClick = (event) =>
-                handlersRef.current.onClick?.(event);
-        }
-        if (hasOnPointerDown) {
-            nextHandlers.onPointerDown = (event) =>
-                handlersRef.current.onPointerDown?.(event);
-        }
-        if (hasOnPointerEnter) {
-            nextHandlers.onPointerEnter = (event) =>
-                handlersRef.current.onPointerEnter?.(event);
-        }
-        if (hasOnPointerLeave) {
-            nextHandlers.onPointerLeave = (event) =>
-                handlersRef.current.onPointerLeave?.(event);
-        }
-        if (hasOnRotatePointerDown) {
-            nextHandlers.onRotatePointerDown = (event) =>
-                handlersRef.current.onRotatePointerDown?.(event);
-        }
-        if (hasOnRotatePointerLeave) {
-            nextHandlers.onRotatePointerLeave = (event) =>
-                handlersRef.current.onRotatePointerLeave?.(event);
-        }
-        if (hasOnRotatePointerUp) {
-            nextHandlers.onRotatePointerUp = (event) =>
-                handlersRef.current.onRotatePointerUp?.(event);
-        }
-        if (hasOnSelectClick) {
-            nextHandlers.onSelectClick = (event) =>
-                handlersRef.current.onSelectClick?.(event);
-        }
-        return nextHandlers;
-    }, [
-        hasOnClick,
-        hasOnPointerDown,
-        hasOnPointerEnter,
-        hasOnPointerLeave,
-        hasOnRotatePointerDown,
-        hasOnRotatePointerLeave,
-        hasOnRotatePointerUp,
-        hasOnSelectClick,
-    ]);
+    const stableHandlers = useMemo(
+        () =>
+            createStableBlockInteractionHandlers(handlersRef, {
+                hasOnClick,
+                hasOnPickupPointerEnter,
+                hasOnPointerDown,
+                hasOnPointerEnter,
+                hasOnPointerLeave,
+                hasOnRotatePointerDown,
+                hasOnRotatePointerLeave,
+                hasOnRotatePointerUp,
+                hasOnSelectClick,
+            }),
+        [
+            hasOnClick,
+            hasOnPickupPointerEnter,
+            hasOnPointerDown,
+            hasOnPointerEnter,
+            hasOnPointerLeave,
+            hasOnRotatePointerDown,
+            hasOnRotatePointerLeave,
+            hasOnRotatePointerUp,
+            hasOnSelectClick,
+        ],
+    );
 
     useLayoutEffect(() => {
         targetRef.current = target;

--- a/packages/game/src/controls/BlockInteractionRegistry.unit.ts
+++ b/packages/game/src/controls/BlockInteractionRegistry.unit.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    type BlockInteractionHandlers,
+    createStableBlockInteractionHandlers,
+} from './BlockInteractionRegistry';
+
+type PickupPointerEnterEvent = Parameters<
+    NonNullable<BlockInteractionHandlers['onPickupPointerEnter']>
+>[0];
+
+describe('createStableBlockInteractionHandlers', () => {
+    it('forwards pickup pointer enter through the current handler ref', () => {
+        const calls: string[] = [];
+        const event = {} as PickupPointerEnterEvent;
+        const handlersRef = {
+            current: {
+                onPickupPointerEnter: () => {
+                    calls.push('initial');
+                },
+            },
+        };
+        const stableHandlers = createStableBlockInteractionHandlers(
+            handlersRef,
+            {
+                hasOnClick: false,
+                hasOnPickupPointerEnter: true,
+                hasOnPointerDown: false,
+                hasOnPointerEnter: false,
+                hasOnPointerLeave: false,
+                hasOnRotatePointerDown: false,
+                hasOnRotatePointerLeave: false,
+                hasOnRotatePointerUp: false,
+                hasOnSelectClick: false,
+            },
+        );
+
+        assert.equal(typeof stableHandlers.onPickupPointerEnter, 'function');
+
+        stableHandlers.onPickupPointerEnter?.(event);
+        handlersRef.current = {
+            onPickupPointerEnter: () => {
+                calls.push('updated');
+            },
+        };
+        stableHandlers.onPickupPointerEnter?.(event);
+
+        assert.deepEqual(calls, ['initial', 'updated']);
+    });
+});

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -68,7 +68,10 @@ import {
     type PickupPlacementPreviewResolver,
     type ResolvedPlacementPreview,
 } from './PickupPlacementResolver';
-import { createPickupSelectionMovingSegments } from './pickupSelection';
+import {
+    createPickupSelectionMoveRequests,
+    createPickupSelectionMovingSegments,
+} from './pickupSelection';
 import { useHoveredBlockStore } from './useHoveredBlockStore';
 
 const groundPlane = new Plane(new Vector3(0, 1, 0), 0);
@@ -1057,19 +1060,9 @@ export function PickableGroup({
             return;
         }
 
-        const moveRequests = getMovingSegments(garden).flatMap((segment) =>
-            segment.blocks.map((segmentBlock) => ({
-                sourcePosition: {
-                    x: segment.sourceStack.position.x,
-                    z: segment.sourceStack.position.z,
-                },
-                destinationPosition: {
-                    x: segment.sourceStack.position.x + relative.x,
-                    z: segment.sourceStack.position.z + relative.z,
-                },
-                blockIndex: segment.sourceStartIndex,
-                sourceBlockId: segmentBlock.id,
-            })),
+        const moveRequests = createPickupSelectionMoveRequests(
+            getMovingSegments(garden),
+            relative,
         );
         const [primaryMoveRequest, ...additionalBlockMoves] = moveRequests;
         if (!primaryMoveRequest) {

--- a/packages/game/src/controls/PickupPlacementResolver.unit.ts
+++ b/packages/game/src/controls/PickupPlacementResolver.unit.ts
@@ -184,6 +184,38 @@ describe('resolvePickupPlacementPreviewForRelative', () => {
         assert.equal(preview?.nextIsBlocked, true);
     });
 
+    it('keeps GardenBox storage blocked for multi-selection previews', () => {
+        const primaryTree = createBlock('Tree', 'primary-tree');
+        const extraTree = createBlock('Tree', 'extra-tree');
+        const gardenBox = createBlock('GardenBox', 'garden-box');
+        const primaryStack = createStack(0, 0, [primaryTree]);
+        const extraStack = createStack(0, 1, [extraTree]);
+        const gardenBoxStack = createStack(1, 0, [gardenBox]);
+
+        const preview = resolvePickupPlacementPreviewForRelative({
+            blockData,
+            gardenIsSandbox: false,
+            localSandboxStorageKey: null,
+            movingSegments: [
+                createMovingSegment({
+                    block: primaryTree,
+                    sourceStack: primaryStack,
+                }),
+                createMovingSegment({
+                    block: extraTree,
+                    sourceStack: extraStack,
+                }),
+            ],
+            relative: new Vector3(1, 0, 0),
+            stacks: [primaryStack, extraStack, gardenBoxStack],
+        });
+
+        assert.equal(preview?.hoveredGardenBoxBlockId, 'garden-box');
+        assert.equal(preview?.canStoreInGardenBox, false);
+        assert.equal(preview?.nextIsBlocked, true);
+        assert.equal(preview?.targetOffsets.length, 2);
+    });
+
     it('routes recyclable selections to recycler targets instead of blocking', () => {
         const raisedBed = createBlock('Raised_Bed', 'raised-bed');
         const recycler = createBlock('RecyclingBin', 'recycler');
@@ -207,6 +239,38 @@ describe('resolvePickupPlacementPreviewForRelative', () => {
 
         assert.equal(preview?.nextIsOverRecycler, true);
         assert.equal(preview?.nextIsBlocked, false);
+        assert.equal(preview?.canStoreInGardenBox, false);
+    });
+
+    it('keeps recycler drops blocked when a raised bed is part of a multi-selection', () => {
+        const raisedBed = createBlock('Raised_Bed', 'raised-bed');
+        const extraTree = createBlock('Tree', 'extra-tree');
+        const recycler = createBlock('RecyclingBin', 'recycler');
+        const raisedBedStack = createStack(0, 0, [raisedBed]);
+        const extraStack = createStack(0, 1, [extraTree]);
+        const recyclerStack = createStack(1, 0, [recycler]);
+
+        const preview = resolvePickupPlacementPreviewForRelative({
+            blockData,
+            gardenIsSandbox: false,
+            localSandboxStorageKey: null,
+            movingSegments: [
+                createMovingSegment({
+                    block: raisedBed,
+                    canRecycle: false,
+                    sourceStack: raisedBedStack,
+                }),
+                createMovingSegment({
+                    block: extraTree,
+                    sourceStack: extraStack,
+                }),
+            ],
+            relative: new Vector3(1, 0, 0),
+            stacks: [raisedBedStack, extraStack, recyclerStack],
+        });
+
+        assert.equal(preview?.nextIsOverRecycler, false);
+        assert.equal(preview?.nextIsBlocked, true);
         assert.equal(preview?.canStoreInGardenBox, false);
     });
 

--- a/packages/game/src/controls/pickupSelection.ts
+++ b/packages/game/src/controls/pickupSelection.ts
@@ -15,6 +15,13 @@ export type AttachedPickupSegment = {
     baseHeight: number;
 };
 
+export type PickupSelectionMoveRequest = {
+    sourcePosition: { x: number; z: number };
+    destinationPosition: { x: number; z: number };
+    blockIndex: number;
+    sourceBlockId: string;
+};
+
 type SelectedSegmentCandidate = {
     target: ActiveDragPreviewTarget;
     sourceStack: Stack;
@@ -167,4 +174,24 @@ export function createPickupSelectionMovingSegments({
             canRecycle: false,
         },
     ];
+}
+
+export function createPickupSelectionMoveRequests(
+    movingSegments: MovingSegment[],
+    relative: { x: number; z: number },
+): PickupSelectionMoveRequest[] {
+    return movingSegments.flatMap((segment) =>
+        segment.blocks.map((segmentBlock) => ({
+            sourcePosition: {
+                x: segment.sourceStack.position.x,
+                z: segment.sourceStack.position.z,
+            },
+            destinationPosition: {
+                x: segment.sourceStack.position.x + relative.x,
+                z: segment.sourceStack.position.z + relative.z,
+            },
+            blockIndex: segment.sourceStartIndex,
+            sourceBlockId: segmentBlock.id,
+        })),
+    );
 }

--- a/packages/game/src/controls/pickupSelection.unit.ts
+++ b/packages/game/src/controls/pickupSelection.unit.ts
@@ -5,7 +5,10 @@ import { Vector3 } from 'three';
 import { createActiveDragPreviewTarget } from '../dragPreviewIdentity';
 import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
-import { createPickupSelectionMovingSegments } from './pickupSelection';
+import {
+    createPickupSelectionMoveRequests,
+    createPickupSelectionMovingSegments,
+} from './pickupSelection';
 
 function createBlock(name: string, id = name): Block {
     return {
@@ -117,6 +120,57 @@ describe('createPickupSelectionMovingSegments', () => {
         );
         assert.equal(segments[0]?.canRecycle, false);
         assert.equal(segments[1]?.canRecycle, false);
+    });
+
+    it('creates move requests for the primary block and additional selected blocks', () => {
+        const primaryBlock = createBlock('Tree', 'primary');
+        const extraBlock = createBlock('Raised_Bed', 'extra');
+        const upperBlock = createBlock('Tree', 'upper');
+        const primaryStack = createStack(0, 0, [primaryBlock]);
+        const extraStack = createStack(2, 1, [extraBlock, upperBlock]);
+        const primaryTarget = createActiveDragPreviewTarget({
+            blockId: primaryBlock.id,
+            blockIndex: 0,
+            stackPosition: primaryStack.position,
+        });
+        const extraTarget = createActiveDragPreviewTarget({
+            blockId: extraBlock.id,
+            blockIndex: 0,
+            stackPosition: extraStack.position,
+        });
+
+        const segments = createPickupSelectionMovingSegments({
+            blockData,
+            canRecyclePrimarySegment: true,
+            primaryTarget,
+            selectedTargets: [primaryTarget, extraTarget],
+            stacks: [primaryStack, extraStack],
+        });
+        const moveRequests = createPickupSelectionMoveRequests(segments, {
+            x: 1,
+            z: -1,
+        });
+
+        assert.deepEqual(moveRequests, [
+            {
+                sourcePosition: { x: 0, z: 0 },
+                destinationPosition: { x: 1, z: -1 },
+                blockIndex: 0,
+                sourceBlockId: 'primary',
+            },
+            {
+                sourcePosition: { x: 2, z: 1 },
+                destinationPosition: { x: 3, z: 0 },
+                blockIndex: 0,
+                sourceBlockId: 'extra',
+            },
+            {
+                sourcePosition: { x: 2, z: 1 },
+                destinationPosition: { x: 3, z: 0 },
+                blockIndex: 0,
+                sourceBlockId: 'upper',
+            },
+        ]);
     });
 
     it('dedupes one stack by the lowest selected block', () => {

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { createActiveDragPreviewTarget } from './dragPreviewIdentity';
 import type { ActiveDragPreview } from './useGameState';
 import { activeDragPreviewsEqual, createGameState } from './useGameState';
 
@@ -92,6 +93,74 @@ test('setActiveDragPreview skips equivalent drag preview updates', () => {
         assert.equal(updateCount, 2);
     } finally {
         unsubscribe();
+        store.getState().audio.dispose();
+    }
+});
+
+test('addPickupSelectionTarget appends new targets and prevents duplicates', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+    const primaryTarget = createActiveDragPreviewTarget({
+        blockId: 'primary',
+        blockIndex: 0,
+        stackPosition: { x: 0, z: 0 },
+    });
+    const extraTarget = createActiveDragPreviewTarget({
+        blockId: 'extra',
+        blockIndex: 0,
+        stackPosition: { x: 1, z: 0 },
+    });
+
+    try {
+        assert.equal(
+            store.getState().addPickupSelectionTarget(primaryTarget),
+            true,
+        );
+        assert.equal(
+            store.getState().addPickupSelectionTarget(primaryTarget),
+            false,
+        );
+        assert.equal(
+            store.getState().addPickupSelectionTarget(extraTarget),
+            true,
+        );
+        assert.deepEqual(store.getState().pickupSelectionTargets, [
+            primaryTarget,
+            extraTarget,
+        ]);
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
+test('clearPickupSelectionTargets resets every active pickup target', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+
+    try {
+        store.getState().setPickupSelectionTargets([
+            createActiveDragPreviewTarget({
+                blockId: 'primary',
+                blockIndex: 0,
+                stackPosition: { x: 0, z: 0 },
+            }),
+            createActiveDragPreviewTarget({
+                blockId: 'extra',
+                blockIndex: 0,
+                stackPosition: { x: 1, z: 0 },
+            }),
+        ]);
+
+        store.getState().clearPickupSelectionTargets();
+
+        assert.deepEqual(store.getState().pickupSelectionTargets, []);
+    } finally {
         store.getState().audio.dispose();
     }
 });


### PR DESCRIPTION
## Summary
- restore Shift multi-block pickup selection for instanced game blocks by forwarding `onPickupPointerEnter` through the block interaction registry
- route pickup selection move payload creation through a small shared helper so primary and additional selected blocks use the same tested mapping
- add focused unit coverage for Shift-add handler forwarding, duplicate prevention, move request creation, cancel/reset clearing, and multi-selection storage/recycler blocked states

Closes #3933

## Validation
- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter www`
- `git diff --check`