### PR TITLE
[codex] Implement invoice pipeline and account billing access

### DIFF
--- a/apps/api/app/api/[...route]/accountBillingRoutes.ts
+++ b/apps/api/app/api/[...route]/accountBillingRoutes.ts
@@ -1,0 +1,368 @@
+import {
+    getAccountBillingInvoice,
+    getAccountBillingInvoices,
+    getAccountBillingReceipt,
+} from '@gredice/storage';
+import { type Context, Hono, type MiddlewareHandler, type Next } from 'hono';
+import { describeRoute, validator as zValidator } from 'hono-openapi';
+import { z } from 'zod';
+import { authSecurity } from '../../../lib/docs/security';
+import {
+    type AuthVariables,
+    authValidator,
+} from '../../../lib/hono/authValidator';
+
+const numericIdParam = z.string().regex(/^\d+$/);
+
+const invoiceParamSchema = z.object({
+    invoiceId: numericIdParam,
+});
+
+const receiptParamSchema = z.object({
+    receiptId: numericIdParam,
+});
+
+type AccountBillingAuthValidator = (
+    roles: string[],
+) => MiddlewareHandler<{ Variables: AuthVariables }>;
+
+export type AccountBillingRouteDeps = {
+    authValidator: AccountBillingAuthValidator;
+    getAccountBillingInvoice: typeof getAccountBillingInvoice;
+    getAccountBillingInvoices: typeof getAccountBillingInvoices;
+    getAccountBillingReceipt: typeof getAccountBillingReceipt;
+};
+
+const defaultDeps: AccountBillingRouteDeps = {
+    authValidator,
+    getAccountBillingInvoice,
+    getAccountBillingInvoices,
+    getAccountBillingReceipt,
+};
+
+type CustomerBillingReceiptRecord = {
+    id: number;
+    receiptNumber: string;
+    yearReceiptNumber: string;
+    issuedAt: Date;
+    totalAmount: string;
+    currency: string;
+    cisStatus: string;
+    jir?: string | null;
+    zki?: string | null;
+    businessName?: string | null;
+    businessAddress?: string | null;
+    paymentMethod: string;
+    paymentReference?: string | null;
+};
+
+type CustomerBillingInvoiceRecord = {
+    id: number;
+    invoiceNumber: string;
+    status: string;
+    issueDate: Date;
+    dueDate: Date;
+    paidDate?: Date | null;
+    totalAmount: string;
+    currency: string;
+    billToName?: string | null;
+    billToEmail: string;
+    invoiceItems: Array<{
+        description: string;
+        quantity: string;
+        totalPrice: string;
+    }>;
+    receipt?: CustomerBillingReceiptRecord | null;
+};
+
+function toIso(value: Date | null | undefined) {
+    return value ? value.toISOString() : null;
+}
+
+function documentUrl(context: Context, path: string) {
+    return new URL(path, context.req.url).toString();
+}
+
+function invoiceDocumentPath(invoiceId: number) {
+    return `/api/accounts/current/billing/invoices/${invoiceId}/document`;
+}
+
+function receiptDocumentPath(receiptId: number) {
+    return `/api/accounts/current/billing/receipts/${receiptId}/document`;
+}
+
+function serializeReceipt(
+    context: Context,
+    receipt: CustomerBillingReceiptRecord | null | undefined,
+) {
+    if (!receipt) {
+        return null;
+    }
+
+    return {
+        id: receipt.id,
+        receiptNumber: receipt.receiptNumber,
+        yearReceiptNumber: receipt.yearReceiptNumber,
+        issuedAt: receipt.issuedAt.toISOString(),
+        totalAmount: receipt.totalAmount,
+        currency: receipt.currency,
+        cisStatus: receipt.cisStatus,
+        jir: receipt.jir,
+        zki: receipt.zki,
+        documentUrl: documentUrl(context, receiptDocumentPath(receipt.id)),
+    };
+}
+
+function serializeInvoice(
+    context: Context,
+    invoice: CustomerBillingInvoiceRecord | null | undefined,
+) {
+    if (!invoice) {
+        return null;
+    }
+
+    return {
+        id: invoice.id,
+        invoiceNumber: invoice.invoiceNumber,
+        status: invoice.status,
+        issueDate: invoice.issueDate.toISOString(),
+        dueDate: invoice.dueDate.toISOString(),
+        paidDate: toIso(invoice.paidDate),
+        totalAmount: invoice.totalAmount,
+        currency: invoice.currency,
+        receipt: serializeReceipt(context, invoice.receipt),
+        documentUrl: documentUrl(context, invoiceDocumentPath(invoice.id)),
+    };
+}
+
+function escapeHtml(value: string | number | null | undefined) {
+    return String(value ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}
+
+function formatMoney(value: string | number, currency: string) {
+    const amount = typeof value === 'number' ? value : Number.parseFloat(value);
+    if (!Number.isFinite(amount)) {
+        return '-';
+    }
+
+    return new Intl.NumberFormat('hr-HR', {
+        currency: currency.toUpperCase(),
+        style: 'currency',
+    }).format(amount);
+}
+
+function renderDocumentShell({
+    body,
+    heading,
+    label,
+}: {
+    body: string;
+    heading: string;
+    label: string;
+}) {
+    return `<!doctype html>
+<html lang="hr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(label)} ${escapeHtml(heading)}</title>
+<style>
+body{margin:0;background:#f4f1ea;color:#1e1b16;font-family:Arial,sans-serif;}
+main{max-width:760px;margin:24px auto;padding:32px;background:#fff;border:1px solid #ddd5c7;}
+h1{font-size:28px;margin:0 0 4px;}
+.label{color:#5f6b3d;font-size:13px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;}
+.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:16px;margin:24px 0;}
+.box{border:1px solid #e5decf;padding:12px;}
+table{width:100%;border-collapse:collapse;margin-top:24px;}
+th,td{border-bottom:1px solid #e5decf;padding:10px;text-align:left;}
+th:last-child,td:last-child{text-align:right;}
+.total{font-size:20px;font-weight:700;text-align:right;margin-top:20px;}
+@media print{body{background:#fff;}main{border:0;margin:0;max-width:none;}}
+</style>
+</head>
+<body><main><div class="label">${escapeHtml(label)}</div><h1>${escapeHtml(heading)}</h1>${body}</main></body>
+</html>`;
+}
+
+function renderInvoiceDocument(invoice: CustomerBillingInvoiceRecord) {
+    const itemRows = invoice.invoiceItems
+        .map(
+            (item) =>
+                `<tr><td>${escapeHtml(item.description)}</td><td>${escapeHtml(
+                    item.quantity,
+                )}</td><td>${escapeHtml(formatMoney(item.totalPrice, invoice.currency))}</td></tr>`,
+        )
+        .join('');
+    const body = `
+<div class="grid">
+<section class="box"><strong>Kupac</strong><br>${escapeHtml(invoice.billToName ?? invoice.billToEmail)}<br>${escapeHtml(invoice.billToEmail)}</section>
+<section class="box"><strong>Datumi</strong><br>Izdano: ${escapeHtml(invoice.issueDate.toLocaleDateString('hr-HR'))}<br>Plaćeno: ${escapeHtml(invoice.paidDate?.toLocaleDateString('hr-HR') ?? '-')}</section>
+</div>
+<table><thead><tr><th>Stavka</th><th>Količina</th><th>Iznos</th></tr></thead><tbody>${itemRows}</tbody></table>
+<p class="total">Ukupno ${escapeHtml(formatMoney(invoice.totalAmount, invoice.currency))}</p>`;
+
+    return renderDocumentShell({
+        body,
+        heading: invoice.invoiceNumber,
+        label: 'Ponuda',
+    });
+}
+
+function renderReceiptDocument(receipt: CustomerBillingReceiptRecord) {
+    const body = `
+<div class="grid">
+<section class="box"><strong>Izdavatelj</strong><br>${escapeHtml(receipt.businessName ?? 'Gredice')}<br>${escapeHtml(receipt.businessAddress)}</section>
+<section class="box"><strong>Fiskalizacija</strong><br>Status: ${escapeHtml(receipt.cisStatus)}<br>JIR: ${escapeHtml(receipt.jir ?? '-')}<br>ZKI: ${escapeHtml(receipt.zki ?? '-')}</section>
+</div>
+<p>Način plaćanja: ${escapeHtml(receipt.paymentMethod)}</p>
+<p>Referenca plaćanja: ${escapeHtml(receipt.paymentReference ?? '-')}</p>
+<p class="total">Ukupno ${escapeHtml(formatMoney(receipt.totalAmount, receipt.currency))}</p>`;
+
+    return renderDocumentShell({
+        body,
+        heading: receipt.yearReceiptNumber,
+        label: 'Fiskalni račun',
+    });
+}
+
+export function createAccountBillingRoutes(
+    deps: AccountBillingRouteDeps = defaultDeps,
+) {
+    return new Hono<{ Variables: AuthVariables }>()
+        .get(
+            '/invoices',
+            describeRoute({
+                description:
+                    'List invoices and receipt status for the current authenticated account.',
+                security: authSecurity,
+                tags: ['Accounts'],
+            }),
+            deps.authValidator(['user', 'admin']),
+            async (context) => {
+                const { accountId } = context.get('authContext');
+                const invoices =
+                    await deps.getAccountBillingInvoices(accountId);
+
+                return context.json({
+                    invoices: invoices.map((invoice) =>
+                        serializeInvoice(context, invoice),
+                    ),
+                });
+            },
+        )
+        .get(
+            '/invoices/:invoiceId',
+            describeRoute({
+                description:
+                    'Get one invoice for the current authenticated account.',
+                security: authSecurity,
+                tags: ['Accounts'],
+            }),
+            deps.authValidator(['user', 'admin']),
+            zValidator('param', invoiceParamSchema),
+            async (context) => {
+                const { accountId } = context.get('authContext');
+                const invoiceId = Number.parseInt(
+                    context.req.valid('param').invoiceId,
+                    10,
+                );
+                const invoice = await deps.getAccountBillingInvoice(
+                    accountId,
+                    invoiceId,
+                );
+                if (!invoice) {
+                    return context.json({ error: 'Invoice not found' }, 404);
+                }
+
+                return context.json({
+                    invoice: serializeInvoice(context, invoice),
+                });
+            },
+        )
+        .get(
+            '/invoices/:invoiceId/document',
+            describeRoute({
+                description:
+                    'Render a printable invoice document for the current authenticated account.',
+                security: authSecurity,
+                tags: ['Accounts'],
+            }),
+            deps.authValidator(['user', 'admin']),
+            zValidator('param', invoiceParamSchema),
+            async (context) => {
+                const { accountId } = context.get('authContext');
+                const invoiceId = Number.parseInt(
+                    context.req.valid('param').invoiceId,
+                    10,
+                );
+                const invoice = await deps.getAccountBillingInvoice(
+                    accountId,
+                    invoiceId,
+                );
+                if (!invoice) {
+                    return context.json({ error: 'Invoice not found' }, 404);
+                }
+
+                return context.html(renderInvoiceDocument(invoice));
+            },
+        )
+        .get(
+            '/receipts/:receiptId/document',
+            describeRoute({
+                description:
+                    'Render a printable receipt document for the current authenticated account.',
+                security: authSecurity,
+                tags: ['Accounts'],
+            }),
+            deps.authValidator(['user', 'admin']),
+            zValidator('param', receiptParamSchema),
+            async (context) => {
+                const { accountId } = context.get('authContext');
+                const receiptId = Number.parseInt(
+                    context.req.valid('param').receiptId,
+                    10,
+                );
+                const receipt = await deps.getAccountBillingReceipt(
+                    accountId,
+                    receiptId,
+                );
+                if (!receipt) {
+                    return context.json({ error: 'Receipt not found' }, 404);
+                }
+
+                return context.html(renderReceiptDocument(receipt));
+            },
+        );
+}
+
+export function createTestAuthMiddleware({
+    accountId = 'test-account',
+    userId = 'test-user',
+}: {
+    accountId?: string;
+    userId?: string;
+} = {}) {
+    return async (
+        context: Context<{ Variables: AuthVariables }>,
+        next: Next,
+    ) => {
+        context.set('authContext', {
+            accountId,
+            userId,
+            user: {
+                id: userId,
+                accountIds: [accountId],
+                role: 'user',
+            },
+        });
+
+        await next();
+    };
+}
+
+export default createAccountBillingRoutes();

--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -66,6 +66,7 @@ import { getPostHogClient } from '../../../lib/posthog-server';
 import { getBjelovarForecast } from '../../../lib/weather/forecast';
 import { populateWeatherFromSymbol } from '../../../lib/weather/populateWeatherFromSymbol';
 import { findClosestForecastEntry } from '../../../lib/weather/weatherNowContract';
+import accountBillingRoutes from './accountBillingRoutes';
 
 const dailyRewards = [5, 10, 15, 20, 25, 50];
 const DAILY_REWARD_TIME_ZONE = 'Europe/Zagreb';
@@ -252,6 +253,7 @@ function pickSunflowerBlock<T extends { id: string }>(blocks: T[]) {
 }
 
 const app = new Hono<{ Variables: AuthVariables }>()
+    .route('/current/billing', accountBillingRoutes)
     .get(
         '/current',
         describeRoute({

--- a/apps/api/lib/billing/accountBillingRoutes.node.spec.ts
+++ b/apps/api/lib/billing/accountBillingRoutes.node.spec.ts
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { MiddlewareHandler } from 'hono';
+import {
+    type AccountBillingRouteDeps,
+    createAccountBillingRoutes,
+    createTestAuthMiddleware,
+} from '../../app/api/[...route]/accountBillingRoutes';
+import type { AuthVariables } from '../hono/authValidator';
+
+const date = new Date('2026-07-05T10:15:00.000Z');
+
+function receipt(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 20,
+        invoiceId: 10,
+        receiptNumber: '5',
+        yearReceiptNumber: '2026-5',
+        subtotal: '25.00',
+        taxAmount: '0.00',
+        totalAmount: '25.00',
+        currency: 'eur',
+        paymentMethod: 'card',
+        paymentReference: 'cs_test',
+        jir: 'jir-123',
+        zki: 'zki-456',
+        cisStatus: 'confirmed',
+        cisReference: null,
+        cisErrorMessage: 'internal failure detail',
+        cisTimestamp: date,
+        cisResponse: '{"secret":"debug"}',
+        issuedAt: date,
+        businessPin: null,
+        businessName: 'Gredice',
+        businessAddress: 'Zagreb',
+        customerPin: null,
+        customerName: null,
+        customerAddress: null,
+        createdAt: date,
+        updatedAt: date,
+        isDeleted: false,
+        invoice: null,
+        ...overrides,
+    };
+}
+
+function invoice(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 10,
+        invoiceNumber: 'PON-2026-0005',
+        accountId: 'account-1',
+        transactionId: 30,
+        subtotal: '25.00',
+        taxAmount: '0.00',
+        totalAmount: '25.00',
+        currency: 'eur',
+        status: 'paid',
+        issueDate: date,
+        dueDate: date,
+        paidDate: date,
+        billToName: 'Kupac',
+        billToEmail: 'kupac@example.com',
+        billToAddress: null,
+        billToCity: null,
+        billToState: null,
+        billToZip: null,
+        billToCountry: 'Hrvatska',
+        notes: null,
+        terms: null,
+        createdAt: date,
+        updatedAt: date,
+        isDeleted: false,
+        account: null,
+        transaction: null,
+        invoiceItems: [
+            {
+                id: 1,
+                invoiceId: 10,
+                description: 'Sadnja',
+                quantity: '1.00',
+                unitPrice: '25.00',
+                totalPrice: '25.00',
+                entityId: '42',
+                entityTypeName: 'operation',
+                createdAt: date,
+                updatedAt: date,
+            },
+        ],
+        receipt: receipt(),
+        ...overrides,
+    };
+}
+
+function unauthorizedAuth(): MiddlewareHandler<{ Variables: AuthVariables }> {
+    return async (context) => {
+        return context.json({ error: 'Unauthorized' }, 401);
+    };
+}
+
+function deps(
+    overrides: Partial<AccountBillingRouteDeps> = {},
+): AccountBillingRouteDeps {
+    return {
+        authValidator: () =>
+            createTestAuthMiddleware({ accountId: 'account-1' }),
+        getAccountBillingInvoice: async () => invoice() as never,
+        getAccountBillingInvoices: async () => [invoice()] as never,
+        getAccountBillingReceipt: async () =>
+            receipt({ invoice: invoice({ receipt: null }) }) as never,
+        ...overrides,
+    };
+}
+
+test('account billing routes reject unauthenticated requests before storage reads', async () => {
+    let readCount = 0;
+    const app = createAccountBillingRoutes(
+        deps({
+            authValidator: () => unauthorizedAuth(),
+            getAccountBillingInvoices: async () => {
+                readCount += 1;
+                return [] as never;
+            },
+        }),
+    );
+
+    const response = await app.request('/invoices');
+
+    assert.equal(response.status, 401);
+    assert.equal(readCount, 0);
+});
+
+test('account billing document routes authenticate before validating params', async () => {
+    let readCount = 0;
+    const app = createAccountBillingRoutes(
+        deps({
+            authValidator: () => unauthorizedAuth(),
+            getAccountBillingInvoice: async () => {
+                readCount += 1;
+                return undefined;
+            },
+        }),
+    );
+
+    const response = await app.request('/invoices/not-a-number/document');
+
+    assert.equal(response.status, 401);
+    assert.equal(readCount, 0);
+});
+
+test('account billing list serializes current-account invoice summaries', async () => {
+    const seenAccountIds: string[] = [];
+    const app = createAccountBillingRoutes(
+        deps({
+            getAccountBillingInvoices: async (accountId) => {
+                seenAccountIds.push(accountId);
+                return [invoice()] as never;
+            },
+        }),
+    );
+
+    const response = await app.request('/invoices');
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(seenAccountIds, ['account-1']);
+    assert.equal(body.invoices[0].invoiceNumber, 'PON-2026-0005');
+    assert.equal(
+        body.invoices[0].documentUrl,
+        'http://localhost/api/accounts/current/billing/invoices/10/document',
+    );
+    assert.equal(body.invoices[0].receipt.cisStatus, 'confirmed');
+    assert.equal('cisResponse' in body.invoices[0].receipt, false);
+    assert.equal('cisErrorMessage' in body.invoices[0].receipt, false);
+});
+
+test('account billing detail denies guessed cross-account invoice IDs', async () => {
+    const calls: Array<{ accountId: string; invoiceId: number }> = [];
+    const app = createAccountBillingRoutes(
+        deps({
+            getAccountBillingInvoice: async (accountId, invoiceId) => {
+                calls.push({ accountId, invoiceId });
+                return undefined;
+            },
+        }),
+    );
+
+    const response = await app.request('/invoices/999');
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(calls, [{ accountId: 'account-1', invoiceId: 999 }]);
+});
+
+test('account billing document routes render customer-safe html', async () => {
+    const app = createAccountBillingRoutes(deps());
+
+    const invoiceResponse = await app.request('/invoices/10/document');
+    const invoiceHtml = await invoiceResponse.text();
+    const receiptResponse = await app.request('/receipts/20/document');
+    const receiptHtml = await receiptResponse.text();
+
+    assert.equal(invoiceResponse.status, 200);
+    assert.match(
+        invoiceResponse.headers.get('content-type') ?? '',
+        /text\/html/,
+    );
+    assert.match(invoiceHtml, /PON-2026-0005/);
+    assert.doesNotMatch(invoiceHtml, /\/admin\//);
+    assert.equal(receiptResponse.status, 200);
+    assert.match(receiptHtml, /2026-5/);
+    assert.doesNotMatch(receiptHtml, /secret/);
+    assert.doesNotMatch(receiptHtml, /\/admin\//);
+});

--- a/apps/api/lib/billing/checkoutInvoiceDraft.node.spec.ts
+++ b/apps/api/lib/billing/checkoutInvoiceDraft.node.spec.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    buildCheckoutInvoiceBillingSnapshot,
+    buildCheckoutInvoiceLineItem,
+} from './checkoutInvoiceDraft';
+
+test('buildCheckoutInvoiceLineItem maps paid Stripe item cents safely', () => {
+    const item = buildCheckoutInvoiceLineItem({
+        amountTotalCents: 2500,
+        entityId: '42',
+        entityTypeName: 'operation',
+        outletOfferId: '77',
+        outletSowingDate: '2026-07-05T00:00:00.000Z',
+        productName: 'Sadnja rajčice',
+        quantity: 2,
+    });
+
+    assert.deepEqual(item, {
+        description: 'Sadnja rajčice (Outlet #77, sjetva 2026-07-05)',
+        entityId: '42',
+        entityTypeName: 'operation',
+        quantity: 2,
+        unitPriceCents: 1250,
+        totalPriceCents: 2500,
+    });
+});
+
+test('buildCheckoutInvoiceLineItem returns null for missing Stripe amount', () => {
+    assert.equal(
+        buildCheckoutInvoiceLineItem({
+            amountTotalCents: null,
+            productName: 'Narudžba',
+            quantity: 1,
+        }),
+        null,
+    );
+});
+
+test('buildCheckoutInvoiceBillingSnapshot keeps customer-safe fields only', () => {
+    assert.deepEqual(
+        buildCheckoutInvoiceBillingSnapshot({
+            customerEmail: ' kupac@example.com ',
+            customerName: ' Kupac ',
+        }),
+        {
+            billToCountry: 'Hrvatska',
+            billToEmail: 'kupac@example.com',
+            billToName: 'Kupac',
+            notes: 'Generirano iz plaćene Gredice checkout transakcije.',
+        },
+    );
+});

--- a/apps/api/lib/billing/checkoutInvoiceDraft.ts
+++ b/apps/api/lib/billing/checkoutInvoiceDraft.ts
@@ -1,0 +1,82 @@
+import type {
+    InvoiceForTransactionBillingSnapshot,
+    InvoiceForTransactionLineItem,
+} from '@gredice/storage';
+
+export interface CheckoutInvoiceLineInput {
+    amountTotalCents: number | null | undefined;
+    entityId?: string | null;
+    entityTypeName?: string | null;
+    metadataName?: string | null;
+    outletOfferId?: string | number | null;
+    outletSowingDate?: string | null;
+    productName?: string | null;
+    quantity?: number | null;
+}
+
+export interface CheckoutInvoiceBillingInput {
+    customerEmail?: string | null;
+    customerName?: string | null;
+}
+
+function cleanText(value: string | null | undefined) {
+    const cleaned = value?.trim();
+    return cleaned ? cleaned : undefined;
+}
+
+function safeQuantity(value: number | null | undefined) {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+        ? value
+        : 1;
+}
+
+export function buildCheckoutInvoiceLineItem({
+    amountTotalCents,
+    entityId,
+    entityTypeName,
+    metadataName,
+    outletOfferId,
+    outletSowingDate,
+    productName,
+    quantity,
+}: CheckoutInvoiceLineInput): InvoiceForTransactionLineItem | null {
+    if (
+        !Number.isInteger(amountTotalCents) ||
+        typeof amountTotalCents !== 'number' ||
+        amountTotalCents < 0
+    ) {
+        return null;
+    }
+
+    const quantityValue = safeQuantity(quantity);
+    const outletSuffix = outletOfferId
+        ? ` (Outlet #${outletOfferId}${
+              outletSowingDate
+                  ? `, sjetva ${outletSowingDate.slice(0, 10)}`
+                  : ''
+          })`
+        : '';
+    const baseDescription =
+        cleanText(productName) ?? cleanText(metadataName) ?? 'Plaćena narudžba';
+
+    return {
+        description: `${baseDescription}${outletSuffix}`,
+        quantity: quantityValue,
+        unitPriceCents: Math.round(amountTotalCents / quantityValue),
+        totalPriceCents: amountTotalCents,
+        entityId: cleanText(entityId),
+        entityTypeName: cleanText(entityTypeName),
+    };
+}
+
+export function buildCheckoutInvoiceBillingSnapshot({
+    customerEmail,
+    customerName,
+}: CheckoutInvoiceBillingInput): InvoiceForTransactionBillingSnapshot {
+    return {
+        billToEmail: cleanText(customerEmail),
+        billToName: cleanText(customerName),
+        billToCountry: 'Hrvatska',
+        notes: 'Generirano iz plaćene Gredice checkout transakcije.',
+    };
+}

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+    buildCheckoutInvoiceBillingSnapshot,
+    buildCheckoutInvoiceLineItem,
+} from '../billing/checkoutInvoiceDraft';
+import {
     __testUtils,
     type ProcessCheckoutSessionDependencies,
     processCheckoutSession,
@@ -80,9 +84,18 @@ function makeDependencies(
         },
         createTransaction: async (...args: unknown[]) => {
             record(calls, 'createTransaction', args);
+            return 901;
         },
         earnSunflowersForPayment: async (...args: unknown[]) => {
             record(calls, 'earnSunflowersForPayment', args);
+        },
+        ensureInvoiceForTransaction: async (...args: unknown[]) => {
+            record(calls, 'ensureInvoiceForTransaction', args);
+            return {
+                status: 'created',
+                invoiceId: 601,
+                invoiceNumber: 'PON-2026-0001',
+            };
         },
         getCompletedTransactionByStripePaymentId: async (
             ...args: unknown[]
@@ -179,6 +192,24 @@ function makeDependencies(
         getStripeCheckoutSession: async (...args: unknown[]) => {
             record(calls, 'getStripeCheckoutSession', args);
             return undefined;
+        },
+        isBillingAutomationEnabled: (...args: unknown[]) => {
+            record(calls, 'isBillingAutomationEnabled', args);
+            return false;
+        },
+        buildCheckoutInvoiceBillingSnapshot: (...args: unknown[]) => {
+            record(calls, 'buildCheckoutInvoiceBillingSnapshot', args);
+            return buildCheckoutInvoiceBillingSnapshot(
+                args[0] as Parameters<
+                    typeof buildCheckoutInvoiceBillingSnapshot
+                >[0],
+            );
+        },
+        buildCheckoutInvoiceLineItem: (...args: unknown[]) => {
+            record(calls, 'buildCheckoutInvoiceLineItem', args);
+            return buildCheckoutInvoiceLineItem(
+                args[0] as Parameters<typeof buildCheckoutInvoiceLineItem>[0],
+            );
         },
         getCartInfo: async (...args: unknown[]) => {
             record(calls, 'getCartInfo', args);
@@ -382,6 +413,105 @@ describe('processCheckoutSession', () => {
                     currency: 'eur',
                 },
             ],
+        );
+        assert.equal(
+            callsNamed(calls, 'ensureInvoiceForTransaction').length,
+            0,
+        );
+    });
+
+    it('generates an invoice from mapped Stripe line items when billing automation is enabled', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSession();
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                return makeCart();
+            },
+            getRaisedBedFieldsWithEvents: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBedFieldsWithEvents', args);
+                return [{ id: 88, positionIndex: 2, active: true }];
+            },
+            isBillingAutomationEnabled: (...args: unknown[]) => {
+                record(calls, 'isBillingAutomationEnabled', args);
+                return true;
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.deepStrictEqual(
+            callsNamed(calls, 'ensureInvoiceForTransaction')[0]?.args,
+            [
+                {
+                    transactionId: 901,
+                    billingSnapshot: {
+                        billToCountry: 'Hrvatska',
+                        billToEmail: 'buyer@example.test',
+                        billToName: undefined,
+                        notes: 'Generirano iz plaćene Gredice checkout transakcije.',
+                    },
+                    items: [
+                        {
+                            description: 'Planting',
+                            entityId: '42',
+                            entityTypeName: 'operation',
+                            quantity: 1,
+                            unitPriceCents: 2500,
+                            totalPriceCents: 2500,
+                        },
+                    ],
+                },
+            ],
+        );
+    });
+
+    it('continues checkout side effects when invoice generation fails', async () => {
+        const calls: RecordedCall[] = [];
+        let getShoppingCartCount = 0;
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSession();
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                getShoppingCartCount += 1;
+                return {
+                    ...makeCart(),
+                    status: getShoppingCartCount > 1 ? 'paid' : 'new',
+                };
+            },
+            getRaisedBedFieldsWithEvents: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBedFieldsWithEvents', args);
+                return [{ id: 88, positionIndex: 2, active: true }];
+            },
+            getUser: async (...args: unknown[]) => {
+                record(calls, 'getUser', args);
+                return { userName: 'buyer@example.test' };
+            },
+            isBillingAutomationEnabled: (...args: unknown[]) => {
+                record(calls, 'isBillingAutomationEnabled', args);
+                return true;
+            },
+            ensureInvoiceForTransaction: async (...args: unknown[]) => {
+                record(calls, 'ensureInvoiceForTransaction', args);
+                throw new Error('invoice db unavailable');
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.equal(
+            callsNamed(calls, 'ensureInvoiceForTransaction').length,
+            1,
+        );
+        assert.equal(
+            callsNamed(calls, 'notifyOrderConfirmationEmail').length,
+            1,
         );
     });
 

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -16,6 +16,7 @@ import {
     createOperation,
     createTransaction,
     earnSunflowersForPayment,
+    ensureInvoiceForTransaction,
     getCompletedTransactionByStripePaymentId,
     getDefaultShoppingCartScheduledDate,
     getInventory,
@@ -24,6 +25,7 @@ import {
     getRaisedBedFieldsWithEvents,
     getShoppingCart,
     getUser,
+    type InvoiceForTransactionLineItem,
     isCartItemDeliverable,
     knownEvents,
     markCartPaidIfAllItemsPaid,
@@ -36,6 +38,11 @@ import {
     withStripePaymentProcessingLock,
 } from '@gredice/storage';
 import { getStripeCheckoutSession } from '@gredice/stripe/server';
+import { isBillingAutomationEnabled } from '../billing/automationFlag';
+import {
+    buildCheckoutInvoiceBillingSnapshot,
+    buildCheckoutInvoiceLineItem,
+} from '../billing/checkoutInvoiceDraft';
 import {
     getCartInfo,
     type ShoppingCartItemWithShopData,
@@ -61,6 +68,7 @@ export type ProcessCheckoutSessionDependencies = {
     createOperation: typeof createOperation;
     createTransaction: typeof createTransaction;
     earnSunflowersForPayment: typeof earnSunflowersForPayment;
+    ensureInvoiceForTransaction: typeof ensureInvoiceForTransaction;
     getCompletedTransactionByStripePaymentId: typeof getCompletedTransactionByStripePaymentId;
     getDefaultShoppingCartScheduledDate: typeof getDefaultShoppingCartScheduledDate;
     getInventory: typeof getInventory;
@@ -80,6 +88,9 @@ export type ProcessCheckoutSessionDependencies = {
     upsertRaisedBedField: typeof upsertRaisedBedField;
     withStripePaymentProcessingLock: typeof withStripePaymentProcessingLock;
     getStripeCheckoutSession: typeof getStripeCheckoutSession;
+    isBillingAutomationEnabled: typeof isBillingAutomationEnabled;
+    buildCheckoutInvoiceBillingSnapshot: typeof buildCheckoutInvoiceBillingSnapshot;
+    buildCheckoutInvoiceLineItem: typeof buildCheckoutInvoiceLineItem;
     getCartInfo: typeof getCartInfo;
     calculateSunflowerAmount: typeof calculateSunflowerAmount;
     buildOrderConfirmationItems: typeof buildOrderConfirmationItems;
@@ -101,6 +112,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     createOperation,
     createTransaction,
     earnSunflowersForPayment,
+    ensureInvoiceForTransaction,
     getCompletedTransactionByStripePaymentId,
     getDefaultShoppingCartScheduledDate,
     getInventory,
@@ -120,6 +132,9 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     upsertRaisedBedField,
     withStripePaymentProcessingLock,
     getStripeCheckoutSession,
+    isBillingAutomationEnabled,
+    buildCheckoutInvoiceBillingSnapshot,
+    buildCheckoutInvoiceLineItem,
     getCartInfo,
     calculateSunflowerAmount,
     buildOrderConfirmationItems,
@@ -414,6 +429,7 @@ async function processPaidCheckoutSession(
     const scheduledDeliveryEmailKeys = new Set<string>();
     let accountId: string | undefined;
     let customerUserId: string | undefined;
+    const invoiceLineItems: InvoiceForTransactionLineItem[] = [];
     for (const item of session.lineItems?.data ?? []) {
         console.debug(`Item: ${item.id} Quantity: ${item.quantity}`);
 
@@ -594,6 +610,25 @@ async function processPaidCheckoutSession(
                 },
                 dependencies,
             );
+
+            const invoiceLineItem = dependencies.buildCheckoutInvoiceLineItem({
+                amountTotalCents: item.amount_total,
+                entityId: itemData.entityId,
+                entityTypeName: itemData.entityTypeName,
+                metadataName: product?.metadata?.name ?? null,
+                outletOfferId: itemData.outletOfferId,
+                outletSowingDate: itemData.outletSowingDate,
+                productName:
+                    typeof product?.name === 'string' ? product.name : null,
+                quantity: item.quantity ?? null,
+            });
+            if (invoiceLineItem) {
+                invoiceLineItems.push(invoiceLineItem);
+            } else {
+                console.warn(
+                    `Missing invoice line amount for Stripe line item ${item.id} in session ${checkoutSessionId}.`,
+                );
+            }
         } catch (error) {
             console.error(
                 `Error processing cart item ${itemData.cartItemId} in session ${checkoutSessionId}`,
@@ -661,19 +696,53 @@ async function processPaidCheckoutSession(
         }
     }
 
+    const customer = customerUserId
+        ? await dependencies.getUser(customerUserId)
+        : null;
+
     // Update all affected carts to mark them as paid if all items are paid
-    await Promise.all([
-        ...uniqueAffectedCartIds.map(dependencies.markCartPaidIfAllItemsPaid),
-        accountId && session.amountTotal
-            ? dependencies.createTransaction({
+    await Promise.all(
+        uniqueAffectedCartIds.map(dependencies.markCartPaidIfAllItemsPaid),
+    );
+
+    const transactionId =
+        accountId && typeof session.amountTotal === 'number'
+            ? await dependencies.createTransaction({
                   accountId,
                   amount: session.amountTotal,
                   stripePaymentId: session.id,
                   status: 'completed',
                   currency: 'eur',
               })
-            : undefined,
-    ]);
+            : undefined;
+
+    if (transactionId && dependencies.isBillingAutomationEnabled()) {
+        try {
+            const invoiceResult =
+                await dependencies.ensureInvoiceForTransaction({
+                    transactionId,
+                    billingSnapshot:
+                        dependencies.buildCheckoutInvoiceBillingSnapshot({
+                            customerEmail: customer?.userName,
+                            customerName: customer?.displayName,
+                        }),
+                    items: invoiceLineItems,
+                });
+            if (invoiceResult.status === 'skipped') {
+                console.warn('Checkout invoice generation skipped', {
+                    checkoutSessionId,
+                    reason: invoiceResult.reason,
+                    transactionId,
+                });
+            }
+        } catch (error) {
+            console.error('Checkout invoice generation failed', {
+                checkoutSessionId,
+                error,
+                transactionId,
+            });
+        }
+    }
 
     const completedCartIds: number[] = [];
     for (const cartId of uniqueAffectedCartIds) {
@@ -682,10 +751,6 @@ async function processPaidCheckoutSession(
             completedCartIds.push(completedCart.id);
         }
     }
-
-    const customer = customerUserId
-        ? await dependencies.getUser(customerUserId)
-        : null;
 
     if (completedCartIds.length > 0) {
         await dependencies.notifyOrderConfirmationEmail({

--- a/apps/app/app/admin/transactions/[transactionId]/actions.ts
+++ b/apps/app/app/admin/transactions/[transactionId]/actions.ts
@@ -1,0 +1,73 @@
+'use server';
+
+import { ensureInvoiceForTransaction, getTransaction } from '@gredice/storage';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { auth } from '../../../../lib/auth/auth';
+import { KnownPages } from '../../../../src/KnownPages';
+
+function invoiceGenerationErrorUrl(transactionId: number, message: string) {
+    const searchParams = new URLSearchParams({
+        invoiceGenerationError: message,
+    });
+    return `${KnownPages.Transaction(transactionId)}?${searchParams.toString()}`;
+}
+
+export async function generateInvoiceForTransactionAction(
+    transactionId: number,
+) {
+    await auth(['admin']);
+
+    let redirectTarget: string;
+    try {
+        const transaction = await getTransaction(transactionId);
+        if (!transaction) {
+            redirectTarget = invoiceGenerationErrorUrl(
+                transactionId,
+                'Transakcija nije pronađena.',
+            );
+        } else {
+            const result = await ensureInvoiceForTransaction({
+                transactionId,
+                billingSnapshot: {
+                    notes: 'Ručno generirano iz admin pregleda transakcije.',
+                },
+                items: [
+                    {
+                        description: `Plaćena Gredice checkout transakcija ${transaction.stripePaymentId}`,
+                        quantity: 1,
+                        unitPriceCents: transaction.amount,
+                        totalPriceCents: transaction.amount,
+                    },
+                ],
+            });
+
+            if (result.status === 'skipped') {
+                console.warn('Manual invoice generation skipped', {
+                    reason: result.reason,
+                    transactionId,
+                });
+                redirectTarget = invoiceGenerationErrorUrl(
+                    transactionId,
+                    result.message,
+                );
+            } else {
+                revalidatePath(KnownPages.Transaction(transactionId));
+                revalidatePath(KnownPages.Invoices);
+                revalidatePath(KnownPages.Invoice(result.invoiceId));
+                redirectTarget = KnownPages.Invoice(result.invoiceId);
+            }
+        }
+    } catch (error) {
+        console.error('Manual invoice generation failed', {
+            error,
+            transactionId,
+        });
+        redirectTarget = invoiceGenerationErrorUrl(
+            transactionId,
+            'Generiranje ponude nije uspjelo. Provjerite podatke transakcije i pokušajte ponovno.',
+        );
+    }
+
+    redirect(redirectTarget);
+}

--- a/apps/app/app/admin/transactions/[transactionId]/page.tsx
+++ b/apps/app/app/admin/transactions/[transactionId]/page.tsx
@@ -1,7 +1,10 @@
 import { getTransaction } from '@gredice/storage';
+import { Alert } from '@gredice/ui/Alert';
 import { Breadcrumbs } from '@gredice/ui/Breadcrumbs';
+import { Button } from '@gredice/ui/Button';
 import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
+import { FileText } from '@gredice/ui/icons';
 import { LocalDateTime } from '@gredice/ui/LocalDateTime';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -20,15 +23,19 @@ import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navig
 import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
 import { KnownPages } from '../../../../src/KnownPages';
 import { InvoicesTable } from '../../invoices/InvoicesTable';
+import { generateInvoiceForTransactionAction } from './actions';
 
 export const dynamic = 'force-dynamic';
 
 export default async function TransactionDetailsPage({
     params,
+    searchParams,
 }: {
     params: Promise<{ transactionId: string }>;
+    searchParams?: Promise<{ invoiceGenerationError?: string }>;
 }) {
     const { transactionId } = await params;
+    const resolvedSearchParams = await searchParams;
     const transactionIdNumber = parseInt(transactionId, 10);
     if (Number.isNaN(transactionIdNumber)) {
         return notFound();
@@ -37,7 +44,19 @@ export default async function TransactionDetailsPage({
     if (!transaction) {
         return notFound();
     }
-    const invoiceCount = transaction.invoices?.length || 0;
+    const invoiceCount =
+        transaction.invoices?.filter((invoice) => !invoice.isDeleted).length ??
+        0;
+    const invoiceGenerationError =
+        typeof resolvedSearchParams?.invoiceGenerationError === 'string'
+            ? resolvedSearchParams.invoiceGenerationError
+            : null;
+    const canGenerateInvoice =
+        transaction.status === 'completed' && invoiceCount === 0;
+    const generateInvoiceAction = generateInvoiceForTransactionAction.bind(
+        null,
+        transaction.id,
+    );
     const propertyItems: EntityDetailsPropertyListItem[] = [
         { id: 'id', label: 'ID transakcije', value: transaction.id },
         { id: 'type', label: 'Tip', value: transaction.status },
@@ -96,12 +115,28 @@ export default async function TransactionDetailsPage({
                     }
                     actions={
                         <Row className="items-center" spacing={2}>
+                            {canGenerateInvoice && (
+                                <form action={generateInvoiceAction}>
+                                    <Button
+                                        size="sm"
+                                        type="submit"
+                                        startDecorator={
+                                            <FileText className="size-4" />
+                                        }
+                                    >
+                                        Generiraj ponudu
+                                    </Button>
+                                </form>
+                            )}
                             <EntityDetailsPropertiesToggle />
                         </Row>
                     }
                     heading="Detalji transakcije"
                 />
                 <EntityDetailsPropertiesLayout properties={propertiesPanel}>
+                    {invoiceGenerationError && (
+                        <Alert color="danger">{invoiceGenerationError}</Alert>
+                    )}
                     <Card>
                         <CardHeader>
                             <CardTitle>Ponude</CardTitle>

--- a/apps/garden/app/racun/naplata/BillingPageClient.tsx
+++ b/apps/garden/app/racun/naplata/BillingPageClient.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import { clientAuthenticated } from '@gredice/client';
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import { FileText, Wallet } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import { useQuery } from '@tanstack/react-query';
+
+type BillingReceipt = {
+    id: number;
+    receiptNumber: string;
+    yearReceiptNumber: string;
+    issuedAt: string;
+    totalAmount: string;
+    currency: string;
+    cisStatus: string;
+    documentUrl: string;
+};
+
+type BillingInvoice = {
+    id: number;
+    invoiceNumber: string;
+    status: string;
+    issueDate: string;
+    paidDate: string | null;
+    totalAmount: string;
+    currency: string;
+    receipt: BillingReceipt | null;
+    documentUrl: string;
+};
+
+type BillingResponse = {
+    invoices: BillingInvoice[];
+};
+
+const billingStatusLabels: Record<string, string> = {
+    cancelled: 'Otkazano',
+    draft: 'Nacrt',
+    paid: 'Plaćeno',
+    pending: 'Na čekanju',
+    sent: 'Poslano',
+};
+
+const receiptStatusLabels: Record<string, string> = {
+    confirmed: 'Fiskalizirano',
+    failed: 'Fiskalizacija nije uspjela',
+    pending: 'Čeka fiskalizaciju',
+    sent: 'Poslano u CIS',
+};
+
+function formatDate(value: string | null) {
+    if (!value) {
+        return '-';
+    }
+
+    return new Intl.DateTimeFormat('hr-HR', {
+        dateStyle: 'medium',
+    }).format(new Date(value));
+}
+
+function formatMoney(value: string, currency: string) {
+    const amount = Number.parseFloat(value);
+    if (!Number.isFinite(amount)) {
+        return '-';
+    }
+
+    return new Intl.NumberFormat('hr-HR', {
+        currency: currency.toUpperCase(),
+        style: 'currency',
+    }).format(amount);
+}
+
+function useBillingInvoices() {
+    return useQuery({
+        queryKey: ['accounts', 'current', 'billing', 'invoices'],
+        queryFn: async () => {
+            const response =
+                await clientAuthenticated().api.accounts.current.billing.invoices.$get();
+            if (response.status === 401) {
+                return null;
+            }
+            if (!response.ok) {
+                throw new Error(
+                    `Failed to fetch billing invoices: ${response.status}`,
+                );
+            }
+
+            return (await response.json()) as BillingResponse;
+        },
+        retry: false,
+        staleTime: 1000 * 60 * 5,
+    });
+}
+
+export function BillingPageClient() {
+    const billingQuery = useBillingInvoices();
+    const invoices = billingQuery.data?.invoices ?? [];
+
+    return (
+        <main className="min-h-dvh bg-[#eef4ef] px-4 py-6 text-[#1f2418] sm:px-6">
+            <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="min-w-0">
+                        <div className="mb-1 flex items-center gap-2 text-[#5f6b3d]">
+                            <Wallet className="size-5" />
+                            <Typography level="body2" semiBold>
+                                Moj račun
+                            </Typography>
+                        </div>
+                        <h1 className="text-2xl font-semibold sm:text-3xl">
+                            Računi i plaćanja
+                        </h1>
+                    </div>
+                    <Button href="/" variant="outlined" color="neutral">
+                        Natrag u vrt
+                    </Button>
+                </div>
+
+                {billingQuery.isLoading && (
+                    <Card className="p-5">
+                        <Typography level="body1">Učitavanje...</Typography>
+                    </Card>
+                )}
+
+                {billingQuery.isError && (
+                    <Alert color="danger">
+                        Računi trenutno nisu dostupni. Osvježite stranicu i
+                        pokušajte ponovno.
+                    </Alert>
+                )}
+
+                {!billingQuery.isLoading &&
+                    !billingQuery.isError &&
+                    invoices.length === 0 && (
+                        <Card className="p-5">
+                            <Typography level="body1" semiBold>
+                                Još nema računa za ovaj račun.
+                            </Typography>
+                            <Typography level="body2" secondary>
+                                Ovdje će se prikazati dokumenti nakon dovršene
+                                kupnje.
+                            </Typography>
+                        </Card>
+                    )}
+
+                {invoices.length > 0 && (
+                    <div className="grid gap-3">
+                        {invoices.map((invoice) => (
+                            <Card className="p-5" key={invoice.id}>
+                                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                                    <div className="min-w-0 space-y-2">
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <Typography level="body1" semiBold>
+                                                {invoice.invoiceNumber}
+                                            </Typography>
+                                            <Chip color="success">
+                                                {billingStatusLabels[
+                                                    invoice.status
+                                                ] ?? invoice.status}
+                                            </Chip>
+                                            {invoice.receipt && (
+                                                <Chip color="neutral">
+                                                    {receiptStatusLabels[
+                                                        invoice.receipt
+                                                            .cisStatus
+                                                    ] ??
+                                                        invoice.receipt
+                                                            .cisStatus}
+                                                </Chip>
+                                            )}
+                                        </div>
+                                        <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm sm:grid-cols-4">
+                                            <div>
+                                                <dt className="text-[#6f7666]">
+                                                    Izdano
+                                                </dt>
+                                                <dd>
+                                                    {formatDate(
+                                                        invoice.issueDate,
+                                                    )}
+                                                </dd>
+                                            </div>
+                                            <div>
+                                                <dt className="text-[#6f7666]">
+                                                    Plaćeno
+                                                </dt>
+                                                <dd>
+                                                    {formatDate(
+                                                        invoice.paidDate,
+                                                    )}
+                                                </dd>
+                                            </div>
+                                            <div>
+                                                <dt className="text-[#6f7666]">
+                                                    Iznos
+                                                </dt>
+                                                <dd className="font-semibold">
+                                                    {formatMoney(
+                                                        invoice.totalAmount,
+                                                        invoice.currency,
+                                                    )}
+                                                </dd>
+                                            </div>
+                                            <div>
+                                                <dt className="text-[#6f7666]">
+                                                    Račun
+                                                </dt>
+                                                <dd>
+                                                    {invoice.receipt
+                                                        ?.yearReceiptNumber ??
+                                                        '-'}
+                                                </dd>
+                                            </div>
+                                        </dl>
+                                    </div>
+                                    <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+                                        <Button
+                                            href={invoice.documentUrl}
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            variant="outlined"
+                                            color="neutral"
+                                            startDecorator={
+                                                <FileText className="size-4" />
+                                            }
+                                        >
+                                            Ponuda
+                                        </Button>
+                                        {invoice.receipt ? (
+                                            <Button
+                                                href={
+                                                    invoice.receipt.documentUrl
+                                                }
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                variant="outlined"
+                                                color="neutral"
+                                                startDecorator={
+                                                    <FileText className="size-4" />
+                                                }
+                                            >
+                                                Račun
+                                            </Button>
+                                        ) : (
+                                            <Button
+                                                disabled
+                                                variant="outlined"
+                                                color="neutral"
+                                            >
+                                                Račun
+                                            </Button>
+                                        )}
+                                    </div>
+                                </div>
+                            </Card>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </main>
+    );
+}

--- a/apps/garden/app/racun/naplata/page.tsx
+++ b/apps/garden/app/racun/naplata/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import { BillingPageClient } from './BillingPageClient';
+
+export const metadata: Metadata = {
+    title: 'Računi i plaćanja | Gredice',
+};
+
+export default function BillingPage() {
+    return <BillingPageClient />;
+}

--- a/apps/garden/tests/garden-account-menu-items.spec.tsx
+++ b/apps/garden/tests/garden-account-menu-items.spec.tsx
@@ -10,6 +10,9 @@ test.describe('Garden account menu items', () => {
 
         await expect(page.getByText('Vrtovi za igru')).toBeVisible();
         await expect(page.getByText('Vrt za igru 1')).toBeVisible();
+        await expect(
+            page.getByRole('menuitem', { name: /Računi/ }),
+        ).toHaveAttribute('href', '/racun/naplata');
         await expect(page.getByText('Kreiraj vrt za igru')).toBeVisible();
 
         const sandboxGardenBox = await page

--- a/packages/game/src/hud/GardenAccountMenuItems.tsx
+++ b/packages/game/src/hud/GardenAccountMenuItems.tsx
@@ -1,5 +1,12 @@
 import { IconButton } from '@gredice/ui/IconButton';
-import { Add, Check, Delete, Joystick, MapPinHouse } from '@gredice/ui/icons';
+import {
+    Add,
+    Check,
+    Delete,
+    FileText,
+    Joystick,
+    MapPinHouse,
+} from '@gredice/ui/icons';
 import {
     DropdownMenuItem,
     DropdownMenuLabel,
@@ -216,6 +223,10 @@ export function GardenAccountMenuItems({
                         <span>Pregled tvojih vrtovima</span>
                     </DropdownMenuItem>
                 )}
+                <DropdownMenuItem className="gap-3" href="/racun/naplata">
+                    <FileText className="size-4" />
+                    <span>Računi i plaćanja</span>
+                </DropdownMenuItem>
             </>
         );
     }
@@ -341,6 +352,15 @@ export function GardenAccountMenuItems({
                     ))}
                 </Fragment>
             ))}
+            {normalGardenGroups.length > 0 && (
+                <>
+                    <DropdownMenuSeparator className="my-2" />
+                    <DropdownMenuItem className="gap-3" href="/racun/naplata">
+                        <FileText className="size-4" />
+                        <span>Računi i plaćanja</span>
+                    </DropdownMenuItem>
+                </>
+            )}
             {normalGardenGroups.length > 0 && showSandboxMenu && (
                 <DropdownMenuSeparator className="my-2" />
             )}

--- a/packages/storage/src/repositories/invoicesRepo.ts
+++ b/packages/storage/src/repositories/invoicesRepo.ts
@@ -7,6 +7,7 @@ import {
     invoiceItems,
     invoices,
     receipts,
+    transactions,
     type UpdateInvoice,
     type UpdateInvoiceItem,
     type UpdateReceipt,
@@ -30,6 +31,48 @@ export interface ReceiptCreationData {
     jir?: string;
     zki?: string;
 }
+
+export interface InvoiceForTransactionLineItem {
+    description: string;
+    quantity?: number | string | null;
+    unitPriceCents: number;
+    totalPriceCents: number;
+    entityId?: string | null;
+    entityTypeName?: string | null;
+}
+
+export interface InvoiceForTransactionBillingSnapshot {
+    billToName?: string | null;
+    billToEmail?: string | null;
+    billToAddress?: string | null;
+    billToCity?: string | null;
+    billToState?: string | null;
+    billToZip?: string | null;
+    billToCountry?: string | null;
+    notes?: string | null;
+    terms?: string | null;
+}
+
+export type EnsureInvoiceForTransactionSkippedReason =
+    | 'transaction_not_found'
+    | 'transaction_not_completed'
+    | 'missing_account'
+    | 'missing_billing_email'
+    | 'missing_items'
+    | 'invalid_item_amount'
+    | 'amount_mismatch';
+
+export type EnsureInvoiceForTransactionResult =
+    | {
+          status: 'created' | 'existing';
+          invoiceId: number;
+          invoiceNumber: string;
+      }
+    | {
+          status: 'skipped';
+          reason: EnsureInvoiceForTransactionSkippedReason;
+          message: string;
+      };
 
 // Invoice CRUD operations
 export async function createInvoice(
@@ -136,6 +179,212 @@ export async function getInvoiceByNumber(invoiceNumber: string) {
     });
 }
 
+function cleanInvoiceText(value: string | null | undefined) {
+    const cleaned = value?.trim();
+    return cleaned ? cleaned : undefined;
+}
+
+function centsToDecimalString(cents: number) {
+    return (cents / 100).toFixed(2);
+}
+
+function normalizeInvoiceQuantity(value: number | string | null | undefined) {
+    const quantity = Number(value ?? 1);
+    return Number.isFinite(quantity) && quantity > 0
+        ? quantity.toFixed(2)
+        : '1.00';
+}
+
+function buildSkippedInvoiceResult(
+    reason: EnsureInvoiceForTransactionSkippedReason,
+    message: string,
+): EnsureInvoiceForTransactionResult {
+    return {
+        status: 'skipped',
+        reason,
+        message,
+    };
+}
+
+async function withInvoiceTransactionGenerationLock<T>(
+    transactionId: number,
+    callback: () => Promise<T>,
+) {
+    if (process.env.GREDICE_TEST_DB_PROVIDER === 'pglite') {
+        return callback();
+    }
+
+    return storage().transaction(async (tx) => {
+        await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtext(${`invoice-transaction:${transactionId}`}));`,
+        );
+
+        return callback();
+    });
+}
+
+export async function ensureInvoiceForTransaction({
+    billingSnapshot,
+    items,
+    transactionId,
+}: {
+    billingSnapshot?: InvoiceForTransactionBillingSnapshot;
+    items: InvoiceForTransactionLineItem[];
+    transactionId: number;
+}): Promise<EnsureInvoiceForTransactionResult> {
+    return withInvoiceTransactionGenerationLock(transactionId, async () => {
+        const existingInvoices = await getAllInvoices({ transactionId });
+        if (existingInvoices.length > 0) {
+            if (existingInvoices.length > 1) {
+                console.warn(
+                    'Multiple active invoices found for transaction during invoice generation',
+                    {
+                        invoiceIds: existingInvoices.map(
+                            (invoice) => invoice.id,
+                        ),
+                        transactionId,
+                    },
+                );
+            }
+
+            const existingInvoice = existingInvoices[0];
+            return {
+                status: 'existing',
+                invoiceId: existingInvoice.id,
+                invoiceNumber: existingInvoice.invoiceNumber,
+            };
+        }
+
+        const transaction = await storage().query.transactions.findFirst({
+            where: and(
+                eq(transactions.id, transactionId),
+                eq(transactions.isDeleted, false),
+            ),
+            with: {
+                account: {
+                    with: {
+                        accountUsers: {
+                            with: {
+                                user: true,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        if (!transaction) {
+            return buildSkippedInvoiceResult(
+                'transaction_not_found',
+                `Transaction ${transactionId} was not found.`,
+            );
+        }
+        if (transaction.status !== 'completed') {
+            return buildSkippedInvoiceResult(
+                'transaction_not_completed',
+                `Transaction ${transactionId} is not completed.`,
+            );
+        }
+        if (!transaction.accountId) {
+            return buildSkippedInvoiceResult(
+                'missing_account',
+                `Transaction ${transactionId} has no account.`,
+            );
+        }
+        if (items.length === 0) {
+            return buildSkippedInvoiceResult(
+                'missing_items',
+                `Transaction ${transactionId} has no invoice line items.`,
+            );
+        }
+
+        const invalidItem = items.find(
+            (item) =>
+                !Number.isInteger(item.unitPriceCents) ||
+                !Number.isInteger(item.totalPriceCents) ||
+                item.unitPriceCents < 0 ||
+                item.totalPriceCents < 0,
+        );
+        if (invalidItem) {
+            return buildSkippedInvoiceResult(
+                'invalid_item_amount',
+                `Transaction ${transactionId} has an invalid invoice line amount.`,
+            );
+        }
+
+        const itemTotalCents = items.reduce(
+            (sum, item) => sum + item.totalPriceCents,
+            0,
+        );
+        if (itemTotalCents !== transaction.amount) {
+            return buildSkippedInvoiceResult(
+                'amount_mismatch',
+                `Transaction ${transactionId} amount ${transaction.amount} does not match invoice item total ${itemTotalCents}.`,
+            );
+        }
+
+        const billToEmail =
+            cleanInvoiceText(billingSnapshot?.billToEmail) ??
+            cleanInvoiceText(
+                transaction.account?.accountUsers[0]?.user.userName,
+            );
+        if (!billToEmail) {
+            return buildSkippedInvoiceResult(
+                'missing_billing_email',
+                `Transaction ${transactionId} has no billing email snapshot.`,
+            );
+        }
+
+        const issueDate = transaction.createdAt;
+        const totalAmount = centsToDecimalString(transaction.amount);
+        const invoiceId = await createInvoice(
+            {
+                accountId: transaction.accountId,
+                transactionId,
+                subtotal: totalAmount,
+                taxAmount: '0.00',
+                totalAmount,
+                currency: transaction.currency.toLowerCase(),
+                status: 'paid',
+                issueDate,
+                dueDate: issueDate,
+                paidDate: issueDate,
+                billToName: cleanInvoiceText(billingSnapshot?.billToName),
+                billToEmail,
+                billToAddress: cleanInvoiceText(billingSnapshot?.billToAddress),
+                billToCity: cleanInvoiceText(billingSnapshot?.billToCity),
+                billToState: cleanInvoiceText(billingSnapshot?.billToState),
+                billToZip: cleanInvoiceText(billingSnapshot?.billToZip),
+                billToCountry:
+                    cleanInvoiceText(billingSnapshot?.billToCountry) ??
+                    'Hrvatska',
+                notes: cleanInvoiceText(billingSnapshot?.notes),
+                terms: cleanInvoiceText(billingSnapshot?.terms),
+            },
+            items.map((item) => ({
+                description:
+                    cleanInvoiceText(item.description) ?? 'Plaćena narudžba',
+                quantity: normalizeInvoiceQuantity(item.quantity),
+                unitPrice: centsToDecimalString(item.unitPriceCents),
+                totalPrice: centsToDecimalString(item.totalPriceCents),
+                entityId: cleanInvoiceText(item.entityId),
+                entityTypeName: cleanInvoiceText(item.entityTypeName),
+            })),
+        );
+        const invoice = await getInvoice(invoiceId);
+        if (!invoice) {
+            throw new Error(
+                `Failed to read created invoice ${invoiceId} for transaction ${transactionId}`,
+            );
+        }
+
+        return {
+            status: 'created',
+            invoiceId,
+            invoiceNumber: invoice.invoiceNumber,
+        };
+    });
+}
+
 export async function getInvoices(accountId: string) {
     return storage().query.invoices.findMany({
         where: and(
@@ -165,6 +414,44 @@ export async function getAllInvoices(filters?: { transactionId?: number }) {
         },
         orderBy: desc(invoices.issueDate),
     });
+}
+
+export async function getAccountBillingInvoices(accountId: string) {
+    const accountInvoices = await getInvoices(accountId);
+
+    return Promise.all(
+        accountInvoices.map(async (invoice) => ({
+            ...invoice,
+            receipt: await getReceiptByInvoice(invoice.id),
+        })),
+    );
+}
+
+export async function getAccountBillingInvoice(
+    accountId: string,
+    invoiceId: number,
+) {
+    const invoice = await getInvoice(invoiceId);
+    if (!invoice || invoice.accountId !== accountId) {
+        return undefined;
+    }
+
+    return {
+        ...invoice,
+        receipt: await getReceiptByInvoice(invoice.id),
+    };
+}
+
+export async function getAccountBillingReceipt(
+    accountId: string,
+    receiptId: number,
+) {
+    const receipt = await getReceipt(receiptId);
+    if (!receipt || receipt.invoice?.accountId !== accountId) {
+        return undefined;
+    }
+
+    return receipt;
 }
 
 export async function getInvoicesByStatus(status: string, accountId?: string) {

--- a/packages/storage/tests/invoicesRepo.node.spec.ts
+++ b/packages/storage/tests/invoicesRepo.node.spec.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
     addInvoiceItem,
@@ -9,8 +10,13 @@ import {
     canEditInvoice,
     changeInvoiceStatus,
     createInvoice,
+    createReceiptFromInvoice,
     createTransaction,
     deleteInvoice,
+    ensureInvoiceForTransaction,
+    getAccountBillingInvoice,
+    getAccountBillingInvoices,
+    getAccountBillingReceipt,
     getAllInvoices,
     getInvoice,
     getInvoiceByNumber,
@@ -198,6 +204,247 @@ test('getInvoicesByTransaction', async () => {
     assert.ok(Array.isArray(invoices));
     assert.strictEqual(invoices.length, 1);
     assert.strictEqual(invoices[0].id, invoiceId);
+});
+
+test('ensureInvoiceForTransaction creates a paid invoice from trusted transaction data', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const transactionId = await createTransaction({
+        accountId,
+        amount: 2500,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId: randomUUID(),
+    });
+
+    const result = await ensureInvoiceForTransaction({
+        transactionId,
+        billingSnapshot: {
+            billToEmail: 'kupac@example.com',
+            billToName: 'Kupac Gredice',
+        },
+        items: [
+            {
+                description: 'Sadnja u vrtu',
+                quantity: 2,
+                unitPriceCents: 1250,
+                totalPriceCents: 2500,
+                entityId: '42',
+                entityTypeName: 'operation',
+            },
+        ],
+    });
+
+    assert.equal(result.status, 'created');
+    assert.ok('invoiceId' in result);
+    const invoice = await getInvoice(result.invoiceId);
+    assert.ok(invoice);
+    assert.equal(invoice.accountId, accountId);
+    assert.equal(invoice.transactionId, transactionId);
+    assert.equal(invoice.status, 'paid');
+    assert.equal(invoice.totalAmount, '25.00');
+    assert.equal(invoice.billToEmail, 'kupac@example.com');
+    assert.equal(invoice.invoiceItems.length, 1);
+    assert.equal(invoice.invoiceItems[0]?.description, 'Sadnja u vrtu');
+    assert.equal(Number(invoice.invoiceItems[0]?.quantity), 2);
+});
+
+test('ensureInvoiceForTransaction returns existing invoice on repeated calls', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const transactionId = await createTransaction({
+        accountId,
+        amount: 1500,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId: randomUUID(),
+    });
+    const input = {
+        transactionId,
+        billingSnapshot: {
+            billToEmail: 'kupac@example.com',
+        },
+        items: [
+            {
+                description: 'Narudžba',
+                unitPriceCents: 1500,
+                totalPriceCents: 1500,
+            },
+        ],
+    };
+
+    const first = await ensureInvoiceForTransaction(input);
+    const second = await ensureInvoiceForTransaction(input);
+
+    assert.equal(first.status, 'created');
+    assert.equal(second.status, 'existing');
+    assert.ok('invoiceId' in first);
+    assert.ok('invoiceId' in second);
+    assert.equal(second.invoiceId, first.invoiceId);
+    assert.equal((await getAllInvoices({ transactionId })).length, 1);
+});
+
+test('ensureInvoiceForTransaction ignores deleted invoice and creates a new active invoice', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const transactionId = await createTransaction({
+        accountId,
+        amount: 900,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId: randomUUID(),
+    });
+    const input = {
+        transactionId,
+        billingSnapshot: {
+            billToEmail: 'kupac@example.com',
+        },
+        items: [
+            {
+                description: 'Narudžba',
+                unitPriceCents: 900,
+                totalPriceCents: 900,
+            },
+        ],
+    };
+
+    const first = await ensureInvoiceForTransaction(input);
+    assert.ok('invoiceId' in first);
+    await deleteInvoice(first.invoiceId);
+
+    const second = await ensureInvoiceForTransaction(input);
+
+    assert.equal(second.status, 'created');
+    assert.ok('invoiceId' in second);
+    assert.notEqual(second.invoiceId, first.invoiceId);
+    const activeInvoices = await getAllInvoices({ transactionId });
+    assert.equal(activeInvoices.length, 1);
+    assert.equal(activeInvoices[0]?.id, second.invoiceId);
+});
+
+test('ensureInvoiceForTransaction skips missing and inconsistent source data', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const pendingTransactionId = await createTransaction({
+        accountId,
+        amount: 900,
+        currency: 'eur',
+        status: 'pending',
+        stripePaymentId: randomUUID(),
+    });
+    const completedTransactionId = await createTransaction({
+        accountId,
+        amount: 900,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId: randomUUID(),
+    });
+
+    assert.deepEqual(
+        await ensureInvoiceForTransaction({
+            transactionId: pendingTransactionId,
+            billingSnapshot: { billToEmail: 'kupac@example.com' },
+            items: [
+                {
+                    description: 'Narudžba',
+                    unitPriceCents: 900,
+                    totalPriceCents: 900,
+                },
+            ],
+        }),
+        {
+            status: 'skipped',
+            reason: 'transaction_not_completed',
+            message: `Transaction ${pendingTransactionId} is not completed.`,
+        },
+    );
+    const missingItems = await ensureInvoiceForTransaction({
+        transactionId: completedTransactionId,
+        billingSnapshot: { billToEmail: 'kupac@example.com' },
+        items: [],
+    });
+    const amountMismatch = await ensureInvoiceForTransaction({
+        transactionId: completedTransactionId,
+        billingSnapshot: { billToEmail: 'kupac@example.com' },
+        items: [
+            {
+                description: 'Narudžba',
+                unitPriceCents: 800,
+                totalPriceCents: 800,
+            },
+        ],
+    });
+
+    assert.equal(missingItems.status, 'skipped');
+    assert.equal(missingItems.reason, 'missing_items');
+    assert.equal(amountMismatch.status, 'skipped');
+    assert.equal(amountMismatch.reason, 'amount_mismatch');
+});
+
+test('account billing reads enforce invoice and receipt ownership', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const otherAccountId = await createTestAccount();
+    const transactionId = await createTransaction({
+        accountId,
+        amount: 2500,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId: randomUUID(),
+    });
+    const otherTransactionId = await createTransaction({
+        accountId: otherAccountId,
+        amount: 1100,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId: randomUUID(),
+    });
+
+    const invoiceResult = await ensureInvoiceForTransaction({
+        transactionId,
+        billingSnapshot: { billToEmail: 'kupac@example.com' },
+        items: [
+            {
+                description: 'Narudžba',
+                unitPriceCents: 2500,
+                totalPriceCents: 2500,
+            },
+        ],
+    });
+    const otherInvoiceResult = await ensureInvoiceForTransaction({
+        transactionId: otherTransactionId,
+        billingSnapshot: { billToEmail: 'drugi@example.com' },
+        items: [
+            {
+                description: 'Druga narudžba',
+                unitPriceCents: 1100,
+                totalPriceCents: 1100,
+            },
+        ],
+    });
+    assert.ok('invoiceId' in invoiceResult);
+    assert.ok('invoiceId' in otherInvoiceResult);
+    const receiptId = await createReceiptFromInvoice(invoiceResult.invoiceId, {
+        paymentMethod: 'card',
+        paymentReference: 'cs_test',
+    });
+
+    const accountInvoices = await getAccountBillingInvoices(accountId);
+    assert.equal(accountInvoices.length, 1);
+    assert.equal(accountInvoices[0]?.id, invoiceResult.invoiceId);
+    assert.equal(accountInvoices[0]?.receipt?.id, receiptId);
+    assert.ok(
+        await getAccountBillingInvoice(accountId, invoiceResult.invoiceId),
+    );
+    assert.equal(
+        await getAccountBillingInvoice(accountId, otherInvoiceResult.invoiceId),
+        undefined,
+    );
+    assert.ok(await getAccountBillingReceipt(accountId, receiptId));
+    assert.equal(
+        await getAccountBillingReceipt(otherAccountId, receiptId),
+        undefined,
+    );
 });
 
 test('getInvoicesByStatus', async () => {


### PR DESCRIPTION
## Summary

Implements the #4036 billing phase: trusted transaction-to-invoice creation, current-account billing access, admin manual generation, and garden billing navigation.

- Adds idempotent invoice creation from completed transactions using server-trusted transaction amounts and validated line items.
- Wires Stripe checkout sessions to build invoice draft line items and create invoices only when `GREDICE_BILLING_AUTOMATION_ENABLED` is enabled.
- Adds current-account billing API routes for invoice lists, invoice detail, and customer-safe invoice/receipt document HTML.
- Adds an admin transaction action to manually generate an invoice for completed transactions while automation remains guarded.
- Adds the garden `/racun/naplata` page and account-menu entry for customer invoice/receipt access.

Closes #4036.
Closes #4004.
Closes #4008.
Closes #4009.
Closes #4010.
Closes #4006.
Closes #4014.
Closes #4015.
Closes #4016.

## Validation

- `pnpm --filter storage test:node invoicesRepo.node.spec.ts`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter app test:unit`
- `pnpm --filter api test:node`
- `pnpm --filter api build`
- `pnpm --filter app build`
- `pnpm --filter garden build`
- `pnpm --filter garden test:run tests/garden-account-menu-items.spec.tsx`
- `pnpm --filter api exec biome check app/api/'[...route]'/accountBillingRoutes.ts app/api/'[...route]'/accountsRoutes.ts lib/billing/checkoutInvoiceDraft.ts lib/billing/checkoutInvoiceDraft.node.spec.ts lib/billing/accountBillingRoutes.node.spec.ts lib/stripe/processCheckoutSession.ts lib/stripe/processCheckoutSession.node.spec.ts`
- `pnpm --filter app exec biome check app/admin/transactions/'[transactionId]'/actions.ts app/admin/transactions/'[transactionId]'/page.tsx`
- `pnpm --filter garden exec biome check app/racun/naplata tests/garden-account-menu-items.spec.tsx`
- `pnpm --filter @gredice/game exec biome check src/hud/GardenAccountMenuItems.tsx`
- `pnpm --filter storage exec biome check src/repositories/invoicesRepo.ts tests/invoicesRepo.node.spec.ts`
- `git diff --check`

Notes: `pnpm --filter app typecheck` and `pnpm --filter api typecheck` are not package scripts. The focused garden Playwright spec requires a prior production build; rerun passed after `pnpm --filter garden build`.