### PR TITLE
feat(www): use shared social login modal pattern

### DIFF
--- a/apps/api/app/api/[...route]/authRoutes.ts
+++ b/apps/api/app/api/[...route]/authRoutes.ts
@@ -211,6 +211,7 @@ const allowedLocalRedirectHosts = new Set([
     'app.gredice.test',
     'vrt.gredice.test',
     'farma.gredice.test',
+    'www.gredice.test',
 ]);
 
 function sanitizeRedirectUrl(redirectUrl?: string) {

--- a/apps/www/app/[...slug]/cmsPageRouteUtils.ts
+++ b/apps/www/app/[...slug]/cmsPageRouteUtils.ts
@@ -74,6 +74,7 @@ const reservedFirstSegments = new Set([
     'podignuta-gredica',
     'pozdrav',
     'preporuke',
+    'prijava',
     'pretraga',
     'racun',
     'radnje',

--- a/apps/www/app/api/oauth-callback/route.ts
+++ b/apps/www/app/api/oauth-callback/route.ts
@@ -1,0 +1,102 @@
+import { cookies, headers } from 'next/headers';
+import { authCookieSettings } from '../../../lib/authCookieSecurity';
+
+const accessTokenExpiryMs = 15 * 60 * 1000;
+const refreshTokenExpiryMs = 30 * 24 * 60 * 60 * 1000;
+
+export async function POST(request: Request) {
+    const headersList = await headers();
+    const origin = headersList.get('origin');
+    const secFetchSite = headersList.get('sec-fetch-site');
+    const requestUrl = new URL(request.url);
+
+    if (
+        secFetchSite &&
+        secFetchSite !== 'same-origin' &&
+        secFetchSite !== 'same-site'
+    ) {
+        console.error(
+            'CSRF check failed: invalid Sec-Fetch-Site header',
+            secFetchSite,
+        );
+        return new Response('Forbidden', { status: 403 });
+    }
+
+    if (origin) {
+        if (origin === 'null') {
+            console.error(
+                'CSRF check failed: null Origin header is not allowed',
+            );
+            return new Response('Forbidden', { status: 403 });
+        }
+
+        let originUrl: URL;
+        try {
+            originUrl = new URL(origin);
+        } catch (error) {
+            console.error(
+                'CSRF check failed: invalid Origin header',
+                origin,
+                error,
+            );
+            return new Response('Forbidden', { status: 403 });
+        }
+
+        const isSameOrigin =
+            originUrl.origin === requestUrl.origin ||
+            (isLocalhost(originUrl.hostname) &&
+                isLocalhost(requestUrl.hostname) &&
+                originUrl.port === requestUrl.port &&
+                originUrl.protocol === requestUrl.protocol);
+
+        if (!isSameOrigin) {
+            console.error(
+                'CSRF check failed: origin mismatch',
+                origin,
+                requestUrl.origin,
+            );
+            return new Response('Forbidden', { status: 403 });
+        }
+    }
+
+    const body: unknown = await request.json();
+    if (
+        !body ||
+        typeof body !== 'object' ||
+        !('token' in body) ||
+        typeof body.token !== 'string'
+    ) {
+        return new Response('Token is required', { status: 400 });
+    }
+
+    const cookieStore = await cookies();
+    const cookieSettings = await authCookieSettings();
+
+    cookieStore.set('gredice_session', body.token, {
+        domain: cookieSettings.domain,
+        expires: new Date(Date.now() + accessTokenExpiryMs),
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: cookieSettings.secure,
+    });
+
+    if ('refreshToken' in body && typeof body.refreshToken === 'string') {
+        cookieStore.set('gredice_refresh', body.refreshToken, {
+            domain: cookieSettings.domain,
+            expires: new Date(Date.now() + refreshTokenExpiryMs),
+            httpOnly: true,
+            sameSite: 'lax',
+            secure: cookieSettings.secure,
+        });
+    }
+
+    return Response.json({ success: true });
+}
+
+function isLocalhost(hostname: string): boolean {
+    return (
+        hostname === 'localhost' ||
+        hostname === '127.0.0.1' ||
+        hostname === '[::1]'
+    );
+}

--- a/apps/www/app/prijava/UrlAuthForward.tsx
+++ b/apps/www/app/prijava/UrlAuthForward.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+import { currentUserQueryKey } from '../../hooks/useCurrentUser';
+
+function safeReturnPath(value: string | null) {
+    if (!value?.startsWith('/') || value.startsWith('//')) {
+        return '/';
+    }
+
+    return value;
+}
+
+export function UrlAuthForward() {
+    const queryClient = useQueryClient();
+    const searchParams = useSearchParams();
+
+    useEffect(() => {
+        const forwardAuthSession = async () => {
+            const returnTo = safeReturnPath(searchParams.get('returnTo'));
+            const error = searchParams.get('error');
+            if (error) {
+                console.error('Authentication error:', error);
+                window.location.replace(returnTo);
+                return;
+            }
+
+            const hash = window.location.hash.substring(1);
+            const params = new URLSearchParams(hash);
+            const token = params.get('token');
+            const refreshToken = params.get('refreshToken');
+
+            if (hash) {
+                window.history.replaceState(
+                    null,
+                    '',
+                    window.location.pathname + window.location.search,
+                );
+            }
+
+            if (token) {
+                try {
+                    const response = await fetch('/api/oauth-callback', {
+                        body: JSON.stringify({ token, refreshToken }),
+                        headers: { 'Content-Type': 'application/json' },
+                        method: 'POST',
+                    });
+
+                    if (!response.ok) {
+                        console.error(
+                            'OAuth callback failed:',
+                            response.status,
+                            response.statusText,
+                        );
+                        window.location.replace(returnTo);
+                        return;
+                    }
+                } catch (fetchError) {
+                    console.error('OAuth callback request error:', fetchError);
+                    window.location.replace(returnTo);
+                    return;
+                }
+            }
+
+            await queryClient.invalidateQueries({
+                queryKey: currentUserQueryKey,
+            });
+            window.location.replace(returnTo);
+        };
+
+        void forwardAuthSession();
+    }, [queryClient, searchParams]);
+
+    return null;
+}

--- a/apps/www/app/prijava/facebook-prijava/povratak/page.tsx
+++ b/apps/www/app/prijava/facebook-prijava/povratak/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import { OAuthCallbackStatus } from '../../../../components/auth/OAuthCallbackStatus';
+
+export const metadata: Metadata = {
+    title: 'Facebook prijava',
+};
+
+export default function FacebookCallbackPage() {
+    return <OAuthCallbackStatus provider="Facebook" />;
+}

--- a/apps/www/app/prijava/google-prijava/povratak/page.tsx
+++ b/apps/www/app/prijava/google-prijava/povratak/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import { OAuthCallbackStatus } from '../../../../components/auth/OAuthCallbackStatus';
+
+export const metadata: Metadata = {
+    title: 'Google prijava',
+};
+
+export default function GoogleCallbackPage() {
+    return <OAuthCallbackStatus provider="Google" />;
+}

--- a/apps/www/components/auth/InlineLoginDialog.tsx
+++ b/apps/www/components/auth/InlineLoginDialog.tsx
@@ -1,7 +1,12 @@
 'use client';
 
-import { clientPublic } from '@gredice/client';
+import { clientPublic, getBrowserGrediceAppOrigin } from '@gredice/client';
 import { Alert } from '@gredice/ui/Alert';
+import {
+    FacebookLoginButton,
+    GoogleLoginButton,
+    useLastLoginProvider,
+} from '@gredice/ui/auth';
 import { Button } from '@gredice/ui/Button';
 import { Input } from '@gredice/ui/Input';
 import { Mail } from '@gredice/ui/icons';
@@ -10,16 +15,22 @@ import { Stack } from '@gredice/ui/Stack';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Typography } from '@gredice/ui/Typography';
 import { useQueryClient } from '@tanstack/react-query';
-import { type FormEvent, useEffect, useState } from 'react';
+import { type FormEvent, useCallback, useEffect, useState } from 'react';
 import { currentUserQueryKey } from '../../hooks/useCurrentUser';
 
 type AuthTab = 'login' | 'register';
+type OAuthProvider = 'google' | 'facebook';
 
 type InlineLoginDialogProps = {
     description?: string;
     onAuthenticated?: () => void;
     onOpenChange: (open: boolean) => void;
     open: boolean;
+};
+
+const oauthCallbackPaths: Record<OAuthProvider, string> = {
+    facebook: '/prijava/facebook-prijava/povratak',
+    google: '/prijava/google-prijava/povratak',
 };
 
 function responseMessage(value: unknown, fallback: string) {
@@ -33,6 +44,10 @@ function responseMessage(value: unknown, fallback: string) {
     }
 
     return fallback;
+}
+
+function currentReturnPath() {
+    return `${window.location.pathname}${window.location.search}${window.location.hash}`;
 }
 
 function EmailPasswordForm({
@@ -50,6 +65,7 @@ function EmailPasswordForm({
     const [password, setPassword] = useState('');
     const [repeatPassword, setRepeatPassword] = useState('');
     const passwordsMatch = password === repeatPassword;
+    const fieldIdPrefix = registration ? 'inline-register' : 'inline-login';
 
     function handleSubmit(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
@@ -66,7 +82,7 @@ function EmailPasswordForm({
                 <Input
                     autoComplete="email"
                     fullWidth
-                    id="inline-login-email"
+                    id={`${fieldIdPrefix}-email`}
                     label="Email"
                     onChange={(event) => setEmail(event.currentTarget.value)}
                     required
@@ -78,7 +94,7 @@ function EmailPasswordForm({
                         registration ? 'new-password' : 'current-password'
                     }
                     fullWidth
-                    id="inline-login-password"
+                    id={`${fieldIdPrefix}-password`}
                     label="Zaporka"
                     onChange={(event) => setPassword(event.currentTarget.value)}
                     required
@@ -90,7 +106,7 @@ function EmailPasswordForm({
                         <Input
                             autoComplete="new-password"
                             fullWidth
-                            id="inline-login-repeat-password"
+                            id={`${fieldIdPrefix}-repeat-password`}
                             label="Ponovi zaporku"
                             onChange={(event) =>
                                 setRepeatPassword(event.currentTarget.value)
@@ -135,21 +151,29 @@ export function InlineLoginDialog({
 }: InlineLoginDialogProps) {
     const queryClient = useQueryClient();
     const [activeTab, setActiveTab] = useState<AuthTab>('login');
+    const [emailExpanded, setEmailExpanded] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [registrationSent, setRegistrationSent] = useState(false);
+    const fetchLastLogin = useCallback(
+        () => clientPublic().api.auth['last-login'].$get(),
+        [],
+    );
+    const lastLoginProvider = useLastLoginProvider(fetchLastLogin);
 
     useEffect(() => {
         if (!open) {
             setError(null);
             setRegistrationSent(false);
             setActiveTab('login');
+            setEmailExpanded(false);
         }
     }, [open]);
 
     function handleTabChange(value: string) {
         if (value === 'login' || value === 'register') {
             setActiveTab(value);
+            setEmailExpanded(false);
             setError(null);
             setRegistrationSent(false);
         }
@@ -214,6 +238,28 @@ export function InlineLoginDialog({
         }
     }
 
+    function handleOAuthLogin(provider: OAuthProvider) {
+        const callbackUrl = new URL(
+            oauthCallbackPaths[provider],
+            window.location.origin,
+        );
+        callbackUrl.searchParams.set('returnTo', currentReturnPath());
+
+        const authUrl = new URL(
+            `/api/auth/${provider}`,
+            getBrowserGrediceAppOrigin('api'),
+        );
+        authUrl.searchParams.set('redirect', callbackUrl.toString());
+        authUrl.searchParams.set(
+            'timeZone',
+            Intl.DateTimeFormat().resolvedOptions().timeZone,
+        );
+
+        window.location.href = authUrl.toString();
+    }
+
+    const authActionLabel = activeTab === 'login' ? 'prijava' : 'registracija';
+
     return (
         <Modal
             className="max-w-md rounded-lg border-tertiary border-b-4 bg-card shadow-2xl"
@@ -241,21 +287,52 @@ export function InlineLoginDialog({
                     </TabsList>
 
                     <Stack spacing={4} className="mt-4">
-                        <TabsContent className="mt-0" value="login">
-                            <EmailPasswordForm
-                                loading={isSubmitting}
-                                onSubmit={handleLogin}
-                                submitText="Prijavi se"
-                            />
-                        </TabsContent>
-                        <TabsContent className="mt-0" value="register">
-                            <EmailPasswordForm
-                                loading={isSubmitting}
-                                onSubmit={handleRegister}
-                                registration
-                                submitText="Registriraj se"
-                            />
-                        </TabsContent>
+                        {!emailExpanded ? (
+                            <Stack spacing={2}>
+                                <GoogleLoginButton
+                                    lastUsed={lastLoginProvider === 'google'}
+                                    onClick={() => handleOAuthLogin('google')}
+                                >
+                                    Google {authActionLabel}
+                                </GoogleLoginButton>
+                                <FacebookLoginButton
+                                    lastUsed={lastLoginProvider === 'facebook'}
+                                    onClick={() => handleOAuthLogin('facebook')}
+                                >
+                                    Facebook {authActionLabel}
+                                </FacebookLoginButton>
+                                <Button
+                                    color="neutral"
+                                    fullWidth
+                                    onClick={() => setEmailExpanded(true)}
+                                    startDecorator={
+                                        <Mail className="size-4 shrink-0" />
+                                    }
+                                    type="button"
+                                    variant="outlined"
+                                >
+                                    Email {authActionLabel}
+                                </Button>
+                            </Stack>
+                        ) : (
+                            <>
+                                <TabsContent className="mt-0" value="login">
+                                    <EmailPasswordForm
+                                        loading={isSubmitting}
+                                        onSubmit={handleLogin}
+                                        submitText="Prijavi se"
+                                    />
+                                </TabsContent>
+                                <TabsContent className="mt-0" value="register">
+                                    <EmailPasswordForm
+                                        loading={isSubmitting}
+                                        onSubmit={handleRegister}
+                                        registration
+                                        submitText="Registriraj se"
+                                    />
+                                </TabsContent>
+                            </>
+                        )}
 
                         {registrationSent ? (
                             <Alert color="success">

--- a/apps/www/components/auth/OAuthCallbackStatus.tsx
+++ b/apps/www/components/auth/OAuthCallbackStatus.tsx
@@ -1,0 +1,41 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
+import { Row } from '@gredice/ui/Row';
+import { Spinner } from '@gredice/ui/Spinner';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { Suspense } from 'react';
+import { UrlAuthForward } from '../../app/prijava/UrlAuthForward';
+
+export function OAuthCallbackStatus({ provider }: { provider: string }) {
+    return (
+        <div className="flex min-h-[70dvh] items-center justify-center p-4">
+            <Card className="w-[350px] p-8">
+                <CardHeader>
+                    <CardTitle className="text-center">
+                        {provider} prijava
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Stack spacing={6}>
+                        <Row spacing={4} justifyContent="center">
+                            <Spinner
+                                className="size-5"
+                                loading
+                                loadingLabel="Prijava u tijeku..."
+                            />
+                            <Typography level="body2">
+                                Prijava u tijeku...
+                            </Typography>
+                        </Row>
+                        <Typography level="body3" center>
+                            Pričekaj dok završimo tvoju prijavu.
+                        </Typography>
+                    </Stack>
+                </CardContent>
+            </Card>
+            <Suspense>
+                <UrlAuthForward />
+            </Suspense>
+        </div>
+    );
+}

--- a/apps/www/lib/authCookieSecurity.ts
+++ b/apps/www/lib/authCookieSecurity.ts
@@ -1,0 +1,124 @@
+import { headers } from 'next/headers';
+
+function isLoopbackHost(hostname: string) {
+    return (
+        hostname === 'localhost' ||
+        hostname === '127.0.0.1' ||
+        hostname === '::1' ||
+        hostname === '[::1]'
+    );
+}
+
+type RequestCookieContext = {
+    forwardedProto?: string;
+    host: string;
+    origin?: string;
+};
+
+function hostnameFromHostHeader(hostHeader: string) {
+    try {
+        return new URL(`http://${hostHeader}`).hostname;
+    } catch {
+        return hostHeader.split(':')[0] ?? '';
+    }
+}
+
+function secureCookieOverride() {
+    const override = process.env.GREDICE_SECURE_AUTH_COOKIES?.trim();
+    if (!override) {
+        return null;
+    }
+
+    const normalized = override.toLowerCase();
+    if (['0', 'false', 'no', 'off'].includes(normalized)) {
+        return false;
+    }
+
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+        return true;
+    }
+
+    throw new Error(`Invalid GREDICE_SECURE_AUTH_COOKIES value: ${override}`);
+}
+
+async function requestCookieContext(): Promise<RequestCookieContext> {
+    const requestHeaders = await headers();
+    return {
+        forwardedProto: requestHeaders
+            .get('x-forwarded-proto')
+            ?.split(',')[0]
+            ?.trim()
+            .toLowerCase(),
+        host: hostnameFromHostHeader(
+            requestHeaders.get('x-forwarded-host') ??
+                requestHeaders.get('host') ??
+                '',
+        ),
+        origin:
+            requestHeaders.get('origin') ??
+            requestHeaders.get('referer') ??
+            undefined,
+    };
+}
+
+function shouldUseSecureCookiesForContext(context: RequestCookieContext) {
+    const override = secureCookieOverride();
+    if (override !== null) {
+        return override;
+    }
+
+    if (context.forwardedProto) {
+        return context.forwardedProto === 'https';
+    }
+
+    if (context.origin) {
+        try {
+            const originUrl = new URL(context.origin);
+            return !(
+                originUrl.protocol === 'http:' &&
+                isLoopbackHost(originUrl.hostname)
+            );
+        } catch {
+            // Fall through to host-based development detection.
+        }
+    }
+
+    return !(
+        process.env.NODE_ENV === 'development' && isLoopbackHost(context.host)
+    );
+}
+
+function configuredCookieDomain() {
+    const domain = process.env.COOKIE_DOMAIN?.trim();
+    return domain || undefined;
+}
+
+function inferredGrediceCookieDomain(hostname: string) {
+    if (hostname === 'gredice.com' || hostname.endsWith('.gredice.com')) {
+        return 'gredice.com';
+    }
+
+    if (hostname === 'gredice.test' || hostname.endsWith('.gredice.test')) {
+        return 'gredice.test';
+    }
+
+    return undefined;
+}
+
+function cookieDomainForContext(context: RequestCookieContext) {
+    if (isLoopbackHost(context.host)) {
+        return undefined;
+    }
+
+    return (
+        configuredCookieDomain() ?? inferredGrediceCookieDomain(context.host)
+    );
+}
+
+export async function authCookieSettings() {
+    const context = await requestCookieContext();
+    return {
+        domain: cookieDomainForContext(context),
+        secure: shouldUseSecureCookiesForContext(context),
+    };
+}

--- a/apps/www/tests/InlineLoginDialogHarness.tsx
+++ b/apps/www/tests/InlineLoginDialogHarness.tsx
@@ -1,0 +1,22 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { InlineLoginDialog } from '../components/auth/InlineLoginDialog';
+
+export function InlineLoginDialogHarness() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <InlineLoginDialog
+                description="Prijavi se za nastavak."
+                onOpenChange={() => undefined}
+                open
+            />
+        </QueryClientProvider>
+    );
+}

--- a/apps/www/tests/inline-login-dialog.spec.tsx
+++ b/apps/www/tests/inline-login-dialog.spec.tsx
@@ -1,0 +1,124 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { InlineLoginDialogHarness } from './InlineLoginDialogHarness';
+import '../app/globals.css';
+
+type OAuthProviderCase = {
+    buttonName: string;
+    callbackPath: string;
+    provider: 'google' | 'facebook';
+};
+
+const oauthProviderCases: OAuthProviderCase[] = [
+    {
+        buttonName: 'Google prijava',
+        callbackPath: '/prijava/google-prijava/povratak',
+        provider: 'google',
+    },
+    {
+        buttonName: 'Facebook prijava',
+        callbackPath: '/prijava/facebook-prijava/povratak',
+        provider: 'facebook',
+    },
+];
+
+test.beforeEach(async ({ page }) => {
+    await page.route('**/api/gredice/api/auth/last-login', (route) =>
+        route.fulfill({ status: 200, json: { provider: null } }),
+    );
+});
+
+test('shows social login first and expands email login on request', async ({
+    mount,
+    page,
+}) => {
+    await mount(<InlineLoginDialogHarness />);
+
+    await expect(
+        page.getByRole('button', { name: 'Google prijava' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Facebook prijava' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Email prijava' }),
+    ).toBeVisible();
+    await expect(page.locator('#inline-login-email')).toBeHidden();
+    await expect(page.locator('#inline-login-password')).toBeHidden();
+
+    await page.getByRole('button', { name: 'Email prijava' }).click();
+
+    await expect(page.locator('#inline-login-email')).toBeVisible();
+    await expect(page.locator('#inline-login-password')).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Prijavi se' }),
+    ).toBeVisible();
+});
+
+test('keeps registration email fields collapsed until email registration is selected', async ({
+    mount,
+    page,
+}) => {
+    await mount(<InlineLoginDialogHarness />);
+
+    await page.getByRole('tab', { name: 'Registracija' }).click();
+
+    await expect(
+        page.getByRole('button', { name: 'Google registracija' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Facebook registracija' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Email registracija' }),
+    ).toBeVisible();
+    await expect(page.locator('#inline-register-email')).toBeHidden();
+    await expect(page.locator('#inline-register-repeat-password')).toBeHidden();
+
+    await page.getByRole('button', { name: 'Email registracija' }).click();
+
+    await expect(page.locator('#inline-register-email')).toBeVisible();
+    await expect(
+        page.locator('#inline-register-repeat-password'),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Registriraj se' }),
+    ).toBeVisible();
+});
+
+for (const { buttonName, callbackPath, provider } of oauthProviderCases) {
+    test(`builds the ${provider} OAuth redirect for the current public page`, async ({
+        mount,
+        page,
+    }) => {
+        const authRequestPattern = `http://localhost:3005/api/auth/${provider}**`;
+        await page.route(authRequestPattern, (route) =>
+            route.fulfill({ status: 204 }),
+        );
+        await mount(<InlineLoginDialogHarness />);
+
+        const [currentOrigin, currentReturnPath] = await page.evaluate(() => [
+            window.location.origin,
+            `${window.location.pathname}${window.location.search}${window.location.hash}`,
+        ]);
+        const authRequestPromise = page.waitForRequest(authRequestPattern);
+
+        await page.getByRole('button', { name: buttonName }).click();
+
+        const authRequest = await authRequestPromise;
+        const authUrl = new URL(authRequest.url());
+        const redirect = authUrl.searchParams.get('redirect');
+        expect(authUrl.searchParams.get('timeZone')).toBeTruthy();
+        expect(redirect).not.toBeNull();
+
+        if (!redirect) {
+            throw new Error('Expected OAuth redirect query parameter.');
+        }
+
+        const redirectUrl = new URL(redirect);
+        expect(redirectUrl.origin).toBe(currentOrigin);
+        expect(redirectUrl.pathname).toBe(callbackPath);
+        expect(redirectUrl.searchParams.get('returnTo')).toBe(
+            currentReturnPath,
+        );
+    });
+}


### PR DESCRIPTION
## Summary
- Update the www inline login dialog to show Google/Facebook first and keep email login/registration collapsed until selected.
- Add www OAuth callback pages and a same-origin token exchange route so social login returns to the public page that opened the modal.
- Reserve `/prijava` from the CMS catch-all and allow local `www.gredice.test` OAuth redirects.

## Validation
- `corepack pnpm --filter api lint`
- `corepack pnpm --filter www lint`
- `corepack pnpm --filter www typecheck`
- `corepack pnpm --filter www test:prepare`
- `corepack pnpm --dir apps/www exec playwright test --project=chromium tests/inline-login-dialog.spec.tsx`
- `corepack pnpm --dir apps/www exec playwright test --project=chromium tests/community-edit-button.spec.tsx`
- `git diff --check`

Closes #3940