### PR TITLE
fix(community-edits): cover all plant lifecycle sections

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantRelationshipsSection.tsx
+++ b/apps/www/app/biljke/[alias]/PlantRelationshipsSection.tsx
@@ -6,6 +6,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
+import { CommunityEditButton } from '../../../components/community-edits/CommunityEditButton';
 import { KnownPages } from '../../../src/KnownPages';
 
 type PlantRelationship = NonNullable<
@@ -13,6 +14,12 @@ type PlantRelationship = NonNullable<
 >[number];
 
 export type PlantRelationships = PlantData['relationships'];
+
+type PlantRelationshipEditTarget = {
+    entityTypeName: 'plant' | 'plantSort';
+    entityId: number;
+    publicPath: string;
+};
 
 export function hasPlantRelationships(
     relationships: PlantRelationships | null | undefined,
@@ -102,8 +109,10 @@ function PlantRelationshipGroup({
 }
 
 export function PlantRelationshipsSection({
+    editTarget,
     relationships,
 }: {
+    editTarget?: PlantRelationshipEditTarget;
     relationships: PlantRelationships | null | undefined;
 }) {
     if (!hasPlantRelationships(relationships)) {
@@ -111,21 +120,38 @@ export function PlantRelationshipsSection({
     }
 
     return (
-        <Stack spacing={4}>
-            <Typography
-                level="h2"
-                className="text-2xl"
-                id={slug('Biljni susjedi')}
-            >
-                Biljni susjedi
-            </Typography>
-            <Typography level="body2" secondary>
-                Biljni susjedi su smjernice za planiranje blizine biljaka.{' '}
-                <Link className="underline" href={KnownPages.CompanionPlanting}>
-                    Saznaj kako ih čitati
-                </Link>
-                .
-            </Typography>
+        <Stack spacing={4} className="group/relationships">
+            <div className="flex items-start justify-between gap-3">
+                <Stack spacing={1}>
+                    <Typography
+                        level="h2"
+                        className="text-2xl"
+                        id={slug('Biljni susjedi')}
+                    >
+                        Biljni susjedi
+                    </Typography>
+                    <Typography level="body2" secondary>
+                        Biljni susjedi su smjernice za planiranje blizine
+                        biljaka.{' '}
+                        <Link
+                            className="underline"
+                            href={KnownPages.CompanionPlanting}
+                        >
+                            Saznaj kako ih čitati
+                        </Link>
+                        .
+                    </Typography>
+                </Stack>
+                {editTarget ? (
+                    <CommunityEditButton
+                        className="mt-1 md:opacity-0 md:transition-opacity md:group-hover/relationships:opacity-100 md:group-focus-within/relationships:opacity-100"
+                        entityTypeName={editTarget.entityTypeName}
+                        entityId={editTarget.entityId}
+                        publicPath={editTarget.publicPath}
+                        sectionKey="relationships"
+                    />
+                ) : null}
+            </div>
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
                 <PlantRelationshipGroup
                     title="Dobri susjedi"

--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -165,6 +165,11 @@ export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
                 )}
                 <PlantHealthSection health={plant.health} />
                 <PlantRelationshipsSection
+                    editTarget={{
+                        entityTypeName: 'plant',
+                        entityId: plant.id,
+                        publicPath: KnownPages.Plant(alias),
+                    }}
                     relationships={plant.relationships}
                 />
                 <PlantSortsList

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -304,7 +304,14 @@ export default async function PlantSortPage(
                     <PlantTips plant={basePlantData} />
                 )}
                 <PlantHealthSection health={health} />
-                <PlantRelationshipsSection relationships={relationships} />
+                <PlantRelationshipsSection
+                    editTarget={{
+                        entityTypeName: 'plantSort',
+                        entityId: sortData.id,
+                        publicPath: sortPath,
+                    }}
+                    relationships={relationships}
+                />
                 <Row spacing={4}>
                     <Typography level="body1">
                         Jesu li ti informacije o ovoj biljci korisne?

--- a/apps/www/components/community-edits/CommunityEditButton.tsx
+++ b/apps/www/components/community-edits/CommunityEditButton.tsx
@@ -111,6 +111,7 @@ type FieldValue =
 
 type SubmitValue =
     | string
+    | string[]
     | {
           min: number;
           max: number;
@@ -140,10 +141,15 @@ const textareaControlClassName =
     'w-full rounded-md border border-border/80 bg-card px-3 py-2 text-sm text-foreground shadow-sm ring-offset-background transition-colors placeholder:text-muted-foreground/70 hover:border-primary/40 focus:border-primary/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted/70 disabled:text-muted-foreground';
 const attributeIconClassName = 'size-4';
 
-type CommunityEditFieldGroup = 'attributes' | 'content' | 'operations';
+type CommunityEditFieldGroup =
+    | 'attributes'
+    | 'content'
+    | 'operations'
+    | 'relationships';
 
 const communityEditFieldGroups = [
     'content',
+    'relationships',
     'attributes',
     'operations',
 ] satisfies CommunityEditFieldGroup[];
@@ -159,6 +165,10 @@ function communityEditFieldGroup(
         return 'attributes';
     }
 
+    if (field.attributePath.startsWith('relationships.')) {
+        return 'relationships';
+    }
+
     return 'content';
 }
 
@@ -168,6 +178,8 @@ function communityEditFieldGroupLabel(group: CommunityEditFieldGroup) {
             return 'Svojstva';
         case 'operations':
             return 'Radnje';
+        case 'relationships':
+            return 'Biljni susjedi';
         case 'content':
             return 'Sadržaj';
     }
@@ -263,6 +275,10 @@ function initialFieldValue(field: CommunityEditableField): FieldValue {
         }
     }
 
+    if (field.controlType === 'reference' && field.multiple) {
+        return referenceListTextFromCurrentValue(field.currentValue);
+    }
+
     return field.currentValue ?? '';
 }
 
@@ -328,6 +344,36 @@ function normalizeJsonValue(value: string) {
     }
 }
 
