### PR TITLE
feat(www): add pricing row images

### DIFF
--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -1,6 +1,8 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
 import { Container } from '@gredice/ui/Container';
+import { OperationImage } from '@gredice/ui/OperationImage';
 import { PageHeader } from '@gredice/ui/PageHeader';
+import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
@@ -9,8 +11,15 @@ import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { formatPrice } from '../../lib/formatPrice';
 import { getHqLocationsData } from '../../lib/getHqLocationsData';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
+import { getPlantSortsData } from '../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
 import { KnownPages } from '../../src/KnownPages';
+import {
+    getPlantSortParentName,
+    getPricedOperationRows,
+    getPricedPlantRows,
+    getPricedPlantSortRows,
+} from './pricingRows';
 
 export const metadata: Metadata = {
     title: 'Cjenik',
@@ -19,25 +28,17 @@ export const metadata: Metadata = {
 };
 
 export default async function PricingPage() {
-    const [plantsData, operationsData, hqLocations] = await Promise.all([
-        getPlantsData(),
-        getOperationsData(),
-        getHqLocationsData(),
-    ]);
+    const [plantsData, plantSortsData, operationsData, hqLocations] =
+        await Promise.all([
+            getPlantsData(),
+            getPlantSortsData(),
+            getOperationsData(),
+            getHqLocationsData(),
+        ]);
 
-    const plantsWithPrices = plantsData
-        .filter((plant) => typeof plant.prices?.perPlant === 'number')
-        .sort((a, b) =>
-            a.information.name.localeCompare(b.information.name, 'hr-HR'),
-        );
-
-    const operationsWithPrices = operationsData
-        .filter(
-            (operation) => typeof operation.prices?.perOperation === 'number',
-        )
-        .sort((a, b) =>
-            a.information.label.localeCompare(b.information.label, 'hr-HR'),
-        );
+    const plantsWithPrices = getPricedPlantRows(plantsData);
+    const plantSortsWithPrices = getPricedPlantSortRows(plantSortsData);
+    const operationsWithPrices = getPricedOperationRows(operationsData);
 
     const sortedHqLocations = [...hqLocations].sort((a, b) =>
         a.information.label.localeCompare(b.information.label, 'hr-HR'),
@@ -54,7 +55,9 @@ export default async function PricingPage() {
 
                 <Card>
                     <CardHeader className="flex-row items-center justify-between">
-                        <CardTitle>Cijene biljaka (po biljci)</CardTitle>
+                        <CardTitle>
+                            Cijene biljaka i sorti (po biljci)
+                        </CardTitle>
                         <FeedbackModal topic="www/pricing/plants" />
                     </CardHeader>
                     <CardContent>
@@ -63,7 +66,7 @@ export default async function PricingPage() {
                                 <thead>
                                     <tr className="border-b">
                                         <th className="text-left py-2 pr-4">
-                                            Biljka
+                                            Biljka ili sorta
                                         </th>
                                         <th className="text-right py-2">
                                             Cijena
@@ -73,15 +76,72 @@ export default async function PricingPage() {
                                 <tbody>
                                     {plantsWithPrices.map((plant) => (
                                         <tr
-                                            key={plant.id}
+                                            key={`plant-${plant.id}`}
                                             className="border-b last:border-b-0"
                                         >
-                                            <td className="py-2 pr-4">
-                                                {plant.information.name}
+                                            <td className="py-2 pr-4 align-middle">
+                                                <div className="flex min-w-56 items-center gap-3">
+                                                    <PlantOrSortImage
+                                                        plant={plant}
+                                                        alt={`Slika biljke ${plant.information.name}`}
+                                                        width={40}
+                                                        height={40}
+                                                        className="size-10 rounded-md object-cover"
+                                                    />
+                                                    <span className="min-w-0">
+                                                        <span className="block truncate font-medium">
+                                                            {
+                                                                plant
+                                                                    .information
+                                                                    .name
+                                                            }
+                                                        </span>
+                                                        <span className="block text-xs text-muted-foreground">
+                                                            Biljka
+                                                        </span>
+                                                    </span>
+                                                </div>
                                             </td>
                                             <td className="py-2 text-right font-medium">
                                                 {formatPrice(
                                                     plant.prices.perPlant,
+                                                )}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                    {plantSortsWithPrices.map((sort) => (
+                                        <tr
+                                            key={`plant-sort-${sort.id}`}
+                                            className="border-b last:border-b-0"
+                                        >
+                                            <td className="py-2 pr-4 align-middle">
+                                                <div className="flex min-w-56 items-center gap-3">
+                                                    <PlantOrSortImage
+                                                        plantSort={sort}
+                                                        alt={`Slika sorte ${sort.information.name}`}
+                                                        width={40}
+                                                        height={40}
+                                                        className="size-10 rounded-md object-cover"
+                                                    />
+                                                    <span className="min-w-0">
+                                                        <span className="block truncate font-medium">
+                                                            {
+                                                                sort.information
+                                                                    .name
+                                                            }
+                                                        </span>
+                                                        <span className="block truncate text-xs text-muted-foreground">
+                                                            Sorta -{' '}
+                                                            {getPlantSortParentName(
+                                                                sort,
+                                                            )}
+                                                        </span>
+                                                    </span>
+                                                </div>
+                                            </td>
+                                            <td className="py-2 text-right font-medium">
+                                                {formatPrice(
+                                                    sort.prices.perPlant,
                                                 )}
                                             </td>
                                         </tr>
@@ -126,8 +186,21 @@ export default async function PricingPage() {
                                             key={operation.id}
                                             className="border-b last:border-b-0"
                                         >
-                                            <td className="py-2 pr-4">
-                                                {operation.information.label}
+                                            <td className="py-2 pr-4 align-middle">
+                                                <div className="flex min-w-56 items-center gap-3">
+                                                    <OperationImage
+                                                        operation={operation}
+                                                        size={40}
+                                                        className="rounded-md bg-muted text-muted-foreground"
+                                                    />
+                                                    <span className="block min-w-0 truncate font-medium">
+                                                        {
+                                                            operation
+                                                                .information
+                                                                .label
+                                                        }
+                                                    </span>
+                                                </div>
                                             </td>
                                             <td className="py-2 text-right font-medium">
                                                 {formatPrice(

--- a/apps/www/app/cjenik/pricingRows.node.spec.ts
+++ b/apps/www/app/cjenik/pricingRows.node.spec.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    getPlantSortParentName,
+    getPricedOperationRows,
+    getPricedPlantRows,
+    getPricedPlantSortRows,
+} from './pricingRows.ts';
+
+test('pricing rows include plants and operations only when numeric prices exist', () => {
+    const plants = getPricedPlantRows([
+        {
+            information: { name: 'Mrkva' },
+            prices: { perPlant: 1.2 },
+        },
+        {
+            information: { name: 'Blitva' },
+            prices: { perPlant: null },
+        },
+        {
+            information: { name: 'Rajčica' },
+        },
+    ]);
+    const operations = getPricedOperationRows([
+        {
+            information: { label: 'Zalijevanje' },
+            prices: { perOperation: 2 },
+        },
+        {
+            information: { label: 'Berba' },
+        },
+    ]);
+
+    assert.deepEqual(
+        plants.map((plant) => plant.information.name),
+        ['Mrkva'],
+    );
+    assert.deepEqual(
+        operations.map((operation) => operation.information.label),
+        ['Zalijevanje'],
+    );
+    assert.equal(plants[0]?.prices.perPlant, 1.2);
+    assert.equal(operations[0]?.prices.perOperation, 2);
+});
+
+test('pricing rows include only plant sorts with their own numeric price', () => {
+    const sorts = getPricedPlantSortRows([
+        {
+            information: {
+                name: 'Roma',
+                plant: { information: { name: 'Rajčica' } },
+            },
+            prices: { perPlant: 1.7 },
+        },
+        {
+            information: {
+                name: 'Nantes',
+                plant: { information: { name: 'Mrkva' } },
+            },
+            prices: { perPlant: 1.1 },
+        },
+        {
+            information: {
+                name: 'Cherry',
+                plant: { information: { name: 'Rajčica' } },
+            },
+        },
+    ]);
+
+    assert.deepEqual(
+        sorts.map(
+            (sort) =>
+                `${getPlantSortParentName(sort)}: ${sort.information.name}`,
+        ),
+        ['Mrkva: Nantes', 'Rajčica: Roma'],
+    );
+    assert.equal(sorts[0]?.prices.perPlant, 1.1);
+});

--- a/apps/www/app/cjenik/pricingRows.ts
+++ b/apps/www/app/cjenik/pricingRows.ts
@@ -1,0 +1,95 @@
+type PerPlantPrice = {
+    prices?: {
+        perPlant?: number | null;
+    } | null;
+};
+
+type PerOperationPrice = {
+    prices?: {
+        perOperation?: number | null;
+    } | null;
+};
+
+type PricedPerPlant<T extends PerPlantPrice> = T & {
+    prices: {
+        perPlant: number;
+    };
+};
+
+type PricedPerOperation<T extends PerOperationPrice> = T & {
+    prices: {
+        perOperation: number;
+    };
+};
+
+type NamedPlant = PerPlantPrice & {
+    information: {
+        name: string;
+    };
+};
+
+type NamedPlantSort = PerPlantPrice & {
+    information: {
+        name: string;
+        plant?: {
+            information?: {
+                name?: string | null;
+            } | null;
+        } | null;
+    };
+};
+
+type NamedOperation = PerOperationPrice & {
+    information: {
+        label: string;
+    };
+};
+
+function hasPerPlantPrice<T extends PerPlantPrice>(
+    entity: T,
+): entity is PricedPerPlant<T> {
+    return typeof entity.prices?.perPlant === 'number';
+}
+
+function hasPerOperationPrice<T extends PerOperationPrice>(
+    entity: T,
+): entity is PricedPerOperation<T> {
+    return typeof entity.prices?.perOperation === 'number';
+}
+
+export function getPricedPlantRows<T extends NamedPlant>(plants: T[]) {
+    return plants
+        .filter(hasPerPlantPrice)
+        .sort((a, b) =>
+            a.information.name.localeCompare(b.information.name, 'hr-HR'),
+        );
+}
+
+export function getPricedPlantSortRows<T extends NamedPlantSort>(sorts: T[]) {
+    return sorts.filter(hasPerPlantPrice).sort((a, b) => {
+        const parentComparison = getPlantSortParentName(a).localeCompare(
+            getPlantSortParentName(b),
+            'hr-HR',
+        );
+
+        if (parentComparison !== 0) {
+            return parentComparison;
+        }
+
+        return a.information.name.localeCompare(b.information.name, 'hr-HR');
+    });
+}
+
+export function getPricedOperationRows<T extends NamedOperation>(
+    operations: T[],
+) {
+    return operations
+        .filter(hasPerOperationPrice)
+        .sort((a, b) =>
+            a.information.label.localeCompare(b.information.label, 'hr-HR'),
+        );
+}
+
+export function getPlantSortParentName(sort: NamedPlantSort) {
+    return sort.information.plant?.information?.name ?? 'Biljka';
+}


### PR DESCRIPTION
## Summary
- Add compact plant thumbnails to cjenik plant price rows using the existing `PlantOrSortImage` helper.
- Add sort-specific price rows when plant sort data exposes its own numeric `prices.perPlant`, with parent plant context.
- Add operation thumbnails/fallback icons to operation price rows using the existing `OperationImage` component.

## Validation
- `pnpm --dir apps/www exec biome check app/cjenik/page.tsx app/cjenik/pricingRows.ts app/cjenik/pricingRows.node.spec.ts`
- `pnpm --dir apps/www exec node --experimental-strip-types --test app/cjenik/pricingRows.node.spec.ts`
- `pnpm --dir apps/www typecheck`
- Local visual smoke at `http://127.0.0.1:4250/cjenik` with live directory data at 1280px and 390px widths: 3 tables rendered, 119 rows rendered, first row media stayed 40x40, no page-level horizontal overflow.

Closes #3947