### PR TITLE
[codex] Fix delivery request grouping

### DIFF
--- a/apps/app/app/admin/delivery/requests/DeliveryRequestGroups.ts
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestGroups.ts
@@ -5,8 +5,12 @@ type DateValue = Date | string | null | undefined;
 type GroupableDeliveryRequest = {
     id: string;
     accountId?: string | null;
-    mode?: string | null;
-    state: string;
+    operation?:
+        | {
+              accountId?: string | null;
+          }
+        | null
+        | undefined;
     slot?:
         | {
               id?: number | null;
@@ -15,34 +19,6 @@ type GroupableDeliveryRequest = {
           }
         | null
         | undefined;
-    address?:
-        | {
-              id?: number | null;
-              contactName?: string | null;
-              phone?: string | null;
-              street1?: string | null;
-              street2?: string | null;
-              postalCode?: string | null;
-              city?: string | null;
-              countryCode?: string | null;
-          }
-        | null
-        | undefined;
-    location?:
-        | {
-              id?: number | null;
-              name?: string | null;
-              street1?: string | null;
-              street2?: string | null;
-              postalCode?: string | null;
-              city?: string | null;
-              countryCode?: string | null;
-          }
-        | null
-        | undefined;
-    requestNotes?: string | null;
-    deliveryNotes?: string | null;
-    cancelReason?: string | null;
     createdAt: Date | string;
     raisedBed?:
         | {
@@ -87,9 +63,19 @@ function dateKey(value: DateValue) {
     return typeof value === 'string' ? value : value.toISOString();
 }
 
+function getAccountKey(request: GroupableDeliveryRequest) {
+    const accountId = request.accountId ?? request.operation?.accountId;
+
+    return accountId ? `account:${accountId}` : `request:${request.id}`;
+}
+
 function getSlotKey(request: GroupableDeliveryRequest) {
     if (typeof request.slot?.id === 'number') {
         return `slot:${request.slot.id}`;
+    }
+
+    if (!request.slot?.startAt && !request.slot?.endAt) {
+        return `slot:unknown:${request.id}`;
     }
 
     return [
@@ -99,54 +85,8 @@ function getSlotKey(request: GroupableDeliveryRequest) {
     ].join(':');
 }
 
-function getDestinationKey(request: GroupableDeliveryRequest) {
-    if (request.mode === 'pickup') {
-        const location = request.location;
-
-        return [
-            'pickup',
-            location?.id ?? 'unknown',
-            normalizeKeyPart(location?.name),
-            normalizeKeyPart(location?.street1),
-            normalizeKeyPart(location?.street2),
-            normalizeKeyPart(location?.postalCode),
-            normalizeKeyPart(location?.city),
-            normalizeKeyPart(location?.countryCode),
-        ].join(':');
-    }
-
-    const address = request.address;
-
-    return [
-        'delivery',
-        address?.id ?? 'unknown',
-        normalizeKeyPart(address?.contactName),
-        normalizeKeyPart(address?.phone),
-        normalizeKeyPart(address?.street1),
-        normalizeKeyPart(address?.street2),
-        normalizeKeyPart(address?.postalCode),
-        normalizeKeyPart(address?.city),
-        normalizeKeyPart(address?.countryCode),
-    ].join(':');
-}
-
-function getNotesKey(request: GroupableDeliveryRequest) {
-    return [
-        normalizeKeyPart(request.requestNotes),
-        normalizeKeyPart(request.deliveryNotes),
-        normalizeKeyPart(request.cancelReason),
-    ].join(':');
-}
-
 function getDeliveryRequestGroupKey(request: GroupableDeliveryRequest) {
-    return [
-        request.accountId ?? 'account:unknown',
-        request.mode ?? 'mode:unknown',
-        request.state,
-        getSlotKey(request),
-        getDestinationKey(request),
-        getNotesKey(request),
-    ].join('|');
+    return [getAccountKey(request), getSlotKey(request)].join('|');
 }
 
 function comparePhysicalIds(left: string, right: string) {

--- a/apps/app/app/admin/delivery/requests/DeliveryRequestGroups.unit.ts
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestGroups.unit.ts
@@ -2,7 +2,25 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { groupDeliveryRequests } from './DeliveryRequestGroups.ts';
 
-type GroupableRequest = Parameters<typeof groupDeliveryRequests>[0][number];
+type BaseGroupableRequest = Parameters<typeof groupDeliveryRequests>[0][number];
+type GroupableRequest = BaseGroupableRequest & {
+    mode: 'delivery' | 'pickup';
+    state: string;
+    address: {
+        id: number;
+        contactName: string;
+        phone: string;
+        street1: string;
+        street2: string | null;
+        postalCode: string;
+        city: string;
+        countryCode: string;
+    } | null;
+    location: null;
+    requestNotes: string | null;
+    deliveryNotes: string | null;
+    cancelReason: string | null;
+};
 
 const slot = {
     id: 10,
@@ -50,7 +68,7 @@ function buildRequest(
     };
 }
 
-test('groups requests for the same destination and slot', () => {
+test('groups requests for the same account and slot in raised bed order', () => {
     const groups = groupDeliveryRequests([
         buildRequest({ id: 'field-3' }),
         buildRequest({
@@ -66,20 +84,18 @@ test('groups requests for the same destination and slot', () => {
     );
 });
 
-test('splits requests when delivery facts differ', () => {
+test('groups requests for the same account and slot regardless of state', () => {
     const groups = groupDeliveryRequests([
         buildRequest({ id: 'confirmed' }),
-        buildRequest({ id: 'ready', state: 'ready' }),
         buildRequest({
-            id: 'other-slot',
-            slot: {
-                id: 11,
-                startAt: new Date('2026-06-30T15:00:00.000Z'),
-                endAt: new Date('2026-06-30T17:00:00.000Z'),
-            },
+            id: 'ready',
+            state: 'ready',
+            requestNotes: 'Napomena kupca',
         }),
         buildRequest({
-            id: 'other-address',
+            id: 'cancelled',
+            state: 'cancelled',
+            cancelReason: 'Vec ubrano.',
             address: {
                 id: 21,
                 contactName: 'Drugi kontakt',
@@ -93,5 +109,43 @@ test('splits requests when delivery facts differ', () => {
         }),
     ]);
 
-    assert.equal(groups.length, 4);
+    assert.equal(groups.length, 1);
+    assert.deepEqual(
+        groups[0]?.requests.map((request) => request.id).toSorted(),
+        ['cancelled', 'confirmed', 'ready'],
+    );
+});
+
+test('splits requests when account or slot differs', () => {
+    const groups = groupDeliveryRequests([
+        buildRequest({ id: 'same-account-and-slot' }),
+        buildRequest({ id: 'other-account', accountId: 'account-2' }),
+        buildRequest({
+            id: 'other-slot',
+            slot: {
+                id: 11,
+                startAt: new Date('2026-06-30T15:00:00.000Z'),
+                endAt: new Date('2026-06-30T17:00:00.000Z'),
+            },
+        }),
+    ]);
+
+    assert.equal(groups.length, 3);
+});
+
+test('uses the operation account when the event projection has no account', () => {
+    const groups = groupDeliveryRequests([
+        buildRequest({
+            id: 'first',
+            accountId: null,
+            operation: { accountId: 'operation-account' },
+        }),
+        buildRequest({
+            id: 'second',
+            accountId: null,
+            operation: { accountId: 'operation-account' },
+        }),
+    ]);
+
+    assert.equal(groups.length, 1);
 });


### PR DESCRIPTION
## Summary

- group admin delivery requests by account and slot instead of request state, destination, or notes
- keep raised bed and field ordering inside each group
- add regression coverage for mixed request states and missing projected account fallback

## Root Cause

Delivery request groups used volatile request facts in the group key, including `state` and cancellation notes. That split the same user/account and delivery slot into multiple visible groups when requests had different states.

## Validation

- `pnpm --filter app run test:unit`
- `pnpm --filter app exec biome check app/admin/delivery/requests/DeliveryRequestGroups.ts app/admin/delivery/requests/DeliveryRequestGroups.unit.ts`
- narrow TypeScript check for the touched files

Note: direct full-app `tsc` is currently blocked by unrelated existing errors elsewhere in the app/generated fiscalization files.