### PR TITLE
[codex] Send order confirmation email after checkout

### DIFF
--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -25,6 +25,10 @@ import { Hono } from 'hono';
 import { describeRoute, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { getCartInfo } from '../../../lib/checkout/cartInfo';
+import {
+    buildOrderConfirmationItems,
+    notifyOrderConfirmationEmail,
+} from '../../../lib/checkout/orderConfirmationEmail';
 import { calculateSunflowerAmount } from '../../../lib/checkout/sunflowerCalculations';
 import {
     type AuthVariables,
@@ -255,6 +259,20 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     }
 
                     await markCartPaidIfAllItemsPaid(cart.id);
+                }
+
+                const completedCart = await getShoppingCart(cart.id);
+                if (completedCart?.status === 'paid') {
+                    await notifyOrderConfirmationEmail({
+                        to: user.userName,
+                        cartId: cart.id,
+                        items: buildOrderConfirmationItems(
+                            cartInfo.items,
+                            calculateSunflowerAmount,
+                        ),
+                        totalAmountCents: null,
+                        currency: null,
+                    });
                 }
             }
 

--- a/apps/api/lib/checkout/orderConfirmationEmail.ts
+++ b/apps/api/lib/checkout/orderConfirmationEmail.ts
@@ -1,0 +1,94 @@
+import type { OrderConfirmationEmailItem } from '@gredice/transactional/emails/Commerce/order-confirmation';
+import { sendOrderConfirmation } from '../email/transactional';
+import type { ShoppingCartItemWithShopData } from './cartInfo';
+
+const CUSTOMER_APP_URL =
+    process.env.GREDICE_GARDEN_APP_URL ?? 'https://vrt.gredice.com';
+
+export interface OrderConfirmationEmailParams {
+    to?: string | null;
+    cartId?: number | null;
+    checkoutSessionId?: string | null;
+    items: OrderConfirmationEmailItem[];
+    totalAmountCents?: number | null;
+    currency?: string | null;
+}
+
+export function buildOrderConfirmationItems(
+    items: ShoppingCartItemWithShopData[],
+    calculateSunflowerAmount: (item: ShoppingCartItemWithShopData) => number,
+): OrderConfirmationEmailItem[] {
+    return items.map((item) => {
+        const quantity = item.amount;
+        if (item.currency === 'sunflower') {
+            return {
+                name: item.shopData.name,
+                quantity,
+                amountSubtotal: calculateSunflowerAmount(item),
+                currency: item.currency,
+            };
+        }
+
+        if (item.currency === 'inventory' || item.usesInventory) {
+            return {
+                name: item.shopData.name,
+                quantity,
+                amountSubtotal: 0,
+                currency: 'inventory',
+            };
+        }
+
+        const unitPrice =
+            typeof item.shopData.discountPrice === 'number'
+                ? item.shopData.discountPrice
+                : item.shopData.price;
+
+        return {
+            name: item.shopData.name,
+            quantity,
+            amountSubtotal:
+                typeof unitPrice === 'number'
+                    ? Math.round(unitPrice * 100) * quantity
+                    : null,
+            currency: item.currency,
+        };
+    });
+}
+
+export async function notifyOrderConfirmationEmail({
+    to,
+    cartId,
+    checkoutSessionId,
+    items,
+    totalAmountCents,
+    currency = 'eur',
+}: OrderConfirmationEmailParams) {
+    const email = to?.trim();
+    if (!email) {
+        console.warn('Skipping order confirmation email: missing recipient', {
+            cartId,
+            checkoutSessionId,
+        });
+        return false;
+    }
+
+    try {
+        await sendOrderConfirmation(email, {
+            email,
+            items,
+            orderReference: cartId ? `Narudžba #${cartId}` : null,
+            totalAmountCents,
+            currency,
+            manageUrl: CUSTOMER_APP_URL,
+        });
+        return true;
+    } catch (error) {
+        console.error('Failed to send order confirmation email', {
+            cartId,
+            checkoutSessionId,
+            hasRecipient: true,
+            error,
+        });
+        return false;
+    }
+}

