### PR TITLE
feat(www): suggest plant stage operations

### DIFF
--- a/apps/api/lib/docs/openApiDocs.ts
+++ b/apps/api/lib/docs/openApiDocs.ts
@@ -1005,6 +1005,7 @@ export async function openApiDocs(
                         'json',
                         'markdown',
                         'number',
+                        'operationSuggestion',
                         'range',
                         'reference',
                         'select',
@@ -1024,6 +1025,14 @@ export async function openApiDocs(
                             label: { type: 'string' },
                             helpText: { type: 'string' },
                         },
+                    },
+                },
+                operationSuggestionStage: {
+                    type: 'object',
+                    required: ['name', 'label'],
+                    properties: {
+                        name: { type: 'string' },
+                        label: { type: 'string' },
                     },
                 },
                 currentValue: { type: ['string', 'null'] },
@@ -1052,7 +1061,7 @@ export async function openApiDocs(
                 fieldKey: { type: 'string' },
                 proposedValue: {
                     description:
-                        'Serialized proposed value. Type is validated against the editable field registry. Text and markdown submissions are stored with replayable patches so non-overlapping edits on the same attribute can be approved later.',
+                        'Serialized proposed value. Type is validated against the editable field registry. Text and markdown submissions are stored with replayable patches so non-overlapping edits on the same attribute can be approved later. Operation suggestions use a structured add/remove intent for a plant-stage operation.',
                 },
                 baseValueHash: {
                     type: ['string', 'null'],

--- a/apps/app/app/admin/community-edits/[requestId]/page.tsx
+++ b/apps/app/app/admin/community-edits/[requestId]/page.tsx
@@ -37,6 +37,18 @@ type CompactTextDiff = {
     added: string;
 };
 
+type CommunityOperationSuggestionValue = {
+    format: 'community-operation-suggestion-v1';
+    intent: 'add' | 'remove';
+    operationId: number;
+    operationLabel: string;
+    stageName: string;
+    stageLabel: string;
+    currentState: 'absent' | 'present';
+    note?: string;
+    source?: string;
+};
+
 function statusLabel(status: CommunityEditRequestStatus) {
     switch (status) {
         case 'pending':
@@ -123,6 +135,60 @@ function parseCompactTextDiff(reviewDiff: string | null) {
     }
 }
 
+function isCommunityOperationSuggestion(
+    value: unknown,
+): value is CommunityOperationSuggestionValue {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'format' in value &&
+        value.format === 'community-operation-suggestion-v1' &&
+        'intent' in value &&
+        (value.intent === 'add' || value.intent === 'remove') &&
+        'operationId' in value &&
+        typeof value.operationId === 'number' &&
+        'operationLabel' in value &&
+        typeof value.operationLabel === 'string' &&
+        'stageName' in value &&
+        typeof value.stageName === 'string' &&
+        'stageLabel' in value &&
+        typeof value.stageLabel === 'string' &&
+        'currentState' in value &&
+        (value.currentState === 'absent' || value.currentState === 'present')
+    );
+}
+
+function parseCommunityOperationSuggestion(value: string | null) {
+    if (!value) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(value);
+        return isCommunityOperationSuggestion(parsed) ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+function operationSuggestionIntentLabel(intent: 'add' | 'remove') {
+    switch (intent) {
+        case 'add':
+            return 'Dodaj radnju';
+        case 'remove':
+            return 'Ukloni radnju';
+    }
+}
+
+function operationSuggestionStateLabel(state: 'absent' | 'present') {
+    switch (state) {
+        case 'absent':
+            return 'Radnja nije bila povezana';
+        case 'present':
+            return 'Radnja je bila povezana';
+    }
+}
+
 function ValueBlock({ label, value }: { label: string; value: string | null }) {
     return (
         <Stack spacing={1} className="min-w-0">
@@ -136,6 +202,58 @@ function ValueBlock({ label, value }: { label: string; value: string | null }) {
                     {value}
                 </pre>
             )}
+        </Stack>
+    );
+}
+
+function OperationSuggestionBlock({
+    suggestion,
+}: {
+    suggestion: CommunityOperationSuggestionValue;
+}) {
+    return (
+        <Stack spacing={3}>
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                <DetailItem label="Namjera">
+                    <Chip
+                        color={
+                            suggestion.intent === 'add' ? 'success' : 'warning'
+                        }
+                        variant="soft"
+                    >
+                        {operationSuggestionIntentLabel(suggestion.intent)}
+                    </Chip>
+                </DetailItem>
+                <DetailItem label="Stadij">
+                    <Typography>
+                        {suggestion.stageLabel} ({suggestion.stageName})
+                    </Typography>
+                </DetailItem>
+                <DetailItem label="Radnja">
+                    <Typography>
+                        {suggestion.operationLabel} #{suggestion.operationId}
+                    </Typography>
+                </DetailItem>
+                <DetailItem label="Stanje pri slanju">
+                    <Typography>
+                        {operationSuggestionStateLabel(suggestion.currentState)}
+                    </Typography>
+                </DetailItem>
+            </div>
+            {suggestion.source ? (
+                <DetailItem label="Izvor">
+                    <Typography className="whitespace-pre-line break-words">
+                        {suggestion.source}
+                    </Typography>
+                </DetailItem>
+            ) : null}
+            {suggestion.note ? (
+                <DetailItem label="Napomena">
+                    <Typography className="whitespace-pre-line">
+                        {suggestion.note}
+                    </Typography>
+                </DetailItem>
+            ) : null}
         </Stack>
     );
 }
@@ -173,6 +291,25 @@ function DiffBlock({ change }: { change: CommunityEditChange }) {
                 Zajednički početak: {diff.prefixLength} znakova, zajednički
                 kraj: {diff.suffixLength} znakova.
             </Typography>
+        </Stack>
+    );
+}
+
+function ChangeBody({ change }: { change: CommunityEditChange }) {
+    const operationSuggestion = parseCommunityOperationSuggestion(
+        change.proposedValue,
+    );
+    if (operationSuggestion) {
+        return <OperationSuggestionBlock suggestion={operationSuggestion} />;
+    }
+
+    return (
+        <Stack spacing={4}>
+            <div className="grid gap-4 lg:grid-cols-2">
+                <ValueBlock label="Trenutno" value={change.previousValue} />
+                <ValueBlock label="Predloženo" value={change.proposedValue} />
+            </div>
+            <DiffBlock change={change} />
         </Stack>
     );
 }
@@ -430,19 +567,7 @@ export default async function CommunityEditDetailPage({
                             </Typography>
                         </CardHeader>
                         <CardContent>
-                            <Stack spacing={4}>
-                                <div className="grid gap-4 lg:grid-cols-2">
-                                    <ValueBlock
-                                        label="Trenutno"
-                                        value={change.previousValue}
-                                    />
-                                    <ValueBlock
-                                        label="Predloženo"
-                                        value={change.proposedValue}
-                                    />
-                                </div>
-                                <DiffBlock change={change} />
-                            </Stack>
+                            <ChangeBody change={change} />
                         </CardContent>
                     </Card>
                 ))}

