### PR TITLE
feat(app): use icon buttons for header add actions

### DIFF
--- a/apps/app/app/admin/automations/page.tsx
+++ b/apps/app/app/admin/automations/page.tsx
@@ -7,8 +7,8 @@ import {
     listAutomationDefinitionRunSummaries,
     listAutomationDefinitions,
 } from '@gredice/storage';
-import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Add } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -167,12 +167,14 @@ export default async function AutomationsPage({
             <AdminPageHeader
                 heading="Automatizacije"
                 actions={
-                    <Button
+                    <IconButton
+                        aria-label="Nova automatizacija"
                         href={KnownPages.AutomationCreate}
-                        startDecorator={<Add className="size-4" />}
+                        title="Nova automatizacija"
+                        variant="solid"
                     >
-                        Nova automatizacija
-                    </Button>
+                        <Add className="size-5" />
+                    </IconButton>
                 }
             />
 

--- a/apps/app/app/admin/delivery/slots/page.tsx
+++ b/apps/app/app/admin/delivery/slots/page.tsx
@@ -1,6 +1,7 @@
 import { getAllTimeSlots, getPickupLocations } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardOverflow } from '@gredice/ui/Card';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Add, Calendar } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -47,12 +48,13 @@ export default async function AdminTimeSlotsPage({
                         />
                         <CreateTimeSlotModal
                             trigger={
-                                <Button
+                                <IconButton
+                                    aria-label="Kreiraj slot"
+                                    title="Kreiraj slot"
                                     variant="solid"
-                                    startDecorator={<Add className="size-4" />}
                                 >
-                                    Kreiraj slot
-                                </Button>
+                                    <Add className="size-5" />
+                                </IconButton>
                             }
                             locations={pickupLocations}
                         />

--- a/apps/app/app/admin/inventory/[inventoryId]/page.tsx
+++ b/apps/app/app/admin/inventory/[inventoryId]/page.tsx
@@ -6,6 +6,7 @@ import {
 } from '@gredice/storage';
 import { Breadcrumbs } from '@gredice/ui/Breadcrumbs';
 import { Card, CardOverflow } from '@gredice/ui/Card';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Add, Edit, Printer } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -143,15 +144,14 @@ export default async function InventoryConfigPage({
                                     <span>Preuzmi PDF</span>
                                 </Row>
                             </Link>
-                            <Link href={KnownPages.InventoryItemCreate(id)}>
-                                <Row
-                                    spacing={2}
-                                    className="text-sm font-medium px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                                >
-                                    <Add className="size-4" />
-                                    <span>Dodaj stavku</span>
-                                </Row>
-                            </Link>
+                            <IconButton
+                                aria-label="Dodaj stavku"
+                                href={KnownPages.InventoryItemCreate(id)}
+                                title="Dodaj stavku"
+                                variant="solid"
+                            >
+                                <Add className="size-5" />
+                            </IconButton>
                             <Link href={KnownPages.InventoryConfigEdit(id)}>
                                 <Row
                                     spacing={2}

--- a/apps/app/app/admin/inventory/page.tsx
+++ b/apps/app/app/admin/inventory/page.tsx
@@ -3,8 +3,8 @@ import {
     getInventoryStatusItemsByConfigIds,
 } from '@gredice/storage';
 import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Add, File } from '@gredice/ui/icons';
-import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
@@ -37,15 +37,14 @@ export default async function InventoryPage() {
         <Stack spacing={4}>
             <AdminPageHeader
                 actions={
-                    <Link href={KnownPages.InventoryCreate}>
-                        <Row
-                            spacing={2}
-                            className="text-sm font-medium px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                        >
-                            <Add className="size-4" />
-                            <span>Nova zaliha</span>
-                        </Row>
-                    </Link>
+                    <IconButton
+                        aria-label="Nova zaliha"
+                        href={KnownPages.InventoryCreate}
+                        title="Nova zaliha"
+                        variant="solid"
+                    >
+                        <Add className="size-5" />
+                    </IconButton>
                 }
             />
 

--- a/apps/app/app/admin/invoices/page.tsx
+++ b/apps/app/app/admin/invoices/page.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@gredice/ui/Button';
 import { Card, CardOverflow } from '@gredice/ui/Card';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Add } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
 import { AdminPageHeader } from '../../../components/admin/navigation';
@@ -16,13 +16,14 @@ export default async function InvoicesPage() {
         <Stack spacing={4}>
             <AdminPageHeader
                 actions={
-                    <Button
-                        variant="solid"
-                        startDecorator={<Add className="size-5 shrink-0" />}
+                    <IconButton
+                        aria-label="Nova ponuda"
                         href={KnownPages.CreateInvoice}
+                        title="Nova ponuda"
+                        variant="solid"
                     >
-                        Nova ponuda
-                    </Button>
+                        <Add className="size-5" />
+                    </IconButton>
                 }
             />
             <Card>

--- a/apps/app/app/admin/operations/BulkOperationCreateModal.tsx
+++ b/apps/app/app/admin/operations/BulkOperationCreateModal.tsx
@@ -12,6 +12,7 @@ import { getEntities } from '../../../components/shared/attributes/actions/entit
 import { UserPickerField } from '../../../components/shared/fields/UserPickerField';
 import { bulkCreateOperationsAction } from '../../(actions)/operationActions';
 import { SelectEntity } from '../raised-beds/[raisedBedId]/SelectEntity';
+import { OperationCreateTrigger } from './OperationCreateTrigger';
 import {
     type TargetSelectionMode,
     TargetsSelectionList,
@@ -115,7 +116,7 @@ export function BulkOperationCreateModal({
     return (
         <Modal
             title={'Nova radnja'}
-            trigger={<Button variant="outlined">Dodaj više</Button>}
+            trigger={<OperationCreateTrigger mode="bulk" />}
             open={open}
             onOpenChange={setOpen}
         >

--- a/apps/app/app/admin/operations/OperationCreateTrigger.tsx
+++ b/apps/app/app/admin/operations/OperationCreateTrigger.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { IconButtonButtonProps } from '@gredice/ui/IconButton';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Add, Layers } from '@gredice/ui/icons';
+
+type OperationCreateTriggerMode = 'single' | 'bulk';
+type OperationCreateTriggerProps = Omit<
+    IconButtonButtonProps,
+    'aria-label' | 'children' | 'title' | 'variant'
+> & {
+    mode: OperationCreateTriggerMode;
+};
+
+const triggerConfig = {
+    single: {
+        Icon: Add,
+        label: 'Dodaj jednu radnju',
+    },
+    bulk: {
+        Icon: Layers,
+        label: 'Dodaj više radnji',
+    },
+} satisfies Record<
+    OperationCreateTriggerMode,
+    {
+        Icon: typeof Add;
+        label: string;
+    }
+>;
+
+export function OperationCreateTrigger({
+    mode,
+    ...triggerProps
+}: OperationCreateTriggerProps) {
+    const { Icon, label } = triggerConfig[mode];
+
+    return (
+        <IconButton
+            {...triggerProps}
+            aria-label={label}
+            title={label}
+            type="button"
+            variant="outlined"
+        >
+            <Icon className="size-4" />
+        </IconButton>
+    );
+}

--- a/apps/app/app/admin/operations/SingleOperationCreateModal.tsx
+++ b/apps/app/app/admin/operations/SingleOperationCreateModal.tsx
@@ -13,6 +13,7 @@ import {
     singleCreateOperationAction,
 } from '../../(actions)/operationActions';
 import { SelectEntity } from '../raised-beds/[raisedBedId]/SelectEntity';
+import { OperationCreateTrigger } from './OperationCreateTrigger';
 import {
     type TargetSelectionMode,
     TargetsSelectionList,
@@ -96,7 +97,7 @@ export function SingleOperationCreateModal({
     return (
         <Modal
             title={'Nova radnja'}
-            trigger={<Button variant="outlined">Dodaj jednu</Button>}
+            trigger={<OperationCreateTrigger mode="single" />}
             open={open}
             onOpenChange={setOpen}
         >

--- a/apps/app/app/admin/outlet/page.tsx
+++ b/apps/app/app/admin/outlet/page.tsx
@@ -7,6 +7,7 @@ import {
     CardOverflow,
     CardTitle,
 } from '@gredice/ui/Card';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Add, Discount } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -63,12 +64,14 @@ export default async function OutletAdminPage() {
         <Stack spacing={4}>
             <AdminPageHeader
                 actions={
-                    <Button
+                    <IconButton
+                        aria-label="Nova outlet ponuda"
                         href={KnownPages.OutletCreate}
-                        startDecorator={<Add className="size-4" />}
+                        title="Nova outlet ponuda"
+                        variant="solid"
                     >
-                        Nova outlet ponuda
-                    </Button>
+                        <Add className="size-5" />
+                    </IconButton>
                 }
                 heading="Outlet"
             />

--- a/apps/app/components/shared/ServerActionIconButton.tsx
+++ b/apps/app/components/shared/ServerActionIconButton.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { IconButton, type IconButtonProps } from '@gredice/ui/IconButton';
+import { IconButton, type IconButtonButtonProps } from '@gredice/ui/IconButton';
 import { startTransition, useState } from 'react';
 
-export type ServerActionIconButtonProps = Omit<IconButtonProps, 'onClick'> & {
+export type ServerActionIconButtonProps = Omit<
+    IconButtonButtonProps,
+    'onClick'
+> & {
     onClick?: () => Promise<void>;
 } & (
         | {

--- a/apps/app/tests/operation-create-trigger.spec.tsx
+++ b/apps/app/tests/operation-create-trigger.spec.tsx
@@ -1,0 +1,109 @@
+import { Modal } from '@gredice/ui/Modal';
+import { expect, test } from '@playwright/experimental-ct-react';
+import { OperationCreateTrigger } from '../app/admin/operations/OperationCreateTrigger';
+
+test('renders operation create actions as icon-only buttons', async ({
+    mount,
+}) => {
+    const component = await mount(
+        <div style={{ display: 'flex', gap: 8 }}>
+            <OperationCreateTrigger mode="single" />
+            <OperationCreateTrigger mode="bulk" />
+        </div>,
+    );
+
+    const single = component.getByRole('button', {
+        name: 'Dodaj jednu radnju',
+    });
+    const bulk = component.getByRole('button', {
+        name: 'Dodaj više radnji',
+    });
+
+    await expect(single).toBeVisible();
+    await expect(single).toHaveAttribute('title', 'Dodaj jednu radnju');
+    await expect(single).toHaveText('');
+    await expect(single.locator('svg')).toHaveCount(1);
+
+    await expect(bulk).toBeVisible();
+    await expect(bulk).toHaveAttribute('title', 'Dodaj više radnji');
+    await expect(bulk).toHaveText('');
+    await expect(bulk.locator('svg')).toHaveCount(1);
+
+    const singleBox = await single.boundingBox();
+    const bulkBox = await bulk.boundingBox();
+
+    if (!singleBox || !bulkBox) {
+        throw new Error('Expected operation create buttons to be measurable');
+    }
+
+    expect(singleBox.width).toBeLessThan(56);
+    expect(bulkBox.width).toBeLessThan(56);
+});
+
+test('opens a modal when used as a dialog trigger', async ({ mount, page }) => {
+    await mount(
+        <Modal
+            title="Nova radnja"
+            trigger={<OperationCreateTrigger mode="single" />}
+        >
+            <div>Obrazac za novu radnju</div>
+        </Modal>,
+    );
+
+    await page.getByRole('button', { name: 'Dodaj jednu radnju' }).click();
+
+    await expect(page.getByText('Obrazac za novu radnju')).toBeVisible();
+});
+
+test.describe('mobile header sizing', () => {
+    test.use({
+        viewport: { width: 390, height: 844 },
+        hasTouch: true,
+        isMobile: true,
+    });
+
+    test('keeps operation create actions visible in a narrow header', async ({
+        mount,
+    }) => {
+        const component = await mount(
+            <div
+                style={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    gap: 8,
+                    justifyContent: 'flex-end',
+                    overflow: 'hidden',
+                    width: 96,
+                }}
+            >
+                <OperationCreateTrigger mode="single" />
+                <OperationCreateTrigger mode="bulk" />
+            </div>,
+        );
+
+        const single = component.getByRole('button', {
+            name: 'Dodaj jednu radnju',
+        });
+        const bulk = component.getByRole('button', {
+            name: 'Dodaj više radnji',
+        });
+
+        await expect(single).toBeVisible();
+        await expect(bulk).toBeVisible();
+
+        const hostBox = await component.boundingBox();
+        const singleBox = await single.boundingBox();
+        const bulkBox = await bulk.boundingBox();
+
+        if (!hostBox || !singleBox || !bulkBox) {
+            throw new Error(
+                'Expected operation header actions to be measurable',
+            );
+        }
+
+        expect(singleBox.x).toBeGreaterThanOrEqual(hostBox.x);
+        expect(bulkBox.x + bulkBox.width).toBeLessThanOrEqual(
+            hostBox.x + hostBox.width,
+        );
+    });
+});

--- a/apps/storybook/stories/packages/ui/primitives/IconButton.stories.tsx
+++ b/apps/storybook/stories/packages/ui/primitives/IconButton.stories.tsx
@@ -1,5 +1,5 @@
 import { IconButton } from '@gredice/ui/IconButton';
-import { MoreHorizontal, Search, Settings } from '@gredice/ui/icons';
+import { Add, MoreHorizontal, Search, Settings } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
@@ -111,6 +111,14 @@ export const Colors: Story = {
                 </IconButton>
             </Row>
         </Stack>
+    ),
+};
+
+export const LinkUsage: Story = {
+    render: () => (
+        <IconButton aria-label="Nova stavka" href="#" variant="solid">
+            <Add className="size-4" />
+        </IconButton>
     ),
 };
 

--- a/packages/ui/src/IconButton/IconButton.tsx
+++ b/packages/ui/src/IconButton/IconButton.tsx
@@ -1,24 +1,39 @@
 import type { ReactNode } from 'react';
-import { Button, type ButtonButtonProps } from '../Button';
+import {
+    Button,
+    type ButtonButtonProps,
+    type ButtonLinkProps,
+} from '../Button';
 import { cx } from '../utils';
 
-export type IconButtonProps = Omit<
+type IconButtonAccessibleLabel =
+    | {
+          'aria-label': string;
+      }
+    | {
+          title: string;
+      }
+    | {
+          'aria-labelledby': string;
+      };
+
+type IconButtonOwnProps = IconButtonAccessibleLabel & {
+    children: ReactNode;
+};
+
+export type IconButtonButtonProps = Omit<
     ButtonButtonProps,
     'endDecorator' | 'fullWidth' | 'startDecorator'
 > &
-    (
-        | {
-              'aria-label': string;
-          }
-        | {
-              title: string;
-          }
-        | {
-              'aria-labelledby': string;
-          }
-    ) & {
-        children: ReactNode;
-    };
+    IconButtonOwnProps;
+
+export type IconButtonLinkProps = Omit<
+    ButtonLinkProps,
+    'endDecorator' | 'fullWidth' | 'startDecorator'
+> &
+    IconButtonOwnProps;
+
+export type IconButtonProps = IconButtonButtonProps | IconButtonLinkProps;
 
 export function IconButton({
     children,

--- a/packages/ui/src/IconButton/index.ts
+++ b/packages/ui/src/IconButton/index.ts
@@ -1,1 +1,6 @@
-export { IconButton, type IconButtonProps } from './IconButton';
+export {
+    IconButton,
+    type IconButtonButtonProps,
+    type IconButtonLinkProps,
+    type IconButtonProps,
+} from './IconButton';


### PR DESCRIPTION
## Summary
- Convert the operations page-header create triggers to icon-only buttons with accessible labels and titles.
- Extend `IconButton` to support link-style buttons, then use it for standard admin header create actions.
- Add focused Playwright component coverage for the operations header triggers and document link usage in Storybook.

Closes #3938

## Validation
- `corepack pnpm exec biome check --write` on touched app, ui, and story files
- `corepack pnpm --filter @gredice/ui typecheck`
- `corepack pnpm --filter storybook typecheck`
- `corepack pnpm --filter app test:prepare`
- `corepack pnpm exec playwright test tests/operation-create-trigger.spec.tsx` from `apps/app`
- `corepack pnpm exec tsc --noEmit --pretty false` from `apps/app` still fails on existing unrelated repo errors; the touched-file `Link` miss found during validation was fixed before commit