### PR TITLE
feat(www): show public garden stats

### DIFF
--- a/apps/www/app/vrtovi/PublicGardenStatsAccordion.tsx
+++ b/apps/www/app/vrtovi/PublicGardenStatsAccordion.tsx
@@ -1,0 +1,78 @@
+import { Accordion } from '@gredice/ui/Accordion';
+import { LayoutGrid, Ruler, Wallet } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import {
+    formatGardenAreaSquareMeters,
+    formatGardenNumber,
+    formatGardenSunflowerPrice,
+    type PublicGardenStats,
+} from './publicGardenFormatting';
+
+export function PublicGardenStatsAccordion({
+    stats,
+}: {
+    stats: PublicGardenStats;
+}) {
+    const statItems = [
+        {
+            id: 'area',
+            icon: Ruler,
+            label: 'Površina',
+            value: formatGardenAreaSquareMeters(stats.areaSquareMeters),
+        },
+        {
+            id: 'blocks',
+            icon: LayoutGrid,
+            label: 'Blokova',
+            value: formatGardenNumber(stats.blockCount),
+        },
+        {
+            id: 'sunflowers',
+            icon: Wallet,
+            label: 'Cijena blokova',
+            value: formatGardenSunflowerPrice(stats.totalSunflowerPrice),
+        },
+    ];
+
+    return (
+        <div className="border-t">
+            <Accordion variant="plain" className="rounded-none">
+                <div className="min-w-0">
+                    <Typography level="body2" className="font-medium">
+                        Statistika vrta
+                    </Typography>
+                    <Typography level="body3" className="text-muted-foreground">
+                        Površina, blokovi i suncokreti
+                    </Typography>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-3">
+                    {statItems.map(({ icon: Icon, id, label, value }) => (
+                        <div
+                            className="flex min-w-0 items-start gap-3 rounded-md bg-muted/40 p-3"
+                            key={id}
+                        >
+                            <Icon
+                                aria-hidden
+                                className="mt-0.5 size-4 shrink-0 text-primary"
+                            />
+                            <div className="min-w-0">
+                                <Typography
+                                    level="body3"
+                                    className="text-muted-foreground"
+                                >
+                                    {label}
+                                </Typography>
+                                <Typography
+                                    level="body2"
+                                    className="truncate font-medium"
+                                >
+                                    {value}
+                                </Typography>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </Accordion>
+        </div>
+    );
+}

--- a/apps/www/app/vrtovi/[gardenId]/page.tsx
+++ b/apps/www/app/vrtovi/[gardenId]/page.tsx
@@ -8,8 +8,13 @@ import { notFound } from 'next/navigation';
 import { KnownPages } from '../../../src/KnownPages';
 import { PublicGardenExplorer } from '../PublicGardenExplorer';
 import { PublicGardenLikeButton } from '../PublicGardenLikeButton';
-import { getPublicGardenForWww } from '../publicGardenData';
+import { PublicGardenStatsAccordion } from '../PublicGardenStatsAccordion';
 import {
+    getPublicGardenBlockDataForWww,
+    getPublicGardenForWww,
+} from '../publicGardenData';
+import {
+    calculatePublicGardenStats,
     countActivePlantsFromPublicGarden,
     formatGardenDate,
     formatGardenNumber,
@@ -84,8 +89,12 @@ export default async function PublicGardenPage({
         notFound();
     }
 
-    const garden = await getPublicGardenForWww(gardenId);
+    const [garden, blockData] = await Promise.all([
+        getPublicGardenForWww(gardenId),
+        getPublicGardenBlockDataForWww(),
+    ]);
     const activePlantCount = countActivePlantsFromPublicGarden(garden);
+    const gardenStats = calculatePublicGardenStats(garden, blockData);
 
     return (
         <Stack spacing={2} className="py-6">
@@ -172,6 +181,7 @@ export default async function PublicGardenPage({
                             initialLikeCount={garden.likeCount}
                         />
                     </div>
+                    <PublicGardenStatsAccordion stats={gardenStats} />
                 </div>
             </Card>
             <Typography

--- a/apps/www/app/vrtovi/publicGardenData.ts
+++ b/apps/www/app/vrtovi/publicGardenData.ts
@@ -1,4 +1,4 @@
-import { clientPublic } from '@gredice/client';
+import { clientPublic, directoriesClient } from '@gredice/client';
 import { notFound } from 'next/navigation';
 import { countActivePlantsFromPublicGarden } from './publicGardenFormatting';
 
@@ -57,6 +57,22 @@ export async function getPublicGardensForWww() {
         ...publicGardens,
         items,
     };
+}
+
+export async function getPublicGardenBlockDataForWww() {
+    try {
+        const { data, error } =
+            await directoriesClient().GET('/entities/block');
+        if (error) {
+            console.error('Failed to fetch public garden block data', error);
+            return undefined;
+        }
+
+        return data ?? [];
+    } catch (error) {
+        console.error('Failed to fetch public garden block data', error);
+        return undefined;
+    }
 }
 
 export async function getPublicGardenForWww(gardenId: number) {

--- a/apps/www/app/vrtovi/publicGardenFormatting.node.spec.ts
+++ b/apps/www/app/vrtovi/publicGardenFormatting.node.spec.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { PublicGardenResponse } from '@gredice/client';
+import {
+    calculatePublicGardenStackStats,
+    formatGardenAreaSquareMeters,
+    formatGardenSunflowerPrice,
+} from './publicGardenFormatting.ts';
+
+const stacks: PublicGardenResponse['stacks'] = {
+    '0': {
+        '0': [
+            {
+                id: 'grass-1',
+                name: 'Block_Grass',
+                rotation: 0,
+                variant: null,
+            },
+            {
+                id: 'stand-1',
+                name: 'LemonadeStand',
+                rotation: 1,
+                variant: null,
+            },
+        ],
+    },
+    '1': {
+        '0': [
+            {
+                id: 'grass-2',
+                name: 'Block_Grass',
+                rotation: 0,
+                variant: null,
+            },
+        ],
+    },
+};
+
+test('calculatePublicGardenStackStats counts block footprints, instances and sunflower prices', () => {
+    assert.deepEqual(
+        calculatePublicGardenStackStats(stacks, [
+            {
+                information: { name: 'Block_Grass' },
+                attributes: {},
+                prices: { sunflowers: 2 },
+            },
+            {
+                information: { name: 'LemonadeStand' },
+                attributes: { spanWidth: 3, spanDepth: 2 },
+                prices: { sunflowers: 140 },
+            },
+        ]),
+        {
+            areaSquareMeters: 6,
+            blockCount: 3,
+            totalSunflowerPrice: 144,
+        },
+    );
+});
+
+test('calculatePublicGardenStackStats falls back to stack cells when block directory data is unavailable', () => {
+    assert.deepEqual(calculatePublicGardenStackStats(stacks), {
+        areaSquareMeters: 2,
+        blockCount: 3,
+        totalSunflowerPrice: null,
+    });
+});
+
+test('garden stat formatters include Croatian units and unknown fallbacks', () => {
+    assert.equal(formatGardenAreaSquareMeters(6), '6 m²');
+    assert.equal(formatGardenSunflowerPrice(1440), '1.440 suncokreta');
+    assert.equal(formatGardenSunflowerPrice(null), '—');
+});

--- a/apps/www/app/vrtovi/publicGardenFormatting.ts
+++ b/apps/www/app/vrtovi/publicGardenFormatting.ts
@@ -1,4 +1,8 @@
 import type { PublicGardenResponse } from '@gredice/client';
+import {
+    type GardenBlockDataLike,
+    getGardenBlockFootprintOffsets,
+} from '@gredice/js/gardenBlocks';
 
 const gardenDateFormatter = new Intl.DateTimeFormat('hr-HR', {
     day: 'numeric',
@@ -8,6 +12,21 @@ const gardenDateFormatter = new Intl.DateTimeFormat('hr-HR', {
 });
 
 const gardenNumberFormatter = new Intl.NumberFormat('hr-HR');
+
+export type PublicGardenStatsBlockData = GardenBlockDataLike & {
+    information: {
+        name: string;
+    };
+    prices?: {
+        sunflowers?: number | null;
+    } | null;
+};
+
+export type PublicGardenStats = {
+    areaSquareMeters: number;
+    blockCount: number;
+    totalSunflowerPrice: number | null;
+};
 
 export function countActivePlantsFromPublicGarden(
     garden: PublicGardenResponse,
@@ -23,14 +42,114 @@ export function countActivePlantsFromPublicGarden(
     );
 }
 
+function createBlockDataByName(
+    blockData: PublicGardenStatsBlockData[] | null | undefined,
+) {
+    const blockDataByName = new Map<string, PublicGardenStatsBlockData>();
+    for (const block of blockData ?? []) {
+        blockDataByName.set(block.information.name, block);
+    }
+    return blockDataByName;
+}
+
+function gardenStatCellKey(x: number, y: number) {
+    return `${x.toString()}|${y.toString()}`;
+}
+
+function toGardenGridCoordinate(value: string) {
+    const coordinate = Number(value);
+    return Number.isFinite(coordinate) ? coordinate : null;
+}
+
+export function calculatePublicGardenStackStats(
+    stacks: PublicGardenResponse['stacks'],
+    blockData?: PublicGardenStatsBlockData[] | null,
+): PublicGardenStats {
+    const blockDataByName = createBlockDataByName(blockData);
+    const hasPriceData = Boolean(blockData);
+    const occupiedCells = new Set<string>();
+    let blockCount = 0;
+    let totalSunflowerPrice = 0;
+
+    for (const [rawX, rows] of Object.entries(stacks)) {
+        const x = toGardenGridCoordinate(rawX);
+        if (x === null) {
+            continue;
+        }
+
+        for (const [rawY, blocks] of Object.entries(rows)) {
+            const y = toGardenGridCoordinate(rawY);
+            if (y === null) {
+                continue;
+            }
+
+            for (const block of blocks) {
+                blockCount += 1;
+
+                const currentBlockData = blockDataByName.get(block.name);
+                for (const offset of getGardenBlockFootprintOffsets(
+                    currentBlockData,
+                    block.rotation ?? 0,
+                )) {
+                    occupiedCells.add(
+                        gardenStatCellKey(x + offset.x, y + offset.y),
+                    );
+                }
+
+                const sunflowerPrice = currentBlockData?.prices?.sunflowers;
+                if (
+                    hasPriceData &&
+                    typeof sunflowerPrice === 'number' &&
+                    Number.isFinite(sunflowerPrice)
+                ) {
+                    totalSunflowerPrice += sunflowerPrice;
+                }
+            }
+        }
+    }
+
+    return {
+        areaSquareMeters: occupiedCells.size,
+        blockCount,
+        totalSunflowerPrice: hasPriceData ? totalSunflowerPrice : null,
+    };
+}
+
+export function calculatePublicGardenStats(
+    garden: PublicGardenResponse,
+    blockData?: PublicGardenStatsBlockData[] | null,
+) {
+    return calculatePublicGardenStackStats(garden.stacks, blockData);
+}
+
+function isFiniteGardenNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+}
+
 export function formatGardenDate(value: Date | string) {
     return gardenDateFormatter.format(new Date(value));
 }
 
 export function formatGardenNumber(value: unknown) {
-    if (typeof value !== 'number' || !Number.isFinite(value)) {
+    if (!isFiniteGardenNumber(value)) {
         return '—';
     }
 
     return gardenNumberFormatter.format(value);
+}
+
+export function formatGardenAreaSquareMeters(value: unknown) {
+    if (!isFiniteGardenNumber(value)) {
+        return '—';
+    }
+
+    return `${gardenNumberFormatter.format(value)} m²`;
+}
+
+export function formatGardenSunflowerPrice(value: unknown) {
+    if (!isFiniteGardenNumber(value)) {
+        return '—';
+    }
+
+    return `${gardenNumberFormatter.format(value)} suncokreta`;
 }


### PR DESCRIPTION
## Summary

Adds a collapsed public-garden stats section on the garden detail page showing:

- garden area in square meters, using shared block footprint spans and rotation
- total placed block count
- total sunflower price for the placed blocks

The page now fetches block directory data alongside the public garden detail so prices and larger block footprints stay aligned with the existing block catalog.

## Validation

- `pnpm --filter www exec node --experimental-strip-types --test ./app/vrtovi/publicGardenFormatting.node.spec.ts`
- `pnpm --filter www typecheck`
- `pnpm --filter www lint`
- `pnpm --filter www build`