### PR TITLE
feat(garden): recycle picked items through HUD

### DIFF
--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -208,6 +208,7 @@ type ItemsHudStoryOptions = {
     isSandbox?: boolean;
     localSandboxStorageKey?: string;
     pickupBlock?: boolean;
+    pickupHudDropTargetActive?: boolean;
     trashTargetActive?: boolean;
 };
 
@@ -252,6 +253,7 @@ function ItemsHudTestProviders({
     localSandboxStorageKey,
     closeup = false,
     pickupBlock = false,
+    pickupHudDropTargetActive = false,
     trashTargetActive = false,
 }: PropsWithChildren<ItemsHudStoryOptions>) {
     const queryClient = useMemo(
@@ -273,6 +275,7 @@ function ItemsHudTestProviders({
                     name: 'Block_Grass',
                     rotation: 0,
                 },
+                itemsHudDropTargetActive: pickupHudDropTargetActive,
                 sandboxBlockTrashDropTargetActive: trashTargetActive,
             });
         }
@@ -290,6 +293,7 @@ function ItemsHudTestProviders({
         closeup,
         localSandboxStorageKey,
         pickupBlock,
+        pickupHudDropTargetActive,
         trashTargetActive,
     ]);
 
@@ -454,6 +458,38 @@ export function SandboxBlockTrashDropTargetStory() {
                 >
                     <BottomControlsTestFrame />
                     <SandboxBlockTrashDropTarget />
+                    <ItemsHudTestFrame />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}
+
+export function ItemsHudDropTargetStory() {
+    return (
+        <ItemsHudTestProviders pickupBlock>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <BottomControlsTestFrame />
+                    <ItemsHudTestFrame />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}
+
+export function ActiveItemsHudDropTargetStory() {
+    return (
+        <ItemsHudTestProviders pickupBlock pickupHudDropTargetActive>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <BottomControlsTestFrame />
                     <ItemsHudTestFrame />
                 </div>
             </div>

--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -1,9 +1,11 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import {
+    ActiveItemsHudDropTargetStory,
     CloseupBottomHudStory,
     ItemsHudAlignmentStory,
     ItemsHudCameraTargetStory,
     ItemsHudControlsTooltipStory,
+    ItemsHudDropTargetStory,
     LocalSandboxItemsHudStory,
     LowSunflowerBalanceItemsHudStory,
     SandboxBlockTrashDropTargetStory,
@@ -186,6 +188,50 @@ test('sandbox trash target appears centered above item picker while dragging', a
         (pickerBox?.y ?? 0) - 8,
     );
     await expect(trashTarget).toHaveClass(/bg-red-600/u);
+});
+
+test('item picker does not show the recycle drop target while idle', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<ItemsHudAlignmentStory />);
+
+    await expect(
+        page.locator('[data-items-hud-drop-target="true"]'),
+    ).toHaveCount(0);
+});
+
+test('item picker reveals a recycle drop target during pickup', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<ItemsHudDropTargetStory />);
+
+    const picker = page.locator('[data-items-hud]');
+    await expect(picker).toHaveAttribute('data-items-hud-drop-target', 'true');
+    await expect(picker).toHaveAttribute(
+        'data-items-hud-drop-target-active',
+        'false',
+    );
+    await expect(page.getByText('Recikliranje')).toBeVisible();
+});
+
+test('item picker highlights while the picked block is over the drop target', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(TABLET_VIEWPORT);
+    await mount(<ActiveItemsHudDropTargetStory />);
+
+    const picker = page.locator('[data-items-hud]');
+    await expect(picker).toHaveAttribute('data-items-hud-drop-target', 'true');
+    await expect(picker).toHaveAttribute(
+        'data-items-hud-drop-target-active',
+        'true',
+    );
+    await expect(picker).toHaveClass(/border-red-500/u);
 });
 
 test('pots and mulch are listed under the decoration picker', async ({

--- a/packages/game/src/controls/PickableGroup.tsx
+++ b/packages/game/src/controls/PickableGroup.tsx
@@ -32,6 +32,7 @@ import {
     useCurrentGardenCache,
 } from '../hooks/useCurrentGarden';
 import { useGardenBoxStoreBlock } from '../hooks/useGardenBoxStoreBlock';
+import { isPointOverItemsHudDropTarget } from '../itemsHudDropTarget';
 import {
     resolveBlockParticleType,
     useParticles,
@@ -68,6 +69,10 @@ import {
     type PickupPlacementPreviewResolver,
     type ResolvedPlacementPreview,
 } from './PickupPlacementResolver';
+import {
+    getMovingSegmentBlockIds,
+    resolvePickupHudDropAction,
+} from './pickupRemovalDropAction';
 import {
     createPickupSelectionMoveRequests,
     createPickupSelectionMovingSegments,
@@ -271,6 +276,9 @@ export function PickableGroup({
     );
     const setSandboxBlockTrashDropTargetActive = useGameState(
         (state) => state.setSandboxBlockTrashDropTargetActive,
+    );
+    const setItemsHudDropTargetActive = useGameState(
+        (state) => state.setItemsHudDropTargetActive,
     );
     const localSandboxStorageKey = useGameState(
         (state) => state.localSandboxStorageKey,
@@ -707,6 +715,7 @@ export function PickableGroup({
         setPickupBlock(null);
         clearPickupSelectionTargets();
         setSandboxBlockTrashDropTargetActive(false);
+        setItemsHudDropTargetActive(false);
     }
 
     function isPointerOverSandboxTrash(clientX: number, clientY: number) {
@@ -769,6 +778,7 @@ export function PickableGroup({
         cleanupPointerSessionListeners();
         setPickupOutlineVisible(false);
         setSandboxBlockTrashDropTargetActive(false);
+        setItemsHudDropTargetActive(false);
         if (resetSpring) {
             dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
         }
@@ -921,27 +931,33 @@ export function PickableGroup({
 
     async function finishPickup(
         preview: ResolvedPlacementPreview | null,
-        deleteRequested: boolean,
+        {
+            hudDropRequested,
+            sandboxTrashDropRequested,
+        }: {
+            hudDropRequested: boolean;
+            sandboxTrashDropRequested: boolean;
+        },
     ) {
         const garden = getCurrentGarden();
         const attachedPlacement = getAttachedPlacement(garden);
         const raisedBed = findRaisedBedByBlockId(garden, block.id);
-        const blockIdsToDelete = deleteRequested
-            ? getMovingSegments(garden).flatMap((segment) =>
-                  segment.blocks.map((segmentBlock) => segmentBlock.id),
-              )
-            : [];
+        const movingSegments = getMovingSegments(garden);
+        const hudDropAction =
+            hudDropRequested && !sandboxTrashDropRequested
+                ? resolvePickupHudDropAction({
+                      forceDelete: Boolean(garden?.isSandbox),
+                      movingSegments,
+                  })
+                : null;
+        const blockIdsToDelete = sandboxTrashDropRequested
+            ? getMovingSegmentBlockIds(movingSegments)
+            : hudDropAction?.type === 'delete'
+              ? hudDropAction.blockIds
+              : [];
 
-        if (deleteRequested) {
+        if (blockIdsToDelete.length > 0) {
             resetPickupVisualState();
-            if (blockIdsToDelete.length === 0) {
-                dragSpringsApi.start({
-                    internalPosition: [0, 0, 0],
-                    scale: 1,
-                });
-                return;
-            }
-
             dragSpringsApi.start({
                 internalPosition: preview
                     ? [
@@ -964,6 +980,44 @@ export function PickableGroup({
                     scale: 1,
                 });
             }
+            return;
+        }
+
+        if (hudDropAction?.type === 'recycle') {
+            clearPickupInteractionState();
+            const activePreviewReset = createActivePreviewResetQueue();
+            dragSpringsApi.start({
+                internalPosition: preview
+                    ? [preview.relative.x, -1.5, preview.relative.z]
+                    : [0, -1.5, 0],
+                scale: 0.1,
+            });
+            triggerPlaceHaptic();
+            await recycleBlock
+                .mutateAsync({
+                    position: stack.position,
+                    blockIndex,
+                    raisedBedId: raisedBed?.id,
+                    attached: attachedPlacement
+                        ? {
+                              position: {
+                                  x: attachedPlacement.candidateStack.position
+                                      .x,
+                                  z: attachedPlacement.candidateStack.position
+                                      .z,
+                              },
+                              blockIndex: attachedPlacement.candidateBlockIndex,
+                          }
+                        : undefined,
+                    onOptimisticUpdate: activePreviewReset.queue,
+                })
+                .finally(activePreviewReset.resetIfUnqueued);
+            return;
+        }
+
+        if (hudDropRequested || sandboxTrashDropRequested) {
+            resetPickupVisualState();
+            dragSpringsApi.start({ internalPosition: [0, 0, 0], scale: 1 });
             return;
         }
 
@@ -1061,7 +1115,7 @@ export function PickableGroup({
         }
 
         const moveRequests = createPickupSelectionMoveRequests(
-            getMovingSegments(garden),
+            movingSegments,
             relative,
         );
         const [primaryMoveRequest, ...additionalBlockMoves] = moveRequests;
@@ -1134,6 +1188,9 @@ export function PickableGroup({
         setSandboxBlockTrashDropTargetActive(
             isPointerOverSandboxTrash(event.clientX, event.clientY),
         );
+        setItemsHudDropTargetActive(
+            isPointOverItemsHudDropTarget(event.clientX, event.clientY),
+        );
 
         refreshPlacementPreviewFromSession(session);
     }
@@ -1168,10 +1225,16 @@ export function PickableGroup({
                 session.lastClientY,
                 session.pickupAnchorOffset,
             ) ?? session.latestPreview;
-        void finishPickup(
-            preview,
-            isPointerOverSandboxTrash(session.lastClientX, session.lastClientY),
-        );
+        void finishPickup(preview, {
+            hudDropRequested: isPointOverItemsHudDropTarget(
+                session.lastClientX,
+                session.lastClientY,
+            ),
+            sandboxTrashDropRequested: isPointerOverSandboxTrash(
+                session.lastClientX,
+                session.lastClientY,
+            ),
+        });
     }
 
     function handleWindowPointerCancel(event: PointerEvent) {

--- a/packages/game/src/controls/pickupRemovalDropAction.ts
+++ b/packages/game/src/controls/pickupRemovalDropAction.ts
@@ -1,0 +1,44 @@
+import type { MovingSegment } from './PickupPlacementResolver';
+
+export type PickupRemovalDropAction =
+    | {
+          type: 'delete';
+          blockIds: string[];
+      }
+    | {
+          type: 'recycle';
+      };
+
+export function getMovingSegmentBlockIds(movingSegments: MovingSegment[]) {
+    const blockIds = new Set<string>();
+
+    for (const segment of movingSegments) {
+        for (const block of segment.blocks) {
+            blockIds.add(block.id);
+        }
+    }
+
+    return Array.from(blockIds);
+}
+
+export function resolvePickupHudDropAction({
+    forceDelete,
+    movingSegments,
+}: {
+    forceDelete: boolean;
+    movingSegments: MovingSegment[];
+}): PickupRemovalDropAction | null {
+    const blockIds = getMovingSegmentBlockIds(movingSegments);
+    if (blockIds.length === 0) {
+        return null;
+    }
+
+    if (!forceDelete && movingSegments[0]?.canRecycle) {
+        return { type: 'recycle' };
+    }
+
+    return {
+        type: 'delete',
+        blockIds,
+    };
+}

--- a/packages/game/src/controls/pickupRemovalDropAction.unit.ts
+++ b/packages/game/src/controls/pickupRemovalDropAction.unit.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import type { MovingSegment } from './PickupPlacementResolver';
+import {
+    getMovingSegmentBlockIds,
+    resolvePickupHudDropAction,
+} from './pickupRemovalDropAction';
+
+function createBlock(name: string, id = name): Block {
+    return {
+        id,
+        name,
+        rotation: 0,
+    };
+}
+
+function createSegment({
+    blocks,
+    canRecycle = false,
+}: {
+    blocks: Block[];
+    canRecycle?: boolean;
+}): MovingSegment {
+    const sourceStack: Stack = {
+        position: new Vector3(0, 0, 0),
+        blocks,
+    };
+
+    return {
+        sourceStack,
+        sourceStartIndex: 0,
+        blocks,
+        baseHeight: 0,
+        canRecycle,
+    };
+}
+
+describe('resolvePickupHudDropAction', () => {
+    it('recycles eligible primary selections outside forced delete targets', () => {
+        const action = resolvePickupHudDropAction({
+            forceDelete: false,
+            movingSegments: [
+                createSegment({
+                    blocks: [createBlock('Raised_Bed', 'raised-bed')],
+                    canRecycle: true,
+                }),
+            ],
+        });
+
+        assert.deepEqual(action, { type: 'recycle' });
+    });
+
+    it('deletes selected moving blocks when recycling is not eligible', () => {
+        const tree = createBlock('Tree', 'tree');
+        const bucket = createBlock('Bucket', 'bucket');
+
+        const action = resolvePickupHudDropAction({
+            forceDelete: false,
+            movingSegments: [
+                createSegment({ blocks: [tree] }),
+                createSegment({ blocks: [bucket] }),
+            ],
+        });
+
+        assert.deepEqual(action, {
+            type: 'delete',
+            blockIds: ['tree', 'bucket'],
+        });
+    });
+
+    it('keeps sandbox trash drops on the delete path even for recyclable blocks', () => {
+        const action = resolvePickupHudDropAction({
+            forceDelete: true,
+            movingSegments: [
+                createSegment({
+                    blocks: [createBlock('Raised_Bed', 'raised-bed')],
+                    canRecycle: true,
+                }),
+            ],
+        });
+
+        assert.deepEqual(action, {
+            type: 'delete',
+            blockIds: ['raised-bed'],
+        });
+    });
+
+    it('returns no action for canceled or empty pickup state', () => {
+        const action = resolvePickupHudDropAction({
+            forceDelete: false,
+            movingSegments: [],
+        });
+
+        assert.equal(action, null);
+    });
+});
+
+describe('getMovingSegmentBlockIds', () => {
+    it('dedupes block ids while preserving first-seen order', () => {
+        const tree = createBlock('Tree', 'tree');
+        const duplicateTree = createBlock('Tree', 'tree');
+        const bucket = createBlock('Bucket', 'bucket');
+
+        assert.deepEqual(
+            getMovingSegmentBlockIds([
+                createSegment({ blocks: [tree, bucket] }),
+                createSegment({ blocks: [duplicateTree] }),
+            ]),
+            ['tree', 'bucket'],
+        );
+    });
+});

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -4,7 +4,7 @@ import { BlockImage } from '@gredice/ui/BlockImage';
 import { Button } from '@gredice/ui/Button';
 import { Divider } from '@gredice/ui/Divider';
 import { IconButton } from '@gredice/ui/IconButton';
-import { Info, Left, Navigate, Up } from '@gredice/ui/icons';
+import { Delete, Info, Left, Navigate, Up } from '@gredice/ui/icons';
 import { Link } from '@gredice/ui/Link';
 import { Popper } from '@gredice/ui/Popper';
 import { Row } from '@gredice/ui/Row';
@@ -17,6 +17,10 @@ import { useBlockData } from '../hooks/useBlockData';
 import { useBlockPlace } from '../hooks/useBlockPlace';
 import { useCurrentAccount } from '../hooks/useCurrentAccount';
 import { useIsSandboxGarden } from '../hooks/useCurrentGarden';
+import {
+    itemsHudDropTargetActiveAttribute,
+    itemsHudDropTargetAttribute,
+} from '../itemsHudDropTarget';
 import { KnownPages } from '../knownPages';
 import { useGameState } from '../useGameState';
 import { HudCard } from './components/HudCard';
@@ -688,22 +692,59 @@ function PickerItem({ label, items, imageSrc }: HudItemPicker) {
 export function ItemsHud() {
     const { data: blockData } = useBlockData();
     const isSandbox = useIsSandboxGarden();
+    const pickupBlock = useGameState((state) => state.pickupBlock);
+    const dropTargetActive = useGameState(
+        (state) => state.itemsHudDropTargetActive,
+    );
     const hudItems = useMemo(
         () => getHudItems({ blockData, isSandbox }),
         [blockData, isSandbox],
     );
+    const dropTargetVisible = Boolean(pickupBlock);
+    const dropTargetLabel = isSandbox ? 'Obriši' : 'Recikliranje';
 
     return (
         <HudCard
             data-items-hud
+            {...(dropTargetVisible
+                ? {
+                      [itemsHudDropTargetAttribute]: 'true',
+                      [itemsHudDropTargetActiveAttribute]: dropTargetActive
+                          ? 'true'
+                          : 'false',
+                  }
+                : {})}
             open
             position="bottom"
-            className="pointer-events-auto static mx-auto mb-1 w-fit max-w-[calc(100vw-1rem)] overflow-x-auto rounded-xl border-0 bg-background/95 shadow-xl shadow-foreground/10 backdrop-blur-sm motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-300 motion-safe:ease-out md:px-1"
+            className={cx(
+                'pointer-events-auto static relative mx-auto mb-1 w-fit max-w-[calc(100vw-1rem)] overflow-x-auto rounded-xl border-0 bg-background/95 shadow-xl shadow-foreground/10 backdrop-blur-sm motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-300 motion-safe:ease-out md:px-1',
+                dropTargetVisible &&
+                    'border-2 border-dashed border-red-300 bg-red-50/95 shadow-red-950/15',
+                dropTargetActive &&
+                    'scale-[1.02] border-red-500 bg-red-100/95 shadow-red-950/25 ring-4 ring-red-500/20',
+            )}
             animateHeight
         >
+            {dropTargetVisible && (
+                <div
+                    aria-hidden="true"
+                    className={cx(
+                        'pointer-events-none absolute inset-0 z-10 grid place-items-center rounded-xl bg-red-600/10 px-3 text-red-700 transition duration-150 ease-out',
+                        dropTargetActive && 'bg-red-600/85 text-white',
+                    )}
+                >
+                    <div className="flex items-center gap-2 rounded-full bg-background/90 px-3 py-1.5 text-sm font-semibold text-red-700 shadow-sm">
+                        <Delete className="size-4" strokeWidth={2.4} />
+                        <span>{dropTargetLabel}</span>
+                    </div>
+                </div>
+            )}
             <Row
                 spacing={1}
-                className="min-w-max md:px-1"
+                className={cx(
+                    'min-w-max md:px-1',
+                    dropTargetVisible && 'opacity-35',
+                )}
                 justifyContent="center"
             >
                 {hudItems.map((item, index) => {

--- a/packages/game/src/itemsHudDropTarget.ts
+++ b/packages/game/src/itemsHudDropTarget.ts
@@ -1,0 +1,35 @@
+export const itemsHudDropTargetAttribute = 'data-items-hud-drop-target';
+export const itemsHudDropTargetActiveAttribute =
+    'data-items-hud-drop-target-active';
+export const itemsHudDropTargetSelector = `[${itemsHudDropTargetAttribute}="true"]`;
+
+export function isPointWithinClientRect(
+    rect: Pick<DOMRect, 'bottom' | 'left' | 'right' | 'top'>,
+    clientX: number,
+    clientY: number,
+) {
+    return (
+        clientX >= rect.left &&
+        clientX <= rect.right &&
+        clientY >= rect.top &&
+        clientY <= rect.bottom
+    );
+}
+
+export function isPointOverItemsHudDropTarget(
+    clientX: number,
+    clientY: number,
+) {
+    const target = document.querySelector<HTMLElement>(
+        itemsHudDropTargetSelector,
+    );
+    if (!target) {
+        return false;
+    }
+
+    return isPointWithinClientRect(
+        target.getBoundingClientRect(),
+        clientX,
+        clientY,
+    );
+}

--- a/packages/game/src/itemsHudDropTarget.unit.ts
+++ b/packages/game/src/itemsHudDropTarget.unit.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isPointWithinClientRect } from './itemsHudDropTarget';
+
+describe('isPointWithinClientRect', () => {
+    const rect = {
+        bottom: 80,
+        left: 10,
+        right: 110,
+        top: 20,
+    };
+
+    it('accepts mouse or touch client coordinates inside the rect', () => {
+        assert.equal(isPointWithinClientRect(rect, 10, 20), true);
+        assert.equal(isPointWithinClientRect(rect, 60, 50), true);
+        assert.equal(isPointWithinClientRect(rect, 110, 80), true);
+    });
+
+    it('rejects coordinates outside the rect', () => {
+        assert.equal(isPointWithinClientRect(rect, 9, 50), false);
+        assert.equal(isPointWithinClientRect(rect, 60, 19), false);
+        assert.equal(isPointWithinClientRect(rect, 111, 50), false);
+        assert.equal(isPointWithinClientRect(rect, 60, 81), false);
+    });
+});

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -280,6 +280,8 @@ export type GameState = {
     ) => void;
     sandboxBlockTrashDropTargetActive: boolean;
     setSandboxBlockTrashDropTargetActive: (active: boolean) => void;
+    itemsHudDropTargetActive: boolean;
+    setItemsHudDropTargetActive: (active: boolean) => void;
     activeDragPreview: ActiveDragPreview | null;
     setActiveDragPreview: (dragPreview: ActiveDragPreview | null) => void;
     openGardenBoxBlockId: string | null;
@@ -538,6 +540,13 @@ export function createGameState({
                 sandboxBlockTrashDropTargetActive
                     ? state
                     : { sandboxBlockTrashDropTargetActive },
+            ),
+        itemsHudDropTargetActive: false,
+        setItemsHudDropTargetActive: (itemsHudDropTargetActive) =>
+            set((state) =>
+                state.itemsHudDropTargetActive === itemsHudDropTargetActive
+                    ? state
+                    : { itemsHudDropTargetActive },
             ),
         activeDragPreview: null,
         setActiveDragPreview: (activeDragPreview) =>


### PR DESCRIPTION
## Summary

- Makes the items HUD become a visible recycle/delete drop target while pickup is active.
- Routes HUD drops through the existing delete or recycle mutations so optimistic garden state, refunds, attached raised-bed handling, and API guards stay on the existing paths.
- Adds focused unit coverage for HUD drop hit-testing/action selection and component coverage for idle, visible, and active HUD target states.

Closes #3930

## Validation

- `corepack pnpm --filter @gredice/game exec tsx --test src/controls/pickupRemovalDropAction.unit.ts src/itemsHudDropTarget.unit.ts`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/items-hud.spec.tsx`
- `git diff --check`