### PR TITLE
fix(api): refresh DHMZ weather forecast feed

### DIFF
--- a/apps/api/app/api/[...route]/data/weatherRoutes.ts
+++ b/apps/api/app/api/[...route]/data/weatherRoutes.ts
@@ -27,6 +27,17 @@ import {
 
 // import { signalcoClient } from '@gredice/signalco';
 
+async function getCachedBjelovarForecast() {
+    return grediceCached(
+        grediceCacheKeys.forecastBjelovar,
+        getBjelovarForecast,
+        60 * 60,
+    ).catch((error) => {
+        console.warn('Weather forecast unavailable', { error });
+        return [];
+    });
+}
+
 const app = new Hono()
     .get(
         '/',
@@ -34,11 +45,7 @@ const app = new Hono()
             description: 'Get weather forecast',
         }),
         async (context) => {
-            const forecast = await grediceCached(
-                grediceCacheKeys.forecastBjelovar,
-                getBjelovarForecast,
-                60 * 60,
-            );
+            const forecast = await getCachedBjelovarForecast();
             setCacheControl(context, cacheControlPresets.weatherShortTerm);
             return context.json(forecast ?? []);
         },
@@ -49,11 +56,7 @@ const app = new Hono()
             description: 'Get current weather',
         }),
         async (context) => {
-            const forecast = await grediceCached(
-                grediceCacheKeys.forecastBjelovar,
-                getBjelovarForecast,
-                60 * 60,
-            );
+            const forecast = await getCachedBjelovarForecast();
 
             // const measurements = await grediceCached(grediceCacheKeys.airSensorOpgIb, async () => {
             //     const airSensorData = await signalcoClient().GET('/entity/{id}', { params: { path: { id: '565c2653-b3eb-4a7e-9399-bf5734128e03' } } });

--- a/apps/api/app/api/internal/cron/update-farm-weather/route.ts
+++ b/apps/api/app/api/internal/cron/update-farm-weather/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 import { notifyWeatherRiskAlerts } from '../../../../../lib/weather/alertNotifications';
 import { getBjelovarForecast } from '../../../../../lib/weather/forecast';
 import { populateWeatherFromSymbol } from '../../../../../lib/weather/populateWeatherFromSymbol';
+import { findClosestForecastEntry } from '../../../../../lib/weather/weatherNowContract';
 
 export const dynamic = 'force-dynamic';
 
@@ -74,26 +75,7 @@ export async function GET(request: NextRequest) {
             );
         }
 
