### PR TITLE
feat(garden): drag HUD items into scene

### DIFF
--- a/apps/garden/tests/ItemsHudStory.tsx
+++ b/apps/garden/tests/ItemsHudStory.tsx
@@ -21,6 +21,7 @@ import { defaultLocalSandboxStorageKey } from '../../../packages/game/src/localS
 import {
     createGameState,
     GameStateContext,
+    useGameState,
 } from '../../../packages/game/src/useGameState';
 
 const now = '2026-05-13T00:00:00.000Z';
@@ -340,10 +341,56 @@ function ItemsHudTestFrame({ closeup = false }: { closeup?: boolean }) {
     );
 }
 
+function HudPlacementDragStateProbe() {
+    const drag = useGameState((state) => state.hudPlacementDrag);
+
+    return (
+        <output data-testid="hud-placement-drag-state">
+            {drag
+                ? `${drag.blockName}:${drag.dropRequest ? 'drop' : 'drag'}`
+                : 'idle'}
+        </output>
+    );
+}
+
 export function ItemsHudAlignmentStory() {
     return (
         <ItemsHudTestProviders>
             <div className="relative h-screen w-screen overflow-hidden">
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <BottomControlsTestFrame />
+                    <ItemsHudTestFrame />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}
+
+export function ItemsHudDragStateStory() {
+    return (
+        <ItemsHudTestProviders>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <HudPlacementDragStateProbe />
+                <div
+                    data-testid="bottom-hud"
+                    className={gameHudBottomBarClassName}
+                >
+                    <BottomControlsTestFrame />
+                    <ItemsHudTestFrame />
+                </div>
+            </div>
+        </ItemsHudTestProviders>
+    );
+}
+
+export function LowSunflowerBalanceItemsHudDragStateStory() {
+    return (
+        <ItemsHudTestProviders accountSunflowers={20}>
+            <div className="relative h-screen w-screen overflow-hidden">
+                <HudPlacementDragStateProbe />
                 <div
                     data-testid="bottom-hud"
                     className={gameHudBottomBarClassName}

--- a/apps/garden/tests/items-hud.spec.tsx
+++ b/apps/garden/tests/items-hud.spec.tsx
@@ -1,12 +1,15 @@
 import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator, Page } from '@playwright/test';
 import {
     ActiveItemsHudDropTargetStory,
     CloseupBottomHudStory,
     ItemsHudAlignmentStory,
     ItemsHudCameraTargetStory,
     ItemsHudControlsTooltipStory,
+    ItemsHudDragStateStory,
     ItemsHudDropTargetStory,
     LocalSandboxItemsHudStory,
+    LowSunflowerBalanceItemsHudDragStateStory,
     LowSunflowerBalanceItemsHudStory,
     SandboxBlockTrashDropTargetStory,
     SandboxItemsHudStory,
@@ -14,6 +17,67 @@ import {
 
 const TABLET_VIEWPORT = { width: 820, height: 1180 };
 const SHORT_MOBILE_VIEWPORT = { width: 414, height: 420 };
+
+async function dragLocatorByMouse(page: Page, locator: Locator) {
+    const box = await locator.boundingBox();
+    expect(box).not.toBeNull();
+
+    const x = (box?.x ?? 0) + (box?.width ?? 0) / 2;
+    const y = (box?.y ?? 0) + (box?.height ?? 0) / 2;
+
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x, y - 96, { steps: 6 });
+    return { x, y: y - 96 };
+}
+
+async function dispatchTouchDrag({
+    endEvent,
+    locator,
+    page,
+}: {
+    endEvent: 'pointercancel' | 'pointerup';
+    locator: Locator;
+    page: Page;
+}) {
+    const box = await locator.boundingBox();
+    expect(box).not.toBeNull();
+
+    const x = (box?.x ?? 0) + (box?.width ?? 0) / 2;
+    const y = (box?.y ?? 0) + (box?.height ?? 0) / 2;
+    const pointerId = 41;
+
+    await locator.dispatchEvent('pointerdown', {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        clientX: x,
+        clientY: y,
+        isPrimary: true,
+        pointerId,
+        pointerType: 'touch',
+    });
+    await page.locator('body').dispatchEvent('pointermove', {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        clientX: x,
+        clientY: y - 96,
+        isPrimary: true,
+        pointerId,
+        pointerType: 'touch',
+    });
+    await page.locator('body').dispatchEvent(endEvent, {
+        bubbles: true,
+        button: 0,
+        buttons: endEvent === 'pointerup' ? 0 : 1,
+        clientX: x,
+        clientY: y - 96,
+        isPrimary: true,
+        pointerId,
+        pointerType: 'touch',
+    });
+}
 
 function getPlacementRequestPosition(body: unknown) {
     if (typeof body !== 'object' || body === null || !('position' in body)) {
@@ -479,6 +543,67 @@ test('item picker disables purchase buttons above the sunflower balance', async 
     });
     await expect(detailsPlaceButton).toBeDisabled();
     await expect(page.getByText('Nedovoljno suncokreta.')).toBeVisible();
+});
+
+test('dragging an affordable picker item requests a scene drop without opening details', async ({
+    mount,
+    page,
+}) => {
+    await mount(<ItemsHudDragStateStory />);
+
+    const dragState = page.getByTestId('hud-placement-drag-state');
+    await expect(dragState).toHaveText('idle');
+
+    await page.getByRole('button', { name: 'Dekoracija' }).click();
+
+    const stoolButton = page.getByRole('button', { name: 'Stool' });
+    await dragLocatorByMouse(page, stoolButton);
+
+    await expect(dragState).toHaveText('Stool:drag');
+    await page.mouse.up();
+    await expect(dragState).toHaveText('Stool:drop');
+    await expect(
+        page.getByText('Mock block for HUD layout tests.'),
+    ).toHaveCount(0);
+});
+
+test('touch drag cancellation clears HUD item placement', async ({
+    mount,
+    page,
+}) => {
+    await mount(<ItemsHudDragStateStory />);
+
+    await page.getByRole('button', { name: 'Dekoracija' }).click();
+
+    const stoolButton = page.getByRole('button', { name: 'Stool' });
+    await dispatchTouchDrag({
+        endEvent: 'pointercancel',
+        locator: stoolButton,
+        page,
+    });
+
+    await expect(page.getByTestId('hud-placement-drag-state')).toHaveText(
+        'idle',
+    );
+});
+
+test('unaffordable item icons do not start HUD drag placement', async ({
+    mount,
+    page,
+}) => {
+    await mount(<LowSunflowerBalanceItemsHudDragStateStory />);
+
+    await page.getByRole('button', { name: 'Alat' }).click();
+
+    const paintRollerButton = page.getByRole('button', {
+        name: 'PaintRoller',
+    });
+    await dragLocatorByMouse(page, paintRollerButton);
+    await page.mouse.up();
+
+    await expect(page.getByTestId('hud-placement-drag-state')).toHaveText(
+        'idle',
+    );
 });
 
 test('item details place button keeps the soft color treatment', async ({

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -12,6 +12,7 @@ import {
 import { BlockInteractionLayer } from './controls/BlockInteractionLayer';
 import { BlockInteractionRegistryProvider } from './controls/BlockInteractionRegistry';
 import { GameCameraRig } from './controls/GameCameraRig';
+import { HudPlacementDragPreview } from './controls/HudPlacementDragPreview';
 import { Bees } from './entities/bees/Bees';
 import { Birds } from './entities/birds/Birds';
 import { Cats } from './entities/cats/Cats';
@@ -289,6 +290,7 @@ export function GameScene({
                     <ParticleSystemProvider>
                         <BlockInteractionRegistryProvider>
                             <PlacementGrid />
+                            <HudPlacementDragPreview />
                             <Environment
                                 noBackground={noBackground}
                                 noWeather={weatherDisabled}

--- a/packages/game/src/controls/GameCameraRig.tsx
+++ b/packages/game/src/controls/GameCameraRig.tsx
@@ -175,8 +175,9 @@ export function GameCameraRig({
     const worldRotate = useGameState((state) => state.worldRotate);
     const view = useGameState((state) => state.view);
     const closeupBlock = useGameState((state) => state.closeupBlock);
-    const isBlockPlacementActive = useGameState((state) =>
-        Boolean(state.pickupBlock),
+    const isBlockPlacementActive = useGameState(
+        (state) =>
+            Boolean(state.pickupBlock) || Boolean(state.hudPlacementDrag),
     );
     const { data: garden } = useCurrentGarden();
 

--- a/packages/game/src/controls/HudPlacementDragPreview.tsx
+++ b/packages/game/src/controls/HudPlacementDragPreview.tsx
@@ -137,7 +137,7 @@ export function HudPlacementDragPreview() {
         }
 
         return {
-            blocks: [block],
+            blocks: [...placementPreview.baseBlocks, block],
             position: new Vector3(
                 placementPreview.position.x,
                 0,

--- a/packages/game/src/controls/HudPlacementDragPreview.tsx
+++ b/packages/game/src/controls/HudPlacementDragPreview.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { Shadow } from '@react-three/drei';
+import { useThree } from '@react-three/fiber';
+import { Suspense, useEffect, useMemo, useRef } from 'react';
+import { Plane, Raycaster, Vector2, Vector3 } from 'three';
+import { EntityFactory } from '../entities/EntityFactory';
+import { blockPickupOutlineStyle } from '../entities/helpers/blockPickupOutlineStyle';
+import { HoverOutline } from '../entities/helpers/HoverOutline';
+import { useBlockData } from '../hooks/useBlockData';
+import { useBlockPlace } from '../hooks/useBlockPlace';
+import { useCurrentAccount } from '../hooks/useCurrentAccount';
+import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { getHudEntityPlacementAvailability } from '../hud/itemPlacementAvailability';
+import type { Block } from '../types/Block';
+import type { Stack } from '../types/Stack';
+import { useGameState } from '../useGameState';
+import {
+    type HudPlacementGridPosition,
+    resolveHudPlacementPreview,
+} from './hudPlacement';
+
+const groundPlane = new Plane(new Vector3(0, 1, 0), 0);
+const previewLift = 0.1;
+const hudSurfaceSelector = '[data-items-hud-surface="true"]';
+
+function isPointInsideElement(
+    clientX: number,
+    clientY: number,
+    element: HTMLElement,
+) {
+    const rect = element.getBoundingClientRect();
+    return (
+        clientX >= rect.left &&
+        clientX <= rect.right &&
+        clientY >= rect.top &&
+        clientY <= rect.bottom
+    );
+}
+
+function isPointOverHudSurface(clientX: number, clientY: number) {
+    return Boolean(
+        document
+            .elementFromPoint(clientX, clientY)
+            ?.closest(hudSurfaceSelector),
+    );
+}
+
+export function HudPlacementDragPreview() {
+    const camera = useThree((state) => state.camera);
+    const gl = useThree((state) => state.gl);
+    const { domElement } = gl;
+    const raycaster = useRef(new Raycaster());
+    const pointerVector = useRef(new Vector2());
+    const intersectionPoint = useRef(new Vector3());
+    const { data: blockData } = useBlockData();
+    const { data: garden } = useCurrentGarden();
+    const { data: account, isLoading: isAccountLoading } = useCurrentAccount();
+    const { mutate: placeBlock } = useBlockPlace();
+    const hudPlacementDrag = useGameState((state) => state.hudPlacementDrag);
+    const clearHudPlacementDrag = useGameState(
+        (state) => state.clearHudPlacementDrag,
+    );
+    const timeOfDay = useGameState((state) => state.timeOfDay);
+
+    const pointerPosition = useMemo<HudPlacementGridPosition | null>(() => {
+        if (!hudPlacementDrag) {
+            return null;
+        }
+
+        if (
+            !isPointInsideElement(
+                hudPlacementDrag.clientX,
+                hudPlacementDrag.clientY,
+                domElement,
+            ) ||
+            isPointOverHudSurface(
+                hudPlacementDrag.clientX,
+                hudPlacementDrag.clientY,
+            )
+        ) {
+            return null;
+        }
+
+        const rect = domElement.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) {
+            return null;
+        }
+
+        pointerVector.current.set(
+            ((hudPlacementDrag.clientX - rect.left) / rect.width) * 2 - 1,
+            ((rect.top - hudPlacementDrag.clientY) / rect.height) * 2 + 1,
+        );
+        raycaster.current.setFromCamera(pointerVector.current, camera);
+        const intersects = raycaster.current.ray.intersectPlane(
+            groundPlane,
+            intersectionPoint.current,
+        );
+        if (!intersects) {
+            return null;
+        }
+
+        return {
+            x: Math.round(intersectionPoint.current.x),
+            z: Math.round(intersectionPoint.current.z),
+        };
+    }, [camera, domElement, hudPlacementDrag]);
+
+    const placementPreview = useMemo(() => {
+        if (!hudPlacementDrag || !pointerPosition) {
+            return null;
+        }
+
+        return resolveHudPlacementPreview({
+            blockData,
+            blockName: hudPlacementDrag.blockName,
+            garden,
+            position: pointerPosition,
+        });
+    }, [blockData, garden, hudPlacementDrag, pointerPosition]);
+
+    const block = useMemo<Block | null>(() => {
+        if (!hudPlacementDrag || !placementPreview) {
+            return null;
+        }
+
+        return {
+            id: `hud-placement-preview:${hudPlacementDrag.blockName}`,
+            name: hudPlacementDrag.blockName,
+            rotation: 0,
+        };
+    }, [hudPlacementDrag, placementPreview]);
+
+    const stack = useMemo<Stack | null>(() => {
+        if (!block || !placementPreview) {
+            return null;
+        }
+
+        return {
+            blocks: [block],
+            position: new Vector3(
+                placementPreview.position.x,
+                0,
+                placementPreview.position.z,
+            ),
+        };
+    }, [block, placementPreview]);
+
+    const blockEntity = blockData?.find(
+        (candidate) =>
+            candidate.information.name === hudPlacementDrag?.blockName,
+    );
+    const availability =
+        blockEntity && garden
+            ? getHudEntityPlacementAvailability({
+                  accountSunflowers: account?.sunflowers.amount,
+                  block: blockEntity,
+                  isAccountLoading,
+                  isSandbox: garden.isSandbox,
+                  timeOfDay,
+              })
+            : null;
+    const isBlocked =
+        !availability?.canPlace || (placementPreview?.isBlocked ?? true);
+    const dropRequestSequence = hudPlacementDrag?.dropRequest?.sequence ?? null;
+
+    useEffect(() => {
+        if (!hudPlacementDrag?.dropRequest || dropRequestSequence === null) {
+            return;
+        }
+
+        if (!placementPreview || isBlocked || !availability?.canPlace) {
+            clearHudPlacementDrag();
+            return;
+        }
+
+        placeBlock({
+            blockName: hudPlacementDrag.blockName,
+            position: {
+                x: placementPreview.position.x,
+                y: placementPreview.position.z,
+            },
+        });
+        clearHudPlacementDrag();
+    }, [
+        availability?.canPlace,
+        clearHudPlacementDrag,
+        dropRequestSequence,
+        hudPlacementDrag,
+        isBlocked,
+        placeBlock,
+        placementPreview,
+    ]);
+
+    if (!hudPlacementDrag || !placementPreview || !block || !stack) {
+        return null;
+    }
+
+    const previewY = placementPreview.hoverHeight + previewLift;
+
+    return (
+        <group name="Interaction:HudPlacementDragPreview">
+            {isBlocked && (
+                <group
+                    position={[
+                        placementPreview.position.x,
+                        placementPreview.hoverHeight,
+                        placementPreview.position.z,
+                    ]}
+                >
+                    <Shadow
+                        color={0xff0000}
+                        colorStop={0.5}
+                        opacity={0.9}
+                        scale={2}
+                    />
+                </group>
+            )}
+            <group
+                position={[
+                    placementPreview.position.x,
+                    previewY,
+                    placementPreview.position.z,
+                ]}
+                scale={isBlocked ? 0.96 : 1.02}
+            >
+                <Suspense fallback={null}>
+                    <HoverOutline
+                        {...blockPickupOutlineStyle}
+                        color={
+                            isBlocked
+                                ? '#ef4444'
+                                : blockPickupOutlineStyle.color
+                        }
+                        hovered
+                    >
+                        <group
+                            position={[
+                                -placementPreview.position.x,
+                                -previewY,
+                                -placementPreview.position.z,
+                            ]}
+                        >
+                            <EntityFactory
+                                name={block.name}
+                                stack={stack}
+                                block={block}
+                                rotation={block.rotation}
+                                noControl
+                            />
+                        </group>
+                    </HoverOutline>
+                </Suspense>
+            </group>
+        </group>
+    );
+}

--- a/packages/game/src/controls/RotatableGroup.tsx
+++ b/packages/game/src/controls/RotatableGroup.tsx
@@ -37,7 +37,13 @@ export function RotatableGroup({
 
     function doRotate() {
         const gameState = gameStateStore?.getState();
-        if (gameState?.isDragging || gameState?.pickupBlock) return false;
+        if (
+            gameState?.isDragging ||
+            gameState?.pickupBlock ||
+            gameState?.hudPlacementDrag
+        ) {
+            return false;
+        }
 
         const garden = getCurrentGarden();
         const attachedRaisedBedBlockId =

--- a/packages/game/src/controls/hudPlacement.ts
+++ b/packages/game/src/controls/hudPlacement.ts
@@ -1,6 +1,7 @@
 import type { BlockData } from '@gredice/client';
 import { getGardenBlockFootprintOffsets } from '@gredice/js/gardenBlocks';
 import { resolveBlockPlacement } from '../hooks/optimisticBlockPlacement';
+import type { Block } from '../types/Block';
 import type { Stack } from '../types/Stack';
 import { getStackHeight } from '../utils/stackHeightCore';
 
@@ -10,6 +11,7 @@ export type HudPlacementGridPosition = {
 };
 
 export type HudPlacementPreview = {
+    baseBlocks: Block[];
     error: string | null;
     hoverHeight: number;
     isBlocked: boolean;
@@ -30,7 +32,7 @@ function getStackAtPosition(
     );
 }
 
-function getHudPlacementHoverHeight({
+function getHudPlacementSupport({
     blockData,
     blockName,
     position,
@@ -44,17 +46,26 @@ function getHudPlacementHoverHeight({
     const blockEntity = blockData.find(
         (block) => block.information.name === blockName,
     );
-    const heights = getGardenBlockFootprintOffsets(blockEntity).map(
-        (offset) => {
-            const stack = getStackAtPosition(stacks, {
-                x: position.x + offset.x,
-                z: position.z + offset.y,
-            });
-            return getStackHeight(blockData, stack);
-        },
-    );
+    let support = {
+        baseBlocks: [] as Block[],
+        hoverHeight: 0,
+    };
 
-    return heights.length > 0 ? Math.max(...heights) : 0;
+    for (const offset of getGardenBlockFootprintOffsets(blockEntity)) {
+        const stack = getStackAtPosition(stacks, {
+            x: position.x + offset.x,
+            z: position.z + offset.y,
+        });
+        const hoverHeight = getStackHeight(blockData, stack);
+        if (hoverHeight > support.hoverHeight) {
+            support = {
+                baseBlocks: stack?.blocks ?? [],
+                hoverHeight,
+            };
+        }
+    }
+
+    return support;
 }
 
 export function resolveHudPlacementPreview({
@@ -75,15 +86,17 @@ export function resolveHudPlacementPreview({
     const placement = resolveBlockPlacement(garden, blockData, blockName, {
         requestedPosition: { x: position.x, y: position.z },
     });
+    const support = getHudPlacementSupport({
+        blockData,
+        blockName,
+        position,
+        stacks: garden.stacks,
+    });
 
     return {
+        baseBlocks: support.baseBlocks,
         error: placement?.valid === false ? placement.error : null,
-        hoverHeight: getHudPlacementHoverHeight({
-            blockData,
-            blockName,
-            position,
-            stacks: garden.stacks,
-        }),
+        hoverHeight: support.hoverHeight,
         isBlocked: placement?.valid !== true,
         position,
     };

--- a/packages/game/src/controls/hudPlacement.ts
+++ b/packages/game/src/controls/hudPlacement.ts
@@ -1,0 +1,90 @@
+import type { BlockData } from '@gredice/client';
+import { getGardenBlockFootprintOffsets } from '@gredice/js/gardenBlocks';
+import { resolveBlockPlacement } from '../hooks/optimisticBlockPlacement';
+import type { Stack } from '../types/Stack';
+import { getStackHeight } from '../utils/stackHeightCore';
+
+export type HudPlacementGridPosition = {
+    x: number;
+    z: number;
+};
+
+export type HudPlacementPreview = {
+    error: string | null;
+    hoverHeight: number;
+    isBlocked: boolean;
+    position: HudPlacementGridPosition;
+};
+
+type GardenWithStacks = {
+    stacks: Stack[];
+};
+
+function getStackAtPosition(
+    stacks: Stack[] | undefined,
+    position: HudPlacementGridPosition,
+) {
+    return stacks?.find(
+        (stack) =>
+            stack.position.x === position.x && stack.position.z === position.z,
+    );
+}
+
+function getHudPlacementHoverHeight({
+    blockData,
+    blockName,
+    position,
+    stacks,
+}: {
+    blockData: BlockData[];
+    blockName: string;
+    position: HudPlacementGridPosition;
+    stacks: Stack[] | undefined;
+}) {
+    const blockEntity = blockData.find(
+        (block) => block.information.name === blockName,
+    );
+    const heights = getGardenBlockFootprintOffsets(blockEntity).map(
+        (offset) => {
+            const stack = getStackAtPosition(stacks, {
+                x: position.x + offset.x,
+                z: position.z + offset.y,
+            });
+            return getStackHeight(blockData, stack);
+        },
+    );
+
+    return heights.length > 0 ? Math.max(...heights) : 0;
+}
+
+export function resolveHudPlacementPreview({
+    blockData,
+    blockName,
+    garden,
+    position,
+}: {
+    blockData: BlockData[] | null | undefined;
+    blockName: string;
+    garden: GardenWithStacks | null | undefined;
+    position: HudPlacementGridPosition;
+}): HudPlacementPreview | null {
+    if (!blockData || !garden) {
+        return null;
+    }
+
+    const placement = resolveBlockPlacement(garden, blockData, blockName, {
+        requestedPosition: { x: position.x, y: position.z },
+    });
+
+    return {
+        error: placement?.valid === false ? placement.error : null,
+        hoverHeight: getHudPlacementHoverHeight({
+            blockData,
+            blockName,
+            position,
+            stacks: garden.stacks,
+        }),
+        isBlocked: placement?.valid !== true,
+        position,
+    };
+}

--- a/packages/game/src/controls/hudPlacement.unit.ts
+++ b/packages/game/src/controls/hudPlacement.unit.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { BlockData } from '@gredice/client';
+import { Vector3 } from 'three';
+import type { Stack } from '../types/Stack';
+import { resolveHudPlacementPreview } from './hudPlacement';
+
+function createBlockData({
+    height = 1,
+    name,
+    stackable = true,
+}: {
+    height?: number;
+    name: string;
+    stackable?: boolean;
+}): BlockData {
+    return {
+        id: name.length,
+        entityType: {
+            id: 8,
+            name: 'block',
+            label: 'Blok',
+        },
+        slug: name,
+        information: {
+            name,
+            shortDescription: name,
+            fullDescription: name,
+            label: name,
+        },
+        attributes: {
+            height,
+            stackable,
+            type: 'decoration',
+            nightOnlyPurchase: false,
+        },
+        prices: {
+            sunflowers: 10,
+        },
+        functions: {
+            recycler: false,
+            raisedBed: name === 'Raised_Bed',
+        },
+        createdAt: '2026-06-01T00:00:00.000Z',
+        updatedAt: '2026-06-01T00:00:00.000Z',
+    };
+}
+
+function createStack(x: number, z: number, name: string): Stack {
+    return {
+        position: new Vector3(x, 0, z),
+        blocks: [
+            {
+                id: `${name}:${x}:${z}`,
+                name,
+                rotation: 0,
+            },
+        ],
+    };
+}
+
+const blockData = [
+    createBlockData({ name: 'Tree' }),
+    createBlockData({ name: 'StoneLarge', stackable: false }),
+    createBlockData({ name: 'Block_Grass', height: 0.2 }),
+];
+
+describe('resolveHudPlacementPreview', () => {
+    it('allows a new HUD item on an exact empty scene cell', () => {
+        const preview = resolveHudPlacementPreview({
+            blockData,
+            blockName: 'Tree',
+            garden: { stacks: [] },
+            position: { x: 4, z: -2 },
+        });
+
+        assert.equal(preview?.isBlocked, false);
+        assert.equal(preview?.error, null);
+        assert.equal(preview?.hoverHeight, 0);
+        assert.deepEqual(preview?.position, { x: 4, z: -2 });
+    });
+
+    it('marks exact invalid targets as blocked instead of falling back nearby', () => {
+        const preview = resolveHudPlacementPreview({
+            blockData,
+            blockName: 'Tree',
+            garden: {
+                stacks: [createStack(0, 0, 'StoneLarge')],
+            },
+            position: { x: 0, z: 0 },
+        });
+
+        assert.equal(preview?.isBlocked, true);
+        assert.match(preview?.error ?? '', /cannot support Tree/u);
+        assert.equal(preview?.hoverHeight, 1);
+        assert.deepEqual(preview?.position, { x: 0, z: 0 });
+    });
+});

--- a/packages/game/src/controls/hudPlacement.unit.ts
+++ b/packages/game/src/controls/hudPlacement.unit.ts
@@ -76,8 +76,27 @@ describe('resolveHudPlacementPreview', () => {
 
         assert.equal(preview?.isBlocked, false);
         assert.equal(preview?.error, null);
+        assert.deepEqual(preview?.baseBlocks, []);
         assert.equal(preview?.hoverHeight, 0);
         assert.deepEqual(preview?.position, { x: 4, z: -2 });
+    });
+
+    it('returns support blocks for stack-height-aware HUD previews', () => {
+        const preview = resolveHudPlacementPreview({
+            blockData,
+            blockName: 'Tree',
+            garden: {
+                stacks: [createStack(0, 0, 'Block_Grass')],
+            },
+            position: { x: 0, z: 0 },
+        });
+
+        assert.equal(preview?.isBlocked, false);
+        assert.equal(preview?.hoverHeight, 0.2);
+        assert.deepEqual(
+            preview?.baseBlocks.map((block) => block.name),
+            ['Block_Grass'],
+        );
     });
 
     it('marks exact invalid targets as blocked instead of falling back nearby', () => {
@@ -92,6 +111,10 @@ describe('resolveHudPlacementPreview', () => {
 
         assert.equal(preview?.isBlocked, true);
         assert.match(preview?.error ?? '', /cannot support Tree/u);
+        assert.deepEqual(
+            preview?.baseBlocks.map((block) => block.name),
+            ['StoneLarge'],
+        );
         assert.equal(preview?.hoverHeight, 1);
         assert.deepEqual(preview?.position, { x: 0, z: 0 });
     });

--- a/packages/game/src/hooks/optimisticBlockPlacement.ts
+++ b/packages/game/src/hooks/optimisticBlockPlacement.ts
@@ -79,6 +79,30 @@ function createPlacementStacks(stacks: Stack[]): GardenBlockStack[] {
     }));
 }
 
+export function resolveBlockPlacement<TGarden extends GardenWithStacks>(
+    garden: TGarden,
+    blockData: PlacementBlockData[] | null | undefined,
+    blockName: string,
+    options: {
+        preferredPosition?: BlockPlacementPosition | null;
+        requestedPosition?: BlockPlacementPosition | null;
+    } = {},
+) {
+    if (!blockData) {
+        return null;
+    }
+
+    return resolveGardenBlockPlacement({
+        blockName,
+        stacks: createPlacementStacks(garden.stacks),
+        blockNameById: createBlockNameById(garden.stacks),
+        blockRotationById: createBlockRotationById(garden.stacks),
+        blockDataByName: createBlockDataByName(blockData),
+        preferredPosition: options.preferredPosition ?? undefined,
+        requestedPosition: options.requestedPosition ?? undefined,
+    });
+}
+
 export function createOptimisticBlockPlacement<
     TGarden extends GardenWithStacks,
 >(
@@ -88,21 +112,14 @@ export function createOptimisticBlockPlacement<
     blockId: string,
     options: {
         preferredPosition?: BlockPlacementPosition | null;
+        requestedPosition?: BlockPlacementPosition | null;
     } = {},
 ) {
-    if (!blockData) {
-        return null;
-    }
-
-    const placement = resolveGardenBlockPlacement({
-        blockName,
-        stacks: createPlacementStacks(garden.stacks),
-        blockNameById: createBlockNameById(garden.stacks),
-        blockRotationById: createBlockRotationById(garden.stacks),
-        blockDataByName: createBlockDataByName(blockData),
-        preferredPosition: options.preferredPosition ?? undefined,
+    const placement = resolveBlockPlacement(garden, blockData, blockName, {
+        preferredPosition: options.preferredPosition,
+        requestedPosition: options.requestedPosition,
     });
-    if (!placement.valid) {
+    if (!placement?.valid) {
         return null;
     }
 

--- a/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
+++ b/packages/game/src/hooks/optimisticBlockPlacement.unit.ts
@@ -239,6 +239,62 @@ describe('createOptimisticBlockPlacement', () => {
             },
         ]);
     });
+
+    it('uses a requested position exactly for dropped HUD items', () => {
+        const placement = createOptimisticBlockPlacement(
+            {
+                stacks: [],
+            },
+            blockData,
+            'Shade',
+            'optimistic-shade',
+            {
+                requestedPosition: { x: 4, y: -2 },
+            },
+        );
+
+        assert.ok(placement);
+        assert.deepStrictEqual(placement.position, new Vector3(4, 0, -2));
+        assert.deepStrictEqual(placement.stacks, [
+            {
+                position: new Vector3(4, 0, -2),
+                blocks: [
+                    {
+                        id: 'optimistic-shade',
+                        name: 'Shade',
+                        rotation: 0,
+                    },
+                ],
+            },
+        ]);
+    });
+
+    it('does not fall back when a requested HUD drop position is invalid', () => {
+        const placement = createOptimisticBlockPlacement(
+            {
+                stacks: [
+                    {
+                        position: new Vector3(0, 0, 0),
+                        blocks: [
+                            {
+                                id: 'water-a',
+                                name: 'Block_Water',
+                                rotation: 0,
+                            },
+                        ],
+                    },
+                ],
+            },
+            blockData,
+            'Shade',
+            'optimistic-shade',
+            {
+                requestedPosition: { x: 0, y: 0 },
+            },
+        );
+
+        assert.equal(placement, null);
+    });
 });
 
 describe('replaceOptimisticBlockId', () => {

--- a/packages/game/src/hooks/useBlockPlace.ts
+++ b/packages/game/src/hooks/useBlockPlace.ts
@@ -205,9 +205,11 @@ export function useBlockPlace() {
                         optimisticBlockId,
                         {
                             preferredPosition:
+                                variables.position ??
                                 getPreferredBlockPlacementPosition(
                                     gameCamera?.getSnapshot(),
                                 ),
+                            requestedPosition: variables.position,
                         },
                     );
                     if (!optimisticPlacement) {

--- a/packages/game/src/hud/ItemsHud.tsx
+++ b/packages/game/src/hud/ItemsHud.tsx
@@ -1,5 +1,4 @@
 import type { BlockData } from '@gredice/client';
-import { isNightOnlyBlockPurchase, isNightTimeOfDay } from '@gredice/js/blocks';
 import { BlockImage } from '@gredice/ui/BlockImage';
 import { Button } from '@gredice/ui/Button';
 import { Divider } from '@gredice/ui/Divider';
@@ -12,7 +11,15 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import Image from 'next/image';
-import { useMemo, useState } from 'react';
+import {
+    type MouseEvent as ReactMouseEvent,
+    type PointerEvent as ReactPointerEvent,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { useBlockData } from '../hooks/useBlockData';
 import { useBlockPlace } from '../hooks/useBlockPlace';
 import { useCurrentAccount } from '../hooks/useCurrentAccount';
@@ -24,6 +31,10 @@ import {
 import { KnownPages } from '../knownPages';
 import { useGameState } from '../useGameState';
 import { HudCard } from './components/HudCard';
+import {
+    getHudEntityPlacementAvailability,
+    type HudEntityPlacementAvailability,
+} from './itemPlacementAvailability';
 
 type HudItemEntity = {
     type: 'entity';
@@ -195,6 +206,248 @@ const sandboxHiddenEntityNames = new Set(['GardenBox']);
 const sandboxPickerImageSrcByLabel = new Map([
     ['Alat', 'https://www.gredice.com/assets/blocks/WateringCan.webp'],
 ]);
+const mouseHudDragStartDistance = 6;
+const touchHudDragStartDistance = 12;
+
+function hudDragStartDistance(pointerType: string) {
+    return pointerType === 'touch'
+        ? touchHudDragStartDistance
+        : mouseHudDragStartDistance;
+}
+
+type HudEntityPlacementState = {
+    availability: HudEntityPlacementAvailability;
+    block: BlockData;
+};
+
+function useHudEntityPlacementState(
+    name: string,
+): HudEntityPlacementState | null {
+    const { data: blockData } = useBlockData();
+    const timeOfDay = useGameState((state) => state.timeOfDay);
+    const { data: account, isLoading: isAccountLoading } = useCurrentAccount();
+    const isSandbox = useIsSandboxGarden();
+    const block = blockData?.find((block) => block.information.name === name);
+    if (!block) {
+        return null;
+    }
+
+    return {
+        availability: getHudEntityPlacementAvailability({
+            accountSunflowers: account?.sunflowers.amount,
+            block,
+            isAccountLoading,
+            isSandbox,
+            timeOfDay,
+        }),
+        block,
+    };
+}
+
+type HudDragSession = {
+    activated: boolean;
+    element: HTMLElement;
+    pointerId: number;
+    pointerType: string;
+    startClientX: number;
+    startClientY: number;
+};
+
+function releasePointerCapture(element: HTMLElement, pointerId: number) {
+    try {
+        if (element.hasPointerCapture(pointerId)) {
+            element.releasePointerCapture(pointerId);
+        }
+    } catch {
+        // Synthetic test events do not always create a browser pointer capture.
+    }
+}
+
+function useHudEntityDragPlacement({
+    blockName,
+    enabled,
+}: {
+    blockName: string;
+    enabled: boolean;
+}) {
+    const sessionRef = useRef<HudDragSession | null>(null);
+    const listenerCleanupRef = useRef<(() => void) | null>(null);
+    const suppressNextClick = useRef(false);
+    const beginHudPlacementDrag = useGameState(
+        (state) => state.beginHudPlacementDrag,
+    );
+    const updateHudPlacementDragPointer = useGameState(
+        (state) => state.updateHudPlacementDragPointer,
+    );
+    const requestHudPlacementDrop = useGameState(
+        (state) => state.requestHudPlacementDrop,
+    );
+    const clearHudPlacementDrag = useGameState(
+        (state) => state.clearHudPlacementDrag,
+    );
+
+    const cleanupSession = useCallback(() => {
+        const session = sessionRef.current;
+        if (session) {
+            releasePointerCapture(session.element, session.pointerId);
+        }
+
+        listenerCleanupRef.current?.();
+        listenerCleanupRef.current = null;
+        sessionRef.current = null;
+    }, []);
+
+    const handlePointerMove = useCallback(
+        (event: PointerEvent) => {
+            const session = sessionRef.current;
+            if (!session || event.pointerId !== session.pointerId) {
+                return;
+            }
+
+            const pointer = {
+                clientX: event.clientX,
+                clientY: event.clientY,
+                pointerId: event.pointerId,
+            };
+
+            if (!session.activated) {
+                const distance = Math.hypot(
+                    event.clientX - session.startClientX,
+                    event.clientY - session.startClientY,
+                );
+                if (distance <= hudDragStartDistance(session.pointerType)) {
+                    return;
+                }
+
+                session.activated = true;
+                suppressNextClick.current = true;
+                beginHudPlacementDrag({
+                    blockName,
+                    pointerType: session.pointerType,
+                    ...pointer,
+                });
+            } else {
+                updateHudPlacementDragPointer(pointer);
+            }
+
+            event.preventDefault();
+        },
+        [beginHudPlacementDrag, blockName, updateHudPlacementDragPointer],
+    );
+
+    const handlePointerUp = useCallback(
+        (event: PointerEvent) => {
+            const session = sessionRef.current;
+            if (!session || event.pointerId !== session.pointerId) {
+                return;
+            }
+
+            if (session.activated) {
+                event.preventDefault();
+                requestHudPlacementDrop({
+                    clientX: event.clientX,
+                    clientY: event.clientY,
+                    pointerId: event.pointerId,
+                });
+            }
+
+            cleanupSession();
+        },
+        [cleanupSession, requestHudPlacementDrop],
+    );
+
+    const handlePointerCancel = useCallback(
+        (event: PointerEvent) => {
+            const session = sessionRef.current;
+            if (!session || event.pointerId !== session.pointerId) {
+                return;
+            }
+
+            if (session.activated) {
+                clearHudPlacementDrag();
+            }
+
+            cleanupSession();
+        },
+        [cleanupSession, clearHudPlacementDrag],
+    );
+
+    const addSessionListeners = useCallback(() => {
+        listenerCleanupRef.current?.();
+
+        const handleWindowPointerMove = (event: PointerEvent) =>
+            handlePointerMove(event);
+        const handleWindowPointerUp = (event: PointerEvent) =>
+            handlePointerUp(event);
+        const handleWindowPointerCancel = (event: PointerEvent) =>
+            handlePointerCancel(event);
+
+        window.addEventListener('pointermove', handleWindowPointerMove, {
+            passive: false,
+        });
+        window.addEventListener('pointerup', handleWindowPointerUp);
+        window.addEventListener('pointercancel', handleWindowPointerCancel);
+
+        listenerCleanupRef.current = () => {
+            window.removeEventListener('pointermove', handleWindowPointerMove);
+            window.removeEventListener('pointerup', handleWindowPointerUp);
+            window.removeEventListener(
+                'pointercancel',
+                handleWindowPointerCancel,
+            );
+        };
+    }, [handlePointerCancel, handlePointerMove, handlePointerUp]);
+
+    useEffect(() => cleanupSession, [cleanupSession]);
+
+    const handlePointerDown = useCallback(
+        (event: ReactPointerEvent<HTMLElement>) => {
+            if (
+                !enabled ||
+                event.button !== 0 ||
+                event.isPrimary === false ||
+                sessionRef.current
+            ) {
+                return;
+            }
+
+            try {
+                event.currentTarget.setPointerCapture(event.pointerId);
+            } catch {
+                // Pointer capture is best-effort for browser-driven drags.
+            }
+
+            sessionRef.current = {
+                activated: false,
+                element: event.currentTarget,
+                pointerId: event.pointerId,
+                pointerType: event.pointerType,
+                startClientX: event.clientX,
+                startClientY: event.clientY,
+            };
+            addSessionListeners();
+        },
+        [addSessionListeners, enabled],
+    );
+
+    const handleClick = useCallback((event: ReactMouseEvent<HTMLElement>) => {
+        if (!suppressNextClick.current) {
+            return;
+        }
+
+        suppressNextClick.current = false;
+        event.preventDefault();
+        event.stopPropagation();
+    }, []);
+
+    return {
+        className: enabled
+            ? 'cursor-grab touch-none active:cursor-grabbing'
+            : '',
+        onClick: handleClick,
+        onPointerDown: handlePointerDown,
+    };
+}
 
 function collectEntityNames(hudItems: HudItem[], names = new Set<string>()) {
     for (const item of hudItems) {
@@ -406,33 +659,25 @@ function PlaceEntityButton({
     name: string;
     simple?: boolean;
 }) {
-    const { data: blockData } = useBlockData();
     const placeBlock = useBlockPlace();
-    const timeOfDay = useGameState((state) => state.timeOfDay);
-    const { data: account, isLoading: isAccountLoading } = useCurrentAccount();
-    // Sandbox ("play") gardens build for free — every block is placeable
-    // regardless of price or night-only availability.
+    const entityPlacement = useHudEntityPlacementState(name);
     const isSandbox = useIsSandboxGarden();
 
-    const block = blockData?.find((block) => block.information.name === name);
-    if (!block) return null;
-    const sunflowerPrice = block.prices.sunflowers ?? 0;
-    const hasSunflowerPrice = sunflowerPrice > 0;
-    const isAvailableNow =
-        isSandbox ||
-        !isNightOnlyBlockPurchase(block) ||
-        isNightTimeOfDay(timeOfDay);
-    const accountSunflowers = account?.sunflowers.amount;
-    const hasEnoughSunflowers =
-        isSandbox ||
-        !hasSunflowerPrice ||
-        (typeof accountSunflowers === 'number' &&
-            accountSunflowers >= sunflowerPrice);
-    const isPlaceable = isSandbox || hasSunflowerPrice;
+    if (!entityPlacement) return null;
+
+    const {
+        availabilityMessage,
+        hasEnoughSunflowers,
+        hasSunflowerPrice,
+        insufficientSunflowersMessage,
+        isAvailableNow,
+        isPlaceable,
+        sunflowerPrice,
+        canPlace,
+    } = entityPlacement.availability;
 
     function placeEntity() {
-        if (!blockData) {
-            console.warn('Cannot place entity, missing data');
+        if (!canPlace) {
             return;
         }
 
@@ -445,14 +690,6 @@ function PlaceEntityButton({
 
     const errorMessage =
         placeBlock.error instanceof Error ? placeBlock.error.message : null;
-    const availabilityMessage =
-        !isAvailableNow && hasSunflowerPrice ? 'Dostupno samo noću.' : null;
-    const insufficientSunflowersMessage =
-        !hasEnoughSunflowers &&
-        !isAccountLoading &&
-        typeof accountSunflowers === 'number'
-            ? 'Nedovoljno suncokreta.'
-            : null;
 
     return (
         <Stack spacing={1}>
@@ -508,10 +745,15 @@ function PlaceEntityButton({
 
 function EntityItem({ name }: HudItemEntity) {
     const [open, setOpen] = useState(false);
-    const { data: blockData } = useBlockData();
+    const entityPlacement = useHudEntityPlacementState(name);
+    const dragPlacement = useHudEntityDragPlacement({
+        blockName: name,
+        enabled: entityPlacement?.availability.canPlace ?? false,
+    });
 
-    const block = blockData?.find((block) => block.information.name === name);
-    if (!block) return null;
+    if (!entityPlacement) return null;
+
+    const { block } = entityPlacement;
 
     return (
         <Stack spacing={2}>
@@ -519,13 +761,17 @@ function EntityItem({ name }: HudItemEntity) {
                 open={open}
                 sideOffset={12}
                 onOpenChange={(open) => setOpen(open)}
+                data-items-hud-surface="true"
                 className="w-fit p-2 max-w-xs md:w-80 border-tertiary border-b-4"
                 trigger={
                     <IconButton
                         aria-label={block.information.label}
                         size="lg"
-                        className="size-16"
+                        className={cx('size-16', dragPlacement.className)}
                         variant="plain"
+                        data-items-hud-entity={name}
+                        onClick={dragPlacement.onClick}
+                        onPointerDown={dragPlacement.onPointerDown}
                     >
                         <BlockImage
                             blockName={name}
@@ -626,6 +872,7 @@ function PickerItem({ label, items, imageSrc }: HudItemPicker) {
             onOpenChange={(open) => {
                 if (!open) setActiveSubPicker(null);
             }}
+            data-items-hud-surface="true"
             trigger={
                 <IconButton
                     aria-label={label}
@@ -706,6 +953,7 @@ export function ItemsHud() {
     return (
         <HudCard
             data-items-hud
+            data-items-hud-surface="true"
             {...(dropTargetVisible
                 ? {
                       [itemsHudDropTargetAttribute]: 'true',

--- a/packages/game/src/hud/itemPlacementAvailability.ts
+++ b/packages/game/src/hud/itemPlacementAvailability.ts
@@ -1,0 +1,59 @@
+import type { BlockData } from '@gredice/client';
+import { isNightOnlyBlockPurchase, isNightTimeOfDay } from '@gredice/js/blocks';
+
+export type HudEntityPlacementAvailability = {
+    availabilityMessage: string | null;
+    canPlace: boolean;
+    hasEnoughSunflowers: boolean;
+    hasSunflowerPrice: boolean;
+    insufficientSunflowersMessage: string | null;
+    isAvailableNow: boolean;
+    isPlaceable: boolean;
+    sunflowerPrice: number;
+};
+
+export function getHudEntityPlacementAvailability({
+    accountSunflowers,
+    block,
+    isAccountLoading,
+    isSandbox,
+    timeOfDay,
+}: {
+    accountSunflowers: number | null | undefined;
+    block: BlockData;
+    isAccountLoading: boolean;
+    isSandbox: boolean;
+    timeOfDay: number;
+}): HudEntityPlacementAvailability {
+    const sunflowerPrice = block.prices.sunflowers ?? 0;
+    const hasSunflowerPrice = sunflowerPrice > 0;
+    const isAvailableNow =
+        isSandbox ||
+        !isNightOnlyBlockPurchase(block) ||
+        isNightTimeOfDay(timeOfDay);
+    const hasEnoughSunflowers =
+        isSandbox ||
+        !hasSunflowerPrice ||
+        (typeof accountSunflowers === 'number' &&
+            accountSunflowers >= sunflowerPrice);
+    const isPlaceable = isSandbox || hasSunflowerPrice;
+    const availabilityMessage =
+        !isAvailableNow && hasSunflowerPrice ? 'Dostupno samo noću.' : null;
+    const insufficientSunflowersMessage =
+        !hasEnoughSunflowers &&
+        !isAccountLoading &&
+        typeof accountSunflowers === 'number'
+            ? 'Nedovoljno suncokreta.'
+            : null;
+
+    return {
+        availabilityMessage,
+        canPlace: isPlaceable && isAvailableNow && hasEnoughSunflowers,
+        hasEnoughSunflowers,
+        hasSunflowerPrice,
+        insufficientSunflowersMessage,
+        isAvailableNow,
+        isPlaceable,
+        sunflowerPrice,
+    };
+}

--- a/packages/game/src/indicators/PlacementGrid.tsx
+++ b/packages/game/src/indicators/PlacementGrid.tsx
@@ -5,7 +5,9 @@ import { useGameState } from '../useGameState';
 export function PlacementGrid() {
     const isPlacementActive = useGameState(
         (state) =>
-            Boolean(state.pickupBlock) || Boolean(state.activeDragPreview),
+            Boolean(state.pickupBlock) ||
+            Boolean(state.activeDragPreview) ||
+            Boolean(state.hudPlacementDrag),
     );
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const isDay = timeOfDay > 0.2 && timeOfDay < 0.8;

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -68,6 +68,32 @@ export type ActiveDragPreview = {
     isOverRecycler: boolean;
 };
 
+export type HudPlacementDropRequest = {
+    clientX: number;
+    clientY: number;
+    sequence: number;
+};
+
+export type HudPlacementDrag = {
+    blockName: string;
+    clientX: number;
+    clientY: number;
+    dropRequest: HudPlacementDropRequest | null;
+    pointerId: number;
+    pointerType: string;
+    startedAt: number;
+};
+
+export type HudPlacementDragStart = Pick<
+    HudPlacementDrag,
+    'blockName' | 'clientX' | 'clientY' | 'pointerId' | 'pointerType'
+>;
+
+export type HudPlacementPointerUpdate = Pick<
+    HudPlacementDrag,
+    'clientX' | 'clientY' | 'pointerId'
+>;
+
 const activeDragPreviewEpsilon = 0.0001;
 
 function activeDragPreviewNumbersEqual(left: number, right: number) {
@@ -284,6 +310,11 @@ export type GameState = {
     setItemsHudDropTargetActive: (active: boolean) => void;
     activeDragPreview: ActiveDragPreview | null;
     setActiveDragPreview: (dragPreview: ActiveDragPreview | null) => void;
+    hudPlacementDrag: HudPlacementDrag | null;
+    beginHudPlacementDrag: (drag: HudPlacementDragStart) => void;
+    updateHudPlacementDragPointer: (pointer: HudPlacementPointerUpdate) => void;
+    requestHudPlacementDrop: (pointer: HudPlacementPointerUpdate) => void;
+    clearHudPlacementDrag: () => void;
     openGardenBoxBlockId: string | null;
     setOpenGardenBoxBlockId: (blockId: string | null) => void;
     gardenBoxTooltip: GardenBoxTooltip | null;
@@ -558,6 +589,60 @@ export function createGameState({
                     ? state
                     : { activeDragPreview },
             ),
+        hudPlacementDrag: null,
+        beginHudPlacementDrag: (drag) =>
+            set({
+                hudPlacementDrag: {
+                    ...drag,
+                    dropRequest: null,
+                    startedAt: Date.now(),
+                },
+            }),
+        updateHudPlacementDragPointer: (pointer) =>
+            set((state) => {
+                const drag = state.hudPlacementDrag;
+                if (!drag || drag.pointerId !== pointer.pointerId) {
+                    return state;
+                }
+
+                if (
+                    drag.clientX === pointer.clientX &&
+                    drag.clientY === pointer.clientY &&
+                    drag.dropRequest === null
+                ) {
+                    return state;
+                }
+
+                return {
+                    hudPlacementDrag: {
+                        ...drag,
+                        clientX: pointer.clientX,
+                        clientY: pointer.clientY,
+                        dropRequest: null,
+                    },
+                };
+            }),
+        requestHudPlacementDrop: (pointer) =>
+            set((state) => {
+                const drag = state.hudPlacementDrag;
+                if (!drag || drag.pointerId !== pointer.pointerId) {
+                    return state;
+                }
+
+                return {
+                    hudPlacementDrag: {
+                        ...drag,
+                        clientX: pointer.clientX,
+                        clientY: pointer.clientY,
+                        dropRequest: {
+                            clientX: pointer.clientX,
+                            clientY: pointer.clientY,
+                            sequence: (drag.dropRequest?.sequence ?? 0) + 1,
+                        },
+                    },
+                };
+            }),
+        clearHudPlacementDrag: () => set({ hudPlacementDrag: null }),
         openGardenBoxBlockId: null,
         setOpenGardenBoxBlockId: (openGardenBoxBlockId) =>
             set({ openGardenBoxBlockId }),


### PR DESCRIPTION
## Summary

- Add HUD item drag sessions that start from affordable, placeable item icons while preserving click/tap details behavior.
- Add scene-side drag preview/drop handling that reuses existing placement constraints, inventory/sunflower/night/sandbox availability, and the existing place mutation.
- Add focused unit and garden component coverage for exact-position placement, mouse drag, touch cancellation, unaffordable items, and click placement regression.

## Validation

- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter garden lint`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/items-hud.spec.tsx`
- `git diff --check`

Closes #3931