### PR TITLE
feat(api): scale sunflower drop chance by sunflower count

### DIFF
--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -57,6 +57,7 @@ import {
 } from '../../../lib/auth/sessionConfig';
 import { authSecurity } from '../../../lib/docs/security';
 import { sendAccountInvitation } from '../../../lib/email/transactional';
+import { getSunflowerDropSpawnChance } from '../../../lib/garden/sunflowerDropChance';
 import { isSunflowerDropWeatherEligible } from '../../../lib/garden/sunflowerDropWeather';
 import {
     type AuthVariables,
@@ -69,7 +70,6 @@ import { findClosestForecastEntry } from '../../../lib/weather/weatherNowContrac
 
 const dailyRewards = [5, 10, 15, 20, 25, 50];
 const DAILY_REWARD_TIME_ZONE = 'Europe/Zagreb';
-const SUNFLOWER_DROP_SPAWN_CHANCE = 0.35;
 const GARDEN_APP_URL =
     process.env.GREDICE_GARDEN_APP_URL ?? 'https://vrt.gredice.com';
 
@@ -635,7 +635,9 @@ const app = new Hono<{ Variables: AuthVariables }>()
 
             const result = await getOrCreateSunflowerDropSpawn({
                 accountId,
-                allowCreate: Math.random() < SUNFLOWER_DROP_SPAWN_CHANCE,
+                allowCreate:
+                    Math.random() <
+                    getSunflowerDropSpawnChance(sunflowerBlocks.length),
                 gardenId,
                 now,
                 sourceBlockId: sourceBlock.id,

--- a/apps/api/lib/garden/sunflowerDropChance.node.spec.ts
+++ b/apps/api/lib/garden/sunflowerDropChance.node.spec.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    getSunflowerDropSpawnChance,
+    SUNFLOWER_DROP_BASE_SPAWN_CHANCE,
+} from './sunflowerDropChance';
+
+function assertNearlyEqual(actual: number, expected: number) {
+    assert.ok(
+        Math.abs(actual - expected) < Number.EPSILON,
+        `Expected ${actual} to equal ${expected}`,
+    );
+}
+
+describe('sunflower drop spawn chance', () => {
+    it('keeps the existing chance for one sunflower', () => {
+        assertNearlyEqual(
+            getSunflowerDropSpawnChance(1),
+            SUNFLOWER_DROP_BASE_SPAWN_CHANCE,
+        );
+    });
+
+    it('increases chance with each additional sunflower', () => {
+        assertNearlyEqual(
+            getSunflowerDropSpawnChance(2),
+            1 - (1 - SUNFLOWER_DROP_BASE_SPAWN_CHANCE) ** 2,
+        );
+        assertNearlyEqual(
+            getSunflowerDropSpawnChance(3),
+            1 - (1 - SUNFLOWER_DROP_BASE_SPAWN_CHANCE) ** 3,
+        );
+        assert.ok(
+            getSunflowerDropSpawnChance(3) > getSunflowerDropSpawnChance(2),
+        );
+        assert.ok(
+            getSunflowerDropSpawnChance(2) > getSunflowerDropSpawnChance(1),
+        );
+    });
+
+    it('does not create a chance without sunflowers', () => {
+        assert.equal(getSunflowerDropSpawnChance(0), 0);
+        assert.equal(getSunflowerDropSpawnChance(-1), 0);
+    });
+
+    it('never exceeds certainty', () => {
+        assert.equal(getSunflowerDropSpawnChance(1_000), 1);
+    });
+});

--- a/apps/api/lib/garden/sunflowerDropChance.ts
+++ b/apps/api/lib/garden/sunflowerDropChance.ts
@@ -1,0 +1,13 @@
+export const SUNFLOWER_DROP_BASE_SPAWN_CHANCE = 0.1;
+
+export function getSunflowerDropSpawnChance(sunflowerCount: number) {
+    const eligibleSunflowerCount = Math.max(0, Math.floor(sunflowerCount));
+    if (eligibleSunflowerCount === 0) {
+        return 0;
+    }
+
+    return Math.min(
+        1,
+        1 - (1 - SUNFLOWER_DROP_BASE_SPAWN_CHANCE) ** eligibleSunflowerCount,
+    );
+}


### PR DESCRIPTION
## Summary
- Scale sunflower drop spawn chance by the number of sunflower blocks in the garden.
- Lower the per-sunflower base chance to 10% while preserving the existing weather and daily-limit gates.
- Add focused coverage for the spawn chance helper.

## Validation
- corepack pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/garden/sunflowerDropChance.node.spec.ts ./lib/garden/sunflowerDropWeather.node.spec.ts
- corepack pnpm --filter api lint
- git diff --check