--- a/apps/api/lib/email/transactional.ts
+++ b/apps/api/lib/email/transactional.ts
@@ -11,6 +11,9 @@ import ResetPasswordEmailTemplate, {
 import WelcomeEmailTemplate, {
     type WelcomeEmailTemplateProps,
 } from '@gredice/transactional/emails/Account/welcome';
+import OrderConfirmationEmailTemplate, {
+    type OrderConfirmationEmailTemplateProps,
+} from '@gredice/transactional/emails/Commerce/order-confirmation';
 import BirthdayEmailTemplate, {
     type BirthdayEmailTemplateProps,
 } from '@gredice/transactional/emails/Notifications/birthday';
@@ -69,6 +72,23 @@ export async function sendWelcome(
         template: WelcomeEmailTemplate(config),
         templateName: 'account-welcome',
         messageType: 'account',
+    });
+}
+
+export async function sendOrderConfirmation(
+    to: string,
+    config: OrderConfirmationEmailTemplateProps,
+) {
+    return await sendEmail({
+        from: 'suncokret@obavijesti.gredice.com',
+        to,
+        subject: 'Gredice - potvrda narudžbe',
+        template: OrderConfirmationEmailTemplate(config),
+        templateName: 'commerce-order-confirmation',
+        messageType: 'commerce',
+        metadata: {
+            orderReference: config.orderReference ?? null,
+        },
     });
 }
 

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -114,6 +114,10 @@ function makeDependencies(
             record(calls, 'getShoppingCart', args);
             return null;
         },