--- a/apps/www/components/community-edits/CommunityEditButton.tsx
+++ b/apps/www/components/community-edits/CommunityEditButton.tsx
@@ -33,6 +33,7 @@ type CommunityEditControlType =
     | 'json'
     | 'markdown'
     | 'number'
+    | 'operationSuggestion'
     | 'range'
     | 'reference'
     | 'select'
@@ -58,8 +59,29 @@ type CommunityEditableField = {
     publicLabel: string;
     helpText?: string;
     options?: CommunityEditableFieldOption[];
+    operationSuggestionStage?: {
+        name: string;
+        label: string;
+    };
     currentValue: string | null;
     baseValueHash: string;
+};
+
+type OperationSuggestionIntent = 'add' | 'remove';
+
+type OperationSuggestionFieldValue = {
+    intent: OperationSuggestionIntent;
+    operationId: string;
+    note: string;
+    source: string;
+};
+
+type OperationSuggestionSubmitValue = {
+    intent: OperationSuggestionIntent;
+    operationId: number;
+    stageName: string;
+    note?: string | null;
+    source?: string | null;
 };
 
 type FieldValue =
@@ -68,6 +90,7 @@ type FieldValue =
           min: string;
           max: string;
       }
+    | OperationSuggestionFieldValue
     | null;
 
 type SubmitValue =
@@ -76,6 +99,7 @@ type SubmitValue =
           min: number;
           max: number;
       }
+    | OperationSuggestionSubmitValue
     | null;
 
 type ButtonStyle = 'button' | 'icon';