-        // Get current weather from forecast
-        const nowLocal = new Date();
-        let closestEntry = null;
-        let minDiff = Infinity;
-
-        for (const day of forecast) {
-            for (const entry of day.entries) {
-                const entryDateTime = new Date(
-                    `${day.date}T${entry.time.toString().padStart(2, '0')}:00:00`,
-                );
-                const diff = Math.abs(
-                    entryDateTime.getTime() - nowLocal.getTime(),
-                );
-                if (diff < minDiff) {
-                    minDiff = diff;
-                    closestEntry = entry;
-                }
-            }
-        }
-
+        const closestEntry = findClosestForecastEntry(forecast, Date.now());
         if (!closestEntry) {
             console.error('Could not find closest forecast entry');
             return Response.json(

--- a/apps/api/lib/weather/forecast.node.spec.ts
+++ b/apps/api/lib/weather/forecast.node.spec.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseBjelovarForecastXml } from './forecast';
+
+const currentFeedXml = `<?xml version="1.0" encoding="utf-8"?>
+<sedamdana>
+  <izmjena run="06">Zadnja izmjena 05.07.2026. u 13:48.</izmjena>
+  <grad ime="ZAGREB" code="ZAGREB">
+    <dan datum="05.07.2026." dtj="Nedjelja" sat="09" leadtime="1">
+      <t_2m>21.2</t_2m>
+      <simbol>2</simbol>
+      <vjetar>C0</vjetar>
+      <oborina>0.0</oborina>
+    </dan>
+  </grad>
+  <grad ime="BJELOVAR" code="BJELOVAR">
+    <dan datum="05.07.2026." dtj="Nedjelja" sat="09" leadtime="1">
+      <t_2m>22.6</t_2m>
+      <simbol>3</simbol>
+      <vjetar>C0</vjetar>
+      <oborina>0.0</oborina>
+    </dan>
+    <dan datum="05.07.2026." dtj="Nedjelja" sat="15" leadtime="7">
+      <t_2m>28.7</t_2m>
+      <simbol>15</simbol>
+      <vjetar>NW1</vjetar>
+      <oborina>0.2</oborina>
+    </dan>
+    <dan datum="06.07.2026." dtj="Ponedjeljak" sat="08" leadtime="24">
+      <t_2m>24.0</t_2m>
+      <simbol>2n</simbol>
+      <vjetar>W2</vjetar>
+      <oborina>1.4</oborina>
+    </dan>
+  </grad>
+</sedamdana>`;
+
+const legacyFeedXml = `<?xml version="1.0" encoding="UTF-8"?>
+<sedmodnevna_aliec>
+  <izmjena run="06">Zadnja izmjena 05.07.2026. u 14:51.</izmjena>
+  <grad ime="Bjelovar" lokacija="Bjelovar" code="14253">
+    <dan datum="05.07.2026." dtj="Nedjelja" sat="11">
+      <t_2m>28</t_2m>
+      <simbol>1</simbol>
+      <vjetar>NE1</vjetar>
+      <oborina>0.0</oborina>
+    </dan>
+    <dan datum="06.07.2026." dtj="Ponedjeljak" sat="2">
+      <t_2m>22</t_2m>
+      <simbol>2n</simbol>
+      <vjetar>C0</vjetar>
+      <oborina>0.0</oborina>
+    </dan>
+  </grad>
+</sedmodnevna_aliec>`;
+
+const staleFeedXml = `<?xml version="1.0" encoding="UTF-8"?>
+<sedmodnevna_aliec>
+  <izmjena run="06">Zadnja izmjena 25.06.2026. u 14:51.</izmjena>
+  <grad ime="Bjelovar" lokacija="Bjelovar" code="14253">
+    <dan datum="01.07.2026." dtj="Srijeda" sat="20">
+      <t_2m>27</t_2m>
+      <simbol>1</simbol>
+      <vjetar>SE1</vjetar>
+      <oborina>0.0</oborina>
+    </dan>
+  </grad>
+</sedmodnevna_aliec>`;
+
+describe('parseBjelovarForecastXml', () => {
+    it('parses the current DHMZ meteogram feed shape', async () => {
+        const forecast = await parseBjelovarForecastXml(
+            currentFeedXml,
+            new Date('2026-07-05T15:03:00+02:00'),
+        );
+
+        assert.equal(forecast.length, 2);
+        assert.equal(forecast[0]?.date, '2026-07-05');
+        assert.equal(forecast[0]?.minTemp, 22.6);
+        assert.equal(forecast[0]?.maxTemp, 28.7);
+        assert.equal(forecast[0]?.rain, 0.2);
+        assert.equal(forecast[0]?.entries[0]?.windDirection, null);
+        assert.equal(forecast[0]?.entries[1]?.windDirection, 'NW');
+        assert.equal(forecast[1]?.entries[0]?.symbol, 2);
+        assert.equal(forecast[1]?.entries[0]?.windStrength, 2);
+    });
+
+    it('keeps compatibility with the legacy DHMZ feed shape', async () => {
+        const forecast = await parseBjelovarForecastXml(
+            legacyFeedXml,
+            new Date('2026-07-05T15:03:00+02:00'),
+        );
+
+        assert.equal(forecast.length, 2);
+        assert.equal(forecast[0]?.date, '2026-07-05');
+        assert.equal(forecast[0]?.entries[0]?.temperature, 28);
+        assert.equal(forecast[0]?.entries[0]?.windDirection, 'NE');
+        assert.equal(forecast[1]?.entries[0]?.windDirection, null);
+    });
+
+    it('rejects stale feeds before cron can write fake current history', async () => {
+        await assert.rejects(
+            () =>
+                parseBjelovarForecastXml(
+                    staleFeedXml,
+                    new Date('2026-07-05T15:03:00+02:00'),
+                ),
+            /stale/,
+        );
+    });
+});

--- a/apps/api/lib/weather/forecast.ts
+++ b/apps/api/lib/weather/forecast.ts
@@ -1,4 +1,10 @@
+import { TZDate } from '@date-fns/tz';
 import { parseStringPromise } from 'xml2js';
+
+const DHMZ_BJELOVAR_FORECAST_URL = 'https://meteo.hr/7d_graf_i_simboli.xml';
+const FORECAST_TIME_ZONE = 'Europe/Zagreb';
+const MAX_SOURCE_AGE_MS = 36 * 60 * 60 * 1000;
+const EXPIRED_FORECAST_GRACE_MS = 3 * 60 * 60 * 1000;
 
 interface WeatherEntry {
     time: number;
@@ -22,7 +28,8 @@ interface DayForecast {
 
 interface CityData {
     $: {
-        ime: string;
+        ime?: string;
+        code?: string;
     };
     dan: Array<{
         $: {
@@ -36,93 +43,269 @@ interface CityData {
     }>;
 }
 
+type XmlTextElement =
+    | string
+    | {
+          _: string;
+          $?: Record<string, string>;
+      };
+
+interface ForecastXmlRoot {
+    izmjena?: XmlTextElement[];
+    grad?: CityData[];
+}
+
 interface ParsedXmlData {
-    sedmodnevna_aliec: {
-        grad: CityData[];
+    sedamdana?: ForecastXmlRoot;
+    sedmodnevna_aliec?: ForecastXmlRoot;
+}
+
+function textValue(value: string[] | undefined): string | null {
+    const firstValue = value?.[0]?.trim();
+    return firstValue ? firstValue : null;
+}
+
+function parseFiniteNumber(value: string | null): number | null {
+    if (!value) return null;
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseForecastDate(value: string | undefined): string | null {
+    if (!value) return null;
+    const match = /^(\d{1,2})\.(\d{1,2})\.(\d{4})\.$/.exec(value.trim());
+    if (!match) return null;
+
+    const day = match[1];
+    const month = match[2];
+    const year = match[3];
+    if (!day || !month || !year) return null;
+
+    return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+}
+
+function forecastEntryDate(date: string, hour: number): Date | null {
+    const [year, month, day] = date.split('-').map(Number);
+    if (!year || !month || !day || !Number.isFinite(hour)) return null;
+
+    return new TZDate(year, month - 1, day, hour, 0, 0, 0, FORECAST_TIME_ZONE);
+}
+
+function parseIssuedAt(value: XmlTextElement[] | undefined): Date | null {
+    const firstValue = value?.[0];
+    const text =
+        typeof firstValue === 'string' ? firstValue : (firstValue?._ ?? null);
+    if (!text) return null;
+
+    const match =
+        /(\d{1,2})\.(\d{1,2})\.(\d{4})\.\s+u\s+(\d{1,2})(?::(\d{2}))?/.exec(
+            text,
+        );
+    if (!match) return null;
+
+    const day = match[1];
+    const month = match[2];
+    const year = match[3];
+    const hour = match[4];
+    const minute = match[5] ?? '0';
+    if (!day || !month || !year || !hour) return null;
+
+    return new TZDate(
+        Number.parseInt(year, 10),
+        Number.parseInt(month, 10) - 1,
+        Number.parseInt(day, 10),
+        Number.parseInt(hour, 10),
+        Number.parseInt(minute, 10),
+        0,
+        0,
+        FORECAST_TIME_ZONE,
+    );
+}
+
+function parseWind(value: string | null): {
+    windDirection: string | null;
+    windStrength: number;
+} {
+    if (!value) {
+        return { windDirection: null, windStrength: 0 };
+    }
+
+    const match = /^([A-Z]+)(\d+)$/.exec(value.trim().toUpperCase());
+    if (!match) {
+        return { windDirection: null, windStrength: 0 };
+    }
+
+    const direction = match[1];
+    const strength = Number.parseInt(match[2] ?? '0', 10);
+    if (!direction || direction === 'C') {
+        return { windDirection: null, windStrength: 0 };
+    }
+
+    return {
+        windDirection: direction,
+        windStrength: Number.isFinite(strength) ? Math.min(strength, 3) : 0,
     };
+}
+
+function normalizeCityName(value: string | undefined): string {
+    return (value ?? '').trim().replaceAll('_', ' ').toLocaleUpperCase('hr-HR');
+}
+
+function isBjelovarForecast(city: CityData): boolean {
+    const name = normalizeCityName(city.$.ime);
+    const code = normalizeCityName(city.$.code);
+    return name === 'BJELOVAR' || code === 'BJELOVAR' || code === '14253';
+}
+
+function parseWeatherEntry(entry: CityData['dan'][number]): {
+    date: string;
+    point: WeatherEntry;
+} | null {
+    const date = parseForecastDate(entry.$.datum);
+    const time = Number.parseInt(entry.$.sat, 10);
+    const temperature = parseFiniteNumber(textValue(entry.t_2m));
+    const symbolText = textValue(entry.simbol)?.replace(/n$/i, '') ?? null;
+    const symbol = symbolText ? Number.parseInt(symbolText, 10) : Number.NaN;
+    const rain = parseFiniteNumber(textValue(entry.oborina)) ?? 0;
+    const { windDirection, windStrength } = parseWind(textValue(entry.vjetar));
+
+    if (
+        !date ||
+        !Number.isInteger(time) ||
+        time < 0 ||
+        time > 23 ||
+        temperature == null ||
+        !Number.isInteger(symbol)
+    ) {
+        return null;
+    }
+
+    return {
+        date,
+        point: {
+            time,
+            temperature,
+            symbol,
+            windDirection,
+            windStrength,
+            rain,
+        },
+    };
+}
+
+function getForecastRoot(data: ParsedXmlData): ForecastXmlRoot | null {
+    return data.sedamdana ?? data.sedmodnevna_aliec ?? null;
+}
+
+function validateForecastFreshness(
+    forecast: DayForecast[],
+    issuedAt: Date | null,
+    now: Date,
+) {
+    const nowTime = now.getTime();
+
+    if (issuedAt && nowTime - issuedAt.getTime() > MAX_SOURCE_AGE_MS) {
+        throw new Error(
+            `DHMZ forecast feed is stale; last update was ${issuedAt.toISOString()}`,
+        );
+    }
+
+    const latestEntryTime = forecast.reduce((latest, day) => {
+        const dayLatest = day.entries.reduce((entryLatest, entry) => {
+            const entryDate = forecastEntryDate(day.date, entry.time);
+            return entryDate
+                ? Math.max(entryLatest, entryDate.getTime())
+                : entryLatest;
+        }, Number.NEGATIVE_INFINITY);
+        return Math.max(latest, dayLatest);
+    }, Number.NEGATIVE_INFINITY);
+
+    if (
+        latestEntryTime === Number.NEGATIVE_INFINITY ||
+        latestEntryTime < nowTime - EXPIRED_FORECAST_GRACE_MS
+    ) {
+        throw new Error('DHMZ forecast feed does not contain current data');
+    }
+}
+
+export async function parseBjelovarForecastXml(
+    xml: string,
+    now: Date = new Date(),
+): Promise<DayForecast[]> {
+    const data: ParsedXmlData = await parseStringPromise(xml);
+    const root = getForecastRoot(data);
+    const bjelovarForecast = root?.grad?.find(isBjelovarForecast);
+
+    if (!root || !bjelovarForecast) {
+        console.warn('Bjelovar forecast not found.');
+        throw new Error('Bjelovar forecast not found.');
+    }
+
+    const forecastByDate = new Map<string, DayForecast>();
+
+    for (const sourceEntry of bjelovarForecast.dan ?? []) {
+        const parsedEntry = parseWeatherEntry(sourceEntry);
+        if (!parsedEntry) continue;
+
+        const { date, point } = parsedEntry;
+        const currentDay = forecastByDate.get(date);
+
+        if (!currentDay) {
+            forecastByDate.set(date, {
+                date,
+                minTemp: point.temperature,
+                maxTemp: point.temperature,
+                windDirection: point.windDirection,
+                windStrength: point.windStrength,
+                entries: [point],
+                symbol: point.symbol,
+                rain: point.rain,
+            });
+            continue;
+        }
+
+        currentDay.minTemp = Math.min(currentDay.minTemp, point.temperature);
+        currentDay.maxTemp = Math.max(currentDay.maxTemp, point.temperature);
+        currentDay.rain += point.rain;
+
+        if (point.windStrength > currentDay.windStrength) {
+            currentDay.windDirection = point.windDirection;
+            currentDay.windStrength = point.windStrength;
+        }
+        currentDay.entries.push(point);
+    }
+
+    const forecast = Array.from(forecastByDate.values())
+        .map((day) => ({
+            ...day,
+            entries: day.entries.sort((a, b) => a.time - b.time),
+            rain: Math.round(day.rain * 10) / 10,
+        }))
+        .sort((a, b) => a.date.localeCompare(b.date));
+
+    if (forecast.length === 0) {
+        throw new Error('No usable Bjelovar forecast entries found.');
+    }
+
+    validateForecastFreshness(forecast, parseIssuedAt(root.izmjena), now);
+
+    return forecast;
 }
 
 export async function getBjelovarForecast(): Promise<DayForecast[]> {
     try {
-        console.info('Fetching forecast data for Bjelovar...');
-        const response = await fetch(
-            'https://prognoza.hr/sedam/hrvatska/7d_meteogrami.xml',
-        );
-        const xml = await response.text();
-        const data: ParsedXmlData = await parseStringPromise(xml);
-
-        const bjelovarForecast = data.sedmodnevna_aliec.grad.find(
-            (city) => city.$.ime === 'Bjelovar',
-        );
-        if (!bjelovarForecast) {
-            console.warn('Bjelovar forecast not found.');
-            throw new Error('Bjelovar forecast not found.');
-        }
-
-        const fiveDayForecast: DayForecast[] = [];
-        let currentDay: DayForecast | null = null;
-
-        for (const entry of bjelovarForecast.dan) {
-            const date = entry.$.datum.replace(
-                /(\d+)\.(\d+)\.(\d+)\./,
-                '$3-$2-$1',
+        console.info('Fetching forecast data for Bjelovar...', {
+            url: DHMZ_BJELOVAR_FORECAST_URL,
+        });
+        const response = await fetch(DHMZ_BJELOVAR_FORECAST_URL);
+        if (!response.ok) {
+            throw new Error(
+                `DHMZ forecast request failed with ${response.status}`,
             );
-            const time = parseInt(entry.$.sat, 10);
-            const temperature = parseInt(entry.t_2m[0], 10);
-            const symbol = parseInt(entry.simbol[0].replace('n', ''), 10);
-            const windRaw = entry.vjetar[0];
-
-            let windDirection: string | null = null;
-            let windStrength = 0;
-            if (windRaw !== 'C') {
-                const match = windRaw.match(/([A-Z]+)(\d+)/);
-                if (match) {
-                    windDirection = match[1];
-                    windStrength = Math.min(parseInt(match[2], 10), 3);
-                }
-            }
-
-            const rain = parseFloat(entry.oborina[0]);
-
-            if (currentDay === null || currentDay.date !== date) {
-                if (fiveDayForecast.length >= 6) break;
-
-                currentDay = {
-                    date,
-                    minTemp: temperature,
-                    maxTemp: temperature,
-                    windDirection: windDirection,
-                    windStrength: windStrength,
-                    entries: [],
-                    symbol,
-                    rain,
-                };
-                fiveDayForecast.push(currentDay);
-            }
-
-            currentDay.minTemp = Math.min(currentDay.minTemp, temperature);
-            currentDay.maxTemp = Math.max(currentDay.maxTemp, temperature);
-
-            if (windStrength > currentDay.windStrength) {
-                currentDay.windDirection = windDirection;
-                currentDay.windStrength = windStrength;
-            }
-            currentDay.entries.push({
-                time,
-                temperature,
-                symbol,
-                windDirection,
-                windStrength,
-                rain,
-            });
         }
 
-        // Sort the forecasts by date
-        fiveDayForecast.sort(
-            (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
-        );
-
-        return fiveDayForecast;
+        const xml = await response.text();
+        return await parseBjelovarForecastXml(xml);
     } catch (error) {
         console.error('Error fetching or parsing weather data:', error);
         throw error;


### PR DESCRIPTION
## Summary
- switch Bjelovar forecast ingestion to DHMZ's current meteogram XML endpoint
- parse both the current `sedamdana` feed and the legacy `sedmodnevna_aliec` shape, including decimal temperatures and calm `C0` wind
- reject stale DHMZ feed metadata before cron can write fake current rows, and reuse the Zagreb-time closest-forecast helper in the cron route
- keep public weather read routes resilient by returning empty/fallback weather when the forecast source is temporarily unavailable

## Root Cause
The graph was receiving data, but it was bad data. The old `https://prognoza.hr/sedam/hrvatska/7d_meteogrami.xml` source is currently stale: it reports `Zadnja izmjena 25.06.2026.` and its Bjelovar forecast ends on `01.07.2026.`. Because the cron picked the closest available forecast entry, it kept writing the stale last value as current weather, which produced the flat line in the chart.

DHMZ's XML users page now lists `https://meteo.hr/7d_graf_i_simboli.xml` for meteograms; the live smoke check against that endpoint returned current Bjelovar forecast rows from `2026-07-05` through `2026-07-12`.

## Validation
- `corepack pnpm --filter api exec biome check --write lib/weather/forecast.ts lib/weather/forecast.node.spec.ts app/api/internal/cron/update-farm-weather/route.ts 'app/api/[...route]/data/weatherRoutes.ts'`
- `corepack pnpm --filter api test:node` (146 tests passed)
- live parser smoke: `getBjelovarForecast()` returned 8 current Bjelovar forecast days from DHMZ
- `corepack pnpm --filter api exec tsc --project tsconfig.json --noEmit --pretty false` is still blocked by unrelated existing `lib/notifications/webPushSender.node.spec.ts` optional-parameter errors