+        getUser: async (...args: unknown[]) => {
+            record(calls, 'getUser', args);
+            return { userName: 'buyer@example.test' };
+        },
         isCartItemDeliverable: async (...args: unknown[]) => {
             record(calls, 'isCartItemDeliverable', args);
             return false;
@@ -188,6 +192,13 @@ function makeDependencies(
             record(calls, 'calculateSunflowerAmount', args);
             return 5000;
         },
+        buildOrderConfirmationItems: (...args: unknown[]) => {
+            record(calls, 'buildOrderConfirmationItems', args);
+            return [];
+        },
+        notifyOrderConfirmationEmail: async (...args: unknown[]) => {
+            record(calls, 'notifyOrderConfirmationEmail', args);
+        },
         notifyDeliveryScheduled: async (...args: unknown[]) => {
             record(calls, 'notifyDeliveryScheduled', args);
         },
@@ -231,6 +242,7 @@ function makeSession() {
                                 cartItemId: '1',
                                 entityId: '42',
                                 entityTypeName: 'operation',
+                                userId: 'user-1',
                                 gardenId: '200',
                                 raisedBedId: '300',
                                 positionIndex: '2',
@@ -367,6 +379,59 @@ describe('processCheckoutSession', () => {
                     amount: 2500,
                     stripePaymentId: 'cs_paid',
                     status: 'completed',
+                    currency: 'eur',
+                },
+            ],
+        );
+    });
+
+    it('sends an order confirmation email after the cart is marked paid', async () => {
+        const calls: RecordedCall[] = [];
+        let getShoppingCartCount = 0;
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSession();
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                getShoppingCartCount += 1;
+                return {
+                    ...makeCart(),
+                    status: getShoppingCartCount > 1 ? 'paid' : 'new',
+                };
+            },
+            getRaisedBedFieldsWithEvents: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBedFieldsWithEvents', args);
+                return [{ id: 88, positionIndex: 2, active: true }];
+            },
+            getUser: async (...args: unknown[]) => {
+                record(calls, 'getUser', args);
+                return { userName: 'buyer@example.test' };
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.deepStrictEqual(callsNamed(calls, 'getUser')[0]?.args, [
+            'user-1',
+        ]);
+        assert.deepStrictEqual(
+            callsNamed(calls, 'notifyOrderConfirmationEmail')[0]?.args,
+            [
+                {
+                    to: 'buyer@example.test',
+                    cartId: 100,
+                    checkoutSessionId: 'cs_paid',
+                    items: [
+                        {
+                            name: 'Planting',
+                            quantity: 1,
+                            amountSubtotal: 2500,
+                            currency: 'eur',
+                        },
+                    ],
+                    totalAmountCents: 2500,
                     currency: 'eur',
                 },
             ],

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -23,6 +23,7 @@ import {
     getRaisedBed,
     getRaisedBedFieldsWithEvents,
     getShoppingCart,
+    getUser,
     isCartItemDeliverable,
     knownEvents,
     markCartPaidIfAllItemsPaid,
@@ -39,6 +40,10 @@ import {
     getCartInfo,
     type ShoppingCartItemWithShopData,
 } from '../checkout/cartInfo';
+import {
+    buildOrderConfirmationItems,
+    notifyOrderConfirmationEmail,
+} from '../checkout/orderConfirmationEmail';
 import { calculateSunflowerAmount } from '../checkout/sunflowerCalculations';
 import { notifyDeliveryScheduled } from '../delivery/emailNotifications';
 import { notifyScheduledDeliveryEmailOnce } from '../delivery/scheduledEmailDeduper';
@@ -63,6 +68,7 @@ export type ProcessCheckoutSessionDependencies = {
     getRaisedBed: typeof getRaisedBed;
     getRaisedBedFieldsWithEvents: typeof getRaisedBedFieldsWithEvents;
     getShoppingCart: typeof getShoppingCart;
+    getUser: typeof getUser;
     isCartItemDeliverable: typeof isCartItemDeliverable;
     knownEvents: typeof knownEvents;
     markCartPaidIfAllItemsPaid: typeof markCartPaidIfAllItemsPaid;
@@ -76,6 +82,8 @@ export type ProcessCheckoutSessionDependencies = {
     getStripeCheckoutSession: typeof getStripeCheckoutSession;
     getCartInfo: typeof getCartInfo;
     calculateSunflowerAmount: typeof calculateSunflowerAmount;
+    buildOrderConfirmationItems: typeof buildOrderConfirmationItems;
+    notifyOrderConfirmationEmail: typeof notifyOrderConfirmationEmail;
     notifyDeliveryScheduled: typeof notifyDeliveryScheduled;
     notifyScheduledDeliveryEmailOnce: typeof notifyScheduledDeliveryEmailOnce;
     getPostHogClient: typeof getPostHogClient;
@@ -100,6 +108,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     getRaisedBed,
     getRaisedBedFieldsWithEvents,
     getShoppingCart,
+    getUser,
     isCartItemDeliverable,
     knownEvents,
     markCartPaidIfAllItemsPaid,
@@ -113,6 +122,8 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     getStripeCheckoutSession,
     getCartInfo,
     calculateSunflowerAmount,
+    buildOrderConfirmationItems,
+    notifyOrderConfirmationEmail,
     notifyDeliveryScheduled,
     notifyScheduledDeliveryEmailOnce,
     getPostHogClient,
@@ -145,6 +156,7 @@ async function processNonStripeCartItems(
     checkoutSessionId?: string | null,
     dependencies: ProcessCheckoutSessionDependencies = realDependencies,
 ): Promise<ShoppingCartItemWithShopData[]> {
+    const processedItems: ShoppingCartItemWithShopData[] = [];
     const inventoryNormalizedCart =
         await dependencies.normalizeShoppingCartInventoryUsage(cartId);
     if (!inventoryNormalizedCart) {
@@ -237,6 +249,7 @@ async function processNonStripeCartItems(
                     dependencies,
                 ),
             ]);
+            processedItems.push(item);
         }
     }
 
@@ -323,13 +336,14 @@ async function processNonStripeCartItems(
                     dependencies,
                 ),
             ]);
+            processedItems.push(item);
 
             // Update the lookup to reflect consumed inventory
             inventoryLookup.set(inventoryKey, available - item.amount);
         }
     }
 
