### PR TITLE
feat(community-edits): improve operation suggestions

### DIFF
--- a/apps/api/lib/docs/openApiDocs.ts
+++ b/apps/api/lib/docs/openApiDocs.ts
@@ -1024,6 +1024,8 @@ export async function openApiDocs(
                             value: { type: 'string' },
                             label: { type: 'string' },
                             helpText: { type: 'string' },
+                            description: { type: 'string' },
+                            iconKey: { type: 'string' },
                         },
                     },
                 },
@@ -1061,7 +1063,7 @@ export async function openApiDocs(
                 fieldKey: { type: 'string' },
                 proposedValue: {
                     description:
-                        'Serialized proposed value. Type is validated against the editable field registry. Text and markdown submissions are stored with replayable patches so non-overlapping edits on the same attribute can be approved later. Operation suggestions use a structured add/remove intent for a plant-stage operation.',
+                        'Serialized proposed value. Type is validated against the editable field registry. Text and markdown submissions are stored with replayable patches so non-overlapping edits on the same attribute can be approved later. Operation suggestions use a structured add/remove intent for existing plant-stage operations and can also propose a new operation name and description.',
                 },
                 baseValueHash: {
                     type: ['string', 'null'],

--- a/apps/app/app/admin/community-edits/[requestId]/page.tsx
+++ b/apps/app/app/admin/community-edits/[requestId]/page.tsx
@@ -37,10 +37,10 @@ type CompactTextDiff = {
     added: string;
 };
 
-type CommunityOperationSuggestionValue = {
+type CommunityOperationSuggestionBaseValue = {
     format: 'community-operation-suggestion-v1';
     intent: 'add' | 'remove';
-    operationId: number;
+    operationMode: 'existing' | 'new';
     operationLabel: string;
     stageName: string;
     stageLabel: string;
@@ -48,6 +48,19 @@ type CommunityOperationSuggestionValue = {
     note?: string;
     source?: string;
 };
+
+type CommunityOperationSuggestionValue =
+    | (CommunityOperationSuggestionBaseValue & {
+          operationMode: 'existing';
+          operationId: number;
+      })
+    | (CommunityOperationSuggestionBaseValue & {
+          intent: 'add';
+          operationMode: 'new';
+          currentState: 'absent';
+          newOperationName: string;
+          newOperationDescription: string;
+      });
 
 function statusLabel(status: CommunityEditRequestStatus) {
     switch (status) {
@@ -138,23 +151,48 @@ function parseCompactTextDiff(reviewDiff: string | null) {
 function isCommunityOperationSuggestion(
     value: unknown,
 ): value is CommunityOperationSuggestionValue {
+    if (
+        typeof value !== 'object' ||
+        value === null ||
+        !('format' in value) ||
+        value.format !== 'community-operation-suggestion-v1' ||
+        !('intent' in value) ||
+        (value.intent !== 'add' && value.intent !== 'remove') ||
+        !('operationLabel' in value) ||
+        typeof value.operationLabel !== 'string' ||
+        !('stageName' in value) ||
+        typeof value.stageName !== 'string' ||
+        !('stageLabel' in value) ||
+        typeof value.stageLabel !== 'string' ||
+        !('currentState' in value) ||
+        (value.currentState !== 'absent' && value.currentState !== 'present') ||
+        ('note' in value &&
+            typeof value.note !== 'undefined' &&
+            typeof value.note !== 'string') ||
+        ('source' in value &&
+            typeof value.source !== 'undefined' &&
+            typeof value.source !== 'string')
+    ) {
+        return false;
+    }
+
+    const operationMode =
+        'operationMode' in value ? value.operationMode : 'existing';
+    if (operationMode === 'new') {
+        return (
+            value.intent === 'add' &&
+            value.currentState === 'absent' &&
+            'newOperationName' in value &&
+            typeof value.newOperationName === 'string' &&
+            'newOperationDescription' in value &&
+            typeof value.newOperationDescription === 'string'
+        );
+    }
+
     return (
-        typeof value === 'object' &&
-        value !== null &&
-        'format' in value &&
-        value.format === 'community-operation-suggestion-v1' &&
-        'intent' in value &&
-        (value.intent === 'add' || value.intent === 'remove') &&
+        operationMode === 'existing' &&
         'operationId' in value &&
-        typeof value.operationId === 'number' &&
-        'operationLabel' in value &&
-        typeof value.operationLabel === 'string' &&
-        'stageName' in value &&
-        typeof value.stageName === 'string' &&
-        'stageLabel' in value &&
-        typeof value.stageLabel === 'string' &&
-        'currentState' in value &&
-        (value.currentState === 'absent' || value.currentState === 'present')
+        typeof value.operationId === 'number'
     );
 }
 
@@ -165,7 +203,32 @@ function parseCommunityOperationSuggestion(value: string | null) {
 
     try {
         const parsed: unknown = JSON.parse(value);
-        return isCommunityOperationSuggestion(parsed) ? parsed : null;
+        if (!isCommunityOperationSuggestion(parsed)) {
+            return null;
+        }
+
+        if (parsed.operationMode === 'new') {
+            return parsed;
+        }
+
+        const suggestion: CommunityOperationSuggestionValue = {
+            format: parsed.format,
+            intent: parsed.intent,
+            operationMode: 'existing',
+            operationId: parsed.operationId,
+            operationLabel: parsed.operationLabel,
+            stageName: parsed.stageName,
+            stageLabel: parsed.stageLabel,
+            currentState: parsed.currentState,
+        };
+        if (parsed.note) {
+            suggestion.note = parsed.note;
+        }
+        if (parsed.source) {
+            suggestion.source = parsed.source;
+        }
+
+        return suggestion;
     } catch {
         return null;
     }
@@ -230,9 +293,21 @@ function OperationSuggestionBlock({
                     </Typography>
                 </DetailItem>
                 <DetailItem label="Radnja">
-                    <Typography>
-                        {suggestion.operationLabel} #{suggestion.operationId}
-                    </Typography>
+                    {suggestion.operationMode === 'new' ? (
+                        <Stack spacing={1}>
+                            <Chip color="info" variant="soft">
+                                Nova radnja
+                            </Chip>
+                            <Typography>
+                                {suggestion.newOperationName}
+                            </Typography>
+                        </Stack>
+                    ) : (
+                        <Typography>
+                            {suggestion.operationLabel} #
+                            {suggestion.operationId}
+                        </Typography>
+                    )}
                 </DetailItem>
                 <DetailItem label="Stanje pri slanju">
                     <Typography>
@@ -240,6 +315,13 @@ function OperationSuggestionBlock({
                     </Typography>
                 </DetailItem>
             </div>
+            {suggestion.operationMode === 'new' ? (
+                <DetailItem label="Opis očekivanja">
+                    <Typography className="whitespace-pre-line break-words">
+                        {suggestion.newOperationDescription}
+                    </Typography>
+                </DetailItem>
+            ) : null}
             {suggestion.source ? (
                 <DetailItem label="Izvor">
                     <Typography className="whitespace-pre-line break-words">

--- a/apps/www/components/community-edits/CommunityEditButton.tsx
+++ b/apps/www/components/community-edits/CommunityEditButton.tsx
@@ -7,6 +7,7 @@ import { Input } from '@gredice/ui/Input';
 import {
     ArrowDownToLine,
     Check,
+    Delete,
     Droplet,
     Edit,
     Leaf,
@@ -22,6 +23,7 @@ import {
     Timer,
 } from '@gredice/ui/icons';
 import { Modal } from '@gredice/ui/Modal';
+import { OperationCategoryIcon } from '@gredice/ui/OperationImage';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -59,6 +61,8 @@ type CommunityEditableFieldOption = {
     value: string;
     label: string;
     helpText?: string;
+    description?: string;
+    iconKey?: string;
 };
 
 type CommunityEditableField = {
@@ -84,18 +88,25 @@ type CommunityEditableField = {
 };
 
 type OperationSuggestionIntent = 'add' | 'remove';
+type OperationSuggestionMode = 'existing' | 'new';
 
 type OperationSuggestionFieldValue = {
     intent: OperationSuggestionIntent;
+    operationMode: OperationSuggestionMode;
     operationId: string;
+    newOperationName: string;
+    newOperationDescription: string;
     note: string;
     source: string;
 };
 
 type OperationSuggestionSubmitValue = {
     intent: OperationSuggestionIntent;
-    operationId: number;
+    operationMode: OperationSuggestionMode;
     stageName: string;
+    operationId?: number;
+    newOperationName?: string | null;
+    newOperationDescription?: string | null;
     note?: string | null;
     source?: string | null;
 };
@@ -240,7 +251,10 @@ function initialFieldValue(field: CommunityEditableField): FieldValue {
     if (field.controlType === 'operationSuggestion') {
         return {
             intent: 'add',
+            operationMode: 'existing',
             operationId: '',
+            newOperationName: '',
+            newOperationDescription: '',
             note: '',
             source: '',
         };
@@ -290,8 +304,14 @@ function isOperationSuggestionValue(
         value !== null &&
         'intent' in value &&
         (value.intent === 'add' || value.intent === 'remove') &&
+        'operationMode' in value &&
+        (value.operationMode === 'existing' || value.operationMode === 'new') &&
         'operationId' in value &&
-        typeof value.operationId === 'string'
+        typeof value.operationId === 'string' &&
+        'newOperationName' in value &&
+        typeof value.newOperationName === 'string' &&
+        'newOperationDescription' in value &&
+        typeof value.newOperationDescription === 'string'
     );
 }
 
@@ -329,6 +349,14 @@ function operationSuggestionOptionsForIntent(
             ? !currentOperationIds.has(option.value)
             : currentOperationIds.has(option.value),
     );
+}
+
+function currentOperationOptions(field: CommunityEditableField) {
+    return operationSuggestionOptionsForIntent(field, 'remove');
+}
+
+function availableOperationOptions(field: CommunityEditableField) {
+    return operationSuggestionOptionsForIntent(field, 'add');
 }
 
 function normalizeJsonValue(value: string) {
@@ -379,18 +407,76 @@ function serializeFieldValue(
     value: FieldValue,
 ): { comparisonValue: string | null; submitValue: SubmitValue } {
     if (field.controlType === 'operationSuggestion') {
-        if (!isOperationSuggestionValue(value) || !value.operationId) {
+        if (!isOperationSuggestionValue(value)) {
             return {
                 comparisonValue: field.currentValue,
                 submitValue: null,
             };
         }
 
+        const stageName =
+            field.operationSuggestionStage?.name ?? field.sectionKey;
+        const note = value.note.trim() || null;
+        const source = value.source.trim() || null;
+
+        if (value.intent === 'remove') {
+            const operationId = Number.parseInt(value.operationId, 10);
+            const selectedOption = currentOperationOptions(field).some(
+                (option) => option.value === value.operationId,
+            );
+            if (!Number.isInteger(operationId) || !selectedOption) {
+                return {
+                    comparisonValue: field.currentValue,
+                    submitValue: null,
+                };
+            }
+
+            const submitValue: OperationSuggestionSubmitValue = {
+                intent: value.intent,
+                operationMode: 'existing',
+                operationId,
+                stageName,
+                note,
+                source,
+            };
+
+            return {
+                comparisonValue: JSON.stringify(submitValue),
+                submitValue,
+            };
+        }
+
+        if (value.operationMode === 'new') {
+            const newOperationName = value.newOperationName.trim();
+            const newOperationDescription =
+                value.newOperationDescription.trim();
+            if (!newOperationName || !newOperationDescription) {
+                return {
+                    comparisonValue: field.currentValue,
+                    submitValue: null,
+                };
+            }
+
+            const submitValue: OperationSuggestionSubmitValue = {
+                intent: value.intent,
+                operationMode: value.operationMode,
+                stageName,
+                newOperationName,
+                newOperationDescription,
+                note,
+                source,
+            };
+
+            return {
+                comparisonValue: JSON.stringify(submitValue),
+                submitValue,
+            };
+        }
+
         const operationId = Number.parseInt(value.operationId, 10);
-        const selectedOption = operationSuggestionOptionsForIntent(
-            field,
-            value.intent,
-        ).some((option) => option.value === value.operationId);
+        const selectedOption = availableOperationOptions(field).some(
+            (option) => option.value === value.operationId,
+        );
         if (!Number.isInteger(operationId) || !selectedOption) {
             return {
                 comparisonValue: field.currentValue,
@@ -400,10 +486,11 @@ function serializeFieldValue(
 
         const submitValue: OperationSuggestionSubmitValue = {
             intent: value.intent,
+            operationMode: value.operationMode,
             operationId,
-            stageName: field.operationSuggestionStage?.name ?? field.sectionKey,
-            note: value.note.trim() || null,
-            source: value.source.trim() || null,
+            stageName,
+            note,
+            source,
         };
 
         return {
@@ -487,6 +574,339 @@ function fieldInputId(prefix: string, field: CommunityEditableField) {
     return `${prefix}-${field.fieldKey.replace(/[^a-z0-9_-]/giu, '-')}`;
 }
 
+function OperationOptionIcon({
+    option,
+}: {
+    option: CommunityEditableFieldOption;
+}) {
+    return (
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-md border border-border/70 bg-background text-foreground">
+            <OperationCategoryIcon
+                aria-hidden
+                categoryName={option.iconKey}
+                className="size-5"
+            />
+        </span>
+    );
+}
+
+function OperationOptionSummary({
+    option,
+}: {
+    option: CommunityEditableFieldOption;
+}) {
+    return (
+        <Row spacing={2} className="min-w-0 items-start">
+            <OperationOptionIcon option={option} />
+            <Stack spacing={0.5} className="min-w-0">
+                <Typography semiBold className="break-words">
+                    {option.label}
+                </Typography>
+                {option.description || option.helpText ? (
+                    <Typography
+                        level="body3"
+                        className="text-pretty text-muted-foreground"
+                    >
+                        {option.description ?? option.helpText}
+                    </Typography>
+                ) : null}
+            </Stack>
+        </Row>
+    );
+}
+
+function OperationSuggestionInput({
+    field,
+    id,
+    onChange,
+    value,
+}: {
+    field: CommunityEditableField;
+    id: string;
+    onChange: (value: FieldValue) => void;
+    value: FieldValue;
+}) {
+    const suggestionValue = isOperationSuggestionValue(value)
+        ? value
+        : {
+              intent: 'add' as const,
+              operationMode: 'existing' as const,
+              operationId: '',
+              newOperationName: '',
+              newOperationDescription: '',
+              note: '',
+              source: '',
+          };
+    const currentOperations = currentOperationOptions(field);
+    const availableOperations = availableOperationOptions(field);
+    const selectedExistingOperation = availableOperations.find(
+        (option) => option.value === suggestionValue.operationId,
+    );
+    const selectedRemovalOperation = currentOperations.find(
+        (option) => option.value === suggestionValue.operationId,
+    );
+    const operationModeOptions: {
+        value: OperationSuggestionMode;
+        label: string;
+    }[] = [
+        { value: 'existing', label: 'Postojeća radnja' },
+        { value: 'new', label: 'Nova radnja' },
+    ];
+
+    return (
+        <Stack spacing={4}>
+            <section className="space-y-2">
+                <Typography level="body3" semiBold>
+                    Trenutne radnje
+                </Typography>
+                {currentOperations.length > 0 ? (
+                    <Stack spacing={2}>
+                        {currentOperations.map((option) => {
+                            const selected =
+                                suggestionValue.intent === 'remove' &&
+                                suggestionValue.operationId === option.value;
+                            return (
+                                <div
+                                    className={cx(
+                                        'grid gap-3 rounded-md border border-border/80 bg-card p-3 shadow-sm sm:grid-cols-[1fr_auto]',
+                                        selected && 'border-primary/70',
+                                    )}
+                                    key={option.value}
+                                >
+                                    <OperationOptionSummary option={option} />
+                                    <Button
+                                        color={selected ? 'primary' : 'danger'}
+                                        onClick={() =>
+                                            onChange({
+                                                ...suggestionValue,
+                                                intent: 'remove',
+                                                operationMode: 'existing',
+                                                operationId: option.value,
+                                            })
+                                        }
+                                        type="button"
+                                        variant={selected ? 'soft' : 'outlined'}
+                                    >
+                                        {selected ? (
+                                            <Check
+                                                aria-hidden
+                                                className="size-4"
+                                            />
+                                        ) : (
+                                            <Delete
+                                                aria-hidden
+                                                className="size-4"
+                                            />
+                                        )}
+                                        {selected ? 'Odabrano' : 'Ukloni'}
+                                    </Button>
+                                </div>
+                            );
+                        })}
+                    </Stack>
+                ) : (
+                    <Typography
+                        level="body3"
+                        className="rounded-md border border-dashed border-border/80 bg-card p-3 text-muted-foreground"
+                    >
+                        Nema trenutno povezanih radnji za ovu fazu.
+                    </Typography>
+                )}
+                {selectedRemovalOperation ? (
+                    <Typography level="body3" className="text-primary">
+                        Prijedlog će tražiti uklanjanje radnje “
+                        {selectedRemovalOperation.label}”.
+                    </Typography>
+                ) : null}
+            </section>
+
+            <section className="space-y-3 rounded-md border border-border/70 bg-card p-3">
+                <Typography level="body3" semiBold>
+                    Predloži dodavanje
+                </Typography>
+                <div className="grid grid-cols-2 gap-1 rounded-md border border-border/80 bg-background p-1 shadow-sm">
+                    {operationModeOptions.map((option) => (
+                        <label
+                            className={cx(
+                                'flex min-h-9 cursor-pointer items-center justify-center rounded-sm px-3 text-center text-sm font-medium transition-colors',
+                                suggestionValue.intent === 'add' &&
+                                    suggestionValue.operationMode ===
+                                        option.value
+                                    ? 'bg-primary text-primary-foreground shadow-sm'
+                                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                            )}
+                            key={option.value}
+                        >
+                            <input
+                                checked={
+                                    suggestionValue.intent === 'add' &&
+                                    suggestionValue.operationMode ===
+                                        option.value
+                                }
+                                className="sr-only"
+                                name={`${id}-operation-mode`}
+                                onChange={() =>
+                                    onChange({
+                                        ...suggestionValue,
+                                        intent: 'add',
+                                        operationMode: option.value,
+                                        operationId:
+                                            option.value === 'new'
+                                                ? ''
+                                                : suggestionValue.operationId,
+                                    })
+                                }
+                                type="radio"
+                                value={option.value}
+                            />
+                            {option.label}
+                        </label>
+                    ))}
+                </div>
+
+                {suggestionValue.intent !== 'add' ||
+                suggestionValue.operationMode === 'existing' ? (
+                    <Stack spacing={2}>
+                        <label
+                            className="space-y-1"
+                            htmlFor={`${id}-operation`}
+                        >
+                            <Typography level="body3">Radnja</Typography>
+                            <select
+                                className={selectControlClassName}
+                                disabled={availableOperations.length === 0}
+                                id={`${id}-operation`}
+                                onChange={(event) =>
+                                    onChange({
+                                        ...suggestionValue,
+                                        intent: 'add',
+                                        operationMode: 'existing',
+                                        operationId: event.currentTarget.value,
+                                    })
+                                }
+                                value={
+                                    availableOperations.some(
+                                        (option) =>
+                                            option.value ===
+                                            suggestionValue.operationId,
+                                    )
+                                        ? suggestionValue.operationId
+                                        : ''
+                                }
+                            >
+                                <option value="">
+                                    {availableOperations.length > 0
+                                        ? 'Odaberi radnju'
+                                        : 'Nema dostupnih radnji'}
+                                </option>
+                                {availableOperations.map((option) => (
+                                    <option
+                                        key={option.value}
+                                        value={option.value}
+                                    >
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                        {selectedExistingOperation ? (
+                            <div className="rounded-md border border-border/80 bg-background p-3">
+                                <OperationOptionSummary
+                                    option={selectedExistingOperation}
+                                />
+                            </div>
+                        ) : (
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                {availableOperations.length > 0
+                                    ? 'Odaberi postojeću radnju koju želiš dodati.'
+                                    : 'Sve postojeće radnje za ovu fazu već su povezane.'}
+                            </Typography>
+                        )}
+                    </Stack>
+                ) : (
+                    <Stack spacing={3}>
+                        <Input
+                            className={inputControlClassName}
+                            fullWidth
+                            id={`${id}-new-operation-name`}
+                            label="Naziv nove radnje"
+                            onChange={(event) =>
+                                onChange({
+                                    ...suggestionValue,
+                                    intent: 'add',
+                                    operationMode: 'new',
+                                    newOperationName: event.currentTarget.value,
+                                })
+                            }
+                            placeholder="Npr. Provjera vlage supstrata"
+                            value={suggestionValue.newOperationName}
+                        />
+                        <label
+                            className="space-y-1"
+                            htmlFor={`${id}-new-operation-description`}
+                        >
+                            <Typography level="body3">
+                                Što očekuješ od radnje?
+                            </Typography>
+                            <textarea
+                                className={cx(
+                                    textareaControlClassName,
+                                    'min-h-24',
+                                )}
+                                id={`${id}-new-operation-description`}
+                                onChange={(event) =>
+                                    onChange({
+                                        ...suggestionValue,
+                                        intent: 'add',
+                                        operationMode: 'new',
+                                        newOperationDescription:
+                                            event.currentTarget.value,
+                                    })
+                                }
+                                placeholder="Opiši kada se radi, što korisnik dobiva i zašto pripada ovoj fazi."
+                                value={suggestionValue.newOperationDescription}
+                            />
+                        </label>
+                    </Stack>
+                )}
+            </section>
+
+            <Input
+                className={inputControlClassName}
+                fullWidth
+                id={`${id}-source`}
+                label="Izvor"
+                onChange={(event) =>
+                    onChange({
+                        ...suggestionValue,
+                        source: event.currentTarget.value,
+                    })
+                }
+                placeholder="Poveznica, knjiga ili opažanje..."
+                value={suggestionValue.source}
+            />
+            <label className="space-y-1" htmlFor={`${id}-note`}>
+                <Typography level="body3">Napomena</Typography>
+                <textarea
+                    className={cx(textareaControlClassName, 'min-h-20')}
+                    id={`${id}-note`}
+                    onChange={(event) =>
+                        onChange({
+                            ...suggestionValue,
+                            note: event.currentTarget.value,
+                        })
+                    }
+                    placeholder="Zašto predlažeš ovu promjenu?"
+                    value={suggestionValue.note}
+                />
+            </label>
+        </Stack>
+    );
+}
+
 function isCommunityEditableField(
     value: unknown,
 ): value is CommunityEditableField {
@@ -516,7 +936,13 @@ function isCommunityEditableField(
                         'value' in option &&
                         typeof option.value === 'string' &&
                         'label' in option &&
-                        typeof option.label === 'string',
+                        typeof option.label === 'string' &&
+                        (!('description' in option) ||
+                            typeof option.description === 'undefined' ||
+                            typeof option.description === 'string') &&
+                        (!('iconKey' in option) ||
+                            typeof option.iconKey === 'undefined' ||
+                            typeof option.iconKey === 'string'),
                 )))
     );
 }
@@ -599,138 +1025,13 @@ function FieldInput({
     value: FieldValue;
 }) {
     if (field.controlType === 'operationSuggestion') {
-        const suggestionValue = isOperationSuggestionValue(value)
-            ? value
-            : {
-                  intent: 'add' as const,
-                  operationId: '',
-                  note: '',
-                  source: '',
-              };
-        const operationOptions = operationSuggestionOptionsForIntent(
-            field,
-            suggestionValue.intent,
-        );
-        const intentOptions: {
-            value: OperationSuggestionIntent;
-            label: string;
-        }[] = [
-            { value: 'add', label: 'Dodaj' },
-            { value: 'remove', label: 'Ukloni' },
-        ];
-
         return (
-            <Stack spacing={3}>
-                <fieldset className="space-y-1">
-                    <legend className="text-sm text-foreground">
-                        Vrsta prijedloga
-                    </legend>
-                    <div className="grid grid-cols-2 gap-1 rounded-md border border-border/80 bg-card p-1 shadow-sm">
-                        {intentOptions.map((option) => (
-                            <label
-                                className={cx(
-                                    'flex h-9 cursor-pointer items-center justify-center rounded-sm px-3 text-sm font-medium transition-colors',
-                                    suggestionValue.intent === option.value
-                                        ? 'bg-primary text-primary-foreground shadow-sm'
-                                        : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
-                                )}
-                                key={option.value}
-                            >
-                                <input
-                                    checked={
-                                        suggestionValue.intent === option.value
-                                    }
-                                    className="sr-only"
-                                    name={`${id}-intent`}
-                                    onChange={() =>
-                                        onChange({
-                                            ...suggestionValue,
-                                            intent: option.value,
-                                            operationId: '',
-                                        })
-                                    }
-                                    type="radio"
-                                    value={option.value}
-                                />
-                                {option.label}
-                            </label>
-                        ))}
-                    </div>
-                </fieldset>
-                <Stack spacing={2}>
-                    <label className="space-y-1" htmlFor={`${id}-operation`}>
-                        <Typography level="body3">Radnja</Typography>
-                        <select
-                            className={selectControlClassName}
-                            disabled={operationOptions.length === 0}
-                            id={`${id}-operation`}
-                            onChange={(event) =>
-                                onChange({
-                                    ...suggestionValue,
-                                    operationId: event.currentTarget.value,
-                                })
-                            }
-                            value={
-                                operationOptions.some(
-                                    (option) =>
-                                        option.value ===
-                                        suggestionValue.operationId,
-                                )
-                                    ? suggestionValue.operationId
-                                    : ''
-                            }
-                        >
-                            <option value="">
-                                {operationOptions.length > 0
-                                    ? 'Odaberi radnju'
-                                    : 'Nema dostupnih radnji'}
-                            </option>
-                            {operationOptions.map((option) => (
-                                <option key={option.value} value={option.value}>
-                                    {option.label}
-                                </option>
-                            ))}
-                        </select>
-                    </label>
-                    {operationOptions.length === 0 ? (
-                        <Typography
-                            level="body3"
-                            className="text-muted-foreground"
-                        >
-                            Nema radnji za ovu namjeru u ovoj fazi.
-                        </Typography>
-                    ) : null}
-                </Stack>
-                <Input
-                    className={inputControlClassName}
-                    fullWidth
-                    id={`${id}-source`}
-                    label="Izvor"
-                    onChange={(event) =>
-                        onChange({
-                            ...suggestionValue,
-                            source: event.currentTarget.value,
-                        })
-                    }
-                    placeholder="Poveznica, knjiga ili opažanje..."
-                    value={suggestionValue.source}
-                />
-                <label className="space-y-1" htmlFor={`${id}-note`}>
-                    <Typography level="body3">Napomena</Typography>
-                    <textarea
-                        className={cx(textareaControlClassName, 'min-h-20')}
-                        id={`${id}-note`}
-                        onChange={(event) =>
-                            onChange({
-                                ...suggestionValue,
-                                note: event.currentTarget.value,
-                            })
-                        }
-                        placeholder="Zašto predlažeš ovu promjenu?"
-                        value={suggestionValue.note}
-                    />
-                </label>
-            </Stack>
+            <OperationSuggestionInput
+                field={field}
+                id={id}
+                onChange={onChange}
+                value={value}
+            />
         );
     }
 

--- a/apps/www/tests/community-edit-button.spec.tsx
+++ b/apps/www/tests/community-edit-button.spec.tsx
@@ -431,6 +431,9 @@ test('shows storage content and operation suggestions in the edit modal', async 
                                 {
                                     value: '987',
                                     label: 'Uklanjanje biljke',
+                                    description:
+                                        'Uklanjanje cijele biljke iz gredice.',
+                                    iconKey: 'storage',
                                 },
                             ],
                         },
@@ -457,6 +460,7 @@ test('shows storage content and operation suggestions in the edit modal', async 
                         fieldKey: 'plant.stage-operations.storage',
                         proposedValue: {
                             intent: 'add',
+                            operationMode: 'existing',
                             operationId: 987,
                             stageName: 'storage',
                             source: 'Terenska bilješka',
@@ -493,6 +497,7 @@ test('shows storage content and operation suggestions in the edit modal', async 
         page.getByText('Ova sekcija trenutno nema javno uređivih polja.'),
     ).toHaveCount(0);
     await expect(page.getByText('Radnje: Skladištenje')).toBeVisible();
+    await expect(page.getByText('Trenutne radnje')).toBeVisible();
 
     const dialogBackground = await page
         .getByRole('dialog')
@@ -503,7 +508,10 @@ test('shows storage content and operation suggestions in the edit modal', async 
     expect(fieldBackground).not.toBe(dialogBackground);
 
     await page.getByLabel('Skladištenje').fill('Zamotati u vlažnu krpu.');
-    await page.getByLabel('Radnja').selectOption('987');
+    await page.getByRole('combobox', { name: /Radnja/u }).selectOption('987');
+    await expect(
+        page.getByText('Uklanjanje cijele biljke iz gredice.'),
+    ).toBeVisible();
     await page.getByLabel('Izvor').fill('Terenska bilješka');
     await page
         .getByRole('textbox', { name: 'Napomena', exact: true })
@@ -512,6 +520,240 @@ test('shows storage content and operation suggestions in the edit modal', async 
 
     await expect(
         page.getByText('Prijedlog #44 je poslan na odobrenje.'),
+    ).toBeVisible();
+});
+
+test('submits operation removal suggestions from current operation cards', async ({
+    mount,
+    page,
+}) => {
+    await page.route('**/api/gredice/api/auth/current-claims', (route) =>
+        route.fulfill({
+            status: 200,
+            json: {
+                id: 'user-1',
+                userName: 'ana',
+                displayName: 'Ana',
+            },
+        }),
+    );
+    await page.route(
+        '**/api/gredice/api/directories/community-edits/entities/plant/1/fields**',
+        (route) =>
+            route.fulfill({
+                status: 200,
+                json: {
+                    entityTypeName: 'plant',
+                    entityId: 1,
+                    sectionKey: 'storage',
+                    fields: [
+                        {
+                            entityTypeName: 'plant',
+                            entityId: 1,
+                            fieldKey: 'plant.stage-operations.storage',
+                            sectionKey: 'storage',
+                            attributeDefinitionId: 13,
+                            attributeValueId: null,
+                            attributePath: 'information.operations',
+                            dataType: 'ref:operation',
+                            controlType: 'operationSuggestion',
+                            multiple: true,
+                            publicLabel: 'Radnje: Skladištenje',
+                            operationSuggestionStage: {
+                                name: 'storage',
+                                label: 'Skladištenje',
+                            },
+                            currentValue: JSON.stringify(['987']),
+                            baseValueHash: 'hash-operations',
+                            options: [
+                                {
+                                    value: '987',
+                                    label: 'Uklanjanje biljke',
+                                    description:
+                                        'Uklanjanje cijele biljke iz gredice.',
+                                    iconKey: 'storage',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            }),
+    );
+    await page.route(
+        '**/api/gredice/api/directories/community-edits',
+        async (route) => {
+            const body = route.request().postDataJSON();
+            expect(body).toMatchObject({
+                entityTypeName: 'plant',
+                entityId: 1,
+                publicPath: '/biljke/blitva',
+                sectionKey: 'storage',
+                changes: [
+                    {
+                        fieldKey: 'plant.stage-operations.storage',
+                        proposedValue: {
+                            intent: 'remove',
+                            operationMode: 'existing',
+                            operationId: 987,
+                            stageName: 'storage',
+                            source: null,
+                            note: 'Ne treba se prikazivati u skladištenju.',
+                        },
+                        baseValueHash: 'hash-operations',
+                    },
+                ],
+            });
+
+            await route.fulfill({
+                status: 201,
+                json: {
+                    status: 'pending_admin_approval',
+                    requestId: 46,
+                    requestStatus: 'pending',
+                    changeCount: 1,
+                },
+            });
+        },
+    );
+
+    await mount(
+        <CommunityEditButtonHarness
+            entityTypeName="plant"
+            entityId={1}
+            publicPath="/biljke/blitva"
+            sectionKey="storage"
+        />,
+    );
+
+    await page.getByTitle('Predloži izmjenu').click();
+    await expect(page.getByText('Uklanjanje biljke')).toBeVisible();
+    await expect(
+        page.getByText('Uklanjanje cijele biljke iz gredice.'),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: /Ukloni/u }).click();
+    await expect(page.getByText(/Prijedlog će tražiti/u)).toBeVisible();
+    await page
+        .getByRole('textbox', { name: 'Napomena', exact: true })
+        .fill('Ne treba se prikazivati u skladištenju.');
+    await page.getByRole('button', { name: 'Pošalji' }).click();
+
+    await expect(
+        page.getByText('Prijedlog #46 je poslan na odobrenje.'),
+    ).toBeVisible();
+});
+
+test('submits new operation suggestions with name and expectation', async ({
+    mount,
+    page,
+}) => {
+    await page.route('**/api/gredice/api/auth/current-claims', (route) =>
+        route.fulfill({
+            status: 200,
+            json: {
+                id: 'user-1',
+                userName: 'ana',
+                displayName: 'Ana',
+            },
+        }),
+    );
+    await page.route(
+        '**/api/gredice/api/directories/community-edits/entities/plant/1/fields**',
+        (route) =>
+            route.fulfill({
+                status: 200,
+                json: {
+                    entityTypeName: 'plant',
+                    entityId: 1,
+                    sectionKey: 'watering',
+                    fields: [
+                        {
+                            entityTypeName: 'plant',
+                            entityId: 1,
+                            fieldKey: 'plant.stage-operations.watering',
+                            sectionKey: 'watering',
+                            attributeDefinitionId: 13,
+                            attributeValueId: null,
+                            attributePath: 'information.operations',
+                            dataType: 'ref:operation',
+                            controlType: 'operationSuggestion',
+                            multiple: true,
+                            publicLabel: 'Radnje: Zalijevanje',
+                            operationSuggestionStage: {
+                                name: 'watering',
+                                label: 'Zalijevanje',
+                            },
+                            currentValue: '[]',
+                            baseValueHash: 'hash-operations',
+                            options: [],
+                        },
+                    ],
+                },
+            }),
+    );
+    await page.route(
+        '**/api/gredice/api/directories/community-edits',
+        async (route) => {
+            const body = route.request().postDataJSON();
+            expect(body).toMatchObject({
+                entityTypeName: 'plant',
+                entityId: 1,
+                publicPath: '/biljke/blitva',
+                sectionKey: 'watering',
+                changes: [
+                    {
+                        fieldKey: 'plant.stage-operations.watering',
+                        proposedValue: {
+                            intent: 'add',
+                            operationMode: 'new',
+                            stageName: 'watering',
+                            newOperationName: 'Provjera vlage supstrata',
+                            newOperationDescription:
+                                'Korisnik očekuje podsjetnik za provjeru vlage prije zalijevanja.',
+                            source: null,
+                            note: 'Nema odgovarajuće postojeće radnje.',
+                        },
+                        baseValueHash: 'hash-operations',
+                    },
+                ],
+            });
+
+            await route.fulfill({
+                status: 201,
+                json: {
+                    status: 'pending_admin_approval',
+                    requestId: 47,
+                    requestStatus: 'pending',
+                    changeCount: 1,
+                },
+            });
+        },
+    );
+
+    await mount(
+        <CommunityEditButtonHarness
+            entityTypeName="plant"
+            entityId={1}
+            publicPath="/biljke/blitva"
+            sectionKey="watering"
+        />,
+    );
+
+    await page.getByTitle('Predloži izmjenu').click();
+    await page.getByText('Nova radnja', { exact: true }).click();
+    await page.getByLabel('Naziv nove radnje').fill('Provjera vlage supstrata');
+    await page
+        .getByLabel('Što očekuješ od radnje?')
+        .fill(
+            'Korisnik očekuje podsjetnik za provjeru vlage prije zalijevanja.',
+        );
+    await page
+        .getByRole('textbox', { name: 'Napomena', exact: true })
+        .fill('Nema odgovarajuće postojeće radnje.');
+    await page.getByRole('button', { name: 'Pošalji' }).click();
+
+    await expect(
+        page.getByText('Prijedlog #47 je poslan na odobrenje.'),
     ).toBeVisible();
 });
 

--- a/packages/storage/src/helpers/communityEditableFields.ts
+++ b/packages/storage/src/helpers/communityEditableFields.ts
@@ -20,6 +20,8 @@ export type CommunityEditableFieldOption = {
     value: string;
     label: string;
     helpText?: string;
+    description?: string;
+    iconKey?: string;
 };
 
 export type CommunityEditableFieldDefinition = {

--- a/packages/storage/src/repositories/communityEditRequestsRepo.ts
+++ b/packages/storage/src/repositories/communityEditRequestsRepo.ts
@@ -102,11 +102,12 @@ export type CreateCommunityEditRequestInput = {
 type EntityRaw = NonNullable<Awaited<ReturnType<typeof getEntityRaw>>>;
 
 export type CommunityOperationSuggestionIntent = 'add' | 'remove';
+export type CommunityOperationSuggestionMode = 'existing' | 'new';
 
-export type CommunityOperationSuggestionValue = {
+type CommunityOperationSuggestionBaseValue = {
     format: 'community-operation-suggestion-v1';
     intent: CommunityOperationSuggestionIntent;
-    operationId: number;
+    operationMode: CommunityOperationSuggestionMode;
     operationLabel: string;
     stageName: PlantStageName;
     stageLabel: string;
@@ -114,6 +115,19 @@ export type CommunityOperationSuggestionValue = {
     note?: string;
     source?: string;
 };
+
+export type CommunityOperationSuggestionValue =
+    | (CommunityOperationSuggestionBaseValue & {
+          operationMode: 'existing';
+          operationId: number;
+      })
+    | (CommunityOperationSuggestionBaseValue & {
+          intent: 'add';
+          operationMode: 'new';
+          currentState: 'absent';
+          newOperationName: string;
+          newOperationDescription: string;
+      });
 
 type ResolvedCommunityEditChange = {
     fieldKey: string;
@@ -441,6 +455,17 @@ async function operationSuggestionOptions(
             value: String(operation.id),
             label: entityLabel(operation),
             helpText: field.operationSuggestionStage?.label,
+            description:
+                rawAttributeValue(
+                    operation,
+                    'information',
+                    'shortDescription',
+                ) ??
+                rawAttributeValue(operation, 'information', 'description') ??
+                undefined,
+            iconKey:
+                operationStageInfo(operation, stagesById)?.name ??
+                field.operationSuggestionStage?.name,
         }))
         .sort((left, right) => left.label.localeCompare(right.label, 'hr'));
 }
@@ -730,6 +755,22 @@ function normalizeOperationSuggestionIntent(
     );
 }
 
+function normalizeOperationSuggestionMode(
+    value: unknown,
+): CommunityOperationSuggestionMode {
+    if (value === 'new' || value === 'existing') {
+        return value;
+    }
+    if (typeof value === 'undefined') {
+        return 'existing';
+    }
+
+    throw new CommunityEditRequestError(
+        'invalid_value',
+        'Operation suggestion must choose an existing or new operation.',
+    );
+}
+
 function normalizeOperationSuggestionOperationId(value: unknown) {
     const normalized = normalizeReferenceId(value);
     if (!normalized) {
@@ -740,6 +781,26 @@ function normalizeOperationSuggestionOperationId(value: unknown) {
     }
 
     return Number.parseInt(normalized, 10);
+}
+
+function normalizeRequiredSuggestionText(
+    value: unknown,
+    fieldLabel: string,
+    maxLength: number,
+) {
+    const normalized = normalizeOptionalSuggestionText(
+        value,
+        fieldLabel,
+        maxLength,
+    );
+    if (!normalized) {
+        throw new CommunityEditRequestError(
+            'invalid_value',
+            `${fieldLabel} is required.`,
+        );
+    }
+
+    return normalized;
 }
 
 async function resolveOperationSuggestionTarget(input: {
@@ -830,6 +891,50 @@ async function normalizeOperationSuggestionValue(
     }
 
     const intent = normalizeOperationSuggestionIntent(value.intent);
+    const operationMode = normalizeOperationSuggestionMode(value.operationMode);
+    const note = normalizeOptionalSuggestionText(value.note, 'Note', 1000);
+    const source = normalizeOptionalSuggestionText(value.source, 'Source', 500);
+
+    if (operationMode === 'new') {
+        if (intent !== 'add') {
+            throw new CommunityEditRequestError(
+                'invalid_value',
+                'New operation suggestions can only be added.',
+            );
+        }
+
+        const newOperationName = normalizeRequiredSuggestionText(
+            value.newOperationName,
+            'New operation name',
+            160,
+        );
+        const newOperationDescription = normalizeRequiredSuggestionText(
+            value.newOperationDescription,
+            'New operation description',
+            2000,
+        );
+
+        const suggestion: CommunityOperationSuggestionValue = {
+            format: 'community-operation-suggestion-v1',
+            intent,
+            operationMode,
+            operationLabel: newOperationName,
+            stageName: field.operationSuggestionStage.name,
+            stageLabel: field.operationSuggestionStage.label,
+            currentState: 'absent',
+            newOperationName,
+            newOperationDescription,
+        };
+        if (note) {
+            suggestion.note = note;
+        }
+        if (source) {
+            suggestion.source = source;
+        }
+
+        return JSON.stringify(suggestion);
+    }
+
     const operationId = normalizeOperationSuggestionOperationId(
         value.operationId,
     );
@@ -859,14 +964,13 @@ async function normalizeOperationSuggestionValue(
     const suggestion: CommunityOperationSuggestionValue = {
         format: 'community-operation-suggestion-v1',
         intent,
+        operationMode,
         operationId,
         operationLabel: target.operationLabel,
         stageName: target.stageName,
         stageLabel: target.stageLabel,
         currentState,
     };
-    const note = normalizeOptionalSuggestionText(value.note, 'Note', 1000);
-    const source = normalizeOptionalSuggestionText(value.source, 'Source', 500);
     if (note) {
         suggestion.note = note;
     }
@@ -1468,8 +1572,6 @@ function parseCommunityOperationSuggestion(
             !isRecord(parsed) ||
             parsed.format !== 'community-operation-suggestion-v1' ||
             (parsed.intent !== 'add' && parsed.intent !== 'remove') ||
-            typeof parsed.operationId !== 'number' ||
-            !Number.isInteger(parsed.operationId) ||
             typeof parsed.operationLabel !== 'string' ||
             !isPlantStageName(parsed.stageName) ||
             typeof parsed.stageLabel !== 'string' ||
@@ -1485,9 +1587,59 @@ function parseCommunityOperationSuggestion(
             return null;
         }
 
+        const operationMode =
+            parsed.operationMode === 'new'
+                ? 'new'
+                : parsed.operationMode === 'existing' ||
+                    typeof parsed.operationMode === 'undefined'
+                  ? 'existing'
+                  : null;
+        if (!operationMode) {
+            return null;
+        }
+
+        if (operationMode === 'new') {
+            if (
+                parsed.intent !== 'add' ||
+                parsed.currentState !== 'absent' ||
+                typeof parsed.newOperationName !== 'string' ||
+                typeof parsed.newOperationDescription !== 'string'
+            ) {
+                return null;
+            }
+
+            const suggestion: CommunityOperationSuggestionValue = {
+                format: 'community-operation-suggestion-v1',
+                intent: parsed.intent,
+                operationMode,
+                operationLabel: parsed.operationLabel,
+                stageName: parsed.stageName,
+                stageLabel: parsed.stageLabel,
+                currentState: parsed.currentState,
+                newOperationName: parsed.newOperationName,
+                newOperationDescription: parsed.newOperationDescription,
+            };
+            if (typeof parsed.note === 'string') {
+                suggestion.note = parsed.note;
+            }
+            if (typeof parsed.source === 'string') {
+                suggestion.source = parsed.source;
+            }
+
+            return suggestion;
+        }
+
+        if (
+            typeof parsed.operationId !== 'number' ||
+            !Number.isInteger(parsed.operationId)
+        ) {
+            return null;
+        }
+
         const suggestion: CommunityOperationSuggestionValue = {
             format: 'community-operation-suggestion-v1',
             intent: parsed.intent,
+            operationMode,
             operationId: parsed.operationId,
             operationLabel: parsed.operationLabel,
             stageName: parsed.stageName,
@@ -1618,6 +1770,9 @@ async function applyOperationSuggestionChange(input: {
             'invalid_value',
             'Operation suggestion change is not valid.',
         );
+    }
+    if (suggestion.operationMode === 'new') {
+        return;
     }
 
     const currentValues = await getCurrentPersistedValues(

--- a/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/communityEditRequestsRepo.node.spec.ts
@@ -40,6 +40,7 @@ type CommunityEditFixture = {
     plantSortLatinNameDefinitionId: number;
     plantSortMaintenanceDefinitionId: number;
     operationNameDefinitionId: number;
+    operationShortDescriptionDefinitionId: number;
     operationStageDefinitionId: number;
     operationApplicationDefinitionId: number;
     stageEntityId: number;
@@ -196,6 +197,14 @@ async function createFixture(): Promise<CommunityEditFixture> {
         entityTypeName: 'operation',
         dataType: 'text',
     });
+    const operationShortDescriptionDefinitionId =
+        await createAttributeDefinition({
+            category: 'information',
+            name: 'shortDescription',
+            label: 'Kratki opis',
+            entityTypeName: 'operation',
+            dataType: 'text',
+        });
     const operationStageDefinitionId = await createAttributeDefinition({
         category: 'attributes',
         name: 'stage',
@@ -240,6 +249,7 @@ async function createFixture(): Promise<CommunityEditFixture> {
         plantSortLatinNameDefinitionId,
         plantSortMaintenanceDefinitionId,
         operationNameDefinitionId,
+        operationShortDescriptionDefinitionId,
         operationStageDefinitionId,
         operationApplicationDefinitionId,
         stageEntityId,
@@ -394,6 +404,7 @@ async function createPublishedPlantSort(input?: {
 async function createPublishedPlantOperation(input?: {
     application?: string;
     name?: string;
+    shortDescription?: string;
     stageEntityId?: number;
 }) {
     const data = await fixture();
@@ -405,6 +416,14 @@ async function createPublishedPlantOperation(input?: {
         entityId,
         value: input?.name ?? 'Malčiranje',
     });
+    if (input?.shortDescription) {
+        await upsertAttributeValue({
+            attributeDefinitionId: data.operationShortDescriptionDefinitionId,
+            entityTypeName: 'operation',
+            entityId,
+            value: input.shortDescription,
+        });
+    }
     await upsertAttributeValue({
         attributeDefinitionId: data.operationStageDefinitionId,
         entityTypeName: 'operation',
@@ -760,6 +779,7 @@ test('community edit requests submit storage content and operation suggestions t
     });
     const operationId = await createPublishedPlantOperation({
         name: 'Uklanjanje biljke',
+        shortDescription: 'Uklanjanje cijele biljke iz gredice.',
         stageEntityId: storageStageId,
     });
     const plantId = await createPublishedPlant({
@@ -785,7 +805,9 @@ test('community edit requests submit storage content and operation suggestions t
         operationField.options?.some(
             (option) =>
                 option.value === String(operationId) &&
-                option.label === 'Uklanjanje biljke',
+                option.label === 'Uklanjanje biljke' &&
+                option.description === 'Uklanjanje cijele biljke iz gredice.' &&
+                option.iconKey === 'storage',
         ),
     );
 
@@ -806,6 +828,7 @@ test('community edit requests submit storage content and operation suggestions t
                 baseValueHash: operationField.baseValueHash,
                 proposedValue: {
                     intent: 'add',
+                    operationMode: 'existing',
                     operationId,
                     stageName: 'storage',
                     source: 'Upute proizvođača',
@@ -1076,6 +1099,10 @@ test('community edit requests create and apply plant operation add suggestions',
     assert.match(request.changes[0]?.proposedValue ?? '', /"intent":"add"/);
     assert.match(
         request.changes[0]?.proposedValue ?? '',
+        /"operationMode":"existing"/,
+    );
+    assert.match(
+        request.changes[0]?.proposedValue ?? '',
         /"currentState":"absent"/,
     );
 
@@ -1131,6 +1158,7 @@ test('community edit requests create and apply plant operation remove suggestion
                 baseValueHash: operationField.baseValueHash,
                 proposedValue: {
                     intent: 'remove',
+                    operationMode: 'existing',
                     operationId,
                     stageName: 'sowing',
                     note: 'Ova radnja ne pripada ovoj biljci.',
@@ -1140,6 +1168,10 @@ test('community edit requests create and apply plant operation remove suggestion
     });
 
     assert.match(request.changes[0]?.proposedValue ?? '', /"intent":"remove"/);
+    assert.match(
+        request.changes[0]?.proposedValue ?? '',
+        /"operationMode":"existing"/,
+    );
     assert.match(
         request.changes[0]?.proposedValue ?? '',
         /"currentState":"present"/,
@@ -1166,6 +1198,69 @@ test('community edit requests create and apply plant operation remove suggestion
             (operation) => operation.id === operationId,
         ) ?? false,
         false,
+    );
+});
+
+test('community edit requests can propose a new plant operation', async () => {
+    const data = await fixture();
+    const plantId = await createPublishedPlant();
+    const operationField = (
+        await getCommunityEditableFieldsForEntity({
+            entityTypeName: 'plant',
+            entityId: plantId,
+            sectionKey: 'sowing',
+        })
+    ).find((field) => field.fieldKey === 'plant.stage-operations.sowing');
+    assert.ok(operationField);
+
+    const request = await createCommunityEditRequest({
+        entityTypeName: 'plant',
+        entityId: plantId,
+        publicPath: '/biljke/test',
+        sectionKey: 'sowing',
+        submitter: { id: data.submitterId, name: 'Community Submitter' },
+        changes: [
+            {
+                fieldKey: 'plant.stage-operations.sowing',
+                baseValueHash: operationField.baseValueHash,
+                proposedValue: {
+                    intent: 'add',
+                    operationMode: 'new',
+                    stageName: 'sowing',
+                    newOperationName: 'Provjera vlage supstrata',
+                    newOperationDescription:
+                        'Korisnik očekuje podsjetnik za provjeru vlage prije klijanja.',
+                    note: 'Nema odgovarajuće postojeće radnje.',
+                },
+            },
+        ],
+    });
+
+    assert.equal(request.status, 'pending');
+    assert.match(
+        request.changes[0]?.proposedValue ?? '',
+        /"operationMode":"new"/,
+    );
+    assert.match(
+        request.changes[0]?.proposedValue ?? '',
+        /"newOperationName":"Provjera vlage supstrata"/,
+    );
+    assert.match(
+        request.changes[0]?.proposedValue ?? '',
+        /"newOperationDescription":"Korisnik očekuje podsjetnik/,
+    );
+
+    const applied = await approveCommunityEditRequest({
+        id: request.id,
+        reviewer: { id: data.reviewerId, name: 'Community Reviewer' },
+    });
+    assert.equal(applied.status, 'applied');
+
+    const entity = await getEntityRaw(plantId);
+    assert.ok(entity);
+    assert.deepEqual(
+        attributeValues(entity, data.plantOperationsDefinitionId),
+        [],
     );
 });
 


### PR DESCRIPTION
## Summary
- Redesign operation community suggestions to show current operation cards with icons/descriptions and removal actions.
- Add existing-operation selection plus a new-operation proposal path with name and expectation fields.
- Extend storage normalization/admin review/API docs/tests for existing vs new operation suggestion payloads.

## Validation
- corepack pnpm --filter www typecheck
- corepack pnpm --filter @gredice/storage test:node -- communityEditRequestsRepo.node.spec.ts
- corepack pnpm --filter www exec playwright test tests/community-edit-button.spec.tsx --project=chromium
- git diff --check

Note: package-wide app tsc still has unrelated existing errors; filtered output for app/admin/community-edits/[requestId]/page.tsx is clean.