+function referenceListTextFromCurrentValue(value: string | null) {
+    if (!value) {
+        return '';
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(value);
+        if (!Array.isArray(parsed)) {
+            return value;
+        }
+
+        return parsed
+            .filter(
+                (entry): entry is string | number =>
+                    typeof entry === 'string' || typeof entry === 'number',
+            )
+            .map(String)
+            .join('\n');
+    } catch {
+        return value;
+    }
+}
+
+function referenceListFromText(value: string) {
+    return value
+        .split(/[\s,;]+/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+}
+
 function serializeFieldValue(
     field: CommunityEditableField,
     value: FieldValue,
@@ -391,6 +437,14 @@ function serializeFieldValue(
     }
 
     const textValue = typeof value === 'string' ? value : '';
+    if (field.controlType === 'reference' && field.multiple) {
+        const references = referenceListFromText(textValue);
+        return {
+            comparisonValue: JSON.stringify(references),
+            submitValue: references,
+        };
+    }
+
     if (field.controlType === 'json') {
         const normalized = normalizeJsonValue(textValue);
         return { comparisonValue: normalized, submitValue: textValue || null };
@@ -723,6 +777,18 @@ function FieldInput({
         );
     }
 
+    if (field.controlType === 'reference' && field.multiple) {
+        return (
+            <textarea
+                className={cx(textareaControlClassName, 'min-h-24')}
+                id={id}
+                onChange={(event) => onChange(event.currentTarget.value)}
+                placeholder="Npr. 12, 34, 56"
+                value={typeof value === 'string' ? value : ''}
+            />
+        );
+    }
+
     if (field.controlType === 'number' || field.controlType === 'reference') {
         return (
             <Input
@@ -939,6 +1005,9 @@ export function CommunityEditButton({
         ),
         operations: fields.filter(
             (field) => communityEditFieldGroup(field) === 'operations',
+        ),
+        relationships: fields.filter(
+            (field) => communityEditFieldGroup(field) === 'relationships',
         ),
     };
 

--- a/apps/www/tests/community-edit-button.spec.tsx
+++ b/apps/www/tests/community-edit-button.spec.tsx
@@ -251,6 +251,122 @@ test('submits a changed section edit for authenticated users', async ({
     ).toBeVisible();
 });
 
+test('submits multiple reference edits for plant relationships', async ({
+    mount,
+    page,
+}) => {
+    await page.route('**/api/gredice/api/auth/current-claims', (route) =>
+        route.fulfill({
+            status: 200,
+            json: {
+                id: 'user-1',
+                userName: 'ana',
+                displayName: 'Ana',
+            },
+        }),
+    );
+    await page.route(
+        '**/api/gredice/api/directories/community-edits/entities/plant/1/fields**',
+        (route) =>
+            route.fulfill({
+                status: 200,
+                json: {
+                    entityTypeName: 'plant',
+                    entityId: 1,
+                    sectionKey: 'relationships',
+                    fields: [
+                        {
+                            entityTypeName: 'plant',
+                            entityId: 1,
+                            fieldKey: 'plant.relationships.companions',
+                            sectionKey: 'relationships',
+                            attributeDefinitionId: 30,
+                            attributeValueId: 40,
+                            attributePath: 'relationships.companions',
+                            dataType: 'ref:plant',
+                            controlType: 'reference',
+                            multiple: true,
+                            publicLabel: 'Dobri susjedi',
+                            helpText:
+                                'ID-jeve biljaka unesi odvojene zarezom ili svaki u novi red.',
+                            currentValue: JSON.stringify(['12', '34']),
+                            baseValueHash: 'hash-companions',
+                        },
+                        {
+                            entityTypeName: 'plant',
+                            entityId: 1,
+                            fieldKey: 'plant.relationships.antagonists',
+                            sectionKey: 'relationships',
+                            attributeDefinitionId: 31,
+                            attributeValueId: null,
+                            attributePath: 'relationships.antagonists',
+                            dataType: 'ref:plant',
+                            controlType: 'reference',
+                            multiple: true,
+                            publicLabel: 'Izbjegavati blizinu',
+                            currentValue: '[]',
+                            baseValueHash: 'hash-antagonists',
+                        },
+                    ],
+                },
+            }),
+    );
+    await page.route(
+        '**/api/gredice/api/directories/community-edits',
+        async (route) => {
+            const body = route.request().postDataJSON();
+            expect(body).toMatchObject({
+                entityTypeName: 'plant',
+                entityId: 1,
+                publicPath: '/biljke/rajcica',
+                sectionKey: 'relationships',
+                changes: [
+                    {
+                        fieldKey: 'plant.relationships.companions',
+                        proposedValue: ['12', '34', '56'],
+                        baseValueHash: 'hash-companions',
+                    },
+                    {
+                        fieldKey: 'plant.relationships.antagonists',
+                        proposedValue: ['78'],
+                        baseValueHash: 'hash-antagonists',
+                    },
+                ],
+            });
+
+            await route.fulfill({
+                status: 201,
+                json: {
+                    status: 'pending_admin_approval',
+                    requestId: 45,
+                    requestStatus: 'pending',
+                    changeCount: 2,
+                },
+            });
+        },
+    );
+
+    await mount(
+        <CommunityEditButtonHarness
+            entityTypeName="plant"
+            entityId={1}
+            publicPath="/biljke/rajcica"
+            sectionKey="relationships"
+        />,
+    );
+
+    await page.getByTitle('Predloži izmjenu').click();
+    await expect(page.getByLabel('Dobri susjedi')).toHaveValue('12\n34');
+
+    await page.getByLabel('Dobri susjedi').fill('12\n34\n56');
+    await page.getByLabel('Izbjegavati blizinu').fill('78');
+    await page.getByRole('button', { name: 'Pošalji' }).click();
+
+    await expect(
+        page.getByText('Prijedlog #45 je poslan na odobrenje.'),
+    ).toBeVisible();
+});
+
 test('shows storage content and operation suggestions in the edit modal', async ({
     mount,
     page,

--- a/packages/game/src/hud/raisedBed/featuredOperations.ts
+++ b/packages/game/src/hud/raisedBed/featuredOperations.ts
@@ -1,13 +1,10 @@
-export type PlantStageName =
-    | 'sowing'
-    | 'soilPreparation'
-    | 'planting'
-    | 'growth'
-    | 'maintenance'
-    | 'watering'
-    | 'flowering'
-    | 'harvest'
-    | 'storage';
+import {
+    PLANT_STAGE_LABELS,
+    PLANT_STAGES,
+    type PlantStageName,
+} from '@gredice/js/plants';
+
+export { PLANT_STAGE_LABELS, PLANT_STAGES, type PlantStageName };
 
 export type PlantFieldStatus =
     | 'new'
@@ -22,105 +19,6 @@ export type PlantFieldStatus =
     | 'harvested'
     | 'died'
     | 'removed';
-
-/**
- * Plant stage configuration - Single source of truth for all plant stages.
- *
- * This constant defines the canonical order, labels, and icon identifiers for all plant stages.
- * It serves as the central definition used across the entire application for:
- * - Operations page stage grouping and ordering
- * - Plant information sections ordering
- * - Stage selection and filtering throughout the UI
- * - Any other plant lifecycle stage representations
- *
- * **Order matters**: The array order defines the logical workflow sequence from
- * soil preparation through to storage. This order is preserved when displaying
- * stages throughout the application.
- *
- * **Properties**:
- * - `name`: Internal identifier (PlantStageName) used in the database and API
- * - `label`: User-facing Croatian label displayed in the UI
- * - `icon`: Icon identifier (currently matches name, reserved for future icon mapping)
- *
- * **Usage Examples**:
- * ```typescript
- * // Get all available stages
- * const stages = PLANT_STAGES;
- *
- * // Filter to only stages present in data
- * const activeStages = PLANT_STAGES.filter(stage =>
- *   myData.some(item => item.stageName === stage.name)
- * );
- *
- * // Map to display labels
- * const labels = PLANT_STAGES.map(stage => stage.label);
- * ```
- *
- * @since 1.0.0
- */
-export const PLANT_STAGES = [
-    {
-        name: 'soilPreparation' as const,
-        label: 'Priprema tla',
-        icon: 'soilPreparation',
-    },
-    {
-        name: 'sowing' as const,
-        label: 'Sijanje',
-        icon: 'sowing',
-    },
-    {
-        name: 'planting' as const,
-        label: 'Sadnja',
-        icon: 'planting',
-    },
-    {
-        name: 'growth' as const,
-        label: 'Rast',
-        icon: 'growth',
-    },
-    {
-        name: 'maintenance' as const,
-        label: 'Održavanje',
-        icon: 'maintenance',
-    },
-    {
-        name: 'watering' as const,
-        label: 'Zalijevanje',
-        icon: 'watering',
-    },
-    {
-        name: 'flowering' as const,
-        label: 'Cvjetanje',
-        icon: 'flowering',
-    },
-    {
-        name: 'harvest' as const,
-        label: 'Berba',
-        icon: 'harvest',
-    },
-    {
-        name: 'storage' as const,
-        label: 'Skladištenje',
-        icon: 'storage',
-    },
-] as const;
-
-/**
- * @deprecated Use PLANT_STAGES array instead. This will be removed in a future version.
- * Legacy map for backwards compatibility.
- */
-export const PLANT_STAGE_LABELS: Record<PlantStageName, string> = {
-    soilPreparation: 'Priprema tla',
-    sowing: 'Sijanje',
-    planting: 'Sadnja',
-    growth: 'Rast',
-    maintenance: 'Održavanje',
-    watering: 'Zalijevanje',
-    flowering: 'Cvjetanje',
-    harvest: 'Berba',
-    storage: 'Skladištenje',
-} as const;
 
 export const PLANT_STATUS_STAGE_SEQUENCE: Record<
     PlantFieldStatus,

--- a/packages/js/src/plants/index.ts
+++ b/packages/js/src/plants/index.ts
@@ -4,3 +4,4 @@ export * from './isPlantRecommended';
 export * from './plantFieldStatusEmoji';
 export * from './plantFieldStatusLabel';
 export * from './plantFieldStatusTransitions';
+export * from './plantStages';

--- a/packages/js/src/plants/plantStages.ts
+++ b/packages/js/src/plants/plantStages.ts
@@ -1,0 +1,79 @@
+export type PlantStageName =
+    | 'sowing'
+    | 'soilPreparation'
+    | 'planting'
+    | 'growth'
+    | 'maintenance'
+    | 'watering'
+    | 'flowering'
+    | 'harvest'
+    | 'storage';
+
+export type PlantStageDefinition = {
+    readonly name: PlantStageName;
+    readonly label: string;
+    readonly icon: PlantStageName;
+};
+
+/**
+ * Canonical plant lifecycle stages in the public display order.
+ */
+export const PLANT_STAGES = [
+    {
+        name: 'soilPreparation',
+        label: 'Priprema tla',
+        icon: 'soilPreparation',
+    },
+    {
+        name: 'sowing',
+        label: 'Sijanje',
+        icon: 'sowing',
+    },
+    {
+        name: 'planting',
+        label: 'Sadnja',
+        icon: 'planting',
+    },
+    {
+        name: 'growth',
+        label: 'Rast',
+        icon: 'growth',
+    },
+    {
+        name: 'maintenance',
+        label: 'Održavanje',
+        icon: 'maintenance',
+    },
+    {
+        name: 'watering',
+        label: 'Zalijevanje',
+        icon: 'watering',
+    },
+    {
+        name: 'flowering',
+        label: 'Cvjetanje',
+        icon: 'flowering',
+    },
+    {
+        name: 'harvest',
+        label: 'Berba',
+        icon: 'harvest',
+    },
+    {
+        name: 'storage',
+        label: 'Skladištenje',
+        icon: 'storage',
+    },
+] as const satisfies readonly PlantStageDefinition[];
+
+export const PLANT_STAGE_LABELS = {
+    soilPreparation: 'Priprema tla',
+    sowing: 'Sijanje',
+    planting: 'Sadnja',
+    growth: 'Rast',
+    maintenance: 'Održavanje',
+    watering: 'Zalijevanje',
+    flowering: 'Cvjetanje',
+    harvest: 'Berba',
+    storage: 'Skladištenje',
+} as const satisfies Record<PlantStageName, string>;

--- a/packages/storage/src/helpers/communityEditableFields.ts
+++ b/packages/storage/src/helpers/communityEditableFields.ts
@@ -1,3 +1,9 @@
+import {
+    PLANT_STAGE_LABELS,
+    PLANT_STAGES,
+    type PlantStageName,
+} from '@gredice/js/plants';
+
 export type CommunityEditControlType =
     | 'boolean'
     | 'json'
@@ -39,18 +45,40 @@ export type CommunityEditableSection = {
 };
 
 export type CommunityEditableOperationSuggestionStage = {
-    name: string;
+    name: PlantStageName;
     label: string;
 };
 
 export const communityEditablePlantOperationStages: CommunityEditableOperationSuggestionStage[] =
-    [
-        { name: 'sowing', label: 'Sjetva' },
-        { name: 'growth', label: 'Rast' },
-        { name: 'watering', label: 'Zalijevanje' },
-        { name: 'harvest', label: 'Berba' },
-        { name: 'storage', label: 'Skladištenje' },
-    ];
+    PLANT_STAGES.map(({ name, label }) => ({ name, label }));
+
+const communityEditablePlantStageInformationFields: CommunityEditableFieldDefinition[] =
+    PLANT_STAGES.map((stage) => ({
+        entityTypeName: 'plant',
+        fieldKey: `plant.${stage.name}`,
+        sectionKey: stage.name,
+        category: 'information',
+        name: stage.name,
+        publicLabel: stage.label,
+        controlType: 'markdown',
+        pageLevel: true,
+        inline: true,
+        maxLength: 16000,
+    }));
+
+const communityEditablePlantSortStageInformationFields: CommunityEditableFieldDefinition[] =
+    PLANT_STAGES.map((stage) => ({
+        entityTypeName: 'plantSort',
+        fieldKey: `plant-sort.${stage.name}`,
+        sectionKey: stage.name,
+        category: 'information',
+        name: stage.name,
+        publicLabel: `${stage.label} sorte`,
+        controlType: 'markdown',
+        pageLevel: true,
+        inline: true,
+        maxLength: 16000,
+    }));
 
 const communityEditablePlantOperationFields: CommunityEditableFieldDefinition[] =
     communityEditablePlantOperationStages.map((stage) => ({
@@ -118,66 +146,7 @@ const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
         inline: true,
         maxLength: 12000,
     },
-    {
-        entityTypeName: 'plant',
-        fieldKey: 'plant.sowing',
-        sectionKey: 'sowing',
-        category: 'information',
-        name: 'sowing',
-        publicLabel: 'Sjetva',
-        controlType: 'markdown',
-        pageLevel: true,
-        inline: true,
-        maxLength: 16000,
-    },
-    {
-        entityTypeName: 'plant',
-        fieldKey: 'plant.growth',
-        sectionKey: 'growth',
-        category: 'information',
-        name: 'growth',
-        publicLabel: 'Rast',
-        controlType: 'markdown',
-        pageLevel: true,
-        inline: true,
-        maxLength: 16000,
-    },
-    {
-        entityTypeName: 'plant',
-        fieldKey: 'plant.watering',
-        sectionKey: 'watering',
-        category: 'information',
-        name: 'watering',
-        publicLabel: 'Zalijevanje',
-        controlType: 'markdown',
-        pageLevel: true,
-        inline: true,
-        maxLength: 16000,
-    },
-    {
-        entityTypeName: 'plant',
-        fieldKey: 'plant.harvest',
-        sectionKey: 'harvest',
-        category: 'information',
-        name: 'harvest',
-        publicLabel: 'Berba',
-        controlType: 'markdown',
-        pageLevel: true,
-        inline: true,
-        maxLength: 16000,
-    },
-    {
-        entityTypeName: 'plant',
-        fieldKey: 'plant.storage',
-        sectionKey: 'storage',
-        category: 'information',
-        name: 'storage',
-        publicLabel: 'Skladištenje',
-        controlType: 'markdown',
-        pageLevel: true,
-        inline: true,
-        maxLength: 16000,
-    },
+    ...communityEditablePlantStageInformationFields,
     {
         entityTypeName: 'plant',
         fieldKey: 'plant.seeding-distance',
@@ -488,54 +457,7 @@ const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
         inline: true,
         maxLength: 12000,
     },
-    {
-        entityTypeName: 'plantSort',
-        fieldKey: 'plant-sort.sowing',
-        sectionKey: 'sowing',
-        category: 'information',
-        name: 'sowing',
-        publicLabel: 'Sjetva sorte',
-        controlType: 'markdown',
-        pageLevel: true,
-        inline: true,
-        maxLength: 16000,
-    },
-    {
-        entityTypeName: 'plantSort',
-        fieldKey: 'plant-sort.growth',
-        sectionKey: 'growth',
-        category: 'information',
-        name: 'growth',
-        publicLabel: 'Rast sorte',
-        controlType: 'markdown',
-        pageLevel: true,
-        inline: true,
-        maxLength: 16000,
-    },
-    {
-        entityTypeName: 'plantSort',
-        fieldKey: 'plant-sort.watering',
-        sectionKey: 'watering',
-        category: 'information',
-        name: 'watering',
-        publicLabel: 'Zalijevanje sorte',
-        controlType: 'markdown',
-        pageLevel: true,
-        inline: true,
-        maxLength: 16000,
-    },
-    {
-        entityTypeName: 'plantSort',
-        fieldKey: 'plant-sort.harvest',
-        sectionKey: 'harvest',
-        category: 'information',
-        name: 'harvest',
-        publicLabel: 'Berba sorte',
-        controlType: 'markdown',
-        pageLevel: true,
-        inline: true,
-        maxLength: 16000,
-    },
+    ...communityEditablePlantSortStageInformationFields,
     {
         entityTypeName: 'operation',
         fieldKey: 'operation.label',
@@ -739,24 +661,24 @@ export function getCommunityEditableSections(entityTypeName: string) {
     );
 }
 
+function isPlantStageName(sectionKey: string): sectionKey is PlantStageName {
+    return sectionKey in PLANT_STAGE_LABELS;
+}
+
 export function communityEditableSectionLabel(sectionKey: string) {
+    if (isPlantStageName(sectionKey)) {
+        return PLANT_STAGE_LABELS[sectionKey];
+    }
+
     switch (sectionKey) {
         case 'attributes':
             return 'Svojstva';
         case 'description':
             return 'Opis';
-        case 'growth':
-            return 'Rast';
-        case 'harvest':
-            return 'Berba';
         case 'instructions':
             return 'Postupak';
         case 'overview':
             return 'Pregled';
-        case 'sowing':
-            return 'Sjetva';
-        case 'watering':
-            return 'Zalijevanje';
         default:
             return sectionKey;
     }

--- a/packages/storage/src/helpers/communityEditableFields.ts
+++ b/packages/storage/src/helpers/communityEditableFields.ts
@@ -3,6 +3,7 @@ import {
     PLANT_STAGES,
     type PlantStageName,
 } from '@gredice/js/plants';
+import { plantRelationshipAttributeNames } from './plantRelationships';
 
 export type CommunityEditControlType =
     | 'boolean'
@@ -96,6 +97,58 @@ const communityEditablePlantOperationFields: CommunityEditableFieldDefinition[] 
         operationSuggestionStage: stage,
     }));
 
+const communityEditablePlantRelationshipFields: CommunityEditableFieldDefinition[] =
+    [
+        {
+            fieldKey: 'plant.relationships.companions',
+            name: plantRelationshipAttributeNames.companions,
+            publicLabel: 'Dobri susjedi',
+            helpText:
+                'ID-jeve biljaka unesi odvojene zarezom ili svaki u novi red.',
+        },
+        {
+            fieldKey: 'plant.relationships.antagonists',
+            name: plantRelationshipAttributeNames.antagonists,
+            publicLabel: 'Izbjegavati blizinu',
+            helpText:
+                'ID-jeve biljaka unesi odvojene zarezom ili svaki u novi red.',
+        },
+    ].map((field) => ({
+        entityTypeName: 'plant',
+        sectionKey: 'relationships',
+        category: 'relationships',
+        controlType: 'reference',
+        pageLevel: true,
+        inline: true,
+        ...field,
+    }));
+
+const communityEditablePlantSortRelationshipFields: CommunityEditableFieldDefinition[] =
+    [
+        {
+            fieldKey: 'plant-sort.relationships.companions',
+            name: plantRelationshipAttributeNames.companions,
+            publicLabel: 'Dobri susjedi sorte',
+            helpText:
+                'ID-jeve biljaka unesi odvojene zarezom ili svaki u novi red.',
+        },
+        {
+            fieldKey: 'plant-sort.relationships.antagonists',
+            name: plantRelationshipAttributeNames.antagonists,
+            publicLabel: 'Izbjegavati blizinu sorte',
+            helpText:
+                'ID-jeve biljaka unesi odvojene zarezom ili svaki u novi red.',
+        },
+    ].map((field) => ({
+        entityTypeName: 'plantSort',
+        sectionKey: 'relationships',
+        category: 'relationships',
+        controlType: 'reference',
+        pageLevel: true,
+        inline: true,
+        ...field,
+    }));
+
 const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
     {
         entityTypeName: 'plant',
@@ -147,6 +200,7 @@ const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
         maxLength: 12000,
     },
     ...communityEditablePlantStageInformationFields,
+    ...communityEditablePlantRelationshipFields,
     {
         entityTypeName: 'plant',
         fieldKey: 'plant.seeding-distance',
@@ -458,6 +512,7 @@ const communityEditableFieldRegistry: CommunityEditableFieldDefinition[] = [
         maxLength: 12000,
     },
     ...communityEditablePlantSortStageInformationFields,
+    ...communityEditablePlantSortRelationshipFields,
     {
         entityTypeName: 'operation',
         fieldKey: 'operation.label',
@@ -679,6 +734,8 @@ export function communityEditableSectionLabel(sectionKey: string) {
             return 'Postupak';
         case 'overview':
             return 'Pregled';
+        case 'relationships':
+            return 'Biljni susjedi';
         default:
             return sectionKey;
     }

--- a/packages/storage/src/repositories/communityEditRequestsRepo.ts
+++ b/packages/storage/src/repositories/communityEditRequestsRepo.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import { createHash } from 'node:crypto';
+import { PLANT_STAGE_LABELS, type PlantStageName } from '@gredice/js/plants';
 import { and, asc, count, desc, eq } from 'drizzle-orm';
 import {
     type CommunityEditableFieldDefinition,
@@ -107,7 +108,7 @@ export type CommunityOperationSuggestionValue = {
     intent: CommunityOperationSuggestionIntent;
     operationId: number;
     operationLabel: string;
-    stageName: string;
+    stageName: PlantStageName;
     stageLabel: string;
     currentState: 'absent' | 'present';
     note?: string;
@@ -164,6 +165,10 @@ function stableValueHash(value: string | null) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
+}
+
+function isPlantStageName(value: unknown): value is PlantStageName {
+    return typeof value === 'string' && value in PLANT_STAGE_LABELS;
 }
 
 function rawAttributeValue(entity: EntityRaw, category: string, name: string) {
@@ -782,7 +787,7 @@ async function resolveOperationSuggestionTarget(input: {
 
     return {
         operationLabel: entityLabel(operation),
-        stageName: stage.name,
+        stageName: input.stage.name,
         stageLabel: stage.label,
     };
 }
@@ -1466,7 +1471,7 @@ function parseCommunityOperationSuggestion(
             typeof parsed.operationId !== 'number' ||
             !Number.isInteger(parsed.operationId) ||
             typeof parsed.operationLabel !== 'string' ||
-            typeof parsed.stageName !== 'string' ||
+            !isPlantStageName(parsed.stageName) ||
             typeof parsed.stageLabel !== 'string' ||
             (parsed.currentState !== 'absent' &&
                 parsed.currentState !== 'present') ||
@@ -1480,7 +1485,23 @@ function parseCommunityOperationSuggestion(
             return null;
         }
 
-        return parsed as CommunityOperationSuggestionValue;
+        const suggestion: CommunityOperationSuggestionValue = {
+            format: 'community-operation-suggestion-v1',
+            intent: parsed.intent,
+            operationId: parsed.operationId,
+            operationLabel: parsed.operationLabel,
+            stageName: parsed.stageName,
+            stageLabel: parsed.stageLabel,
+            currentState: parsed.currentState,
+        };
+        if (typeof parsed.note === 'string') {
+            suggestion.note = parsed.note;
+        }
+        if (typeof parsed.source === 'string') {
+            suggestion.source = parsed.source;
+        }
+
+        return suggestion;
     } catch {
         return null;
     }

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -27,12 +27,16 @@ import {
 import { createTestDb } from './testDb';
 
 type CommunityEditFixture = {
+    plantAntagonistsDefinitionId: number;
+    plantCompanionsDefinitionId: number;
     plantDescriptionDefinitionId: number;
     plantGerminationTypeDefinitionId: number;
     plantMaintenanceDefinitionId: number;
     plantOperationsDefinitionId: number;
     plantSeedingDistanceDefinitionId: number;
     plantStorageDefinitionId: number;
+    plantSortAntagonistsDefinitionId: number;
+    plantSortCompanionsDefinitionId: number;
     plantSortLatinNameDefinitionId: number;
     plantSortMaintenanceDefinitionId: number;
     operationNameDefinitionId: number;
@@ -124,6 +128,22 @@ async function createFixture(): Promise<CommunityEditFixture> {
         dataType: 'ref:operation',
         multiple: true,
     });
+    const plantCompanionsDefinitionId = await createAttributeDefinition({
+        category: 'relationships',
+        name: 'companions',
+        label: 'Dobri susjedi',
+        entityTypeName: 'plant',
+        dataType: 'ref:plant',
+        multiple: true,
+    });
+    const plantAntagonistsDefinitionId = await createAttributeDefinition({
+        category: 'relationships',
+        name: 'antagonists',
+        label: 'Loši susjedi',
+        entityTypeName: 'plant',
+        dataType: 'ref:plant',
+        multiple: true,
+    });
     await upsertEntityType({ name: 'plantSort', label: 'Sorta biljke' });
     const plantSortLatinNameDefinitionId = await createAttributeDefinition({
         category: 'information',
@@ -138,6 +158,22 @@ async function createFixture(): Promise<CommunityEditFixture> {
         label: 'Održavanje sorte',
         entityTypeName: 'plantSort',
         dataType: 'markdown',
+    });
+    const plantSortCompanionsDefinitionId = await createAttributeDefinition({
+        category: 'relationships',
+        name: 'companions',
+        label: 'Dobri susjedi sorte',
+        entityTypeName: 'plantSort',
+        dataType: 'ref:plant',
+        multiple: true,
+    });
+    const plantSortAntagonistsDefinitionId = await createAttributeDefinition({
+        category: 'relationships',
+        name: 'antagonists',
+        label: 'Loši susjedi sorte',
+        entityTypeName: 'plantSort',
+        dataType: 'ref:plant',
+        multiple: true,
     });
     const stageNameDefinitionId = await createAttributeDefinition({
         category: 'information',
@@ -191,12 +227,16 @@ async function createFixture(): Promise<CommunityEditFixture> {
     });
 
     return {
+        plantAntagonistsDefinitionId,
+        plantCompanionsDefinitionId,
         plantDescriptionDefinitionId,
         plantGerminationTypeDefinitionId,
         plantMaintenanceDefinitionId,
         plantOperationsDefinitionId,
         plantSeedingDistanceDefinitionId,
         plantStorageDefinitionId,
+        plantSortAntagonistsDefinitionId,
+        plantSortCompanionsDefinitionId,
         plantSortLatinNameDefinitionId,
         plantSortMaintenanceDefinitionId,
         operationNameDefinitionId,
@@ -211,6 +251,8 @@ async function createFixture(): Promise<CommunityEditFixture> {
 }
 
 async function createPublishedPlant(input?: {
+    antagonistIds?: number[];
+    companionIds?: number[];
     description?: string;
     germinationType?: string;
     maintenance?: string;
@@ -260,6 +302,26 @@ async function createPublishedPlant(input?: {
             order: String(index),
         });
     }
+    for (const [index, companionId] of (input?.companionIds ?? []).entries()) {
+        await upsertAttributeValue({
+            attributeDefinitionId: data.plantCompanionsDefinitionId,
+            entityTypeName: 'plant',
+            entityId,
+            value: String(companionId),
+            order: String(index),
+        });
+    }
+    for (const [index, antagonistId] of (
+        input?.antagonistIds ?? []
+    ).entries()) {
+        await upsertAttributeValue({
+            attributeDefinitionId: data.plantAntagonistsDefinitionId,
+            entityTypeName: 'plant',
+            entityId,
+            value: String(antagonistId),
+            order: String(index),
+        });
+    }
     return entityId;
 }
 
@@ -286,6 +348,8 @@ async function createPublishedPlantStage(input: {
 }
 
 async function createPublishedPlantSort(input?: {
+    antagonistIds?: number[];
+    companionIds?: number[];
     latinName?: string;
     maintenance?: string;
 }) {
@@ -304,6 +368,26 @@ async function createPublishedPlantSort(input?: {
         entityId,
         value: input?.maintenance ?? 'Sortu redovito pregledavati.',
     });
+    for (const [index, companionId] of (input?.companionIds ?? []).entries()) {
+        await upsertAttributeValue({
+            attributeDefinitionId: data.plantSortCompanionsDefinitionId,
+            entityTypeName: 'plantSort',
+            entityId,
+            value: String(companionId),
+            order: String(index),
+        });
+    }
+    for (const [index, antagonistId] of (
+        input?.antagonistIds ?? []
+    ).entries()) {
+        await upsertAttributeValue({
+            attributeDefinitionId: data.plantSortAntagonistsDefinitionId,
+            entityTypeName: 'plantSort',
+            entityId,
+            value: String(antagonistId),
+            order: String(index),
+        });
+    }
     return entityId;
 }
 
@@ -397,6 +481,20 @@ test('community editable registry resolves allowed plant and operation fields', 
                 (field) => field.fieldKey === 'plant.stage-operations.storage',
             ),
     );
+    assert.ok(
+        plantSections
+            .find((section) => section.key === 'relationships')
+            ?.fields.some(
+                (field) => field.fieldKey === 'plant.relationships.companions',
+            ),
+    );
+    assert.ok(
+        plantSections
+            .find((section) => section.key === 'relationships')
+            ?.fields.some(
+                (field) => field.fieldKey === 'plant.relationships.antagonists',
+            ),
+    );
 
     for (const stage of PLANT_STAGES) {
         const sectionFields =
@@ -434,6 +532,14 @@ test('community editable registry resolves allowed plant and operation fields', 
         plantSortSections
             .find((section) => section.key === 'overview')
             ?.fields.some((field) => field.fieldKey === 'plant-sort.name'),
+    );
+    assert.ok(
+        plantSortSections
+            .find((section) => section.key === 'relationships')
+            ?.fields.some(
+                (field) =>
+                    field.fieldKey === 'plant-sort.relationships.companions',
+            ),
     );
     assert.ok(
         getCommunityEditableSections('operation')
@@ -524,6 +630,40 @@ test('community editable registry resolves allowed plant and operation fields', 
         ),
     );
 
+    const companionId = await createPublishedPlant({
+        description: 'Prijateljska biljka.',
+    });
+    const antagonistId = await createPublishedPlant({
+        description: 'Biljka za odvajanje.',
+    });
+    const relationshipPlantId = await createPublishedPlant({
+        companionIds: [companionId],
+        antagonistIds: [antagonistId],
+    });
+    const relationshipFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plant',
+        entityId: relationshipPlantId,
+        sectionKey: 'relationships',
+    });
+    assert.ok(
+        relationshipFields.some(
+            (field) =>
+                field.fieldKey === 'plant.relationships.companions' &&
+                field.controlType === 'reference' &&
+                field.multiple &&
+                field.currentValue === JSON.stringify([String(companionId)]),
+        ),
+    );
+    assert.ok(
+        relationshipFields.some(
+            (field) =>
+                field.fieldKey === 'plant.relationships.antagonists' &&
+                field.controlType === 'reference' &&
+                field.multiple &&
+                field.currentValue === JSON.stringify([String(antagonistId)]),
+        ),
+    );
+
     const plantSortId = await createPublishedPlantSort();
     const plantSortFields = await getCommunityEditableFieldsForEntity({
         entityTypeName: 'plantSort',
@@ -551,6 +691,25 @@ test('community editable registry resolves allowed plant and operation fields', 
                 field.fieldKey === 'plant-sort.maintenance' &&
                 field.controlType === 'markdown' &&
                 field.currentValue === 'Sortu redovito pregledavati.',
+        ),
+    );
+
+    const plantSortRelationshipId = await createPublishedPlantSort({
+        companionIds: [companionId],
+    });
+    const plantSortRelationshipFields =
+        await getCommunityEditableFieldsForEntity({
+            entityTypeName: 'plantSort',
+            entityId: plantSortRelationshipId,
+            sectionKey: 'relationships',
+        });
+    assert.ok(
+        plantSortRelationshipFields.some(
+            (field) =>
+                field.fieldKey === 'plant-sort.relationships.companions' &&
+                field.controlType === 'reference' &&
+                field.multiple &&
+                field.currentValue === JSON.stringify([String(companionId)]),
         ),
     );
 
@@ -682,6 +841,88 @@ test('community edit requests submit storage content and operation suggestions t
     assert.deepEqual(
         attributeValues(entity, data.plantOperationsDefinitionId),
         [String(operationId)],
+    );
+});
+
+test('community edit requests submit plant relationship references', async () => {
+    const data = await fixture();
+    const basilId = await createPublishedPlant({
+        description: 'Dobro se slaže s rajčicom.',
+    });
+    const calendulaId = await createPublishedPlant({
+        description: 'Koristan cvijet u blizini.',
+    });
+    const fennelId = await createPublishedPlant({
+        description: 'Bolje ga je odvojiti.',
+    });
+    const plantId = await createPublishedPlant({
+        companionIds: [basilId],
+    });
+    const relationshipFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plant',
+        entityId: plantId,
+        sectionKey: 'relationships',
+    });
+    const companionsField = relationshipFields.find(
+        (field) => field.fieldKey === 'plant.relationships.companions',
+    );
+    const antagonistsField = relationshipFields.find(
+        (field) => field.fieldKey === 'plant.relationships.antagonists',
+    );
+    assert.ok(companionsField);
+    assert.ok(antagonistsField);
+    assert.equal(companionsField.controlType, 'reference');
+    assert.equal(companionsField.multiple, true);
+    assert.equal(
+        companionsField.currentValue,
+        JSON.stringify([String(basilId)]),
+    );
+    assert.equal(antagonistsField.currentValue, '[]');
+
+    const request = await createCommunityEditRequest({
+        entityTypeName: 'plant',
+        entityId: plantId,
+        publicPath: '/biljke/rajcica',
+        sectionKey: 'relationships',
+        submitter: { id: data.submitterId, name: 'Community Submitter' },
+        changes: [
+            {
+                fieldKey: 'plant.relationships.companions',
+                baseValueHash: companionsField.baseValueHash,
+                proposedValue: [String(basilId), String(calendulaId)],
+            },
+            {
+                fieldKey: 'plant.relationships.antagonists',
+                baseValueHash: antagonistsField.baseValueHash,
+                proposedValue: [String(fennelId)],
+            },
+        ],
+    });
+
+    assert.equal(request.status, 'pending');
+    assert.deepEqual(
+        request.changes.map((change) => change.proposedValue),
+        [
+            JSON.stringify([String(basilId), String(calendulaId)]),
+            JSON.stringify([String(fennelId)]),
+        ],
+    );
+
+    const applied = await approveCommunityEditRequest({
+        id: request.id,
+        reviewer: { id: data.reviewerId, name: 'Community Reviewer' },
+    });
+    assert.equal(applied.status, 'applied');
+
+    const entity = await getEntityRaw(plantId);
+    assert.ok(entity);
+    assert.deepEqual(
+        attributeValues(entity, data.plantCompanionsDefinitionId),
+        [String(basilId), String(calendulaId)],
+    );
+    assert.deepEqual(
+        attributeValues(entity, data.plantAntagonistsDefinitionId),
+        [String(fennelId)],
     );
 });
 

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
+import { PLANT_STAGES } from '@gredice/js/plants';
 import {
     accountUsers,
     approveCommunityEditRequest,
@@ -28,10 +29,12 @@ import { createTestDb } from './testDb';
 type CommunityEditFixture = {
     plantDescriptionDefinitionId: number;
     plantGerminationTypeDefinitionId: number;
+    plantMaintenanceDefinitionId: number;
     plantOperationsDefinitionId: number;
     plantSeedingDistanceDefinitionId: number;
     plantStorageDefinitionId: number;
     plantSortLatinNameDefinitionId: number;
+    plantSortMaintenanceDefinitionId: number;
     operationNameDefinitionId: number;
     operationStageDefinitionId: number;
     operationApplicationDefinitionId: number;
@@ -92,6 +95,13 @@ async function createFixture(): Promise<CommunityEditFixture> {
         entityTypeName: 'plant',
         dataType: 'markdown',
     });
+    const plantMaintenanceDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'maintenance',
+        label: 'Održavanje',
+        entityTypeName: 'plant',
+        dataType: 'markdown',
+    });
     const plantSeedingDistanceDefinitionId = await createAttributeDefinition({
         category: 'attributes',
         name: 'seedingDistance',
@@ -121,6 +131,13 @@ async function createFixture(): Promise<CommunityEditFixture> {
         label: 'Latinski naziv',
         entityTypeName: 'plantSort',
         dataType: 'text',
+    });
+    const plantSortMaintenanceDefinitionId = await createAttributeDefinition({
+        category: 'information',
+        name: 'maintenance',
+        label: 'Održavanje sorte',
+        entityTypeName: 'plantSort',
+        dataType: 'markdown',
     });
     const stageNameDefinitionId = await createAttributeDefinition({
         category: 'information',
@@ -176,10 +193,12 @@ async function createFixture(): Promise<CommunityEditFixture> {
     return {
         plantDescriptionDefinitionId,
         plantGerminationTypeDefinitionId,
+        plantMaintenanceDefinitionId,
         plantOperationsDefinitionId,
         plantSeedingDistanceDefinitionId,
         plantStorageDefinitionId,
         plantSortLatinNameDefinitionId,
+        plantSortMaintenanceDefinitionId,
         operationNameDefinitionId,
         operationStageDefinitionId,
         operationApplicationDefinitionId,
@@ -194,6 +213,7 @@ async function createFixture(): Promise<CommunityEditFixture> {
 async function createPublishedPlant(input?: {
     description?: string;
     germinationType?: string;
+    maintenance?: string;
     operationIds?: number[];
     seedingDistance?: string;
     storage?: string;
@@ -224,6 +244,12 @@ async function createPublishedPlant(input?: {
         entityTypeName: 'plant',
         entityId,
         value: input?.storage ?? 'Čuvati na hladnom mjestu.',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: data.plantMaintenanceDefinitionId,
+        entityTypeName: 'plant',
+        entityId,
+        value: input?.maintenance ?? 'Redovito uklanjati korov.',
     });
     for (const [index, operationId] of (input?.operationIds ?? []).entries()) {
         await upsertAttributeValue({
@@ -259,7 +285,10 @@ async function createPublishedPlantStage(input: {
     return entityId;
 }
 
-async function createPublishedPlantSort(input?: { latinName?: string }) {
+async function createPublishedPlantSort(input?: {
+    latinName?: string;
+    maintenance?: string;
+}) {
     const data = await fixture();
     const entityId = await createEntity('plantSort');
     await updateEntity({ id: entityId, state: 'published' });
@@ -268,6 +297,12 @@ async function createPublishedPlantSort(input?: { latinName?: string }) {
         entityTypeName: 'plantSort',
         entityId,
         value: input?.latinName ?? 'Solanum sortum',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: data.plantSortMaintenanceDefinitionId,
+        entityTypeName: 'plantSort',
+        entityId,
+        value: input?.maintenance ?? 'Sortu redovito pregledavati.',
     });
     return entityId;
 }
@@ -362,8 +397,41 @@ test('community editable registry resolves allowed plant and operation fields', 
                 (field) => field.fieldKey === 'plant.stage-operations.storage',
             ),
     );
+
+    for (const stage of PLANT_STAGES) {
+        const sectionFields =
+            plantSections.find((section) => section.key === stage.name)
+                ?.fields ?? [];
+        assert.ok(
+            sectionFields.some(
+                (field) => field.fieldKey === `plant.${stage.name}`,
+            ),
+            `Expected plant ${stage.name} content field.`,
+        );
+        assert.ok(
+            sectionFields.some(
+                (field) =>
+                    field.fieldKey === `plant.stage-operations.${stage.name}`,
+            ),
+            `Expected plant ${stage.name} operation suggestion field.`,
+        );
+    }
+
+    const plantSortSections = getCommunityEditableSections('plantSort');
+    for (const stage of PLANT_STAGES) {
+        const sectionFields =
+            plantSortSections.find((section) => section.key === stage.name)
+                ?.fields ?? [];
+        assert.ok(
+            sectionFields.some(
+                (field) => field.fieldKey === `plant-sort.${stage.name}`,
+            ),
+            `Expected plant sort ${stage.name} content field.`,
+        );
+    }
+
     assert.ok(
-        getCommunityEditableSections('plantSort')
+        plantSortSections
             .find((section) => section.key === 'overview')
             ?.fields.some((field) => field.fieldKey === 'plant-sort.name'),
     );
@@ -434,6 +502,28 @@ test('community editable registry resolves allowed plant and operation fields', 
         ),
     );
 
+    const maintenanceFields = await getCommunityEditableFieldsForEntity({
+        entityTypeName: 'plant',
+        entityId: plantId,
+        sectionKey: 'maintenance',
+    });
+    assert.ok(
+        maintenanceFields.some(
+            (field) =>
+                field.fieldKey === 'plant.maintenance' &&
+                field.controlType === 'markdown' &&
+                field.currentValue === 'Redovito uklanjati korov.',
+        ),
+    );
+    assert.ok(
+        maintenanceFields.some(
+            (field) =>
+                field.fieldKey === 'plant.stage-operations.maintenance' &&
+                field.controlType === 'operationSuggestion' &&
+                field.operationSuggestionStage?.name === 'maintenance',
+        ),
+    );
+
     const plantSortId = await createPublishedPlantSort();
     const plantSortFields = await getCommunityEditableFieldsForEntity({
         entityTypeName: 'plantSort',
@@ -446,6 +536,21 @@ test('community editable registry resolves allowed plant and operation fields', 
                 field.fieldKey === 'plant-sort.latin-name' &&
                 field.controlType === 'text' &&
                 field.currentValue === 'Solanum sortum',
+        ),
+    );
+
+    const plantSortMaintenanceFields =
+        await getCommunityEditableFieldsForEntity({
+            entityTypeName: 'plantSort',
+            entityId: plantSortId,
+            sectionKey: 'maintenance',
+        });
+    assert.ok(
+        plantSortMaintenanceFields.some(
+            (field) =>
+                field.fieldKey === 'plant-sort.maintenance' &&
+                field.controlType === 'markdown' &&
+                field.currentValue === 'Sortu redovito pregledavati.',
         ),
     );
 


### PR DESCRIPTION
## Summary
- move plant lifecycle stage definitions into @gredice/js/plants and keep @gredice/game exports compatible
- generate plant and plant sort community-edit content fields from the shared stage list
- generate plant operation suggestion fields for every lifecycle section, including Priprema tla and Održavanje
- add community edits for Biljni susjedi on plant and sort pages
- expose Dobri susjedi and Izbjegavati blizinu as multi-reference edit fields
- let the community edit modal edit multiple reference IDs as a comma/newline-separated list
- tighten stored operation suggestion parsing to canonical stage names

## Validation
- corepack pnpm --filter @gredice/js lint
- corepack pnpm --filter @gredice/storage lint
- corepack pnpm --filter @gredice/game lint
- corepack pnpm --filter @gredice/game typecheck
- corepack pnpm --filter www lint
- corepack pnpm --filter www typecheck
- corepack pnpm --filter @gredice/storage test:node -- communityEditRequestsRepo.node.spec.ts
- corepack pnpm --filter www exec playwright test tests/community-edit-button.spec.tsx --project=chromium
- git diff --check