### PR TITLE
fix(www): submit feedback rating immediately

### DIFF
--- a/apps/api/app/api/[...route]/feedbackRoutes.ts
+++ b/apps/api/app/api/[...route]/feedbackRoutes.ts
@@ -76,13 +76,24 @@ const app = new Hono<{ Variables: AuthVariables }>()
         async (context) => {
             const { feedbackId } = context.req.valid('param');
             const feedback = context.req.valid('json');
-            const id = await updateFeedback(feedbackId, feedback);
+            const updatedFeedback = await updateFeedback(feedbackId, feedback);
 
-            if (!id) {
+            if (!updatedFeedback) {
                 return context.json({ error: 'Feedback not found' }, 404);
             }
 
-            return context.json({ id });
+            if (Object.hasOwn(feedback, 'score')) {
+                (await getPostHogClient()).capture({
+                    distinctId: 'anonymous',
+                    event: 'feedback_updated',
+                    properties: {
+                        topic: updatedFeedback.topic,
+                        score: updatedFeedback.score ?? undefined,
+                    },
+                });
+            }
+
+            return context.json({ id: updatedFeedback.id });
         },
     );
 

--- a/apps/api/app/api/[...route]/feedbackRoutes.ts
+++ b/apps/api/app/api/[...route]/feedbackRoutes.ts
@@ -1,4 +1,4 @@
-import { createFeedback, getFeedbacks } from '@gredice/storage';
+import { createFeedback, getFeedbacks, updateFeedback } from '@gredice/storage';
 import { Hono } from 'hono';
 import { describeRoute, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
@@ -7,6 +7,19 @@ import {
     authValidator,
 } from '../../../lib/hono/authValidator';
 import { getPostHogClient } from '../../../lib/posthog-server';
+
+const feedbackUpdateSchema = z
+    .object({
+        score: z.string().nullable().optional(),
+        comment: z.string().nullable().optional(),
+    })
+    .strict()
+    .refine(
+        (feedback) =>
+            Object.hasOwn(feedback, 'score') ||
+            Object.hasOwn(feedback, 'comment'),
+        { message: 'At least one feedback field is required' },
+    );
 
 const app = new Hono<{ Variables: AuthVariables }>()
     .get(
@@ -29,7 +42,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
             'json',
             z.object({
                 topic: z.string().nonempty(),
-                data: z.any().nullable().optional(),
+                data: z.unknown().nullable().optional(),
                 score: z.string().nullable().optional(),
                 comment: z.string().nullable().optional(),
             }),
@@ -45,6 +58,30 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     score: feedback.score ?? undefined,
                 },
             });
+            return context.json({ id });
+        },
+    )
+    .patch(
+        '/:feedbackId',
+        describeRoute({
+            description: 'Update an existing feedback rating or comment',
+        }),
+        zValidator(
+            'param',
+            z.object({
+                feedbackId: z.string().uuid(),
+            }),
+        ),
+        zValidator('json', feedbackUpdateSchema),
+        async (context) => {
+            const { feedbackId } = context.req.valid('param');
+            const feedback = context.req.valid('json');
+            const id = await updateFeedback(feedbackId, feedback);
+
+            if (!id) {
+                return context.json({ error: 'Feedback not found' }, 404);
+            }
+
             return context.json({ id });
         },
     );

--- a/apps/www/components/shared/feedback/FeedbackModal.tsx
+++ b/apps/www/components/shared/feedback/FeedbackModal.tsx
@@ -10,12 +10,29 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useCurrentUser } from '../../../hooks/useCurrentUser';
 import {
     FeedbackTrigger,
     type FeedbackTriggerProps,
 } from './FeedbackTriggerLike';