-    return cartInfo.items;
+    return processedItems;
 }
 
 export async function processCheckoutSession(
@@ -395,9 +409,11 @@ async function processPaidCheckoutSession(
         name?: string | null;
         quantity?: number | null;
         amountSubtotal?: number | null;
+        currency?: string | null;
     }[] = [];
     const scheduledDeliveryEmailKeys = new Set<string>();
     let accountId: string | undefined;
+    let customerUserId: string | undefined;
     for (const item of session.lineItems?.data ?? []) {
         console.debug(`Item: ${item.id} Quantity: ${item.quantity}`);
 
@@ -434,6 +450,7 @@ async function processPaidCheckoutSession(
                 (item as { amount_subtotal?: number }).amount_subtotal ??
                 item.amount_total ??
                 null,
+            currency: 'eur',
         });
 
         // Extract metadata from the product
@@ -477,6 +494,7 @@ async function processPaidCheckoutSession(
 
         // Save accountId from metadata if not already set
         accountId ??= itemData.accountId;
+        customerUserId ??= itemData.userId;
 
         // Validate required metadata (accountId can be derived from cart)
         if (
@@ -583,7 +601,6 @@ async function processPaidCheckoutSession(
             );
         }
 
-        // TODO: Send email to customer
         // TODO: Send invoice to customer
     }
 
@@ -627,13 +644,19 @@ async function processPaidCheckoutSession(
     const uniqueAffectedCartIds = Array.from(new Set(affectedCartIds));
     if (accountId && uniqueAffectedCartIds.length > 0) {
         for (const cartId of uniqueAffectedCartIds) {
-            await processNonStripeCartItems(
+            const nonStripeItems = await processNonStripeCartItems(
                 cartId,
                 accountId,
                 deliveryInfo,
                 scheduledDeliveryEmailKeys,
                 session.id,
                 dependencies,
+            );
+            purchasedItems.push(
+                ...dependencies.buildOrderConfirmationItems(
+                    nonStripeItems,
+                    dependencies.calculateSunflowerAmount,
+                ),
             );
         }
     }
@@ -652,10 +675,42 @@ async function processPaidCheckoutSession(
             : undefined,
     ]);
 
+    const completedCartIds: number[] = [];
+    for (const cartId of uniqueAffectedCartIds) {
+        const completedCart = await dependencies.getShoppingCart(cartId);
+        if (completedCart?.status === 'paid') {
+            completedCartIds.push(completedCart.id);
+        }
+    }
+
+    const customer = customerUserId
+        ? await dependencies.getUser(customerUserId)
+        : null;
+
+    if (completedCartIds.length > 0) {
+        await dependencies.notifyOrderConfirmationEmail({
+            to: customer?.userName,
+            cartId: completedCartIds.length === 1 ? completedCartIds[0] : null,
+            checkoutSessionId: session.id,
+            items: purchasedItems,
+            totalAmountCents: session.amountTotal ?? null,
+            currency: 'eur',
+        });
+    } else {
+        console.warn(
+            'Skipping order confirmation email: no affected cart is paid',
+            {
+                checkoutSessionId: session.id,
+                affectedCartIds: uniqueAffectedCartIds,
+            },
+        );
+    }
+
     await dependencies.notifyPurchase({
         accountId,
         amountTotal: session.amountTotal ?? null,
         checkoutSessionId: session.id ?? null,
+        customerEmail: customer?.userName ?? null,
         items: purchasedItems,
     });
 

--- a/packages/transactional/emails/Commerce/order-confirmation.tsx
+++ b/packages/transactional/emails/Commerce/order-confirmation.tsx
@@ -1,0 +1,150 @@
+import { Head, Html, Preview, Section, Tailwind, Text } from 'react-email';
+import { ContentCard } from '../../components/ContentCard';
+import { Divider } from '../../components/Divider';
+import { GrediceLogotype } from '../../components/GrediceLogotype';
+import { Header } from '../../components/Header';
+import { Paragraph } from '../../components/Paragraph';
+import { PrimaryButton } from '../../components/PrimaryButton';
+import { GrediceDisclaimer } from '../../components/shared/GrediceDisclaimer';
+
+export interface OrderConfirmationEmailItem {
+    name?: string | null;
+    quantity?: number | null;
+    amountSubtotal?: number | null;
+    currency?: string | null;
+}
+
+export interface OrderConfirmationEmailTemplateProps {
+    email: string;
+    items: OrderConfirmationEmailItem[];
+    orderReference?: string | null;
+    totalAmountCents?: number | null;
+    currency?: string | null;
+    manageUrl?: string;
+    appName?: string;
+    appDomain?: string;
+}
+
+function formatQuantity(quantity?: number | null) {
+    return typeof quantity === 'number' && quantity > 0 ? quantity : 1;
+}
+
+function formatCurrency(amountCents: number, currency?: string | null) {
+    const currencyCode = currency?.toUpperCase() || 'EUR';
+    try {
+        return new Intl.NumberFormat('hr-HR', {
+            style: 'currency',
+            currency: currencyCode,
+        }).format(amountCents / 100);
+    } catch {
+        return `${(amountCents / 100).toFixed(2)} ${currencyCode}`;
+    }
+}
+
+function formatAmount(item: OrderConfirmationEmailItem) {
+    if (typeof item.amountSubtotal !== 'number') {
+        return null;
+    }
+
+    if (item.currency === 'sunflower') {
+        return `${item.amountSubtotal} suncokreta`;
+    }
+
+    if (item.currency === 'inventory') {
+        return 'Ruksak';
+    }
+
+    if (item.amountSubtotal === 0) {
+        return 'Uključeno';
+    }
+
+    return formatCurrency(item.amountSubtotal, item.currency);
+}
+
+export default function OrderConfirmationEmailTemplate({
+    email,
+    items,
+    orderReference,
+    totalAmountCents,
+    currency = 'eur',
+    manageUrl = 'https://vrt.gredice.com',
+    appName = 'Gredice',
+    appDomain = 'gredice.com',
+}: OrderConfirmationEmailTemplateProps) {
+    const previewText = `${appName} - potvrda narudžbe`;
+    const visibleItems: OrderConfirmationEmailItem[] =
+        items.length > 0 ? items : [{ name: 'Narudžba' }];
+
+    return (
+        <Html>
+            <Head />
+            <Preview>{previewText}</Preview>
+            <Tailwind>
+                <ContentCard>
+                    <Section className="text-center">
+                        <GrediceLogotype />
+                    </Section>
+                    <Header>Potvrda narudžbe</Header>
+                    <Paragraph>Bok!</Paragraph>
+                    <Paragraph>
+                        Tvoja narudžba je potvrđena. Pripremili smo stavke za
+                        tvoj vrt i pratit ćemo ih kroz dogovorene radnje,
+                        dostavu ili preuzimanje.
+                    </Paragraph>
+                    {orderReference ? (
+                        <Paragraph>
+                            <strong>Referenca:</strong> {orderReference}
+                        </Paragraph>
+                    ) : null}
+                    <Section className="my-[24px]">
+                        {visibleItems.map((item) => {
+                            const amount = formatAmount(item);
+                            const quantity = formatQuantity(item.quantity);
+                            const itemKey = [
+                                item.name?.trim() || 'item',
+                                quantity,
+                                item.amountSubtotal ?? 'unknown',
+                                item.currency ?? 'none',
+                            ].join('-');
+                            return (
+                                <Section
+                                    className="border-[#eaeaea] border-t border-solid py-[12px]"
+                                    key={itemKey}
+                                >
+                                    <Text className="m-0 text-[14px] font-semibold leading-[22px] text-black">
+                                        {quantity}x{' '}
+                                        {item.name?.trim() || 'Stavka'}
+                                    </Text>
+                                    {amount ? (
+                                        <Text className="m-0 text-[13px] leading-[20px] text-[#475569]">
+                                            {amount}
+                                        </Text>
+                                    ) : null}
+                                </Section>
+                            );
+                        })}
+                    </Section>
+                    {typeof totalAmountCents === 'number' ? (
+                        <Paragraph>
+                            <strong>Ukupno:</strong>{' '}
+                            {formatCurrency(totalAmountCents, currency)}
+                        </Paragraph>
+                    ) : null}
+                    <Paragraph>
+                        Ako narudžba uključuje radnje u vrtu, vidjet ćeš ih u
+                        aplikaciji čim budu zakazane ili dovršene. Za stavke s
+                        dostavom poslat ćemo posebnu obavijest o terminu.
+                    </Paragraph>
+                    <Section className="my-[32px] text-center">
+                        <PrimaryButton href={manageUrl}>
+                            Otvori svoj vrt
+                        </PrimaryButton>
+                    </Section>
+                    <Paragraph>{appName} tim</Paragraph>
+                    <Divider className="my-[26px]" />
+                    <GrediceDisclaimer email={email} appDomain={appDomain} />
+                </ContentCard>
+            </Tailwind>
+        </Html>
+    );
+}

--- a/packages/transactional/tests/orderConfirmationEmail.node.spec.tsx
+++ b/packages/transactional/tests/orderConfirmationEmail.node.spec.tsx
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import { createElement } from 'react';
+import OrderConfirmationEmailTemplate from '../emails/Commerce/order-confirmation';
+import { assertHtmlIncludes, renderNonEmpty } from './renderEmail';
+
+test('order-confirmation renders order reference, items, and total', async () => {
+    const html = await renderNonEmpty(
+        createElement(OrderConfirmationEmailTemplate, {
+            email: 'order@example.test',
+            items: [
+                {
+                    name: 'Rajčica',
+                    quantity: 2,
+                    amountSubtotal: 900,
+                    currency: 'eur',
+                },
+                {
+                    name: 'Suncokret nagrada',
+                    quantity: 1,
+                    amountSubtotal: 120,
+                    currency: 'sunflower',
+                },
+            ],
+            manageUrl: 'https://example.test/vrt',
+            orderReference: 'Narudžba #42',
+            totalAmountCents: 900,
+            currency: 'eur',
+        }),
+    );
+
+    assertHtmlIncludes(html, 'Narudžba #42');
+    assertHtmlIncludes(html, 'Rajčica');
+    assertHtmlIncludes(html, 'Suncokret nagrada');
+    assertHtmlIncludes(html, '120 suncokreta');
+    assertHtmlIncludes(html, 'https://example.test/vrt');
+});


### PR DESCRIPTION
## Summary

Adds transactional order confirmation emails after checkout completes.

- Adds a reusable commerce order confirmation React Email template.
- Sends confirmations through the existing ACS transactional email path.
- Wires Stripe checkout confirmations after affected carts reload as `paid`.
- Wires sunflower and inventory checkout confirmations after the cart reloads as `paid`.
- Keeps email delivery failures non-fatal and logged with checkout/cart context.

## Impact

Customers now receive a confirmation email for completed checkout flows, independent of whether the checkout used Stripe, sunflowers, or inventory. The confirmation links back to the garden app and includes item details plus the cart-based order reference where available.

This is the reusable checkout email foundation for later billing document delivery, which should compose with this path instead of sending duplicate checkout confirmations.

Closes #4034.

## Validation

- `pnpm --filter @gredice/transactional test:node`
- `pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/stripe/processCheckoutSession.node.spec.ts`
- `pnpm --filter api lint`
- `pnpm --filter @gredice/transactional lint`
- `git diff --check origin/main...HEAD`

Note: direct `pnpm --filter api exec tsc --noEmit --pretty false` was previously blocked by existing unrelated errors in `apps/api/lib/notifications/webPushSender.node.spec.ts:211`.