### PR TITLE
fix(game): avoid plant mulch becoming bed-wide

### DIFF
--- a/packages/game/src/entities/raisedBed/raisedBedMulchVisualRewards.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedMulchVisualRewards.ts
@@ -59,17 +59,29 @@ export function isFieldMulchApplication(
     return application === 'plant';
 }
 
-function activeMulchRewards({
-    appliedOperations,
-    operations,
-    raisedBedId,
-}: ResolveRaisedBedMulchVisualRewardsInput) {
-    return resolveOperationVisualRewards({
-        appliedOperations: appliedOperations.map((operation) => ({
-            ...operation,
-            raisedBedId: operation.raisedBedId ?? raisedBedId,
-        })),
+function activeMulchRewards(
+    {
+        appliedOperations,
         operations,
+        raisedBedId,
+    }: ResolveRaisedBedMulchVisualRewardsInput,
+    isTargetApplication: (application: string | null | undefined) => boolean,
+) {
+    const targetOperations = operations.filter((operation) =>
+        isTargetApplication(operation.attributes?.application),
+    );
+    const targetOperationIds = new Set(
+        targetOperations.map((operation) => operation.id),
+    );
+
+    return resolveOperationVisualRewards({
+        appliedOperations: appliedOperations
+            .filter((operation) => targetOperationIds.has(operation.entityId))
+            .map((operation) => ({
+                ...operation,
+                raisedBedId: operation.raisedBedId ?? raisedBedId,
+            })),
+        operations: targetOperations,
     }).filter((reward) => reward.family === 'mulch' && reward.active);
 }
 
@@ -77,7 +89,7 @@ export function resolveActiveRaisedBedMulchReward(
     input: ResolveRaisedBedMulchVisualRewardsInput,
 ) {
     return (
-        activeMulchRewards(input).find(
+        activeMulchRewards(input, isBedMulchApplication).find(
             (reward) =>
                 reward.scope === 'raisedBed' &&
                 reward.raisedBedId === input.raisedBedId,
@@ -90,7 +102,7 @@ export function resolveActiveFieldMulchRewardsByFieldId(
 ) {
     const rewardsByFieldId = new Map<number, OperationVisualReward>();
 
-    for (const reward of activeMulchRewards(input)) {
+    for (const reward of activeMulchRewards(input, isFieldMulchApplication)) {
         if (
             reward.scope !== 'field' ||
             reward.raisedBedId !== input.raisedBedId ||

--- a/packages/game/src/entities/raisedBed/raisedBedMulchVisualRewards.unit.ts
+++ b/packages/game/src/entities/raisedBed/raisedBedMulchVisualRewards.unit.ts
@@ -161,6 +161,43 @@ test('nested whole-bed mulch operation inherits the current raised bed', () => {
     assert.equal(reward?.entityId, 1);
 });
 
+test('plant mulch without a field is not promoted to whole-bed mulch', () => {
+    const reward = resolveActiveRaisedBedMulchReward({
+        raisedBedId: 10,
+        operations,
+        appliedOperations: [
+            applied(260, {
+                completedAt: '2026-06-02T08:00:00.000Z',
+                entityId: 3,
+                raisedBedId: 10,
+            }),
+        ],
+    });
+
+    assert.equal(reward, null);
+});
+
+test('newer plant mulch without a field does not mask whole-bed mulch', () => {
+    const reward = resolveActiveRaisedBedMulchReward({
+        raisedBedId: 10,
+        operations,
+        appliedOperations: [
+            applied(270, {
+                completedAt: '2026-06-01T08:00:00.000Z',
+                entityId: 1,
+                raisedBedId: 10,
+            }),
+            applied(271, {
+                completedAt: '2026-06-02T08:00:00.000Z',
+                entityId: 3,
+                raisedBedId: 10,
+            }),
+        ],
+    });
+
+    assert.equal(reward?.entityId, 1);
+});
+
 test('field remove-mulch reward clears only the matching field', () => {
     const rewardsByFieldId = resolveActiveFieldMulchRewardsByFieldId({
         raisedBedId: 10,


### PR DESCRIPTION
## Summary

- Keep raised-bed mulch visuals scoped to operation definitions with bed-level applications.
- Keep field mulch visuals scoped to plant-level operation definitions.
- Add regressions for plant mulch operations that are missing a field id so they do not become full-bed overlays or mask real bed mulch.

## Root Cause

Live DB investigation found Hrabra Jabuka had a completed `malchStrawPlant` operation with `application: "plant"`, `visualReward: "mulch"`, and `raisedBedFieldId: null`. The renderer resolved that no-field plant operation as a raised-bed reward, so the bed displayed full mulch even though no bed-wide mulch had been applied.

## Validation

- `corepack pnpm bootstrap`
- `pnpm --filter @gredice/game test -- raisedBedMulchVisualRewards.unit.ts`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter www typecheck`
- `pnpm --filter @gredice/game exec biome check src/entities/raisedBed/raisedBedMulchVisualRewards.ts src/entities/raisedBed/raisedBedMulchVisualRewards.unit.ts`
- `git diff --check`