### PR TITLE
feat(game): prevent pink edge bleeding in palette textures

### DIFF
--- a/packages/game/src/utils/configureGameGLTFMaterials.ts
+++ b/packages/game/src/utils/configureGameGLTFMaterials.ts
@@ -1,0 +1,42 @@
+import {
+    ClampToEdgeWrapping,
+    type Material,
+    NearestFilter,
+    Texture,
+} from 'three';
+
+const colorPaletteMaterialName = 'Material.ColorPaletteMain';
+
+type GameGLTFWithColorPaletteMaterial = {
+    materials?: {
+        [colorPaletteMaterialName]?: Material;
+    };
+};
+
+function getMaterialMap(material: Material | undefined): Texture | null {
+    if (!material || !('map' in material)) {
+        return null;
+    }
+
+    return material.map instanceof Texture ? material.map : null;
+}
+
+export function configureGameGLTFColorPaletteMaterials(
+    gltf: GameGLTFWithColorPaletteMaterial,
+) {
+    const colorPaletteTexture = getMaterialMap(
+        gltf.materials?.[colorPaletteMaterialName],
+    );
+
+    if (!colorPaletteTexture) {
+        return;
+    }
+
+    // Palette textures are color lookups; mipmaps blend neighboring swatches and can leak pink edge pixels.
+    colorPaletteTexture.magFilter = NearestFilter;
+    colorPaletteTexture.minFilter = NearestFilter;
+    colorPaletteTexture.generateMipmaps = false;
+    colorPaletteTexture.wrapS = ClampToEdgeWrapping;
+    colorPaletteTexture.wrapT = ClampToEdgeWrapping;
+    colorPaletteTexture.needsUpdate = true;
+}

--- a/packages/game/src/utils/configureGameGLTFMaterials.unit.ts
+++ b/packages/game/src/utils/configureGameGLTFMaterials.unit.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    ClampToEdgeWrapping,
+    LinearFilter,
+    LinearMipmapLinearFilter,
+    MeshBasicMaterial,
+    MeshStandardMaterial,
+    NearestFilter,
+    RepeatWrapping,
+    Texture,
+} from 'three';
+import { configureGameGLTFColorPaletteMaterials } from './configureGameGLTFMaterials';
+
+test('configures color palette textures without mipmap sampling', () => {
+    const texture = new Texture();
+    texture.magFilter = LinearFilter;
+    texture.minFilter = LinearMipmapLinearFilter;
+    texture.generateMipmaps = true;
+    texture.wrapS = RepeatWrapping;
+    texture.wrapT = RepeatWrapping;
+    const material = new MeshStandardMaterial({ map: texture });
+
+    configureGameGLTFColorPaletteMaterials({
+        materials: {
+            'Material.ColorPaletteMain': material,
+        },
+    });
+
+    assert.equal(texture.magFilter, NearestFilter);
+    assert.equal(texture.minFilter, NearestFilter);
+    assert.equal(texture.generateMipmaps, false);
+    assert.equal(texture.wrapS, ClampToEdgeWrapping);
+    assert.equal(texture.wrapT, ClampToEdgeWrapping);
+    assert.equal(texture.version, 1);
+});
+
+test('ignores missing or untextured color palette materials', () => {
+    assert.doesNotThrow(() => {
+        configureGameGLTFColorPaletteMaterials({});
+        configureGameGLTFColorPaletteMaterials({
+            materials: {
+                'Material.ColorPaletteMain': new MeshBasicMaterial(),
+            },
+        });
+    });
+});

--- a/packages/game/src/utils/useGameGLTF.ts
+++ b/packages/game/src/utils/useGameGLTF.ts
@@ -1,7 +1,9 @@
 import { useGLTF } from '@react-three/drei';
+import { useMemo } from 'react';
 import { type GameAssetName, gameAssetModels } from '../data/models';
 import type { GLTFResult } from '../models/GameAssets';
 import { useGameState } from '../useGameState';
+import { configureGameGLTFColorPaletteMaterials } from './configureGameGLTFMaterials';
 
 export function resolveGameAssetModelUrl(
     appBaseUrl: string,
@@ -21,7 +23,12 @@ export function preloadGameAssetModels(
 
 export function useGameGLTF(assetName: GameAssetName) {
     const appBaseUrl = useGameState((state) => state.appBaseUrl);
-    return useGLTF(
+    const gltf = useGLTF(
         resolveGameAssetModelUrl(appBaseUrl, assetName),
     ) as unknown as GLTFResult;
+
+    return useMemo(() => {
+        configureGameGLTFColorPaletteMaterials(gltf);
+        return gltf;
+    }, [gltf]);
 }


### PR DESCRIPTION
## Summary
- Add a GLTF material configurator that forces the color palette texture to use nearest sampling and clamped edges.
- Apply the texture fix when loading game GLTF assets so palette swatches do not bleed pink pixels at tile boundaries.
- Cover the new behavior with unit tests for configured and ignored material cases.

## Testing
- Unit tests added for palette texture configuration and no-op handling.
- Not run (not requested).