### PR TITLE
feat(game): add block geometry merging feature flag

### DIFF
--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -24,6 +24,13 @@ export const rainWetOverlayFlag = flag<boolean>({
     options: booleanFlagOptions,
 });
 
+export const blockGeometryMergingFlag = flag<boolean>({
+    key: 'blockGeometryMerging',
+    description: 'Enable merged geometry chunks for stable terrain blocks.',
+    decide: () => false,
+    options: booleanFlagOptions,
+});
+
 export const enableDebugCloseupFlag = flag<boolean>({
     key: 'enableDebugCloseup',
     decide: () => false,

--- a/apps/garden/app/flags.ts
+++ b/apps/garden/app/flags.ts
@@ -27,7 +27,7 @@ export const rainWetOverlayFlag = flag<boolean>({
 export const blockGeometryMergingFlag = flag<boolean>({
     key: 'blockGeometryMerging',
     description: 'Enable merged geometry chunks for stable terrain blocks.',
-    decide: () => false,
+    decide: () => true,
     options: booleanFlagOptions,
 });
 

--- a/apps/garden/app/page.tsx
+++ b/apps/garden/app/page.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from 'react';
 import LoginModal from '../components/auth/LoginModal';
 import { GameSceneWithAnalytics } from '../components/game/GameSceneWithAnalytics';
 import {
+    blockGeometryMergingFlag,
     enableDebugHudFlag,
     enableSuncokretChatFlag,
     enableSuncokretDebugFlag,
@@ -17,6 +18,7 @@ export default async function Home() {
     const suppressOpeningHud =
         cookieStore.get(impersonationFlagCookieName)?.value === '1';
     const flags: ComponentProps<typeof GameSceneWithAnalytics>['flags'] = {
+        enableBlockGeometryMergingFlag: await blockGeometryMergingFlag(),
         enableDebugHudFlag: await enableDebugHudFlag(),
         enableRainWetOverlayFlag: await rainWetOverlayFlag(),
         enableSuncokretChatFlag: await enableSuncokretChatFlag(),

--- a/apps/www/app/flags.ts
+++ b/apps/www/app/flags.ts
@@ -12,6 +12,13 @@ export const lSystemPlantsFlag = flag<boolean>({
     options: booleanFlagOptions,
 });
 
+export const blockGeometryMergingFlag = flag<boolean>({
+    key: 'blockGeometryMerging',
+    description: 'Enable merged geometry chunks for stable terrain blocks.',
+    decide: () => false,
+    options: booleanFlagOptions,
+});
+
 export const recipesFlag = flag<boolean>({
     key: 'recipes',
     description: 'Enable recipes pages and recipe detail routes.',

--- a/apps/www/app/flags.ts
+++ b/apps/www/app/flags.ts
@@ -15,7 +15,7 @@ export const lSystemPlantsFlag = flag<boolean>({
 export const blockGeometryMergingFlag = flag<boolean>({
     key: 'blockGeometryMerging',
     description: 'Enable merged geometry chunks for stable terrain blocks.',
-    decide: () => false,
+    decide: () => true,
     options: booleanFlagOptions,
 });
 

--- a/apps/www/app/korisnici/[publicId]/ProfilePageClient.tsx
+++ b/apps/www/app/korisnici/[publicId]/ProfilePageClient.tsx
@@ -8,10 +8,14 @@ import { useState } from 'react';
 import { PublicGardenViewerDynamic } from './PublicGardenViewerDynamic';
 
 type ProfilePageClientProps = {
+    enableBlockGeometryMerging?: boolean;
     publicId: string;
 };
 
-export function ProfilePageClient({ publicId }: ProfilePageClientProps) {
+export function ProfilePageClient({
+    enableBlockGeometryMerging = false,
+    publicId,
+}: ProfilePageClientProps) {
     const profileQuery = useQuery({
         queryKey: ['public-profile', publicId],
         queryFn: async () => {
@@ -138,6 +142,9 @@ export function ProfilePageClient({ publicId }: ProfilePageClientProps) {
                     ) : (
                         <PublicGardenViewerDynamic
                             className="h-full"
+                            enableBlockGeometryMerging={
+                                enableBlockGeometryMerging
+                            }
                             garden={gardenQuery.data}
                         />
                     )}

--- a/apps/www/app/korisnici/[publicId]/page.tsx
+++ b/apps/www/app/korisnici/[publicId]/page.tsx
@@ -1,3 +1,4 @@
+import { blockGeometryMergingFlag } from '../../flags';
 import { ProfilePageClient } from './ProfilePageClient';
 
 type ProfilePageProps = {
@@ -7,7 +8,15 @@ type ProfilePageProps = {
 };
 
 export default async function ProfilePage({ params }: ProfilePageProps) {
-    const { publicId } = await params;
+    const [{ publicId }, enableBlockGeometryMerging] = await Promise.all([
+        params,
+        blockGeometryMergingFlag(),
+    ]);
 
-    return <ProfilePageClient publicId={publicId} />;
+    return (
+        <ProfilePageClient
+            enableBlockGeometryMerging={enableBlockGeometryMerging}
+            publicId={publicId}
+        />
+    );
 }

--- a/apps/www/app/vrtovi/PublicGardenExplorer.tsx
+++ b/apps/www/app/vrtovi/PublicGardenExplorer.tsx
@@ -9,11 +9,13 @@ import { PublicGardenViewerDynamic } from './PublicGardenViewerDynamic';
 
 export function PublicGardenExplorer({
     className,
+    enableBlockGeometryMerging = false,
     framed = true,
     garden,
     size = 'default',
 }: {
     className?: string;
+    enableBlockGeometryMerging?: boolean;
     framed?: boolean;
     garden: PublicGardenViewerProps['garden'];
     size?: 'card' | 'default';
@@ -90,6 +92,7 @@ export function PublicGardenExplorer({
                 <PublicGardenViewerDynamic
                     className="size-full"
                     deferDetails={false}
+                    enableBlockGeometryMerging={enableBlockGeometryMerging}
                     garden={garden}
                 />
                 {supportsFullscreen ? (

--- a/apps/www/app/vrtovi/[gardenId]/page.tsx
+++ b/apps/www/app/vrtovi/[gardenId]/page.tsx
@@ -6,6 +6,7 @@ import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { KnownPages } from '../../../src/KnownPages';
+import { blockGeometryMergingFlag } from '../../flags';
 import { PublicGardenExplorer } from '../PublicGardenExplorer';
 import { PublicGardenLikeButton } from '../PublicGardenLikeButton';
 import { PublicGardenStatsAccordion } from '../PublicGardenStatsAccordion';
@@ -89,9 +90,10 @@ export default async function PublicGardenPage({
         notFound();
     }
 
-    const [garden, blockData] = await Promise.all([
+    const [garden, blockData, enableBlockGeometryMerging] = await Promise.all([
         getPublicGardenForWww(gardenId),
         getPublicGardenBlockDataForWww(),
+        blockGeometryMergingFlag(),
     ]);
     const activePlantCount = countActivePlantsFromPublicGarden(garden);
     const gardenStats = calculatePublicGardenStats(garden, blockData);
@@ -114,6 +116,7 @@ export default async function PublicGardenPage({
                 }}
             >
                 <PublicGardenExplorer
+                    enableBlockGeometryMerging={enableBlockGeometryMerging}
                     framed={false}
                     garden={garden}
                     size="card"

--- a/packages/game/src/GameFlagsContext.tsx
+++ b/packages/game/src/GameFlagsContext.tsx
@@ -10,6 +10,7 @@ export interface GameFeatureFlags {
     enableRaisedBedFieldOperationsFlag?: boolean;
     enableRaisedBedFieldWateringFlag?: boolean;
     enableRaisedBedFieldDiaryFlag?: boolean;
+    enableBlockGeometryMergingFlag?: boolean;
     enableRainWetOverlayFlag?: boolean;
     enableSuncokretChatFlag?: boolean;
     enableSuncokretDebugFlag?: boolean;

--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -381,6 +381,9 @@ export function GameScene({
                                     </Suspense>
                                 )}
                                 <EntityInstances
+                                    enableBlockGeometryMerging={Boolean(
+                                        flags?.enableBlockGeometryMergingFlag,
+                                    )}
                                     farmId={garden?.farmId}
                                     quality={qualityProfile}
                                     renderGroundDecorations={

--- a/packages/game/src/entities/AdditionalEntityInstances.tsx
+++ b/packages/game/src/entities/AdditionalEntityInstances.tsx
@@ -80,6 +80,9 @@ type CommonWeatherProps = Pick<
     EntityInstancesBlockBaseProps,
     'renderSnow' | 'snowOverlayMinCoverage'
 >;
+type BlockGeometryMergingProps = {
+    enableBlockGeometryMerging?: boolean;
+};
 
 type ScaleTuple = [number, number, number];
 type ScaleInput = number | ScaleTuple | { x: number; y: number; z: number };
@@ -372,9 +375,11 @@ function InstancedWaterSurfaceMaterial() {
 }
 
 function BlockGroundInstances({
+    enableBlockGeometryMerging = false,
     stacks,
     ...commonSnowProps
-}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+}: { stacks: Stack[] | undefined } & CommonWeatherProps &
+    BlockGeometryMergingProps) {
     const { nodes } = useGameGLTF('BlockGround');
     const groundMaterial11 = useGroundPatchMaterial(
         nodes.Block_Ground_1.material,
@@ -408,7 +413,7 @@ function BlockGroundInstances({
                     slopeExponent: 3.2,
                     noiseScale: 1.7,
                 }}
-                renderStableChunksAsMergedGeometry
+                renderStableChunksAsMergedGeometry={enableBlockGeometryMerging}
                 {...commonSnowProps}
             />
             <EntityInstancesGeometry
@@ -421,7 +426,7 @@ function BlockGroundInstances({
                     slopeExponent: 3.2,
                     noiseScale: 1.7,
                 }}
-                renderStableChunksAsMergedGeometry
+                renderStableChunksAsMergedGeometry={enableBlockGeometryMerging}
                 {...commonSnowProps}
             />
         </>
@@ -2384,9 +2389,11 @@ const birdHouseRoofNodes = [
 ] satisfies (keyof GLTFResult['nodes'])[];
 
 function SimpleAdditionalInstances({
+    enableBlockGeometryMerging = false,
     stacks,
     ...commonSnowProps
-}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+}: { stacks: Stack[] | undefined } & CommonWeatherProps &
+    BlockGeometryMergingProps) {
     const snowmanMaterial = useMemo(
         () =>
             new MeshStandardMaterial({
@@ -2412,7 +2419,7 @@ function SimpleAdditionalInstances({
                     slopeExponent: 2.2,
                     noiseScale: 1.8,
                 }}
-                renderStableChunksAsMergedGeometry
+                renderStableChunksAsMergedGeometry={enableBlockGeometryMerging}
                 {...commonSnowProps}
             />
             <AssetBlock
@@ -2428,7 +2435,7 @@ function SimpleAdditionalInstances({
                     slopeExponent: 2.2,
                     noiseScale: 1.8,
                 }}
-                renderStableChunksAsMergedGeometry
+                renderStableChunksAsMergedGeometry={enableBlockGeometryMerging}
                 {...commonSnowProps}
             />
             <AssetBlock
@@ -2448,7 +2455,7 @@ function SimpleAdditionalInstances({
                     slopeExponent: 2.2,
                     noiseScale: 1.8,
                 }}
-                renderStableChunksAsMergedGeometry
+                renderStableChunksAsMergedGeometry={enableBlockGeometryMerging}
                 {...commonSnowProps}
             />
             <AssetBlock
@@ -2507,13 +2514,23 @@ function SimpleAdditionalInstances({
 }
 
 export function AdditionalEntityInstances({
+    enableBlockGeometryMerging = false,
     stacks,
     ...commonSnowProps
-}: { stacks: Stack[] | undefined } & CommonWeatherProps) {
+}: { stacks: Stack[] | undefined } & CommonWeatherProps &
+    BlockGeometryMergingProps) {
     return (
         <>
-            <BlockGroundInstances stacks={stacks} {...commonSnowProps} />
-            <SimpleAdditionalInstances stacks={stacks} {...commonSnowProps} />
+            <BlockGroundInstances
+                enableBlockGeometryMerging={enableBlockGeometryMerging}
+                stacks={stacks}
+                {...commonSnowProps}
+            />
+            <SimpleAdditionalInstances
+                enableBlockGeometryMerging={enableBlockGeometryMerging}
+                stacks={stacks}
+                {...commonSnowProps}
+            />
             <WaterBlockInstances stacks={stacks} />
             <RaisedBedInstances stacks={stacks} {...commonSnowProps} />
             <ShadeInstances stacks={stacks} {...commonSnowProps} />

--- a/packages/game/src/entities/EntityInstances.tsx
+++ b/packages/game/src/entities/EntityInstances.tsx
@@ -206,12 +206,14 @@ function EntityInstancesAssetBlock(props: EntityInstancesAssetBlockProps) {
 }
 
 export function EntityInstances({
+    enableBlockGeometryMerging = false,
     farmId,
     quality,
     renderGroundDecorations,
     stacks,
     renderDetails = true,
 }: {
+    enableBlockGeometryMerging?: boolean;
     farmId?: number | null;
     quality?: GameQualityProfile;
     renderGroundDecorations?: boolean;
@@ -281,7 +283,7 @@ export function EntityInstances({
         snowOverlayMinCoverage: qualityProfile.snowOverlayMinCoverage,
     };
     const mergedTerrainChunkProps = {
-        renderStableChunksAsMergedGeometry: true,
+        renderStableChunksAsMergedGeometry: enableBlockGeometryMerging,
     };
 
     return (
@@ -766,6 +768,7 @@ export function EntityInstances({
             />
             <Suspense fallback={null}>
                 <AdditionalEntityInstances
+                    enableBlockGeometryMerging={enableBlockGeometryMerging}
                     stacks={stacks}
                     {...commonSnowProps}
                 />

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -69,6 +69,7 @@ export type PublicGardenViewerProps = HTMLAttributes<HTMLDivElement> & {
     stacks?: PublicGardenStack[];
     appBaseUrl?: string;
     spriteBaseUrl?: string;
+    enableBlockGeometryMerging?: boolean;
     deferDetails?: boolean;
     className?: string;
 };
@@ -212,6 +213,7 @@ function publicGardenTimeLocation(
 }
 
 function PublicGardenScene({
+    enableBlockGeometryMerging,
     initialView,
     className,
     garden,
@@ -219,6 +221,7 @@ function PublicGardenScene({
     normalizedStacks,
     renderDetails,
 }: {
+    enableBlockGeometryMerging: boolean;
     initialView: PublicGardenInitialView;
     className?: string;
     garden?: ReturnType<typeof publicGardenForGameState>;
@@ -264,6 +267,9 @@ function PublicGardenScene({
                                     )),
                                 )}
                                 <EntityInstances
+                                    enableBlockGeometryMerging={
+                                        enableBlockGeometryMerging
+                                    }
                                     farmId={garden?.farmId}
                                     quality={qualityProfile}
                                     renderGroundDecorations={
@@ -363,6 +369,7 @@ function SeedPublicGardenQueryCache({
 export function PublicGardenViewer({
     appBaseUrl,
     spriteBaseUrl,
+    enableBlockGeometryMerging = false,
     deferDetails = true,
     garden,
     stacks,
@@ -435,6 +442,9 @@ export function PublicGardenViewer({
                         {(gardenCacheReady) => (
                             <PublicGardenScene
                                 className={className}
+                                enableBlockGeometryMerging={
+                                    enableBlockGeometryMerging
+                                }
                                 garden={gameGarden}
                                 gardenCacheReady={gardenCacheReady}
                                 initialView={initialView}


### PR DESCRIPTION
## Summary
- add `blockGeometryMerging` as a `flags/next` boolean flag for garden and www flag discovery
- pass the evaluated flag into the main game scene and public garden viewers
- gate stable terrain block geometry merging behind the flag instead of hard-enabling it at render call sites

## Validation
- `pnpm lint --filter @gredice/game --filter garden --filter www`
- `pnpm test --filter @gredice/game`
- `pnpm typecheck --filter @gredice/game --filter garden --filter www`
- `git diff --check`