### PR TITLE
Implement receipt automation and billing document emails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
               - packages/auth/**
               - packages/directory-types/**
               - packages/email/**
+              - packages/fiscalization/**
               - packages/google/**
               - packages/js/**
               - packages/notifications/**

--- a/apps/api/lib/billing/billingDocumentEmail.node.spec.ts
+++ b/apps/api/lib/billing/billingDocumentEmail.node.spec.ts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { SelectEmailMessage } from '@gredice/storage';
+import type { sendBillingDocuments } from '../email/transactional';
+import {
+    billingDocumentDeliveryKey,
+    notifyBillingDocumentsEmail,
+} from './billingDocumentEmail';
+
+const date = new Date('2026-07-05T10:00:00.000Z');
+
+type SendBillingDocumentsArgs = Parameters<typeof sendBillingDocuments>;
+
+function emailMessage(
+    overrides: Partial<SelectEmailMessage> = {},
+): SelectEmailMessage {
+    return {
+        id: 123,
+        provider: 'acs',
+        providerMessageId: null,
+        status: 'sent',
+        providerStatus: null,
+        fromAddress: 'suncokret@obavijesti.gredice.com',
+        subject: 'Gredice - dokumenti narudžbe',
+        templateName: 'commerce-billing-documents',
+        messageType: 'commerce',
+        recipients: {
+            to: [{ address: 'kupac@example.test' }],
+        },
+        attachments: [],
+        metadata: {},
+        htmlBody: null,
+        textBody: null,
+        errorCode: null,
+        errorMessage: null,
+        queuedAt: date,
+        sentAt: date,
+        completedAt: date,
+        createdAt: date,
+        updatedAt: date,
+        lastAttemptAt: null,
+        bouncedAt: null,
+        ...overrides,
+    };
+}
+
+test('notifyBillingDocumentsEmail skips missing recipient', async () => {
+    let sendCount = 0;
+    const result = await notifyBillingDocumentsEmail(
+        {
+            invoiceId: 42,
+            invoiceNumber: 'PON-2026-0042',
+            to: ' ',
+        },
+        {
+            getEmailMessageByTemplateAndMetadata: async () => undefined,
+            sendBillingDocuments: async () => {
+                sendCount += 1;
+            },
+        },
+    );
+
+    assert.deepEqual(result, {
+        status: 'skipped',
+        reason: 'missing_recipient',
+    });
+    assert.equal(sendCount, 0);
+});
+
+test('notifyBillingDocumentsEmail skips active duplicate delivery log', async () => {
+    let sendCount = 0;
+    const result = await notifyBillingDocumentsEmail(
+        {
+            invoiceId: 42,
+            invoiceNumber: 'PON-2026-0042',
+            to: 'kupac@example.test',
+        },
+        {
+            getEmailMessageByTemplateAndMetadata: async () =>
+                emailMessage({ id: 123 }),
+            sendBillingDocuments: async () => {
+                sendCount += 1;
+            },
+        },
+    );
+
+    assert.deepEqual(result, {
+        status: 'skipped',
+        reason: 'already_sent',
+        emailMessageId: 123,
+    });
+    assert.equal(sendCount, 0);
+});
+
+test('notifyBillingDocumentsEmail sends invoice and receipt links with idempotency metadata', async () => {
+    const sends: SendBillingDocumentsArgs[] = [];
+    const lookups: unknown[] = [];
+    const result = await notifyBillingDocumentsEmail(
+        {
+            cartIds: [100],
+            checkoutSessionId: 'cs_paid',
+            invoiceId: 42,
+            invoiceNumber: 'PON-2026-0042',
+            receiptId: 77,
+            receiptNumber: '2026-77',
+            to: 'kupac@example.test',
+        },
+        {
+            getEmailMessageByTemplateAndMetadata: async (query) => {
+                lookups.push(query);
+                return undefined;
+            },
+            sendBillingDocuments: async (...args: SendBillingDocumentsArgs) => {
+                sends.push(args);
+            },
+        },
+    );
+
+    assert.deepEqual(result, { status: 'sent' });
+    assert.deepEqual(lookups, [
+        {
+            metadataKey: 'billingDeliveryKey',
+            metadataValue: billingDocumentDeliveryKey(42),
+            statuses: ['queued', 'sending', 'sent'],
+            templateName: 'commerce-billing-documents',
+        },
+    ]);
+    assert.equal(sends.length, 1);
+    assert.equal(sends[0]?.[0], 'kupac@example.test');
+    assert.match(
+        sends[0]?.[1].invoiceUrl ?? '',
+        /\/api\/accounts\/current\/billing\/invoices\/42\/document$/,
+    );
+    assert.match(
+        sends[0]?.[1].receiptUrl ?? '',
+        /\/api\/accounts\/current\/billing\/receipts\/77\/document$/,
+    );
+    assert.deepEqual(sends[0]?.[2], {
+        billingDeliveryKey: billingDocumentDeliveryKey(42),
+        cartIds: [100],
+        checkoutSessionId: 'cs_paid',
+        invoiceId: 42,
+        receiptId: 77,
+    });
+});
+
+test('notifyBillingDocumentsEmail reports send failures without throwing', async () => {
+    const result = await notifyBillingDocumentsEmail(
+        {
+            invoiceId: 42,
+            invoiceNumber: 'PON-2026-0042',
+            to: 'kupac@example.test',
+        },
+        {
+            getEmailMessageByTemplateAndMetadata: async () => undefined,
+            sendBillingDocuments: async () => {
+                throw new Error('acs offline');
+            },
+        },
+    );
+
+    assert.deepEqual(result, {
+        status: 'failed',
+        message: 'acs offline',
+    });
+});

--- a/apps/api/lib/billing/billingDocumentEmail.ts
+++ b/apps/api/lib/billing/billingDocumentEmail.ts
@@ -1,0 +1,144 @@
+import {
+    type EmailStatus,
+    getEmailMessageByTemplateAndMetadata,
+} from '@gredice/storage';
+import { sendBillingDocuments } from '../email/transactional';
+
+export const billingDocumentsTemplateName = 'commerce-billing-documents';
+const activeEmailStatuses = [
+    'queued',
+    'sending',
+    'sent',
+] satisfies EmailStatus[];
+
+const API_APP_URL =
+    process.env.GREDICE_API_APP_URL ?? 'https://api.gredice.com';
+const CUSTOMER_APP_URL =
+    process.env.GREDICE_GARDEN_APP_URL ?? 'https://vrt.gredice.com';
+
+export interface BillingDocumentsEmailParams {
+    to?: string | null;
+    invoiceId: number;
+    invoiceNumber: string;
+    receiptId?: number | null;
+    receiptNumber?: string | null;
+    checkoutSessionId?: string | null;
+    cartIds?: number[];
+}
+
+type BillingDocumentsEmailDeps = {
+    getEmailMessageByTemplateAndMetadata: typeof getEmailMessageByTemplateAndMetadata;
+    sendBillingDocuments: typeof sendBillingDocuments;
+};
+
+const defaultDeps: BillingDocumentsEmailDeps = {
+    getEmailMessageByTemplateAndMetadata,
+    sendBillingDocuments,
+};
+
+function absoluteUrl(baseUrl: string, path: string) {
+    const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+    return new URL(path, base).toString();
+}
+
+export function billingDocumentDeliveryKey(invoiceId: number) {
+    return `billing-documents:invoice:${invoiceId}`;
+}
+
+export function invoiceDocumentUrl(invoiceId: number) {
+    return absoluteUrl(
+        API_APP_URL,
+        `/api/accounts/current/billing/invoices/${invoiceId}/document`,
+    );
+}
+
+export function receiptDocumentUrl(receiptId: number) {
+    return absoluteUrl(
+        API_APP_URL,
+        `/api/accounts/current/billing/receipts/${receiptId}/document`,
+    );
+}
+
+export function accountBillingUrl() {
+    return absoluteUrl(CUSTOMER_APP_URL, '/racun/naplata');
+}
+
+export type NotifyBillingDocumentsEmailResult =
+    | { status: 'sent' }
+    | {
+          status: 'skipped';
+          reason: 'missing_recipient' | 'already_sent';
+          emailMessageId?: number;
+      }
+    | { status: 'failed'; message: string };
+
+export async function notifyBillingDocumentsEmail(
+    {
+        cartIds,
+        checkoutSessionId,
+        invoiceId,
+        invoiceNumber,
+        receiptId,
+        receiptNumber,
+        to,
+    }: BillingDocumentsEmailParams,
+    deps: BillingDocumentsEmailDeps = defaultDeps,
+): Promise<NotifyBillingDocumentsEmailResult> {
+    const email = to?.trim();
+    if (!email) {
+        console.warn('Skipping billing documents email: missing recipient', {
+            checkoutSessionId,
+            invoiceId,
+        });
+        return { status: 'skipped', reason: 'missing_recipient' };
+    }
+
+    const deliveryKey = billingDocumentDeliveryKey(invoiceId);
+    const existingEmail = await deps.getEmailMessageByTemplateAndMetadata({
+        metadataKey: 'billingDeliveryKey',
+        metadataValue: deliveryKey,
+        statuses: [...activeEmailStatuses],
+        templateName: billingDocumentsTemplateName,
+    });
+    if (existingEmail) {
+        return {
+            status: 'skipped',
+            reason: 'already_sent',
+            emailMessageId: existingEmail.id,
+        };
+    }
+
+    try {
+        await deps.sendBillingDocuments(
+            email,
+            {
+                billingUrl: accountBillingUrl(),
+                email,
+                invoiceNumber,
+                invoiceUrl: invoiceDocumentUrl(invoiceId),
+                receiptNumber,
+                receiptUrl: receiptId ? receiptDocumentUrl(receiptId) : null,
+            },
+            {
+                billingDeliveryKey: deliveryKey,
+                cartIds: cartIds ?? [],
+                checkoutSessionId: checkoutSessionId ?? null,
+                invoiceId,
+                receiptId: receiptId ?? null,
+            },
+        );
+        return { status: 'sent' };
+    } catch (error) {
+        const message =
+            error instanceof Error
+                ? error.message
+                : 'Failed to send billing documents email.';
+        console.error('Failed to send billing documents email', {
+            checkoutSessionId,
+            invoiceId,
+            hasRecipient: true,
+            error,
+        });
+        return { status: 'failed', message };
+    }
+}

--- a/apps/api/lib/billing/receiptFiscalization.node.spec.ts
+++ b/apps/api/lib/billing/receiptFiscalization.node.spec.ts
@@ -1,0 +1,264 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    fiscalizeReceipt,
+    issueReceiptForPaidInvoice,
+} from '@gredice/fiscalization/server';
+import type {
+    getAllFiscalizationSettings,
+    getFiscalizationUserSettings,
+    getReceipt,
+} from '@gredice/storage';
+
+const date = new Date('2026-07-05T10:00:00.000Z');
+
+type ReceiptRecord = NonNullable<Awaited<ReturnType<typeof getReceipt>>>;
+type FiscalizationSettings = Awaited<
+    ReturnType<typeof getAllFiscalizationSettings>
+>;
+type FiscalizationUserSettings = NonNullable<
+    Awaited<ReturnType<typeof getFiscalizationUserSettings>>
+>;
+type FiscalizationPosSettings = NonNullable<
+    FiscalizationSettings['posSettings']
+>;
+
+function receipt(overrides: Partial<ReceiptRecord> = {}): ReceiptRecord {
+    return {
+        id: 77,
+        invoiceId: 42,
+        receiptNumber: '7',
+        yearReceiptNumber: '2026-7',
+        subtotal: '25.00',
+        taxAmount: '0.00',
+        totalAmount: '25.00',
+        currency: 'eur',
+        paymentMethod: 'card',
+        paymentReference: 'cs_paid',
+        jir: null,
+        zki: null,
+        cisStatus: 'pending',
+        cisReference: null,
+        cisErrorMessage: null,
+        cisTimestamp: null,
+        cisResponse: 'previous debug',
+        issuedAt: date,
+        businessPin: null,
+        businessName: 'Gredice d.o.o.',
+        businessAddress: 'Zagreb',
+        customerPin: null,
+        customerName: null,
+        customerAddress: null,
+        createdAt: date,
+        updatedAt: date,
+        isDeleted: false,
+        invoice: null,
+        ...overrides,
+    };
+}
+
+function userSettings(
+    overrides: Partial<FiscalizationUserSettings> = {},
+): FiscalizationUserSettings {
+    return {
+        id: 1,
+        pin: '12345678901',
+        useVat: true,
+        environment: 'educ',
+        certBase64: Buffer.from('cert').toString('base64'),
+        certPassword: 'secret',
+        receiptNumberOnDevice: false,
+        isActive: true,
+        createdAt: date,
+        updatedAt: date,
+        isDeleted: false,
+        ...overrides,
+    };
+}
+
+function posSettings(
+    overrides: Partial<FiscalizationPosSettings> = {},
+): FiscalizationPosSettings {
+    return {
+        id: 1,
+        posId: '1',
+        premiseId: 'WEB',
+        isActive: true,
+        createdAt: date,
+        updatedAt: date,
+        isDeleted: false,
+        ...overrides,
+    };
+}
+
+test('issueReceiptForPaidInvoice fills business settings and delegates idempotent issuing', async () => {
+    const calls: unknown[] = [];
+
+    const result = await issueReceiptForPaidInvoice(
+        {
+            invoiceId: 42,
+            paymentReference: 'cs_paid',
+        },
+        {
+            getFiscalizationUserSettings: async () => userSettings(),
+            ensureReceiptForInvoice: async (...args: unknown[]) => {
+                calls.push(args);
+                return {
+                    status: 'created',
+                    receiptId: 77,
+                    receiptNumber: '7',
+                    yearReceiptNumber: '2026-7',
+                };
+            },
+        },
+    );
+
+    assert.equal(result.status, 'created');
+    assert.deepEqual(calls, [
+        [
+            42,
+            {
+                issuedAt: undefined,
+                paymentMethod: 'card',
+                paymentReference: 'cs_paid',
+                businessPin: '12345678901',
+                businessName: 'Gredice d.o.o.',
+                businessAddress:
+                    'Ulica Julija Knifera 3, 10000 Zagreb, Hrvatska',
+            },
+        ],
+    ]);
+});
+
+test('fiscalizeReceipt records missing fiscalization settings as failed', async () => {
+    const updates: unknown[] = [];
+
+    const result = await fiscalizeReceipt(77, {
+        getReceipt: async () => receipt(),
+        getAllFiscalizationSettings: async () => ({
+            userSettings: null,
+            posSettings: null,
+        }),
+        receiptRequest: async () => {
+            throw new Error('should not call CIS');
+        },
+        updateReceiptFiscalization: async (...args: unknown[]) => {
+            updates.push(args);
+        },
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.ok('reason' in result);
+    assert.equal(result.reason, 'missing_user_settings');
+    assert.deepEqual(updates, [
+        [
+            77,
+            {
+                zki: undefined,
+                cisStatus: 'failed',
+                cisErrorMessage:
+                    'Fiscalization user settings not found for account.',
+                cisTimestamp: updates[0]?.[1]?.cisTimestamp,
+                cisResponse: 'previous debug',
+            },
+        ],
+    ]);
+});
+
+test('fiscalizeReceipt records CIS rejection response', async () => {
+    const updates: unknown[] = [];
+
+    const result = await fiscalizeReceipt(77, {
+        getReceipt: async () => receipt(),
+        getAllFiscalizationSettings: async () => ({
+            userSettings: userSettings(),
+            posSettings: posSettings(),
+        }),
+        receiptRequest: async () => ({
+            success: false,
+            zki: 'zki-failed',
+            responseText: '<xml>failed</xml>',
+            errors: [{ errorMessage: 'CIS says no' }],
+        }),
+        updateReceiptFiscalization: async (...args: unknown[]) => {
+            updates.push(args);
+        },
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.ok('reason' in result);
+    assert.equal(result.reason, 'cis_rejected');
+    assert.equal(updates[0]?.[1]?.zki, 'zki-failed');
+    assert.equal(updates[0]?.[1]?.cisResponse, '<xml>failed</xml>');
+    assert.equal(updates[0]?.[1]?.cisErrorMessage, 'CIS says no');
+});
+
+test('fiscalizeReceipt records successful confirmation', async () => {
+    const updates: unknown[] = [];
+
+    const result = await fiscalizeReceipt(77, {
+        getReceipt: async () => receipt(),
+        getAllFiscalizationSettings: async () => ({
+            userSettings: userSettings(),
+            posSettings: posSettings(),
+        }),
+        receiptRequest: async () => ({
+            success: true,
+            dateTime: date,
+            receiptNumber: '7',
+            jir: 'jir-123',
+            zki: 'zki-123',
+            responseText: '<xml>ok</xml>',
+        }),
+        updateReceiptFiscalization: async (...args: unknown[]) => {
+            updates.push(args);
+        },
+    });
+
+    assert.deepEqual(result, {
+        status: 'confirmed',
+        receiptId: 77,
+        receiptNumber: '7',
+        jir: 'jir-123',
+        zki: 'zki-123',
+    });
+    assert.deepEqual(updates, [
+        [
+            77,
+            {
+                jir: 'jir-123',
+                zki: 'zki-123',
+                cisTimestamp: date,
+                cisStatus: 'confirmed',
+                cisErrorMessage: null,
+                cisReference: '7',
+                cisResponse: '<xml>ok</xml>',
+            },
+        ],
+    ]);
+});
+
+test('fiscalizeReceipt returns existing confirmed receipt without calling CIS', async () => {
+    let requestCount = 0;
+
+    const result = await fiscalizeReceipt(77, {
+        getReceipt: async () =>
+            receipt({
+                cisStatus: 'confirmed',
+                jir: 'jir-123',
+                zki: 'zki-123',
+            }),
+        getAllFiscalizationSettings: async () => ({
+            userSettings: null,
+            posSettings: null,
+        }),
+        receiptRequest: async () => {
+            requestCount += 1;
+            throw new Error('should not call CIS');
+        },
+        updateReceiptFiscalization: async () => undefined,
+    });
+
+    assert.equal(result.status, 'existing');
+    assert.equal(requestCount, 0);
+});

--- a/apps/api/lib/email/transactional.ts
+++ b/apps/api/lib/email/transactional.ts
@@ -11,6 +11,9 @@ import ResetPasswordEmailTemplate, {
 import WelcomeEmailTemplate, {
     type WelcomeEmailTemplateProps,
 } from '@gredice/transactional/emails/Account/welcome';
+import BillingDocumentsEmailTemplate, {
+    type BillingDocumentsEmailTemplateProps,
+} from '@gredice/transactional/emails/Commerce/billing-documents';
 import OrderConfirmationEmailTemplate, {
     type OrderConfirmationEmailTemplateProps,
 } from '@gredice/transactional/emails/Commerce/order-confirmation';
@@ -89,6 +92,22 @@ export async function sendOrderConfirmation(
         metadata: {
             orderReference: config.orderReference ?? null,
         },
+    });
+}
+
+export async function sendBillingDocuments(
+    to: string,
+    config: BillingDocumentsEmailTemplateProps,
+    metadata: Record<string, unknown>,
+) {
+    return await sendEmail({
+        from: 'suncokret@obavijesti.gredice.com',
+        to,
+        subject: 'Gredice - dokumenti narudžbe',
+        template: BillingDocumentsEmailTemplate(config),
+        templateName: 'commerce-billing-documents',
+        messageType: 'commerce',
+        metadata,
     });
 }
 

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -97,6 +97,29 @@ function makeDependencies(
                 invoiceNumber: 'PON-2026-0001',
             };
         },
+        issueReceiptForPaidInvoice: async (...args: unknown[]) => {
+            record(calls, 'issueReceiptForPaidInvoice', args);
+            return {
+                status: 'created',
+                receiptId: 701,
+                receiptNumber: '1',
+                yearReceiptNumber: '2026-1',
+            };
+        },
+        fiscalizeReceipt: async (...args: unknown[]) => {
+            record(calls, 'fiscalizeReceipt', args);
+            return {
+                status: 'confirmed',
+                receiptId: 701,
+                receiptNumber: '1',
+                jir: 'jir-123',
+                zki: 'zki-123',
+            };
+        },
+        notifyBillingDocumentsEmail: async (...args: unknown[]) => {
+            record(calls, 'notifyBillingDocumentsEmail', args);
+            return { status: 'sent' };
+        },
         getCompletedTransactionByStripePaymentId: async (
             ...args: unknown[]
         ) => {
@@ -467,6 +490,82 @@ describe('processCheckoutSession', () => {
                 },
             ],
         );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'issueReceiptForPaidInvoice')[0]?.args,
+            [
+                {
+                    invoiceId: 601,
+                    paymentReference: 'cs_paid',
+                },
+            ],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'fiscalizeReceipt')[0]?.args,
+            [701],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'notifyBillingDocumentsEmail')[0]?.args,
+            [
+                {
+                    to: 'buyer@example.test',
+                    cartIds: [100],
+                    checkoutSessionId: 'cs_paid',
+                    invoiceId: 601,
+                    invoiceNumber: 'PON-2026-0001',
+                    receiptId: 701,
+                    receiptNumber: '2026-1',
+                },
+            ],
+        );
+    });
+
+    it('omits receipt links from billing email when checkout fiscalization fails', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSession();
+            },
+            getShoppingCart: async (...args: unknown[]) => {
+                record(calls, 'getShoppingCart', args);
+                return makeCart();
+            },
+            getRaisedBedFieldsWithEvents: async (...args: unknown[]) => {
+                record(calls, 'getRaisedBedFieldsWithEvents', args);
+                return [{ id: 88, positionIndex: 2, active: true }];
+            },
+            isBillingAutomationEnabled: (...args: unknown[]) => {
+                record(calls, 'isBillingAutomationEnabled', args);
+                return true;
+            },
+            fiscalizeReceipt: async (...args: unknown[]) => {
+                record(calls, 'fiscalizeReceipt', args);
+                return {
+                    status: 'failed',
+                    reason: 'cis_rejected',
+                    receiptId: 701,
+                    message: 'CIS says no',
+                    zki: 'zki-123',
+                };
+            },
+        });
+
+        await processCheckoutSession('cs_paid', dependencies);
+
+        assert.deepStrictEqual(
+            callsNamed(calls, 'notifyBillingDocumentsEmail')[0]?.args,
+            [
+                {
+                    to: 'buyer@example.test',
+                    cartIds: [100],
+                    checkoutSessionId: 'cs_paid',
+                    invoiceId: 601,
+                    invoiceNumber: 'PON-2026-0001',
+                    receiptId: null,
+                    receiptNumber: null,
+                },
+            ],
+        );
     });
 
     it('continues checkout side effects when invoice generation fails', async () => {
@@ -512,6 +611,11 @@ describe('processCheckoutSession', () => {
         assert.equal(
             callsNamed(calls, 'notifyOrderConfirmationEmail').length,
             1,
+        );
+        assert.equal(callsNamed(calls, 'issueReceiptForPaidInvoice').length, 0);
+        assert.equal(
+            callsNamed(calls, 'notifyBillingDocumentsEmail').length,
+            0,
         );
     });
 

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -1,4 +1,8 @@
 import {
+    fiscalizeReceipt,
+    issueReceiptForPaidInvoice,
+} from '@gredice/fiscalization/server';
+import {
     isRaisedBedAbandoned,
     RAISED_BED_ABANDONED_ACTIONS_DISABLED_MESSAGE,
     RAISED_BED_ABANDONED_DUE_TO_INACTIVITY_MESSAGE,
@@ -39,6 +43,7 @@ import {
 } from '@gredice/storage';
 import { getStripeCheckoutSession } from '@gredice/stripe/server';
 import { isBillingAutomationEnabled } from '../billing/automationFlag';
+import { notifyBillingDocumentsEmail } from '../billing/billingDocumentEmail';
 import {
     buildCheckoutInvoiceBillingSnapshot,
     buildCheckoutInvoiceLineItem,
@@ -98,6 +103,9 @@ export type ProcessCheckoutSessionDependencies = {
     notifyDeliveryScheduled: typeof notifyDeliveryScheduled;
     notifyScheduledDeliveryEmailOnce: typeof notifyScheduledDeliveryEmailOnce;
     getPostHogClient: typeof getPostHogClient;
+    issueReceiptForPaidInvoice: typeof issueReceiptForPaidInvoice;
+    fiscalizeReceipt: typeof fiscalizeReceipt;
+    notifyBillingDocumentsEmail: typeof notifyBillingDocumentsEmail;
 };
 
 const realDependencies: ProcessCheckoutSessionDependencies = {
@@ -142,6 +150,9 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     notifyDeliveryScheduled,
     notifyScheduledDeliveryEmailOnce,
     getPostHogClient,
+    issueReceiptForPaidInvoice,
+    fiscalizeReceipt,
+    notifyBillingDocumentsEmail,
 };
 
 /**
@@ -734,9 +745,60 @@ async function processPaidCheckoutSession(
                     reason: invoiceResult.reason,
                     transactionId,
                 });
+            } else {
+                const receiptResult =
+                    await dependencies.issueReceiptForPaidInvoice({
+                        invoiceId: invoiceResult.invoiceId,
+                        paymentReference: session.id,
+                    });
+                if (receiptResult.status === 'skipped') {
+                    console.warn('Checkout receipt issuing skipped', {
+                        checkoutSessionId,
+                        invoiceId: invoiceResult.invoiceId,
+                        reason: receiptResult.reason,
+                        transactionId,
+                    });
+                } else {
+                    const fiscalizationResult =
+                        await dependencies.fiscalizeReceipt(
+                            receiptResult.receiptId,
+                        );
+                    const hasFiscalizedReceipt =
+                        fiscalizationResult.status === 'confirmed' ||
+                        fiscalizationResult.status === 'existing';
+                    if (fiscalizationResult.status === 'failed') {
+                        console.warn('Checkout receipt fiscalization failed', {
+                            checkoutSessionId,
+                            reason: fiscalizationResult.reason,
+                            receiptId: receiptResult.receiptId,
+                            transactionId,
+                        });
+                    } else if (fiscalizationResult.status === 'skipped') {
+                        console.warn('Checkout receipt fiscalization skipped', {
+                            checkoutSessionId,
+                            reason: fiscalizationResult.reason,
+                            receiptId: receiptResult.receiptId,
+                            transactionId,
+                        });
+                    }
+
+                    await dependencies.notifyBillingDocumentsEmail({
+                        to: customer?.userName,
+                        cartIds: uniqueAffectedCartIds,
+                        checkoutSessionId: session.id,
+                        invoiceId: invoiceResult.invoiceId,
+                        invoiceNumber: invoiceResult.invoiceNumber,
+                        receiptId: hasFiscalizedReceipt
+                            ? receiptResult.receiptId
+                            : null,
+                        receiptNumber: hasFiscalizedReceipt
+                            ? receiptResult.yearReceiptNumber
+                            : null,
+                    });
+                }
             }
         } catch (error) {
-            console.error('Checkout invoice generation failed', {
+            console.error('Checkout billing document automation failed', {
                 checkoutSessionId,
                 error,
                 transactionId,

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -61,6 +61,7 @@
         "@gredice/auth": "workspace:*",
         "@gredice/directory-types": "workspace:*",
         "@gredice/email": "workspace:*",
+        "@gredice/fiscalization": "workspace:*",
         "@gredice/js": "workspace:*",
         "@gredice/notifications": "workspace:*",
         "@gredice/signalco": "workspace:*",

--- a/apps/app/app/admin/invoices/[invoiceId]/actions.ts
+++ b/apps/app/app/admin/invoices/[invoiceId]/actions.ts
@@ -1,11 +1,9 @@
 'use server';
 
+import { issueReceiptForPaidInvoice } from '@gredice/fiscalization/server';
 import {
     cancelInvoice,
     changeInvoiceStatus,
-    createReceiptFromInvoice,
-    getFiscalizationUserSettings,
-    getInvoice,
     getReceiptByInvoice,
     type InvoiceStatus,
     softDeleteInvoice,
@@ -78,25 +76,14 @@ export async function deleteInvoiceAction(invoiceId: number) {
 export async function createReceiptAction(invoiceId: number) {
     await auth(['admin']);
 
+    let receiptId: number;
     try {
-        // TODO: Retrieve from settings
-        const invoice = await getInvoice(invoiceId);
-        const userSettings = await getFiscalizationUserSettings();
-        if (!userSettings) {
-            throw new Error('Fiscalization user settings not found');
+        const result = await issueReceiptForPaidInvoice({ invoiceId });
+        if (result.status === 'skipped') {
+            throw new Error(result.message);
         }
 
-        const receiptId = await createReceiptFromInvoice(invoiceId, {
-            paymentMethod: 'card',
-            businessPin: userSettings.pin,
-            businessName: 'Gredice d.o.o.',
-            businessAddress: 'Ulica Julija Knifera 3, 10000 Zagreb, Hrvatska',
-            customerAddress: invoice?.billToAddress,
-            customerName: invoice?.billToName,
-            paymentReference: invoice?.transactionId?.toString(),
-        });
-
-        redirect(KnownPages.Receipt(receiptId));
+        receiptId = result.receiptId;
     } catch (error) {
         console.error('Error creating receipt:', error);
         return {
@@ -107,6 +94,8 @@ export async function createReceiptAction(invoiceId: number) {
                     : 'Failed to create receipt',
         };
     }
+
+    redirect(KnownPages.Receipt(receiptId));
 }
 
 export async function getInvoiceReceiptAction(invoiceId: number) {

--- a/apps/app/app/admin/receipts/[receiptId]/actions.ts
+++ b/apps/app/app/admin/receipts/[receiptId]/actions.ts
@@ -1,12 +1,7 @@
 'use server';
 
-import { receiptRequest } from '@gredice/fiscalization';
-import {
-    getAllFiscalizationSettings,
-    getReceipt,
-    softDeleteReceipt,
-    updateReceiptFiscalization,
-} from '@gredice/storage';
+import { fiscalizeReceipt } from '@gredice/fiscalization/server';
+import { getReceipt, softDeleteReceipt } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { auth } from '../../../../lib/auth/auth';
@@ -50,88 +45,14 @@ export async function deleteReceiptAction(receiptId: number) {
 export async function fiscalizeReceiptAction(receiptId: number) {
     await auth(['admin']);
 
-    const receipt = await getReceipt(receiptId);
-    if (!receipt) {
-        throw new Error('Receipt not found');
+    const result = await fiscalizeReceipt(receiptId);
+    if (result.status === 'skipped') {
+        throw new Error(result.message);
     }
-
-    // Get fiscalization settings for the account
-    const fiscalizationSettings = await getAllFiscalizationSettings();
-    if (!fiscalizationSettings.userSettings) {
-        throw new Error('Fiscalization user settings not found for account');
-    }
-    if (!fiscalizationSettings.posSettings) {
-        throw new Error('Fiscalization POS settings not found for account');
-    }
-
-    try {
-        const response = await receiptRequest(
-            {
-                date: receipt.issuedAt,
-                receiptNumber: receipt.receiptNumber,
-                totalAmount: Number(receipt.totalAmount),
-            },
-            {
-                posSettings: {
-                    posId: fiscalizationSettings.posSettings.posId,
-                    premiseId: fiscalizationSettings.posSettings.premiseId,
-                },
-                posUser: {
-                    posPin: fiscalizationSettings.userSettings.pin,
-                },
-                userSettings: {
-                    pin: fiscalizationSettings.userSettings.pin,
-                    environment: fiscalizationSettings.userSettings
-                        .environment as 'educ' | 'prod',
-                    useVat: fiscalizationSettings.userSettings.useVat,
-                    credentials: {
-                        password:
-                            fiscalizationSettings.userSettings.certPassword,
-                        cert: Buffer.from(
-                            fiscalizationSettings.userSettings.certBase64,
-                            'base64',
-                        ).toString('binary'),
-                    },
-                    receiptNumberOnDevice:
-                        fiscalizationSettings.userSettings
-                            .receiptNumberOnDevice,
-                },
-            },
-        );
-
-        if (!response.success) {
-            const { responseText, errors, zki } = response;
-            await updateReceiptFiscalization(receiptId, {
-                zki,
-                cisStatus: 'failed',
-                cisErrorMessage: errors?.[0]?.errorMessage ?? null,
-                cisResponse: responseText,
-            });
-            return;
-        }
-
-        const { dateTime, receiptNumber, responseText, jir, zki } = response;
-
-        await updateReceiptFiscalization(receiptId, {
-            jir,
-            zki,
-            cisTimestamp: dateTime,
-            cisStatus: 'confirmed',
-            cisErrorMessage: null,
-            cisReference: receiptNumber, // Assuming receiptNumber is the reference
-            cisResponse: responseText,
-        });
-    } catch (error) {
-        console.error('Error fiscalizing receipt:', error);
-        const errorMessage =
-            error instanceof Error
-                ? error.message
-                : 'Failed to fiscalize receipt';
-        await updateReceiptFiscalization(receiptId, {
-            cisStatus: 'failed',
-            cisErrorMessage: errorMessage,
-            cisTimestamp: new Date(),
-            cisResponse: 'no response',
+    if (result.status === 'failed') {
+        console.warn('Receipt fiscalization failed', {
+            reason: result.reason,
+            receiptId,
         });
     }
 

--- a/packages/fiscalization/package.json
+++ b/packages/fiscalization/package.json
@@ -3,7 +3,8 @@
     "version": "1.0.0",
     "private": true,
     "exports": {
-        ".": "./src/index.ts"
+        ".": "./src/index.ts",
+        "./server": "./src/server.ts"
     },
     "scripts": {
         "clean": "rimraf .turbo dist build out coverage tsconfig.tsbuildinfo",
@@ -25,8 +26,10 @@
         "wsdl-tsclient": "1.7.1"
     },
     "dependencies": {
+        "@gredice/storage": "workspace:*",
         "node-forge": "1.4.0",
         "qrcode": "1.5.4",
+        "server-only": "0.0.1",
         "soap": "1.9.3",
         "undici": "8.5.0",
         "xml-crypto": "6.1.2",

--- a/packages/fiscalization/src/clients/requests/echoRequest.ts
+++ b/packages/fiscalization/src/clients/requests/echoRequest.ts
@@ -1,5 +1,5 @@
 import type { UserSettings } from '../../@types/UserSettings';
-import type { String as EchoRequest } from '../../generated/1-9-0-educ/fiskalizacijaservice';
+import type { String as EchoRequest } from '../../generated/1-9-0-educ/fiskalizacijaservice/definitions/String';
 import { type FisRequest, fisClient } from '../shared';
 
 export type EchoRequestResult =

--- a/packages/fiscalization/src/clients/requests/receiptRequest.ts
+++ b/packages/fiscalization/src/clients/requests/receiptRequest.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { PosSettings } from '../../@types/PosSettings';
 import type { PosUser } from '../../@types/PosUser';
 import type { UserSettings } from '../../@types/UserSettings';
-import type { RacunZahtjev } from '../../generated/1-9-0-educ/fiskalizacijaservice';
+import type { RacunZahtjev } from '../../generated/1-9-0-educ/fiskalizacijaservice/definitions/RacunZahtjev';
 import { generateZki } from '../generateZki';
 import { soapDateTime } from '../helpers/soapDateTime';
 import { type FisRequest, fisClient, prepareXml } from '../shared';

--- a/packages/fiscalization/src/clients/shared.ts
+++ b/packages/fiscalization/src/clients/shared.ts
@@ -1,8 +1,8 @@
 import { WSDL } from 'soap';
 import { Agent, request as undiciRequest } from 'undici';
 import type { UserSettings } from '../@types/UserSettings';
-import { createClientAsync as createClientAsyncEduc } from '../generated/1-9-0-educ/fiskalizacijaservice';
-import { createClientAsync as createClientAsyncProd } from '../generated/1-9-0-prod/fiskalizacijaservice';
+import { createClientAsync as createClientAsyncEduc } from '../generated/1-9-0-educ/fiskalizacijaservice/client';
+import { createClientAsync as createClientAsyncProd } from '../generated/1-9-0-prod/fiskalizacijaservice/client';
 import { signXml } from './signXml';
 
 const testEndpoint = 'https://cistest.apis-it.hr:8449/FiskalizacijaServiceTest';

--- a/packages/fiscalization/src/server.ts
+++ b/packages/fiscalization/src/server.ts
@@ -1,0 +1,247 @@
+import 'server-only';
+
+import {
+    ensureReceiptForInvoice,
+    getAllFiscalizationSettings,
+    getFiscalizationUserSettings,
+    getReceipt,
+    type ReceiptForInvoiceData,
+    updateReceiptFiscalization,
+} from '@gredice/storage';
+import {
+    type ReceiptRequestResult,
+    receiptRequest,
+} from './clients/requests/receiptRequest';
+
+const DEFAULT_BUSINESS_NAME = 'Gredice d.o.o.';
+const DEFAULT_BUSINESS_ADDRESS =
+    'Ulica Julija Knifera 3, 10000 Zagreb, Hrvatska';
+
+type ReceiptRequestFn = typeof receiptRequest;
+type FiscalizationEnvironment = 'educ' | 'prod';
+
+export interface IssueReceiptForPaidInvoiceInput {
+    invoiceId: number;
+    issuedAt?: Date | null;
+    paymentMethod?: ReceiptForInvoiceData['paymentMethod'];
+    paymentReference?: string | null;
+}
+
+type IssueReceiptForPaidInvoiceDeps = {
+    ensureReceiptForInvoice: typeof ensureReceiptForInvoice;
+    getFiscalizationUserSettings: typeof getFiscalizationUserSettings;
+};
+
+const issueReceiptDeps: IssueReceiptForPaidInvoiceDeps = {
+    ensureReceiptForInvoice,
+    getFiscalizationUserSettings,
+};
+
+export async function issueReceiptForPaidInvoice(
+    input: IssueReceiptForPaidInvoiceInput,
+    deps: IssueReceiptForPaidInvoiceDeps = issueReceiptDeps,
+) {
+    const userSettings = await deps.getFiscalizationUserSettings();
+
+    return deps.ensureReceiptForInvoice(input.invoiceId, {
+        issuedAt: input.issuedAt,
+        paymentMethod: input.paymentMethod ?? 'card',
+        paymentReference: input.paymentReference,
+        businessPin: userSettings?.pin,
+        businessName: DEFAULT_BUSINESS_NAME,
+        businessAddress: DEFAULT_BUSINESS_ADDRESS,
+    });
+}
+
+export type FiscalizeReceiptFailedReason =
+    | 'missing_user_settings'
+    | 'missing_pos_settings'
+    | 'cis_rejected'
+    | 'request_failed';
+
+export type FiscalizeReceiptResult =
+    | {
+          status: 'confirmed' | 'existing';
+          receiptId: number;
+          receiptNumber: string;
+          jir?: string | null;
+          zki?: string | null;
+      }
+    | {
+          status: 'failed';
+          reason: FiscalizeReceiptFailedReason;
+          receiptId: number;
+          message: string;
+          zki?: string | null;
+      }
+    | {
+          status: 'skipped';
+          reason: 'receipt_not_found';
+          message: string;
+      };
+
+type FiscalizeReceiptDeps = {
+    getAllFiscalizationSettings: typeof getAllFiscalizationSettings;
+    getReceipt: typeof getReceipt;
+    receiptRequest: ReceiptRequestFn;
+    updateReceiptFiscalization: typeof updateReceiptFiscalization;
+};
+
+const fiscalizeReceiptDeps: FiscalizeReceiptDeps = {
+    getAllFiscalizationSettings,
+    getReceipt,
+    receiptRequest,
+    updateReceiptFiscalization,
+};
+
+function normalizeFiscalizationEnvironment(
+    environment: string,
+): FiscalizationEnvironment {
+    return environment === 'prod' ? 'prod' : 'educ';
+}
+
+async function markReceiptFiscalizationFailed(
+    receipt: NonNullable<Awaited<ReturnType<typeof getReceipt>>>,
+    reason: FiscalizeReceiptFailedReason,
+    message: string,
+    deps: Pick<FiscalizeReceiptDeps, 'updateReceiptFiscalization'>,
+    response?: Pick<
+        Extract<ReceiptRequestResult, { success: false }>,
+        'responseText' | 'zki'
+    >,
+): Promise<FiscalizeReceiptResult> {
+    await deps.updateReceiptFiscalization(receipt.id, {
+        zki: response?.zki ?? receipt.zki ?? undefined,
+        cisStatus: 'failed',
+        cisErrorMessage: message,
+        cisTimestamp: new Date(),
+        cisResponse: response?.responseText ?? receipt.cisResponse,
+    });
+
+    return {
+        status: 'failed',
+        reason,
+        receiptId: receipt.id,
+        message,
+        zki: response?.zki ?? receipt.zki,
+    };
+}
+
+export async function fiscalizeReceipt(
+    receiptId: number,
+    deps: FiscalizeReceiptDeps = fiscalizeReceiptDeps,
+): Promise<FiscalizeReceiptResult> {
+    const receipt = await deps.getReceipt(receiptId);
+    if (!receipt) {
+        return {
+            status: 'skipped',
+            reason: 'receipt_not_found',
+            message: `Receipt ${receiptId} was not found.`,
+        };
+    }
+
+    if (receipt.cisStatus === 'confirmed' && receipt.jir) {
+        return {
+            status: 'existing',
+            receiptId: receipt.id,
+            receiptNumber: receipt.receiptNumber,
+            jir: receipt.jir,
+            zki: receipt.zki,
+        };
+    }
+
+    const fiscalizationSettings = await deps.getAllFiscalizationSettings();
+    if (!fiscalizationSettings.userSettings) {
+        return markReceiptFiscalizationFailed(
+            receipt,
+            'missing_user_settings',
+            'Fiscalization user settings not found for account.',
+            deps,
+        );
+    }
+    if (!fiscalizationSettings.posSettings) {
+        return markReceiptFiscalizationFailed(
+            receipt,
+            'missing_pos_settings',
+            'Fiscalization POS settings not found for account.',
+            deps,
+        );
+    }
+
+    try {
+        const response = await deps.receiptRequest(
+            {
+                date: receipt.issuedAt,
+                receiptNumber: receipt.receiptNumber,
+                totalAmount: Number(receipt.totalAmount),
+            },
+            {
+                posSettings: {
+                    posId: fiscalizationSettings.posSettings.posId,
+                    premiseId: fiscalizationSettings.posSettings.premiseId,
+                },
+                posUser: {
+                    posPin: fiscalizationSettings.userSettings.pin,
+                },
+                userSettings: {
+                    pin: fiscalizationSettings.userSettings.pin,
+                    environment: normalizeFiscalizationEnvironment(
+                        fiscalizationSettings.userSettings.environment,
+                    ),
+                    useVat: fiscalizationSettings.userSettings.useVat,
+                    credentials: {
+                        password:
+                            fiscalizationSettings.userSettings.certPassword,
+                        cert: Buffer.from(
+                            fiscalizationSettings.userSettings.certBase64,
+                            'base64',
+                        ).toString('binary'),
+                    },
+                    receiptNumberOnDevice:
+                        fiscalizationSettings.userSettings
+                            .receiptNumberOnDevice,
+                },
+            },
+        );
+
+        if (!response.success) {
+            return markReceiptFiscalizationFailed(
+                receipt,
+                'cis_rejected',
+                response.errors?.[0]?.errorMessage ??
+                    'Fiscalization request was rejected.',
+                deps,
+                response,
+            );
+        }
+
+        await deps.updateReceiptFiscalization(receipt.id, {
+            jir: response.jir,
+            zki: response.zki,
+            cisTimestamp: response.dateTime,
+            cisStatus: 'confirmed',
+            cisErrorMessage: null,
+            cisReference: response.receiptNumber,
+            cisResponse: response.responseText,
+        });
+
+        return {
+            status: 'confirmed',
+            receiptId: receipt.id,
+            receiptNumber: receipt.receiptNumber,
+            jir: response.jir,
+            zki: response.zki,
+        };
+    } catch (error) {
+        const message =
+            error instanceof Error
+                ? error.message
+                : 'Failed to fiscalize receipt.';
+        return markReceiptFiscalizationFailed(
+            receipt,
+            'request_failed',
+            message,
+            deps,
+        );
+    }
+}

--- a/packages/storage/src/repositories/emailsRepo.ts
+++ b/packages/storage/src/repositories/emailsRepo.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import { storage } from '..';
 import {
     type EmailLogAttachment,
@@ -121,5 +121,28 @@ export function getEmailMessageByProviderId(
 ): Promise<SelectEmailMessage | undefined> {
     return storage().query.emailMessages.findFirst({
         where: eq(emailMessages.providerMessageId, providerMessageId),
+    });
+}
+
+export function getEmailMessageByTemplateAndMetadata({
+    metadataKey,
+    metadataValue,
+    statuses,
+    templateName,
+}: {
+    metadataKey: string;
+    metadataValue: string;
+    statuses?: EmailStatus[];
+    templateName: string;
+}): Promise<SelectEmailMessage | undefined> {
+    return storage().query.emailMessages.findFirst({
+        where: and(
+            eq(emailMessages.templateName, templateName),
+            sql<boolean>`${emailMessages.metadata}->>${metadataKey} = ${metadataValue}`,
+            statuses && statuses.length > 0
+                ? inArray(emailMessages.status, statuses)
+                : undefined,
+        ),
+        orderBy: desc(emailMessages.createdAt),
     });
 }

--- a/packages/storage/src/repositories/invoicesRepo.ts
+++ b/packages/storage/src/repositories/invoicesRepo.ts
@@ -74,6 +74,28 @@ export type EnsureInvoiceForTransactionResult =
           message: string;
       };
 
+export interface ReceiptForInvoiceData
+    extends Omit<ReceiptCreationData, 'jir' | 'zki'> {
+    issuedAt?: Date | null;
+}
+
+export type EnsureReceiptForInvoiceSkippedReason =
+    | 'invoice_not_found'
+    | 'invoice_not_paid';
+
+export type EnsureReceiptForInvoiceResult =
+    | {
+          status: 'created' | 'existing';
+          receiptId: number;
+          receiptNumber: string;
+          yearReceiptNumber: string;
+      }
+    | {
+          status: 'skipped';
+          reason: EnsureReceiptForInvoiceSkippedReason;
+          message: string;
+      };
+
 // Invoice CRUD operations
 export async function createInvoice(
     invoice: InsertInvoice,
@@ -206,6 +228,17 @@ function buildSkippedInvoiceResult(
     };
 }
 
+function buildSkippedReceiptResult(
+    reason: EnsureReceiptForInvoiceSkippedReason,
+    message: string,
+): EnsureReceiptForInvoiceResult {
+    return {
+        status: 'skipped',
+        reason,
+        message,
+    };
+}
+
 async function withInvoiceTransactionGenerationLock<T>(
     transactionId: number,
     callback: () => Promise<T>,
@@ -217,6 +250,23 @@ async function withInvoiceTransactionGenerationLock<T>(
     return storage().transaction(async (tx) => {
         await tx.execute(
             sql`select pg_advisory_xact_lock(hashtext(${`invoice-transaction:${transactionId}`}));`,
+        );
+
+        return callback();
+    });
+}
+
+async function withReceiptInvoiceGenerationLock<T>(
+    invoiceId: number,
+    callback: () => Promise<T>,
+) {
+    if (process.env.GREDICE_TEST_DB_PROVIDER === 'pglite') {
+        return callback();
+    }
+
+    return storage().transaction(async (tx) => {
+        await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtext(${`receipt-invoice:${invoiceId}`}));`,
         );
 
         return callback();
@@ -381,6 +431,74 @@ export async function ensureInvoiceForTransaction({
             status: 'created',
             invoiceId,
             invoiceNumber: invoice.invoiceNumber,
+        };
+    });
+}
+
+export async function ensureReceiptForInvoice(
+    invoiceId: number,
+    receiptData: ReceiptForInvoiceData,
+): Promise<EnsureReceiptForInvoiceResult> {
+    return withReceiptInvoiceGenerationLock(invoiceId, async () => {
+        const existingReceipt = await getReceiptByInvoice(invoiceId);
+        if (existingReceipt) {
+            return {
+                status: 'existing',
+                receiptId: existingReceipt.id,
+                receiptNumber: existingReceipt.receiptNumber,
+                yearReceiptNumber: existingReceipt.yearReceiptNumber,
+            };
+        }
+
+        const invoice = await getInvoice(invoiceId);
+        if (!invoice) {
+            return buildSkippedReceiptResult(
+                'invoice_not_found',
+                `Invoice ${invoiceId} was not found.`,
+            );
+        }
+        if (invoice.status !== 'paid') {
+            return buildSkippedReceiptResult(
+                'invoice_not_paid',
+                `Invoice ${invoiceId} is not paid.`,
+            );
+        }
+
+        const issuedAt = receiptData.issuedAt ?? invoice.paidDate ?? new Date();
+        const receiptId = await createReceipt({
+            invoiceId,
+            subtotal: invoice.subtotal,
+            taxAmount: invoice.taxAmount,
+            totalAmount: invoice.totalAmount,
+            currency: invoice.currency,
+            paymentMethod: receiptData.paymentMethod,
+            paymentReference:
+                receiptData.paymentReference ??
+                invoice.transaction?.stripePaymentId ??
+                invoice.transactionId?.toString(),
+            businessPin: receiptData.businessPin,
+            businessName: receiptData.businessName,
+            businessAddress: receiptData.businessAddress,
+            customerPin: receiptData.customerPin,
+            customerName: receiptData.customerName ?? invoice.billToName,
+            customerAddress:
+                receiptData.customerAddress ?? invoice.billToAddress,
+            issuedAt,
+            cisStatus: 'pending',
+        });
+
+        const receipt = await getReceipt(receiptId);
+        if (!receipt) {
+            throw new Error(
+                `Failed to create receipt for invoice ${invoiceId}`,
+            );
+        }
+
+        return {
+            status: 'created',
+            receiptId,
+            receiptNumber: receipt.receiptNumber,
+            yearReceiptNumber: receipt.yearReceiptNumber,
         };
     });
 }
@@ -790,42 +908,12 @@ export async function createReceiptFromInvoice(
     invoiceId: number,
     receiptData: Omit<ReceiptCreationData, 'jir' | 'zki'>,
 ) {
-    // Get the invoice details
-    const invoice = await getInvoice(invoiceId);
-    if (!invoice) {
-        throw new Error('Invoice not found');
+    const result = await ensureReceiptForInvoice(invoiceId, receiptData);
+    if (result.status === 'skipped') {
+        throw new Error(result.message);
     }
 
-    if (invoice.status !== 'paid') {
-        throw new Error('Can only create receipt for paid invoices');
-    }
-
-    // Check if receipt already exists for this invoice
-    const existingReceipt = await getReceiptByInvoice(invoiceId);
-    if (existingReceipt) {
-        throw new Error('Receipt already exists for this invoice');
-    }
-
-    // Generate receipt number
-    const receiptToInsert = {
-        invoiceId,
-        subtotal: invoice.subtotal,
-        taxAmount: invoice.taxAmount,
-        totalAmount: invoice.totalAmount,
-        currency: invoice.currency,
-        paymentMethod: receiptData.paymentMethod,
-        paymentReference: receiptData.paymentReference,
-        businessPin: receiptData.businessPin,
-        businessName: receiptData.businessName,
-        businessAddress: receiptData.businessAddress,
-        customerPin: receiptData.customerPin,
-        customerName: receiptData.customerName,
-        customerAddress: receiptData.customerAddress,
-        cisStatus: 'pending', // Start as pending, not fiscalized yet
-    } satisfies Omit<InsertReceipt, 'yearReceiptNumber'>;
-
-    const receiptId = await createReceipt(receiptToInsert);
-    return receiptId;
+    return result.receiptId;
 }
 
 // Receipt CRUD operations

--- a/packages/storage/tests/emailsRepo.node.spec.ts
+++ b/packages/storage/tests/emailsRepo.node.spec.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createEmailMessageLog,
+    getEmailMessageByTemplateAndMetadata,
+} from '@gredice/storage';
+import { createTestDb } from './testDb';
+
+test('getEmailMessageByTemplateAndMetadata filters active billing delivery logs', async () => {
+    createTestDb();
+    const deliveryKey = 'billing-documents:invoice:42';
+
+    await createEmailMessageLog({
+        fromAddress: 'suncokret@obavijesti.gredice.com',
+        subject: 'Gredice - dokumenti narudžbe',
+        templateName: 'commerce-billing-documents',
+        messageType: 'commerce',
+        recipients: { to: [{ address: 'kupac@example.test' }] },
+        metadata: { billingDeliveryKey: deliveryKey },
+        status: 'failed',
+    });
+
+    assert.equal(
+        await getEmailMessageByTemplateAndMetadata({
+            metadataKey: 'billingDeliveryKey',
+            metadataValue: deliveryKey,
+            statuses: ['queued', 'sending', 'sent'],
+            templateName: 'commerce-billing-documents',
+        }),
+        undefined,
+    );
+
+    const sent = await createEmailMessageLog({
+        fromAddress: 'suncokret@obavijesti.gredice.com',
+        subject: 'Gredice - dokumenti narudžbe',
+        templateName: 'commerce-billing-documents',
+        messageType: 'commerce',
+        recipients: { to: [{ address: 'kupac@example.test' }] },
+        metadata: { billingDeliveryKey: deliveryKey },
+        status: 'sent',
+    });
+
+    const found = await getEmailMessageByTemplateAndMetadata({
+        metadataKey: 'billingDeliveryKey',
+        metadataValue: deliveryKey,
+        statuses: ['queued', 'sending', 'sent'],
+        templateName: 'commerce-billing-documents',
+    });
+
+    assert.equal(found?.id, sent.id);
+});

--- a/packages/storage/tests/invoicesRepo.node.spec.ts
+++ b/packages/storage/tests/invoicesRepo.node.spec.ts
@@ -14,6 +14,7 @@ import {
     createTransaction,
     deleteInvoice,
     ensureInvoiceForTransaction,
+    ensureReceiptForInvoice,
     getAccountBillingInvoice,
     getAccountBillingInvoices,
     getAccountBillingReceipt,
@@ -282,6 +283,54 @@ test('ensureInvoiceForTransaction returns existing invoice on repeated calls', a
     assert.ok('invoiceId' in second);
     assert.equal(second.invoiceId, first.invoiceId);
     assert.equal((await getAllInvoices({ transactionId })).length, 1);
+});
+
+test('ensureReceiptForInvoice creates one receipt for repeated paid invoice calls', async () => {
+    createTestDb();
+    const invoiceData = await baseInvoice();
+    invoiceData.status = 'paid';
+    invoiceData.paidDate = new Date('2026-07-05T10:00:00.000Z');
+    const invoiceId = await createInvoice(invoiceData);
+
+    const first = await ensureReceiptForInvoice(invoiceId, {
+        paymentMethod: 'card',
+        paymentReference: 'cs_test_123',
+        businessPin: '12345678901',
+        businessName: 'Gredice d.o.o.',
+        businessAddress: 'Zagreb',
+    });
+    const second = await ensureReceiptForInvoice(invoiceId, {
+        paymentMethod: 'card',
+        paymentReference: 'cs_test_123',
+    });
+
+    assert.equal(first.status, 'created');
+    assert.equal(second.status, 'existing');
+    assert.ok('receiptId' in first);
+    assert.ok('receiptId' in second);
+    assert.equal(second.receiptId, first.receiptId);
+    const receipt = await getReceipt(first.receiptId);
+    assert.ok(receipt);
+    assert.equal(receipt.paymentReference, 'cs_test_123');
+    assert.equal(receipt.customerName, invoiceData.billToName);
+    assert.equal(
+        receipt.issuedAt.toISOString(),
+        invoiceData.paidDate.toISOString(),
+    );
+});
+
+test('ensureReceiptForInvoice skips unpaid invoices', async () => {
+    createTestDb();
+    const invoiceData = await baseInvoice();
+    const invoiceId = await createInvoice(invoiceData);
+
+    const result = await ensureReceiptForInvoice(invoiceId, {
+        paymentMethod: 'card',
+    });
+
+    assert.equal(result.status, 'skipped');
+    assert.ok('reason' in result);
+    assert.equal(result.reason, 'invoice_not_paid');
 });
 
 test('ensureInvoiceForTransaction ignores deleted invoice and creates a new active invoice', async () => {

--- a/packages/transactional/emails/Commerce/billing-documents.tsx
+++ b/packages/transactional/emails/Commerce/billing-documents.tsx
@@ -1,0 +1,93 @@
+import { Head, Html, Preview, Section, Tailwind, Text } from 'react-email';
+import { ContentCard } from '../../components/ContentCard';
+import { Divider } from '../../components/Divider';
+import { GrediceLogotype } from '../../components/GrediceLogotype';
+import { Header } from '../../components/Header';
+import { Paragraph } from '../../components/Paragraph';
+import { PrimaryButton } from '../../components/PrimaryButton';
+import { GrediceDisclaimer } from '../../components/shared/GrediceDisclaimer';
+
+export interface BillingDocumentsEmailTemplateProps {
+    email: string;
+    invoiceNumber: string;
+    invoiceUrl: string;
+    receiptNumber?: string | null;
+    receiptUrl?: string | null;
+    billingUrl?: string;
+    appName?: string;
+    appDomain?: string;
+}
+
+export default function BillingDocumentsEmailTemplate({
+    email,
+    invoiceNumber,
+    invoiceUrl,
+    receiptNumber,
+    receiptUrl,
+    billingUrl = 'https://vrt.gredice.com/racun/naplata',
+    appName = 'Gredice',
+    appDomain = 'gredice.com',
+}: BillingDocumentsEmailTemplateProps) {
+    const previewText = `${appName} - dokumenti narudžbe`;
+
+    return (
+        <Html>
+            <Head />
+            <Preview>{previewText}</Preview>
+            <Tailwind>
+                <ContentCard>
+                    <Section className="text-center">
+                        <GrediceLogotype />
+                    </Section>
+                    <Header>Dokumenti narudžbe</Header>
+                    <Paragraph>Bok!</Paragraph>
+                    <Paragraph>
+                        Tvoji dokumenti za plaćenu narudžbu su spremni u
+                        korisničkom računu.
+                    </Paragraph>
+                    <Section className="my-[24px]">
+                        <Text className="m-0 text-[14px] font-semibold leading-[22px] text-black">
+                            Ponuda {invoiceNumber}
+                        </Text>
+                        <Text className="m-0 text-[13px] leading-[20px] text-[#475569]">
+                            Dokument ponude možeš otvoriti direktno iz ovog
+                            emaila ili kroz pregled naplate.
+                        </Text>
+                        <Section className="mt-[16px]">
+                            <PrimaryButton href={invoiceUrl}>
+                                Otvori ponudu
+                            </PrimaryButton>
+                        </Section>
+                    </Section>
+                    {receiptUrl ? (
+                        <Section className="my-[24px]">
+                            <Text className="m-0 text-[14px] font-semibold leading-[22px] text-black">
+                                Fiskalni račun {receiptNumber ?? ''}
+                            </Text>
+                            <Text className="m-0 text-[13px] leading-[20px] text-[#475569]">
+                                Fiskalni račun je povezan s istom narudžbom.
+                            </Text>
+                            <Section className="mt-[16px]">
+                                <PrimaryButton href={receiptUrl}>
+                                    Otvori račun
+                                </PrimaryButton>
+                            </Section>
+                        </Section>
+                    ) : null}
+                    <Paragraph>
+                        Sve dokumente možeš pronaći i u odjeljku Računi i
+                        plaćanja.
+                    </Paragraph>
+                    <Section className="my-[32px] text-center">
+                        <PrimaryButton href={billingUrl}>
+                            Računi i plaćanja
+                        </PrimaryButton>
+                    </Section>
+                    <Paragraph>{appName} tim</Paragraph>
+                    <Divider className="my-[26px]" />
+                    <GrediceDisclaimer email={email} appDomain={appDomain} />
+                </ContentCard>
+            </Tailwind>
+        </Html>
+    );
+}

--- a/packages/transactional/tests/billingDocumentsEmail.node.spec.tsx
+++ b/packages/transactional/tests/billingDocumentsEmail.node.spec.tsx
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import { createElement } from 'react';
+import BillingDocumentsEmailTemplate from '../emails/Commerce/billing-documents';
+import { assertHtmlIncludes, renderNonEmpty } from './renderEmail';
+
+test('billing-documents renders invoice, receipt, and billing links', async () => {
+    const html = await renderNonEmpty(
+        createElement(BillingDocumentsEmailTemplate, {
+            email: 'kupac@example.test',
+            invoiceNumber: 'PON-2026-0042',
+            invoiceUrl: 'https://api.gredice.test/api/invoice',
+            receiptNumber: '2026-7',
+            receiptUrl: 'https://api.gredice.test/api/receipt',
+            billingUrl: 'https://vrt.gredice.test/racun/naplata',
+        }),
+    );
+
+    assertHtmlIncludes(html, 'PON-2026-0042');
+    assertHtmlIncludes(html, '2026-7');
+    assertHtmlIncludes(html, 'https://api.gredice.test/api/invoice');
+    assertHtmlIncludes(html, 'https://api.gredice.test/api/receipt');
+    assertHtmlIncludes(html, 'https://vrt.gredice.test/racun/naplata');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@gredice/email':
         specifier: workspace:*
         version: link:../../packages/email
+      '@gredice/fiscalization':
+        specifier: workspace:*
+        version: link:../../packages/fiscalization
       '@gredice/js':
         specifier: workspace:*
         version: link:../../packages/js
@@ -1055,12 +1058,18 @@ importers:
 
   packages/fiscalization:
     dependencies:
+      '@gredice/storage':
+        specifier: workspace:*
+        version: link:../storage
       node-forge:
         specifier: 1.4.0
         version: 1.4.0
       qrcode:
         specifier: 1.5.4
         version: 1.5.4
+      server-only:
+        specifier: 0.0.1
+        version: 0.0.1
       soap:
         specifier: 1.9.3
         version: 1.9.3


### PR DESCRIPTION
## Summary
- issue receipts idempotently for paid billing invoices and reuse the shared fiscalization service from checkout/admin actions
- fiscalize receipts with persisted failure/audit states and avoid generated SOAP barrel imports that break isolated-module builds
- send idempotent billing document emails with invoice/receipt links after checkout documents exist

## Tests
- pnpm --filter storage test:node invoicesRepo.node.spec.ts emailsRepo.node.spec.ts
- pnpm --filter api test:node
- pnpm --filter app test:unit
- pnpm --filter @gredice/fiscalization test:unit
- pnpm --filter @gredice/transactional test:node
- pnpm --filter api exec node --conditions=react-server --import tsx --test lib/billing/billingDocumentEmail.node.spec.ts lib/billing/receiptFiscalization.node.spec.ts lib/stripe/processCheckoutSession.node.spec.ts
- pnpm --filter api build
- pnpm --filter app build
- corepack pnpm install --frozen-lockfile --filter api... --filter .
- corepack pnpm install --frozen-lockfile --filter app... --filter .
- node ./scripts/check-ci-filters.mjs
- git diff --check

Closes #4037.
Closes #776.
Closes #4020.
Closes #4021.
Closes #4022.
Closes #713.
Closes #4017.
Closes #4018.
Closes #4019.