### PR TITLE
feat(game): use live farm weather in public garden preview

### DIFF
--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -241,7 +241,10 @@ export function GameScene({
     );
     const gardenBackgroundPalette = garden?.backgroundPalette;
     useClearSandboxEnvironmentOverrides(garden);
-    useWeatherNow(!isLocalSandbox && !weatherDisabled && !weather);
+    useWeatherNow(
+        !isLocalSandbox && !weatherDisabled && !weather && garden !== undefined,
+        garden?.farmId,
+    );
     const isLoading = gardenLoading;
 
     useEffect(() => {
@@ -356,6 +359,7 @@ export function GameScene({
                                     </Suspense>
                                 )}
                                 <EntityInstances
+                                    farmId={garden?.farmId}
                                     quality={qualityProfile}
                                     renderGroundDecorations={
                                         renderDetails && zoom !== 'far'
@@ -386,6 +390,7 @@ export function GameScene({
                                 {renderDetails && zoom !== 'far' && (
                                     <Suspense fallback={null}>
                                         <Cats
+                                            farmId={garden?.farmId}
                                             stacks={garden?.stacks}
                                             weather={weather}
                                             weatherDisabled={weatherDisabled}
@@ -395,6 +400,7 @@ export function GameScene({
                                 {renderDetails && zoom !== 'far' && (
                                     <Suspense fallback={null}>
                                         <Dogs
+                                            farmId={garden?.farmId}
                                             stacks={garden?.stacks}
                                             weather={weather}
                                             weatherDisabled={weatherDisabled}
@@ -404,6 +410,7 @@ export function GameScene({
                                 {renderDetails && zoom !== 'far' && (
                                     <Suspense fallback={null}>
                                         <Bees
+                                            farmId={garden?.farmId}
                                             garden={garden}
                                             groundDecorationDensity={
                                                 qualityProfile.groundDecorationDensity

--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -206,11 +206,13 @@ function EntityInstancesAssetBlock(props: EntityInstancesAssetBlockProps) {
 }
 
 export function EntityInstances({
+    farmId,
     quality,
     renderGroundDecorations,
     stacks,
     renderDetails = true,
 }: {
+    farmId?: number | null;
     quality?: GameQualityProfile;
     renderGroundDecorations?: boolean;
     stacks: Stack[] | undefined;
@@ -487,6 +489,7 @@ export function EntityInstances({
             {shouldRenderGroundDecorations && (
                 <GroundBlockDecorations
                     density={qualityProfile.groundDecorationDensity}
+                    farmId={farmId}
                     stacks={stacks}
                 />
             )}

--- a/packages/game/src/entities/bees/Bees.tsx
+++ b/packages/game/src/entities/bees/Bees.tsx
@@ -1480,11 +1480,13 @@ function resolveBeeWeather({
 }
 
 export function Bees({
+    farmId,
     garden,
     groundDecorationDensity = 1,
     weather,
     weatherDisabled = false,
 }: {
+    farmId?: number | null;
     garden: BeeGarden | null | undefined;
     groundDecorationDensity?: number;
     weather?: BeeWeatherOverride;
@@ -1493,7 +1495,10 @@ export function Bees({
     const { data: blockData } = useBlockData();
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const gameWeather = useGameState((state) => state.weather);
-    const { data: weatherNow } = useWeatherNow(!weatherDisabled && !weather);
+    const { data: weatherNow } = useWeatherNow(
+        !weatherDisabled && !weather,
+        farmId,
+    );
     const beeWeather = resolveBeeWeather({
         gameWeather,
         weatherDisabled,

--- a/packages/game/src/entities/cats/Cats.tsx
+++ b/packages/game/src/entities/cats/Cats.tsx
@@ -1763,10 +1763,12 @@ function resolveCatWeather({
 }
 
 export function Cats({
+    farmId,
     stacks,
     weather,
     weatherDisabled = false,
 }: {
+    farmId?: number | null;
     stacks: Stack[] | undefined;
     weather?: CatWeatherOverride;
     weatherDisabled?: boolean;
@@ -1791,7 +1793,10 @@ export function Cats({
         () => animalPresenceEntries.filter((entry) => entry.species === 'Dog'),
         [animalPresenceEntries],
     );
-    const { data: weatherNow } = useWeatherNow(!weatherDisabled && !weather);
+    const { data: weatherNow } = useWeatherNow(
+        !weatherDisabled && !weather,
+        farmId,
+    );
     const catWeather = resolveCatWeather({
         gameWeather,
         weatherDisabled,

--- a/packages/game/src/entities/dogs/Dogs.tsx
+++ b/packages/game/src/entities/dogs/Dogs.tsx
@@ -1958,10 +1958,12 @@ function resolveDogWeather({
 }
 
 export function Dogs({
+    farmId,
     stacks,
     weather,
     weatherDisabled = false,
 }: {
+    farmId?: number | null;
     stacks: Stack[] | undefined;
     weather?: DogWeatherOverride;
     weatherDisabled?: boolean;
@@ -1986,7 +1988,10 @@ export function Dogs({
         () => animalPresenceEntries.filter((entry) => entry.species === 'Cat'),
         [animalPresenceEntries],
     );
-    const { data: weatherNow } = useWeatherNow(!weatherDisabled && !weather);
+    const { data: weatherNow } = useWeatherNow(
+        !weatherDisabled && !weather,
+        farmId,
+    );
     const dogWeather = resolveDogWeather({
         gameWeather,
         weatherDisabled,

--- a/packages/game/src/entities/groundDecorations/BlockSurfaceDecorationSprites.tsx
+++ b/packages/game/src/entities/groundDecorations/BlockSurfaceDecorationSprites.tsx
@@ -50,7 +50,7 @@ function ResolvedBlockSurfaceDecorationSprites({
 }: DirectBlockSurfaceDecorationSpritesProps) {
     const { data: garden } = useCurrentGarden();
     const gameWeather = useGameState((state) => state.weather);
-    const { data: weatherNow } = useWeatherNow();
+    const { data: weatherNow } = useWeatherNow(true, garden?.farmId);
     const placements = useMemo(
         () =>
             getBlockSurfaceDecorations({

--- a/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundBlockDecorations.tsx
@@ -22,6 +22,7 @@ import { getGroundDecorationBlocks } from './groundDecorationBlocks';
 const blockSurfaceYOffset = 0.2;
 type GroundBlockDecorationsProps = {
     density: number;
+    farmId?: number | null;
     stacks: Stack[] | undefined;
 };
 
@@ -81,6 +82,7 @@ function useStableDecorationInstances(instances: GroundDecorationInstance[]) {
 
 export function GroundBlockDecorations({
     density,
+    farmId,
     stacks,
 }: GroundBlockDecorationsProps) {
     const { data: blockData } = useBlockData();
@@ -222,5 +224,10 @@ export function GroundBlockDecorations({
         return null;
     }
 
-    return <GroundDecorationInstances instances={decorationInstances} />;
+    return (
+        <GroundDecorationInstances
+            farmId={farmId}
+            instances={decorationInstances}
+        />
+    );
 }

--- a/packages/game/src/entities/groundDecorations/GroundDecorationInstances.tsx
+++ b/packages/game/src/entities/groundDecorations/GroundDecorationInstances.tsx
@@ -312,8 +312,10 @@ if ( diffuseColor.a < vGroundDecorationAlphaTest ) discard;
 }
 
 export function GroundDecorationInstances({
+    farmId,
     instances,
 }: {
+    farmId?: number | null;
     instances: GroundDecorationInstance[];
 }) {
     const profileBatchesRef = useRef(
@@ -419,6 +421,7 @@ export function GroundDecorationInstances({
                         <GroundDecorationPageInstances
                             key={pageIndex}
                             atlasPage={page}
+                            farmId={farmId}
                             instances={pageInstances}
                             manifestSprites={manifest.sprites}
                             recordProfileBatch={recordProfileBatch}
@@ -432,11 +435,13 @@ export function GroundDecorationInstances({
 
 function GroundDecorationPageInstances({
     atlasPage,
+    farmId,
     instances,
     manifestSprites,
     recordProfileBatch,
 }: {
     atlasPage: SpriteAtlasPage;
+    farmId?: number | null;
     instances: GroundDecorationInstance[];
     manifestSprites: Record<string, SpriteAtlasSprite>;
     recordProfileBatch: RecordGroundDecorationProfileBatch;
@@ -497,6 +502,7 @@ function GroundDecorationPageInstances({
     return (
         <GroundDecorationInstancedBatch
             batch={batch}
+            farmId={farmId}
             recordProfileBatch={recordProfileBatch}
             texture={texture}
         />
@@ -505,10 +511,12 @@ function GroundDecorationPageInstances({
 
 function GroundDecorationInstancedBatch({
     batch,
+    farmId,
     recordProfileBatch,
     texture,
 }: {
     batch: GroundDecorationBatch;
+    farmId?: number | null;
     recordProfileBatch: RecordGroundDecorationProfileBatch;
     texture: NonNullable<ReturnType<typeof useSpriteAtlasTexture>['texture']>;
 }) {
@@ -531,7 +539,7 @@ function GroundDecorationInstancedBatch({
     const gameCamera = useGameState((state) => state.gameCamera);
     const timeOfDay = useGameState((state) => state.timeOfDay);
     const weather = useGameState((state) => state.weather);
-    const { data: weatherNow } = useWeatherNow();
+    const { data: weatherNow } = useWeatherNow(true, farmId);
     const windSpeed =
         typeof weather?.windSpeed === 'number'
             ? weather.windSpeed

--- a/packages/game/src/hud/DebugHud.tsx
+++ b/packages/game/src/hud/DebugHud.tsx
@@ -327,7 +327,7 @@ export function DebugHud() {
 
     const { data: blockData } = useBlockData();
     const { data: garden } = useCurrentGarden();
-    const { data: weather } = useWeatherNow();
+    const { data: weather } = useWeatherNow(true, garden?.farmId);
     const specialEntityDebugEntries = useMemo(
         () =>
             getSpecialEntityDebugEntries({

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import * as SunCalc from 'suncalc';
 import { Color, type Vector3 } from 'three';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
+import { useLiveTime } from '../hooks/useLiveTime';
 import { useSnapshotTime } from '../hooks/useSnapshotTime';
 import { useWeatherNow } from '../hooks/useWeatherNow';
 import type { Stack } from '../types/Stack';
@@ -666,8 +667,9 @@ export function Environment({
 }: EnvironmentProps) {
     const qualityProfile = quality ?? resolveGameQualityProfile();
 
-    const currentTime = useSnapshotTime();
+    const currentTime = useLiveTime();
     const timeOfDay = useGameState((state) => state.timeOfDay);
+    const syncTimeOfDay = useGameState((state) => state.syncTimeOfDay);
     const backgroundPaletteIndex = useGameState(
         (state) => state.backgroundPaletteIndex,
     );
@@ -693,15 +695,16 @@ export function Environment({
     const weatherDisabled = noWeather || weatherVisualizationDisabled;
 
     const { data: garden } = useCurrentGarden();
-    const location = garden
-        ? {
-              lat: garden.location.lat ?? 0,
-              lon: garden.location.lon ?? 0,
-          }
-        : {
-              lat: 45.739,
-              lon: 16.572,
-          };
+    const location = useMemo(
+        () => ({
+            lat: garden?.location.lat ?? defaultLocation.lat,
+            lon: garden?.location.lon ?? defaultLocation.lon,
+        }),
+        [garden?.location.lat, garden?.location.lon],
+    );
+    useEffect(() => {
+        syncTimeOfDay(location, currentTime);
+    }, [currentTime, location, syncTimeOfDay]);
     const shadowCameraSize = useMemo(() => {
         const stacks = garden?.stacks;
         if (!stacks?.length) {
@@ -721,7 +724,7 @@ export function Environment({
     const gameWeather = useGameState((state) => state.weather);
     const hasWeatherOverride = Boolean(gameWeather ?? weather);
     const { data: weatherNow } = useWeatherNow(
-        !weatherDisabled && !hasWeatherOverride,
+        !weatherDisabled && !hasWeatherOverride && garden !== undefined,
         garden?.farmId,
     );
     const overrideWeather = weatherDisabled

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -41,6 +41,7 @@ import {
 import { triggerSelectionHaptic } from './utils/haptics';
 import {
     defaultGameLocation,
+    type GameLocation,
     getGameSunriseSunset,
     resolveGameTimeOfDay,
 } from './utils/timeOfDay';
@@ -289,6 +290,8 @@ export type GameState = {
     ) => GameBackgroundPaletteKey;
     weatherVisualizationDisabled: boolean;
     setWeatherVisualizationDisabled: (disabled: boolean) => void;
+    timeLocation: GameLocation;
+    syncTimeOfDay: (location?: GameLocation, currentTime?: Date) => void;
     timeOfDay: number;
     sunsetTime: Date | null;
     sunriseTime: Date | null;
@@ -405,6 +408,7 @@ export function createGameState({
     localSandboxStorageKey,
     localSandboxInitialStacks,
     mockGardenProfile,
+    timeLocation: initialTimeLocation,
     winterMode,
 }: {
     appBaseUrl: string;
@@ -417,6 +421,7 @@ export function createGameState({
     localSandboxStorageKey?: string;
     localSandboxInitialStacks?: Stack[];
     mockGardenProfile?: MockGardenProfile;
+    timeLocation?: GameLocation;
     winterMode?: WinterMode;
 }) {
     const dayNightCycleDisabled =
@@ -430,9 +435,14 @@ export function createGameState({
         initialBackgroundPaletteIndex,
     );
     const weatherVisualizationDisabled = isWeatherVisualizationDisabled();
+    const timeLocation = initialTimeLocation ?? defaultGameLocation;
     const now = freezeTime ?? new Date();
-    const timeOfDay = resolveGameTimeOfDay(now, dayNightCycleDisabled);
-    const { sunrise, sunset } = getGameSunriseSunset(defaultGameLocation, now);
+    const timeOfDay = resolveGameTimeOfDay(
+        now,
+        dayNightCycleDisabled,
+        timeLocation,
+    );
+    const { sunrise, sunset } = getGameSunriseSunset(timeLocation, now);
     return createStore<GameState>((set, get) => ({
         isMock: isMock,
         mockGardenProfile: mockGardenProfile ?? 'default',
@@ -446,8 +456,9 @@ export function createGameState({
         freezeTime,
         setFreezeTime: (freezeTime) => {
             const referenceTime = freezeTime ?? new Date();
+            const timeLocation = get().timeLocation;
             const { sunrise, sunset } = getGameSunriseSunset(
-                defaultGameLocation,
+                timeLocation,
                 referenceTime,
             );
             set({
@@ -455,6 +466,7 @@ export function createGameState({
                 timeOfDay: resolveGameTimeOfDay(
                     referenceTime,
                     get().dayNightCycleDisabled,
+                    timeLocation,
                 ),
                 sunriseTime: sunrise,
                 sunsetTime: sunset,
@@ -468,6 +480,7 @@ export function createGameState({
                 timeOfDay: resolveGameTimeOfDay(
                     get().freezeTime ?? new Date(),
                     disabled,
+                    get().timeLocation,
                 ),
             });
         },
@@ -531,6 +544,25 @@ export function createGameState({
             persistWeatherVisualizationDisabled(disabled);
             set({
                 weatherVisualizationDisabled: disabled,
+            });
+        },
+        timeLocation,
+        syncTimeOfDay: (location, currentTime) => {
+            const timeLocation = location ?? get().timeLocation;
+            const referenceTime = get().freezeTime ?? currentTime ?? new Date();
+            const { sunrise, sunset } = getGameSunriseSunset(
+                timeLocation,
+                referenceTime,
+            );
+            set({
+                timeLocation,
+                timeOfDay: resolveGameTimeOfDay(
+                    referenceTime,
+                    get().dayNightCycleDisabled,
+                    timeLocation,
+                ),
+                sunriseTime: sunrise,
+                sunsetTime: sunset,
             });
         },
         timeOfDay,
@@ -862,8 +894,9 @@ export function createGameState({
         setWeather: (weather) => set({ weather }),
         clearEnvironmentOverrides: () => {
             const referenceTime = new Date();
+            const timeLocation = get().timeLocation;
             const { sunrise, sunset } = getGameSunriseSunset(
-                defaultGameLocation,
+                timeLocation,
                 referenceTime,
             );
             set({
@@ -872,6 +905,7 @@ export function createGameState({
                 timeOfDay: resolveGameTimeOfDay(
                     referenceTime,
                     get().dayNightCycleDisabled,
+                    timeLocation,
                 ),
                 sunriseTime: sunrise,
                 sunsetTime: sunset,

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import { createActiveDragPreviewTarget } from './dragPreviewIdentity';
 import type { ActiveDragPreview } from './useGameState';
 import { activeDragPreviewsEqual, createGameState } from './useGameState';
+import { getGameSunriseSunset, getGameTimeOfDay } from './utils/timeOfDay';
 
 function createPreview(): ActiveDragPreview {
     return {
@@ -160,6 +161,68 @@ test('clearPickupSelectionTargets resets every active pickup target', () => {
         store.getState().clearPickupSelectionTargets();
 
         assert.deepEqual(store.getState().pickupSelectionTargets, []);
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
+test('createGameState resolves time of day from the provided location', () => {
+    const referenceTime = new Date('2026-07-04T20:15:00.000Z');
+    const timeLocation = { lat: 64.1466, lon: -21.9426 };
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: referenceTime,
+        isMock: true,
+        timeLocation,
+    });
+
+    try {
+        const { sunrise, sunset } = getGameSunriseSunset(
+            timeLocation,
+            referenceTime,
+        );
+
+        assert.equal(
+            store.getState().timeOfDay,
+            getGameTimeOfDay(timeLocation, referenceTime),
+        );
+        assert.equal(
+            store.getState().sunriseTime?.getTime(),
+            sunrise.getTime(),
+        );
+        assert.equal(store.getState().sunsetTime?.getTime(), sunset.getTime());
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
+test('syncTimeOfDay refreshes time of day for a new garden location', () => {
+    const referenceTime = new Date('2026-07-04T20:15:00.000Z');
+    const timeLocation = { lat: 45.9, lon: 16.84 };
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: null,
+        isMock: true,
+    });
+
+    try {
+        const { sunrise, sunset } = getGameSunriseSunset(
+            timeLocation,
+            referenceTime,
+        );
+
+        store.getState().syncTimeOfDay(timeLocation, referenceTime);
+
+        assert.deepEqual(store.getState().timeLocation, timeLocation);
+        assert.equal(
+            store.getState().timeOfDay,
+            getGameTimeOfDay(timeLocation, referenceTime),
+        );
+        assert.equal(
+            store.getState().sunriseTime?.getTime(),
+            sunrise.getTime(),
+        );
+        assert.equal(store.getState().sunsetTime?.getTime(), sunset.getTime());
     } finally {
         store.getState().audio.dispose();
     }

--- a/packages/game/src/utils/timeOfDay.ts
+++ b/packages/game/src/utils/timeOfDay.ts
@@ -77,10 +77,11 @@ export function getGameTimeOfDay(location: GameLocation, currentTime: Date) {
 export function resolveGameTimeOfDay(
     currentTime: Date,
     dayNightCycleDisabled: boolean,
+    location: GameLocation = defaultGameLocation,
 ) {
     return dayNightCycleDisabled
         ? ALWAYS_DAY_TIME
-        : getGameTimeOfDay(defaultGameLocation, currentTime);
+        : getGameTimeOfDay(location, currentTime);
 }
 
 export function createDateForGameTimeOfDay(

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -44,6 +44,7 @@ import {
     type GameStateStore,
     useDisposeGameStateStore,
 } from '../useGameState';
+import type { GameLocation } from '../utils/timeOfDay';
 
 export type PublicGardenBlock = Block;
 
@@ -153,6 +154,26 @@ function publicGardenForGameState(
     };
 }
 
+function publicGardenTimeLocation(
+    garden: PublicGardenDetail | undefined,
+): GameLocation | undefined {
+    if (!garden) {
+        return undefined;
+    }
+
+    if (
+        !Number.isFinite(garden.latitude) ||
+        !Number.isFinite(garden.longitude)
+    ) {
+        return undefined;
+    }
+
+    return {
+        lat: garden.latitude,
+        lon: garden.longitude,
+    };
+}
+
 function PublicGardenScene({
     cameraPosition,
     className,
@@ -208,6 +229,7 @@ function PublicGardenScene({
                                     )),
                                 )}
                                 <EntityInstances
+                                    farmId={garden?.farmId}
                                     quality={qualityProfile}
                                     renderGroundDecorations={
                                         renderLivingDetails
@@ -222,17 +244,24 @@ function PublicGardenScene({
                                 )}
                                 {renderLivingDetails && (
                                     <Suspense fallback={null}>
-                                        <Cats stacks={normalizedStacks} />
+                                        <Cats
+                                            farmId={garden?.farmId}
+                                            stacks={normalizedStacks}
+                                        />
                                     </Suspense>
                                 )}
                                 {renderLivingDetails && (
                                     <Suspense fallback={null}>
-                                        <Dogs stacks={normalizedStacks} />
+                                        <Dogs
+                                            farmId={garden?.farmId}
+                                            stacks={normalizedStacks}
+                                        />
                                     </Suspense>
                                 )}
                                 {renderLivingDetails && garden && (
                                     <Suspense fallback={null}>
                                         <Bees
+                                            farmId={garden.farmId}
                                             garden={garden}
                                             groundDecorationDensity={
                                                 qualityProfile.groundDecorationDensity
@@ -304,13 +333,15 @@ export function PublicGardenViewer({
 }: PublicGardenViewerProps) {
     const resolvedAppBaseUrl = appBaseUrl || 'https://vrt.gredice.com';
     const resolvedSpriteBaseUrl = spriteBaseUrl ?? resolvedAppBaseUrl;
+    const initialTimeLocation = publicGardenTimeLocation(garden);
     const storeRef = useRef<GameStateStore>(null);
     if (!storeRef.current) {
         storeRef.current = createGameState({
             appBaseUrl: resolvedAppBaseUrl,
             spriteBaseUrl: resolvedSpriteBaseUrl,
-            freezeTime: new Date(2024, 5, 21, 12, 0, 0),
+            freezeTime: null,
             isMock: false,
+            timeLocation: initialTimeLocation,
             winterMode: 'summer',
         });
     }


### PR DESCRIPTION
## Summary
- remove the fixed June 2024 noon snapshot from the public garden viewer so it starts from the current time
- sync scene time-of-day from the loaded garden coordinates and refresh it as the clock advances
- pass the garden farm id through weather, animal, debug, and ground-decoration weather consumers

## Validation
- `corepack pnpm --filter @gredice/game lint`
- `corepack pnpm --filter @gredice/game test`
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter www`