### PR TITLE
feat(game): connect adjacent mulch patches

### DIFF
--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -24,6 +24,7 @@ import {
     type GroundPatchSurface,
     useGroundPatchMaterial,
 } from './helpers/groundPatchMaterial';
+import { MulchPatchInstances } from './raisedBed/MulchPatch';
 import { tulipBouquetStems } from './tulipBouquet';
 
 export const instancedBlockNames = [
@@ -545,39 +546,7 @@ export function EntityInstances({
                 snowLift={0.002}
                 {...commonSnowProps}
             />
-            <EntityInstancesAssetBlock
-                assetName="MulchHey"
-                stacks={stacks}
-                name="MulchHey"
-                scale={[3, 3, 3]}
-                geometry={(gltf) => gltf.nodes.Mulch_Hey.geometry}
-                material={(gltf) => gltf.nodes.Mulch_Hey.material}
-                snow={snowPresets.mulch}
-                snowLift={0.002}
-                {...commonSnowProps}
-            />
-            <EntityInstancesAssetBlock
-                assetName="MulchCoconut"
-                stacks={stacks}
-                name="MulchCoconut"
-                scale={[3, 3, 3]}
-                geometry={(gltf) => gltf.nodes.Mulch_Coconut.geometry}
-                material={(gltf) => gltf.nodes.Mulch_Coconut.material}
-                snow={snowPresets.mulch}
-                snowLift={0.002}
-                {...commonSnowProps}
-            />
-            <EntityInstancesAssetBlock
-                assetName="MulchWood"
-                stacks={stacks}
-                name="MulchWood"
-                scale={[3, 3, 3]}
-                geometry={(gltf) => gltf.nodes.Mulch_Wood.geometry}
-                material={(gltf) => gltf.nodes.Mulch_Wood.material}
-                snow={snowPresets.mulch}
-                snowLift={0.002}
-                {...commonSnowProps}
-            />
+            <MulchPatchInstances stacks={stacks} {...commonSnowProps} />
             {tulipBouquetStems.map((stem) => (
                 <EntityInstancesAssetBlock
                     key={`Tulip-${stem.key}`}

--- a/packages/game/src/entities/raisedBed/MulchCoconut.tsx
+++ b/packages/game/src/entities/raisedBed/MulchCoconut.tsx
@@ -1,33 +1,6 @@
-import { animated } from '@react-spring/three';
-import { SnowOverlay } from '../../snow/SnowOverlay';
-import { snowPresets } from '../../snow/snowPresets';
 import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProps';
-import { useStackHeight } from '../../utils/getStackHeight';
-import { useGameGLTF } from '../../utils/useGameGLTF';
-import { useAnimatedEntityRotation } from '../helpers/useAnimatedEntityRotation';
+import { MulchPatchEntity } from './MulchPatch';
 
-export function MulchCoconut({ stack, block, rotation }: EntityInstanceProps) {
-    const { nodes, materials } = useGameGLTF('MulchCoconut');
-    const [animatedRotation] = useAnimatedEntityRotation(rotation);
-    const currentStackHeight = useStackHeight(stack, block);
-
-    return (
-        <animated.group
-            position={stack.position.clone().setY(currentStackHeight)}
-            rotation={animatedRotation as unknown as [number, number, number]}
-        >
-            <mesh
-                castShadow
-                receiveShadow
-                scale={3}
-                geometry={nodes.Mulch_Coconut.geometry}
-                material={materials['Material.ColorPaletteMain']}
-            >
-                <SnowOverlay
-                    geometry={nodes.Mulch_Coconut.geometry}
-                    {...snowPresets.mulch}
-                />
-            </mesh>
-        </animated.group>
-    );
+export function MulchCoconut(props: EntityInstanceProps) {
+    return <MulchPatchEntity {...props} />;
 }

--- a/packages/game/src/entities/raisedBed/MulchHey.tsx
+++ b/packages/game/src/entities/raisedBed/MulchHey.tsx
@@ -1,33 +1,6 @@
-import { animated } from '@react-spring/three';
-import { SnowOverlay } from '../../snow/SnowOverlay';
-import { snowPresets } from '../../snow/snowPresets';
 import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProps';
-import { useStackHeight } from '../../utils/getStackHeight';
-import { useGameGLTF } from '../../utils/useGameGLTF';
-import { useAnimatedEntityRotation } from '../helpers/useAnimatedEntityRotation';
+import { MulchPatchEntity } from './MulchPatch';
 
-export function MulchHey({ stack, block, rotation }: EntityInstanceProps) {
-    const { nodes, materials } = useGameGLTF('MulchHey');
-    const [animatedRotation] = useAnimatedEntityRotation(rotation);
-    const currentStackHeight = useStackHeight(stack, block);
-
-    return (
-        <animated.group
-            position={stack.position.clone().setY(currentStackHeight)}
-            rotation={animatedRotation as unknown as [number, number, number]}
-        >
-            <mesh
-                castShadow
-                receiveShadow
-                scale={3}
-                geometry={nodes.Mulch_Hey.geometry}
-                material={materials['Material.ColorPaletteMain']}
-            >
-                <SnowOverlay
-                    geometry={nodes.Mulch_Hey.geometry}
-                    {...snowPresets.mulch}
-                />
-            </mesh>
-        </animated.group>
-    );
+export function MulchHey(props: EntityInstanceProps) {
+    return <MulchPatchEntity {...props} />;
 }

--- a/packages/game/src/entities/raisedBed/MulchPatch.tsx
+++ b/packages/game/src/entities/raisedBed/MulchPatch.tsx
@@ -34,10 +34,12 @@ const mulchPatchVertexParameters = `
 attribute float mulchEdge;
 attribute vec4 mulchBounds;
 attribute vec4 mulchExposedEdges;
+attribute vec4 mulchInnerCorners;
 varying vec3 vMulchPatchPosition;
 varying float vMulchEdge;
 varying vec4 vMulchBounds;
 varying vec4 vMulchExposedEdges;
+varying vec4 vMulchInnerCorners;
 `;
 
 const mulchPatchVertex = `
@@ -45,6 +47,7 @@ vMulchPatchPosition = position;
 vMulchEdge = mulchEdge;
 vMulchBounds = mulchBounds;
 vMulchExposedEdges = mulchExposedEdges;
+vMulchInnerCorners = mulchInnerCorners;
 `;
 
 const mulchPatchFragmentParameters = `
@@ -52,23 +55,70 @@ varying vec3 vMulchPatchPosition;
 varying float vMulchEdge;
 varying vec4 vMulchBounds;
 varying vec4 vMulchExposedEdges;
+varying vec4 vMulchInnerCorners;
 `;
 
 const mulchPatchColorFragment = `
-float mulchPatchEdgeDistance = 1000.0;
+const float mulchPatchInnerCornerRadius = 0.11;
+const float mulchPatchStraightEdgeBandWidth = 0.14;
+const float mulchPatchInnerEdgeBandWidth = 0.055;
+float mulchPatchStraightEdgeDistance = 1000.0;
+float mulchPatchInnerEdgeDistance = 1000.0;
 if (vMulchExposedEdges.x > 0.5) {
-    mulchPatchEdgeDistance = min(mulchPatchEdgeDistance, abs(vMulchPatchPosition.x - vMulchBounds.y));
+    mulchPatchStraightEdgeDistance = min(mulchPatchStraightEdgeDistance, abs(vMulchPatchPosition.x - vMulchBounds.y));
 }
 if (vMulchExposedEdges.y > 0.5) {
-    mulchPatchEdgeDistance = min(mulchPatchEdgeDistance, abs(vMulchPatchPosition.z - vMulchBounds.z));
+    mulchPatchStraightEdgeDistance = min(mulchPatchStraightEdgeDistance, abs(vMulchPatchPosition.z - vMulchBounds.z));
 }
 if (vMulchExposedEdges.z > 0.5) {
-    mulchPatchEdgeDistance = min(mulchPatchEdgeDistance, abs(vMulchPatchPosition.x - vMulchBounds.x));
+    mulchPatchStraightEdgeDistance = min(mulchPatchStraightEdgeDistance, abs(vMulchPatchPosition.x - vMulchBounds.x));
 }
 if (vMulchExposedEdges.w > 0.5) {
-    mulchPatchEdgeDistance = min(mulchPatchEdgeDistance, abs(vMulchPatchPosition.z - vMulchBounds.w));
+    mulchPatchStraightEdgeDistance = min(mulchPatchStraightEdgeDistance, abs(vMulchPatchPosition.z - vMulchBounds.w));
 }
-float mulchPatchEdgeBand = 1.0 - smoothstep(0.0, 0.14, mulchPatchEdgeDistance);
+if (
+    vMulchInnerCorners.x > 0.5 &&
+    vMulchPatchPosition.x > vMulchBounds.y - mulchPatchInnerCornerRadius - mulchPatchInnerEdgeBandWidth &&
+    vMulchPatchPosition.z < vMulchBounds.z + mulchPatchInnerCornerRadius + mulchPatchInnerEdgeBandWidth
+) {
+    mulchPatchInnerEdgeDistance = min(
+        mulchPatchInnerEdgeDistance,
+        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.y - mulchPatchInnerCornerRadius, vMulchBounds.z + mulchPatchInnerCornerRadius)) - mulchPatchInnerCornerRadius)
+    );
+}
+if (
+    vMulchInnerCorners.y > 0.5 &&
+    vMulchPatchPosition.x > vMulchBounds.y - mulchPatchInnerCornerRadius - mulchPatchInnerEdgeBandWidth &&
+    vMulchPatchPosition.z > vMulchBounds.w - mulchPatchInnerCornerRadius - mulchPatchInnerEdgeBandWidth
+) {
+    mulchPatchInnerEdgeDistance = min(
+        mulchPatchInnerEdgeDistance,
+        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.y - mulchPatchInnerCornerRadius, vMulchBounds.w - mulchPatchInnerCornerRadius)) - mulchPatchInnerCornerRadius)
+    );
+}
+if (
+    vMulchInnerCorners.z > 0.5 &&
+    vMulchPatchPosition.x < vMulchBounds.x + mulchPatchInnerCornerRadius + mulchPatchInnerEdgeBandWidth &&
+    vMulchPatchPosition.z < vMulchBounds.z + mulchPatchInnerCornerRadius + mulchPatchInnerEdgeBandWidth
+) {
+    mulchPatchInnerEdgeDistance = min(
+        mulchPatchInnerEdgeDistance,
+        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.x + mulchPatchInnerCornerRadius, vMulchBounds.z + mulchPatchInnerCornerRadius)) - mulchPatchInnerCornerRadius)
+    );
+}
+if (
+    vMulchInnerCorners.w > 0.5 &&
+    vMulchPatchPosition.x < vMulchBounds.x + mulchPatchInnerCornerRadius + mulchPatchInnerEdgeBandWidth &&
+    vMulchPatchPosition.z > vMulchBounds.w - mulchPatchInnerCornerRadius - mulchPatchInnerEdgeBandWidth
+) {
+    mulchPatchInnerEdgeDistance = min(
+        mulchPatchInnerEdgeDistance,
+        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.x + mulchPatchInnerCornerRadius, vMulchBounds.w - mulchPatchInnerCornerRadius)) - mulchPatchInnerCornerRadius)
+    );
+}
+float mulchPatchStraightEdgeBand = 1.0 - smoothstep(0.0, mulchPatchStraightEdgeBandWidth, mulchPatchStraightEdgeDistance);
+float mulchPatchInnerEdgeBand = 1.0 - smoothstep(0.0, mulchPatchInnerEdgeBandWidth, mulchPatchInnerEdgeDistance);
+float mulchPatchEdgeBand = max(mulchPatchStraightEdgeBand, mulchPatchInnerEdgeBand);
 float mulchPatchShade = max(vMulchEdge, mulchPatchEdgeBand * 0.82);
 diffuseColor.rgb *= mix(1.0, 0.78, mulchPatchShade);
 `;

--- a/packages/game/src/entities/raisedBed/MulchPatch.tsx
+++ b/packages/game/src/entities/raisedBed/MulchPatch.tsx
@@ -1,0 +1,283 @@
+import { useEffect, useMemo } from 'react';
+import { type BufferGeometry, DoubleSide } from 'three';
+import { useBlockData } from '../../hooks/useBlockData';
+import { SnowOverlay } from '../../snow/SnowOverlay';
+import { snowPresets } from '../../snow/snowPresets';
+import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProps';
+import type { Stack } from '../../types/Stack';
+import { getStackHeight, useStackHeight } from '../../utils/getStackHeight';
+import {
+    type EntityBlockInstance,
+    EntityInstancesGeometry,
+    useEntityBlockInstances,
+} from '../EntityInstancesBlock';
+import {
+    createMulchPatchGeometry,
+    getMulchPatchConnectionsFromMask,
+    isMulchBlockName,
+    isolatedMulchPatchConnectionMask,
+    type MulchBlockName,
+    type MulchPatchTarget,
+    mulchBlockNames,
+    mulchPatchConnectionMasks,
+    resolveMulchPatchConnectionMask,
+} from './mulchPatchGeometry';
+
+const mulchPatchSize: [number, number] = [1, 1];
+const mulchPatchColors = {
+    MulchCoconut: '#6a4930',
+    MulchHey: '#9a7b3e',
+    MulchWood: '#4f3524',
+} satisfies Record<MulchBlockName, string>;
+
+type StackMulchPatchTarget = MulchPatchTarget & {
+    blockId: string;
+    stackX: number;
+    stackZ: number;
+};
+
+type MulchPatchRenderGroup = {
+    blockName: MulchBlockName;
+    instances: EntityBlockInstance[];
+    mask: number;
+};
+
+export function MulchPatchMaterial({
+    blockName,
+}: {
+    blockName: MulchBlockName;
+}) {
+    return (
+        <meshStandardMaterial
+            color={mulchPatchColors[blockName]}
+            flatShading
+            metalness={0}
+            roughness={0.96}
+            side={DoubleSide}
+        />
+    );
+}
+
+export function useMulchPatchGeometry(mask: number) {
+    const geometry = useMemo(
+        () =>
+            createMulchPatchGeometry({
+                connections: getMulchPatchConnectionsFromMask(mask),
+            }),
+        [mask],
+    );
+
+    useEffect(() => () => geometry.dispose(), [geometry]);
+
+    return geometry;
+}
+
+export function useMulchPatchGeometries() {
+    const geometries = useMemo(() => {
+        const map = new Map<number, BufferGeometry>();
+
+        for (const mask of mulchPatchConnectionMasks) {
+            map.set(
+                mask,
+                createMulchPatchGeometry({
+                    connections: getMulchPatchConnectionsFromMask(mask),
+                }),
+            );
+        }
+
+        return map;
+    }, []);
+
+    useEffect(
+        () => () => {
+            for (const geometry of geometries.values()) {
+                geometry.dispose();
+            }
+        },
+        [geometries],
+    );
+
+    return geometries;
+}
+
+function getMulchPatchRenderGroups(
+    instances: EntityBlockInstance[] | undefined,
+) {
+    const targets: MulchPatchTarget[] =
+        instances?.map((instance) => ({
+            position: instance.position,
+            size: mulchPatchSize,
+        })) ?? [];
+    const groups = new Map<string, MulchPatchRenderGroup>();
+
+    instances?.forEach((instance, index) => {
+        if (!isMulchBlockName(instance.block.name)) {
+            return;
+        }
+
+        const target = targets[index];
+        const mask = target
+            ? resolveMulchPatchConnectionMask(target, targets)
+            : isolatedMulchPatchConnectionMask;
+        const key = `${instance.block.name}:${mask}`;
+        const group = groups.get(key);
+        const patchInstance = {
+            ...instance,
+            rotation: 0,
+        };
+
+        if (group) {
+            group.instances.push(patchInstance);
+            return;
+        }
+
+        groups.set(key, {
+            blockName: instance.block.name,
+            instances: [patchInstance],
+            mask,
+        });
+    });
+
+    return [...groups.values()];
+}
+
+function createStackMulchPatchTargets({
+    blockData,
+    stacks,
+}: {
+    blockData: ReturnType<typeof useBlockData>['data'];
+    stacks: Stack[] | undefined;
+}) {
+    if (!blockData || !stacks) {
+        return [];
+    }
+
+    const targets: StackMulchPatchTarget[] = [];
+
+    for (const stack of stacks) {
+        for (const block of stack.blocks) {
+            if (!isMulchBlockName(block.name)) {
+                continue;
+            }
+
+            targets.push({
+                blockId: block.id,
+                position: [
+                    stack.position.x,
+                    getStackHeight(blockData, stack, block),
+                    stack.position.z,
+                ],
+                size: mulchPatchSize,
+                stackX: stack.position.x,
+                stackZ: stack.position.z,
+            });
+        }
+    }
+
+    return targets;
+}
+
+function findStackMulchPatchTarget({
+    blockId,
+    stackX,
+    stackZ,
+    targets,
+}: {
+    blockId: string;
+    stackX: number;
+    stackZ: number;
+    targets: StackMulchPatchTarget[];
+}) {
+    return targets.find(
+        (target) =>
+            target.blockId === blockId &&
+            target.stackX === stackX &&
+            target.stackZ === stackZ,
+    );
+}
+
+export function MulchPatchEntity({
+    block,
+    stack,
+    stacks,
+}: EntityInstanceProps) {
+    const { data: blockData } = useBlockData();
+    const currentStackHeight = useStackHeight(stack, block);
+    const targets = useMemo(
+        () => createStackMulchPatchTargets({ blockData, stacks }),
+        [blockData, stacks],
+    );
+    const target = findStackMulchPatchTarget({
+        blockId: block.id,
+        stackX: stack.position.x,
+        stackZ: stack.position.z,
+        targets,
+    });
+    const mask = target
+        ? resolveMulchPatchConnectionMask(target, targets)
+        : isolatedMulchPatchConnectionMask;
+    const geometry = useMulchPatchGeometry(mask);
+
+    if (!isMulchBlockName(block.name)) {
+        return null;
+    }
+
+    return (
+        <group
+            position={[stack.position.x, currentStackHeight, stack.position.z]}
+        >
+            <mesh castShadow receiveShadow geometry={geometry}>
+                <MulchPatchMaterial blockName={block.name} />
+                <SnowOverlay geometry={geometry} {...snowPresets.mulch} />
+            </mesh>
+        </group>
+    );
+}
+
+export function MulchPatchInstances({
+    renderSnow,
+    snowOverlayMinCoverage,
+    stacks,
+}: {
+    renderSnow?: boolean;
+    snowOverlayMinCoverage?: number;
+    stacks: Stack[] | undefined;
+}) {
+    const blockInstances = useEntityBlockInstances({
+        names: mulchBlockNames,
+        stacks,
+    });
+    const renderGroups = useMemo(
+        () => getMulchPatchRenderGroups(blockInstances),
+        [blockInstances],
+    );
+    const geometries = useMulchPatchGeometries();
+
+    return (
+        <>
+            {renderGroups.map((group) => {
+                const geometry = geometries.get(group.mask);
+
+                if (!geometry) {
+                    return null;
+                }
+
+                return (
+                    <EntityInstancesGeometry
+                        key={`${group.blockName}:${group.mask}`}
+                        geometry={geometry}
+                        instanceKey={`${group.blockName}:mulch-patch:${group.mask}`}
+                        instances={group.instances}
+                        materialNode={
+                            <MulchPatchMaterial blockName={group.blockName} />
+                        }
+                        renderSnow={renderSnow}
+                        snow={snowPresets.mulch}
+                        snowLift={0.002}
+                        snowOverlayMinCoverage={snowOverlayMinCoverage}
+                    />
+                );
+            })}
+        </>
+    );
+}

--- a/packages/game/src/entities/raisedBed/MulchPatch.tsx
+++ b/packages/game/src/entities/raisedBed/MulchPatch.tsx
@@ -83,7 +83,7 @@ if (
 ) {
     mulchPatchInnerEdgeDistance = min(
         mulchPatchInnerEdgeDistance,
-        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.y - mulchPatchInnerCornerRadius, vMulchBounds.z + mulchPatchInnerCornerRadius)) - mulchPatchInnerCornerRadius)
+        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.y, vMulchBounds.z)) - mulchPatchInnerCornerRadius)
     );
 }
 if (
@@ -93,7 +93,7 @@ if (
 ) {
     mulchPatchInnerEdgeDistance = min(
         mulchPatchInnerEdgeDistance,
-        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.y - mulchPatchInnerCornerRadius, vMulchBounds.w - mulchPatchInnerCornerRadius)) - mulchPatchInnerCornerRadius)
+        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.y, vMulchBounds.w)) - mulchPatchInnerCornerRadius)
     );
 }
 if (
@@ -103,7 +103,7 @@ if (
 ) {
     mulchPatchInnerEdgeDistance = min(
         mulchPatchInnerEdgeDistance,
-        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.x + mulchPatchInnerCornerRadius, vMulchBounds.z + mulchPatchInnerCornerRadius)) - mulchPatchInnerCornerRadius)
+        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.x, vMulchBounds.z)) - mulchPatchInnerCornerRadius)
     );
 }
 if (
@@ -113,7 +113,7 @@ if (
 ) {
     mulchPatchInnerEdgeDistance = min(
         mulchPatchInnerEdgeDistance,
-        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.x + mulchPatchInnerCornerRadius, vMulchBounds.w - mulchPatchInnerCornerRadius)) - mulchPatchInnerCornerRadius)
+        abs(length(vMulchPatchPosition.xz - vec2(vMulchBounds.x, vMulchBounds.w)) - mulchPatchInnerCornerRadius)
     );
 }
 float mulchPatchStraightEdgeBand = 1.0 - smoothstep(0.0, mulchPatchStraightEdgeBandWidth, mulchPatchStraightEdgeDistance);
