### PR TITLE
feat(app): improve delivery request controls

### DIFF
--- a/apps/app/app/admin/delivery/requests/DeliveryRequestContents.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestContents.tsx
@@ -1,4 +1,5 @@
 import { Chip } from '@gredice/ui/Chip';
+import { PlantOrSortImage } from '@gredice/ui/plants';
 import { RaisedBedLabel } from '@gredice/ui/raisedBeds';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -8,7 +9,7 @@ function getPlantSortName(request: DeliveryRequestDetails) {
     return (
         request.plantSort?.information?.name ??
         request.plantSort?.information?.plant?.information?.name ??
-        'Nepoznata sorta'
+        null
     );
 }
 
@@ -31,28 +32,43 @@ export function DeliveryRequestContents({
 }) {
     const plantSortName = getPlantSortName(request);
     const operationLabel = getOperationLabel(request);
+    const primaryLabel = plantSortName ?? operationLabel ?? 'Radnja bez naziva';
+    const secondaryLabel = plantSortName ? operationLabel : null;
     const fieldLabel = getFieldLabel(request);
 
     return (
         <Stack spacing={0.75} className="min-w-0">
-            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-                <Typography level="body2" semiBold className="min-w-0 truncate">
-                    {plantSortName}
-                </Typography>
-                {operationLabel ? (
-                    <Typography
-                        level="body3"
-                        className="min-w-0 truncate text-muted-foreground"
-                    >
-                        {operationLabel}
-                    </Typography>
+            <div className="flex min-w-0 items-center gap-2">
+                {plantSortName ? (
+                    <PlantOrSortImage
+                        plantSort={request.plantSort}
+                        width={28}
+                        height={28}
+                        className="size-7 shrink-0 rounded-md border border-border object-cover"
+                    />
                 ) : null}
+                <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <Typography
+                        level="body2"
+                        semiBold
+                        className="min-w-0 truncate"
+                    >
+                        {primaryLabel}
+                    </Typography>
+                    {secondaryLabel ? (
+                        <Typography
+                            level="body3"
+                            className="min-w-0 truncate text-muted-foreground"
+                        >
+                            {secondaryLabel}
+                        </Typography>
+                    ) : null}
+                </div>
             </div>
             <div className="flex min-w-0 flex-wrap items-center gap-2">
                 {request.raisedBed ? (
                     <RaisedBedLabel
                         physicalId={request.raisedBed.physicalId}
-                        name={request.raisedBed.name}
                         size="compact"
                         className="min-w-0"
                     />

--- a/apps/app/app/admin/delivery/requests/DeliveryRequestGroupStatusAction.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestGroupStatusAction.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Navigate } from '@gredice/ui/icons';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { progressDeliveryRequestGroupStatusAction } from './actions';
+import { getNextDeliveryRequestStatus } from './DeliveryRequestStatusFlow';
+import type { DeliveryRequestActionData } from './DeliveryRequestTypes';
+
+export function DeliveryRequestGroupStatusAction({
+    requests,
+}: {
+    requests: DeliveryRequestActionData[];
+}) {
+    const router = useRouter();
+    const [isPending, setIsPending] = useState(false);
+    const actionableRequests = requests.filter((request) =>
+        getNextDeliveryRequestStatus(request.state),
+    );
+
+    if (requests.length < 2 || actionableRequests.length === 0) {
+        return null;
+    }
+
+    async function progressGroupStatus() {
+        setIsPending(true);
+
+        try {
+            const formData = new FormData();
+            for (const request of requests) {
+                formData.append('requestIds', request.id);
+            }
+
+            const result = await progressDeliveryRequestGroupStatusAction(
+                null,
+                formData,
+            );
+            if (!result.success) {
+                alert(result.message);
+                return;
+            }
+
+            router.refresh();
+        } finally {
+            setIsPending(false);
+        }
+    }
+
+    return (
+        <Button
+            type="button"
+            variant="outlined"
+            color="neutral"
+            size="sm"
+            loading={isPending}
+            disabled={isPending}
+            startDecorator={<Navigate className="size-4 shrink-0" />}
+            title="Pomakni sve neotkazane zahtjeve u sljedeći status"
+            onClick={() => {
+                void progressGroupStatus();
+            }}
+        >
+            Pomakni grupu
+        </Button>
+    );
+}

--- a/apps/app/app/admin/delivery/requests/DeliveryRequestListItem.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestListItem.tsx
@@ -9,6 +9,7 @@ import {
 } from './DeliveryDestinationDetails';
 import { DeliveryRequestActionButtons } from './DeliveryRequestActionButtons';
 import { DeliveryRequestContents } from './DeliveryRequestContents';
+import { DeliveryRequestGroupStatusAction } from './DeliveryRequestGroupStatusAction';
 import type { DeliveryRequestGroup } from './DeliveryRequestGroups';
 import type { DeliveryRequestDetails } from './DeliveryRequestListTypes';
 import { DeliveryRequestSlotAction } from './DeliveryRequestSlotAction';
@@ -44,32 +45,40 @@ export function DeliveryRequestListItem({
 
     const destinationTitle = getDeliveryRequestDestinationTitle(primaryRequest);
     const groupedRequestCount = group.requests.length;
+    const groupActionRequests = group.requests.map(getActionRequest);
 
     return (
-        <li className="group transition-colors hover:bg-muted/40">
-            <div className="px-3 py-3 sm:px-4">
-                <Stack spacing={1} className="min-w-0 flex-1">
-                    <div className="flex min-w-0 flex-wrap items-center gap-2">
-                        <Typography
-                            level="body1"
-                            component="h3"
-                            semiBold
-                            className="min-w-0 truncate"
-                        >
-                            {destinationTitle}
-                        </Typography>
-                        <DeliveryRequestModeChip
-                            mode={primaryRequest.mode}
-                            size="sm"
+        <li className="group border-l-4 border-l-primary/60 transition-colors hover:bg-muted/30">
+            <div className="bg-muted/35 px-3 py-3 sm:px-4">
+                <div className="flex min-w-0 flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <Stack spacing={1} className="min-w-0 flex-1">
+                        <div className="flex min-w-0 flex-wrap items-center gap-2">
+                            <Typography
+                                level="body1"
+                                component="h3"
+                                semiBold
+                                className="min-w-0 truncate"
+                            >
+                                {destinationTitle}
+                            </Typography>
+                            <DeliveryRequestModeChip
+                                mode={primaryRequest.mode}
+                                size="sm"
+                            />
+                            {groupedRequestCount > 1 ? (
+                                <Chip color="neutral" size="sm" variant="soft">
+                                    {groupedRequestCount} zahtjeva
+                                </Chip>
+                            ) : null}
+                        </div>
+                        <DeliveryDestinationDetails request={primaryRequest} />
+                    </Stack>
+                    <div className="flex shrink-0 justify-start lg:justify-end">
+                        <DeliveryRequestGroupStatusAction
+                            requests={groupActionRequests}
                         />
-                        {groupedRequestCount > 1 ? (
-                            <Chip color="neutral" size="sm" variant="soft">
-                                {groupedRequestCount} zahtjeva
-                            </Chip>
-                        ) : null}
                     </div>
-                    <DeliveryDestinationDetails request={primaryRequest} />
-                </Stack>
+                </div>
             </div>
             <ul className="divide-y border-t bg-background/60">
                 {group.requests.map((request) => {

--- a/apps/app/app/admin/delivery/requests/DeliveryRequestStatusAction.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestStatusAction.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check, ShoppingCart, Truck } from '@gredice/ui/icons';
+import { Check, ShoppingCart, Truck, Undo } from '@gredice/ui/icons';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -13,6 +13,7 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { DeliveryRequestStatusChip } from '../components';
 import { updateDeliveryRequestStatusAction } from './actions';
+import { getNextDeliveryRequestStatus } from './DeliveryRequestStatusFlow';
 import type { DeliveryRequestActionData } from './DeliveryRequestTypes';
 
 type NextStatusAction = {
@@ -22,34 +23,44 @@ type NextStatusAction = {
 };
 
 function getNextStatusAction(state: string): NextStatusAction | undefined {
-    switch (state) {
-        case 'pending':
+    const nextStatus = getNextDeliveryRequestStatus(state);
+
+    switch (nextStatus) {
+        case 'confirmed':
             return {
                 status: 'confirmed',
                 label: 'Potvrdi',
                 icon: <Check className="size-4 shrink-0" />,
             };
-        case 'confirmed':
+        case 'preparing':
             return {
                 status: 'preparing',
                 label: 'U pripremi',
                 icon: <ShoppingCart className="size-4 shrink-0" />,
             };
-        case 'preparing':
+        case 'ready':
             return {
                 status: 'ready',
                 label: 'Spreman',
                 icon: <Truck className="size-4 shrink-0" />,
             };
-        case 'ready':
+        case 'fulfilled':
             return {
                 status: 'fulfilled',
                 label: 'Ispunjen',
                 icon: <Check className="size-4 shrink-0" />,
             };
-        default:
-            return undefined;
     }
+
+    if (state === 'cancelled') {
+        return {
+            status: 'confirmed',
+            label: 'Vrati u potvrđeno',
+            icon: <Undo className="size-4 shrink-0" />,
+        };
+    }
+
+    return undefined;
 }
 
 export function DeliveryRequestStatusAction({

--- a/apps/app/app/admin/delivery/requests/DeliveryRequestStatusFlow.ts
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestStatusFlow.ts
@@ -1,0 +1,22 @@
+export type DeliveryRequestProgressStatus =
+    | 'confirmed'
+    | 'preparing'
+    | 'ready'
+    | 'fulfilled';
+
+export function getNextDeliveryRequestStatus(
+    state: string,
+): DeliveryRequestProgressStatus | undefined {
+    switch (state) {
+        case 'pending':
+            return 'confirmed';
+        case 'confirmed':
+            return 'preparing';
+        case 'preparing':
+            return 'ready';
+        case 'ready':
+            return 'fulfilled';
+        default:
+            return undefined;
+    }
+}

--- a/apps/app/app/admin/delivery/requests/DeliveryRequestsFilters.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestsFilters.tsx
@@ -13,7 +13,8 @@ const STATUS_FILTER_OPTIONS: FilterOption = {
     label: 'Status zahtjeva',
     icon: <Check className="size-4" />,
     options: [
-        { value: '', label: 'Svi statusi' },
+        { value: 'active', label: 'Aktivni statusi' },
+        { value: 'all', label: 'Svi statusi' },
         { value: 'pending', label: 'Na čekanju' },
         { value: 'confirmed', label: 'Potvrđen' },
         { value: 'preparing', label: 'U pripremi' },
@@ -47,7 +48,7 @@ export function DeliveryRequestsFilters() {
             filters={filters}
             defaultValues={{
                 from: 'last-30-days',
-                status: '',
+                status: 'active',
                 mode: '',
             }}
             className="flex"

--- a/apps/app/app/admin/delivery/requests/DeliveryRequestsList.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestsList.tsx
@@ -3,8 +3,6 @@ import {
     getDeliveryRequestsWithEvents,
     TimeSlotStatuses,
 } from '@gredice/storage';
-import { Chip } from '@gredice/ui/Chip';
-import { Typography } from '@gredice/ui/Typography';
 import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
 import { getDateFromTimeFilter } from '../../../../lib/utils/timeFilters';
 import { groupDeliveryRequests } from './DeliveryRequestGroups';
@@ -25,8 +23,9 @@ export async function DeliveryRequestsList({
         getAllTimeSlots(),
     ]);
 
-    const statusFilter =
+    const statusParam =
         typeof searchParams?.status === 'string' ? searchParams.status : '';
+    const statusFilter = statusParam || 'active';
     const modeFilter =
         typeof searchParams?.mode === 'string' ? searchParams.mode : '';
     const fromFilter =
@@ -35,7 +34,11 @@ export async function DeliveryRequestsList({
 
     let filteredRequests = deliveryRequests;
 
-    if (statusFilter) {
+    if (statusFilter === 'active') {
+        filteredRequests = filteredRequests.filter(
+            (request) => request.state !== 'fulfilled',
+        );
+    } else if (statusFilter && statusFilter !== 'all') {
         filteredRequests = filteredRequests.filter(
             (request) => request.state === statusFilter,
         );
@@ -93,29 +96,6 @@ export async function DeliveryRequestsList({
     return (
         <DeliveryRequestSlotsProvider slots={slotOptions}>
             <div className="min-w-0">
-                <div className="flex min-w-0 flex-col gap-2 border-b bg-card px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="flex min-w-0 flex-wrap items-center gap-2">
-                        <Chip color="neutral" size="sm" variant="soft">
-                            {deliveryRequestGroups.length}
-                        </Chip>
-                        <Typography
-                            level="body3"
-                            className="text-muted-foreground"
-                        >
-                            Grupirani zahtjevi za dostavu
-                        </Typography>
-                        {deliveryRequestGroups.length !==
-                        sortedDeliveryRequests.length ? (
-                            <Typography
-                                level="body3"
-                                className="text-muted-foreground"
-                            >
-                                {sortedDeliveryRequests.length} zahtjeva
-                            </Typography>
-                        ) : null}
-                    </div>
-                </div>
-
                 {deliveryRequestGroups.length === 0 ? (
                     <div className="p-4">
                         <NoDataPlaceholder>

--- a/apps/app/app/admin/delivery/requests/DeliveryRequestsList.tsx
+++ b/apps/app/app/admin/delivery/requests/DeliveryRequestsList.tsx
@@ -1,4 +1,5 @@
 import {
+    DeliveryRequestStates,
     getAllTimeSlots,
     getDeliveryRequestsWithEvents,
     TimeSlotStatuses,
@@ -36,7 +37,9 @@ export async function DeliveryRequestsList({
 
     if (statusFilter === 'active') {
         filteredRequests = filteredRequests.filter(
-            (request) => request.state !== 'fulfilled',
+            (request) =>
+                request.state !== DeliveryRequestStates.FULFILLED &&
+                request.state !== DeliveryRequestStates.CANCELLED,
         );
     } else if (statusFilter && statusFilter !== 'all') {
         filteredRequests = filteredRequests.filter(

--- a/apps/app/app/admin/delivery/requests/actions.ts
+++ b/apps/app/app/admin/delivery/requests/actions.ts
@@ -11,10 +11,78 @@ import {
     getDeliveryRequest,
     prepareDeliveryRequest,
     readyDeliveryRequest,
+    uncancelDeliveryRequest,
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import { notifyDeliveryCancelled } from '../../../../../api/lib/delivery/emailNotifications';
 import { auth } from '../../../../lib/auth/auth';
+import { getNextDeliveryRequestStatus } from './DeliveryRequestStatusFlow';
+
+async function applyDeliveryRequestStatus({
+    requestId,
+    status,
+    cancelReason,
+    notes,
+}: {
+    requestId: string;
+    status: string;
+    cancelReason?: string;
+    notes?: string;
+}) {
+    const request = await getDeliveryRequest(requestId);
+
+    if (!request) {
+        throw new Error('Zahtjev za dostavu nije pronađen');
+    }
+
+    // TODO: Refactor this so we don't call 3 similar requests for each
+    //       status change, notification should be piped through notification service
+    //       which should send emails to users and slack messages to admins
+    if (status === DeliveryRequestStates.CONFIRMED) {
+        if (request.state === DeliveryRequestStates.CANCELLED) {
+            await uncancelDeliveryRequest(requestId);
+        } else {
+            await confirmDeliveryRequest(requestId);
+        }
+        await notifyDeliveryRequestEvent(requestId, 'updated', {
+            status,
+            note: notes,
+        });
+    } else if (status === DeliveryRequestStates.CANCELLED) {
+        await cancelDeliveryRequest(
+            requestId,
+            'admin',
+            cancelReason ?? '',
+            notes,
+        );
+        await notifyDeliveryRequestEvent(requestId, 'cancelled', {
+            reason: cancelReason,
+            note: notes,
+            status,
+        });
+        await notifyDeliveryCancelled(requestId);
+    } else if (status === DeliveryRequestStates.PREPARING) {
+        await prepareDeliveryRequest(requestId);
+        await notifyDeliveryRequestEvent(requestId, 'updated', {
+            status,
+            note: notes,
+        });
+    } else if (status === DeliveryRequestStates.READY) {
+        await readyDeliveryRequest(requestId);
+        await notifyDeliveryRequestEvent(requestId, 'updated', {
+            status,
+            note: notes,
+        });
+    } else if (status === DeliveryRequestStates.FULFILLED) {
+        await fulfillDeliveryRequest(requestId, notes);
+        await notifyDeliveryRequestEvent(requestId, 'updated', {
+            status,
+            note: notes,
+        });
+    } else {
+        throw new Error('Nepoznat status zahtjeva');
+    }
+}
 
 export async function updateDeliveryRequestStatusAction(
     _prevState: unknown,
@@ -23,10 +91,21 @@ export async function updateDeliveryRequestStatusAction(
     try {
         await auth(['admin']);
 
-        const requestId = formData.get('requestId') as string;
-        const status = formData.get('status') as string;
-        const cancelReason = formData.get('cancelReason') as string;
-        const notes = (formData.get('notes') as string) || undefined;
+        const requestIdValue = formData.get('requestId');
+        const statusValue = formData.get('status');
+        const cancelReasonValue = formData.get('cancelReason');
+        const notesValue = formData.get('notes');
+        const requestId =
+            typeof requestIdValue === 'string' ? requestIdValue : '';
+        const status = typeof statusValue === 'string' ? statusValue : '';
+        const cancelReason =
+            typeof cancelReasonValue === 'string'
+                ? cancelReasonValue
+                : undefined;
+        const notes =
+            typeof notesValue === 'string' && notesValue.length > 0
+                ? notesValue
+                : undefined;
 
         if (!requestId || !status) {
             return {
@@ -35,57 +114,12 @@ export async function updateDeliveryRequestStatusAction(
             };
         }
 
-        // TODO: Refactor this so we don't call 3 similar requests for each
-        //       status change, notification should be piped through notification service
-        //       which should send emails to users and slack messages to admins
-        if (status === DeliveryRequestStates.CONFIRMED) {
-            await confirmDeliveryRequest(requestId);
-        } else if (status === DeliveryRequestStates.CANCELLED) {
-            await cancelDeliveryRequest(
-                requestId,
-                'admin',
-                cancelReason,
-                notes,
-            );
-            await notifyDeliveryRequestEvent(requestId, 'cancelled', {
-                reason: cancelReason,
-                note: notes,
-                status,
-            });
-            await notifyDeliveryCancelled(requestId);
-        } else if (status === DeliveryRequestStates.PREPARING) {
-            await prepareDeliveryRequest(requestId);
-            await notifyDeliveryRequestEvent(requestId, 'updated', {
-                status,
-                note: notes,
-            });
-        } else if (status === DeliveryRequestStates.READY) {
-            await readyDeliveryRequest(requestId);
-            await notifyDeliveryRequestEvent(requestId, 'updated', {
-                status,
-                note: notes,
-            });
-        } else if (status === DeliveryRequestStates.FULFILLED) {
-            await fulfillDeliveryRequest(requestId, notes);
-            await notifyDeliveryRequestEvent(requestId, 'updated', {
-                status,
-                note: notes,
-            });
-        } else {
-            throw new Error('Nepoznat status zahtjeva');
-        }
-
-        if (
-            status !== DeliveryRequestStates.CANCELLED &&
-            status !== DeliveryRequestStates.PREPARING &&
-            status !== DeliveryRequestStates.READY &&
-            status !== DeliveryRequestStates.FULFILLED
-        ) {
-            await notifyDeliveryRequestEvent(requestId, 'updated', {
-                status,
-                note: notes,
-            });
-        }
+        await applyDeliveryRequestStatus({
+            requestId,
+            status,
+            cancelReason,
+            notes,
+        });
 
         revalidatePath('/admin/delivery/requests');
 
@@ -98,6 +132,73 @@ export async function updateDeliveryRequestStatusAction(
         return {
             success: false,
             message: 'Greška pri ažuriranju statusa zahtjeva',
+        };
+    }
+}
+
+export async function progressDeliveryRequestGroupStatusAction(
+    _prevState: unknown,
+    formData: FormData,
+) {
+    try {
+        await auth(['admin']);
+
+        const requestIds = formData
+            .getAll('requestIds')
+            .filter(
+                (requestId): requestId is string =>
+                    typeof requestId === 'string' && requestId.length > 0,
+            );
+
+        if (requestIds.length === 0) {
+            return {
+                success: false,
+                message: 'Nema zahtjeva za ažuriranje',
+            };
+        }
+
+        let updatedCount = 0;
+
+        for (const requestId of requestIds) {
+            const request = await getDeliveryRequest(requestId);
+            if (!request) {
+                continue;
+            }
+
+            const nextStatus = getNextDeliveryRequestStatus(request.state);
+            if (!nextStatus) {
+                continue;
+            }
+
+            await applyDeliveryRequestStatus({
+                requestId,
+                status: nextStatus,
+            });
+            updatedCount += 1;
+        }
+
+        if (updatedCount === 0) {
+            return {
+                success: false,
+                message:
+                    'Nema zahtjeva koji se mogu pomaknuti u sljedeći status',
+            };
+        }
+
+        revalidatePath('/admin/delivery/requests');
+
+        return {
+            success: true,
+            message: `Ažurirano zahtjeva: ${updatedCount}`,
+        };
+    } catch (error) {
+        console.error(
+            'Error progressing delivery request group status:',
+            error,
+        );
+        return {
+            success: false,
+            message: 'Greška pri ažuriranju statusa grupe zahtjeva',
         };
     }
 }

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -253,12 +253,16 @@ function reconstructDeliveryRequestState(
             requestNotes = asString(data.requestNotes);
         } else if (event.type === knownEventTypes.delivery.requestConfirmed) {
             state = DeliveryRequestStates.CONFIRMED;
+            cancelReason = undefined;
         } else if (event.type === knownEventTypes.delivery.requestPreparing) {
             state = DeliveryRequestStates.PREPARING;
+            cancelReason = undefined;
         } else if (event.type === knownEventTypes.delivery.requestReady) {
             state = DeliveryRequestStates.READY;
+            cancelReason = undefined;
         } else if (event.type === knownEventTypes.delivery.requestFulfilled) {
             state = DeliveryRequestStates.FULFILLED;
+            cancelReason = undefined;
             deliveryNotes = data.deliveryNotes ?? deliveryNotes;
         } else if (event.type === knownEventTypes.delivery.requestSlotChanged) {
             slotId = asNumber(data.newSlotId);
@@ -1157,6 +1161,26 @@ export async function cancelDeliveryRequest(
             cancelReason,
             note,
             cancelledBy: actorId,
+        }),
+    );
+}
+
+export async function uncancelDeliveryRequest(
+    requestId: string,
+): Promise<void> {
+    const request = await getDeliveryRequest(requestId);
+
+    if (!request) {
+        throw new Error('Delivery request not found');
+    }
+
+    if (request.state !== DeliveryRequestStates.CANCELLED) {
+        return;
+    }
+
+    await createEvent(
+        knownEvents.delivery.requestConfirmedV1(requestId, {
+            status: DeliveryRequestStates.CONFIRMED,
         }),
     );
 }

--- a/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
     acceptOperation,
+    cancelDeliveryRequest,
     changeDeliveryRequestSlot,
     createAttributeDefinition,
     createDeliveryRequest,
@@ -24,6 +25,7 @@ import {
     raisedBeds,
     storage,
     TimeSlotStatuses,
+    uncancelDeliveryRequest,
     updateEntity,
     upsertAttributeValue,
     upsertEntityType,
@@ -427,4 +429,32 @@ test('getDeliveryRequestsWithEvents uses the traced harvest plant sort for plant
     assert.equal(request.plantSort?.id, fixture.originalPlantSortId);
     assert.notEqual(request.plantSort?.id, fixture.latestPlantSortId);
     assert.equal(request.plantSort?.information.name, 'Original tomato');
+});
+
+test('uncancelDeliveryRequest restores cancelled requests to confirmed', async () => {
+    const fixture = await createDeliveryRequestWithTraceFixture();
+
+    await cancelDeliveryRequest(fixture.requestId, 'admin', 'Pogrešan termin');
+
+    const cancelledRequests = await getDeliveryRequestsWithEvents(
+        fixture.accountId,
+    );
+    const cancelledRequest = cancelledRequests.find(
+        (request) => request.id === fixture.requestId,
+    );
+
+    assert.equal(cancelledRequest?.state, DeliveryRequestStates.CANCELLED);
+    assert.equal(cancelledRequest?.cancelReason, 'Pogrešan termin');
+
+    await uncancelDeliveryRequest(fixture.requestId);
+
+    const restoredRequests = await getDeliveryRequestsWithEvents(
+        fixture.accountId,
+    );
+    const restoredRequest = restoredRequests.find(
+        (request) => request.id === fixture.requestId,
+    );
+
+    assert.equal(restoredRequest?.state, DeliveryRequestStates.CONFIRMED);
+    assert.equal(restoredRequest?.cancelReason, undefined);
 });


### PR DESCRIPTION
## Summary
- remove the low-value delivery request count header and make request groups visually stronger
- default delivery requests to active statuses while keeping explicit all/fulfilled filters available
- add per-group next-status progression for non-cancelled requests and allow cancelled requests to be restored to confirmed
- simplify row content by hiding user-assigned raised-bed names, avoiding `Nepoznata sorta` when the operation has no plant field, and showing compact plant/sort imagery

## Validation
- `corepack pnpm --filter app exec biome check --write app/admin/delivery/requests/DeliveryRequestContents.tsx app/admin/delivery/requests/DeliveryRequestListItem.tsx app/admin/delivery/requests/DeliveryRequestStatusAction.tsx app/admin/delivery/requests/DeliveryRequestsFilters.tsx app/admin/delivery/requests/DeliveryRequestsList.tsx app/admin/delivery/requests/actions.ts app/admin/delivery/requests/DeliveryRequestGroupStatusAction.tsx app/admin/delivery/requests/DeliveryRequestStatusFlow.ts`
- `corepack pnpm --filter @gredice/storage exec biome check --write src/repositories/deliveryRequestsRepo.ts tests/deliveryRequestsRepo.node.spec.ts`
- `corepack pnpm --filter @gredice/storage test -- deliveryRequestsRepo.node.spec.ts`
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server" corepack pnpm --filter app exec node --import tsx --test app/admin/delivery/requests/DeliveryRequestGroups.unit.ts`
- `git diff --check`

## Notes
- Broad direct `tsc --noEmit` checks for `app` and `@gredice/storage` were attempted, but both currently fail on unrelated existing workspace errors outside this change.