+
+type FeedbackScore = 'like' | 'dislike' | 'neutral';
+
+type FeedbackUpdate = {
+    score: FeedbackScore;
+    comment?: string;
+};
+
+function feedbackScoreValue(score: FeedbackScore) {
+    if (score === 'like') {
+        return '1';
+    }
+    if (score === 'dislike') {
+        return '-1';
+    }
+    return '0';
+}
 
 export type FeedbackModalProps = {
     title?: string;
@@ -33,47 +50,169 @@ export function FeedbackModal({
     ...rest
 }: FeedbackModalProps) {
     const [open, setOpen] = useState(false);
-    const [score, setScore] = useState<'like' | 'dislike' | 'neutral' | null>(
-        null,
-    );
+    const [score, setScore] = useState<FeedbackScore | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState(false);
     const { data: user } = useCurrentUser();
+    const feedbackIdRef = useRef<string | null>(null);
+    const requestQueueRef = useRef(Promise.resolve());
+    const requestVersionRef = useRef(0);
+    const interactionKeyRef = useRef(0);
+    const dataRef = useRef(data);
+    const userRef = useRef(user);
 
-    async function handleFeedback(formData: FormData) {
-        const comment = formData.get('comment') as string;
-        await clientPublic().api.feedback.$post({
+    useEffect(() => {
+        dataRef.current = data;
+    }, [data]);
+
+    useEffect(() => {
+        userRef.current = user;
+    }, [user]);
+
+    function feedbackData() {
+        const currentData = dataRef.current;
+        const currentUser = userRef.current;
+
+        if (!currentUser) {
+            return currentData;
+        }
+
+        return {
+            ...(currentData ?? {}),
+            userId: currentUser.id,
+        };
+    }
+
+    function resetFeedbackInteraction() {
+        interactionKeyRef.current += 1;
+        feedbackIdRef.current = null;
+        requestQueueRef.current = Promise.resolve();
+        setIsSubmitting(false);
+        setSubmitError(false);
+        setScore(null);
+    }
+
+    async function persistFeedback(
+        update: FeedbackUpdate,
+        interactionKey: number,
+    ) {
+        if (interactionKey !== interactionKeyRef.current) {
+            return true;
+        }
+
+        const scoreValue = feedbackScoreValue(update.score);
+        const feedbackId = feedbackIdRef.current;
+
+        if (feedbackId) {
+            const response = await clientPublic().api.feedback[
+                ':feedbackId'
+            ].$patch({
+                param: { feedbackId },
+                json: {
+                    score: scoreValue,
+                    comment: update.comment,
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(`Feedback update failed: ${response.status}`);
+            }
+
+            return true;
+        }
+
+        const response = await clientPublic().api.feedback.$post({
             json: {
                 topic,
-                data: user
-                    ? {
-                          ...(data ?? {}),
-                          userId: user.id,
-                      }
-                    : data,
-                score: (score === 'like'
-                    ? 1
-                    : score === 'dislike'
-                      ? -1
-                      : 0
-                ).toString(),
-                comment,
+                data: feedbackData(),
+                score: scoreValue,
+                comment: update.comment,
             },
         });
 
+        if (!response.ok) {
+            throw new Error(`Feedback create failed: ${response.status}`);
+        }
+
+        const body = await response.json();
+        if (interactionKey === interactionKeyRef.current) {
+            feedbackIdRef.current = body.id;
+        }
+
+        return true;
+    }
+
+    function queueFeedback(update: FeedbackUpdate) {
+        const interactionKey = interactionKeyRef.current;
+        const requestVersion = requestVersionRef.current + 1;
+        requestVersionRef.current = requestVersion;
+        setIsSubmitting(true);
+        setSubmitError(false);
+
+        const request = requestQueueRef.current
+            .catch(() => undefined)
+            .then(async () => {
+                try {
+                    return await persistFeedback(update, interactionKey);
+                } catch (error) {
+                    console.error(error);
+                    if (interactionKey === interactionKeyRef.current) {
+                        setSubmitError(true);
+                    }
+                    return false;
+                }
+            });
+
+        requestQueueRef.current = request.then(() => undefined);
+        void request.finally(() => {
+            if (requestVersionRef.current === requestVersion) {
+                setIsSubmitting(false);
+            }
+        });
+
+        return request;
+    }
+
+    async function handleFeedback(formData: FormData) {
+        const commentValue = formData.get('comment');
+        const comment = typeof commentValue === 'string' ? commentValue : '';
+        const submitted = await queueFeedback({
+            score: score ?? 'neutral',
+            comment,
+        });
+
+        if (!submitted) {
+            return;
+        }
+
         // TODO: Show notification feedback was submitted
 
-        setScore(null);
-        setOpen?.(false);
+        resetFeedbackInteraction();
+        setOpen(false);
     }
 
     function handleDisplay(feedback: 'like' | 'dislike') {
         setScore(feedback);
+        void queueFeedback({ score: feedback });
+    }
+
+    function handleModalScoreChange(feedback: FeedbackScore) {
+        setScore(feedback);
+        void queueFeedback({ score: feedback });
+    }
+
+    function handleOpenChange(nextOpen: boolean) {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+            resetFeedbackInteraction();
+        }
     }
 
     return (
         <Popper
             open={open}
             title={title ?? 'Tvoje mišljenje'}
-            onOpenChange={setOpen}
+            onOpenChange={handleOpenChange}
             trigger={<FeedbackTrigger onFeedback={handleDisplay} {...rest} />}
         >
             <form action={handleFeedback}>
@@ -90,7 +229,7 @@ export function FeedbackModal({
                                     'bg-red-200 text-red-800',
                             )}
                             title="Ne sviđa mi se"
-                            onClick={() => setScore('dislike')}
+                            onClick={() => handleModalScoreChange('dislike')}
                         >
                             <SmileSad />
                         </IconButton>
@@ -102,7 +241,7 @@ export function FeedbackModal({
                                     'bg-neutral-200 text-neutral-800',
                             )}
                             title="Ne znam"
-                            onClick={() => setScore('neutral')}
+                            onClick={() => handleModalScoreChange('neutral')}
                         >
                             <SmileMeh />
                         </IconButton>
@@ -114,7 +253,7 @@ export function FeedbackModal({
                                     'bg-green-200 text-green-800',
                             )}
                             title="Sviđa mi se"
-                            onClick={() => setScore('like')}
+                            onClick={() => handleModalScoreChange('like')}
                         >
                             <SmileHappy />
                         </IconButton>
@@ -124,9 +263,15 @@ export function FeedbackModal({
                         placeholder="Komentar"
                         autoFocus={score !== 'neutral'}
                     />
+                    {submitError ? (
+                        <Typography level="body2" className="text-red-700">
+                            Nismo uspjeli spremiti mišljenje. Pokušaj ponovno.
+                        </Typography>
+                    ) : null}
                     <Button
                         variant="outlined"
                         type="submit"
+                        disabled={isSubmitting}
                         endDecorator={<Send className="size-4" />}
                     >
                         Pošalji

--- a/apps/www/tests/FeedbackModalHarness.tsx
+++ b/apps/www/tests/FeedbackModalHarness.tsx
@@ -1,0 +1,36 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from 'next-themes';
+import {
+    FeedbackModal,
+    type FeedbackModalProps,
+} from '../components/shared/feedback/FeedbackModal';
+import { type CurrentUser, currentUserQueryKey } from '../hooks/useCurrentUser';
+
+type FeedbackModalHarnessProps = FeedbackModalProps & {
+    currentUser?: CurrentUser | null;
+};
+
+export function FeedbackModalHarness({
+    currentUser,
+    ...props
+}: FeedbackModalHarnessProps) {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+
+    if (currentUser !== undefined) {
+        queryClient.setQueryData(currentUserQueryKey, currentUser);
+    }
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <ThemeProvider attribute="class">
+                <FeedbackModal {...props} />
+            </ThemeProvider>
+        </QueryClientProvider>
+    );
+}

--- a/apps/www/tests/feedback-modal.spec.tsx
+++ b/apps/www/tests/feedback-modal.spec.tsx
@@ -1,0 +1,216 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { FeedbackModalHarness } from './FeedbackModalHarness';
+import '../app/globals.css';
+
+type FeedbackRequest = {
+    method: string;
+    pathname: string;
+    body: unknown;
+};
+
+const currentUser = {
+    id: 'user-1',
+    userName: 'ana',
+    displayName: 'Ana',
+};
+
+test('submits the selected thumbs rating immediately', async ({
+    mount,
+    page,
+}) => {
+    const requests: FeedbackRequest[] = [];
+
+    await page.route('**/api/gredice/api/feedback**', async (route) => {
+        const request = route.request();
+        requests.push({
+            method: request.method(),
+            pathname: new URL(request.url()).pathname,
+            body: request.postDataJSON(),
+        });
+
+        await route.fulfill({
+            status: 200,
+            json: { id: '11111111-1111-4111-8111-111111111111' },
+        });
+    });
+
+    await mount(
+        <FeedbackModalHarness
+            topic="www/test-feedback"
+            data={{ page: 'plant' }}
+            currentUser={currentUser}
+        />,
+    );
+
+    await page.getByTitle('Sviđa mi se', { exact: true }).click();
+
+    await expect.poll(() => requests.length).toBe(1);
+    expect(requests[0]).toMatchObject({
+        method: 'POST',
+        pathname: '/api/gredice/api/feedback',
+        body: {
+            topic: 'www/test-feedback',
+            data: {
+                page: 'plant',
+                userId: 'user-1',
+            },
+            score: '1',
+        },
+    });
+});
+
+test('updates the created feedback with a comment instead of creating another row', async ({
+    mount,
+    page,
+}) => {
+    const requests: FeedbackRequest[] = [];
+
+    await page.route('**/api/gredice/api/feedback**', async (route) => {
+        const request = route.request();
+        requests.push({
+            method: request.method(),
+            pathname: new URL(request.url()).pathname,
+            body: request.postDataJSON(),
+        });
+
+        await route.fulfill({
+            status: 200,
+            json: { id: '22222222-2222-4222-8222-222222222222' },
+        });
+    });
+
+    await mount(
+        <FeedbackModalHarness
+            topic="www/test-feedback"
+            data={{ page: 'plant' }}
+            currentUser={currentUser}
+        />,
+    );
+
+    await page.getByTitle('Ne sviđa mi se').first().click();
+    const form = page.locator('form').filter({
+        hasText: 'Kako ti se sviđa ovaj sadržaj?',
+    });
+    await form.getByPlaceholder('Komentar').fill('Nedostaje detalja.');
+    await form.getByRole('button', { name: 'Pošalji' }).click();
+
+    await expect.poll(() => requests.length).toBe(2);
+    expect(requests.map((request) => request.method)).toEqual([
+        'POST',
+        'PATCH',
+    ]);
+    expect(requests[1]).toMatchObject({
+        pathname:
+            '/api/gredice/api/feedback/22222222-2222-4222-8222-222222222222',
+        body: {
+            score: '-1',
+            comment: 'Nedostaje detalja.',
+        },
+    });
+});
+
+test('updates the same feedback when the rating changes in the modal', async ({
+    mount,
+    page,
+}) => {
+    const requests: FeedbackRequest[] = [];
+
+    await page.route('**/api/gredice/api/feedback**', async (route) => {
+        const request = route.request();
+        requests.push({
+            method: request.method(),
+            pathname: new URL(request.url()).pathname,
+            body: request.postDataJSON(),
+        });
+
+        await route.fulfill({
+            status: 200,
+            json: { id: '33333333-3333-4333-8333-333333333333' },
+        });
+    });
+
+    await mount(
+        <FeedbackModalHarness
+            topic="www/test-feedback"
+            data={{ page: 'plant' }}
+            currentUser={currentUser}
+        />,
+    );
+
+    await page.getByTitle('Sviđa mi se', { exact: true }).click();
+    const form = page.locator('form').filter({
+        hasText: 'Kako ti se sviđa ovaj sadržaj?',
+    });
+    await form.getByTitle('Ne sviđa mi se').click();
+
+    await expect.poll(() => requests.length).toBe(2);
+    expect(requests.map((request) => request.method)).toEqual([
+        'POST',
+        'PATCH',
+    ]);
+    expect(requests[1]).toMatchObject({
+        pathname:
+            '/api/gredice/api/feedback/33333333-3333-4333-8333-333333333333',
+        body: {
+            score: '-1',
+        },
+    });
+});
+
+test('keeps the interaction recoverable when the immediate submit fails', async ({
+    mount,
+    page,
+}) => {
+    const requests: FeedbackRequest[] = [];
+
+    await page.route('**/api/gredice/api/feedback**', async (route) => {
+        const request = route.request();
+        requests.push({
+            method: request.method(),
+            pathname: new URL(request.url()).pathname,
+            body: request.postDataJSON(),
+        });
+
+        if (requests.length === 1) {
+            await route.fulfill({
+                status: 500,
+                json: { error: 'Feedback failed' },
+            });
+            return;
+        }
+
+        await route.fulfill({
+            status: 200,
+            json: { id: '44444444-4444-4444-8444-444444444444' },
+        });
+    });
+
+    await mount(
+        <FeedbackModalHarness
+            topic="www/test-feedback"
+            data={{ page: 'plant' }}
+            currentUser={currentUser}
+        />,
+    );
+
+    await page.getByTitle('Sviđa mi se', { exact: true }).click();
+    await expect(
+        page.getByText('Nismo uspjeli spremiti mišljenje. Pokušaj ponovno.'),
+    ).toBeVisible();
+
+    const form = page.locator('form').filter({
+        hasText: 'Kako ti se sviđa ovaj sadržaj?',
+    });
+    await form.getByPlaceholder('Komentar').fill('Može jasnije.');
+    await form.getByRole('button', { name: 'Pošalji' }).click();
+
+    await expect.poll(() => requests.length).toBe(2);
+    expect(requests.map((request) => request.method)).toEqual(['POST', 'POST']);
+    expect(requests[1]).toMatchObject({
+        pathname: '/api/gredice/api/feedback',
+        body: {
+            score: '1',
+            comment: 'Može jasnije.',
+        },
+    });
+});

--- a/packages/storage/src/repositories/feedbacksRepo.ts
+++ b/packages/storage/src/repositories/feedbacksRepo.ts
@@ -30,7 +30,11 @@ export async function updateFeedback(id: string, feedback: UpdateFeedback) {
         .update(feedbacks)
         .set(feedback)
         .where(eq(feedbacks.id, id))
-        .returning({ id: feedbacks.id });
+        .returning({
+            id: feedbacks.id,
+            score: feedbacks.score,
+            topic: feedbacks.topic,
+        });
 
-    return updated[0]?.id ?? null;
+    return updated[0] ?? null;
 }

--- a/packages/storage/src/repositories/feedbacksRepo.ts
+++ b/packages/storage/src/repositories/feedbacksRepo.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from 'node:crypto';
-import { desc } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import { feedbacks, type InsertFeedback } from '../schema';
 import { storage } from '../storage';
+
+export type UpdateFeedback = Partial<Pick<InsertFeedback, 'comment' | 'score'>>;
 
 export async function getFeedbacks(offset: number = 0, limit: number = 1000) {
     return storage().query.feedbacks.findMany({
@@ -21,4 +23,14 @@ export async function createFeedback(feedback: InsertFeedback) {
             })
             .returning({ id: feedbacks.id })
     )[0].id;
+}
+
+export async function updateFeedback(id: string, feedback: UpdateFeedback) {
+    const updated = await storage()
+        .update(feedbacks)
+        .set(feedback)
+        .where(eq(feedbacks.id, id))
+        .returning({ id: feedbacks.id });
+
+    return updated[0]?.id ?? null;
 }

--- a/packages/storage/tests/feedbacksRepo.node.spec.ts
+++ b/packages/storage/tests/feedbacksRepo.node.spec.ts
@@ -20,12 +20,16 @@ test('updateFeedback changes rating and comment without creating another row', a
         comment: null,
     });
 
-    const updatedId = await updateFeedback(id, {
+    const updatedFeedback = await updateFeedback(id, {
         score: '-1',
         comment: 'Nedostaje detalja.',
     });
 
-    assert.equal(updatedId, id);
+    assert.deepEqual(updatedFeedback, {
+        id,
+        topic,
+        score: '-1',
+    });
 
     const rows = await storage()
         .select({
@@ -50,11 +54,11 @@ test('updateFeedback changes rating and comment without creating another row', a
 test('updateFeedback returns null for an unknown feedback id', async () => {
     createTestDb();
 
-    const updatedId = await updateFeedback(randomUUID(), {
+    const updatedFeedback = await updateFeedback(randomUUID(), {
         score: '0',
     });
 
-    assert.equal(updatedId, null);
+    assert.equal(updatedFeedback, null);
 });
 
 test('updateFeedback preserves omitted fields', async () => {
@@ -67,11 +71,15 @@ test('updateFeedback preserves omitted fields', async () => {
         comment: 'Jasno.',
     });
 
-    const updatedId = await updateFeedback(id, {
+    const updatedFeedback = await updateFeedback(id, {
         score: '-1',
     });
 
-    assert.equal(updatedId, id);
+    assert.deepEqual(updatedFeedback, {
+        id,
+        topic,
+        score: '-1',
+    });
 
     const rows = await storage()
         .select({

--- a/packages/storage/tests/feedbacksRepo.node.spec.ts
+++ b/packages/storage/tests/feedbacksRepo.node.spec.ts
@@ -56,3 +56,35 @@ test('updateFeedback returns null for an unknown feedback id', async () => {
 
     assert.equal(updatedId, null);
 });
+
+test('updateFeedback preserves omitted fields', async () => {
+    createTestDb();
+    const topic = `www/test-feedback/${randomUUID()}`;
+    const id = await createFeedback({
+        topic,
+        data: { page: 'pricing' },
+        score: '1',
+        comment: 'Jasno.',
+    });
+
+    const updatedId = await updateFeedback(id, {
+        score: '-1',
+    });
+
+    assert.equal(updatedId, id);
+
+    const rows = await storage()
+        .select({
+            score: feedbacks.score,
+            comment: feedbacks.comment,
+        })
+        .from(feedbacks)
+        .where(eq(feedbacks.id, id));
+
+    assert.deepEqual(rows, [
+        {
+            score: '-1',
+            comment: 'Jasno.',
+        },
+    ]);
+});

--- a/packages/storage/tests/feedbacksRepo.node.spec.ts
+++ b/packages/storage/tests/feedbacksRepo.node.spec.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    createFeedback,
+    feedbacks,
+    storage,
+    updateFeedback,
+} from '@gredice/storage';
+import { eq } from 'drizzle-orm';
+import { createTestDb } from './testDb';
+
+test('updateFeedback changes rating and comment without creating another row', async () => {
+    createTestDb();
+    const topic = `www/test-feedback/${randomUUID()}`;
+    const id = await createFeedback({
+        topic,
+        data: { page: 'plant', userId: 'user-1' },
+        score: '1',
+        comment: null,
+    });
+
+    const updatedId = await updateFeedback(id, {
+        score: '-1',
+        comment: 'Nedostaje detalja.',
+    });
+
+    assert.equal(updatedId, id);
+
+    const rows = await storage()
+        .select({
+            id: feedbacks.id,
+            topic: feedbacks.topic,
+            score: feedbacks.score,
+            comment: feedbacks.comment,
+        })
+        .from(feedbacks)
+        .where(eq(feedbacks.topic, topic));
+
+    assert.deepEqual(rows, [
+        {
+            id,
+            topic,
+            score: '-1',
+            comment: 'Nedostaje detalja.',
+        },
+    ]);
+});
+
+test('updateFeedback returns null for an unknown feedback id', async () => {
+    createTestDb();
+
+    const updatedId = await updateFeedback(randomUUID(), {
+        score: '0',
+    });
+
+    assert.equal(updatedId, null);
+});


### PR DESCRIPTION
## Summary
- submit thumbs up/down feedback as soon as the trigger is clicked
- keep the created feedback id and PATCH the same record for modal comments or rating changes
- add storage/API update support plus focused component and storage tests

## Validation
- pnpm --filter www lint
- pnpm --filter api lint
- pnpm --filter @gredice/storage lint
- pnpm --filter www typecheck
- pnpm --filter @gredice/storage run test:node feedbacksRepo.node.spec.ts
- pnpm --filter www test:prepare
- GREDICE_PLAYWRIGHT_REUSE_SERVER=true pnpm --filter www exec playwright test tests/feedback-modal.spec.tsx --project=chromium
- pnpm --filter api build
- git diff --check

## Notes
- Raw full-package storage `tsc --noEmit` still hits existing unrelated script/spec type errors.
- Raw API `tsc --noEmit` still hits an existing unrelated notification spec type issue; `api build` passes.

Closes #3946