@@ -164,7 +164,7 @@ function createMulchPatchMaterial(blockName: MulchBlockName) {
                 `#include <color_fragment>\n${mulchPatchColorFragment}`,
             );
     };
-    material.customProgramCacheKey = () => 'mulch-patch-edge-shading-v1';
+    material.customProgramCacheKey = () => 'mulch-patch-edge-shading-v2';
     material.needsUpdate = true;
 
     return material;

--- a/packages/game/src/entities/raisedBed/MulchPatch.tsx
+++ b/packages/game/src/entities/raisedBed/MulchPatch.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { type BufferGeometry, DoubleSide } from 'three';
+import { type BufferGeometry, DoubleSide, MeshStandardMaterial } from 'three';
 import { useBlockData } from '../../hooks/useBlockData';
 import { SnowOverlay } from '../../snow/SnowOverlay';
 import { snowPresets } from '../../snow/snowPresets';
@@ -30,6 +30,49 @@ const mulchPatchColors = {
     MulchWood: '#4f3524',
 } satisfies Record<MulchBlockName, string>;
 
+const mulchPatchVertexParameters = `
+attribute float mulchEdge;
+attribute vec4 mulchBounds;
+attribute vec4 mulchExposedEdges;
+varying vec3 vMulchPatchPosition;
+varying float vMulchEdge;
+varying vec4 vMulchBounds;
+varying vec4 vMulchExposedEdges;
+`;
+
+const mulchPatchVertex = `
+vMulchPatchPosition = position;
+vMulchEdge = mulchEdge;
+vMulchBounds = mulchBounds;
+vMulchExposedEdges = mulchExposedEdges;
+`;
+
+const mulchPatchFragmentParameters = `
+varying vec3 vMulchPatchPosition;
+varying float vMulchEdge;
+varying vec4 vMulchBounds;
+varying vec4 vMulchExposedEdges;
+`;
+
+const mulchPatchColorFragment = `
+float mulchPatchEdgeDistance = 1000.0;
+if (vMulchExposedEdges.x > 0.5) {
+    mulchPatchEdgeDistance = min(mulchPatchEdgeDistance, abs(vMulchPatchPosition.x - vMulchBounds.y));
+}
+if (vMulchExposedEdges.y > 0.5) {
+    mulchPatchEdgeDistance = min(mulchPatchEdgeDistance, abs(vMulchPatchPosition.z - vMulchBounds.z));
+}
+if (vMulchExposedEdges.z > 0.5) {
+    mulchPatchEdgeDistance = min(mulchPatchEdgeDistance, abs(vMulchPatchPosition.x - vMulchBounds.x));
+}
+if (vMulchExposedEdges.w > 0.5) {
+    mulchPatchEdgeDistance = min(mulchPatchEdgeDistance, abs(vMulchPatchPosition.z - vMulchBounds.w));
+}
+float mulchPatchEdgeBand = 1.0 - smoothstep(0.0, 0.14, mulchPatchEdgeDistance);
+float mulchPatchShade = max(vMulchEdge, mulchPatchEdgeBand * 0.82);
+diffuseColor.rgb *= mix(1.0, 0.78, mulchPatchShade);
+`;
+
 type StackMulchPatchTarget = MulchPatchTarget & {
     blockId: string;
     stackX: number;
@@ -42,20 +85,54 @@ type MulchPatchRenderGroup = {
     mask: number;
 };
 
+function createMulchPatchMaterial(blockName: MulchBlockName) {
+    const material = new MeshStandardMaterial({
+        color: mulchPatchColors[blockName],
+        flatShading: true,
+        metalness: 0,
+        roughness: 0.96,
+        side: DoubleSide,
+    });
+
+    material.onBeforeCompile = (shader) => {
+        shader.vertexShader = shader.vertexShader
+            .replace(
+                '#include <common>',
+                `#include <common>\n${mulchPatchVertexParameters}`,
+            )
+            .replace(
+                '#include <begin_vertex>',
+                `#include <begin_vertex>\n${mulchPatchVertex}`,
+            );
+        shader.fragmentShader = shader.fragmentShader
+            .replace(
+                '#include <common>',
+                `#include <common>\n${mulchPatchFragmentParameters}`,
+            )
+            .replace(
+                '#include <color_fragment>',
+                `#include <color_fragment>\n${mulchPatchColorFragment}`,
+            );
+    };
+    material.customProgramCacheKey = () => 'mulch-patch-edge-shading-v1';
+    material.needsUpdate = true;
+
+    return material;
+}
+
 export function MulchPatchMaterial({
     blockName,
 }: {
     blockName: MulchBlockName;
 }) {
-    return (
-        <meshStandardMaterial
-            color={mulchPatchColors[blockName]}
-            flatShading
-            metalness={0}
-            roughness={0.96}
-            side={DoubleSide}
-        />
+    const material = useMemo(
+        () => createMulchPatchMaterial(blockName),
+        [blockName],
     );
+
+    useEffect(() => () => material.dispose(), [material]);
+
+    return <primitive attach="material" object={material} />;
 }
 
 export function useMulchPatchGeometry(mask: number) {

--- a/packages/game/src/entities/raisedBed/MulchWood.tsx
+++ b/packages/game/src/entities/raisedBed/MulchWood.tsx
@@ -1,33 +1,6 @@
-import { animated } from '@react-spring/three';
-import { SnowOverlay } from '../../snow/SnowOverlay';
-import { snowPresets } from '../../snow/snowPresets';
 import type { EntityInstanceProps } from '../../types/runtime/EntityInstanceProps';
-import { useStackHeight } from '../../utils/getStackHeight';
-import { useGameGLTF } from '../../utils/useGameGLTF';
-import { useAnimatedEntityRotation } from '../helpers/useAnimatedEntityRotation';
+import { MulchPatchEntity } from './MulchPatch';
 
-export function MulchWood({ stack, block, rotation }: EntityInstanceProps) {
-    const { nodes, materials } = useGameGLTF('MulchWood');
-    const [animatedRotation] = useAnimatedEntityRotation(rotation);
-    const currentStackHeight = useStackHeight(stack, block);
-
-    return (
-        <animated.group
-            position={stack.position.clone().setY(currentStackHeight)}
-            rotation={animatedRotation as unknown as [number, number, number]}
-        >
-            <mesh
-                castShadow
-                receiveShadow
-                scale={3}
-                geometry={nodes.Mulch_Wood.geometry}
-                material={materials['Material.ColorPaletteMain']}
-            >
-                <SnowOverlay
-                    geometry={nodes.Mulch_Wood.geometry}
-                    {...snowPresets.mulch}
-                />
-            </mesh>
-        </animated.group>
-    );
+export function MulchWood(props: EntityInstanceProps) {
+    return <MulchPatchEntity {...props} />;
 }

--- a/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
+++ b/packages/game/src/entities/raisedBed/RaisedBedMulchOverlays.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import type { BufferGeometry, Material } from 'three';
+import type { BufferGeometry } from 'three';
 import {
     type ActiveDragPreviewTarget,
     createActiveDragPreviewTarget,
@@ -27,6 +27,14 @@ import {
     type RaisedBedOrientation,
 } from '../../utils/raisedBedOrientation';
 import { useGameGLTF } from '../../utils/useGameGLTF';
+import { MulchPatchMaterial, useMulchPatchGeometries } from './MulchPatch';
+import {
+    fullMulchPatchConnectionMask,
+    isMulchBlockName,
+    type MulchBlockName,
+    type MulchPatchTarget,
+    resolveMulchPatchConnectionMask,
+} from './mulchPatchGeometry';
 import { appliedMulchOperationsOldestFirst } from './raisedBedMulchOperationOrder';
 import {
     isFieldMulchApplication,
@@ -37,7 +45,6 @@ import {
 
 const combinedOverlap = 0.1;
 const halfOverlap = combinedOverlap / 2;
-const fieldMulchScale: [number, number, number] = [1, 3, 1];
 
 type CurrentGardenData = NonNullable<
     NonNullable<ReturnType<typeof useCurrentGarden>['data']>
@@ -69,10 +76,11 @@ type RaisedBedPlacement = {
     stackBlockIndex: number;
 };
 
-type MulchAssetLookup = {
-    MulchCoconut: GLTFResult;
-    MulchHey: GLTFResult;
-    MulchWood: GLTFResult;
+type FieldMulchPatch = {
+    blockName: MulchBlockName;
+    key: string;
+    position: [number, number, number];
+    scale: [number, number, number];
 };
 
 function timestampMs(value: Date | string | null | undefined) {
@@ -399,33 +407,6 @@ function getUnionFootprintBounds(boundsList: FootprintBounds[]) {
     };
 }
 
-function getMulchAsset(
-    assets: MulchAssetLookup,
-    blockName: string,
-): { geometry: BufferGeometry; material: Material | Material[] } | null {
-    if (blockName === 'MulchHey') {
-        return {
-            geometry: assets.MulchHey.nodes.Mulch_Hey.geometry,
-            material: assets.MulchHey.materials['Material.ColorPaletteMain'],
-        };
-    }
-    if (blockName === 'MulchCoconut') {
-        return {
-            geometry: assets.MulchCoconut.nodes.Mulch_Coconut.geometry,
-            material:
-                assets.MulchCoconut.materials['Material.ColorPaletteMain'],
-        };
-    }
-    if (blockName === 'MulchWood') {
-        return {
-            geometry: assets.MulchWood.nodes.Mulch_Wood.geometry,
-            material: assets.MulchWood.materials['Material.ColorPaletteMain'],
-        };
-    }
-
-    return null;
-}
-
 function getFullBedSurfaceBounds(
     placements: RaisedBedPlacement[],
     nodes: GLTFResult['nodes'],
@@ -453,37 +434,38 @@ function getFullBedPosition(surfaceBounds: FootprintBounds, surfaceY: number) {
     ] as [number, number, number];
 }
 
-function getFullBedScale(
-    surfaceBounds: FootprintBounds,
-    mulchGeometry: BufferGeometry,
-) {
-    const mulchBounds = getGeometryFootprintBounds(mulchGeometry);
-    const mulchWidth = mulchBounds.maxX - mulchBounds.minX;
-    const mulchDepth = mulchBounds.maxZ - mulchBounds.minZ;
+function getFullBedScale(surfaceBounds: FootprintBounds) {
     const surfaceWidth = surfaceBounds.maxX - surfaceBounds.minX;
     const surfaceDepth = surfaceBounds.maxZ - surfaceBounds.minZ;
 
-    if (mulchWidth <= 0 || mulchDepth <= 0) {
-        return [3, 3, 3] as [number, number, number];
-    }
+    return [surfaceWidth, 1, surfaceDepth] satisfies [number, number, number];
+}
 
-    return [surfaceWidth / mulchWidth, 3, surfaceDepth / mulchDepth] as [
-        number,
-        number,
-        number,
-    ];
+function getFieldMulchScale(orientation: RaisedBedOrientation) {
+    return (
+        orientation === 'vertical' ? [0.285, 1, 0.27] : [0.27, 1, 0.285]
+    ) satisfies [number, number, number];
+}
+
+function getFieldMulchPatchTargets(
+    patches: readonly FieldMulchPatch[],
+): MulchPatchTarget[] {
+    return patches.map((patch) => ({
+        position: patch.position,
+        size: [patch.scale[0], patch.scale[2]],
+    }));
 }
 
 function MulchMesh({
+    blockName,
     geometry,
-    material,
     minSnowCoverage,
     position,
     renderSnow,
     scale,
 }: {
+    blockName: MulchBlockName;
     geometry: BufferGeometry;
-    material: Material | Material[];
     minSnowCoverage: number;
     position: [number, number, number];
     renderSnow: boolean;
@@ -491,13 +473,8 @@ function MulchMesh({
 }) {
     return (
         <group position={position}>
-            <mesh
-                castShadow
-                receiveShadow
-                scale={scale}
-                geometry={geometry}
-                material={material}
-            >
+            <mesh castShadow receiveShadow scale={scale} geometry={geometry}>
+                <MulchPatchMaterial blockName={blockName} />
                 {renderSnow && (
                     <SnowOverlay
                         geometry={geometry}
@@ -529,11 +506,7 @@ export function RaisedBedMulchOverlays({
     const { data: operations } = useOperations();
     const { data: blockData } = useBlockData();
     const { nodes: raisedBedNodes } = useGameGLTF('RaisedBed');
-    const mulchAssets = {
-        MulchCoconut: useGameGLTF('MulchCoconut'),
-        MulchHey: useGameGLTF('MulchHey'),
-        MulchWood: useGameGLTF('MulchWood'),
-    };
+    const mulchPatchGeometries = useMulchPatchGeometries();
     const qualityProfile = quality ?? resolveGameQualityProfile();
     const activeDragPreview = useGameState((state) =>
         activeDragPreviewTouchesRaisedBed(
@@ -622,38 +595,33 @@ export function RaisedBedMulchOverlays({
 
         if (fullBedAppliedMulch) {
             const visual = fullBedAppliedMulch;
-            if (visual) {
-                const mulchAsset = getMulchAsset(mulchAssets, visual.blockName);
-                if (mulchAsset) {
-                    const surfaceBounds = getFullBedSurfaceBounds(
-                        placements,
-                        raisedBedNodes,
-                    );
-                    overlays.push(
-                        <MulchMesh
-                            key={`raised-bed-mulch-${raisedBed.id}-${visual.blockId}`}
-                            geometry={mulchAsset.geometry}
-                            material={mulchAsset.material}
-                            minSnowCoverage={
-                                qualityProfile.snowOverlayMinCoverage
-                            }
-                            position={getFullBedPosition(
-                                surfaceBounds,
-                                getRaisedBedSurfaceY(placements[0].origin),
-                            )}
-                            renderSnow={renderSnow}
-                            scale={getFullBedScale(
-                                surfaceBounds,
-                                mulchAsset.geometry,
-                            )}
-                        />,
-                    );
-                }
+            const mulchGeometry = mulchPatchGeometries.get(
+                fullMulchPatchConnectionMask,
+            );
+            if (visual && isMulchBlockName(visual.blockName) && mulchGeometry) {
+                const surfaceBounds = getFullBedSurfaceBounds(
+                    placements,
+                    raisedBedNodes,
+                );
+                overlays.push(
+                    <MulchMesh
+                        key={`raised-bed-mulch-${raisedBed.id}-${visual.blockId}`}
+                        blockName={visual.blockName}
+                        geometry={mulchGeometry}
+                        minSnowCoverage={qualityProfile.snowOverlayMinCoverage}
+                        position={getFullBedPosition(
+                            surfaceBounds,
+                            getRaisedBedSurfaceY(placements[0].origin),
+                        )}
+                        renderSnow={renderSnow}
+                        scale={getFullBedScale(surfaceBounds)}
+                    />,
+                );
             }
             continue;
         }
 
-        const fieldMulchByPositionIndex = new Map<number, string>();
+        const fieldMulchByPositionIndex = new Map<number, MulchBlockName>();
         const appliedFieldMulchRewardsByFieldId =
             resolveActiveFieldMulchRewardsByFieldId({
                 appliedOperations: raisedBed.appliedOperations ?? [],
@@ -665,7 +633,11 @@ export function RaisedBedMulchOverlays({
             Array.from(appliedFieldMulchRewardsByFieldId.values()),
         )) {
             const visual = mulchVisualByOperationId.get(reward.entityId);
-            if (!visual || !isFieldMulchApplication(visual.application)) {
+            if (
+                !visual ||
+                !isMulchBlockName(visual.blockName) ||
+                !isFieldMulchApplication(visual.application)
+            ) {
                 continue;
             }
 
@@ -687,6 +659,9 @@ export function RaisedBedMulchOverlays({
         }
 
         const orientation = raisedBed.orientation ?? 'vertical';
+        const fieldMulchPatches: FieldMulchPatch[] = [];
+        const fieldScale = getFieldMulchScale(orientation);
+
         for (const [positionIndex, blockName] of fieldMulchByPositionIndex) {
             const placement = getPlacementForPositionIndex(
                 placements,
@@ -696,25 +671,40 @@ export function RaisedBedMulchOverlays({
                 continue;
             }
 
-            const mulchAsset = getMulchAsset(mulchAssets, blockName);
-            if (!mulchAsset) {
+            fieldMulchPatches.push({
+                blockName,
+                key: `raised-bed-field-mulch-${raisedBed.id}-${positionIndex}-${blockName}`,
+                position: getFieldWorldPosition({
+                    blockIndex: placement.blockIndex,
+                    localPositionIndex: placement.localPositionIndex,
+                    orientation,
+                    origin: placement.origin,
+                }),
+                scale: fieldScale,
+            });
+        }
+
+        const fieldTargets = getFieldMulchPatchTargets(fieldMulchPatches);
+        for (const [patchIndex, patch] of fieldMulchPatches.entries()) {
+            const target = fieldTargets[patchIndex];
+            const mask = target
+                ? resolveMulchPatchConnectionMask(target, fieldTargets)
+                : fullMulchPatchConnectionMask;
+            const geometry = mulchPatchGeometries.get(mask);
+
+            if (!geometry) {
                 continue;
             }
 
             overlays.push(
                 <MulchMesh
-                    key={`raised-bed-field-mulch-${raisedBed.id}-${positionIndex}-${blockName}`}
-                    geometry={mulchAsset.geometry}
-                    material={mulchAsset.material}
+                    key={patch.key}
+                    blockName={patch.blockName}
+                    geometry={geometry}
                     minSnowCoverage={qualityProfile.snowOverlayMinCoverage}
-                    position={getFieldWorldPosition({
-                        blockIndex: placement.blockIndex,
-                        localPositionIndex: placement.localPositionIndex,
-                        orientation,
-                        origin: placement.origin,
-                    })}
+                    position={patch.position}
                     renderSnow={renderSnow}
-                    scale={fieldMulchScale}
+                    scale={patch.scale}
                 />,
             );
         }

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
@@ -373,75 +373,6 @@ function shouldRenderMulchPatchSide(input: {
     return true;
 }
 
-function isPointInInnerCornerArea({
-    corner,
-    point,
-    radius,
-}: {
-    corner: 'ne' | 'nw' | 'se' | 'sw';
-    point: MulchPatchPoint;
-    radius: number;
-}) {
-    const tolerance = 0.0001;
-
-    if (corner === 'ne') {
-        return (
-            point.x >= 0.5 - radius - tolerance &&
-            point.z <= -0.5 + radius + tolerance
-        );
-    }
-    if (corner === 'nw') {
-        return (
-            point.x >= 0.5 - radius - tolerance &&
-            point.z >= 0.5 - radius - tolerance
-        );
-    }
-    if (corner === 'se') {
-        return (
-            point.x <= -0.5 + radius + tolerance &&
-            point.z <= -0.5 + radius + tolerance
-        );
-    }
-
-    return (
-        point.x <= -0.5 + radius + tolerance &&
-        point.z >= 0.5 - radius - tolerance
-    );
-}
-
-function isInnerCornerMulchPatchSide({
-    connections,
-    current,
-    next,
-}: {
-    connections: MulchPatchConnections;
-    current: MulchPatchPoint;
-    next: MulchPatchPoint;
-}) {
-    const innerCornerRadius = 0.11;
-    const innerCorners = [
-        connections.n && connections.e && !connections.ne ? 'ne' : null,
-        connections.n && connections.w && !connections.nw ? 'nw' : null,
-        connections.s && connections.e && !connections.se ? 'se' : null,
-        connections.s && connections.w && !connections.sw ? 'sw' : null,
-    ] as const;
-
-    return innerCorners.some(
-        (corner) =>
-            corner &&
-            isPointInInnerCornerArea({
-                corner,
-                point: current,
-                radius: innerCornerRadius,
-            }) &&
-            isPointInInnerCornerArea({
-                corner,
-                point: next,
-                radius: innerCornerRadius,
-            }),
-    );
-}
-
 export function createMulchPatchGeometry({
     connections,
 }: {
@@ -546,39 +477,18 @@ export function createMulchPatchGeometry({
                 next,
             })
         ) {
-            if (
-                isInnerCornerMulchPatchSide({
-                    connections,
-                    current,
-                    next,
-                })
-            ) {
-                addTriangle(current, topY, 1, next, bottomY, 1, next, topY, 1);
-                addTriangle(
-                    current,
-                    topY,
-                    1,
-                    current,
-                    bottomY,
-                    1,
-                    next,
-                    bottomY,
-                    1,
-                );
-            } else {
-                addTriangle(current, topY, 1, next, topY, 1, next, bottomY, 1);
-                addTriangle(
-                    current,
-                    topY,
-                    1,
-                    next,
-                    bottomY,
-                    1,
-                    current,
-                    bottomY,
-                    1,
-                );
-            }
+            addTriangle(current, topY, 1, next, topY, 1, next, bottomY, 1);
+            addTriangle(
+                current,
+                topY,
+                1,
+                next,
+                bottomY,
+                1,
+                current,
+                bottomY,
+                1,
+            );
         }
     }
 

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
@@ -48,6 +48,7 @@ type MulchPatchBounds = {
 };
 
 type MulchPatchCorner = {
+    kind: 'inner' | 'none' | 'outer';
     radius: number;
 };
 
@@ -200,17 +201,20 @@ function getMulchPatchPerimeter(connections: MulchPatchConnections) {
     }): MulchPatchCorner {
         if (!xConnection && !zConnection) {
             return {
+                kind: 'outer',
                 radius: outerCornerRadius,
             };
         }
 
         if (xConnection && zConnection && !diagonal) {
             return {
+                kind: 'inner',
                 radius: innerCornerRadius,
             };
         }
 
         return {
+            kind: 'none',
             radius: 0,
         };
     }
@@ -280,43 +284,55 @@ function getMulchPatchPerimeter(connections: MulchPatchConnections) {
     addPoint({ x: minX + southEastCorner.radius, z: minZ });
     addPoint({ x: maxX - northEastCorner.radius, z: minZ });
     addCornerArc({
-        center: {
-            x: maxX - northEastCorner.radius,
-            z: minZ + northEastCorner.radius,
-        },
-        endAngle: 0,
+        center:
+            northEastCorner.kind === 'inner'
+                ? { x: maxX, z: minZ }
+                : {
+                      x: maxX - northEastCorner.radius,
+                      z: minZ + northEastCorner.radius,
+                  },
+        endAngle: northEastCorner.kind === 'inner' ? Math.PI / 2 : 0,
         radius: northEastCorner.radius,
-        startAngle: -Math.PI / 2,
+        startAngle: northEastCorner.kind === 'inner' ? Math.PI : -Math.PI / 2,
     });
     addPoint({ x: maxX, z: maxZ - northWestCorner.radius });
     addCornerArc({
-        center: {
-            x: maxX - northWestCorner.radius,
-            z: maxZ - northWestCorner.radius,
-        },
-        endAngle: Math.PI / 2,
+        center:
+            northWestCorner.kind === 'inner'
+                ? { x: maxX, z: maxZ }
+                : {
+                      x: maxX - northWestCorner.radius,
+                      z: maxZ - northWestCorner.radius,
+                  },
+        endAngle: northWestCorner.kind === 'inner' ? -Math.PI : Math.PI / 2,
         radius: northWestCorner.radius,
-        startAngle: 0,
+        startAngle: northWestCorner.kind === 'inner' ? -Math.PI / 2 : 0,
     });
     addPoint({ x: minX + southWestCorner.radius, z: maxZ });
     addCornerArc({
-        center: {
-            x: minX + southWestCorner.radius,
-            z: maxZ - southWestCorner.radius,
-        },
-        endAngle: Math.PI,
+        center:
+            southWestCorner.kind === 'inner'
+                ? { x: minX, z: maxZ }
+                : {
+                      x: minX + southWestCorner.radius,
+                      z: maxZ - southWestCorner.radius,
+                  },
+        endAngle: southWestCorner.kind === 'inner' ? -Math.PI / 2 : Math.PI,
         radius: southWestCorner.radius,
-        startAngle: Math.PI / 2,
+        startAngle: southWestCorner.kind === 'inner' ? 0 : Math.PI / 2,
     });
     addPoint({ x: minX, z: minZ + southEastCorner.radius });
     addCornerArc({
-        center: {
-            x: minX + southEastCorner.radius,
-            z: minZ + southEastCorner.radius,
-        },
-        endAngle: (Math.PI * 3) / 2,
+        center:
+            southEastCorner.kind === 'inner'
+                ? { x: minX, z: minZ }
+                : {
+                      x: minX + southEastCorner.radius,
+                      z: minZ + southEastCorner.radius,
+                  },
+        endAngle: southEastCorner.kind === 'inner' ? 0 : (Math.PI * 3) / 2,
         radius: southEastCorner.radius,
-        startAngle: Math.PI,
+        startAngle: southEastCorner.kind === 'inner' ? Math.PI / 2 : Math.PI,
     });
 
     const last = perimeter[perimeter.length - 1];

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
@@ -17,7 +17,11 @@ const mulchBlockNameLookup: Record<MulchBlockName, true> = {
 export type MulchPatchConnections = {
     e: boolean;
     n: boolean;
+    ne: boolean;
+    nw: boolean;
     s: boolean;
+    se: boolean;
+    sw: boolean;
     w: boolean;
 };
 
@@ -39,7 +43,7 @@ type MulchPatchBounds = {
 };
 
 export const mulchPatchConnectionMasks = Array.from(
-    { length: 16 },
+    { length: 256 },
     (_, mask) => mask,
 );
 
@@ -47,7 +51,11 @@ export const isolatedMulchPatchConnectionMask = 0;
 export const fullMulchPatchConnectionMask = getMulchPatchConnectionMask({
     e: true,
     n: true,
+    ne: true,
+    nw: true,
     s: true,
+    se: true,
+    sw: true,
     w: true,
 });
 
@@ -64,13 +72,18 @@ export function isMulchBlockName(name: string): name is MulchBlockName {
 }
 
 export function getMulchPatchConnectionMask(
-    connections: MulchPatchConnections,
+    connections: Pick<MulchPatchConnections, 'e' | 'n' | 's' | 'w'> &
+        Partial<Pick<MulchPatchConnections, 'ne' | 'nw' | 'se' | 'sw'>>,
 ) {
     return (
         (connections.n ? 1 : 0) |
         (connections.e ? 2 : 0) |
         (connections.s ? 4 : 0) |
-        (connections.w ? 8 : 0)
+        (connections.w ? 8 : 0) |
+        (connections.ne ? 16 : 0) |
+        (connections.nw ? 32 : 0) |
+        (connections.se ? 64 : 0) |
+        (connections.sw ? 128 : 0)
     );
 }
 
@@ -80,7 +93,11 @@ export function getMulchPatchConnectionsFromMask(
     return {
         e: (mask & 2) !== 0,
         n: (mask & 1) !== 0,
+        ne: (mask & 16) !== 0,
+        nw: (mask & 32) !== 0,
         s: (mask & 4) !== 0,
+        se: (mask & 64) !== 0,
+        sw: (mask & 128) !== 0,
         w: (mask & 8) !== 0,
     };
 }
@@ -94,7 +111,11 @@ export function resolveMulchPatchConnectionMask(
     const connections: MulchPatchConnections = {
         e: false,
         n: false,
+        ne: false,
+        nw: false,
         s: false,
+        se: false,
+        sw: false,
         w: false,
     };
 
@@ -126,6 +147,20 @@ export function resolveMulchPatchConnectionMask(
                 connections.w = true;
             }
         }
+
+        if (nearlyEqual(candidateX - x, xDistance)) {
+            if (nearlyEqual(z - candidateZ, zDistance)) {
+                connections.ne = true;
+            } else if (nearlyEqual(candidateZ - z, zDistance)) {
+                connections.nw = true;
+            }
+        } else if (nearlyEqual(x - candidateX, xDistance)) {
+            if (nearlyEqual(z - candidateZ, zDistance)) {
+                connections.se = true;
+            } else if (nearlyEqual(candidateZ - z, zDistance)) {
+                connections.sw = true;
+            }
+        }
     }
 
     return getMulchPatchConnectionMask(connections);
@@ -138,11 +173,53 @@ function getMulchPatchPerimeter(connections: MulchPatchConnections) {
     const maxX = connections.n ? connectedHalfSize : isolatedHalfSize;
     const minZ = connections.e ? -connectedHalfSize : -isolatedHalfSize;
     const maxZ = connections.w ? connectedHalfSize : isolatedHalfSize;
-    const cornerRadius = Math.min(0.15, (maxX - minX) / 3, (maxZ - minZ) / 3);
-    const southEastCorner = !connections.s && !connections.e ? cornerRadius : 0;
-    const northEastCorner = !connections.n && !connections.e ? cornerRadius : 0;
-    const northWestCorner = !connections.n && !connections.w ? cornerRadius : 0;
-    const southWestCorner = !connections.s && !connections.w ? cornerRadius : 0;
+    const outerCornerRadius = Math.min(
+        0.15,
+        (maxX - minX) / 3,
+        (maxZ - minZ) / 3,
+    );
+    const innerCornerRadius = connectedHalfSize - isolatedHalfSize;
+
+    function getCornerRadius({
+        diagonal,
+        xConnection,
+        zConnection,
+    }: {
+        diagonal: boolean;
+        xConnection: boolean;
+        zConnection: boolean;
+    }) {
+        if (!xConnection && !zConnection) {
+            return outerCornerRadius;
+        }
+
+        if (xConnection && zConnection && !diagonal) {
+            return innerCornerRadius;
+        }
+
+        return 0;
+    }
+
+    const southEastCorner = getCornerRadius({
+        diagonal: connections.se,
+        xConnection: connections.s,
+        zConnection: connections.e,
+    });
+    const northEastCorner = getCornerRadius({
+        diagonal: connections.ne,
+        xConnection: connections.n,
+        zConnection: connections.e,
+    });
+    const northWestCorner = getCornerRadius({
+        diagonal: connections.nw,
+        xConnection: connections.n,
+        zConnection: connections.w,
+    });
+    const southWestCorner = getCornerRadius({
+        diagonal: connections.sw,
+        xConnection: connections.s,
+        zConnection: connections.w,
+    });
     const perimeter: MulchPatchPoint[] = [];
 
     function addPoint(point: MulchPatchPoint) {

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
@@ -31,6 +31,13 @@ type MulchPatchPoint = {
     z: number;
 };
 
+type MulchPatchBounds = {
+    maxX: number;
+    maxZ: number;
+    minX: number;
+    minZ: number;
+};
+
 export const mulchPatchConnectionMasks = Array.from(
     { length: 16 },
     (_, mask) => mask,
@@ -131,30 +138,93 @@ function getMulchPatchPerimeter(connections: MulchPatchConnections) {
     const maxX = connections.n ? connectedHalfSize : isolatedHalfSize;
     const minZ = connections.e ? -connectedHalfSize : -isolatedHalfSize;
     const maxZ = connections.w ? connectedHalfSize : isolatedHalfSize;
-    const cornerInset = Math.min(0.08, (maxX - minX) / 3, (maxZ - minZ) / 3);
-    const southEastCorner = !connections.s && !connections.e ? cornerInset : 0;
-    const northEastCorner = !connections.n && !connections.e ? cornerInset : 0;
-    const northWestCorner = !connections.n && !connections.w ? cornerInset : 0;
-    const southWestCorner = !connections.s && !connections.w ? cornerInset : 0;
-    const points: MulchPatchPoint[] = [
-        { x: minX + southEastCorner, z: minZ },
-        { x: maxX - northEastCorner, z: minZ },
-        { x: maxX, z: minZ + northEastCorner },
-        { x: maxX, z: maxZ - northWestCorner },
-        { x: maxX - northWestCorner, z: maxZ },
-        { x: minX + southWestCorner, z: maxZ },
-        { x: minX, z: maxZ - southWestCorner },
-        { x: minX, z: minZ + southEastCorner },
-    ];
+    const cornerRadius = Math.min(0.15, (maxX - minX) / 3, (maxZ - minZ) / 3);
+    const southEastCorner = !connections.s && !connections.e ? cornerRadius : 0;
+    const northEastCorner = !connections.n && !connections.e ? cornerRadius : 0;
+    const northWestCorner = !connections.n && !connections.w ? cornerRadius : 0;
+    const southWestCorner = !connections.s && !connections.w ? cornerRadius : 0;
+    const perimeter: MulchPatchPoint[] = [];
 
-    const perimeter = points.filter((point, index) => {
-        const previous = points[index - 1];
-        return (
-            !previous ||
-            !nearlyEqual(point.x, previous.x) ||
-            !nearlyEqual(point.z, previous.z)
-        );
+    function addPoint(point: MulchPatchPoint) {
+        const previous = perimeter[perimeter.length - 1];
+        if (
+            previous &&
+            nearlyEqual(point.x, previous.x) &&
+            nearlyEqual(point.z, previous.z)
+        ) {
+            return;
+        }
+
+        perimeter.push(point);
+    }
+
+    function addCornerArc({
+        center,
+        endAngle,
+        radius,
+        startAngle,
+    }: {
+        center: MulchPatchPoint;
+        endAngle: number;
+        radius: number;
+        startAngle: number;
+    }) {
+        const segmentCount = 5;
+
+        if (radius <= 0) {
+            return;
+        }
+
+        for (let index = 1; index <= segmentCount; index += 1) {
+            const progress = index / segmentCount;
+            const angle = startAngle + (endAngle - startAngle) * progress;
+            addPoint({
+                x: center.x + Math.cos(angle) * radius,
+                z: center.z + Math.sin(angle) * radius,
+            });
+        }
+    }
+
+    addPoint({ x: minX + southEastCorner, z: minZ });
+    addPoint({ x: maxX - northEastCorner, z: minZ });
+    addCornerArc({
+        center: { x: maxX - northEastCorner, z: minZ + northEastCorner },
+        endAngle: 0,
+        radius: northEastCorner,
+        startAngle: -Math.PI / 2,
     });
+    addPoint({ x: maxX, z: maxZ - northWestCorner });
+    addCornerArc({
+        center: { x: maxX - northWestCorner, z: maxZ - northWestCorner },
+        endAngle: Math.PI / 2,
+        radius: northWestCorner,
+        startAngle: 0,
+    });
+    addPoint({ x: minX + southWestCorner, z: maxZ });
+    addCornerArc({
+        center: { x: minX + southWestCorner, z: maxZ - southWestCorner },
+        endAngle: Math.PI,
+        radius: southWestCorner,
+        startAngle: Math.PI / 2,
+    });
+    addPoint({ x: minX, z: minZ + southEastCorner });
+    addCornerArc({
+        center: { x: minX + southEastCorner, z: minZ + southEastCorner },
+        endAngle: (Math.PI * 3) / 2,
+        radius: southEastCorner,
+        startAngle: Math.PI,
+    });
+
+    const last = perimeter[perimeter.length - 1];
+    const first = perimeter[0];
+    if (
+        first &&
+        last &&
+        nearlyEqual(first.x, last.x) &&
+        nearlyEqual(first.z, last.z)
+    ) {
+        perimeter.pop();
+    }
 
     return {
         bounds: {
@@ -168,7 +238,7 @@ function getMulchPatchPerimeter(connections: MulchPatchConnections) {
 }
 
 function shouldRenderMulchPatchSide(input: {
-    bounds: ReturnType<typeof getMulchPatchPerimeter>['bounds'];
+    bounds: MulchPatchBounds;
     connections: MulchPatchConnections;
     current: MulchPatchPoint;
     next: MulchPatchPoint;
@@ -208,23 +278,43 @@ export function createMulchPatchGeometry({
     const topEdgeY = 0.018;
     const bottomY = 0;
     const positions: number[] = [];
+    const edgeShades: number[] = [];
+    const boundsAttributes: number[] = [];
+    const exposedEdgeAttributes: number[] = [];
     const { bounds, perimeter } = getMulchPatchPerimeter(connections);
+    const exposedEdges = [
+        connections.n ? 0 : 1,
+        connections.e ? 0 : 1,
+        connections.s ? 0 : 1,
+        connections.w ? 0 : 1,
+    ];
 
-    function addVertex(point: MulchPatchPoint, y: number) {
+    function addVertex(point: MulchPatchPoint, y: number, edgeShade: number) {
         positions.push(point.x, y, point.z);
+        edgeShades.push(edgeShade);
+        boundsAttributes.push(
+            bounds.minX,
+            bounds.maxX,
+            bounds.minZ,
+            bounds.maxZ,
+        );
+        exposedEdgeAttributes.push(...exposedEdges);
     }
 
     function addTriangle(
         first: MulchPatchPoint,
         firstY: number,
+        firstEdgeShade: number,
         second: MulchPatchPoint,
         secondY: number,
+        secondEdgeShade: number,
         third: MulchPatchPoint,
         thirdY: number,
+        thirdEdgeShade: number,
     ) {
-        addVertex(first, firstY);
-        addVertex(second, secondY);
-        addVertex(third, thirdY);
+        addVertex(first, firstY, firstEdgeShade);
+        addVertex(second, secondY, secondEdgeShade);
+        addVertex(third, thirdY, thirdEdgeShade);
     }
 
     const center = { x: 0, z: 0 };
@@ -234,7 +324,17 @@ export function createMulchPatchGeometry({
             continue;
         }
 
-        addTriangle(center, topCenterY, next, topEdgeY, current, topEdgeY);
+        addTriangle(
+            center,
+            topCenterY,
+            0,
+            next,
+            topEdgeY,
+            0,
+            current,
+            topEdgeY,
+            0,
+        );
 
         if (
             shouldRenderMulchPatchSide({
@@ -244,13 +344,45 @@ export function createMulchPatchGeometry({
                 next,
             })
         ) {
-            addTriangle(current, topEdgeY, next, topEdgeY, next, bottomY);
-            addTriangle(current, topEdgeY, next, bottomY, current, bottomY);
+            addTriangle(
+                current,
+                topEdgeY,
+                1,
+                next,
+                topEdgeY,
+                1,
+                next,
+                bottomY,
+                1,
+            );
+            addTriangle(
+                current,
+                topEdgeY,
+                1,
+                next,
+                bottomY,
+                1,
+                current,
+                bottomY,
+                1,
+            );
         }
     }
 
     const geometry = new BufferGeometry();
     geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
+    geometry.setAttribute(
+        'mulchEdge',
+        new Float32BufferAttribute(edgeShades, 1),
+    );
+    geometry.setAttribute(
+        'mulchBounds',
+        new Float32BufferAttribute(boundsAttributes, 4),
+    );
+    geometry.setAttribute(
+        'mulchExposedEdges',
+        new Float32BufferAttribute(exposedEdgeAttributes, 4),
+    );
     geometry.computeVertexNormals();
     geometry.computeBoundingBox();
     geometry.computeBoundingSphere();

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
@@ -1,0 +1,259 @@
+import { BufferGeometry, Float32BufferAttribute } from 'three';
+
+export type MulchBlockName = 'MulchCoconut' | 'MulchHey' | 'MulchWood';
+
+export const mulchBlockNames: MulchBlockName[] = [
+    'MulchHey',
+    'MulchCoconut',
+    'MulchWood',
+];
+
+const mulchBlockNameLookup: Record<MulchBlockName, true> = {
+    MulchCoconut: true,
+    MulchHey: true,
+    MulchWood: true,
+};
+
+export type MulchPatchConnections = {
+    e: boolean;
+    n: boolean;
+    s: boolean;
+    w: boolean;
+};
+
+export type MulchPatchTarget = {
+    position: readonly [number, number, number];
+    size: readonly [number, number];
+};
+
+type MulchPatchPoint = {
+    x: number;
+    z: number;
+};
+
+export const mulchPatchConnectionMasks = Array.from(
+    { length: 16 },
+    (_, mask) => mask,
+);
+
+export const isolatedMulchPatchConnectionMask = 0;
+export const fullMulchPatchConnectionMask = getMulchPatchConnectionMask({
+    e: true,
+    n: true,
+    s: true,
+    w: true,
+});
+
+function nearlyEqual(left: number, right: number, tolerance = 0.0001) {
+    return Math.abs(left - right) <= tolerance;
+}
+
+function getMulchPatchTargetDistance(leftSize: number, rightSize: number) {
+    return (leftSize + rightSize) / 2;
+}
+
+export function isMulchBlockName(name: string): name is MulchBlockName {
+    return name in mulchBlockNameLookup;
+}
+
+export function getMulchPatchConnectionMask(
+    connections: MulchPatchConnections,
+) {
+    return (
+        (connections.n ? 1 : 0) |
+        (connections.e ? 2 : 0) |
+        (connections.s ? 4 : 0) |
+        (connections.w ? 8 : 0)
+    );
+}
+
+export function getMulchPatchConnectionsFromMask(
+    mask: number,
+): MulchPatchConnections {
+    return {
+        e: (mask & 2) !== 0,
+        n: (mask & 1) !== 0,
+        s: (mask & 4) !== 0,
+        w: (mask & 8) !== 0,
+    };
+}
+
+export function resolveMulchPatchConnectionMask(
+    target: MulchPatchTarget,
+    targets: readonly MulchPatchTarget[],
+) {
+    const [x, y, z] = target.position;
+    const [width, depth] = target.size;
+    const connections: MulchPatchConnections = {
+        e: false,
+        n: false,
+        s: false,
+        w: false,
+    };
+
+    for (const candidate of targets) {
+        if (candidate === target) {
+            continue;
+        }
+
+        const [candidateX, candidateY, candidateZ] = candidate.position;
+        if (!nearlyEqual(candidateY, y)) {
+            continue;
+        }
+
+        const xDistance = getMulchPatchTargetDistance(width, candidate.size[0]);
+        const zDistance = getMulchPatchTargetDistance(depth, candidate.size[1]);
+
+        if (nearlyEqual(candidateZ, z)) {
+            if (nearlyEqual(candidateX - x, xDistance)) {
+                connections.n = true;
+            } else if (nearlyEqual(x - candidateX, xDistance)) {
+                connections.s = true;
+            }
+        }
+
+        if (nearlyEqual(candidateX, x)) {
+            if (nearlyEqual(z - candidateZ, zDistance)) {
+                connections.e = true;
+            } else if (nearlyEqual(candidateZ - z, zDistance)) {
+                connections.w = true;
+            }
+        }
+    }
+
+    return getMulchPatchConnectionMask(connections);
+}
+
+function getMulchPatchPerimeter(connections: MulchPatchConnections) {
+    const isolatedHalfSize = 0.39;
+    const connectedHalfSize = 0.5;
+    const minX = connections.s ? -connectedHalfSize : -isolatedHalfSize;
+    const maxX = connections.n ? connectedHalfSize : isolatedHalfSize;
+    const minZ = connections.e ? -connectedHalfSize : -isolatedHalfSize;
+    const maxZ = connections.w ? connectedHalfSize : isolatedHalfSize;
+    const cornerInset = Math.min(0.08, (maxX - minX) / 3, (maxZ - minZ) / 3);
+    const southEastCorner = !connections.s && !connections.e ? cornerInset : 0;
+    const northEastCorner = !connections.n && !connections.e ? cornerInset : 0;
+    const northWestCorner = !connections.n && !connections.w ? cornerInset : 0;
+    const southWestCorner = !connections.s && !connections.w ? cornerInset : 0;
+    const points: MulchPatchPoint[] = [
+        { x: minX + southEastCorner, z: minZ },
+        { x: maxX - northEastCorner, z: minZ },
+        { x: maxX, z: minZ + northEastCorner },
+        { x: maxX, z: maxZ - northWestCorner },
+        { x: maxX - northWestCorner, z: maxZ },
+        { x: minX + southWestCorner, z: maxZ },
+        { x: minX, z: maxZ - southWestCorner },
+        { x: minX, z: minZ + southEastCorner },
+    ];
+
+    const perimeter = points.filter((point, index) => {
+        const previous = points[index - 1];
+        return (
+            !previous ||
+            !nearlyEqual(point.x, previous.x) ||
+            !nearlyEqual(point.z, previous.z)
+        );
+    });
+
+    return {
+        bounds: {
+            maxX,
+            maxZ,
+            minX,
+            minZ,
+        },
+        perimeter,
+    };
+}
+
+function shouldRenderMulchPatchSide(input: {
+    bounds: ReturnType<typeof getMulchPatchPerimeter>['bounds'];
+    connections: MulchPatchConnections;
+    current: MulchPatchPoint;
+    next: MulchPatchPoint;
+}) {
+    const { bounds, connections, current, next } = input;
+    const onNorth =
+        nearlyEqual(current.x, bounds.maxX) && nearlyEqual(next.x, bounds.maxX);
+    const onSouth =
+        nearlyEqual(current.x, bounds.minX) && nearlyEqual(next.x, bounds.minX);
+    const onEast =
+        nearlyEqual(current.z, bounds.minZ) && nearlyEqual(next.z, bounds.minZ);
+    const onWest =
+        nearlyEqual(current.z, bounds.maxZ) && nearlyEqual(next.z, bounds.maxZ);
+
+    if (onNorth && connections.n) {
+        return false;
+    }
+    if (onSouth && connections.s) {
+        return false;
+    }
+    if (onEast && connections.e) {
+        return false;
+    }
+    if (onWest && connections.w) {
+        return false;
+    }
+
+    return true;
+}
+
+export function createMulchPatchGeometry({
+    connections,
+}: {
+    connections: MulchPatchConnections;
+}) {
+    const topCenterY = 0.026;
+    const topEdgeY = 0.018;
+    const bottomY = 0;
+    const positions: number[] = [];
+    const { bounds, perimeter } = getMulchPatchPerimeter(connections);
+
+    function addVertex(point: MulchPatchPoint, y: number) {
+        positions.push(point.x, y, point.z);
+    }
+
+    function addTriangle(
+        first: MulchPatchPoint,
+        firstY: number,
+        second: MulchPatchPoint,
+        secondY: number,
+        third: MulchPatchPoint,
+        thirdY: number,
+    ) {
+        addVertex(first, firstY);
+        addVertex(second, secondY);
+        addVertex(third, thirdY);
+    }
+
+    const center = { x: 0, z: 0 };
+    for (const [index, current] of perimeter.entries()) {
+        const next = perimeter[(index + 1) % perimeter.length];
+        if (!next) {
+            continue;
+        }
+
+        addTriangle(center, topCenterY, next, topEdgeY, current, topEdgeY);
+
+        if (
+            shouldRenderMulchPatchSide({
+                bounds,
+                connections,
+                current,
+                next,
+            })
+        ) {
+            addTriangle(current, topEdgeY, next, topEdgeY, next, bottomY);
+            addTriangle(current, topEdgeY, next, bottomY, current, bottomY);
+        }
+    }
+
+    const geometry = new BufferGeometry();
+    geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
+    geometry.computeVertexNormals();
+    geometry.computeBoundingBox();
+    geometry.computeBoundingSphere();
+
+    return geometry;
+}

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.ts
@@ -1,4 +1,9 @@
-import { BufferGeometry, Float32BufferAttribute } from 'three';
+import {
+    BufferGeometry,
+    Float32BufferAttribute,
+    ShapeUtils,
+    Vector2,
+} from 'three';
 
 export type MulchBlockName = 'MulchCoconut' | 'MulchHey' | 'MulchWood';
 
@@ -40,6 +45,10 @@ type MulchPatchBounds = {
     maxZ: number;
     minX: number;
     minZ: number;
+};
+
+type MulchPatchCorner = {
+    radius: number;
 };
 
 export const mulchPatchConnectionMasks = Array.from(
@@ -180,7 +189,7 @@ function getMulchPatchPerimeter(connections: MulchPatchConnections) {
     );
     const innerCornerRadius = connectedHalfSize - isolatedHalfSize;
 
-    function getCornerRadius({
+    function getCorner({
         diagonal,
         xConnection,
         zConnection,
@@ -188,34 +197,40 @@ function getMulchPatchPerimeter(connections: MulchPatchConnections) {
         diagonal: boolean;
         xConnection: boolean;
         zConnection: boolean;
-    }) {
+    }): MulchPatchCorner {
         if (!xConnection && !zConnection) {
-            return outerCornerRadius;
+            return {
+                radius: outerCornerRadius,
+            };
         }
 
         if (xConnection && zConnection && !diagonal) {
-            return innerCornerRadius;
+            return {
+                radius: innerCornerRadius,
+            };
         }
 
-        return 0;
+        return {
+            radius: 0,
+        };
     }
 
-    const southEastCorner = getCornerRadius({
+    const southEastCorner = getCorner({
         diagonal: connections.se,
         xConnection: connections.s,
         zConnection: connections.e,
     });
-    const northEastCorner = getCornerRadius({
+    const northEastCorner = getCorner({
         diagonal: connections.ne,
         xConnection: connections.n,
         zConnection: connections.e,
     });
-    const northWestCorner = getCornerRadius({
+    const northWestCorner = getCorner({
         diagonal: connections.nw,
         xConnection: connections.n,
         zConnection: connections.w,
     });
-    const southWestCorner = getCornerRadius({
+    const southWestCorner = getCorner({
         diagonal: connections.sw,
         xConnection: connections.s,
         zConnection: connections.w,
@@ -262,33 +277,45 @@ function getMulchPatchPerimeter(connections: MulchPatchConnections) {
         }
     }
 
-    addPoint({ x: minX + southEastCorner, z: minZ });
-    addPoint({ x: maxX - northEastCorner, z: minZ });
+    addPoint({ x: minX + southEastCorner.radius, z: minZ });
+    addPoint({ x: maxX - northEastCorner.radius, z: minZ });
     addCornerArc({
-        center: { x: maxX - northEastCorner, z: minZ + northEastCorner },
+        center: {
+            x: maxX - northEastCorner.radius,
+            z: minZ + northEastCorner.radius,
+        },
         endAngle: 0,
-        radius: northEastCorner,
+        radius: northEastCorner.radius,
         startAngle: -Math.PI / 2,
     });
-    addPoint({ x: maxX, z: maxZ - northWestCorner });
+    addPoint({ x: maxX, z: maxZ - northWestCorner.radius });
     addCornerArc({
-        center: { x: maxX - northWestCorner, z: maxZ - northWestCorner },
+        center: {
+            x: maxX - northWestCorner.radius,
+            z: maxZ - northWestCorner.radius,
+        },
         endAngle: Math.PI / 2,
-        radius: northWestCorner,
+        radius: northWestCorner.radius,
         startAngle: 0,
     });
-    addPoint({ x: minX + southWestCorner, z: maxZ });
+    addPoint({ x: minX + southWestCorner.radius, z: maxZ });
     addCornerArc({
-        center: { x: minX + southWestCorner, z: maxZ - southWestCorner },
+        center: {
+            x: minX + southWestCorner.radius,
+            z: maxZ - southWestCorner.radius,
+        },
         endAngle: Math.PI,
-        radius: southWestCorner,
+        radius: southWestCorner.radius,
         startAngle: Math.PI / 2,
     });
-    addPoint({ x: minX, z: minZ + southEastCorner });
+    addPoint({ x: minX, z: minZ + southEastCorner.radius });
     addCornerArc({
-        center: { x: minX + southEastCorner, z: minZ + southEastCorner },
+        center: {
+            x: minX + southEastCorner.radius,
+            z: minZ + southEastCorner.radius,
+        },
         endAngle: (Math.PI * 3) / 2,
-        radius: southEastCorner,
+        radius: southEastCorner.radius,
         startAngle: Math.PI,
     });
 
@@ -346,24 +373,99 @@ function shouldRenderMulchPatchSide(input: {
     return true;
 }
 
+function isPointInInnerCornerArea({
+    corner,
+    point,
+    radius,
+}: {
+    corner: 'ne' | 'nw' | 'se' | 'sw';
+    point: MulchPatchPoint;
+    radius: number;
+}) {
+    const tolerance = 0.0001;
+
+    if (corner === 'ne') {
+        return (
+            point.x >= 0.5 - radius - tolerance &&
+            point.z <= -0.5 + radius + tolerance
+        );
+    }
+    if (corner === 'nw') {
+        return (
+            point.x >= 0.5 - radius - tolerance &&
+            point.z >= 0.5 - radius - tolerance
+        );
+    }
+    if (corner === 'se') {
+        return (
+            point.x <= -0.5 + radius + tolerance &&
+            point.z <= -0.5 + radius + tolerance
+        );
+    }
+
+    return (
+        point.x <= -0.5 + radius + tolerance &&
+        point.z >= 0.5 - radius - tolerance
+    );
+}
+
+function isInnerCornerMulchPatchSide({
+    connections,
+    current,
+    next,
+}: {
+    connections: MulchPatchConnections;
+    current: MulchPatchPoint;
+    next: MulchPatchPoint;
+}) {
+    const innerCornerRadius = 0.11;
+    const innerCorners = [
+        connections.n && connections.e && !connections.ne ? 'ne' : null,
+        connections.n && connections.w && !connections.nw ? 'nw' : null,
+        connections.s && connections.e && !connections.se ? 'se' : null,
+        connections.s && connections.w && !connections.sw ? 'sw' : null,
+    ] as const;
+
+    return innerCorners.some(
+        (corner) =>
+            corner &&
+            isPointInInnerCornerArea({
+                corner,
+                point: current,
+                radius: innerCornerRadius,
+            }) &&
+            isPointInInnerCornerArea({
+                corner,
+                point: next,
+                radius: innerCornerRadius,
+            }),
+    );
+}
+
 export function createMulchPatchGeometry({
     connections,
 }: {
     connections: MulchPatchConnections;
 }) {
-    const topCenterY = 0.026;
-    const topEdgeY = 0.018;
+    const topY = 0.026;
     const bottomY = 0;
     const positions: number[] = [];
     const edgeShades: number[] = [];
     const boundsAttributes: number[] = [];
     const exposedEdgeAttributes: number[] = [];
+    const innerCornerAttributes: number[] = [];
     const { bounds, perimeter } = getMulchPatchPerimeter(connections);
     const exposedEdges = [
         connections.n ? 0 : 1,
         connections.e ? 0 : 1,
         connections.s ? 0 : 1,
         connections.w ? 0 : 1,
+    ];
+    const innerCorners = [
+        connections.n && connections.e && !connections.ne ? 1 : 0,
+        connections.n && connections.w && !connections.nw ? 1 : 0,
+        connections.s && connections.e && !connections.se ? 1 : 0,
+        connections.s && connections.w && !connections.sw ? 1 : 0,
     ];
 
     function addVertex(point: MulchPatchPoint, y: number, edgeShade: number) {
@@ -376,6 +478,7 @@ export function createMulchPatchGeometry({
             bounds.maxZ,
         );
         exposedEdgeAttributes.push(...exposedEdges);
+        innerCornerAttributes.push(...innerCorners);
     }
 
     function addTriangle(
@@ -394,24 +497,46 @@ export function createMulchPatchGeometry({
         addVertex(third, thirdY, thirdEdgeShade);
     }
 
-    const center = { x: 0, z: 0 };
+    function getTopNormalY(
+        first: MulchPatchPoint,
+        second: MulchPatchPoint,
+        third: MulchPatchPoint,
+    ) {
+        const abX = second.x - first.x;
+        const abZ = second.z - first.z;
+        const acX = third.x - first.x;
+        const acZ = third.z - first.z;
+
+        return abZ * acX - abX * acZ;
+    }
+
+    for (const triangle of ShapeUtils.triangulateShape(
+        perimeter.map((point) => new Vector2(point.x, point.z)),
+        [],
+    )) {
+        const firstIndex = triangle[0];
+        const secondIndex = triangle[1];
+        const thirdIndex = triangle[2];
+        const first = firstIndex == null ? undefined : perimeter[firstIndex];
+        const second = secondIndex == null ? undefined : perimeter[secondIndex];
+        const third = thirdIndex == null ? undefined : perimeter[thirdIndex];
+
+        if (!first || !second || !third) {
+            continue;
+        }
+
+        if (getTopNormalY(first, second, third) >= 0) {
+            addTriangle(first, topY, 0, second, topY, 0, third, topY, 0);
+        } else {
+            addTriangle(first, topY, 0, third, topY, 0, second, topY, 0);
+        }
+    }
+
     for (const [index, current] of perimeter.entries()) {
         const next = perimeter[(index + 1) % perimeter.length];
         if (!next) {
             continue;
         }
-
-        addTriangle(
-            center,
-            topCenterY,
-            0,
-            next,
-            topEdgeY,
-            0,
-            current,
-            topEdgeY,
-            0,
-        );
 
         if (
             shouldRenderMulchPatchSide({
@@ -421,28 +546,39 @@ export function createMulchPatchGeometry({
                 next,
             })
         ) {
-            addTriangle(
-                current,
-                topEdgeY,
-                1,
-                next,
-                topEdgeY,
-                1,
-                next,
-                bottomY,
-                1,
-            );
-            addTriangle(
-                current,
-                topEdgeY,
-                1,
-                next,
-                bottomY,
-                1,
-                current,
-                bottomY,
-                1,
-            );
+            if (
+                isInnerCornerMulchPatchSide({
+                    connections,
+                    current,
+                    next,
+                })
+            ) {
+                addTriangle(current, topY, 1, next, bottomY, 1, next, topY, 1);
+                addTriangle(
+                    current,
+                    topY,
+                    1,
+                    current,
+                    bottomY,
+                    1,
+                    next,
+                    bottomY,
+                    1,
+                );
+            } else {
+                addTriangle(current, topY, 1, next, topY, 1, next, bottomY, 1);
+                addTriangle(
+                    current,
+                    topY,
+                    1,
+                    next,
+                    bottomY,
+                    1,
+                    current,
+                    bottomY,
+                    1,
+                );
+            }
         }
     }
 
@@ -459,6 +595,10 @@ export function createMulchPatchGeometry({
     geometry.setAttribute(
         'mulchExposedEdges',
         new Float32BufferAttribute(exposedEdgeAttributes, 4),
+    );
+    geometry.setAttribute(
+        'mulchInnerCorners',
+        new Float32BufferAttribute(innerCornerAttributes, 4),
     );
     geometry.computeVertexNormals();
     geometry.computeBoundingBox();

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.unit.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.unit.ts
@@ -56,6 +56,71 @@ function hasBottomEdgeAtX(geometry: BufferGeometry, x: number) {
     return false;
 }
 
+function hasTopEdgeShadeAtX(
+    geometry: BufferGeometry,
+    x: number,
+    edgeShade: number,
+) {
+    const position = geometry.getAttribute('position');
+    const mulchEdge = geometry.getAttribute('mulchEdge');
+
+    for (let index = 0; index < position.count; index += 3) {
+        const triangle = [index, index + 1, index + 2];
+
+        for (const firstIndex of triangle) {
+            for (const secondIndex of triangle) {
+                if (firstIndex >= secondIndex) {
+                    continue;
+                }
+
+                if (
+                    rounded(position.getX(firstIndex)) === rounded(x) &&
+                    rounded(position.getX(secondIndex)) === rounded(x) &&
+                    rounded(position.getY(firstIndex)) === 0.018 &&
+                    rounded(position.getY(secondIndex)) === 0.018 &&
+                    rounded(mulchEdge.getX(firstIndex)) === edgeShade &&
+                    rounded(mulchEdge.getX(secondIndex)) === edgeShade
+                ) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+function getMulchEdgeRange(geometry: BufferGeometry) {
+    const position = geometry.getAttribute('position');
+    const mulchEdge = geometry.getAttribute('mulchEdge');
+    assert.equal(mulchEdge.count, position.count);
+
+    const values = Array.from({ length: mulchEdge.count }, (_, index) =>
+        rounded(mulchEdge.getX(index)),
+    );
+
+    return {
+        max: Math.max(...values),
+        min: Math.min(...values),
+    };
+}
+
+function hasRoundedOuterCornerPoint(geometry: BufferGeometry) {
+    const position = geometry.getAttribute('position');
+
+    for (let index = 0; index < position.count; index += 1) {
+        const x = rounded(position.getX(index));
+        const y = rounded(position.getY(index));
+        const z = rounded(position.getZ(index));
+
+        if (y === 0.018 && x > 0.32 && x < 0.38 && z > 0.32 && z < 0.38) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 test('mulch patch target resolver connects neighbors on the same height only', () => {
     const target = {
         position: [0, 1, 0],
@@ -108,6 +173,8 @@ test('isolated mulch patch keeps an inset rounded footprint', () => {
         minY: 0,
         minZ: -0.39,
     });
+    assert.equal(hasRoundedOuterCornerPoint(geometry), true);
+    assert.deepEqual(getMulchEdgeRange(geometry), { max: 1, min: 0 });
 
     geometry.dispose();
 });
@@ -133,6 +200,7 @@ test('connected mulch patch reaches neighbor edges without internal walls', () =
         minZ: -0.39,
     });
     assert.equal(hasBottomEdgeAtX(northConnected, 0.5), false);
+    assert.equal(hasTopEdgeShadeAtX(northConnected, 0.5, 0), true);
 
     northConnected.dispose();
 });

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.unit.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.unit.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { BufferGeometry } from 'three';
+import {
+    createMulchPatchGeometry,
+    fullMulchPatchConnectionMask,
+    getMulchPatchConnectionMask,
+    getMulchPatchConnectionsFromMask,
+    isolatedMulchPatchConnectionMask,
+    resolveMulchPatchConnectionMask,
+} from './mulchPatchGeometry';
+
+function rounded(value: number) {
+    return Number(value.toFixed(6));
+}
+
+function getBounds(geometry: BufferGeometry) {
+    geometry.computeBoundingBox();
+    const box = geometry.boundingBox;
+    assert.ok(box);
+
+    return {
+        maxX: rounded(box.max.x),
+        maxY: rounded(box.max.y),
+        maxZ: rounded(box.max.z),
+        minX: rounded(box.min.x),
+        minY: rounded(box.min.y),
+        minZ: rounded(box.min.z),
+    };
+}
+
+function hasBottomEdgeAtX(geometry: BufferGeometry, x: number) {
+    const position = geometry.getAttribute('position');
+
+    for (let index = 0; index < position.count; index += 3) {
+        const triangle = [index, index + 1, index + 2];
+
+        for (const firstIndex of triangle) {
+            for (const secondIndex of triangle) {
+                if (firstIndex >= secondIndex) {
+                    continue;
+                }
+
+                if (
+                    rounded(position.getX(firstIndex)) === rounded(x) &&
+                    rounded(position.getX(secondIndex)) === rounded(x) &&
+                    rounded(position.getY(firstIndex)) === 0 &&
+                    rounded(position.getY(secondIndex)) === 0
+                ) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+test('mulch patch target resolver connects neighbors on the same height only', () => {
+    const target = {
+        position: [0, 1, 0],
+        size: [1, 1],
+    } satisfies {
+        position: readonly [number, number, number];
+        size: readonly [number, number];
+    };
+    const sameHeightNorth = {
+        position: [1, 1, 0],
+        size: [1, 1],
+    } satisfies typeof target;
+    const sameHeightEast = {
+        position: [0, 1, -1],
+        size: [1, 1],
+    } satisfies typeof target;
+    const differentHeightSouth = {
+        position: [-1, 1.25, 0],
+        size: [1, 1],
+    } satisfies typeof target;
+
+    assert.equal(
+        resolveMulchPatchConnectionMask(target, [
+            target,
+            sameHeightNorth,
+            sameHeightEast,
+            differentHeightSouth,
+        ]),
+        getMulchPatchConnectionMask({
+            e: true,
+            n: true,
+            s: false,
+            w: false,
+        }),
+    );
+});
+
+test('isolated mulch patch keeps an inset rounded footprint', () => {
+    const geometry = createMulchPatchGeometry({
+        connections: getMulchPatchConnectionsFromMask(
+            isolatedMulchPatchConnectionMask,
+        ),
+    });
+
+    assert.deepEqual(getBounds(geometry), {
+        maxX: 0.39,
+        maxY: 0.026,
+        maxZ: 0.39,
+        minX: -0.39,
+        minY: 0,
+        minZ: -0.39,
+    });
+
+    geometry.dispose();
+});
+
+test('connected mulch patch reaches neighbor edges without internal walls', () => {
+    const northConnected = createMulchPatchGeometry({
+        connections: getMulchPatchConnectionsFromMask(
+            getMulchPatchConnectionMask({
+                e: false,
+                n: true,
+                s: false,
+                w: false,
+            }),
+        ),
+    });
+
+    assert.deepEqual(getBounds(northConnected), {
+        maxX: 0.5,
+        maxY: 0.026,
+        maxZ: 0.39,
+        minX: -0.39,
+        minY: 0,
+        minZ: -0.39,
+    });
+    assert.equal(hasBottomEdgeAtX(northConnected, 0.5), false);
+
+    northConnected.dispose();
+});
+
+test('fully connected mulch patch fills the tile without skirt walls', () => {
+    const geometry = createMulchPatchGeometry({
+        connections: getMulchPatchConnectionsFromMask(
+            fullMulchPatchConnectionMask,
+        ),
+    });
+
+    assert.deepEqual(getBounds(geometry), {
+        maxX: 0.5,
+        maxY: 0.026,
+        maxZ: 0.5,
+        minX: -0.5,
+        minY: 0.018,
+        minZ: -0.5,
+    });
+
+    geometry.dispose();
+});

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.unit.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.unit.ts
@@ -178,7 +178,7 @@ function hasRoundedOuterCornerPoint(geometry: BufferGeometry) {
     return false;
 }
 
-function hasRoundedInnerCornerPoint(geometry: BufferGeometry) {
+function hasRoundedInnerCornerCutoutPoint(geometry: BufferGeometry) {
     const position = geometry.getAttribute('position');
 
     for (let index = 0; index < position.count; index += 1) {
@@ -186,7 +186,7 @@ function hasRoundedInnerCornerPoint(geometry: BufferGeometry) {
         const y = rounded(position.getY(index));
         const z = rounded(position.getZ(index));
 
-        if (y === topY && x > 0.43 && x < 0.49 && z < -0.43 && z > -0.49) {
+        if (y === topY && x > 0.4 && x < 0.44 && z < -0.41 && z > -0.45) {
             return true;
         }
     }
@@ -305,7 +305,7 @@ test('diagonal holes round the inner corner between connected edges', () => {
         minZ: -0.5,
     });
     assert.equal(hasTopPoint(geometry, 0.5, -0.5), false);
-    assert.equal(hasRoundedInnerCornerPoint(geometry), true);
+    assert.equal(hasRoundedInnerCornerCutoutPoint(geometry), true);
     assert.deepEqual(
         getFirstVec4Attribute(geometry, 'mulchInnerCorners'),
         [1, 0, 0, 0],

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.unit.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.unit.ts
@@ -56,6 +56,49 @@ function hasBottomEdgeAtX(geometry: BufferGeometry, x: number) {
     return false;
 }
 
+function hasBottomEdgeAtZ(geometry: BufferGeometry, z: number) {
+    const position = geometry.getAttribute('position');
+
+    for (let index = 0; index < position.count; index += 3) {
+        const triangle = [index, index + 1, index + 2];
+
+        for (const firstIndex of triangle) {
+            for (const secondIndex of triangle) {
+                if (firstIndex >= secondIndex) {
+                    continue;
+                }
+
+                if (
+                    rounded(position.getZ(firstIndex)) === rounded(z) &&
+                    rounded(position.getZ(secondIndex)) === rounded(z) &&
+                    rounded(position.getY(firstIndex)) === 0 &&
+                    rounded(position.getY(secondIndex)) === 0
+                ) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+function hasTopPoint(geometry: BufferGeometry, x: number, z: number) {
+    const position = geometry.getAttribute('position');
+
+    for (let index = 0; index < position.count; index += 1) {
+        if (
+            rounded(position.getX(index)) === rounded(x) &&
+            rounded(position.getY(index)) === 0.018 &&
+            rounded(position.getZ(index)) === rounded(z)
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function hasTopEdgeShadeAtX(
     geometry: BufferGeometry,
     x: number,
@@ -121,6 +164,22 @@ function hasRoundedOuterCornerPoint(geometry: BufferGeometry) {
     return false;
 }
 
+function hasRoundedInnerCornerPoint(geometry: BufferGeometry) {
+    const position = geometry.getAttribute('position');
+
+    for (let index = 0; index < position.count; index += 1) {
+        const x = rounded(position.getX(index));
+        const y = rounded(position.getY(index));
+        const z = rounded(position.getZ(index));
+
+        if (y === 0.018 && x > 0.43 && x < 0.49 && z < -0.43 && z > -0.49) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 test('mulch patch target resolver connects neighbors on the same height only', () => {
     const target = {
         position: [0, 1, 0],
@@ -141,6 +200,10 @@ test('mulch patch target resolver connects neighbors on the same height only', (
         position: [-1, 1.25, 0],
         size: [1, 1],
     } satisfies typeof target;
+    const sameHeightNorthEast = {
+        position: [1, 1, -1],
+        size: [1, 1],
+    } satisfies typeof target;
 
     assert.equal(
         resolveMulchPatchConnectionMask(target, [
@@ -148,10 +211,12 @@ test('mulch patch target resolver connects neighbors on the same height only', (
             sameHeightNorth,
             sameHeightEast,
             differentHeightSouth,
+            sameHeightNorthEast,
         ]),
         getMulchPatchConnectionMask({
             e: true,
             n: true,
+            ne: true,
             s: false,
             w: false,
         }),
@@ -203,6 +268,52 @@ test('connected mulch patch reaches neighbor edges without internal walls', () =
     assert.equal(hasTopEdgeShadeAtX(northConnected, 0.5, 0), true);
 
     northConnected.dispose();
+});
+
+test('diagonal holes round the inner corner between connected edges', () => {
+    const geometry = createMulchPatchGeometry({
+        connections: getMulchPatchConnectionsFromMask(
+            getMulchPatchConnectionMask({
+                e: true,
+                n: true,
+                s: false,
+                w: false,
+            }),
+        ),
+    });
+
+    assert.deepEqual(getBounds(geometry), {
+        maxX: 0.5,
+        maxY: 0.026,
+        maxZ: 0.39,
+        minX: -0.39,
+        minY: 0,
+        minZ: -0.5,
+    });
+    assert.equal(hasTopPoint(geometry, 0.5, -0.5), false);
+    assert.equal(hasRoundedInnerCornerPoint(geometry), true);
+    assert.equal(hasBottomEdgeAtX(geometry, 0.5), false);
+    assert.equal(hasBottomEdgeAtZ(geometry, -0.5), false);
+
+    geometry.dispose();
+});
+
+test('diagonal mulch keeps solid connected corners filled', () => {
+    const geometry = createMulchPatchGeometry({
+        connections: getMulchPatchConnectionsFromMask(
+            getMulchPatchConnectionMask({
+                e: true,
+                n: true,
+                ne: true,
+                s: false,
+                w: false,
+            }),
+        ),
+    });
+
+    assert.equal(hasTopPoint(geometry, 0.5, -0.5), true);
+
+    geometry.dispose();
 });
 
 test('fully connected mulch patch fills the tile without skirt walls', () => {

--- a/packages/game/src/entities/raisedBed/mulchPatchGeometry.unit.ts
+++ b/packages/game/src/entities/raisedBed/mulchPatchGeometry.unit.ts
@@ -10,6 +10,8 @@ import {
     resolveMulchPatchConnectionMask,
 } from './mulchPatchGeometry';
 
+const topY = 0.026;
+
 function rounded(value: number) {
     return Number(value.toFixed(6));
 }
@@ -89,7 +91,7 @@ function hasTopPoint(geometry: BufferGeometry, x: number, z: number) {
     for (let index = 0; index < position.count; index += 1) {
         if (
             rounded(position.getX(index)) === rounded(x) &&
-            rounded(position.getY(index)) === 0.018 &&
+            rounded(position.getY(index)) === topY &&
             rounded(position.getZ(index)) === rounded(z)
         ) {
             return true;
@@ -119,8 +121,8 @@ function hasTopEdgeShadeAtX(
                 if (
                     rounded(position.getX(firstIndex)) === rounded(x) &&
                     rounded(position.getX(secondIndex)) === rounded(x) &&
-                    rounded(position.getY(firstIndex)) === 0.018 &&
-                    rounded(position.getY(secondIndex)) === 0.018 &&
+                    rounded(position.getY(firstIndex)) === topY &&
+                    rounded(position.getY(secondIndex)) === topY &&
                     rounded(mulchEdge.getX(firstIndex)) === edgeShade &&
                     rounded(mulchEdge.getX(secondIndex)) === edgeShade
                 ) {
@@ -148,6 +150,18 @@ function getMulchEdgeRange(geometry: BufferGeometry) {
     };
 }
 
+function getFirstVec4Attribute(geometry: BufferGeometry, name: string) {
+    const attribute = geometry.getAttribute(name);
+    assert.ok(attribute);
+
+    return [
+        rounded(attribute.getX(0)),
+        rounded(attribute.getY(0)),
+        rounded(attribute.getZ(0)),
+        rounded(attribute.getW(0)),
+    ];
+}
+
 function hasRoundedOuterCornerPoint(geometry: BufferGeometry) {
     const position = geometry.getAttribute('position');
 
@@ -156,7 +170,7 @@ function hasRoundedOuterCornerPoint(geometry: BufferGeometry) {
         const y = rounded(position.getY(index));
         const z = rounded(position.getZ(index));
 
-        if (y === 0.018 && x > 0.32 && x < 0.38 && z > 0.32 && z < 0.38) {
+        if (y === topY && x > 0.32 && x < 0.38 && z > 0.32 && z < 0.38) {
             return true;
         }
     }
@@ -172,7 +186,7 @@ function hasRoundedInnerCornerPoint(geometry: BufferGeometry) {
         const y = rounded(position.getY(index));
         const z = rounded(position.getZ(index));
 
-        if (y === 0.018 && x > 0.43 && x < 0.49 && z < -0.43 && z > -0.49) {
+        if (y === topY && x > 0.43 && x < 0.49 && z < -0.43 && z > -0.49) {
             return true;
         }
     }
@@ -292,6 +306,10 @@ test('diagonal holes round the inner corner between connected edges', () => {
     });
     assert.equal(hasTopPoint(geometry, 0.5, -0.5), false);
     assert.equal(hasRoundedInnerCornerPoint(geometry), true);
+    assert.deepEqual(
+        getFirstVec4Attribute(geometry, 'mulchInnerCorners'),
+        [1, 0, 0, 0],
+    );
     assert.equal(hasBottomEdgeAtX(geometry, 0.5), false);
     assert.equal(hasBottomEdgeAtZ(geometry, -0.5), false);
 
@@ -312,6 +330,10 @@ test('diagonal mulch keeps solid connected corners filled', () => {
     });
 
     assert.equal(hasTopPoint(geometry, 0.5, -0.5), true);
+    assert.deepEqual(
+        getFirstVec4Attribute(geometry, 'mulchInnerCorners'),
+        [0, 0, 0, 0],
+    );
 
     geometry.dispose();
 });
@@ -328,7 +350,7 @@ test('fully connected mulch patch fills the tile without skirt walls', () => {
         maxY: 0.026,
         maxZ: 0.5,
         minX: -0.5,
-        minY: 0.018,
+        minY: topY,
         minZ: -0.5,
     });
 


### PR DESCRIPTION
## What changed

- Replaced the isolated mulch mound rendering with a shared procedural mulch patch for `MulchHey`, `MulchCoconut`, and `MulchWood`.
- Connected adjacent mulch blocks when their rendered surfaces are on the same height, while keeping higher/lower mulch visually separate.
- Reused the same patch geometry for raised-bed visual reward overlays, including full-bed mulch and field-level mulch rewards.
- Added unit coverage for mulch patch neighbor masks, geometry bounds, and connected-edge wall behavior.

## Why

Adjacent mulch decorations previously stayed as separate raised mounds with visible gaps. The new renderer treats mulch as a continuous patch surface when neighboring mulch is on the same level, matching the intended in-game decoration behavior for placed blocks and raised-bed reward visuals.

## Validation

- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `git diff --check`
- Browser sanity check on `http://localhost:4141/debug/sandbox` with seeded adjacent mulch blocks: full-size canvas, nonblank screenshot, connected 3x3 mulch patch visible, separate higher patch not connected.
- Browser sanity check on `http://localhost:4141/debug/profile/game?profile=operation-rewards&details=1&quality=medium&legend=0`: full-size canvas and nonblank screenshot for raised-bed reward rendering.

Known local-only browser noise: the garden dev server proxied account/sunflower API requests to an unavailable local API on `4145`; the debug pages themselves returned `200` and the scene checks passed.
