### PR TITLE
feat(farm): add notifications list

### DIFF
--- a/apps/api/app/api/[...route]/notificationsRoutes.ts
+++ b/apps/api/app/api/[...route]/notificationsRoutes.ts
@@ -30,6 +30,7 @@ import {
     validateHostedImageUrl,
 } from '../../../lib/http/safeUrls';
 import { notificationRolloutFlags } from '../../../lib/notifications/notificationRollout';
+import { notificationCenterRoles } from '../../../lib/notifications/notificationRouteRoles';
 import {
     pushDeviceResponse,
     pushDeviceUpsertSchema,
@@ -559,7 +560,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
             description:
                 'Get notifications for a user. This will return a list of notifications for the specified user and current account.',
         }),
-        authValidator(['user', 'admin']),
+        authValidator([...notificationCenterRoles]),
         zValidator(
             'query',
             z.object({
@@ -625,7 +626,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
     .put(
         '/',
         describeRoute({ description: 'Update notifications read status' }),
-        authValidator(['user', 'admin']),
+        authValidator([...notificationCenterRoles]),
         zValidator(
             'json',
             z.object({
@@ -675,7 +676,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
     .patch(
         '/:id',
         describeRoute({ description: 'Change notification' }),
-        authValidator(['user', 'admin']),
+        authValidator([...notificationCenterRoles]),
         zValidator('param', z.object({ id: z.string() })),
         zValidator(
             'json',

--- a/apps/api/lib/notifications/notificationRouteRoles.node.spec.ts
+++ b/apps/api/lib/notifications/notificationRouteRoles.node.spec.ts
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { notificationCenterRoles } from './notificationRouteRoles';
+
+test('notification center routes allow Farm farmer users', () => {
+    assert.deepEqual(notificationCenterRoles, ['user', 'farmer', 'admin']);
+});

--- a/apps/api/lib/notifications/notificationRouteRoles.ts
+++ b/apps/api/lib/notifications/notificationRouteRoles.ts
@@ -1,0 +1,1 @@
+export const notificationCenterRoles = ['user', 'farmer', 'admin'] as const;

--- a/apps/farm/app/notifications/FarmNotificationList.tsx
+++ b/apps/farm/app/notifications/FarmNotificationList.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardOverflow,
+    CardTitle,
+} from '@gredice/ui/Card';
+import { Approved, Inbox } from '@gredice/ui/icons';
+import { List } from '@gredice/ui/List';
+import { Row } from '@gredice/ui/Row';
+import { Skeleton } from '@gredice/ui/Skeleton';
+import { Stack } from '@gredice/ui/Stack';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
+import { Typography } from '@gredice/ui/Typography';
+import { FarmNotificationListItem } from './FarmNotificationListItem';
+import type { FarmNotificationNavigationTarget } from './notificationLinks';
+import type {
+    FarmNotification,
+    FarmNotificationsFilter,
+} from './notificationTypes';
+
+interface FarmNotificationListProps {
+    filter: FarmNotificationsFilter;
+    isError?: boolean;
+    isLoading?: boolean;
+    markAllPending?: boolean;
+    notifications: FarmNotification[];
+    onFilterChange: (filter: FarmNotificationsFilter) => void;
+    onMarkAllRead: (notificationIds: string[]) => void;
+    onNotificationOpen: (
+        notification: FarmNotification,
+        target: FarmNotificationNavigationTarget | null,
+    ) => void;
+    onNotificationReadChange: (
+        notification: FarmNotification,
+        read: boolean,
+    ) => void;
+    onRetry?: () => void;
+    readPendingIds?: ReadonlySet<string>;
+}
+
+export function filterFarmNotifications(
+    notifications: FarmNotification[],
+    filter: FarmNotificationsFilter,
+) {
+    if (filter === 'all') {
+        return notifications;
+    }
+
+    return notifications.filter((notification) => !notification.readAt);
+}
+
+export function setFarmNotificationReadState(
+    notifications: FarmNotification[],
+    id: string,
+    read: boolean,
+    readAt = new Date(),
+) {
+    return notifications.map((notification) =>
+        notification.id === id
+            ? {
+                  ...notification,
+                  readAt: read ? readAt : null,
+              }
+            : notification,
+    );
+}
+
+export function setFarmNotificationsReadState(
+    notifications: FarmNotification[],
+    ids: string[],
+    readAt = new Date(),
+) {
+    const idSet = new Set(ids);
+    return notifications.map((notification) =>
+        idSet.has(notification.id)
+            ? {
+                  ...notification,
+                  readAt,
+              }
+            : notification,
+    );
+}
+
+function FarmNotificationSkeletons() {
+    return (
+        <Stack spacing={0} aria-hidden="true">
+            {[0, 1, 2].map((item) => (
+                <div key={item} className="border-b p-4 last:border-b-0">
+                    <Row spacing={3} className="items-start">
+                        <Skeleton className="size-14 shrink-0 sm:size-16" />
+                        <Stack spacing={2} className="min-w-0 flex-1">
+                            <Skeleton className="h-5 w-2/3" />
+                            <Skeleton className="h-12 w-full" />
+                            <Skeleton className="h-4 w-32" />
+                        </Stack>
+                    </Row>
+                </div>
+            ))}
+        </Stack>
+    );
+}
+
+function EmptyNotificationsState({
+    filter,
+    onShowAll,
+}: {
+    filter: FarmNotificationsFilter;
+    onShowAll: () => void;
+}) {
+    return (
+        <Stack
+            spacing={3}
+            alignItems="center"
+            className="px-4 py-12 text-center"
+        >
+            <span className="flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                <Inbox className="size-6" />
+            </span>
+            <Stack spacing={1}>
+                <Typography semiBold>
+                    {filter === 'unread'
+                        ? 'Nema nepročitanih obavijesti.'
+                        : 'Nema obavijesti.'}
+                </Typography>
+                {filter === 'unread' && (
+                    <Typography level="body2" secondary>
+                        Sve pročitane obavijesti dostupne su u prikazu Sve.
+                    </Typography>
+                )}
+            </Stack>
+            {filter === 'unread' && (
+                <Button variant="plain" size="sm" onClick={onShowAll}>
+                    Prikaži sve
+                </Button>
+            )}
+        </Stack>
+    );
+}
+
+export function FarmNotificationList({
+    filter,
+    isError,
+    isLoading,
+    markAllPending,
+    notifications,
+    onFilterChange,
+    onMarkAllRead,
+    onNotificationOpen,
+    onNotificationReadChange,
+    onRetry,
+    readPendingIds,
+}: FarmNotificationListProps) {
+    const visibleNotifications = filterFarmNotifications(notifications, filter);
+    const unreadNotificationIds = notifications
+        .filter((notification) => !notification.readAt)
+        .map((notification) => notification.id);
+    const hasUnreadNotifications = unreadNotificationIds.length > 0;
+
+    return (
+        <Card className="p-0">
+            <CardHeader className="p-4">
+                <Row
+                    alignItems="start"
+                    justifyContent="space-between"
+                    spacing={3}
+                    className="flex-wrap gap-y-3"
+                >
+                    <Stack spacing={1}>
+                        <CardTitle>Obavijesti</CardTitle>
+                        <Typography level="body2" secondary>
+                            {hasUnreadNotifications
+                                ? `${unreadNotificationIds.length.toString()} nepročitano`
+                                : 'Sve je pročitano'}
+                        </Typography>
+                    </Stack>
+                    <Button
+                        size="sm"
+                        variant="outlined"
+                        disabled={!hasUnreadNotifications}
+                        loading={markAllPending}
+                        onClick={() => onMarkAllRead(unreadNotificationIds)}
+                        startDecorator={<Approved className="size-4" />}
+                    >
+                        Označi sve kao pročitane
+                    </Button>
+                </Row>
+            </CardHeader>
+            <CardContent>
+                <Tabs
+                    value={filter}
+                    onValueChange={(value) => {
+                        if (value === 'unread' || value === 'all') {
+                            onFilterChange(value);
+                        }
+                    }}
+                >
+                    <TabsList aria-label="Prikaz obavijesti">
+                        <TabsTrigger value="unread">Nepročitane</TabsTrigger>
+                        <TabsTrigger value="all">Sve</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value={filter} className="mt-4" forceMount>
+                        {isError ? (
+                            <Alert
+                                color="danger"
+                                endDecorator={
+                                    onRetry ? (
+                                        <Button
+                                            size="sm"
+                                            variant="outlined"
+                                            onClick={onRetry}
+                                        >
+                                            Pokušaj ponovno
+                                        </Button>
+                                    ) : undefined
+                                }
+                            >
+                                Obavijesti nisu učitane.
+                            </Alert>
+                        ) : null}
+                    </TabsContent>
+                </Tabs>
+            </CardContent>
+            <CardOverflow>
+                {isLoading ? (
+                    <FarmNotificationSkeletons />
+                ) : !isError && visibleNotifications.length === 0 ? (
+                    <EmptyNotificationsState
+                        filter={filter}
+                        onShowAll={() => onFilterChange('all')}
+                    />
+                ) : !isError ? (
+                    <List
+                        variant="outlined"
+                        className="rounded-none border-x-0 border-b-0"
+                    >
+                        {visibleNotifications.map((notification) => (
+                            <FarmNotificationListItem
+                                key={notification.id}
+                                notification={notification}
+                                onNotificationOpen={onNotificationOpen}
+                                onReadChange={onNotificationReadChange}
+                                readPending={readPendingIds?.has(
+                                    notification.id,
+                                )}
+                            />
+                        ))}
+                    </List>
+                ) : null}
+            </CardOverflow>
+        </Card>
+    );
+}

--- a/apps/farm/app/notifications/FarmNotificationListItem.tsx
+++ b/apps/farm/app/notifications/FarmNotificationListItem.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { Check, ExternalLink, Inbox } from '@gredice/ui/icons';
+import { ListItem } from '@gredice/ui/ListItem';
+import { Markdown } from '@gredice/ui/Markdown';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import {
+    type FarmNotificationNavigationTarget,
+    resolveFarmNotificationNavigationTarget,
+} from './notificationLinks';
+import type { FarmNotification } from './notificationTypes';
+
+interface FarmNotificationListItemProps {
+    notification: FarmNotification;
+    onNotificationOpen: (
+        notification: FarmNotification,
+        target: FarmNotificationNavigationTarget | null,
+    ) => void;
+    onReadChange: (notification: FarmNotification, read: boolean) => void;
+    readPending?: boolean;
+}
+
+function formatTimestamp(timestamp: Date) {
+    return timestamp.toLocaleDateString('hr-HR', {
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        month: 'long',
+        year: 'numeric',
+    });
+}
+
+export function FarmNotificationListItem({
+    notification,
+    onNotificationOpen,
+    onReadChange,
+    readPending,
+}: FarmNotificationListItemProps) {
+    const isRead = Boolean(notification.readAt);
+    const target = resolveFarmNotificationNavigationTarget(notification);
+    const mediaUrl = notification.iconUrl ?? notification.imageUrl;
+    const readToggleLabel = isRead
+        ? `Označi obavijest "${notification.header}" kao nepročitanu`
+        : `Označi obavijest "${notification.header}" kao pročitanu`;
+
+    return (
+        <div className="relative">
+            <ListItem
+                className={cx(
+                    'rounded-none px-3 py-3 pr-12 sm:px-4',
+                    !isRead && 'bg-secondary/40 hover:bg-secondary/60',
+                )}
+                data-testid={`farm-notification-${notification.id}`}
+                nodeId={notification.id}
+                onSelected={() => onNotificationOpen(notification, target)}
+                label={
+                    <Row spacing={3} className="items-start">
+                        <div className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-background text-muted-foreground sm:size-16">
+                            {mediaUrl ? (
+                                <>
+                                    {/* biome-ignore lint/performance/noImgElement: Notification media can come from campaign URLs outside Next image config. */}
+                                    <img
+                                        src={mediaUrl}
+                                        alt=""
+                                        className="size-full object-cover"
+                                    />
+                                </>
+                            ) : (
+                                <Inbox className="size-6" />
+                            )}
+                        </div>
+                        <Stack spacing={1} className="min-w-0">
+                            <Row spacing={2} className="min-w-0 items-start">
+                                <Typography
+                                    level="body2"
+                                    semiBold
+                                    className="min-w-0 flex-1"
+                                >
+                                    {notification.header}
+                                </Typography>
+                                {target?.kind === 'external' && (
+                                    <ExternalLink className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                                )}
+                            </Row>
+                            <div className="text-sm font-normal leading-relaxed text-foreground">
+                                <Markdown>{notification.content}</Markdown>
+                            </div>
+                            <Row spacing={2} className="flex-wrap gap-y-1">
+                                <Typography
+                                    level="body3"
+                                    className="text-muted-foreground"
+                                    title={notification.timestamp.toLocaleString(
+                                        'hr-HR',
+                                    )}
+                                >
+                                    {formatTimestamp(notification.timestamp)}
+                                </Typography>
+                                {!isRead && (
+                                    <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-900">
+                                        Nepročitano
+                                    </span>
+                                )}
+                            </Row>
+                        </Stack>
+                    </Row>
+                }
+            />
+            <button
+                type="button"
+                aria-label={readToggleLabel}
+                title={readToggleLabel}
+                disabled={readPending}
+                className={cx(
+                    "absolute right-3 top-3 size-5 rounded-full outline-2 outline-offset-2 transition-colors hover:outline focus-visible:outline disabled:opacity-50 group before:absolute before:-inset-3 before:rounded-full before:content-['']",
+                    isRead
+                        ? 'border border-muted-foreground/50 bg-background'
+                        : 'bg-green-600 text-white',
+                )}
+                onClick={() => onReadChange(notification, !isRead)}
+            >
+                {!isRead && (
+                    <Check className="size-5 shrink-0 text-white sm:hidden sm:group-hover:block" />
+                )}
+            </button>
+        </div>
+    );
+}

--- a/apps/farm/app/notifications/FarmNotificationsPanel.tsx
+++ b/apps/farm/app/notifications/FarmNotificationsPanel.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { FarmNotificationList } from './FarmNotificationList';
+import type { FarmNotificationNavigationTarget } from './notificationLinks';
+import {
+    useFarmNotifications,
+    useMarkFarmNotificationsRead,
+    useSetFarmNotificationRead,
+} from './notificationsClient';
+import type {
+    FarmNotification,
+    FarmNotificationsFilter,
+} from './notificationTypes';
+
+function navigateToNotificationTarget(
+    router: ReturnType<typeof useRouter>,
+    target: FarmNotificationNavigationTarget,
+) {
+    if (target.kind === 'internal') {
+        router.push(target.href);
+        return;
+    }
+
+    window.location.assign(target.href);
+}
+
+export function FarmNotificationsPanel() {
+    const router = useRouter();
+    const [filter, setFilter] = useState<FarmNotificationsFilter>('unread');
+    const notificationsQuery = useFarmNotifications(filter);
+    const setNotificationRead = useSetFarmNotificationRead();
+    const markNotificationsRead = useMarkFarmNotificationsRead();
+    const pendingReadId = setNotificationRead.variables?.id;
+    const readPendingIds = pendingReadId ? new Set([pendingReadId]) : undefined;
+
+    function handleNotificationOpen(
+        notification: FarmNotification,
+        target: FarmNotificationNavigationTarget | null,
+    ) {
+        if (!notification.readAt) {
+            setNotificationRead.mutate({
+                id: notification.id,
+                read: true,
+            });
+        }
+
+        if (target) {
+            navigateToNotificationTarget(router, target);
+        }
+    }
+
+    function handleNotificationReadChange(
+        notification: FarmNotification,
+        read: boolean,
+    ) {
+        setNotificationRead.mutate({
+            id: notification.id,
+            read,
+        });
+    }
+
+    return (
+        <FarmNotificationList
+            filter={filter}
+            isError={notificationsQuery.isError}
+            isLoading={notificationsQuery.isPending}
+            markAllPending={markNotificationsRead.isPending}
+            notifications={notificationsQuery.data ?? []}
+            onFilterChange={setFilter}
+            onMarkAllRead={(notificationIds) =>
+                markNotificationsRead.mutate(notificationIds)
+            }
+            onNotificationOpen={handleNotificationOpen}
+            onNotificationReadChange={handleNotificationReadChange}
+            onRetry={() => notificationsQuery.refetch()}
+            readPendingIds={readPendingIds}
+        />
+    );
+}

--- a/apps/farm/app/notifications/NotificationsList.spec.tsx
+++ b/apps/farm/app/notifications/NotificationsList.spec.tsx
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { FarmNotificationListHarness } from '../../playwright/FarmNotificationListHarness';
+
+test('filters unread and all notifications, then toggles read state', async ({
+    mount,
+    page,
+}) => {
+    await mount(<FarmNotificationListHarness />);
+
+    await expect(page.getByText('Nova radnja')).toBeVisible();
+    await expect(page.getByText('Stara obavijest')).toHaveCount(0);
+
+    await page.getByRole('tab', { name: 'Sve' }).click();
+    await expect(page.getByText('Stara obavijest')).toBeVisible();
+
+    await page
+        .getByRole('button', {
+            name: 'Označi obavijest "Nova radnja" kao pročitanu',
+        })
+        .click();
+    await page.getByRole('tab', { name: 'Nepročitane' }).click();
+    await expect(page.getByText('Nova radnja')).toHaveCount(0);
+});
+
+test('marks all visible unread notifications as read', async ({
+    mount,
+    page,
+}) => {
+    await mount(<FarmNotificationListHarness />);
+
+    await page
+        .getByRole('button', { name: 'Označi sve kao pročitane' })
+        .click();
+
+    await expect(page.getByText('Nema nepročitanih obavijesti.')).toBeVisible();
+    await page.getByRole('tab', { name: 'Sve' }).click();
+    await expect(page.getByText('Nova radnja')).toBeVisible();
+});
+
+test('opens Farm raised-bed targets and safely ignores unsupported garden links', async ({
+    mount,
+    page,
+}) => {
+    await mount(<FarmNotificationListHarness />);
+
+    await page.getByTestId('farm-notification-notification-raised-bed').click();
+    await expect(page.getByTestId('opened-target')).toHaveText(
+        '/raised-beds/42',
+    );
+    await expect(page.getByText('Gredica za pregled')).toHaveCount(0);
+
+    await page
+        .getByTestId('farm-notification-notification-unsupported')
+        .click();
+    await expect(page.getByTestId('opened-target')).toHaveText('none');
+});

--- a/apps/farm/app/notifications/notificationLinks.ts
+++ b/apps/farm/app/notifications/notificationLinks.ts
@@ -1,0 +1,115 @@
+import type { Route } from 'next';
+import type { FarmNotification } from './notificationTypes';
+
+export type FarmNotificationNavigationTarget =
+    | {
+          href: Route;
+          kind: 'internal';
+      }
+    | {
+          href: string;
+          kind: 'external';
+      };
+
+const farmRoutePrefixes = [
+    '/',
+    '/greenhouse',
+    '/notifications',
+    '/operations',
+    '/payouts',
+    '/plants',
+    '/raised-beds',
+    '/schedule',
+    '/settings',
+];
+
+const farmHostnames = new Set([
+    'farma.gredice.com',
+    'farma.gredice.test',
+    'localhost',
+    '127.0.0.1',
+]);
+
+const gardenHostnames = new Set(['vrt.gredice.com', 'vrt.gredice.test']);
+
+function isFarmPath(pathname: string) {
+    return farmRoutePrefixes.some((prefix) => {
+        if (prefix === '/') {
+            return pathname === '/';
+        }
+
+        return pathname === prefix || pathname.startsWith(`${prefix}/`);
+    });
+}
+
+function internalTarget(href: string): FarmNotificationNavigationTarget {
+    return {
+        href: href as Route,
+        kind: 'internal',
+    };
+}
+
+function normalizeFarmRelativeUrl(url: URL) {
+    const href = `${url.pathname}${url.search}${url.hash}`;
+    return internalTarget(href);
+}
+
+function resolveUrlTarget(value: string | null) {
+    if (!value) {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed || trimmed.startsWith('//')) {
+        return null;
+    }
+
+    try {
+        const url = new URL(trimmed, 'https://farma.gredice.com');
+
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+            return null;
+        }
+
+        if (gardenHostnames.has(url.hostname)) {
+            return null;
+        }
+
+        if (farmHostnames.has(url.hostname) && isFarmPath(url.pathname)) {
+            return normalizeFarmRelativeUrl(url);
+        }
+
+        if (url.origin === 'https://farma.gredice.com') {
+            return isFarmPath(url.pathname)
+                ? normalizeFarmRelativeUrl(url)
+                : null;
+        }
+
+        return {
+            href: url.toString(),
+            kind: 'external',
+        } satisfies FarmNotificationNavigationTarget;
+    } catch {
+        return null;
+    }
+}
+
+export function resolveFarmNotificationNavigationTarget(
+    notification: Pick<
+        FarmNotification,
+        'actionUrl' | 'linkUrl' | 'raisedBedId'
+    >,
+): FarmNotificationNavigationTarget | null {
+    if (
+        typeof notification.raisedBedId === 'number' &&
+        Number.isInteger(notification.raisedBedId) &&
+        notification.raisedBedId > 0
+    ) {
+        return internalTarget(`/raised-beds/${notification.raisedBedId}`);
+    }
+
+    return (
+        resolveUrlTarget(notification.linkUrl) ??
+        resolveUrlTarget(notification.actionUrl)
+    );
+}

--- a/apps/farm/app/notifications/notificationTypes.ts
+++ b/apps/farm/app/notifications/notificationTypes.ts
@@ -1,0 +1,15 @@
+export type FarmNotificationsFilter = 'unread' | 'all';
+
+export type FarmNotification = {
+    id: string;
+    actionUrl: string | null;
+    content: string;
+    createdAt: Date;
+    header: string;
+    iconUrl: string | null;
+    imageUrl: string | null;
+    linkUrl: string | null;
+    raisedBedId: number | null;
+    readAt: Date | null;
+    timestamp: Date;
+};

--- a/apps/farm/app/notifications/notificationsClient.ts
+++ b/apps/farm/app/notifications/notificationsClient.ts
@@ -1,0 +1,145 @@
+'use client';
+
+import { clientAuthenticated } from '@gredice/client';
+import { useCurrentUser } from '@gredice/ui/auth';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+    FarmNotification,
+    FarmNotificationsFilter,
+} from './notificationTypes';
+
+export const farmNotificationsQueryKey = ['farm', 'notifications'];
+
+async function fetchNotificationsResponse({
+    filter,
+    limit,
+    userId,
+}: {
+    filter: FarmNotificationsFilter;
+    limit: number;
+    userId: string;
+}) {
+    const response = await clientAuthenticated().api.notifications.$get({
+        query: {
+            userId,
+            read: filter === 'all' ? 'true' : undefined,
+            page: '0',
+            limit: limit.toString(),
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error('Failed to fetch farm notifications');
+    }
+
+    return response.json();
+}
+
+type ApiNotification = Awaited<
+    ReturnType<typeof fetchNotificationsResponse>
+>[number];
+
+function parseFarmNotification(
+    notification: ApiNotification,
+): FarmNotification {
+    return {
+        ...notification,
+        actionUrl: notification.actionUrl ?? null,
+        createdAt: new Date(notification.createdAt),
+        iconUrl: notification.iconUrl ?? null,
+        imageUrl: notification.imageUrl ?? null,
+        linkUrl: notification.linkUrl ?? null,
+        raisedBedId: notification.raisedBedId ?? null,
+        readAt: notification.readAt ? new Date(notification.readAt) : null,
+        timestamp: new Date(notification.timestamp),
+    };
+}
+
+export function useFarmNotifications(
+    filter: FarmNotificationsFilter,
+    limit = 1000,
+) {
+    const { data: currentUser } = useCurrentUser();
+    const userId = currentUser?.userId;
+
+    return useQuery({
+        enabled: Boolean(userId),
+        queryFn: async () => {
+            if (!userId) {
+                return [];
+            }
+
+            const notifications = await fetchNotificationsResponse({
+                filter,
+                limit,
+                userId,
+            });
+
+            return notifications.map(parseFarmNotification);
+        },
+        queryKey: [...farmNotificationsQueryKey, { filter, limit, userId }],
+        staleTime: 1000 * 60,
+    });
+}
+
+export function useSetFarmNotificationRead() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ id, read }: { id: string; read: boolean }) => {
+            const response = await clientAuthenticated().api.notifications[
+                ':id'
+            ].$patch({
+                json: {
+                    read: read.toString(),
+                    readWhere: 'farm',
+                },
+                param: { id },
+            });
+
+            if (!response.ok) {
+                throw new Error(
+                    'Failed to update farm notification read state',
+                );
+            }
+
+            return { id, read };
+        },
+        onSettled: () => {
+            queryClient.invalidateQueries({
+                queryKey: farmNotificationsQueryKey,
+            });
+        },
+    });
+}
+
+export function useMarkFarmNotificationsRead() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (notificationIds: string[]) => {
+            if (notificationIds.length === 0) {
+                return;
+            }
+
+            const response = await clientAuthenticated().api.notifications.$put(
+                {
+                    json: {
+                        notificationIds,
+                        read: 'true',
+                        readWhere: 'farm',
+                    },
+                },
+            );
+
+            if (!response.ok) {
+                throw new Error('Failed to mark farm notifications as read');
+            }
+        },
+        onSettled: () => {
+            queryClient.invalidateQueries({
+                queryKey: farmNotificationsQueryKey,
+            });
+        },
+    });
+}

