### PR TITLE
feat(www): use sunflower emoji for garden prices

### DIFF
--- a/apps/www/app/vrtovi/publicGardenFormatting.node.spec.ts
+++ b/apps/www/app/vrtovi/publicGardenFormatting.node.spec.ts
@@ -68,6 +68,6 @@ test('calculatePublicGardenStackStats falls back to stack cells when block direc
 
 test('garden stat formatters include Croatian units and unknown fallbacks', () => {
     assert.equal(formatGardenAreaSquareMeters(6), '6 m²');
-    assert.equal(formatGardenSunflowerPrice(1440), '1.440 suncokreta');
+    assert.equal(formatGardenSunflowerPrice(1440), '1.440 🌻');
     assert.equal(formatGardenSunflowerPrice(null), '—');
 });

--- a/apps/www/app/vrtovi/publicGardenFormatting.ts
+++ b/apps/www/app/vrtovi/publicGardenFormatting.ts
@@ -151,5 +151,5 @@ export function formatGardenSunflowerPrice(value: unknown) {
         return '—';
     }
 
-    return `${gardenNumberFormatter.format(value)} suncokreta`;
+    return `${gardenNumberFormatter.format(value)} 🌻`;
 }


### PR DESCRIPTION
## Summary

Updates the public garden stats price formatter to display sunflower prices with the 🌻 emoji instead of the word `suncokreta`.

This changes values like `11.552 suncokreta` to `11.552 🌻` and keeps the existing unknown-value fallback.

## Validation

- `pnpm --filter www exec node --experimental-strip-types --test ./app/vrtovi/publicGardenFormatting.node.spec.ts`
- `pnpm --filter www typecheck`
- `pnpm --filter www lint`