### PR TITLE
fix(app): link schedule operations internally

### DIFF
--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -37,6 +37,7 @@ import { OperationCompletionEvidenceEditModal } from './OperationCompletionEvide
 import { OperationRequirementIcons } from './OperationRequirementIcons';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
 import { ScheduleOperationVisual } from './ScheduleTaskVisual';
+import { getScheduleOperationHref } from './scheduleOperationLinks';
 import {
     createOperationAssignedUsers,
     parseScheduledDateInput,
@@ -525,18 +526,11 @@ export function FarmOperationsScheduleSection({
                                     operation={operationData}
                                     label={operationLabel}
                                 />
-                                <a
+                                <Link
                                     className="min-w-0 flex-1"
-                                    href={
-                                        operationData?.information?.label
-                                            ? KnownPages.GrediceOperation(
-                                                  operationData.information
-                                                      .label,
-                                              )
-                                            : KnownPages.GrediceOperations
-                                    }
-                                    target="_blank"
-                                    rel="noopener noreferrer"
+                                    href={getScheduleOperationHref(
+                                        operation.id,
+                                    )}
                                 >
                                     <Typography
                                         level="body1"
@@ -549,7 +543,7 @@ export function FarmOperationsScheduleSection({
                                     >
                                         {operationLabel}
                                     </Typography>
-                                </a>
+                                </Link>
                                 {operationStatusText && (
                                     <Typography
                                         level="body2"

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -39,6 +39,7 @@ import { OperationCompletionEvidenceEditModal } from './OperationCompletionEvide
 import { OperationRequirementIcons } from './OperationRequirementIcons';
 import { RescheduleOperationModal } from './RescheduleOperationModal';
 import { ScheduleOperationVisual } from './ScheduleTaskVisual';
+import { getScheduleOperationHref } from './scheduleOperationLinks';
 import {
     createOperationAssignedUsers,
     parseScheduledDateInput,
@@ -153,9 +154,7 @@ export function RaisedBedOperationsScheduleSection({
         return {
             id: `operation-${operation.id}`,
             text,
-            link: operationData?.information?.label
-                ? KnownPages.GrediceOperation(operationData?.information?.label)
-                : KnownPages.GrediceOperations,
+            link: getScheduleOperationHref(operation.id),
             approved:
                 operation.isAccepted &&
                 !isOperationCompleted(operation.status) &&
@@ -615,18 +614,11 @@ export function RaisedBedOperationsScheduleSection({
                                         operation={operationData}
                                         label={operationLabel}
                                     />
-                                    <a
+                                    <Link
                                         className="min-w-0 flex-1"
-                                        href={
-                                            operationData?.information?.label
-                                                ? KnownPages.GrediceOperation(
-                                                      operationData?.information
-                                                          ?.label,
-                                                  )
-                                                : KnownPages.GrediceOperations
-                                        }
-                                        target="_blank"
-                                        rel="noopener noreferrer"
+                                        href={getScheduleOperationHref(
+                                            operation.id,
+                                        )}
                                     >
                                         <Typography
                                             level="body1"
@@ -639,7 +631,7 @@ export function RaisedBedOperationsScheduleSection({
                                         >
                                             {operationLabel}
                                         </Typography>
-                                    </a>
+                                    </Link>
                                     {operationStatusText && (
                                         <Typography
                                             level="body2"

--- a/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
+++ b/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
@@ -4,6 +4,7 @@ import {
     getScheduledFieldsForDay,
     getScheduledOperationsForDay,
 } from './scheduleDayFilters.ts';
+import { getScheduleOperationHref } from './scheduleOperationLinks.ts';
 import {
     isDayBulkFieldApprovalTargetVisible,
     isDayBulkFieldAssignmentTargetVisible,
@@ -115,6 +116,10 @@ test('pending verification operation remains visible today until verified', () =
         ]).map((operation) => operation.id),
         [1],
     );
+});
+
+test('schedule operation links point to internal operation details', () => {
+    assert.equal(getScheduleOperationHref(123), '/admin/operations/123');
 });
 
 test('day operation bulk actions honor optimistic terminal statuses', () => {

--- a/apps/app/app/admin/schedule/scheduleOperationLinks.ts
+++ b/apps/app/app/admin/schedule/scheduleOperationLinks.ts
@@ -1,0 +1,5 @@
+import { KnownPages } from '../../../src/KnownPages';
+
+export function getScheduleOperationHref(operationId: number) {
+    return KnownPages.Operation(operationId);
+}


### PR DESCRIPTION
## Summary
- route raised-bed schedule operation rows to internal app operation details
- route farm schedule operation rows to internal app operation details
- add a focused unit assertion for the schedule operation href helper

## Validation
- `corepack pnpm --filter app test:unit`
- `corepack pnpm typecheck --filter app`
- `corepack pnpm lint --filter app`
- `corepack pnpm --filter app exec biome check --write app/admin/schedule/FarmOperationsScheduleSection.tsx app/admin/schedule/RaisedBedOperationsScheduleSection.tsx app/admin/schedule/scheduleDayFilters.unit.ts app/admin/schedule/scheduleOperationLinks.ts`
- `git diff --check`

Closes #3934