### PR TITLE
feat(www): use login modal for community edits

### DIFF
--- a/apps/www/components/auth/InlineLoginDialog.tsx
+++ b/apps/www/components/auth/InlineLoginDialog.tsx
@@ -26,6 +26,7 @@ type InlineLoginDialogProps = {
     onAuthenticated?: () => void;
     onOpenChange: (open: boolean) => void;
     open: boolean;
+    returnTo?: string;
 };
 
 const oauthCallbackPaths: Record<OAuthProvider, string> = {
@@ -148,6 +149,7 @@ export function InlineLoginDialog({
     onAuthenticated,
     onOpenChange,
     open,
+    returnTo,
 }: InlineLoginDialogProps) {
     const queryClient = useQueryClient();
     const [activeTab, setActiveTab] = useState<AuthTab>('login');
@@ -243,7 +245,10 @@ export function InlineLoginDialog({
             oauthCallbackPaths[provider],
             window.location.origin,
         );
-        callbackUrl.searchParams.set('returnTo', currentReturnPath());
+        callbackUrl.searchParams.set(
+            'returnTo',
+            returnTo ?? currentReturnPath(),
+        );
 
         const authUrl = new URL(
             `/api/auth/${provider}`,

--- a/apps/www/components/community-edits/CommunityEditButton.tsx
+++ b/apps/www/components/community-edits/CommunityEditButton.tsx
@@ -13,7 +13,7 @@ import { cx } from '@gredice/ui/utils';
 import dynamic from 'next/dynamic';
 import { useEffect, useId, useMemo, useState } from 'react';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
-import { KnownPages } from '../../src/KnownPages';
+import { InlineLoginDialog } from '../auth/InlineLoginDialog';
 
 const CommunityMarkdownInput = dynamic(
     () =>
@@ -24,6 +24,9 @@ const CommunityMarkdownInput = dynamic(
         ssr: false,
     },
 );
+
+const communityEditEntityParam = 'communityEditEntity';
+const communityEditSectionParam = 'communityEditSection';
 
 type CommunityEditControlType =
     | 'boolean'
@@ -233,6 +236,51 @@ function isSubmitResponse(value: unknown): value is { requestId: number } {
     );
 }
 
+function communityEditReturnPath({
+    entityKey,
+    fallbackPath,
+    sectionKey,
+}: {
+    entityKey: string;
+    fallbackPath: string;
+    sectionKey: string;
+}) {
+    const url =
+        typeof window === 'undefined'
+            ? new URL(fallbackPath, 'https://www.gredice.com')
+            : new URL(window.location.href);
+
+    url.searchParams.set(communityEditEntityParam, entityKey);
+    if (sectionKey) {
+        url.searchParams.set(communityEditSectionParam, sectionKey);
+    } else {
+        url.searchParams.delete(communityEditSectionParam);
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function currentCommunityEditReturnRequest() {
+    if (typeof window === 'undefined') {
+        return null;
+    }
+
+    const url = new URL(window.location.href);
+    return {
+        entityKey: url.searchParams.get(communityEditEntityParam),
+        sectionKey: url.searchParams.get(communityEditSectionParam) ?? '',
+        clear() {
+            url.searchParams.delete(communityEditEntityParam);
+            url.searchParams.delete(communityEditSectionParam);
+            window.history.replaceState(
+                window.history.state,
+                '',
+                `${url.pathname}${url.search}${url.hash}`,
+            );
+        },
+    };
+}
+
 function FieldInput({
     field,
     id,
@@ -354,6 +402,7 @@ export function CommunityEditButton({
     sectionKey,
 }: CommunityEditButtonProps) {
     const [open, setOpen] = useState(false);
+    const [loginOpen, setLoginOpen] = useState(false);
     const [fields, setFields] = useState<CommunityEditableField[]>([]);
     const [values, setValues] = useState<Record<string, FieldValue>>({});
     const [submitterNote, setSubmitterNote] = useState('');
@@ -365,6 +414,38 @@ export function CommunityEditButton({
     );
     const fieldIdPrefix = useId();
     const { data: user, isLoading: isLoadingUser } = useCurrentUser();
+    const communityEditEntityKey = `${entityTypeName}:${entityId}`;
+    const communityEditSectionKey = sectionKey ?? '';
+    const communityEditReturnTo = useMemo(
+        () =>
+            communityEditReturnPath({
+                entityKey: communityEditEntityKey,
+                fallbackPath: publicPath,
+                sectionKey: communityEditSectionKey,
+            }),
+        [communityEditEntityKey, communityEditSectionKey, publicPath],
+    );
+
+    useEffect(() => {
+        const returnRequest = currentCommunityEditReturnRequest();
+        if (
+            !returnRequest ||
+            returnRequest.entityKey !== communityEditEntityKey ||
+            returnRequest.sectionKey !== communityEditSectionKey
+        ) {
+            return;
+        }
+
+        setOpen(true);
+        setLoginOpen(false);
+        returnRequest.clear();
+    }, [communityEditEntityKey, communityEditSectionKey]);
+
+    useEffect(() => {
+        if (!open) {
+            setLoginOpen(false);
+        }
+    }, [open]);
 
     useEffect(() => {
         if (!open || !user) {
@@ -543,9 +624,23 @@ export function CommunityEditButton({
                         <Typography level="body2">
                             Za slanje prijedloga treba se prijaviti.
                         </Typography>
-                        <Button href={KnownPages.GardenApp} variant="outlined">
-                            Prijavi se u vrt
+                        <Button
+                            onClick={() => setLoginOpen(true)}
+                            type="button"
+                            variant="outlined"
+                        >
+                            Prijavi se i nastavi
                         </Button>
+                        <InlineLoginDialog
+                            description="Prijavi se za slanje prijedloga i nastavi uređivati ovu sekciju."
+                            onAuthenticated={() => {
+                                setLoginOpen(false);
+                                setOpen(true);
+                            }}
+                            onOpenChange={setLoginOpen}
+                            open={loginOpen}
+                            returnTo={communityEditReturnTo}
+                        />
                     </Stack>
                 ) : successRequestId ? (
                     <Stack spacing={2}>

--- a/apps/www/tests/community-edit-button.spec.tsx
+++ b/apps/www/tests/community-edit-button.spec.tsx
@@ -6,6 +6,9 @@ test('prompts anonymous users before editing', async ({ mount, page }) => {
     await page.route('**/api/gredice/api/auth/current-claims', (route) =>
         route.fulfill({ status: 401, json: { error: 'Unauthorized' } }),
     );
+    await page.route('**/api/gredice/api/auth/last-login', (route) =>
+        route.fulfill({ status: 200, json: { provider: null } }),
+    );
 
     await mount(
         <CommunityEditButtonHarness
@@ -21,6 +24,139 @@ test('prompts anonymous users before editing', async ({ mount, page }) => {
     await expect(
         page.getByText('Za slanje prijedloga treba se prijaviti.'),
     ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Prijavi se i nastavi' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Prijavi se u vrt' }),
+    ).toHaveCount(0);
+});
+
+test('loads the same edit context after inline email login', async ({
+    mount,
+    page,
+}) => {
+    let authenticated = false;
+    await page.route('**/api/gredice/api/auth/current-claims', (route) => {
+        if (!authenticated) {
+            return route.fulfill({
+                status: 401,
+                json: { error: 'Unauthorized' },
+            });
+        }
+
+        return route.fulfill({
+            status: 200,
+            json: {
+                id: 'user-1',
+                userName: 'ana',
+                displayName: 'Ana',
+            },
+        });
+    });
+    await page.route('**/api/gredice/api/auth/last-login', (route) =>
+        route.fulfill({ status: 200, json: { provider: null } }),
+    );
+    await page.route('**/api/gredice/api/auth/login', (route) => {
+        authenticated = true;
+        return route.fulfill({ status: 200, json: { ok: true } });
+    });
+    await page.route(
+        '**/api/gredice/api/directories/community-edits/entities/plant/1/fields**',
+        (route) =>
+            route.fulfill({
+                status: 200,
+                json: {
+                    entityTypeName: 'plant',
+                    entityId: 1,
+                    sectionKey: 'overview',
+                    fields: [
+                        {
+                            entityTypeName: 'plant',
+                            entityId: 1,
+                            fieldKey: 'plant.description',
+                            sectionKey: 'overview',
+                            attributeDefinitionId: 10,
+                            attributeValueId: 20,
+                            attributePath: 'information.description',
+                            dataType: 'text',
+                            controlType: 'text',
+                            multiple: false,
+                            publicLabel: 'Opis biljke',
+                            currentValue: 'Stari opis',
+                            baseValueHash: 'hash-1',
+                        },
+                    ],
+                },
+            }),
+    );
+
+    await mount(
+        <CommunityEditButtonHarness
+            entityTypeName="plant"
+            entityId={1}
+            publicPath="/biljke/rajcica"
+            sectionKey="overview"
+        />,
+    );
+
+    await page.getByTitle('Predloži izmjenu').click();
+    await page.getByRole('button', { name: 'Prijavi se i nastavi' }).click();
+    await expect(
+        page.getByRole('button', { name: 'Google prijava' }),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Email prijava' }).click();
+    await page.locator('#inline-login-email').fill('ana@example.com');
+    await page.locator('#inline-login-password').fill('tajna-lozinka');
+    await page.getByRole('button', { name: 'Prijavi se' }).click();
+
+    await expect(page.getByLabel('Opis biljke')).toHaveValue('Stari opis');
+});
+
+test('preserves the community edit context in OAuth return paths', async ({
+    mount,
+    page,
+}) => {
+    const authRequestPattern = 'http://localhost:3005/api/auth/google**';
+    await page.route('**/api/gredice/api/auth/current-claims', (route) =>
+        route.fulfill({ status: 401, json: { error: 'Unauthorized' } }),
+    );
+    await page.route('**/api/gredice/api/auth/last-login', (route) =>
+        route.fulfill({ status: 200, json: { provider: null } }),
+    );
+    await page.route(authRequestPattern, (route) =>
+        route.fulfill({ status: 204 }),
+    );
+
+    await mount(
+        <CommunityEditButtonHarness
+            entityTypeName="plant"
+            entityId={1}
+            publicPath="/biljke/rajcica"
+            sectionKey="overview"
+        />,
+    );
+
+    await page.getByTitle('Predloži izmjenu').click();
+    await page.getByRole('button', { name: 'Prijavi se i nastavi' }).click();
+    const authRequestPromise = page.waitForRequest(authRequestPattern);
+
+    await page.getByRole('button', { name: 'Google prijava' }).click();
+
+    const authRequest = await authRequestPromise;
+    const authUrl = new URL(authRequest.url());
+    const redirect = authUrl.searchParams.get('redirect');
+    expect(redirect).not.toBeNull();
+
+    if (!redirect) {
+        throw new Error('Expected OAuth redirect query parameter.');
+    }
+
+    const returnTo = new URL(redirect).searchParams.get('returnTo');
+    expect(returnTo).not.toBeNull();
+    expect(returnTo).toContain('communityEditEntity=plant%3A1');
+    expect(returnTo).toContain('communityEditSection=overview');
 });
 
 test('submits a changed section edit for authenticated users', async ({


### PR DESCRIPTION
## Summary
- replace the community edit garden-app login link with the shared www login dialog
- keep email login inside the edit modal and reload editable fields after authentication
- preserve entity and section context through OAuth return URLs so the same edit modal reopens after social login

Closes #3942

## Validation
- `corepack pnpm --dir apps/www exec biome check --write components/auth/InlineLoginDialog.tsx components/community-edits/CommunityEditButton.tsx tests/community-edit-button.spec.tsx`
- `corepack pnpm --filter www typecheck`
- `corepack pnpm --dir apps/www run test:prepare` (build completed; external api.gredice.com DNS fetches logged ENOTFOUND warnings while static fallback paths continued)
- `corepack pnpm --dir apps/www exec playwright test --project=chromium tests/community-edit-button.spec.tsx`
- `git diff --check`