--- a/apps/farm/app/notifications/page.tsx
+++ b/apps/farm/app/notifications/page.tsx
@@ -1,0 +1,40 @@
+import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import LoginDialog from '../../components/auth/LoginDialog';
+import { HomeButton } from '../../components/HomeButton';
+import { auth } from '../../lib/auth/auth';
+import { FarmNotificationsPanel } from './FarmNotificationsPanel';
+
+export const dynamic = 'force-dynamic';
+
+function FarmNotificationsContent() {
+    return (
+        <div className="mx-auto w-full max-w-5xl space-y-4 p-4">
+            <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-2">
+                <HomeButton />
+                <Stack spacing={0} className="min-w-0">
+                    <Typography level="h3" semiBold>
+                        Obavijesti
+                    </Typography>
+                </Stack>
+            </div>
+            <FarmNotificationsPanel />
+        </div>
+    );
+}
+
+export default function FarmNotificationsPage() {
+    const authFarmer = auth.bind(null, ['farmer', 'admin']);
+
+    return (
+        <div className="min-h-[100dvh] w-full bg-background">
+            <AuthProtectedSection auth={authFarmer}>
+                <FarmNotificationsContent />
+            </AuthProtectedSection>
+            <SignedOut auth={authFarmer}>
+                <LoginDialog />
+            </SignedOut>
+        </div>
+    );
+}

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -14,6 +14,7 @@ import {
     Calendar,
     Euro,
     Fence,
+    Inbox,
     MapPinHouse,
     Settings,
     Shield,
@@ -157,6 +158,16 @@ async function FarmerDashboard() {
                                 href="/schedule"
                             >
                                 Dnevni zadaci
+                            </Button>
+                            <Button
+                                variant="soft"
+                                size="lg"
+                                fullWidth
+                                className="h-24 flex-col text-center text-base"
+                                startDecorator={<Inbox className="size-6" />}
+                                href="/notifications"
+                            >
+                                Obavijesti
                             </Button>
                             <Button
                                 variant="soft"

--- a/apps/farm/playwright/FarmNotificationListHarness.tsx
+++ b/apps/farm/playwright/FarmNotificationListHarness.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import {
+    FarmNotificationList,
+    setFarmNotificationReadState,
+    setFarmNotificationsReadState,
+} from '../app/notifications/FarmNotificationList';
+import type { FarmNotification } from '../app/notifications/notificationTypes';
+
+const baseDate = new Date('2026-07-04T08:30:00.000Z');
+
+const initialNotifications: FarmNotification[] = [
+    {
+        id: 'notification-unread',
+        actionUrl: null,
+        content: 'Dodijeljena ti je radnja **Zalijevanje**.',
+        createdAt: baseDate,
+        header: 'Nova radnja',
+        iconUrl: null,
+        imageUrl: null,
+        linkUrl: null,
+        raisedBedId: null,
+        readAt: null,
+        timestamp: baseDate,
+    },
+    {
+        id: 'notification-read',
+        actionUrl: null,
+        content: 'Podsjetnik je već pregledan.',
+        createdAt: baseDate,
+        header: 'Stara obavijest',
+        iconUrl: null,
+        imageUrl: null,
+        linkUrl: null,
+        raisedBedId: null,
+        readAt: new Date('2026-07-04T09:00:00.000Z'),
+        timestamp: baseDate,
+    },
+    {
+        id: 'notification-raised-bed',
+        actionUrl: null,
+        content: 'Gredica treba pregled.',
+        createdAt: baseDate,
+        header: 'Gredica za pregled',
+        iconUrl: null,
+        imageUrl: null,
+        linkUrl: 'https://vrt.gredice.com?gredica=Test',
+        raisedBedId: 42,
+        readAt: null,
+        timestamp: baseDate,
+    },
+    {
+        id: 'notification-unsupported',
+        actionUrl: null,
+        content: 'Stara vrtna poveznica nema Farm odredište.',
+        createdAt: baseDate,
+        header: 'Vrtna poveznica',
+        iconUrl: null,
+        imageUrl: null,
+        linkUrl: 'https://vrt.gredice.com?gredica=BezIda',
+        raisedBedId: null,
+        readAt: null,
+        timestamp: baseDate,
+    },
+];
+
+export function FarmNotificationListHarness() {
+    const [filter, setFilter] = useState<'unread' | 'all'>('unread');
+    const [notifications, setNotifications] = useState(initialNotifications);
+    const [openedTarget, setOpenedTarget] = useState('not-opened');
+
+    return (
+        <>
+            <FarmNotificationList
+                filter={filter}
+                notifications={notifications}
+                onFilterChange={setFilter}
+                onMarkAllRead={(ids) =>
+                    setNotifications((current) =>
+                        setFarmNotificationsReadState(current, ids, baseDate),
+                    )
+                }
+                onNotificationOpen={(notification, target) => {
+                    if (!notification.readAt) {
+                        setNotifications((current) =>
+                            setFarmNotificationReadState(
+                                current,
+                                notification.id,
+                                true,
+                                baseDate,
+                            ),
+                        );
+                    }
+                    setOpenedTarget(target?.href ?? 'none');
+                }}
+                onNotificationReadChange={(notification, read) =>
+                    setNotifications((current) =>
+                        setFarmNotificationReadState(
+                            current,
+                            notification.id,
+                            read,
+                            baseDate,
+                        ),
+                    )
+                }
+            />
+            <output data-testid="opened-target">{openedTarget}</output>
+        </>
+    );
+}

--- a/apps/farm/src/KnownPages.ts
+++ b/apps/farm/src/KnownPages.ts
@@ -3,6 +3,7 @@ import type { Route } from 'next';
 export const KnownPages = {
     Landing: '/',
     Greenhouse: '/greenhouse',
+    Notifications: '/notifications',
     RaisedBeds: '/raised-beds',
     RaisedBed: (raisedBedId: number) => `/raised-beds/${raisedBedId}` as Route,
     Schedule: '/schedule',


### PR DESCRIPTION
Closes #3928.

## Summary
- add a Farm `/notifications` route with unread/all views, empty/loading/error states, notification media, timestamps, read toggles, and mark-all-read
- add Farm notification client hooks that use the existing authenticated notifications API with `readWhere: farm`
- map raised-bed notifications to Farm raised-bed pages and safely ignore unsupported garden-only deep links
- add a dashboard entry point and focused Playwright component coverage

## Validation
- `pnpm lint --filter farm`
- `pnpm --filter farm test:run app/notifications/NotificationsList.spec.tsx`
- `pnpm --filter farm test:prepare`