### PR TITLE
feat(www): improve community edit modal

### DIFF
--- a/apps/www/app/biljke/[alias]/InformationSection.tsx
+++ b/apps/www/app/biljke/[alias]/InformationSection.tsx
@@ -161,7 +161,7 @@ export async function InformationSection({
                     </div>
                 )}
             </Stack>
-            <Stack spacing={2}>
+            <Stack spacing={4}>
                 {attributeCards}
                 <Stack
                     className={cx(

--- a/apps/www/app/radnje/OperationCard.tsx
+++ b/apps/www/app/radnje/OperationCard.tsx
@@ -24,12 +24,12 @@ export function OperationCard({
 
     return (
         <a
-            className="group block h-full rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            className="group/operation-card block h-full rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             href={KnownPages.Operation(operation.information.label)}
         >
             <Card
                 className={cx(
-                    'h-full border-tertiary border-b-4 transition-colors group-hover:bg-accent group-hover:text-accent-foreground',
+                    'h-full border-tertiary border-b-4 transition-colors group-hover/operation-card:bg-accent group-hover/operation-card:text-accent-foreground',
                     compact && 'p-1',
                 )}
             >

--- a/apps/www/components/community-edits/CommunityEditButton.tsx
+++ b/apps/www/components/community-edits/CommunityEditButton.tsx
@@ -114,6 +114,15 @@ export type CommunityEditButtonProps = {
     className?: string;
 };
 
+const fieldPanelClassName =
+    'rounded-lg border border-border/70 bg-muted/30 p-3 shadow-sm';
+const inputControlClassName =
+    'w-full border-border/80 bg-card shadow-sm transition-colors hover:border-primary/40 focus-within:border-primary/50';
+const selectControlClassName =
+    'h-10 w-full rounded-md border border-border/80 bg-card px-3 text-sm text-foreground shadow-sm ring-offset-background transition-colors hover:border-primary/40 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted/70 disabled:text-muted-foreground';
+const textareaControlClassName =
+    'w-full rounded-md border border-border/80 bg-card px-3 py-2 text-sm text-foreground shadow-sm ring-offset-background transition-colors placeholder:text-muted-foreground/70 hover:border-primary/40 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted/70 disabled:text-muted-foreground';
+
 function initialFieldValue(field: CommunityEditableField): FieldValue {
     if (field.controlType === 'operationSuggestion') {
         return {
@@ -445,33 +454,57 @@ function FieldInput({
             field,
             suggestionValue.intent,
         );
+        const intentOptions: {
+            value: OperationSuggestionIntent;
+            label: string;
+        }[] = [
+            { value: 'add', label: 'Dodaj' },
+            { value: 'remove', label: 'Ukloni' },
+        ];
 
         return (
-            <Stack spacing={2}>
-                <div className="grid gap-2 sm:grid-cols-2">
-                    <label className="space-y-1" htmlFor={`${id}-intent`}>
-                        <Typography level="body3">Namjera</Typography>
-                        <select
-                            className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                            id={`${id}-intent`}
-                            onChange={(event) =>
-                                onChange({
-                                    ...suggestionValue,
-                                    intent: event.currentTarget
-                                        .value as OperationSuggestionIntent,
-                                    operationId: '',
-                                })
-                            }
-                            value={suggestionValue.intent}
-                        >
-                            <option value="add">Dodaj radnju</option>
-                            <option value="remove">Ukloni radnju</option>
-                        </select>
-                    </label>
+            <Stack spacing={3}>
+                <fieldset className="space-y-1">
+                    <legend className="text-sm text-foreground">
+                        Vrsta prijedloga
+                    </legend>
+                    <div className="grid grid-cols-2 gap-1 rounded-md border border-border/80 bg-card p-1 shadow-sm">
+                        {intentOptions.map((option) => (
+                            <label
+                                className={cx(
+                                    'flex h-9 cursor-pointer items-center justify-center rounded-sm px-3 text-sm font-medium transition-colors',
+                                    suggestionValue.intent === option.value
+                                        ? 'bg-primary text-primary-foreground shadow-sm'
+                                        : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                                )}
+                                key={option.value}
+                            >
+                                <input
+                                    checked={
+                                        suggestionValue.intent === option.value
+                                    }
+                                    className="sr-only"
+                                    name={`${id}-intent`}
+                                    onChange={() =>
+                                        onChange({
+                                            ...suggestionValue,
+                                            intent: option.value,
+                                            operationId: '',
+                                        })
+                                    }
+                                    type="radio"
+                                    value={option.value}
+                                />
+                                {option.label}
+                            </label>
+                        ))}
+                    </div>
+                </fieldset>
+                <Stack spacing={2}>
                     <label className="space-y-1" htmlFor={`${id}-operation`}>
                         <Typography level="body3">Radnja</Typography>
                         <select
-                            className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                            className={selectControlClassName}
                             disabled={operationOptions.length === 0}
                             id={`${id}-operation`}
                             onChange={(event) =>
@@ -502,8 +535,18 @@ function FieldInput({
                             ))}
                         </select>
                     </label>
-                </div>
+                    {operationOptions.length === 0 ? (
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Nema radnji za ovu namjeru u ovoj fazi.
+                        </Typography>
+                    ) : null}
+                </Stack>
                 <Input
+                    className={inputControlClassName}
+                    fullWidth
                     id={`${id}-source`}
                     label="Izvor"
                     onChange={(event) =>
@@ -518,7 +561,7 @@ function FieldInput({
                 <label className="space-y-1" htmlFor={`${id}-note`}>
                     <Typography level="body3">Napomena</Typography>
                     <textarea
-                        className="min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        className={cx(textareaControlClassName, 'min-h-20')}
                         id={`${id}-note`}
                         onChange={(event) =>
                             onChange({
@@ -547,7 +590,7 @@ function FieldInput({
     if (field.controlType === 'boolean') {
         return (
             <select
-                className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                className={selectControlClassName}
                 id={id}
                 onChange={(event) => onChange(event.currentTarget.value)}
                 value={typeof value === 'string' ? value : ''}
@@ -562,7 +605,7 @@ function FieldInput({
     if (field.controlType === 'select') {
         return (
             <select
-                className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                className={selectControlClassName}
                 id={id}
                 onChange={(event) => onChange(event.currentTarget.value)}
                 value={typeof value === 'string' ? value : ''}
@@ -580,6 +623,8 @@ function FieldInput({
     if (field.controlType === 'number' || field.controlType === 'reference') {
         return (
             <Input
+                className={inputControlClassName}
+                fullWidth
                 id={id}
                 inputMode={
                     field.controlType === 'reference' ? 'numeric' : 'decimal'
@@ -604,6 +649,8 @@ function FieldInput({
         return (
             <div className="grid gap-2 sm:grid-cols-2">
                 <Input
+                    className={inputControlClassName}
+                    fullWidth
                     id={`${id}-min`}
                     inputMode="decimal"
                     label="Najmanje"
@@ -617,6 +664,8 @@ function FieldInput({
                     value={rangeValue.min}
                 />
                 <Input
+                    className={inputControlClassName}
+                    fullWidth
                     id={`${id}-max`}
                     inputMode="decimal"
                     label="Najviše"
@@ -636,7 +685,7 @@ function FieldInput({
     if (field.controlType === 'json') {
         return (
             <textarea
-                className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm"
+                className={cx(textareaControlClassName, 'min-h-32 font-mono')}
                 id={id}
                 onChange={(event) => onChange(event.currentTarget.value)}
                 value={typeof value === 'string' ? value : ''}
@@ -646,7 +695,7 @@ function FieldInput({
 
     return (
         <textarea
-            className="min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            className={cx(textareaControlClassName, 'min-h-24')}
             id={id}
             onChange={(event) => onChange(event.currentTarget.value)}
             value={typeof value === 'string' ? value : ''}
@@ -854,13 +903,13 @@ export function CommunityEditButton({
 
     return (
         <Modal
-            className="max-w-3xl"
+            className="max-w-3xl border-border/70 shadow-xl"
             onOpenChange={setOpen}
             open={open}
             title={triggerLabel}
             trigger={trigger}
         >
-            <Stack spacing={4}>
+            <Stack spacing={5}>
                 <Row spacing={2} className="items-start justify-between gap-4">
                     <Stack spacing={1}>
                         <Typography level="h3">{triggerLabel}</Typography>
@@ -882,7 +931,10 @@ export function CommunityEditButton({
                         Provjeravam prijavu...
                     </Typography>
                 ) : !user ? (
-                    <Stack spacing={3}>
+                    <Stack
+                        spacing={3}
+                        className="rounded-lg border border-border/70 bg-muted/30 p-4"
+                    >
                         <Typography level="body2">
                             Za slanje prijedloga treba se prijaviti.
                         </Typography>
@@ -905,7 +957,10 @@ export function CommunityEditButton({
                         />
                     </Stack>
                 ) : successRequestId ? (
-                    <Stack spacing={2}>
+                    <Stack
+                        spacing={2}
+                        className="rounded-lg border border-green-700/20 bg-green-700/10 p-4"
+                    >
                         <Typography>
                             Prijedlog #{successRequestId} je poslan na
                             odobrenje.
@@ -921,19 +976,31 @@ export function CommunityEditButton({
                 ) : (
                     <Stack spacing={4}>
                         {isLoadingFields ? (
-                            <Typography level="body2">
-                                Učitavam polja...
-                            </Typography>
+                            <div className="rounded-lg border border-border/70 bg-muted/30 p-4">
+                                <Typography level="body2">
+                                    Učitavam polja...
+                                </Typography>
+                            </div>
                         ) : fields.length === 0 ? (
-                            <Typography level="body2">
-                                Ova sekcija trenutno nema javno uređivih polja.
-                            </Typography>
+                            <div className="rounded-lg border border-border/70 bg-muted/30 p-4">
+                                <Typography level="body2">
+                                    Ova sekcija trenutno nema javno uređivih
+                                    polja.
+                                </Typography>
+                            </div>
                         ) : (
                             fields.map((field) => {
                                 const id = fieldInputId(fieldIdPrefix, field);
                                 return (
-                                    <Stack key={field.fieldKey} spacing={2}>
-                                        <label htmlFor={id}>
+                                    <Stack
+                                        className={fieldPanelClassName}
+                                        key={field.fieldKey}
+                                        spacing={2}
+                                    >
+                                        <label
+                                            className="space-y-1"
+                                            htmlFor={id}
+                                        >
                                             <Typography level="body2" semiBold>
                                                 {field.publicLabel}
                                             </Typography>
@@ -970,7 +1037,10 @@ export function CommunityEditButton({
                                 Napomena za administratora
                             </Typography>
                             <textarea
-                                className="min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                                className={cx(
+                                    textareaControlClassName,
+                                    'min-h-20',
+                                )}
                                 onChange={(event) =>
                                     setSubmitterNote(event.currentTarget.value)
                                 }
@@ -980,9 +1050,14 @@ export function CommunityEditButton({
                         </label>
 
                         {error ? (
-                            <Typography level="body2" className="text-red-700">
-                                {error}
-                            </Typography>
+                            <div className="rounded-md border border-red-700/20 bg-red-700/10 p-3">
+                                <Typography
+                                    level="body2"
+                                    className="text-red-700"
+                                >
+                                    {error}
+                                </Typography>
+                            </div>
                         ) : null}
 
                         <Row spacing={2} className="justify-end">

--- a/apps/www/components/community-edits/CommunityMarkdownInput.tsx
+++ b/apps/www/components/community-edits/CommunityMarkdownInput.tsx
@@ -35,7 +35,7 @@ export function CommunityMarkdownInput({
     value: string;
 }) {
     return (
-        <div className="overflow-hidden rounded-md border border-input bg-background">
+        <div className="overflow-hidden rounded-md border border-border/80 bg-card shadow-sm ring-offset-background transition-colors hover:border-primary/40 focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
             <MDXEditor
                 className={cx(
                     markdownEditorClassNames,
@@ -43,7 +43,7 @@ export function CommunityMarkdownInput({
                 )}
                 contentEditableClassName={cx(
                     markdownEditorContentEditableClassName,
-                    'min-h-32',
+                    'min-h-32 bg-card',
                 )}
                 markdown={value}
                 onChange={onChange}

--- a/apps/www/tests/community-edit-button.spec.tsx
+++ b/apps/www/tests/community-edit-button.spec.tsx
@@ -251,6 +251,154 @@ test('submits a changed section edit for authenticated users', async ({
     ).toBeVisible();
 });
 
+test('shows storage content and operation suggestions in the edit modal', async ({
+    mount,
+    page,
+}) => {
+    await page.route('**/api/gredice/api/auth/current-claims', (route) =>
+        route.fulfill({
+            status: 200,
+            json: {
+                id: 'user-1',
+                userName: 'ana',
+                displayName: 'Ana',
+            },
+        }),
+    );
+    await page.route(
+        '**/api/gredice/api/directories/community-edits/entities/plant/1/fields**',
+        (route) =>
+            route.fulfill({
+                status: 200,
+                json: {
+                    entityTypeName: 'plant',
+                    entityId: 1,
+                    sectionKey: 'storage',
+                    fields: [
+                        {
+                            entityTypeName: 'plant',
+                            entityId: 1,
+                            fieldKey: 'plant.storage',
+                            sectionKey: 'storage',
+                            attributeDefinitionId: 12,
+                            attributeValueId: 22,
+                            attributePath: 'information.storage',
+                            dataType: 'markdown',
+                            controlType: 'text',
+                            multiple: false,
+                            publicLabel: 'Skladištenje',
+                            helpText: 'Savjeti za čuvanje nakon berbe.',
+                            currentValue: 'Čuvati na hladnom.',
+                            baseValueHash: 'hash-storage',
+                        },
+                        {
+                            entityTypeName: 'plant',
+                            entityId: 1,
+                            fieldKey: 'plant.stage-operations.storage',
+                            sectionKey: 'storage',
+                            attributeDefinitionId: 13,
+                            attributeValueId: null,
+                            attributePath: 'information.operations',
+                            dataType: 'ref:operation',
+                            controlType: 'operationSuggestion',
+                            multiple: true,
+                            publicLabel: 'Radnje: Skladištenje',
+                            helpText:
+                                'Predloži dodavanje ili uklanjanje radnje.',
+                            operationSuggestionStage: {
+                                name: 'storage',
+                                label: 'Skladištenje',
+                            },
+                            currentValue: '[]',
+                            baseValueHash: 'hash-operations',
+                            options: [
+                                {
+                                    value: '987',
+                                    label: 'Uklanjanje biljke',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            }),
+    );
+    await page.route(
+        '**/api/gredice/api/directories/community-edits',
+        async (route) => {
+            const body = route.request().postDataJSON();
+            expect(body).toMatchObject({
+                entityTypeName: 'plant',
+                entityId: 1,
+                publicPath: '/biljke/blitva',
+                sectionKey: 'storage',
+                changes: [
+                    {
+                        fieldKey: 'plant.storage',
+                        proposedValue: 'Zamotati u vlažnu krpu.',
+                        baseValueHash: 'hash-storage',
+                    },
+                    {
+                        fieldKey: 'plant.stage-operations.storage',
+                        proposedValue: {
+                            intent: 'add',
+                            operationId: 987,
+                            stageName: 'storage',
+                            source: 'Terenska bilješka',
+                            note: 'Radnja pripada skladištenju.',
+                        },
+                        baseValueHash: 'hash-operations',
+                    },
+                ],
+            });
+
+            await route.fulfill({
+                status: 201,
+                json: {
+                    status: 'pending_admin_approval',
+                    requestId: 44,
+                    requestStatus: 'pending',
+                    changeCount: 2,
+                },
+            });
+        },
+    );
+
+    await mount(
+        <CommunityEditButtonHarness
+            entityTypeName="plant"
+            entityId={1}
+            publicPath="/biljke/blitva"
+            sectionKey="storage"
+        />,
+    );
+
+    await page.getByTitle('Predloži izmjenu').click();
+    await expect(
+        page.getByText('Ova sekcija trenutno nema javno uređivih polja.'),
+    ).toHaveCount(0);
+    await expect(page.getByText('Radnje: Skladištenje')).toBeVisible();
+
+    const dialogBackground = await page
+        .getByRole('dialog')
+        .evaluate((element) => getComputedStyle(element).backgroundColor);
+    const fieldBackground = await page
+        .getByLabel('Skladištenje')
+        .evaluate((element) => getComputedStyle(element).backgroundColor);
+    expect(fieldBackground).not.toBe(dialogBackground);
+
+    await page.getByLabel('Skladištenje').fill('Zamotati u vlažnu krpu.');
+    await page.getByLabel('Radnja').selectOption('987');
+    await page.getByLabel('Izvor').fill('Terenska bilješka');
+    await page
+        .getByRole('textbox', { name: 'Napomena', exact: true })
+        .fill('Radnja pripada skladištenju.');
+    await page.getByRole('button', { name: 'Pošalji' }).click();
+
+    await expect(
+        page.getByText('Prijedlog #44 je poslan na odobrenje.'),
+    ).toBeVisible();
+});
+
 test('submits select field edits for authenticated users', async ({
     mount,
     page,

--- a/apps/www/tests/operation-card-hover.spec.tsx
+++ b/apps/www/tests/operation-card-hover.spec.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { ComponentProps } from 'react';
+import { OperationCard } from '../app/radnje/OperationCard';
+import '../app/globals.css';
+
+const operation = {
+    id: 1,
+    attributes: {
+        application: 'plant',
+        deliverable: false,
+        duration: 15,
+        stage: {
+            id: 1,
+            information: {
+                name: 'harvest',
+                label: 'Berba',
+            },
+        },
+    },
+    image: {
+        cover: {
+            url: '',
+        },
+    },
+    information: {
+        description: 'Opis radnje.',
+        instructions: 'Upute za radnju.',
+        label: 'Testna radnja',
+        name: 'testna-radnja',
+        shortDescription: 'Kratak opis radnje.',
+    },
+    prices: {
+        perOperation: 1,
+    },
+} satisfies ComponentProps<typeof OperationCard>['operation'];
+
+test('scopes hover highlight to operation card groups', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <div className="group" data-testid="section-hover-wrapper">
+            <OperationCard operation={operation} variant="compact" />
+        </div>,
+    );
+
+    const link = page.getByRole('link', { name: /Testna radnja/ });
+    const card = link.locator('> div').first();
+    const linkClasses = (await link.getAttribute('class'))?.split(/\s+/) ?? [];
+    const cardClasses = (await card.getAttribute('class'))?.split(/\s+/) ?? [];
+
+    expect(linkClasses).toContain('group/operation-card');
+    expect(linkClasses).not.toContain('group');
+    expect(cardClasses).toContain('group-hover/operation-card:bg-accent');
+    expect(cardClasses).toContain(
+        'group-hover/operation-card:text-accent-foreground',
+    );
+    expect(cardClasses).not.toContain('group-hover:bg-accent');
+    expect(cardClasses).not.toContain('group-hover:text-accent-foreground');
+});

--- a/packages/storage/src/helpers/communityEditableFields.ts
+++ b/packages/storage/src/helpers/communityEditableFields.ts
@@ -49,6 +49,7 @@ export const communityEditablePlantOperationStages: CommunityEditableOperationSu
         { name: 'growth', label: 'Rast' },
         { name: 'watering', label: 'Zalijevanje' },
         { name: 'harvest', label: 'Berba' },
+        { name: 'storage', label: 'Skladištenje' },
     ];
 
 const communityEditablePlantOperationFields: CommunityEditableFieldDefinition[] =
@@ -160,6 +161,18 @@ const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
         category: 'information',
         name: 'harvest',
         publicLabel: 'Berba',
+        controlType: 'markdown',
+        pageLevel: true,
+        inline: true,
+        maxLength: 16000,
+    },
+    {
+        entityTypeName: 'plant',
+        fieldKey: 'plant.storage',
+        sectionKey: 'storage',
+        category: 'information',
+        name: 'storage',
+        publicLabel: 'Skladištenje',
         controlType: 'markdown',
         pageLevel: true,
         inline: true,

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -30,11 +30,14 @@ type CommunityEditFixture = {
     plantGerminationTypeDefinitionId: number;
     plantOperationsDefinitionId: number;
     plantSeedingDistanceDefinitionId: number;
+    plantStorageDefinitionId: number;
     plantSortLatinNameDefinitionId: number;
     operationNameDefinitionId: number;
     operationStageDefinitionId: number;
     operationApplicationDefinitionId: number;
     stageEntityId: number;
+    stageNameDefinitionId: number;
+    stageLabelDefinitionId: number;
     submitterId: string;
     reviewerId: string;
 };
@@ -79,6 +82,13 @@ async function createFixture(): Promise<CommunityEditFixture> {
         category: 'information',
         name: 'description',
         label: 'Opis',
+        entityTypeName: 'plant',
+        dataType: 'markdown',
+    });
+    const plantStorageDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'storage',
+        label: 'Skladištenje',
         entityTypeName: 'plant',
         dataType: 'markdown',
     });
@@ -168,11 +178,14 @@ async function createFixture(): Promise<CommunityEditFixture> {
         plantGerminationTypeDefinitionId,
         plantOperationsDefinitionId,
         plantSeedingDistanceDefinitionId,
+        plantStorageDefinitionId,
         plantSortLatinNameDefinitionId,
         operationNameDefinitionId,
         operationStageDefinitionId,
         operationApplicationDefinitionId,
         stageEntityId,
+        stageNameDefinitionId,
+        stageLabelDefinitionId,
         submitterId,
         reviewerId,
     };
@@ -183,6 +196,7 @@ async function createPublishedPlant(input?: {
     germinationType?: string;
     operationIds?: number[];
     seedingDistance?: string;
+    storage?: string;
 }) {
     const data = await fixture();
     const entityId = await createEntity('plant');
@@ -205,6 +219,12 @@ async function createPublishedPlant(input?: {
         entityId,
         value: input?.germinationType ?? 'Klijanje u mraku',
     });
+    await upsertAttributeValue({
+        attributeDefinitionId: data.plantStorageDefinitionId,
+        entityTypeName: 'plant',
+        entityId,
+        value: input?.storage ?? 'Čuvati na hladnom mjestu.',
+    });
     for (const [index, operationId] of (input?.operationIds ?? []).entries()) {
         await upsertAttributeValue({
             attributeDefinitionId: data.plantOperationsDefinitionId,
@@ -214,6 +234,28 @@ async function createPublishedPlant(input?: {
             order: String(index),
         });
     }
+    return entityId;
+}
+
+async function createPublishedPlantStage(input: {
+    name: string;
+    label: string;
+}) {
+    const data = await fixture();
+    const entityId = await createEntity('plantStage');
+    await updateEntity({ id: entityId, state: 'published' });
+    await upsertAttributeValue({
+        attributeDefinitionId: data.stageNameDefinitionId,
+        entityTypeName: 'plantStage',
+        entityId,
+        value: input.name,
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: data.stageLabelDefinitionId,
+        entityTypeName: 'plantStage',
+        entityId,
+        value: input.label,
+    });
     return entityId;
 }
 
@@ -309,6 +351,18 @@ test('community editable registry resolves allowed plant and operation fields', 
             ?.fields.some((field) => field.fieldKey === 'plant.yield-type'),
     );
     assert.ok(
+        plantSections
+            .find((section) => section.key === 'storage')
+            ?.fields.some((field) => field.fieldKey === 'plant.storage'),
+    );
+    assert.ok(
+        plantSections
+            .find((section) => section.key === 'storage')
+            ?.fields.some(
+                (field) => field.fieldKey === 'plant.stage-operations.storage',
+            ),
+    );
+    assert.ok(
         getCommunityEditableSections('plantSort')
             .find((section) => section.key === 'overview')
             ?.fields.some((field) => field.fieldKey === 'plant-sort.name'),
@@ -356,6 +410,28 @@ test('community editable registry resolves allowed plant and operation fields', 
     assert.equal(
         plantFields.some((field) => field.fieldKey.includes('price')),
         false,
+    );
+
+    const storageFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plant',
+        entityId: plantId,
+        sectionKey: 'storage',
+    });
+    assert.ok(
+        storageFields.some(
+            (field) =>
+                field.fieldKey === 'plant.storage' &&
+                field.controlType === 'markdown' &&
+                field.currentValue === 'Čuvati na hladnom mjestu.',
+        ),
+    );
+    assert.ok(
+        storageFields.some(
+            (field) =>
+                field.fieldKey === 'plant.stage-operations.storage' &&
+                field.controlType === 'operationSuggestion' &&
+                field.operationSuggestionStage?.name === 'storage',
+        ),
     );
 
     const plantSortId = await createPublishedPlantSort();
@@ -409,6 +485,98 @@ test('community editable registry resolves allowed plant and operation fields', 
                 field.options?.some((option) => option.value === 'farm') &&
                 field.options?.some((option) => option.value === 'garden'),
         ),
+    );
+});
+
+test('community edit requests submit storage content and operation suggestions together', async () => {
+    const data = await fixture();
+    const storageStageId = await createPublishedPlantStage({
+        name: 'storage',
+        label: 'Skladištenje',
+    });
+    const operationId = await createPublishedPlantOperation({
+        name: 'Uklanjanje biljke',
+        stageEntityId: storageStageId,
+    });
+    const plantId = await createPublishedPlant({
+        storage: 'Listove čuvati u hladnjaku.',
+    });
+    const storageFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plant',
+        entityId: plantId,
+        sectionKey: 'storage',
+    });
+    const storageContentField = storageFields.find(
+        (field) => field.fieldKey === 'plant.storage',
+    );
+    const operationField = storageFields.find(
+        (field) => field.fieldKey === 'plant.stage-operations.storage',
+    );
+    assert.ok(storageContentField);
+    assert.ok(operationField);
+    assert.equal(storageContentField.controlType, 'markdown');
+    assert.equal(operationField.controlType, 'operationSuggestion');
+    assert.equal(operationField.operationSuggestionStage?.name, 'storage');
+    assert.ok(
+        operationField.options?.some(
+            (option) =>
+                option.value === String(operationId) &&
+                option.label === 'Uklanjanje biljke',
+        ),
+    );
+
+    const request = await createCommunityEditRequest({
+        entityTypeName: 'plant',
+        entityId: plantId,
+        publicPath: '/biljke/blitva',
+        sectionKey: 'storage',
+        submitter: { id: data.submitterId, name: 'Community Submitter' },
+        changes: [
+            {
+                fieldKey: 'plant.storage',
+                baseValueHash: storageContentField.baseValueHash,
+                proposedValue: 'Listove čuvati u vlažnoj krpi u hladnjaku.',
+            },
+            {
+                fieldKey: 'plant.stage-operations.storage',
+                baseValueHash: operationField.baseValueHash,
+                proposedValue: {
+                    intent: 'add',
+                    operationId,
+                    stageName: 'storage',
+                    source: 'Upute proizvođača',
+                    note: 'Korisno je prikazati uklanjanje nakon berbe.',
+                },
+            },
+        ],
+    });
+
+    assert.equal(request.status, 'pending');
+    assert.equal(request.changes.length, 2);
+    assert.match(
+        request.changes[0]?.proposedValue ?? '',
+        /vlažnoj krpi u hladnjaku/,
+    );
+    assert.match(
+        request.changes[1]?.proposedValue ?? '',
+        /community-operation-suggestion-v1/,
+    );
+
+    const applied = await approveCommunityEditRequest({
+        id: request.id,
+        reviewer: { id: data.reviewerId, name: 'Community Reviewer' },
+    });
+    assert.equal(applied.status, 'applied');
+
+    const entity = await getEntityRaw(plantId);
+    assert.ok(entity);
+    assert.equal(
+        attributeValue(entity, data.plantStorageDefinitionId),
+        'Listove čuvati u vlažnoj krpi u hladnjaku.',
+    );
+    assert.deepEqual(
+        attributeValues(entity, data.plantOperationsDefinitionId),
+        [String(operationId)],
     );
 });
 


### PR DESCRIPTION
## Summary

- Add storage as a community-editable plant content section and expose storage operation suggestions.
- Redesign the community edit modal controls with clearer field grouping, stronger input contrast, a segmented operation intent control, and polished loading/empty/success/error states.
- Add storage community edit regression coverage for both repository behavior and the public modal submit flow.

## Validation

- `corepack pnpm lint --filter www --filter @gredice/storage`
- `corepack pnpm typecheck --filter www`
- `corepack pnpm --filter @gredice/storage test:node -- communityEditRequestsRepo.node.spec.ts`
- `corepack pnpm --filter www test:prepare`
- `corepack pnpm --filter www exec playwright test tests/community-edit-button.spec.tsx --project=chromium`
- `git diff --check`