@@ -91,6 +115,15 @@ export type CommunityEditButtonProps = {
 };
 
 function initialFieldValue(field: CommunityEditableField): FieldValue {
+    if (field.controlType === 'operationSuggestion') {
+        return {
+            intent: 'add',
+            operationId: '',
+            note: '',
+            source: '',
+        };
+    }
+
     if (field.controlType === 'range') {
         if (!field.currentValue) {
             return { min: '', max: '' };
@@ -123,6 +156,55 @@ function initialFieldValue(field: CommunityEditableField): FieldValue {
     return field.currentValue ?? '';
 }
 
+function isOperationSuggestionValue(
+    value: FieldValue,
+): value is OperationSuggestionFieldValue {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'intent' in value &&
+        (value.intent === 'add' || value.intent === 'remove') &&
+        'operationId' in value &&
+        typeof value.operationId === 'string'
+    );
+}
+
+function operationIdsFromCurrentValue(field: CommunityEditableField) {
+    if (!field.currentValue) {
+        return new Set<string>();
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(field.currentValue);
+        if (!Array.isArray(parsed)) {
+            return new Set<string>();
+        }
+
+        return new Set(
+            parsed
+                .filter(
+                    (entry): entry is string | number =>
+                        typeof entry === 'string' || typeof entry === 'number',
+                )
+                .map(String),
+        );
+    } catch {
+        return new Set<string>();
+    }
+}
+
+function operationSuggestionOptionsForIntent(
+    field: CommunityEditableField,
+    intent: OperationSuggestionIntent,
+) {
+    const currentOperationIds = operationIdsFromCurrentValue(field);
+    return (field.options ?? []).filter((option) =>
+        intent === 'add'
+            ? !currentOperationIds.has(option.value)
+            : currentOperationIds.has(option.value),
+    );
+}
+
 function normalizeJsonValue(value: string) {
     const trimmed = value.trim();
     if (!trimmed) {
@@ -140,8 +222,46 @@ function serializeFieldValue(
     field: CommunityEditableField,
     value: FieldValue,
 ): { comparisonValue: string | null; submitValue: SubmitValue } {
+    if (field.controlType === 'operationSuggestion') {
+        if (!isOperationSuggestionValue(value) || !value.operationId) {
+            return {
+                comparisonValue: field.currentValue,
+                submitValue: null,
+            };
+        }
+
+        const operationId = Number.parseInt(value.operationId, 10);
+        const selectedOption = operationSuggestionOptionsForIntent(
+            field,
+            value.intent,
+        ).some((option) => option.value === value.operationId);
+        if (!Number.isInteger(operationId) || !selectedOption) {
+            return {
+                comparisonValue: field.currentValue,
+                submitValue: null,
+            };
+        }
+
+        const submitValue: OperationSuggestionSubmitValue = {
+            intent: value.intent,
+            operationId,
+            stageName: field.operationSuggestionStage?.name ?? field.sectionKey,
+            note: value.note.trim() || null,
+            source: value.source.trim() || null,
+        };
+
+        return {
+            comparisonValue: JSON.stringify(submitValue),
+            submitValue,
+        };
+    }
+
     if (field.controlType === 'range') {
-        if (!value || typeof value === 'string') {
+        if (
+            !value ||
+            typeof value === 'string' ||
+            isOperationSuggestionValue(value)
+        ) {
             return { comparisonValue: null, submitValue: null };
         }
 
@@ -312,6 +432,108 @@ function FieldInput({
     onChange: (value: FieldValue) => void;
     value: FieldValue;
 }) {
+    if (field.controlType === 'operationSuggestion') {
+        const suggestionValue = isOperationSuggestionValue(value)
+            ? value
+            : {
+                  intent: 'add' as const,
+                  operationId: '',
+                  note: '',
+                  source: '',
+              };
+        const operationOptions = operationSuggestionOptionsForIntent(
+            field,
+            suggestionValue.intent,
+        );
+
+        return (
+            <Stack spacing={2}>
+                <div className="grid gap-2 sm:grid-cols-2">
+                    <label className="space-y-1" htmlFor={`${id}-intent`}>
+                        <Typography level="body3">Namjera</Typography>
+                        <select
+                            className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                            id={`${id}-intent`}
+                            onChange={(event) =>
+                                onChange({
+                                    ...suggestionValue,
+                                    intent: event.currentTarget
+                                        .value as OperationSuggestionIntent,
+                                    operationId: '',
+                                })
+                            }
+                            value={suggestionValue.intent}
+                        >
+                            <option value="add">Dodaj radnju</option>
+                            <option value="remove">Ukloni radnju</option>
+                        </select>
+                    </label>
+                    <label className="space-y-1" htmlFor={`${id}-operation`}>
+                        <Typography level="body3">Radnja</Typography>
+                        <select
+                            className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                            disabled={operationOptions.length === 0}
+                            id={`${id}-operation`}
+                            onChange={(event) =>
+                                onChange({
+                                    ...suggestionValue,
+                                    operationId: event.currentTarget.value,
+                                })
+                            }
+                            value={
+                                operationOptions.some(
+                                    (option) =>
+                                        option.value ===
+                                        suggestionValue.operationId,
+                                )
+                                    ? suggestionValue.operationId
+                                    : ''
+                            }
+                        >
+                            <option value="">
+                                {operationOptions.length > 0
+                                    ? 'Odaberi radnju'
+                                    : 'Nema dostupnih radnji'}
+                            </option>
+                            {operationOptions.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                </div>
+                <Input
+                    id={`${id}-source`}
+                    label="Izvor"
+                    onChange={(event) =>
+                        onChange({
+                            ...suggestionValue,
+                            source: event.currentTarget.value,
+                        })
+                    }
+                    placeholder="Poveznica, knjiga ili opažanje..."
+                    value={suggestionValue.source}
+                />
+                <label className="space-y-1" htmlFor={`${id}-note`}>
+                    <Typography level="body3">Napomena</Typography>
+                    <textarea
+                        className="min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        id={`${id}-note`}
+                        onChange={(event) =>
+                            onChange({
+                                ...suggestionValue,
+                                note: event.currentTarget.value,
+                            })
+                        }
+                        placeholder="Zašto predlažeš ovu promjenu?"
+                        value={suggestionValue.note}
+                    />
+                </label>
+            </Stack>
+        );
+    }
+
     if (field.controlType === 'markdown') {
         return (
             <CommunityMarkdownInput
@@ -371,7 +593,9 @@ function FieldInput({
 
     if (field.controlType === 'range') {
         const rangeValue =
-            value && typeof value !== 'string'
+            value &&
+            typeof value !== 'string' &&
+            !isOperationSuggestionValue(value)
                 ? value
                 : {
                       min: '',

--- a/packages/storage/src/helpers/communityEditableFields.ts
+++ b/packages/storage/src/helpers/communityEditableFields.ts
@@ -3,6 +3,7 @@ export type CommunityEditControlType =
     | 'json'
     | 'markdown'
     | 'number'
+    | 'operationSuggestion'
     | 'range'
     | 'reference'
     | 'select'
@@ -27,6 +28,7 @@ export type CommunityEditableFieldDefinition = {
     inline: boolean;
     allowJson?: boolean;
     maxLength?: number;
+    operationSuggestionStage?: CommunityEditableOperationSuggestionStage;
     options?: CommunityEditableFieldOption[];
 };
 
@@ -35,6 +37,35 @@ export type CommunityEditableSection = {
     label: string;
     fields: CommunityEditableFieldDefinition[];
 };
+
+export type CommunityEditableOperationSuggestionStage = {
+    name: string;
+    label: string;
+};
+
+export const communityEditablePlantOperationStages: CommunityEditableOperationSuggestionStage[] =
+    [
+        { name: 'sowing', label: 'Sjetva' },
+        { name: 'growth', label: 'Rast' },
+        { name: 'watering', label: 'Zalijevanje' },
+        { name: 'harvest', label: 'Berba' },
+    ];
+
+const communityEditablePlantOperationFields: CommunityEditableFieldDefinition[] =
+    communityEditablePlantOperationStages.map((stage) => ({
+        entityTypeName: 'plant',
+        fieldKey: `plant.stage-operations.${stage.name}`,
+        sectionKey: stage.name,
+        category: 'information',
+        name: 'operations',
+        publicLabel: `Radnje: ${stage.label}`,
+        helpText:
+            'Predloži dodavanje ili uklanjanje radnje koja se prikazuje u ovoj fazi biljke.',
+        controlType: 'operationSuggestion',
+        pageLevel: true,
+        inline: true,
+        operationSuggestionStage: stage,
+    }));
 
 const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
     {
@@ -383,6 +414,7 @@ const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
         pageLevel: true,
         inline: true,
     },
+    ...communityEditablePlantOperationFields,
     {
         entityTypeName: 'plantSort',
         fieldKey: 'plant-sort.name',

--- a/packages/storage/src/repositories/communityEditRequestsRepo.ts
+++ b/packages/storage/src/repositories/communityEditRequestsRepo.ts
@@ -23,7 +23,7 @@ import {
     flushAttributeValueMutationSideEffects,
     upsertAttributeValue,
 } from './attributeValuesRepo';
-import { getEntityRaw } from './entitiesRepo';
+import { getEntitiesRaw, getEntityRaw } from './entitiesRepo';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = Parameters<
@@ -79,6 +79,7 @@ export type CommunityEditableFieldSnapshot = {
     publicLabel: string;
     helpText?: string;
     options?: CommunityEditableFieldDefinition['options'];
+    operationSuggestionStage?: CommunityEditableFieldDefinition['operationSuggestionStage'];
     currentValue: string | null;
     baseValueHash: string;
 };
@@ -98,6 +99,20 @@ export type CreateCommunityEditRequestInput = {
 };
 
 type EntityRaw = NonNullable<Awaited<ReturnType<typeof getEntityRaw>>>;
+
+export type CommunityOperationSuggestionIntent = 'add' | 'remove';
+
+export type CommunityOperationSuggestionValue = {
+    format: 'community-operation-suggestion-v1';
+    intent: CommunityOperationSuggestionIntent;
+    operationId: number;
+    operationLabel: string;
+    stageName: string;
+    stageLabel: string;
+    currentState: 'absent' | 'present';
+    note?: string;
+    source?: string;
+};
 
 type ResolvedCommunityEditChange = {
     fieldKey: string;
@@ -147,6 +162,54 @@ function stableValueHash(value: string | null) {
         .digest('hex');
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function rawAttributeValue(entity: EntityRaw, category: string, name: string) {
+    return (
+        entity.attributes.find(
+            (attribute) =>
+                !attribute.isDeleted &&
+                attribute.attributeDefinition.category === category &&
+                attribute.attributeDefinition.name === name,
+        )?.value ?? null
+    );
+}
+
+function entityLabel(entity: EntityRaw) {
+    return (
+        rawAttributeValue(entity, 'information', 'label') ??
+        rawAttributeValue(entity, 'information', 'name') ??
+        `${entity.entityType.label} ${entity.id}`
+    );
+}
+
+function booleanAttributeValue(value: string | null) {
+    return value === 'true';
+}
+
+function operationIdsFromSerializedValue(value: string | null) {
+    if (!value) {
+        return new Set<string>();
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(value);
+        if (!Array.isArray(parsed)) {
+            return new Set<string>();
+        }
+
+        return new Set(
+            parsed
+                .map(normalizeReferenceId)
+                .filter((entry): entry is string => Boolean(entry)),
+        );
+    } catch {
+        return new Set<string>();
+    }
+}
+
 function activeAttributeValues(
     entity: EntityRaw,
     attributeDefinitionId: number,
@@ -187,6 +250,8 @@ function controlTypeMatchesDataType(
             return dataType === 'markdown';
         case 'number':
             return dataType === 'number';
+        case 'operationSuggestion':
+            return dataType === 'ref:operation';
         case 'range':
             return dataType === 'range' || dataType.startsWith('range|');
         case 'reference':
@@ -259,6 +324,12 @@ function resolveFieldSnapshot(
             `Field ${field.fieldKey} cannot use select for multiple values.`,
         );
     }
+    if (field.controlType === 'operationSuggestion' && !definition.multiple) {
+        throw new CommunityEditRequestError(
+            'unsupported_data_type',
+            `Field ${field.fieldKey} must be backed by a multiple operation reference.`,
+        );
+    }
 
     const values = activeAttributeValues(entity, definition.id);
     const currentValue = serializedCurrentValue(values, definition.multiple);
@@ -277,6 +348,7 @@ function resolveFieldSnapshot(
         publicLabel: field.publicLabel,
         helpText: field.helpText,
         options: field.options,
+        operationSuggestionStage: field.operationSuggestionStage,
         currentValue,
         baseValueHash: stableValueHash(currentValue),
     };
@@ -297,6 +369,92 @@ async function getCommunityEditableEntity(
     return entity;
 }
 
+async function plantStageInfoById() {
+    const stages = (await getEntitiesRaw(
+        'plantStage',
+        'published',
+    )) as EntityRaw[];
+
+    return new Map(
+        stages.map((stage) => [
+            stage.id,
+            {
+                name: rawAttributeValue(stage, 'information', 'name'),
+                label:
+                    rawAttributeValue(stage, 'information', 'label') ??
+                    rawAttributeValue(stage, 'information', 'name') ??
+                    `Stadij ${stage.id}`,
+            },
+        ]),
+    );
+}
+
+function operationStageInfo(
+    operation: EntityRaw,
+    stagesById: Awaited<ReturnType<typeof plantStageInfoById>>,
+) {
+    const stageId = normalizeReferenceId(
+        rawAttributeValue(operation, 'attributes', 'stage'),
+    );
+    if (!stageId) {
+        return null;
+    }
+
+    const stage = stagesById.get(Number.parseInt(stageId, 10));
+    return stage?.name ? stage : null;
+}
+
+async function operationSuggestionOptions(
+    field: CommunityEditableFieldDefinition,
+) {
+    if (
+        field.controlType !== 'operationSuggestion' ||
+        !field.operationSuggestionStage
+    ) {
+        return field.options;
+    }
+
+    const [operations, stagesById] = await Promise.all([
+        getEntitiesRaw('operation', 'published') as Promise<EntityRaw[]>,
+        plantStageInfoById(),
+    ]);
+
+    return operations
+        .filter((operation) => {
+            const stage = operationStageInfo(operation, stagesById);
+            return (
+                operation.entityTypeName === 'operation' &&
+                rawAttributeValue(operation, 'attributes', 'application') ===
+                    'plant' &&
+                !booleanAttributeValue(
+                    rawAttributeValue(operation, 'attributes', 'internal'),
+                ) &&
+                stage?.name === field.operationSuggestionStage?.name
+            );
+        })
+        .map((operation) => ({
+            value: String(operation.id),
+            label: entityLabel(operation),
+            helpText: field.operationSuggestionStage?.label,
+        }))
+        .sort((left, right) => left.label.localeCompare(right.label, 'hr'));
+}
+
+async function resolveFieldSnapshotForResponse(
+    entity: EntityRaw,
+    field: CommunityEditableFieldDefinition,
+) {
+    const snapshot = resolveFieldSnapshot(entity, field);
+    if (field.controlType !== 'operationSuggestion') {
+        return snapshot;
+    }
+
+    return {
+        ...snapshot,
+        options: await operationSuggestionOptions(field),
+    };
+}
+
 export async function getCommunityEditableFieldsForEntity(input: {
     entityTypeName: string;
     entityId: number;
@@ -307,19 +465,24 @@ export async function getCommunityEditableFieldsForEntity(input: {
         input.entityId,
     );
 
-    return getCommunityEditableFieldDefinitions(
-        input.entityTypeName,
-        input.sectionKey,
-    ).flatMap((field) => {
-        try {
-            return [resolveFieldSnapshot(entity, field)];
-        } catch (error) {
-            if (error instanceof CommunityEditRequestError) {
-                return [];
+    const fields = await Promise.all(
+        getCommunityEditableFieldDefinitions(
+            input.entityTypeName,
+            input.sectionKey,
+        ).map(async (field) => {
+            try {
+                return await resolveFieldSnapshotForResponse(entity, field);
+            } catch (error) {
+                if (error instanceof CommunityEditRequestError) {
+                    return null;
+                }
+                throw error;
             }
-            throw error;
-        }
-    });
+        }),
+    );
+    return fields.filter(
+        (field): field is CommunityEditableFieldSnapshot => field !== null,
+    );
 }
 
 function normalizeNullableString(value: string, maxLength?: number) {
@@ -520,6 +683,195 @@ function normalizeJsonValue(
     return JSON.stringify(value);
 }
 
+function normalizeOptionalSuggestionText(
+    value: unknown,
+    fieldLabel: string,
+    maxLength: number,
+) {
+    if (value === null || typeof value === 'undefined') {
+        return undefined;
+    }
+    if (typeof value !== 'string') {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            `${fieldLabel} must be text.`,
+        );
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    if (trimmed.length > maxLength) {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            `${fieldLabel} must be ${maxLength} characters or fewer.`,
+        );
+    }
+
+    return trimmed;
+}
+
+function normalizeOperationSuggestionIntent(
+    value: unknown,
+): CommunityOperationSuggestionIntent {
+    if (value === 'add' || value === 'remove') {
+        return value;
+    }
+
+    throw new CommunityEditRequestError(
+        'invalid_value',
+        'Operation suggestion must choose add or remove.',
+    );
+}
+
+function normalizeOperationSuggestionOperationId(value: unknown) {
+    const normalized = normalizeReferenceId(value);
+    if (!normalized) {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            'Operation suggestion must include an operation ID.',
+        );
+    }
+
+    return Number.parseInt(normalized, 10);
+}
+
+async function resolveOperationSuggestionTarget(input: {
+    operationId: number;
+    stage: NonNullable<
+        CommunityEditableFieldDefinition['operationSuggestionStage']
+    >;
+}) {
+    const operation = await getEntityRaw(input.operationId);
+    if (
+        operation?.entityTypeName !== 'operation' ||
+        operation.state !== 'published'
+    ) {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            `Operation ${input.operationId} is not a published operation.`,
+        );
+    }
+
+    if (rawAttributeValue(operation, 'attributes', 'application') !== 'plant') {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            'Operation suggestions can only use operations applied to a plant.',
+        );
+    }
+
+    if (
+        booleanAttributeValue(
+            rawAttributeValue(operation, 'attributes', 'internal'),
+        )
+    ) {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            'Internal operations cannot be suggested for public plant pages.',
+        );
+    }
+
+    const stage = operationStageInfo(operation, await plantStageInfoById());
+    if (stage?.name !== input.stage.name) {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            `Operation ${input.operationId} does not belong to the ${input.stage.label} stage.`,
+        );
+    }
+
+    return {
+        operationLabel: entityLabel(operation),
+        stageName: stage.name,
+        stageLabel: stage.label,
+    };
+}
+
+async function normalizeOperationSuggestionValue(
+    value: unknown,
+    field: CommunityEditableFieldDefinition,
+    snapshot: CommunityEditableFieldSnapshot,
+) {
+    if (!field.operationSuggestionStage) {
+        throw new CommunityEditRequestError(
+            'unsupported_data_type',
+            `Field ${field.fieldKey} is missing operation suggestion stage metadata.`,
+        );
+    }
+
+    if (!snapshot.multiple || snapshot.dataType !== 'ref:operation') {
+        throw new CommunityEditRequestError(
+            'unsupported_data_type',
+            `Field ${field.fieldKey} must be backed by multiple operation references.`,
+        );
+    }
+
+    if (!isRecord(value)) {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            `Field ${field.fieldKey} expects an operation suggestion.`,
+        );
+    }
+
+    const stageName =
+        typeof value.stageName === 'string'
+            ? value.stageName
+            : field.operationSuggestionStage.name;
+    if (stageName !== field.operationSuggestionStage.name) {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            `Field ${field.fieldKey} only accepts ${field.operationSuggestionStage.label} suggestions.`,
+        );
+    }
+
+    const intent = normalizeOperationSuggestionIntent(value.intent);
+    const operationId = normalizeOperationSuggestionOperationId(
+        value.operationId,
+    );
+    const target = await resolveOperationSuggestionTarget({
+        operationId,
+        stage: field.operationSuggestionStage,
+    });
+    const currentOperationIds = operationIdsFromSerializedValue(
+        snapshot.currentValue,
+    );
+    const currentState = currentOperationIds.has(String(operationId))
+        ? 'present'
+        : 'absent';
+    if (intent === 'add' && currentState === 'present') {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            `${target.operationLabel} is already linked to this plant.`,
+        );
+    }
+    if (intent === 'remove' && currentState === 'absent') {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            `${target.operationLabel} is not linked to this plant.`,
+        );
+    }
+
+    const suggestion: CommunityOperationSuggestionValue = {
+        format: 'community-operation-suggestion-v1',
+        intent,
+        operationId,
+        operationLabel: target.operationLabel,
+        stageName: target.stageName,
+        stageLabel: target.stageLabel,
+        currentState,
+    };
+    const note = normalizeOptionalSuggestionText(value.note, 'Note', 1000);
+    const source = normalizeOptionalSuggestionText(value.source, 'Source', 500);
+    if (note) {
+        suggestion.note = note;
+    }
+    if (source) {
+        suggestion.source = source;
+    }
+
+    return JSON.stringify(suggestion);
+}
+
 function normalizeSelectValue(
     value: unknown,
     field: CommunityEditableFieldDefinition,
@@ -556,7 +908,7 @@ function normalizeSelectValue(
     }
 }
 
-function normalizeProposedValue(
+async function normalizeProposedValue(
     value: unknown,
     field: CommunityEditableFieldDefinition,
     snapshot: CommunityEditableFieldSnapshot,
@@ -571,6 +923,12 @@ function normalizeProposedValue(
             return normalizeTextValue(value, field);
         case 'number':
             return normalizeNumberValue(value, field);
+        case 'operationSuggestion':
+            return await normalizeOperationSuggestionValue(
+                value,
+                field,
+                snapshot,
+            );
         case 'range':
             return normalizeRangeValue(value, field);
         case 'reference':
@@ -631,6 +989,10 @@ function createReviewDiff(
     previousValue: string | null,
     proposedValue: string | null,
 ) {
+    if (controlType === 'operationSuggestion') {
+        return proposedValue;
+    }
+
     if (controlType !== 'text' && controlType !== 'markdown') {
         return null;
     }
@@ -823,11 +1185,11 @@ function applyTextValuePatch(valuePatch: string | null, currentValue: string) {
     return patchedValue;
 }
 
-function resolveSubmittedChange(
+async function resolveSubmittedChange(
     entity: EntityRaw,
     submittedChange: CreateCommunityEditRequestInput['changes'][number],
     sectionKey?: string | null,
-): ResolvedCommunityEditChange {
+): Promise<ResolvedCommunityEditChange> {
     const field = getCommunityEditableFieldDefinition(
         entity.entityTypeName,
         submittedChange.fieldKey,
@@ -848,6 +1210,7 @@ function resolveSubmittedChange(
 
     const snapshot = resolveFieldSnapshot(entity, field);
     if (
+        field.controlType !== 'operationSuggestion' &&
         submittedChange.baseValueHash &&
         submittedChange.baseValueHash !== snapshot.baseValueHash
     ) {
@@ -857,7 +1220,7 @@ function resolveSubmittedChange(
         );
     }
 
-    const proposedValue = normalizeProposedValue(
+    const proposedValue = await normalizeProposedValue(
         submittedChange.proposedValue,
         field,
         snapshot,
@@ -893,11 +1256,13 @@ export async function createCommunityEditRequest(
         input.entityTypeName,
         input.entityId,
     );
-    const changes = input.changes
-        .map((change) =>
-            resolveSubmittedChange(entity, change, input.sectionKey),
+    const changes = (
+        await Promise.all(
+            input.changes.map((change) =>
+                resolveSubmittedChange(entity, change, input.sectionKey),
+            ),
         )
-        .filter((change) => change.previousValue !== change.proposedValue);
+    ).filter((change) => change.previousValue !== change.proposedValue);
 
     if (changes.length === 0) {
         throw new CommunityEditRequestError(
@@ -1085,6 +1450,42 @@ function parseMultipleProposedValue(value: string | null) {
     return parsed.map((entry) => (entry === null ? null : String(entry)));
 }
 
+function parseCommunityOperationSuggestion(
+    value: string | null,
+): CommunityOperationSuggestionValue | null {
+    if (!value) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(value);
+        if (
+            !isRecord(parsed) ||
+            parsed.format !== 'community-operation-suggestion-v1' ||
+            (parsed.intent !== 'add' && parsed.intent !== 'remove') ||
+            typeof parsed.operationId !== 'number' ||
+            !Number.isInteger(parsed.operationId) ||
+            typeof parsed.operationLabel !== 'string' ||
+            typeof parsed.stageName !== 'string' ||
+            typeof parsed.stageLabel !== 'string' ||
+            (parsed.currentState !== 'absent' &&
+                parsed.currentState !== 'present') ||
+            ('note' in parsed &&
+                typeof parsed.note !== 'undefined' &&
+                typeof parsed.note !== 'string') ||
+            ('source' in parsed &&
+                typeof parsed.source !== 'undefined' &&
+                typeof parsed.source !== 'string')
+        ) {
+            return null;
+        }
+
+        return parsed as CommunityOperationSuggestionValue;
+    } catch {
+        return null;
+    }
+}
+
 async function getCurrentPersistedValues(
     db: DatabaseClient,
     entityId: number,
@@ -1181,6 +1582,82 @@ async function applyMultipleChange(input: {
     }
 }
 
+async function applyOperationSuggestionChange(input: {
+    db: DatabaseClient;
+    sideEffects: ReturnType<typeof createAttributeValueMutationSideEffects>;
+    entityTypeName: string;
+    entityId: number;
+    attributeDefinitionId: number;
+    proposedValue: string | null;
+    actor: CommunityEditActor;
+}) {
+    const suggestion = parseCommunityOperationSuggestion(input.proposedValue);
+    if (!suggestion) {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            'Operation suggestion change is not valid.',
+        );
+    }
+
+    const currentValues = await getCurrentPersistedValues(
+        input.db,
+        input.entityId,
+        input.attributeDefinitionId,
+    );
+    const operationValue = String(suggestion.operationId);
+    const existingValue = currentValues.find(
+        (value) => value.value === operationValue,
+    );
+
+    if (suggestion.intent === 'add') {
+        if (existingValue) {
+            return;
+        }
+
+        await resolveOperationSuggestionTarget({
+            operationId: suggestion.operationId,
+            stage: {
+                name: suggestion.stageName,
+                label: suggestion.stageLabel,
+            },
+        });
+        await upsertAttributeValue(
+            {
+                attributeDefinitionId: input.attributeDefinitionId,
+                entityTypeName: input.entityTypeName,
+                entityId: input.entityId,
+                value: operationValue,
+                order: String(currentValues.length),
+            },
+            {
+                id: input.actor.id,
+                name: input.actor.name ?? undefined,
+            },
+            {
+                db: input.db,
+                sideEffects: input.sideEffects,
+            },
+        );
+        return;
+    }
+
+    if (!existingValue) {
+        return;
+    }
+
+    await deleteAttributeValue(
+        existingValue.id,
+        {
+            id: input.actor.id,
+            name: input.actor.name ?? undefined,
+        },
+        {
+            db: input.db,
+            sideEffects: input.sideEffects,
+        },
+    );
+}
+
 function resolveApplicableProposedValue(input: {
     field: CommunityEditableFieldDefinition;
     snapshot: CommunityEditableFieldSnapshot;
@@ -1191,6 +1668,20 @@ function resolveApplicableProposedValue(input: {
         valuePatch: string | null;
     };
 }) {
+    if (input.field.controlType === 'operationSuggestion') {
+        if (!parseCommunityOperationSuggestion(input.change.proposedValue)) {
+            return {
+                proposedValue: null,
+                conflictReason: `Field ${input.change.fieldKey} has an invalid operation suggestion payload.`,
+            };
+        }
+
+        return {
+            proposedValue: input.change.proposedValue,
+            conflictReason: null,
+        };
+    }
+
     if (input.snapshot.baseValueHash === input.change.baseValueHash) {
         return {
             proposedValue: input.change.proposedValue,
@@ -1245,6 +1736,7 @@ export async function approveCommunityEditRequest(input: {
 
     const preparedChanges: {
         change: (typeof request.changes)[number];
+        field: CommunityEditableFieldDefinition;
         attributeValueId: number | null;
         proposedValue: string | null;
     }[] = [];
@@ -1294,6 +1786,7 @@ export async function approveCommunityEditRequest(input: {
 
         preparedChanges.push({
             change,
+            field,
             attributeValueId: snapshot.attributeValueId,
             proposedValue: applicationValue.proposedValue,
         });
@@ -1316,10 +1809,21 @@ export async function approveCommunityEditRequest(input: {
 
             for (const {
                 change,
+                field,
                 attributeValueId,
                 proposedValue,
             } of preparedChanges) {
-                if (change.attributeDefinition.multiple) {
+                if (field.controlType === 'operationSuggestion') {
+                    await applyOperationSuggestionChange({
+                        db: tx,
+                        sideEffects,
+                        entityTypeName: request.entityTypeName,
+                        entityId: request.entityId,
+                        attributeDefinitionId: change.attributeDefinitionId,
+                        proposedValue,
+                        actor: input.reviewer,
+                    });
+                } else if (change.attributeDefinition.multiple) {
                     await applyMultipleChange({
                         db: tx,
                         sideEffects,

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -13,6 +13,7 @@ import {
     getCommunityEditableFieldsForEntity,
     getCommunityEditableSections,
     getCommunityEditRequest,
+    getEntityFormatted,
     getEntityRaw,
     getEntityRevisions,
     rejectCommunityEditRequest,
@@ -27,8 +28,10 @@ import { createTestDb } from './testDb';
 type CommunityEditFixture = {
     plantDescriptionDefinitionId: number;
     plantGerminationTypeDefinitionId: number;
+    plantOperationsDefinitionId: number;
     plantSeedingDistanceDefinitionId: number;
     plantSortLatinNameDefinitionId: number;
+    operationNameDefinitionId: number;
     operationStageDefinitionId: number;
     operationApplicationDefinitionId: number;
     stageEntityId: number;
@@ -93,6 +96,14 @@ async function createFixture(): Promise<CommunityEditFixture> {
         entityTypeName: 'plant',
         dataType: 'text',
     });
+    const plantOperationsDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'operations',
+        label: 'Radnje',
+        entityTypeName: 'plant',
+        dataType: 'ref:operation',
+        multiple: true,
+    });
     await upsertEntityType({ name: 'plantSort', label: 'Sorta biljke' });
     const plantSortLatinNameDefinitionId = await createAttributeDefinition({
         category: 'information',
@@ -106,6 +117,20 @@ async function createFixture(): Promise<CommunityEditFixture> {
         name: 'name',
         label: 'Naziv',
         entityTypeName: 'plantStage',
+        dataType: 'text',
+    });
+    const stageLabelDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'label',
+        label: 'Oznaka',
+        entityTypeName: 'plantStage',
+        dataType: 'text',
+    });
+    const operationNameDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'name',
+        label: 'Naziv',
+        entityTypeName: 'operation',
         dataType: 'text',
     });
     const operationStageDefinitionId = await createAttributeDefinition({
@@ -129,14 +154,22 @@ async function createFixture(): Promise<CommunityEditFixture> {
         attributeDefinitionId: stageNameDefinitionId,
         entityTypeName: 'plantStage',
         entityId: stageEntityId,
+        value: 'sowing',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: stageLabelDefinitionId,
+        entityTypeName: 'plantStage',
+        entityId: stageEntityId,
         value: 'Sjetva',
     });
 
     return {
         plantDescriptionDefinitionId,
         plantGerminationTypeDefinitionId,
+        plantOperationsDefinitionId,
         plantSeedingDistanceDefinitionId,
         plantSortLatinNameDefinitionId,
+        operationNameDefinitionId,
         operationStageDefinitionId,
         operationApplicationDefinitionId,
         stageEntityId,
@@ -148,6 +181,7 @@ async function createFixture(): Promise<CommunityEditFixture> {
 async function createPublishedPlant(input?: {
     description?: string;
     germinationType?: string;
+    operationIds?: number[];
     seedingDistance?: string;
 }) {
     const data = await fixture();
@@ -171,6 +205,15 @@ async function createPublishedPlant(input?: {
         entityId,
         value: input?.germinationType ?? 'Klijanje u mraku',
     });
+    for (const [index, operationId] of (input?.operationIds ?? []).entries()) {
+        await upsertAttributeValue({
+            attributeDefinitionId: data.plantOperationsDefinitionId,
+            entityTypeName: 'plant',
+            entityId,
+            value: String(operationId),
+            order: String(index),
+        });
+    }
     return entityId;
 }
 
@@ -187,6 +230,35 @@ async function createPublishedPlantSort(input?: { latinName?: string }) {
     return entityId;
 }
 
+async function createPublishedPlantOperation(input?: {
+    application?: string;
+    name?: string;
+    stageEntityId?: number;
+}) {
+    const data = await fixture();
+    const entityId = await createEntity('operation');
+    await updateEntity({ id: entityId, state: 'published' });
+    await upsertAttributeValue({
+        attributeDefinitionId: data.operationNameDefinitionId,
+        entityTypeName: 'operation',
+        entityId,
+        value: input?.name ?? 'Malčiranje',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: data.operationStageDefinitionId,
+        entityTypeName: 'operation',
+        entityId,
+        value: String(input?.stageEntityId ?? data.stageEntityId),
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: data.operationApplicationDefinitionId,
+        entityTypeName: 'operation',
+        entityId,
+        value: input?.application ?? 'plant',
+    });
+    return entityId;
+}
+
 function attributeValue(
     entity: NonNullable<Awaited<ReturnType<typeof getEntityRaw>>>,
     attributeDefinitionId: number,
@@ -196,6 +268,19 @@ function attributeValue(
             attribute.attributeDefinitionId === attributeDefinitionId &&
             !attribute.isDeleted,
     )?.value;
+}
+
+function attributeValues(
+    entity: NonNullable<Awaited<ReturnType<typeof getEntityRaw>>>,
+    attributeDefinitionId: number,
+) {
+    return entity.attributes
+        .filter(
+            (attribute) =>
+                attribute.attributeDefinitionId === attributeDefinitionId &&
+                !attribute.isDeleted,
+        )
+        .map((attribute) => attribute.value);
 }
 
 test('community editable registry resolves allowed plant and operation fields', async () => {
@@ -419,6 +504,154 @@ test('community edit requests validate select field options', async () => {
         (error: unknown) =>
             error instanceof CommunityEditRequestError &&
             error.code === 'invalid_value',
+    );
+});
+
+test('community edit requests create and apply plant operation add suggestions', async () => {
+    const data = await fixture();
+    const operationId = await createPublishedPlantOperation({
+        name: 'Malčiranje',
+    });
+    const plantId = await createPublishedPlant();
+    const operationField = (
+        await getCommunityEditableFieldsForEntity({
+            entityTypeName: 'plant',
+            entityId: plantId,
+            sectionKey: 'sowing',
+        })
+    ).find((field) => field.fieldKey === 'plant.stage-operations.sowing');
+    assert.ok(operationField);
+    assert.equal(operationField.controlType, 'operationSuggestion');
+    assert.equal(operationField.operationSuggestionStage?.name, 'sowing');
+    assert.ok(
+        operationField.options?.some(
+            (option) =>
+                option.value === String(operationId) &&
+                option.label === 'Malčiranje',
+        ),
+    );
+
+    const request = await createCommunityEditRequest({
+        entityTypeName: 'plant',
+        entityId: plantId,
+        publicPath: '/biljke/test',
+        sectionKey: 'sowing',
+        submitter: { id: data.submitterId, name: 'Community Submitter' },
+        changes: [
+            {
+                fieldKey: 'plant.stage-operations.sowing',
+                baseValueHash: operationField.baseValueHash,
+                proposedValue: {
+                    intent: 'add',
+                    operationId,
+                    stageName: 'sowing',
+                    source: 'Terenska bilješka',
+                    note: 'Malčiranje je korisno nakon sjetve.',
+                },
+            },
+        ],
+    });
+
+    assert.equal(request.status, 'pending');
+    assert.equal(request.changes.length, 1);
+    assert.equal(request.changes[0]?.previousValue, '[]');
+    assert.match(
+        request.changes[0]?.proposedValue ?? '',
+        /community-operation-suggestion-v1/,
+    );
+    assert.match(request.changes[0]?.proposedValue ?? '', /"intent":"add"/);
+    assert.match(
+        request.changes[0]?.proposedValue ?? '',
+        /"currentState":"absent"/,
+    );
+
+    const applied = await approveCommunityEditRequest({
+        id: request.id,
+        reviewer: { id: data.reviewerId, name: 'Community Reviewer' },
+    });
+    assert.equal(applied.status, 'applied');
+
+    const entity = await getEntityRaw(plantId);
+    assert.ok(entity);
+    assert.deepEqual(
+        attributeValues(entity, data.plantOperationsDefinitionId),
+        [String(operationId)],
+    );
+
+    const formatted = await getEntityFormatted<{
+        information?: { operations?: { id: number }[] };
+    }>(plantId);
+    assert.ok(
+        formatted?.information?.operations?.some(
+            (operation) => operation.id === operationId,
+        ),
+    );
+});
+
+test('community edit requests create and apply plant operation remove suggestions', async () => {
+    const data = await fixture();
+    const operationId = await createPublishedPlantOperation({
+        name: 'Uklanjanje malča',
+    });
+    const plantId = await createPublishedPlant({
+        operationIds: [operationId],
+    });
+    const operationField = (
+        await getCommunityEditableFieldsForEntity({
+            entityTypeName: 'plant',
+            entityId: plantId,
+            sectionKey: 'sowing',
+        })
+    ).find((field) => field.fieldKey === 'plant.stage-operations.sowing');
+    assert.ok(operationField);
+
+    const request = await createCommunityEditRequest({
+        entityTypeName: 'plant',
+        entityId: plantId,
+        publicPath: '/biljke/test',
+        sectionKey: 'sowing',
+        submitter: { id: data.submitterId, name: 'Community Submitter' },
+        changes: [
+            {
+                fieldKey: 'plant.stage-operations.sowing',
+                baseValueHash: operationField.baseValueHash,
+                proposedValue: {
+                    intent: 'remove',
+                    operationId,
+                    stageName: 'sowing',
+                    note: 'Ova radnja ne pripada ovoj biljci.',
+                },
+            },
+        ],
+    });
+
+    assert.match(request.changes[0]?.proposedValue ?? '', /"intent":"remove"/);
+    assert.match(
+        request.changes[0]?.proposedValue ?? '',
+        /"currentState":"present"/,
+    );
+
+    const applied = await approveCommunityEditRequest({
+        id: request.id,
+        reviewer: { id: data.reviewerId, name: 'Community Reviewer' },
+    });
+    assert.equal(applied.status, 'applied');
+
+    const entity = await getEntityRaw(plantId);
+    assert.ok(entity);
+    assert.deepEqual(
+        attributeValues(entity, data.plantOperationsDefinitionId),
+        [],
+    );
+
+    const formatted = await getEntityFormatted<{
+        information?: { operations?: { id: number }[] };
+    }>(plantId);
+    assert.equal(
+        formatted?.information?.operations?.some(
+            (operation) => operation.id === operationId,
+        ) ?? false,
+        false,
     );
 });
 


### PR DESCRIPTION
Closes #3944

## Summary
- add plant stage operation suggestion fields for community edits
- store add/remove operation intents as normalized review payloads and apply them through attribute mutations
- render structured operation suggestion details in admin review
- add public modal controls for intent, operation, source, and note

## Validation
- `corepack pnpm --dir packages/storage exec biome check src/helpers/communityEditableFields.ts src/repositories/communityEditRequestsRepo.ts tests/communityEditRequestsRepo.node.spec.ts`
- `corepack pnpm --dir apps/www exec biome check components/community-edits/CommunityEditButton.tsx`
- `corepack pnpm --dir apps/app exec biome check app/admin/community-edits/[requestId]/page.tsx`
- `corepack pnpm --dir apps/api exec biome check lib/docs/openApiDocs.ts`
- `corepack pnpm --dir packages/storage run test:node communityEditRequestsRepo.node.spec.ts`
- `corepack pnpm --filter www typecheck`
- `corepack pnpm --dir apps/www run test:prepare`
- `corepack pnpm --dir apps/www exec playwright test --project=chromium tests/community-edit-button.spec.tsx`
- `git diff --check`

## Notes
- Direct `apps/app` tsc was previously blocked by unrelated existing app-wide errors outside this change; the targeted admin file is covered by the app Biome check.