### PR TITLE
[Sunflowers] Wire checkout, garden purchase, and public package surfaces

### DIFF
--- a/apps/api/app/api/[...route]/accountsRoutes.ts
+++ b/apps/api/app/api/[...route]/accountsRoutes.ts
@@ -21,6 +21,7 @@ import {
     getGardenBlocks,
     getOrCreateSunflowerDropSpawn,
     getReferralAccountSummary,
+    getSunflowerPackageEligibilityForAccount,
     getSunflowers,
     getSunflowersHistory,
     getTutorialChecklistState,
@@ -48,7 +49,7 @@ import AccountDeleteConfirmationTemplate from '@gredice/transactional/emails/Acc
 import { addDays, differenceInCalendarDays, startOfDay } from 'date-fns';
 import { Hono } from 'hono';
 import { setCookie as honoSetCookie } from 'hono/cookie';
-import { describeRoute, validator as zValidator } from 'hono-openapi';
+import { describeRoute, resolver, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { createJwt, verifyJwt } from '../../../lib/auth/auth';
 import {
@@ -64,6 +65,10 @@ import {
     authValidator,
 } from '../../../lib/hono/authValidator';
 import { getPostHogClient } from '../../../lib/posthog-server';
+import {
+    buildSunflowerPackageCatalogResponse,
+    sunflowerPackageCatalogResponseSchema,
+} from '../../../lib/sunflowers/packageCatalog';
 import { getBjelovarForecast } from '../../../lib/weather/forecast';
 import { populateWeatherFromSymbol } from '../../../lib/weather/populateWeatherFromSymbol';
 import { findClosestForecastEntry } from '../../../lib/weather/weatherNowContract';
@@ -556,6 +561,33 @@ const app = new Hono<{ Variables: AuthVariables }>()
         },
     )
 
+    .get(
+        '/current/sunflowers/packages',
+        describeRoute({
+            description:
+                'Get active sunflower packages with eligibility for the current account',
+            security: authSecurity,
+            responses: {
+                200: {
+                    description: 'Active sunflower package catalog',
+                    content: {
+                        'application/json': {
+                            schema: resolver(
+                                sunflowerPackageCatalogResponseSchema,
+                            ),
+                        },
+                    },
+                },
+            },
+        }),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { accountId } = context.get('authContext');
+            const packages =
+                await getSunflowerPackageEligibilityForAccount(accountId);
+            return context.json(buildSunflowerPackageCatalogResponse(packages));
+        },
+    )
     .get(
         '/current/sunflowers',
         describeRoute({

--- a/apps/api/app/api/[...route]/checkoutRoutes.ts
+++ b/apps/api/app/api/[...route]/checkoutRoutes.ts
@@ -3,6 +3,7 @@ import {
     consumeInventoryItem,
     getAccount,
     getShoppingCart,
+    getSunflowerPackageEligibilityForAccount,
     getUser,
     markCartPaidIfAllItemsPaid,
     normalizeShoppingCartInventoryUsage,
@@ -14,6 +15,7 @@ import {
     reserveOutletOffer,
     setCartItemPaid,
     spendSunflowers,
+    sunflowerPackageEntityTypeName,
 } from '@gredice/storage';
 import {
     type CheckoutItem,
@@ -22,7 +24,7 @@ import {
     stripeSessionCancel,
 } from '@gredice/stripe/server';
 import { Hono } from 'hono';
-import { describeRoute, validator as zValidator } from 'hono-openapi';
+import { describeRoute, resolver, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
 import { getCartInfo } from '../../../lib/checkout/cartInfo';
 import {
@@ -30,12 +32,17 @@ import {
     notifyOrderConfirmationEmail,
 } from '../../../lib/checkout/orderConfirmationEmail';
 import { calculateSunflowerAmount } from '../../../lib/checkout/sunflowerCalculations';
+import { authSecurity } from '../../../lib/docs/security';
 import {
     type AuthVariables,
     authValidator,
 } from '../../../lib/hono/authValidator';
 import { getPostHogClient } from '../../../lib/posthog-server';
 import { processItem } from '../../../lib/stripe/processCheckoutSession';
+import {
+    buildSunflowerPackageCatalogResponse,
+    sunflowerPackageCatalogResponseSchema,
+} from '../../../lib/sunflowers/packageCatalog';
 
 const STRIPE_MIN_CHECKOUT_SESSION_LIFETIME_MINUTES = 30;
 const OUTLET_CHECKOUT_HOLD_MINUTES = Math.max(
@@ -44,11 +51,47 @@ const OUTLET_CHECKOUT_HOLD_MINUTES = Math.max(
     STRIPE_MIN_CHECKOUT_SESSION_LIFETIME_MINUTES + 1,
 );
 
+const packageCheckoutBodySchema = z.object({
+    returnContext: z
+        .object({
+            source: z.enum(['garden', 'www']).optional(),
+            path: z.string().max(200).optional(),
+        })
+        .optional(),
+});
+
 function addMinutes(date: Date, minutes: number) {
     return new Date(date.getTime() + minutes * 60 * 1000);
 }
 
 const app = new Hono<{ Variables: AuthVariables }>()
+    .get(
+        '/sunflower-packages',
+        describeRoute({
+            description:
+                'Get active sunflower packages with eligibility for package checkout',
+            security: authSecurity,
+            responses: {
+                200: {
+                    description: 'Active sunflower package catalog',
+                    content: {
+                        'application/json': {
+                            schema: resolver(
+                                sunflowerPackageCatalogResponseSchema,
+                            ),
+                        },
+                    },
+                },
+            },
+        }),
+        authValidator(['user', 'admin']),
+        async (context) => {
+            const { accountId } = context.get('authContext');
+            const packages =
+                await getSunflowerPackageEligibilityForAccount(accountId);
+            return context.json(buildSunflowerPackageCatalogResponse(packages));
+        },
+    )
     .post(
         '/checkout',
         describeRoute({
@@ -419,6 +462,139 @@ const app = new Hono<{ Variables: AuthVariables }>()
             });
 
             return context.json({ success: true });
+        },
+    )
+    .post(
+        '/sunflower-packages/:code',
+        describeRoute({
+            description:
+                'Create a Stripe checkout session for an eligible sunflower package',
+            security: authSecurity,
+        }),
+        authValidator(['user', 'admin']),
+        zValidator(
+            'param',
+            z.object({
+                code: z.string().trim().min(1).max(80),
+            }),
+        ),
+        zValidator('json', packageCheckoutBodySchema),
+        async (context) => {
+            const { accountId, userId } = context.get('authContext');
+            const { code } = context.req.valid('param');
+            const { returnContext } = context.req.valid('json');
+
+            const [account, user, packages] = await Promise.all([
+                getAccount(accountId),
+                getUser(userId),
+                getSunflowerPackageEligibilityForAccount(accountId),
+            ]);
+            if (!account) {
+                return context.json({ error: 'Account not found' }, 404);
+            }
+            if (!user) {
+                return context.json({ error: 'User not found' }, 404);
+            }
+
+            const packageData =
+                packages.find((pkg) => pkg.code === code) ?? null;
+            if (!packageData) {
+                return context.json({ error: 'Package not found' }, 404);
+            }
+            if (!packageData.eligible) {
+                return context.json(
+                    {
+                        error: 'Package is not eligible',
+                        reason:
+                            packageData.ineligibleReason === 'already_purchased'
+                                ? 'already_used'
+                                : 'not_eligible',
+                    },
+                    409,
+                );
+            }
+            if (
+                packageData.currency !== 'eur' ||
+                packageData.priceCents <= 0 ||
+                packageData.sunflowers <= 0
+            ) {
+                console.warn('Invalid sunflower package checkout data', {
+                    code,
+                    currency: packageData.currency,
+                    priceCents: packageData.priceCents,
+                    sunflowers: packageData.sunflowers,
+                });
+                return context.json({ error: 'Package is not available' }, 400);
+            }
+
+            const { customerId, sessionId, url } = await stripeCheckout(
+                {
+                    id: account.id,
+                    email: user.userName,
+                    name: user.userName,
+                    stripeCustomerId: account.stripeCustomerId ?? undefined,
+                },
+                {
+                    items: [
+                        {
+                            product: {
+                                name: packageData.name,
+                                description:
+                                    packageData.descriptionShort ?? undefined,
+                                imageUrls: [
+                                    'https://cdn.gredice.com/sunflower-large.svg',
+                                ],
+                                metadata: {
+                                    kind: 'sunflowerPackage',
+                                    entityTypeName:
+                                        sunflowerPackageEntityTypeName,
+                                    entityId: packageData.entityId,
+                                    packageCode: packageData.code,
+                                    packageRole: packageData.role,
+                                    accountId: account.id,
+                                    userId: user.id,
+                                    sunflowers: packageData.sunflowers,
+                                    baseSunflowers: packageData.baseSunflowers,
+                                    bonusSunflowers:
+                                        packageData.bonusSunflowers,
+                                    priceCents: packageData.priceCents,
+                                    currency: packageData.currency,
+                                    returnContextSource:
+                                        returnContext?.source ?? null,
+                                    returnContextPath:
+                                        returnContext?.path ?? null,
+                                },
+                            },
+                            price: {
+                                valueInCents: packageData.priceCents,
+                                currency: 'eur',
+                            },
+                            quantity: 1,
+                        },
+                    ],
+                    allowPromotionCodes: false,
+                },
+            );
+
+            if (account.stripeCustomerId !== customerId) {
+                await assignStripeCustomerId(account.id, customerId);
+            }
+
+            (await getPostHogClient()).capture({
+                distinctId: accountId,
+                event: 'checkout_initiated',
+                properties: {
+                    checkout_kind: 'sunflower_package',
+                    package_code: packageData.code,
+                    package_role: packageData.role,
+                    price_cents: packageData.priceCents,
+                    sunflowers: packageData.sunflowers,
+                    bonus_sunflowers: packageData.bonusSunflowers,
+                    payment_method: 'stripe',
+                },
+            });
+
+            return context.json({ sessionId, url });
         },
     )
     .delete(

--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { SunflowerPackageAlreadyPurchasedError } from '@gredice/storage';
 import {
     buildCheckoutInvoiceBillingSnapshot,
     buildCheckoutInvoiceLineItem,
@@ -96,6 +97,10 @@ function makeDependencies(
                 invoiceId: 601,
                 invoiceNumber: 'PON-2026-0001',
             };
+        },
+        getSunflowerPackageByCode: async (...args: unknown[]) => {
+            record(calls, 'getSunflowerPackageByCode', args);
+            return null;
         },
         issueReceiptForPaidInvoice: async (...args: unknown[]) => {
             record(calls, 'issueReceiptForPaidInvoice', args);
@@ -198,6 +203,13 @@ function makeDependencies(
         },
         spendSunflowers: async (...args: unknown[]) => {
             record(calls, 'spendSunflowers', args);
+        },
+        topUpSunflowerPackage: async (...args: unknown[]) => {
+            record(calls, 'topUpSunflowerPackage', args);
+            return {
+                topUp: { status: 'created', entry: { id: 801 } },
+                bonus: { status: 'created', entry: { id: 802 } },
+            };
         },
         updateRaisedBed: async (...args: unknown[]) => {
             record(calls, 'updateRaisedBed', args);
@@ -309,6 +321,76 @@ function makeSession() {
                 },
             ],
         },
+    };
+}
+
+function makeSunflowerPackageSession({
+    amountTotal = 4999,
+    lineAmountTotal = 4999,
+    lineAmountSubtotal = 4999,
+} = {}) {
+    return {
+        id: 'cs_package_paid',
+        status: 'complete',
+        paymentStatus: 'paid',
+        amountTotal,
+        lineItems: {
+            data: [
+                {
+                    id: 'li_package_1',
+                    quantity: 1,
+                    amount_total: lineAmountTotal,
+                    amount_subtotal: lineAmountSubtotal,
+                    price: {
+                        product: {
+                            id: 'prod_package_1',
+                            name: 'Puna gredica',
+                            metadata: {
+                                kind: 'sunflowerPackage',
+                                accountId: 'account-1',
+                                userId: 'user-1',
+                                entityTypeName: 'sunflowerPackage',
+                                entityId: '77',
+                                packageCode: 'puna_gredica',
+                                packageRole: 'initial_one_time',
+                                sunflowers: '60000',
+                                baseSunflowers: '50000',
+                                bonusSunflowers: '10000',
+                                priceCents: '4999',
+                                currency: 'eur',
+                            },
+                        },
+                    },
+                },
+            ],
+        },
+    };
+}
+
+function makeSunflowerPackageData() {
+    return {
+        entityId: 77,
+        code: 'puna_gredica',
+        name: 'Puna gredica',
+        tag: 'Jednokratna ponuda',
+        descriptionShort: 'Početni paket.',
+        descriptionLong: 'Početni paket za Gredice saldo.',
+        cta: 'Kupi paket',
+        displayOrder: 10,
+        priceCents: 4999,
+        priceEur: 49.99,
+        currency: 'eur',
+        sunflowers: 60000,
+        baseSunflowers: 50000,
+        bonusSunflowers: 10000,
+        bonusPercentage: 20,
+        role: 'initial_one_time',
+        isActive: true,
+        isOneTime: true,
+        oneTimeScope: 'account',
+        upsellTriggerCode: null,
+        showInPrimaryList: false,
+        eligible: true,
     };
 }
 
@@ -514,6 +596,354 @@ describe('processCheckoutSession', () => {
                     invoiceNumber: 'PON-2026-0001',
                     receiptId: 701,
                     receiptNumber: '2026-1',
+                },
+            ],
+        );
+    });
+
+    it('fulfills a paid sunflower package without cart processing or loyalty earning', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSunflowerPackageSession();
+            },
+            getSunflowerPackageByCode: async (...args: unknown[]) => {
+                record(calls, 'getSunflowerPackageByCode', args);
+                return makeSunflowerPackageData();
+            },
+            isBillingAutomationEnabled: (...args: unknown[]) => {
+                record(calls, 'isBillingAutomationEnabled', args);
+                return true;
+            },
+        });
+
+        await processCheckoutSession('cs_package_paid', dependencies);
+
+        assert.equal(callsNamed(calls, 'getShoppingCart').length, 0);
+        assert.equal(callsNamed(calls, 'earnSunflowersForPayment').length, 0);
+        assert.deepStrictEqual(
+            callsNamed(calls, 'topUpSunflowerPackage')[0]?.args,
+            [
+                {
+                    accountId: 'account-1',
+                    packageCode: 'puna_gredica',
+                    packageEntityId: 77,
+                    sunflowers: 60000,
+                    bonusSunflowers: 10000,
+                    priceCents: 4999,
+                    idempotencyKey:
+                        'stripe:cs_package_paid:sunflowerPackage:puna_gredica',
+                    enforceOneTime: true,
+                    sourceType: 'stripeCheckoutSession',
+                    sourceId: 'cs_package_paid',
+                    reason: 'sunflowerPackage:puna_gredica',
+                    metadata: {
+                        checkoutSessionId: 'cs_package_paid',
+                        lineItemId: 'li_package_1',
+                        packageRole: 'initial_one_time',
+                        catalogPriceCents: 4999,
+                        paidAmountCents: 4999,
+                    },
+                },
+            ],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'createTransaction')[0]?.args,
+            [
+                {
+                    accountId: 'account-1',
+                    amount: 4999,
+                    stripePaymentId: 'cs_package_paid',
+                    status: 'completed',
+                    currency: 'eur',
+                },
+            ],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'ensureInvoiceForTransaction')[0]?.args,
+            [
+                {
+                    transactionId: 901,
+                    billingSnapshot: {
+                        billToCountry: 'Hrvatska',
+                        billToEmail: 'buyer@example.test',
+                        billToName: undefined,
+                        notes: 'Generirano iz plaćene Gredice checkout transakcije.',
+                    },
+                    items: [
+                        {
+                            description: 'Puna gredica',
+                            quantity: 1,
+                            unitPriceCents: 4999,
+                            totalPriceCents: 4999,
+                            entityId: '77',
+                            entityTypeName: 'sunflowerPackage',
+                        },
+                    ],
+                },
+            ],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'notifyOrderConfirmationEmail')[0]?.args,
+            [
+                {
+                    to: 'buyer@example.test',
+                    cartId: null,
+                    checkoutSessionId: 'cs_package_paid',
+                    items: [
+                        {
+                            name: 'Puna gredica',
+                            quantity: 1,
+                            amountSubtotal: 4999,
+                            currency: 'eur',
+                        },
+                    ],
+                    totalAmountCents: 4999,
+                    currency: 'eur',
+                },
+            ],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'posthog.capture').at(-1)?.args,
+            [
+                {
+                    distinctId: 'account-1',
+                    event: 'sunflower_package_fulfilled',
+                    properties: {
+                        checkout_session_id: 'cs_package_paid',
+                        transaction_id: 901,
+                        package_code: 'puna_gredica',
+                        package_role: 'initial_one_time',
+                        price_cents: 4999,
+                        paid_amount_cents: 4999,
+                        sunflowers: 60000,
+                        bonus_sunflowers: 10000,
+                        duplicate_one_time_purchase: false,
+                        ledger_entry_ids: [801, 802],
+                    },
+                },
+            ],
+        );
+    });
+
+    it('fulfills a discounted paid sunflower package with the actual paid amount', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSunflowerPackageSession({
+                    amountTotal: 3999,
+                    lineAmountTotal: 3999,
+                    lineAmountSubtotal: 4999,
+                });
+            },
+            getSunflowerPackageByCode: async (...args: unknown[]) => {
+                record(calls, 'getSunflowerPackageByCode', args);
+                return makeSunflowerPackageData();
+            },
+        });
+
+        await processCheckoutSession('cs_package_paid', dependencies);
+
+        const topUpInput = callsNamed(calls, 'topUpSunflowerPackage')[0]
+            ?.args[0];
+        assert.ok(isRecord(topUpInput));
+        assert.equal(topUpInput.priceCents, 3999);
+        assert.deepStrictEqual(
+            callsNamed(calls, 'createTransaction')[0]?.args,
+            [
+                {
+                    accountId: 'account-1',
+                    amount: 3999,
+                    stripePaymentId: 'cs_package_paid',
+                    status: 'completed',
+                    currency: 'eur',
+                },
+            ],
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'notifyOrderConfirmationEmail')[0]?.args,
+            [
+                {
+                    to: 'buyer@example.test',
+                    cartId: null,
+                    checkoutSessionId: 'cs_package_paid',
+                    items: [
+                        {
+                            name: 'Puna gredica',
+                            quantity: 1,
+                            amountSubtotal: 3999,
+                            currency: 'eur',
+                        },
+                    ],
+                    totalAmountCents: 3999,
+                    currency: 'eur',
+                },
+            ],
+        );
+        assert.equal(
+            callsNamed(calls, 'posthog.capture').some((call) => {
+                const event = call.args[0];
+                return (
+                    isRecord(event) &&
+                    event.event === 'sunflower_package_fulfillment_failed'
+                );
+            }),
+            false,
+        );
+    });
+
+    it('replays sunflower package fulfillment through idempotent ledger top-up without a duplicate transaction', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSunflowerPackageSession();
+            },
+            getCompletedTransactionByStripePaymentId: async (
+                ...args: unknown[]
+            ) => {
+                record(calls, 'getCompletedTransactionByStripePaymentId', args);
+                return { id: 902 };
+            },
+            getSunflowerPackageByCode: async (...args: unknown[]) => {
+                record(calls, 'getSunflowerPackageByCode', args);
+                return makeSunflowerPackageData();
+            },
+        });
+
+        await processCheckoutSession('cs_package_paid', dependencies);
+
+        assert.equal(callsNamed(calls, 'topUpSunflowerPackage').length, 1);
+        assert.equal(callsNamed(calls, 'createTransaction').length, 0);
+        assert.equal(
+            callsNamed(calls, 'ensureInvoiceForTransaction').length,
+            0,
+        );
+        assert.equal(
+            callsNamed(calls, 'notifyOrderConfirmationEmail').length,
+            0,
+        );
+        assert.equal(callsNamed(calls, 'notifyPurchase').length, 0);
+        assert.equal(callsNamed(calls, 'posthog.capture').length, 0);
+    });
+
+    it('does not credit a sunflower package when Stripe metadata mismatches current package data', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSunflowerPackageSession();
+            },
+            getSunflowerPackageByCode: async (...args: unknown[]) => {
+                record(calls, 'getSunflowerPackageByCode', args);
+                return {
+                    ...makeSunflowerPackageData(),
+                    priceCents: 5999,
+                };
+            },
+        });
+
+        await processCheckoutSession('cs_package_paid', dependencies);
+
+        assert.equal(callsNamed(calls, 'topUpSunflowerPackage').length, 0);
+        assert.equal(callsNamed(calls, 'createTransaction').length, 0);
+        assert.deepStrictEqual(callsNamed(calls, 'posthog.capture')[0]?.args, [
+            {
+                distinctId: 'account-1',
+                event: 'sunflower_package_fulfillment_failed',
+                properties: {
+                    checkout_session_id: 'cs_package_paid',
+                    package_code: 'puna_gredica',
+                    reason: 'metadata_mismatch:price_cents',
+                },
+            },
+        ]);
+    });
+
+    it('credits paid base sunflowers when a duplicate one-time session was already purchased', async () => {
+        const calls: RecordedCall[] = [];
+        const dependencies = makeDependencies(calls, {
+            getStripeCheckoutSession: async (...args: unknown[]) => {
+                record(calls, 'getStripeCheckoutSession', args);
+                return makeSunflowerPackageSession();
+            },
+            getSunflowerPackageByCode: async (...args: unknown[]) => {
+                record(calls, 'getSunflowerPackageByCode', args);
+                return makeSunflowerPackageData();
+            },
+            topUpSunflowerPackage: async (...args: unknown[]) => {
+                record(calls, 'topUpSunflowerPackage', args);
+                const input = args[0];
+                if (isRecord(input) && input.enforceOneTime === true) {
+                    throw new SunflowerPackageAlreadyPurchasedError(
+                        'account-1',
+                        'puna_gredica',
+                    );
+                }
+                return {
+                    topUp: { status: 'created', entry: { id: 803 } },
+                    bonus: null,
+                };
+            },
+        });
+
+        await processCheckoutSession('cs_package_paid', dependencies);
+
+        assert.equal(callsNamed(calls, 'topUpSunflowerPackage').length, 2);
+        const duplicateTopUpInput = callsNamed(
+            calls,
+            'topUpSunflowerPackage',
+        )[1]?.args[0];
+        assert.ok(isRecord(duplicateTopUpInput));
+        assert.equal(duplicateTopUpInput.sunflowers, 50000);
+        assert.equal(duplicateTopUpInput.bonusSunflowers, 0);
+        assert.equal(duplicateTopUpInput.enforceOneTime, false);
+        assert.equal(
+            duplicateTopUpInput.idempotencyKey,
+            'stripe:cs_package_paid:sunflowerPackage:puna_gredica:duplicate_paid_base',
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'createTransaction')[0]?.args,
+            [
+                {
+                    accountId: 'account-1',
+                    amount: 4999,
+                    stripePaymentId: 'cs_package_paid',
+                    status: 'completed',
+                    currency: 'eur',
+                },
+            ],
+        );
+        assert.equal(
+            callsNamed(calls, 'posthog.capture').some((call) => {
+                const event = call.args[0];
+                return (
+                    isRecord(event) &&
+                    event.event === 'sunflower_package_fulfillment_failed'
+                );
+            }),
+            false,
+        );
+        assert.deepStrictEqual(
+            callsNamed(calls, 'posthog.capture').at(-1)?.args,
+            [
+                {
+                    distinctId: 'account-1',
+                    event: 'sunflower_package_fulfilled',
+                    properties: {
+                        checkout_session_id: 'cs_package_paid',
+                        transaction_id: 901,
+                        package_code: 'puna_gredica',
+                        package_role: 'initial_one_time',
+                        price_cents: 4999,
+                        paid_amount_cents: 4999,
+                        sunflowers: 50000,
+                        bonus_sunflowers: 0,
+                        duplicate_one_time_purchase: true,
+                        ledger_entry_ids: [803],
+                    },
                 },
             ],
         );

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -28,6 +28,7 @@ import {
     getRaisedBed,
     getRaisedBedFieldsWithEvents,
     getShoppingCart,
+    getSunflowerPackageByCode,
     getUser,
     type InvoiceForTransactionLineItem,
     isCartItemDeliverable,
@@ -35,8 +36,11 @@ import {
     markCartPaidIfAllItemsPaid,
     normalizeShoppingCartInventoryUsage,
     normalizeShoppingCartScheduledDates,
+    SunflowerPackageAlreadyPurchasedError,
     setCartItemPaid,
     spendSunflowers,
+    sunflowerPackageEntityTypeName,
+    topUpSunflowerPackage,
     updateRaisedBed,
     upsertRaisedBedField,
     withStripePaymentProcessingLock,
@@ -74,6 +78,7 @@ export type ProcessCheckoutSessionDependencies = {
     createTransaction: typeof createTransaction;
     earnSunflowersForPayment: typeof earnSunflowersForPayment;
     ensureInvoiceForTransaction: typeof ensureInvoiceForTransaction;
+    getSunflowerPackageByCode: typeof getSunflowerPackageByCode;
     getCompletedTransactionByStripePaymentId: typeof getCompletedTransactionByStripePaymentId;
     getDefaultShoppingCartScheduledDate: typeof getDefaultShoppingCartScheduledDate;
     getInventory: typeof getInventory;
@@ -89,6 +94,7 @@ export type ProcessCheckoutSessionDependencies = {
     normalizeShoppingCartScheduledDates: typeof normalizeShoppingCartScheduledDates;
     setCartItemPaid: typeof setCartItemPaid;
     spendSunflowers: typeof spendSunflowers;
+    topUpSunflowerPackage: typeof topUpSunflowerPackage;
     updateRaisedBed: typeof updateRaisedBed;
     upsertRaisedBedField: typeof upsertRaisedBedField;
     withStripePaymentProcessingLock: typeof withStripePaymentProcessingLock;
@@ -121,6 +127,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     createTransaction,
     earnSunflowersForPayment,
     ensureInvoiceForTransaction,
+    getSunflowerPackageByCode,
     getCompletedTransactionByStripePaymentId,
     getDefaultShoppingCartScheduledDate,
     getInventory,
@@ -136,6 +143,7 @@ const realDependencies: ProcessCheckoutSessionDependencies = {
     normalizeShoppingCartScheduledDates,
     setCartItemPaid,
     spendSunflowers,
+    topUpSunflowerPackage,
     updateRaisedBed,
     upsertRaisedBedField,
     withStripePaymentProcessingLock,
@@ -172,6 +180,140 @@ function sortObjectKeys(obj: unknown): unknown {
             result[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
             return result;
         }, {});
+}
+
+type PaidCheckoutSession = NonNullable<
+    Awaited<ReturnType<typeof getStripeCheckoutSession>>
+>;
+type StripeCheckoutLineItem = PaidCheckoutSession['lineItems']['data'][number];
+
+type SunflowerPackageCheckoutLineItem = {
+    lineItemId: string;
+    productName: string | null;
+    amountTotal: number;
+    quantity: number;
+    accountId: string;
+    userId: string;
+    entityId: number;
+    entityTypeName: string;
+    packageCode: string;
+    packageRole: string;
+    sunflowers: number;
+    baseSunflowers: number;
+    bonusSunflowers: number;
+    priceCents: number;
+    currency: string;
+};
+
+function readMetadataString(
+    metadata: Record<string, unknown> | undefined,
+    key: string,
+) {
+    const value = metadata?.[key];
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : null;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return String(value);
+    }
+    return null;
+}
+
+function readMetadataInteger(
+    metadata: Record<string, unknown> | undefined,
+    key: string,
+) {
+    const value = metadata?.[key];
+    if (typeof value === 'number' && Number.isInteger(value)) {
+        return value;
+    }
+    if (typeof value === 'string' && /^\d+$/u.test(value.trim())) {
+        return Number.parseInt(value.trim(), 10);
+    }
+    return null;
+}
+
+function parseSunflowerPackageCheckoutLineItem(
+    item: StripeCheckoutLineItem,
+): SunflowerPackageCheckoutLineItem | null {
+    const product = item.price?.product;
+    if (typeof product === 'string' || product?.deleted) {
+        return null;
+    }
+
+    const metadata = product?.metadata;
+    if (metadata?.kind !== 'sunflowerPackage') {
+        return null;
+    }
+
+    const accountId = readMetadataString(metadata, 'accountId');
+    const userId = readMetadataString(metadata, 'userId');
+    const entityTypeName = readMetadataString(metadata, 'entityTypeName');
+    const packageCode = readMetadataString(metadata, 'packageCode');
+    const packageRole = readMetadataString(metadata, 'packageRole');
+    const currency = readMetadataString(metadata, 'currency');
+    const entityId = readMetadataInteger(metadata, 'entityId');
+    const sunflowers = readMetadataInteger(metadata, 'sunflowers');
+    const baseSunflowers = readMetadataInteger(metadata, 'baseSunflowers');
+    const bonusSunflowers = readMetadataInteger(metadata, 'bonusSunflowers');
+    const priceCents = readMetadataInteger(metadata, 'priceCents');
+
+    if (
+        !accountId ||
+        !userId ||
+        !entityTypeName ||
+        !packageCode ||
+        !packageRole ||
+        !currency ||
+        entityId === null ||
+        sunflowers === null ||
+        baseSunflowers === null ||
+        bonusSunflowers === null ||
+        priceCents === null ||
+        typeof item.amount_total !== 'number'
+    ) {
+        return null;
+    }
+
+    return {
+        lineItemId: item.id,
+        productName: typeof product?.name === 'string' ? product.name : null,
+        amountTotal: item.amount_total,
+        quantity: item.quantity ?? 1,
+        accountId,
+        userId,
+        entityId,
+        entityTypeName,
+        packageCode,
+        packageRole,
+        sunflowers,
+        baseSunflowers,
+        bonusSunflowers,
+        priceCents,
+        currency,
+    };
+}
+
+function hasSunflowerPackageCheckoutMetadata(item: StripeCheckoutLineItem) {
+    const product = item.price?.product;
+    if (typeof product === 'string' || product?.deleted) {
+        return false;
+    }
+    return product?.metadata?.kind === 'sunflowerPackage';
+}
+
+function getSunflowerPackageCheckoutLineItems(session: PaidCheckoutSession) {
+    const packageLineItems = (session.lineItems?.data ?? []).filter(
+        hasSunflowerPackageCheckoutMetadata,
+    );
+    const items = packageLineItems
+        .map(parseSunflowerPackageCheckoutLineItem)
+        .filter((item) => item !== null);
+    return {
+        items,
+        malformedCount: packageLineItems.length - items.length,
+    };
 }
 
 async function processNonStripeCartItems(
@@ -412,6 +554,370 @@ export async function processCheckoutSession(
     );
 }
 
+async function recordSunflowerPackageFulfillmentFailure({
+    accountId,
+    checkoutSessionId,
+    dependencies,
+    packageCode,
+    reason,
+}: {
+    accountId?: string | null;
+    checkoutSessionId: string;
+    dependencies: ProcessCheckoutSessionDependencies;
+    packageCode?: string | null;
+    reason: string;
+}) {
+    console.warn('Sunflower package fulfillment failed', {
+        accountId,
+        checkoutSessionId,
+        packageCode,
+        reason,
+    });
+
+    if (!accountId) {
+        return;
+    }
+
+    (await dependencies.getPostHogClient()).capture({
+        distinctId: accountId,
+        event: 'sunflower_package_fulfillment_failed',
+        properties: {
+            checkout_session_id: checkoutSessionId,
+            package_code: packageCode ?? null,
+            reason,
+        },
+    });
+}
+
+async function processSunflowerPackageCheckoutSession({
+    checkoutSessionId,
+    dependencies,
+    existingTransactionId,
+    packageItem,
+    session,
+}: {
+    checkoutSessionId: string;
+    dependencies: ProcessCheckoutSessionDependencies;
+    existingTransactionId?: number;
+    packageItem: SunflowerPackageCheckoutLineItem;
+    session: PaidCheckoutSession;
+}) {
+    if (session.amountTotal !== packageItem.amountTotal) {
+        await recordSunflowerPackageFulfillmentFailure({
+            accountId: packageItem.accountId,
+            checkoutSessionId,
+            dependencies,
+            packageCode: packageItem.packageCode,
+            reason: 'session_amount_mismatch',
+        });
+        return;
+    }
+
+    const paidAmountCents = packageItem.amountTotal;
+    const packageData = await dependencies.getSunflowerPackageByCode(
+        packageItem.packageCode,
+    );
+    if (!packageData) {
+        await recordSunflowerPackageFulfillmentFailure({
+            accountId: packageItem.accountId,
+            checkoutSessionId,
+            dependencies,
+            packageCode: packageItem.packageCode,
+            reason: 'package_not_available',
+        });
+        return;
+    }
+
+    const mismatches = [
+        packageItem.entityTypeName === sunflowerPackageEntityTypeName
+            ? null
+            : 'entity_type',
+        packageItem.entityId === packageData.entityId ? null : 'entity_id',
+        packageItem.packageRole === packageData.role ? null : 'role',
+        packageItem.currency === packageData.currency ? null : 'currency',
+        packageItem.priceCents === packageData.priceCents
+            ? null
+            : 'price_cents',
+        paidAmountCents > 0 && paidAmountCents <= packageData.priceCents
+            ? null
+            : 'line_amount',
+        packageItem.sunflowers === packageData.sunflowers ? null : 'sunflowers',
+        packageItem.baseSunflowers === packageData.baseSunflowers
+            ? null
+            : 'base_sunflowers',
+        packageItem.bonusSunflowers === packageData.bonusSunflowers
+            ? null
+            : 'bonus_sunflowers',
+    ].filter((mismatch) => mismatch !== null);
+
+    if (mismatches.length > 0 || packageData.currency !== 'eur') {
+        await recordSunflowerPackageFulfillmentFailure({
+            accountId: packageItem.accountId,
+            checkoutSessionId,
+            dependencies,
+            packageCode: packageItem.packageCode,
+            reason: `metadata_mismatch:${mismatches.join(',')}`,
+        });
+        return;
+    }
+
+    try {
+        const oneTimeAccountPackage =
+            packageData.isOneTime && packageData.oneTimeScope === 'account';
+        const idempotencyKey = `stripe:${session.id}:sunflowerPackage:${packageData.code}`;
+        const ledgerMetadata = {
+            checkoutSessionId: session.id,
+            lineItemId: packageItem.lineItemId,
+            packageRole: packageData.role,
+            catalogPriceCents: packageData.priceCents,
+            paidAmountCents,
+        };
+        let creditedSunflowers = packageData.sunflowers;
+        let creditedBonusSunflowers = packageData.bonusSunflowers;
+        let duplicateOneTimePurchase = false;
+        let topUpResult: Awaited<
+            ReturnType<
+                ProcessCheckoutSessionDependencies['topUpSunflowerPackage']
+            >
+        >;
+        try {
+            topUpResult = await dependencies.topUpSunflowerPackage({
+                accountId: packageItem.accountId,
+                packageCode: packageData.code,
+                packageEntityId: packageData.entityId,
+                sunflowers: packageData.sunflowers,
+                bonusSunflowers: packageData.bonusSunflowers,
+                priceCents: paidAmountCents,
+                idempotencyKey,
+                enforceOneTime: oneTimeAccountPackage,
+                sourceType: 'stripeCheckoutSession',
+                sourceId: session.id,
+                reason: `sunflowerPackage:${packageData.code}`,
+                metadata: ledgerMetadata,
+            });
+        } catch (error) {
+            if (
+                !(error instanceof SunflowerPackageAlreadyPurchasedError) ||
+                !oneTimeAccountPackage
+            ) {
+                throw error;
+            }
+            if (packageData.baseSunflowers <= 0) {
+                await recordSunflowerPackageFulfillmentFailure({
+                    accountId: packageItem.accountId,
+                    checkoutSessionId,
+                    dependencies,
+                    packageCode: packageItem.packageCode,
+                    reason: 'already_purchased',
+                });
+                return;
+            }
+
+            console.warn(
+                'One-time sunflower package was already purchased before a paid duplicate session fulfilled; crediting paid base sunflowers without duplicate bonus.',
+                {
+                    accountId: packageItem.accountId,
+                    checkoutSessionId,
+                    packageCode: packageData.code,
+                },
+            );
+            duplicateOneTimePurchase = true;
+            creditedSunflowers = packageData.baseSunflowers;
+            creditedBonusSunflowers = 0;
+            topUpResult = await dependencies.topUpSunflowerPackage({
+                accountId: packageItem.accountId,
+                packageCode: packageData.code,
+                packageEntityId: packageData.entityId,
+                sunflowers: creditedSunflowers,
+                bonusSunflowers: 0,
+                priceCents: paidAmountCents,
+                idempotencyKey: `${idempotencyKey}:duplicate_paid_base`,
+                enforceOneTime: false,
+                sourceType: 'stripeCheckoutSession',
+                sourceId: session.id,
+                reason: `sunflowerPackage:${packageData.code}:duplicatePaid`,
+                metadata: {
+                    ...ledgerMetadata,
+                    duplicateOneTimePurchase: true,
+                    originalSunflowers: packageData.sunflowers,
+                    originalBonusSunflowers: packageData.bonusSunflowers,
+                },
+            });
+        }
+
+        const transactionId =
+            existingTransactionId ??
+            (await dependencies.createTransaction({
+                accountId: packageItem.accountId,
+                amount: paidAmountCents,
+                stripePaymentId: session.id,
+                status: 'completed',
+                currency: 'eur',
+            }));
+
+        if (existingTransactionId) {
+            console.info(
+                `Checkout session ${checkoutSessionId} already has transaction ${existingTransactionId}; sunflower package ledger replayed idempotently.`,
+            );
+            return;
+        }
+
+        const customer = await dependencies.getUser(packageItem.userId);
+        const invoiceLineItem = dependencies.buildCheckoutInvoiceLineItem({
+            amountTotalCents: packageItem.amountTotal,
+            entityId: packageData.entityId.toString(),
+            entityTypeName: sunflowerPackageEntityTypeName,
+            metadataName: packageData.name,
+            productName: packageItem.productName ?? packageData.name,
+            quantity: packageItem.quantity,
+        });
+
+        if (dependencies.isBillingAutomationEnabled() && invoiceLineItem) {
+            try {
+                const invoiceResult =
+                    await dependencies.ensureInvoiceForTransaction({
+                        transactionId,
+                        billingSnapshot:
+                            dependencies.buildCheckoutInvoiceBillingSnapshot({
+                                customerEmail: customer?.userName,
+                                customerName: customer?.displayName,
+                            }),
+                        items: [invoiceLineItem],
+                    });
+                if (invoiceResult.status === 'skipped') {
+                    console.warn('Sunflower package invoice skipped', {
+                        checkoutSessionId,
+                        reason: invoiceResult.reason,
+                        transactionId,
+                    });
+                } else {
+                    const receiptResult =
+                        await dependencies.issueReceiptForPaidInvoice({
+                            invoiceId: invoiceResult.invoiceId,
+                            paymentReference: session.id,
+                        });
+                    if (receiptResult.status === 'skipped') {
+                        console.warn('Sunflower package receipt skipped', {
+                            checkoutSessionId,
+                            invoiceId: invoiceResult.invoiceId,
+                            reason: receiptResult.reason,
+                            transactionId,
+                        });
+                    } else {
+                        const fiscalizationResult =
+                            await dependencies.fiscalizeReceipt(
+                                receiptResult.receiptId,
+                            );
+                        const hasFiscalizedReceipt =
+                            fiscalizationResult.status === 'confirmed' ||
+                            fiscalizationResult.status === 'existing';
+                        if (fiscalizationResult.status === 'failed') {
+                            console.warn(
+                                'Sunflower package receipt fiscalization failed',
+                                {
+                                    checkoutSessionId,
+                                    reason: fiscalizationResult.reason,
+                                    receiptId: receiptResult.receiptId,
+                                    transactionId,
+                                },
+                            );
+                        } else if (fiscalizationResult.status === 'skipped') {
+                            console.warn(
+                                'Sunflower package receipt fiscalization skipped',
+                                {
+                                    checkoutSessionId,
+                                    reason: fiscalizationResult.reason,
+                                    receiptId: receiptResult.receiptId,
+                                    transactionId,
+                                },
+                            );
+                        }
+
+                        await dependencies.notifyBillingDocumentsEmail({
+                            to: customer?.userName,
+                            checkoutSessionId: session.id,
+                            invoiceId: invoiceResult.invoiceId,
+                            invoiceNumber: invoiceResult.invoiceNumber,
+                            receiptId: hasFiscalizedReceipt
+                                ? receiptResult.receiptId
+                                : null,
+                            receiptNumber: hasFiscalizedReceipt
+                                ? receiptResult.yearReceiptNumber
+                                : null,
+                        });
+                    }
+                }
+            } catch (error) {
+                console.error(
+                    'Sunflower package billing document automation failed',
+                    {
+                        checkoutSessionId,
+                        error,
+                        transactionId,
+                    },
+                );
+            }
+        }
+
+        const purchasedItems = [
+            {
+                name: packageData.name,
+                quantity: 1,
+                amountSubtotal: paidAmountCents,
+                currency: 'eur',
+            },
+        ];
+        await dependencies.notifyOrderConfirmationEmail({
+            to: customer?.userName,
+            cartId: null,
+            checkoutSessionId: session.id,
+            items: purchasedItems,
+            totalAmountCents: paidAmountCents,
+            currency: 'eur',
+        });
+        await dependencies.notifyPurchase({
+            accountId: packageItem.accountId,
+            amountTotal: paidAmountCents,
+            checkoutSessionId: session.id,
+            customerEmail: customer?.userName ?? null,
+            items: purchasedItems,
+        });
+
+        const ledgerEntryIds = [
+            topUpResult.topUp.entry.id,
+            topUpResult.bonus?.entry.id,
+        ].filter((id) => typeof id === 'number');
+        (await dependencies.getPostHogClient()).capture({
+            distinctId: packageItem.accountId,
+            event: 'sunflower_package_fulfilled',
+            properties: {
+                checkout_session_id: session.id,
+                transaction_id: transactionId,
+                package_code: packageData.code,
+                package_role: packageData.role,
+                price_cents: packageData.priceCents,
+                paid_amount_cents: paidAmountCents,
+                sunflowers: creditedSunflowers,
+                bonus_sunflowers: creditedBonusSunflowers,
+                duplicate_one_time_purchase: duplicateOneTimePurchase,
+                ledger_entry_ids: ledgerEntryIds,
+            },
+        });
+    } catch (error) {
+        if (error instanceof SunflowerPackageAlreadyPurchasedError) {
+            await recordSunflowerPackageFulfillmentFailure({
+                accountId: packageItem.accountId,
+                checkoutSessionId,
+                dependencies,
+                packageCode: packageItem.packageCode,
+                reason: 'already_purchased',
+            });
+            return;
+        }
+        throw error;
+    }
+}
+
 async function processPaidCheckoutSession(
     checkoutSessionId: string,
     session: NonNullable<Awaited<ReturnType<typeof getStripeCheckoutSession>>>,
@@ -419,6 +925,39 @@ async function processPaidCheckoutSession(
 ) {
     const alreadyProcessed =
         await dependencies.getCompletedTransactionByStripePaymentId(session.id);
+    const sunflowerPackageCheckout =
+        getSunflowerPackageCheckoutLineItems(session);
+    if (sunflowerPackageCheckout.malformedCount > 0) {
+        await recordSunflowerPackageFulfillmentFailure({
+            checkoutSessionId,
+            dependencies,
+            packageCode: null,
+            reason: 'malformed_package_metadata',
+        });
+        return;
+    }
+    const sunflowerPackageLineItems = sunflowerPackageCheckout.items;
+    if (sunflowerPackageLineItems.length > 1) {
+        await recordSunflowerPackageFulfillmentFailure({
+            checkoutSessionId,
+            dependencies,
+            packageCode: null,
+            reason: 'multiple_package_line_items',
+        });
+        return;
+    }
+    const sunflowerPackageLineItem = sunflowerPackageLineItems[0];
+    if (sunflowerPackageLineItem) {
+        await processSunflowerPackageCheckoutSession({
+            checkoutSessionId,
+            dependencies,
+            existingTransactionId: alreadyProcessed?.id,
+            packageItem: sunflowerPackageLineItem,
+            session,
+        });
+        return;
+    }
+
     if (alreadyProcessed) {
         console.info(
             `Checkout session ${checkoutSessionId} already processed; skipping.`,

--- a/apps/api/lib/sunflowers/packageCatalog.ts
+++ b/apps/api/lib/sunflowers/packageCatalog.ts
@@ -1,0 +1,93 @@
+import type { SunflowerPackage } from '@gredice/storage';
+import { z } from 'zod';
+
+const packageRoleSchema = z.enum(['initial_one_time', 'main', 'upsell']);
+const packageIneligibleReasonSchema = z.enum(['already_used']);
+
+export const sunflowerPackageResponseSchema = z.object({
+    code: z.string(),
+    name: z.string(),
+    priceCents: z.number().int().nonnegative(),
+    priceEur: z.number().nonnegative(),
+    currency: z.string(),
+    sunflowers: z.number().int().positive(),
+    baseSunflowers: z.number().int().positive(),
+    bonusSunflowers: z.number().int().nonnegative(),
+    bonusPercentage: z.number().int().nonnegative(),
+    tag: z.string().nullable(),
+    descriptionShort: z.string().nullable(),
+    descriptionLong: z.string().nullable(),
+    cta: z.string().nullable(),
+    role: packageRoleSchema,
+    eligible: z.boolean(),
+    ineligibleReason: packageIneligibleReasonSchema.nullable(),
+    displayOrder: z.number(),
+    showInPrimaryList: z.boolean(),
+    isOneTime: z.boolean(),
+    upsellTriggerCode: z.string().nullable(),
+});
+
+export const sunflowerPackageCatalogResponseSchema = z.object({
+    packages: z.array(sunflowerPackageResponseSchema),
+    groups: z.object({
+        initialOffer: z.array(z.string()),
+        main: z.array(z.string()),
+        upsell: z.array(z.string()),
+    }),
+});
+
+export type SunflowerPackageResponse = z.infer<
+    typeof sunflowerPackageResponseSchema
+>;
+
+function ineligibleReasonForPackage(pkg: SunflowerPackage) {
+    if (pkg.ineligibleReason === 'already_purchased') {
+        return 'already_used';
+    }
+    return null;
+}
+
+export function sunflowerPackageToResponse(pkg: SunflowerPackage) {
+    return {
+        code: pkg.code,
+        name: pkg.name,
+        priceCents: pkg.priceCents,
+        priceEur: pkg.priceEur,
+        currency: pkg.currency,
+        sunflowers: pkg.sunflowers,
+        baseSunflowers: pkg.baseSunflowers,
+        bonusSunflowers: pkg.bonusSunflowers,
+        bonusPercentage: pkg.bonusPercentage,
+        tag: pkg.tag,
+        descriptionShort: pkg.descriptionShort,
+        descriptionLong: pkg.descriptionLong,
+        cta: pkg.cta,
+        role: pkg.role,
+        eligible: pkg.eligible ?? true,
+        ineligibleReason: ineligibleReasonForPackage(pkg),
+        displayOrder: pkg.displayOrder,
+        showInPrimaryList: pkg.showInPrimaryList,
+        isOneTime: pkg.isOneTime,
+        upsellTriggerCode: pkg.upsellTriggerCode,
+    };
+}
+
+export function buildSunflowerPackageCatalogResponse(
+    packages: SunflowerPackage[],
+) {
+    const responsePackages = packages.map(sunflowerPackageToResponse);
+    return {
+        packages: responsePackages,
+        groups: {
+            initialOffer: responsePackages
+                .filter((pkg) => pkg.role === 'initial_one_time')
+                .map((pkg) => pkg.code),
+            main: responsePackages
+                .filter((pkg) => pkg.role === 'main' && pkg.showInPrimaryList)
+                .map((pkg) => pkg.code),
+            upsell: responsePackages
+                .filter((pkg) => pkg.role === 'upsell')
+                .map((pkg) => pkg.code),
+        },
+    };
+}

--- a/apps/garden/tests/SunflowersHudStory.tsx
+++ b/apps/garden/tests/SunflowersHudStory.tsx
@@ -1,7 +1,151 @@
 import * as ReactQuery from '@tanstack/react-query';
+import {
+    AppRouterContext,
+    type AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import {
+    PathnameContext,
+    SearchParamsContext,
+} from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { type PropsWithChildren, useMemo } from 'react';
+import { GameAnalyticsProvider } from '../../../packages/game/src/analytics/GameAnalyticsContext';
+import {
+    type SunflowerPackageCatalog,
+    sunflowerPackageKeys,
+} from '../../../packages/game/src/hooks/useSunflowerPackages';
 import { SunflowersHud } from '../../../packages/game/src/hud/SunflowersHud';
+import { SunflowerPackagesPanel } from '../../../packages/game/src/shared-ui/sunflowers/SunflowerPackagesPanel';
 import { SunflowersList } from '../../../packages/game/src/shared-ui/sunflowers/SunflowersList';
+
+const sunflowerPackageCatalog = {
+    packages: [
+        {
+            code: 'puna_gredica',
+            name: 'Puna gredica',
+            priceCents: 4999,
+            priceEur: 49.99,
+            currency: 'eur',
+            sunflowers: 60000,
+            baseSunflowers: 50000,
+            bonusSunflowers: 10000,
+            bonusPercentage: 20,
+            tag: 'Jednokratna ponuda',
+            descriptionShort: 'Početni paket za prvu veliku kupnju u vrtu.',
+            descriptionLong: null,
+            cta: 'Kupi početni paket',
+            role: 'initial_one_time',
+            eligible: true,
+            ineligibleReason: null,
+            displayOrder: 10,
+            showInPrimaryList: false,
+            isOneTime: true,
+            upsellTriggerCode: null,
+        },
+        {
+            code: 'mali_zalogaj',
+            name: 'Mali zalogaj',
+            priceCents: 499,
+            priceEur: 4.99,
+            currency: 'eur',
+            sunflowers: 5000,
+            baseSunflowers: 5000,
+            bonusSunflowers: 0,
+            bonusPercentage: 0,
+            tag: null,
+            descriptionShort: 'Mala nadoplata za brzu vrtnu akciju.',
+            descriptionLong: null,
+            cta: 'Kupi mali zalogaj',
+            role: 'main',
+            eligible: true,
+            ineligibleReason: null,
+            displayOrder: 20,
+            showInPrimaryList: true,
+            isOneTime: false,
+            upsellTriggerCode: null,
+        },
+        {
+            code: 'vrtna_kosarica',
+            name: 'Vrtna košarica',
+            priceCents: 3999,
+            priceEur: 39.99,
+            currency: 'eur',
+            sunflowers: 42000,
+            baseSunflowers: 40000,
+            bonusSunflowers: 2000,
+            bonusPercentage: 5,
+            tag: 'Najpopularnije',
+            descriptionShort: 'Najpraktičniji paket za redovite narudžbe.',
+            descriptionLong: null,
+            cta: 'Kupi vrtnu košaricu',
+            role: 'main',
+            eligible: true,
+            ineligibleReason: null,
+            displayOrder: 30,
+            showInPrimaryList: true,
+            isOneTime: false,
+            upsellTriggerCode: null,
+        },
+        {
+            code: 'mirna_sezona',
+            name: 'Mirna sezona',
+            priceCents: 9999,
+            priceEur: 99.99,
+            currency: 'eur',
+            sunflowers: 110000,
+            baseSunflowers: 100000,
+            bonusSunflowers: 10000,
+            bonusPercentage: 10,
+            tag: 'Najbolja vrijednost',
+            descriptionShort: 'Veći saldo za mirnu sezonu održavanja vrta.',
+            descriptionLong: null,
+            cta: 'Kupi mirnu sezonu',
+            role: 'main',
+            eligible: true,
+            ineligibleReason: null,
+            displayOrder: 40,
+            showInPrimaryList: true,
+            isOneTime: false,
+            upsellTriggerCode: null,
+        },
+        {
+            code: 'majstor_vrtlar',
+            name: 'Majstor vrtlar',
+            priceCents: 26999,
+            priceEur: 269.99,
+            currency: 'eur',
+            sunflowers: 300000,
+            baseSunflowers: 270000,
+            bonusSunflowers: 30000,
+            bonusPercentage: 11,
+            tag: 'Master upsell',
+            descriptionShort: 'Najveći paket za intenzivnu vrtnu sezonu.',
+            descriptionLong: null,
+            cta: 'Odaberi majstor paket',
+            role: 'upsell',
+            eligible: true,
+            ineligibleReason: null,
+            displayOrder: 50,
+            showInPrimaryList: false,
+            isOneTime: false,
+            upsellTriggerCode: 'mirna_sezona',
+        },
+    ],
+    groups: {
+        initialOffer: ['puna_gredica'],
+        main: ['mali_zalogaj', 'vrtna_kosarica', 'mirna_sezona'],
+        upsell: ['majstor_vrtlar'],
+    },
+} satisfies SunflowerPackageCatalog;
+
+const nextNavigationRouter = {
+    back: () => undefined,
+    forward: () => undefined,
+    prefetch: () => undefined,
+    push: () => undefined,
+    refresh: () => undefined,
+    replace: () => undefined,
+} satisfies AppRouterInstance;
 
 function createSunflowersHudQueryClient({
     accountSunflowers,
@@ -45,8 +189,23 @@ function createSunflowersHudQueryClient({
         total: 0,
         totalSunflowers: cartSunflowers,
     });
+    queryClient.setQueryData(sunflowerPackageKeys, sunflowerPackageCatalog);
 
     return queryClient;
+}
+
+function NextNavigationTestProvider({ children }: PropsWithChildren) {
+    const searchParams = useMemo(() => new URLSearchParams(), []);
+
+    return (
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <PathnameContext.Provider value="/vrt">
+                <SearchParamsContext.Provider value={searchParams}>
+                    {children}
+                </SearchParamsContext.Provider>
+            </PathnameContext.Provider>
+        </AppRouterContext.Provider>
+    );
 }
 
 function SunflowersHudTestProviders({
@@ -123,6 +282,48 @@ export function SunflowersPendingDetailsStory({
             >
                 <SunflowersList limit={5} pendingSunflowers={cartSunflowers} />
             </SunflowersHudTestProviders>
+        </div>
+    );
+}
+
+export function SunflowerPackagesPanelStory({
+    initialOfferUsed = false,
+}: {
+    initialOfferUsed?: boolean;
+}) {
+    const queryClient = useMemo(() => {
+        const client = createSunflowersHudQueryClient({
+            accountSunflowers: 9034,
+            cartSunflowers: 0,
+        });
+        client.setQueryData(sunflowerPackageKeys, {
+            ...sunflowerPackageCatalog,
+            packages: sunflowerPackageCatalog.packages.map((pkg) =>
+                pkg.code === 'puna_gredica'
+                    ? {
+                          ...pkg,
+                          eligible: !initialOfferUsed,
+                          ineligibleReason: initialOfferUsed
+                              ? 'already_used'
+                              : null,
+                      }
+                    : pkg,
+            ),
+        } satisfies SunflowerPackageCatalog);
+        return client;
+    }, [initialOfferUsed]);
+
+    return (
+        <div className="max-w-4xl p-6">
+            <NuqsTestingAdapter>
+                <NextNavigationTestProvider>
+                    <ReactQuery.QueryClientProvider client={queryClient}>
+                        <GameAnalyticsProvider capture={() => undefined}>
+                            <SunflowerPackagesPanel />
+                        </GameAnalyticsProvider>
+                    </ReactQuery.QueryClientProvider>
+                </NextNavigationTestProvider>
+            </NuqsTestingAdapter>
         </div>
     );
 }

--- a/apps/garden/tests/sunflowers-hud.spec.tsx
+++ b/apps/garden/tests/sunflowers-hud.spec.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import {
+    SunflowerPackagesPanelStory,
     SunflowersHudStory,
     SunflowersPendingDetailsStory,
 } from './SunflowersHudStory';
@@ -49,5 +50,49 @@ test.describe('Sunflowers HUD', () => {
         await expect(page.getByText('Zadaci za novi vrt')).toBeVisible();
         await expect(page.getByText('+25')).toBeVisible();
         await expect(page.getByText('Nepoznato')).toHaveCount(0);
+    });
+
+    test('shows sunflower packages and master upsell in the purchase panel', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<SunflowerPackagesPanelStory />);
+
+        await expect(page.getByText('Početna ponuda')).toBeVisible();
+        await expect(
+            page.getByText('Puna gredica', { exact: true }),
+        ).toBeVisible();
+        await expect(page.getByText('Glavni paketi')).toBeVisible();
+        await expect(
+            page.getByText('Mali zalogaj', { exact: true }),
+        ).toBeVisible();
+        await expect(
+            page.getByText('Vrtna košarica', { exact: true }),
+        ).toBeVisible();
+        await expect(
+            page.getByText('Mirna sezona', { exact: true }),
+        ).toBeVisible();
+
+        await page.getByRole('button', { name: 'Kupi mirnu sezonu' }).click();
+
+        await expect(page.getByText('Želiš veći saldo?')).toBeVisible();
+        await expect(page.getByText('Majstor vrtlar')).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Odaberi majstor paket' }),
+        ).toBeVisible();
+    });
+
+    test('disables the one-time package after it has been used', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<SunflowerPackagesPanelStory initialOfferUsed />);
+
+        await expect(
+            page.getByText('Ova ponuda je već iskorištena na tvom računu.'),
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Kupi početni paket' }),
+        ).toBeDisabled();
     });
 });

--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -13,6 +13,7 @@ import { getHqLocationsData } from '../../lib/getHqLocationsData';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
 import { getPlantSortsData } from '../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
+import { getPublicSunflowerPackages } from '../../lib/sunflowerPackages';
 import { KnownPages } from '../../src/KnownPages';
 import {
     buildDeliveryPricingRows,
@@ -23,17 +24,27 @@ import {
 export const metadata: Metadata = {
     title: 'Cjenik',
     description:
-        'Pregled svih cijena: biljke, radnje i dostava na jednom mjestu.',
+        'Pregled svih cijena: paketi suncokreta, biljke, radnje i dostava na jednom mjestu.',
 };
 
+const sunflowerFormatter = new Intl.NumberFormat('hr-HR', {
+    maximumFractionDigits: 0,
+});
+
 export default async function PricingPage() {
-    const [plantsData, plantSortsData, operationsData, hqLocations] =
-        await Promise.all([
-            getPlantsData(),
-            getPlantSortsData(),
-            getOperationsData(),
-            getHqLocationsData(),
-        ]);
+    const [
+        plantsData,
+        plantSortsData,
+        operationsData,
+        hqLocations,
+        sunflowerPackages,
+    ] = await Promise.all([
+        getPlantsData(),
+        getPlantSortsData(),
+        getOperationsData(),
+        getHqLocationsData(),
+        getPublicSunflowerPackages(),
+    ]);
 
     const plantPricingRows = buildPlantPricingRows(plantsData, plantSortsData);
     const operationPricingRows = buildOperationPricingRows(operationsData);
@@ -48,8 +59,100 @@ export default async function PricingPage() {
                 <PageHeader
                     padded
                     header="💶 Cjenik"
-                    subHeader="Sve cijene na jednom mjestu: biljke, sorte, radnje i dostava"
+                    subHeader="Sve cijene na jednom mjestu: paketi suncokreta, biljke, sorte, radnje i dostava"
                 />
+
+                <Card>
+                    <CardHeader className="flex-row items-center justify-between">
+                        <CardTitle>Paketi suncokreta</CardTitle>
+                        <FeedbackModal topic="www/pricing/sunflowers" />
+                    </CardHeader>
+                    <CardContent>
+                        <Stack spacing={3}>
+                            <Typography level="body2" secondary>
+                                Suncokreti su prepaid Gredice bodovi za vrtne
+                                akcije. Kod korištenja salda vrijedi
+                                orijentacijski odnos 1 EUR ≈ 1.000 suncokreta, a
+                                bonus se dodaje kao dodatni broj suncokreta.
+                            </Typography>
+                            {sunflowerPackages.length > 0 ? (
+                                <div className="overflow-x-auto">
+                                    <table className="w-full border-collapse">
+                                        <thead>
+                                            <tr className="border-b">
+                                                <th className="py-2 pr-4 text-left">
+                                                    Paket
+                                                </th>
+                                                <th className="py-2 pr-4 text-right">
+                                                    Suncokreti
+                                                </th>
+                                                <th className="py-2 pr-4 text-right">
+                                                    Bonus
+                                                </th>
+                                                <th className="py-2 text-right">
+                                                    Cijena
+                                                </th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {sunflowerPackages.map((pkg) => (
+                                                <tr
+                                                    key={pkg.code}
+                                                    className="border-b last:border-b-0"
+                                                >
+                                                    <td className="py-2 pr-4 align-middle">
+                                                        <span className="block font-medium">
+                                                            {pkg.name}
+                                                        </span>
+                                                        <span className="block text-xs text-muted-foreground">
+                                                            {pkg.isOneTime
+                                                                ? 'Jednokratna ponuda'
+                                                                : pkg.role ===
+                                                                    'upsell'
+                                                                  ? 'Najveći paket'
+                                                                  : (pkg.tag ??
+                                                                    'Glavni paket')}
+                                                        </span>
+                                                    </td>
+                                                    <td className="py-2 pr-4 text-right font-medium tabular-nums">
+                                                        {sunflowerFormatter.format(
+                                                            pkg.sunflowers,
+                                                        )}
+                                                    </td>
+                                                    <td className="py-2 pr-4 text-right tabular-nums">
+                                                        {pkg.bonusSunflowers > 0
+                                                            ? `+${sunflowerFormatter.format(pkg.bonusSunflowers)}`
+                                                            : '-'}
+                                                    </td>
+                                                    <td className="py-2 text-right font-medium">
+                                                        {formatPrice(
+                                                            pkg.priceEur,
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            ) : (
+                                <Typography level="body2" secondary>
+                                    Paketi se trenutno ne mogu učitati. Aktualni
+                                    saldo i kupnja dostupni su u vrtu.
+                                </Typography>
+                            )}
+                            <Typography level="body2" secondary>
+                                Detalje o korištenju salda pročitaj na stranici{' '}
+                                <Link
+                                    className="underline"
+                                    href={KnownPages.Sunflowers}
+                                >
+                                    Suncokreti
+                                </Link>
+                                .
+                            </Typography>
+                        </Stack>
+                    </CardContent>
+                </Card>
 
                 <Card>
                     <CardHeader className="flex-row items-center justify-between">

--- a/apps/www/app/legalno/uvjeti-koristenja/page.tsx
+++ b/apps/www/app/legalno/uvjeti-koristenja/page.tsx
@@ -7,7 +7,8 @@ import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
     title: 'Uvjeti korištenja',
-    description: 'Uvjeti korištenja web stranice Gredice.',
+    description:
+        'Uvjeti korištenja web stranice Gredice, uključujući pravila za suncokrete i Gredice saldo.',
 };
 
 export default function UvjetiKoristenjaPage() {
@@ -51,7 +52,36 @@ export default function UvjetiKoristenjaPage() {
                             ograničavajući se na, pretraživanje, interakcije s
                             drugim korisnicima i dijeljenje sadržaja.
                         </li>
+                        <li>
+                            &quot;<strong>Suncokreti</strong>&quot; označavaju
+                            Gredice bodove odnosno prepaid saldo koji se koristi
+                            samo unutar Gredica za vrtne akcije i povezane
+                            usluge.
+                        </li>
                     </ul>
+                    <h2>Suncokreti i prepaid saldo</h2>
+                    <p>
+                        Suncokreti se evidentiraju na korisničkom računu kao
+                        Gredice saldo. Nisu opće sredstvo plaćanja, ne prenose
+                        se na druge korisnike i ne mogu se zamijeniti za
+                        gotovinu osim u slučajevima u kojima je povrat zakonski
+                        obvezan ili ga Gredice izričito odobre.
+                    </p>
+                    <p>
+                        Kod naručivanja vrtne akcije saldo se može najprije
+                        rezervirati. Ako se akcija otkaže prije obrade,
+                        rezervacija se otpušta i vraća na raspoloživi saldo.
+                        Nakon izvršene akcije rezervirani iznos se naplaćuje iz
+                        salda, a povezani dokumenti dostupni su u korisničkom
+                        profilu kada su izdani.
+                    </p>
+                    <p>
+                        Bonus suncokreti iz paketa služe za korištenje unutar
+                        Gredica i ne predstavljaju zaseban novčani iznos.
+                        Povrati i korekcije rješavaju se prema pravilima na
+                        stranici{' '}
+                        <a href="/povrati-i-povrat-novca">Povrat novca</a>.
+                    </p>
                     <h2>Prava i obveze pri korištenju Platforme</h2>
                     <p>Korištenjem Platforme potrebno je:</p>
                     <ul>

--- a/apps/www/app/povrati-i-povrat-novca/page.tsx
+++ b/apps/www/app/povrati-i-povrat-novca/page.tsx
@@ -8,7 +8,7 @@ import { KnownPages } from '../../src/KnownPages';
 export const metadata: Metadata = {
     title: 'Povrat novca',
     description:
-        'Informacije o 30-dnevnoj politici povrata novca za biljke, sorte i radnje na tržištu Hrvatske.',
+        'Informacije o povratu novca, suncokretima, rezervacijama i korekcijama Gredice salda.',
 };
 
 export default function RefundsPage() {
@@ -38,11 +38,32 @@ export default function RefundsPage() {
                             prema dogovoru sa podrškom.
                         </li>
                     </ul>
+                    <h2>Suncokreti i Gredice saldo</h2>
+                    <p>
+                        Suncokreti su prepaid Gredice bodovi koji se koriste
+                        samo unutar Gredica za vrtne akcije i povezane usluge.
+                        Ne prenose se na druge korisnike i ne mogu se zamijeniti
+                        za gotovinu osim kada je povrat zakonski obvezan ili ga
+                        Gredice izričito odobre.
+                    </p>
+                    <p>
+                        Kada naručiš akciju u vrtu, potreban broj suncokreta
+                        najprije se rezervira. Ako se akcija otkaže prije
+                        obrade, rezervacija se otpušta i suncokreti se vraćaju
+                        na raspoloživi saldo.
+                    </p>
+                    <p>
+                        Nakon što je akcija izvršena i naplaćena iz salda,
+                        eventualni povrat ili korekcija rješava se kroz
+                        korisničku podršku. Bonus suncokreti iz paketa ne
+                        predstavljaju zaseban novčani iznos i ne obećavaju
+                        automatski gotovinski povrat.
+                    </p>
                     <h2>Kako zatražiti povrat</h2>
                     <p>
                         Javi se našoj podršci i opiši razlog nezadovoljstva.
                         Nakon provjere zahtjeva predložit ćemo puni povrat novca
-                        ili suncokreta.
+                        ili korekciju Gredice salda.
                     </p>
                     <p>
                         Kontakt stranicu možeš otvoriti ovdje:{' '}

--- a/apps/www/app/suncokreti/page.tsx
+++ b/apps/www/app/suncokreti/page.tsx
@@ -1,63 +1,250 @@
-import type { SectionData } from '@gredice/ui/cms';
-import { SectionsView } from '@gredice/ui/cms';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import { Container } from '@gredice/ui/Container';
+import { Navigate } from '@gredice/ui/icons';
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import Image from 'next/image';
-import { sectionsComponentRegistry } from '../../components/shared/sectionsComponentRegistry';
+import Link from 'next/link';
+import {
+    getPublicSunflowerPackages,
+    type PublicSunflowerPackage,
+} from '../../lib/sunflowerPackages';
+import { KnownPages } from '../../src/KnownPages';
 
 export const metadata: Metadata = {
-    title: 'Suncokreti',
-    description: 'Sve što trebaš znati o suncokretima.',
+    title: 'Suncokreti i Gredice saldo',
+    description:
+        'Suncokreti su prepaid Gredice bodovi za vrtne akcije. Pogledaj pakete, bonus suncokrete i pravila korištenja salda.',
 };
 
-const sectionsData: SectionData[] = [
-    {
-        component: 'Faq1',
-        header: 'Sve što trebaš znati o suncokretima',
-        description:
-            'Suncokreti ne dolaze samo u jednoj boji i veličini. Postoje različite vrste suncokreta, a svaka od njih ima svoje karakteristike i boje.',
-        features: [
-            {
-                header: 'Što su suncokreti?',
-                description:
-                    'Sakupljaj i koristi suncokrete za uređenje i dekoraciju vrta ili kupnju i brigu o svojim biljkama 🌱',
-            },
-            {
-                header: 'Kako skupljam suncokrete?',
-                description:
-                    'Suncokrete dobiješ prilikom registracije, redovitim posjetima svog vrta te za svaku odrađenu radnju u vrtu. Također, za svaku kupnju od 1 € dobivaš 🌻10. Ujedno, posjeti svoj vrt svaki dan i uvijek će te čekati novi 🌻.',
-            },
-            {
-                header: 'Za što se mogu koristiti suncokreti?',
-                description:
-                    'Suncokrete možeš koristiti za ukrašavanje svog vrta te brigu o gredicama i biljkama. Suncokrete možeš koristiti umjesto plaćanja pojedinih akcija. 🌻1000 je jednako 1 € prilikom korištenja za akcije ili kupnju biljaka u svom vrtu.',
-            },
-        ],
-    },
-];
+const sunflowerFormatter = new Intl.NumberFormat('hr-HR', {
+    maximumFractionDigits: 0,
+});
+const euroFormatter = new Intl.NumberFormat('hr-HR', {
+    currency: 'EUR',
+    style: 'currency',
+});
 
-export default function SunflowersPage() {
+function packagePrice(pkg: PublicSunflowerPackage) {
+    return euroFormatter.format(pkg.priceCents / 100);
+}
+
+function packageCtaUrl() {
+    return `${KnownPages.GardenApp}/?pregled=suncokreti`;
+}
+
+function packageCard(pkg: PublicSunflowerPackage) {
     return (
-        <Stack>
-            <PageHeader
-                header="Suncokreti"
-                subHeader={`Sakupljaj i koristi suncokrete za uređenje i dekoraciju vrta ili kupnju i brigu o svojim biljkama 🌱`}
-                padded
-                visual={
-                    <Image
-                        src="https://cdn.gredice.com/sunflower-large.svg"
-                        alt="Suncokret"
-                        width={192}
-                        height={192}
-                        priority
-                    />
-                }
-            />
-            <SectionsView
-                sectionsData={sectionsData}
-                componentsRegistry={sectionsComponentRegistry}
-            />
-        </Stack>
+        <Card key={pkg.code} className="h-full border-tertiary border-b-4">
+            <CardHeader>
+                <div className="flex items-start justify-between gap-3">
+                    <Stack spacing={1}>
+                        <CardTitle>{pkg.name}</CardTitle>
+                        {pkg.tag ? (
+                            <Chip size="sm" variant="soft">
+                                {pkg.tag}
+                            </Chip>
+                        ) : null}
+                    </Stack>
+                    <Typography level="body1" bold className="tabular-nums">
+                        {packagePrice(pkg)}
+                    </Typography>
+                </div>
+            </CardHeader>
+            <CardContent>
+                <Stack spacing={3}>
+                    <Typography level="h3" className="tabular-nums">
+                        {sunflowerFormatter.format(pkg.sunflowers)} 🌻
+                    </Typography>
+                    {pkg.bonusSunflowers > 0 ? (
+                        <Typography level="body2" className="text-primary">
+                            +{sunflowerFormatter.format(pkg.bonusSunflowers)}{' '}
+                            bonus suncokreta
+                        </Typography>
+                    ) : null}
+                    {pkg.descriptionShort ? (
+                        <Typography level="body2" secondary>
+                            {pkg.descriptionShort}
+                        </Typography>
+                    ) : null}
+                    {pkg.isOneTime ? (
+                        <Typography level="body3" secondary>
+                            Jednokratna ponuda po korisničkom računu.
+                        </Typography>
+                    ) : null}
+                    {pkg.role === 'upsell' ? (
+                        <Typography level="body3" secondary>
+                            Najveći paket prikazuje se u vrtu nakon odabira
+                            paketa Mirna sezona.
+                        </Typography>
+                    ) : null}
+                    <Button
+                        href={packageCtaUrl()}
+                        endDecorator={<Navigate className="size-4" />}
+                        size="sm"
+                    >
+                        {pkg.cta ?? 'Kupi paket'}
+                    </Button>
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+}
+
+export default async function SunflowersPage() {
+    const packages = await getPublicSunflowerPackages();
+    const initialOffer = packages.filter(
+        (pkg) => pkg.role === 'initial_one_time',
+    );
+    const mainPackages = packages.filter(
+        (pkg) => pkg.role === 'main' && pkg.showInPrimaryList,
+    );
+    const upsellPackages = packages.filter((pkg) => pkg.role === 'upsell');
+
+    return (
+        <Container maxWidth="lg">
+            <Stack spacing={6}>
+                <PageHeader
+                    header="Suncokreti"
+                    subHeader="Gredice bodovi za vrtne akcije u tvojoj gredici"
+                    padded
+                    visual={
+                        <Image
+                            src="https://cdn.gredice.com/sunflower-large.svg"
+                            alt="Suncokret"
+                            width={192}
+                            height={192}
+                            priority
+                        />
+                    }
+                />
+
+                <section className="grid gap-4 md:grid-cols-[1.2fr_0.8fr]">
+                    <Card className="border-tertiary border-b-4">
+                        <CardHeader>
+                            <CardTitle>Kako funkcionira saldo</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Stack spacing={3}>
+                                <Typography level="body1">
+                                    Suncokreti su Gredice bodovi koje koristiš
+                                    za vrtne akcije - sadnju, sjetvu,
+                                    zalijevanje, plijevljenje, fotografiranje,
+                                    berbu, dostavu i druge zadatke u svojoj
+                                    gredici.
+                                </Typography>
+                                <Typography level="body2" secondary>
+                                    Kod korištenja salda vrijedi orijentacijski
+                                    odnos 1 EUR ≈ 1.000 suncokreta. Saldo se
+                                    evidentira na korisničkom računu i dostupan
+                                    je u vrtu nakon uspješne uplate.
+                                </Typography>
+                                <Typography level="body2" secondary>
+                                    Suncokreti se mogu koristiti samo unutar
+                                    Gredica, ne prenose se na druge korisnike i
+                                    ne mijenjaju se za gotovinu osim kod
+                                    zakonski obveznih ili odobrenih povrata.
+                                </Typography>
+                            </Stack>
+                        </CardContent>
+                    </Card>
+                    <Card className="border-tertiary border-b-4">
+                        <CardHeader>
+                            <CardTitle>Korištenje u vrtu</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Stack spacing={3}>
+                                <Typography level="body2" secondary>
+                                    Pri naručivanju vrtne akcije suncokreti se
+                                    najprije rezerviraju. Ako se akcija otkaže
+                                    prije obrade, rezervacija se vraća na saldo.
+                                </Typography>
+                                <Typography level="body2" secondary>
+                                    Nakon izvršene akcije rezervirani iznos se
+                                    naplaćuje iz salda, a dokumenti su dostupni
+                                    u korisničkom profilu.
+                                </Typography>
+                                <Link
+                                    className="font-medium text-primary underline-offset-4 hover:underline"
+                                    href={KnownPages.Refunds}
+                                >
+                                    Pravila povrata i korekcija
+                                </Link>
+                            </Stack>
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <section className="space-y-4">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                        <Stack spacing={1}>
+                            <Typography level="h2">
+                                Paketi suncokreta
+                            </Typography>
+                            <Typography level="body2" secondary>
+                                Bonus je prikazan kao dodatni broj suncokreta
+                                koji se dodaje na Gredice saldo.
+                            </Typography>
+                        </Stack>
+                        <Button
+                            href={packageCtaUrl()}
+                            variant="outlined"
+                            endDecorator={<Navigate className="size-4" />}
+                        >
+                            Otvori vrt
+                        </Button>
+                    </div>
+
+                    {packages.length === 0 ? (
+                        <Card>
+                            <CardContent noHeader>
+                                <Typography level="body2" secondary>
+                                    Paketi se trenutno ne mogu učitati.
+                                    Suncokrete možeš kupiti iz profila u vrtu
+                                    čim je katalog dostupan.
+                                </Typography>
+                            </CardContent>
+                        </Card>
+                    ) : null}
+
+                    {initialOffer.length > 0 ? (
+                        <Stack spacing={2}>
+                            <Typography level="body1" bold>
+                                Početna ponuda
+                            </Typography>
+                            <div className="grid gap-4 md:grid-cols-2">
+                                {initialOffer.map(packageCard)}
+                            </div>
+                        </Stack>
+                    ) : null}
+
+                    {mainPackages.length > 0 ? (
+                        <Stack spacing={2}>
+                            <Typography level="body1" bold>
+                                Glavni paketi
+                            </Typography>
+                            <div className="grid gap-4 md:grid-cols-3">
+                                {mainPackages.map(packageCard)}
+                            </div>
+                        </Stack>
+                    ) : null}
+
+                    {upsellPackages.length > 0 ? (
+                        <Stack spacing={2}>
+                            <Typography level="body1" bold>
+                                Najveći paket
+                            </Typography>
+                            <div className="grid gap-4 md:grid-cols-2">
+                                {upsellPackages.map(packageCard)}
+                            </div>
+                        </Stack>
+                    ) : null}
+                </section>
+            </Stack>
+        </Container>
     );
 }

--- a/apps/www/lib/sunflowerPackages.ts
+++ b/apps/www/lib/sunflowerPackages.ts
@@ -1,0 +1,181 @@
+import { getServerGrediceApiOrigin } from '@gredice/client';
+import { cache } from 'react';
+
+export type PublicSunflowerPackage = {
+    entityId: number;
+    code: string;
+    name: string;
+    tag: string | null;
+    descriptionShort: string | null;
+    descriptionLong: string | null;
+    cta: string | null;
+    displayOrder: number;
+    priceCents: number;
+    priceEur: number;
+    currency: string;
+    sunflowers: number;
+    baseSunflowers: number;
+    bonusSunflowers: number;
+    bonusPercentage: number;
+    role: 'initial_one_time' | 'main' | 'upsell';
+    isActive: boolean;
+    isOneTime: boolean;
+    upsellTriggerCode: string | null;
+    showInPrimaryList: boolean;
+};
+
+function record(value: unknown): Record<string, unknown> | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+    return Object.fromEntries(Object.entries(value));
+}
+
+function stringValue(source: Record<string, unknown> | undefined, key: string) {
+    const value = source?.[key];
+    if (typeof value !== 'string') {
+        return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+
+function numberValue(source: Record<string, unknown> | undefined, key: string) {
+    const value = source?.[key];
+    const number =
+        typeof value === 'number'
+            ? value
+            : typeof value === 'string'
+              ? Number.parseFloat(value)
+              : Number.NaN;
+    return Number.isFinite(number) ? number : null;
+}
+
+function booleanValue(
+    source: Record<string, unknown> | undefined,
+    key: string,
+    defaultValue: boolean,
+) {
+    const value = source?.[key];
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'string') {
+        return value === 'true';
+    }
+    return defaultValue;
+}
+
+function packageRole(
+    value: string | null,
+): PublicSunflowerPackage['role'] | null {
+    if (
+        value === 'initial_one_time' ||
+        value === 'main' ||
+        value === 'upsell'
+    ) {
+        return value;
+    }
+    return null;
+}
+
+function normalizeSunflowerPackage(
+    entity: Record<string, unknown>,
+): PublicSunflowerPackage | null {
+    const entityId = typeof entity.id === 'number' ? entity.id : null;
+    const presentation = record(entity.presentation);
+    const pricing = record(entity.pricing);
+    const availability = record(entity.availability);
+    const code = stringValue(presentation, 'code');
+    const name = stringValue(presentation, 'name');
+    const displayOrder = numberValue(presentation, 'displayOrder');
+    const priceEur = numberValue(pricing, 'priceEur');
+    const sunflowers = numberValue(pricing, 'sunflowers');
+    const baseSunflowers = numberValue(pricing, 'baseSunflowers');
+    const bonusSunflowers = numberValue(pricing, 'bonusSunflowers');
+    const bonusPercentage = numberValue(pricing, 'bonusPercentage');
+    const role = packageRole(stringValue(availability, 'packageRole'));
+    const currency = stringValue(pricing, 'currency');
+
+    if (
+        entityId === null ||
+        !code ||
+        !name ||
+        displayOrder === null ||
+        priceEur === null ||
+        sunflowers === null ||
+        baseSunflowers === null ||
+        bonusSunflowers === null ||
+        bonusPercentage === null ||
+        !role ||
+        !currency
+    ) {
+        return null;
+    }
+
+    return {
+        entityId,
+        code,
+        name,
+        tag: stringValue(presentation, 'tag'),
+        descriptionShort: stringValue(presentation, 'descriptionShort'),
+        descriptionLong: stringValue(presentation, 'descriptionLong'),
+        cta: stringValue(presentation, 'cta'),
+        displayOrder,
+        priceCents: Math.round(priceEur * 100),
+        priceEur,
+        currency,
+        sunflowers,
+        baseSunflowers,
+        bonusSunflowers,
+        bonusPercentage,
+        role,
+        isActive: booleanValue(availability, 'isActive', true),
+        isOneTime: booleanValue(availability, 'isOneTime', false),
+        upsellTriggerCode: stringValue(availability, 'upsellTriggerCode'),
+        showInPrimaryList: booleanValue(
+            availability,
+            'showInPrimaryList',
+            true,
+        ),
+    };
+}
+
+function isActiveSunflowerPackage(
+    pkg: PublicSunflowerPackage | null,
+): pkg is PublicSunflowerPackage {
+    return pkg?.isActive === true;
+}
+
+export const getPublicSunflowerPackages = cache(async () => {
+    try {
+        const response = await fetch(
+            `${getServerGrediceApiOrigin()}/api/directories/entities/sunflowerPackage`,
+            { next: { revalidate: 300 } },
+        );
+        if (!response.ok) {
+            console.error('Failed to fetch sunflower packages', {
+                status: response.status,
+                statusText: response.statusText,
+            });
+            return [];
+        }
+
+        const payload: unknown = await response.json();
+        if (!Array.isArray(payload)) {
+            return [];
+        }
+
+        return payload
+            .map((entity) => normalizeSunflowerPackage(record(entity) ?? {}))
+            .filter(isActiveSunflowerPackage)
+            .sort(
+                (left, right) =>
+                    left.displayOrder - right.displayOrder ||
+                    left.code.localeCompare(right.code),
+            );
+    } catch (error) {
+        console.error('Failed to fetch sunflower packages', error);
+        return [];
+    }
+});

--- a/packages/game/src/hooks/useSunflowerPackageCheckout.ts
+++ b/packages/game/src/hooks/useSunflowerPackageCheckout.ts
@@ -1,0 +1,78 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { currentAccountKeys } from './useCurrentAccount';
+import { sunflowerPackageKeys } from './useSunflowerPackages';
+
+type SunflowerPackageCheckoutInput = {
+    code: string;
+};
+
+export class SunflowerPackageCheckoutError extends Error {
+    constructor(public readonly reason: string) {
+        super(reason);
+        this.name = 'SunflowerPackageCheckoutError';
+    }
+}
+
+function currentReturnPath() {
+    if (typeof window === 'undefined') {
+        return '/';
+    }
+    return `${window.location.pathname}${window.location.search}`;
+}
+
+export function useSunflowerPackageCheckout() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ code }: SunflowerPackageCheckoutInput) => {
+            const response = await clientAuthenticated().api.checkout[
+                'sunflower-packages'
+            ][':code'].$post({
+                param: { code },
+                json: {
+                    returnContext: {
+                        source: 'garden',
+                        path: currentReturnPath(),
+                    },
+                },
+            });
+
+            if (response.status === 409) {
+                const body = await response.json();
+                throw new SunflowerPackageCheckoutError(
+                    'reason' in body && typeof body.reason === 'string'
+                        ? body.reason
+                        : 'not_eligible',
+                );
+            }
+            if (!response.ok) {
+                throw new Error(
+                    `Failed to create sunflower package checkout: ${response.status} ${response.statusText}`,
+                );
+            }
+
+            return response.json();
+        },
+        onError: (error) => {
+            if (
+                error instanceof SunflowerPackageCheckoutError &&
+                error.reason === 'already_used'
+            ) {
+                queryClient.invalidateQueries({
+                    queryKey: sunflowerPackageKeys,
+                });
+            }
+        },
+        onSuccess: (data) => {
+            queryClient.invalidateQueries({ queryKey: currentAccountKeys });
+            queryClient.invalidateQueries({ queryKey: sunflowerPackageKeys });
+            if (data.url) {
+                window.location.href = data.url;
+            }
+        },
+        scope: {
+            id: 'sunflower-package-checkout',
+        },
+    });
+}

--- a/packages/game/src/hooks/useSunflowerPackages.ts
+++ b/packages/game/src/hooks/useSunflowerPackages.ts
@@ -1,0 +1,37 @@
+import { clientAuthenticated } from '@gredice/client';
+import { useQuery } from '@tanstack/react-query';
+
+export const sunflowerPackageKeys = [
+    'accounts',
+    'current',
+    'sunflowers',
+    'packages',
+];
+
+export async function fetchSunflowerPackageCatalog() {
+    const response =
+        await clientAuthenticated().api.accounts.current.sunflowers.packages.$get();
+    if (response.status === 401) {
+        return null;
+    }
+    if (!response.ok) {
+        throw new Error(
+            `Failed to fetch sunflower packages: ${response.status} ${response.statusText}`,
+        );
+    }
+    return response.json();
+}
+
+export type SunflowerPackageCatalog = NonNullable<
+    Awaited<ReturnType<typeof fetchSunflowerPackageCatalog>>
+>;
+export type SunflowerPackageData = SunflowerPackageCatalog['packages'][0];
+
+export function useSunflowerPackages() {
+    return useQuery({
+        queryKey: sunflowerPackageKeys,
+        queryFn: fetchSunflowerPackageCatalog,
+        retry: false,
+        staleTime: 1000 * 60 * 5,
+    });
+}

--- a/packages/game/src/hud/SunflowersHud.tsx
+++ b/packages/game/src/hud/SunflowersHud.tsx
@@ -148,7 +148,7 @@ function SunflowersCard({ pendingSunflowers }: { pendingSunflowers: number }) {
                     className="rounded-t-none"
                     onClick={() => setProfileModalOpen('suncokreti')}
                 >
-                    Prikaži sve aktivnosti
+                    Pregled i kupnja suncokreta
                 </Button>
             </Stack>
         </Stack>

--- a/packages/game/src/modals/components/SunflowersTab.tsx
+++ b/packages/game/src/modals/components/SunflowersTab.tsx
@@ -4,6 +4,7 @@ import { Typography } from '@gredice/ui/Typography';
 import Image from 'next/image';
 import { useCurrentAccount } from '../../hooks/useCurrentAccount';
 import { DailyRewardOverview } from '../../shared-ui/sunflowers/DailyRewardOverview';
+import { SunflowerPackagesPanel } from '../../shared-ui/sunflowers/SunflowerPackagesPanel';
 import { SunflowersList } from '../../shared-ui/sunflowers/SunflowersList';
 
 export function SunflowersTab() {
@@ -14,7 +15,10 @@ export function SunflowersTab() {
             <Typography level="h4" className="hidden md:block">
                 🌻 Suncokreti
             </Typography>
-            <Stack spacing={2} className="max-h-[calc(100dvh-12rem)]">
+            <Stack
+                spacing={3}
+                className="max-h-[calc(100dvh-12rem)] overflow-y-auto pr-1"
+            >
                 <div className="relative md:mt-0">
                     <span className="absolute text-5xl -top-12 right-6 hidden md:block">
                         <Image
@@ -42,7 +46,8 @@ export function SunflowersTab() {
                         <DailyRewardOverview />
                     </CardContent>
                 </Card>
-                <div className="overflow-y-auto max-h-[calc(100dvh-20rem)] md:max-h-[calc(100dvh-24rem)] rounded-lg text-card-foreground bg-card border shadow-xs p-4">
+                <SunflowerPackagesPanel />
+                <div className="rounded-lg text-card-foreground bg-card border shadow-xs p-4">
                     <SunflowersList />
                 </div>
             </Stack>

--- a/packages/game/src/shared-ui/sunflowers/SunflowerPackagesPanel.tsx
+++ b/packages/game/src/shared-ui/sunflowers/SunflowerPackagesPanel.tsx
@@ -1,0 +1,382 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import { useSearchParam } from '@gredice/ui/hooks';
+import { AI, Check, Navigate } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useGameAnalytics } from '../../analytics/GameAnalyticsContext';
+import { currentAccountKeys } from '../../hooks/useCurrentAccount';
+import {
+    SunflowerPackageCheckoutError,
+    useSunflowerPackageCheckout,
+} from '../../hooks/useSunflowerPackageCheckout';
+import {
+    type SunflowerPackageData,
+    sunflowerPackageKeys,
+    useSunflowerPackages,
+} from '../../hooks/useSunflowerPackages';
+import { formatSunflowers } from '../../utils/sunflowerPricing';
+
+const euroFormatter = new Intl.NumberFormat('hr-HR', {
+    currency: 'EUR',
+    style: 'currency',
+});
+
+function packagesByCodes(
+    packages: SunflowerPackageData[],
+    codes: string[] | undefined,
+) {
+    const byCode = new Map(packages.map((pkg) => [pkg.code, pkg]));
+    return (codes ?? [])
+        .map((code) => byCode.get(code) ?? null)
+        .filter((pkg) => pkg !== null);
+}
+
+function packageBonusText(pkg: SunflowerPackageData) {
+    if (pkg.bonusSunflowers <= 0) {
+        return null;
+    }
+    return `+${formatSunflowers(pkg.bonusSunflowers)} bonus suncokreta`;
+}
+
+function packagePrice(pkg: SunflowerPackageData) {
+    return euroFormatter.format(pkg.priceCents / 100);
+}
+
+export function SunflowerPackagesPanel() {
+    const { data, isError, isLoading } = useSunflowerPackages();
+    const checkout = useSunflowerPackageCheckout();
+    const queryClient = useQueryClient();
+    const { track } = useGameAnalytics();
+    const [returnStatus, setReturnStatus] = useSearchParam('status');
+    const [checkoutStatus, setCheckoutStatus] = useState<
+        'success' | 'cancel' | null
+    >(null);
+    const [activeCheckoutCode, setActiveCheckoutCode] = useState<string | null>(
+        null,
+    );
+    const [upsellTriggerCode, setUpsellTriggerCode] = useState<string | null>(
+        null,
+    );
+    const didTrackCatalogView = useRef(false);
+
+    useEffect(() => {
+        if (returnStatus !== 'success' && returnStatus !== 'cancel') {
+            return;
+        }
+        setCheckoutStatus(returnStatus);
+        setReturnStatus(undefined);
+        queryClient.invalidateQueries({ queryKey: currentAccountKeys });
+        queryClient.invalidateQueries({ queryKey: sunflowerPackageKeys });
+    }, [queryClient, returnStatus, setReturnStatus]);
+
+    useEffect(() => {
+        if (!data || didTrackCatalogView.current) {
+            return;
+        }
+        didTrackCatalogView.current = true;
+        track('sunflower_package_catalog_viewed', {
+            package_count: data.packages.length,
+            initial_offer_count: data.groups.initialOffer.length,
+            main_package_count: data.groups.main.length,
+        });
+    }, [data, track]);
+
+    const packages = data?.packages ?? [];
+    const initialOffers = useMemo(
+        () => packagesByCodes(packages, data?.groups.initialOffer),
+        [data?.groups.initialOffer, packages],
+    );
+    const mainPackages = useMemo(
+        () => packagesByCodes(packages, data?.groups.main),
+        [data?.groups.main, packages],
+    );
+    const upsellPackage = packages.find(
+        (pkg) =>
+            pkg.role === 'upsell' &&
+            pkg.upsellTriggerCode === upsellTriggerCode &&
+            pkg.eligible,
+    );
+    const upsellTriggerPackage = mainPackages.find(
+        (pkg) => pkg.code === upsellTriggerCode,
+    );
+
+    function startCheckout(
+        pkg: SunflowerPackageData,
+        source: 'direct' | 'upsell_accept' | 'upsell_decline',
+    ) {
+        setActiveCheckoutCode(pkg.code);
+        track('sunflower_package_selected', {
+            package_code: pkg.code,
+            package_role: pkg.role,
+            price_cents: pkg.priceCents,
+            source,
+            sunflowers: pkg.sunflowers,
+        });
+        if (source === 'upsell_accept') {
+            track('sunflower_package_upsell_accepted', {
+                package_code: pkg.code,
+                trigger_package_code: pkg.upsellTriggerCode,
+            });
+        }
+        if (source === 'upsell_decline') {
+            track('sunflower_package_upsell_declined', {
+                package_code: pkg.code,
+                upsell_package_code: upsellPackage?.code ?? null,
+            });
+        }
+        checkout.mutate(
+            { code: pkg.code },
+            {
+                onSettled: () => setActiveCheckoutCode(null),
+            },
+        );
+    }
+
+    function handleMainPackage(pkg: SunflowerPackageData) {
+        const nextUpsell = packages.find(
+            (candidate) =>
+                candidate.role === 'upsell' &&
+                candidate.upsellTriggerCode === pkg.code &&
+                candidate.eligible,
+        );
+        if (!nextUpsell) {
+            startCheckout(pkg, 'direct');
+            return;
+        }
+        setUpsellTriggerCode(pkg.code);
+        track('sunflower_package_upsell_shown', {
+            package_code: nextUpsell.code,
+            trigger_package_code: pkg.code,
+        });
+    }
+
+    function packageCard(pkg: SunflowerPackageData, featured = false) {
+        const disabled = !pkg.eligible || checkout.isPending;
+        const bonusText = packageBonusText(pkg);
+        return (
+            <Card
+                key={pkg.code}
+                className={cx(
+                    'min-h-52 border-tertiary/30',
+                    featured && 'border-primary/40 bg-primary/5',
+                )}
+            >
+                <CardContent noHeader>
+                    <Stack spacing={3} className="h-full">
+                        <Row justifyContent="space-between" alignItems="start">
+                            <Stack spacing={1} className="min-w-0">
+                                <Typography level="body1" bold>
+                                    {pkg.name}
+                                </Typography>
+                                {pkg.tag ? (
+                                    <Chip size="sm" variant="soft">
+                                        {pkg.tag}
+                                    </Chip>
+                                ) : null}
+                            </Stack>
+                            <Typography
+                                level="body2"
+                                bold
+                                className="tabular-nums"
+                            >
+                                {packagePrice(pkg)}
+                            </Typography>
+                        </Row>
+                        <Stack spacing={1}>
+                            <Typography level="h4" className="tabular-nums">
+                                {formatSunflowers(pkg.sunflowers)} 🌻
+                            </Typography>
+                            {bonusText ? (
+                                <Typography
+                                    level="body3"
+                                    className="text-primary"
+                                >
+                                    {bonusText}
+                                </Typography>
+                            ) : null}
+                        </Stack>
+                        {pkg.descriptionShort ? (
+                            <Typography
+                                level="body3"
+                                className="min-h-10 text-muted-foreground"
+                            >
+                                {pkg.descriptionShort}
+                            </Typography>
+                        ) : null}
+                        {pkg.ineligibleReason === 'already_used' ? (
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                Ova ponuda je već iskorištena na tvom računu.
+                            </Typography>
+                        ) : null}
+                        <Button
+                            size="sm"
+                            fullWidth
+                            disabled={disabled}
+                            loading={activeCheckoutCode === pkg.code}
+                            endDecorator={<Navigate className="size-4" />}
+                            onClick={() =>
+                                pkg.role === 'main'
+                                    ? handleMainPackage(pkg)
+                                    : startCheckout(pkg, 'direct')
+                            }
+                        >
+                            {pkg.cta ?? 'Kupi paket'}
+                        </Button>
+                    </Stack>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const checkoutError =
+        checkout.error instanceof SunflowerPackageCheckoutError
+            ? checkout.error.reason
+            : checkout.error
+              ? 'checkout_failed'
+              : null;
+
+    return (
+        <Stack spacing={4}>
+            <Stack spacing={1}>
+                <Typography level="h5">Paketi suncokreta</Typography>
+                <Typography level="body3" className="text-muted-foreground">
+                    Nadoplati Gredice saldo za sadnju, zalijevanje,
+                    plijevljenje, fotografiranje, berbu i dostavu.
+                </Typography>
+            </Stack>
+
+            {checkoutStatus === 'success' ? (
+                <Alert color="success" startDecorator={<Check />}>
+                    Plaćanje je zaprimljeno. Ako se saldo još nije promijenio,
+                    pričekaj trenutak dok se uplata obradi.
+                </Alert>
+            ) : null}
+            {checkoutStatus === 'cancel' ? (
+                <Alert color="neutral">
+                    Plaćanje je otkazano. Paket možeš ponovno odabrati kad
+                    želiš.
+                </Alert>
+            ) : null}
+            {checkoutError ? (
+                <Alert color="warning">
+                    {checkoutError === 'already_used'
+                        ? 'Ova jednokratna ponuda je već iskorištena na tvom računu.'
+                        : 'Paket trenutno nije moguće kupiti. Pokušaj ponovno za nekoliko trenutaka.'}
+                </Alert>
+            ) : null}
+            {isError ? (
+                <Alert color="warning">
+                    Paketi se trenutno ne mogu učitati, ali saldo i aktivnosti
+                    su i dalje dostupni.
+                </Alert>
+            ) : null}
+            {isLoading ? (
+                <Card className="min-h-32 animate-pulse bg-muted/40" />
+            ) : null}
+
+            {initialOffers.length > 0 ? (
+                <Stack spacing={2}>
+                    <Typography level="body2" bold>
+                        Početna ponuda
+                    </Typography>
+                    <div className="grid grid-cols-1 gap-3">
+                        {initialOffers.map((pkg) => packageCard(pkg, true))}
+                    </div>
+                </Stack>
+            ) : null}
+
+            {mainPackages.length > 0 ? (
+                <Stack spacing={2}>
+                    <Typography level="body2" bold>
+                        Glavni paketi
+                    </Typography>
+                    <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+                        {mainPackages.map((pkg) => packageCard(pkg))}
+                    </div>
+                </Stack>
+            ) : null}
+
+            {upsellPackage && upsellTriggerPackage ? (
+                <Card className="border-primary/40 bg-primary/5">
+                    <CardContent noHeader>
+                        <Stack spacing={4}>
+                            <Row spacing={3} alignItems="start">
+                                <AI className="mt-1 size-5 shrink-0 text-primary" />
+                                <Stack spacing={1}>
+                                    <Typography level="body1" bold>
+                                        Želiš veći saldo?
+                                    </Typography>
+                                    <Typography
+                                        level="body3"
+                                        className="text-muted-foreground"
+                                    >
+                                        Umjesto paketa{' '}
+                                        {upsellTriggerPackage.name}
+                                        možeš uzeti {upsellPackage.name} s
+                                        ukupno{' '}
+                                        {formatSunflowers(
+                                            upsellPackage.sunflowers,
+                                        )}{' '}
+                                        suncokreta.
+                                    </Typography>
+                                </Stack>
+                            </Row>
+                            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                <Button
+                                    size="sm"
+                                    loading={
+                                        activeCheckoutCode ===
+                                        upsellPackage.code
+                                    }
+                                    onClick={() =>
+                                        startCheckout(
+                                            upsellPackage,
+                                            'upsell_accept',
+                                        )
+                                    }
+                                >
+                                    {upsellPackage.cta ?? 'Odaberi veći paket'}
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="outlined"
+                                    loading={
+                                        activeCheckoutCode ===
+                                        upsellTriggerPackage.code
+                                    }
+                                    onClick={() =>
+                                        startCheckout(
+                                            upsellTriggerPackage,
+                                            'upsell_decline',
+                                        )
+                                    }
+                                >
+                                    Nastavi s {upsellTriggerPackage.name}
+                                </Button>
+                            </div>
+                            <Button
+                                size="sm"
+                                variant="plain"
+                                onClick={() => setUpsellTriggerCode(null)}
+                            >
+                                Vrati me na pakete
+                            </Button>
+                        </Stack>
+                    </CardContent>
+                </Card>
+            ) : null}
+        </Stack>
+    );
+}

--- a/packages/storage/src/repositories/sunflowerLedgerRepo.ts
+++ b/packages/storage/src/repositories/sunflowerLedgerRepo.ts
@@ -75,6 +75,7 @@ export type SunflowerPackageTopUpInput = LedgerSourceInput & {
     bonusSunflowers?: number;
     priceCents?: number | null;
     idempotencyKey: string;
+    enforceOneTime?: boolean;
 };
 
 export type ReserveSunflowersInput = LedgerSourceInput & {
@@ -129,6 +130,16 @@ function assertNonZeroInteger(fieldName: string, value: number) {
 function assertReason(reason: string | null | undefined) {
     if (!reason || reason.trim().length === 0) {
         throw new Error('reason is required.');
+    }
+}
+
+export class SunflowerPackageAlreadyPurchasedError extends Error {
+    constructor(
+        public readonly accountId: string,
+        public readonly packageCode: string,
+    ) {
+        super(`Sunflower package ${packageCode} was already purchased.`);
+        this.name = 'SunflowerPackageAlreadyPurchasedError';
     }
 }
 
@@ -357,6 +368,27 @@ export async function topUpSunflowerPackage(input: SunflowerPackageTopUpInput) {
                     ? { status: 'existing' as const, entry: existingBonus }
                     : null,
             };
+        }
+
+        if (input.enforceOneTime) {
+            const previousTopUp =
+                await tx.query.sunflowerLedgerEntries.findFirst({
+                    where: and(
+                        eq(sunflowerLedgerEntries.accountId, input.accountId),
+                        eq(sunflowerLedgerEntries.entryType, 'top_up'),
+                        eq(
+                            sunflowerLedgerEntries.packageCode,
+                            input.packageCode,
+                        ),
+                        eq(sunflowerLedgerEntries.isDeleted, false),
+                    ),
+                });
+            if (previousTopUp) {
+                throw new SunflowerPackageAlreadyPurchasedError(
+                    input.accountId,
+                    input.packageCode,
+                );
+            }
         }
 
         const topUp = {

--- a/packages/storage/tests/sunflowerPackagesRepo.node.spec.ts
+++ b/packages/storage/tests/sunflowerPackagesRepo.node.spec.ts
@@ -6,6 +6,7 @@ import {
     getSunflowerPackageByCode,
     getSunflowerPackageEligibilityForAccount,
     getSunflowerPackages,
+    SunflowerPackageAlreadyPurchasedError,
     seedSunflowerPackageCatalog,
     storage,
     sunflowerPackageEntityTypeName,
@@ -192,6 +193,47 @@ test('topUpSunflowerPackage does not create a bonus on replay after a bonus-less
     });
     assert.equal(replay.topUp.status, 'existing');
     assert.equal(replay.bonus, null);
+});
+
+test('topUpSunflowerPackage enforces one-time package purchases while preserving replay idempotency', async () => {
+    createTestDb();
+    await seedSunflowerPackageCatalog();
+    const accountId = await createTestAccount();
+
+    const firstTopUp = await topUpSunflowerPackage({
+        accountId,
+        packageCode: 'puna_gredica',
+        sunflowers: 60000,
+        bonusSunflowers: 10000,
+        priceCents: 4999,
+        idempotencyKey: 'checkout-session-one-time-first',
+        enforceOneTime: true,
+    });
+    const replayTopUp = await topUpSunflowerPackage({
+        accountId,
+        packageCode: 'puna_gredica',
+        sunflowers: 60000,
+        bonusSunflowers: 10000,
+        priceCents: 4999,
+        idempotencyKey: 'checkout-session-one-time-first',
+        enforceOneTime: true,
+    });
+
+    assert.equal(firstTopUp.topUp.status, 'created');
+    assert.equal(replayTopUp.topUp.status, 'existing');
+    await assert.rejects(
+        () =>
+            topUpSunflowerPackage({
+                accountId,
+                packageCode: 'puna_gredica',
+                sunflowers: 60000,
+                bonusSunflowers: 10000,
+                priceCents: 4999,
+                idempotencyKey: 'checkout-session-one-time-second',
+                enforceOneTime: true,
+            }),
+        SunflowerPackageAlreadyPurchasedError,
+    );
 });
 
 test('getSunflowerPackages rejects malformed numeric package data', async () => {

--- a/packages/stripe/src/lib/server/serverStripe.ts
+++ b/packages/stripe/src/lib/server/serverStripe.ts
@@ -171,6 +171,7 @@ export async function stripeCheckout(
     data: {
         items: CheckoutItem[];
         expiresAt?: Date;
+        allowPromotionCodes?: boolean;
     },
 ) {
     try {
@@ -193,7 +194,7 @@ export async function stripeCheckout(
                 },
                 quantity: item.quantity,
             })),
-            allow_promotion_codes: true,
+            allow_promotion_codes: data.allowPromotionCodes ?? true,
             mode: 'payment',
             locale: 'hr',
             cancel_url: getReturnUrl({ status: 'cancel' }),


### PR DESCRIPTION
## Summary
- Add authenticated sunflower package catalog APIs and Stripe checkout/fulfillment for prepaid sunflower packages.
- Wire package purchase UI into the garden sunflower tab, including one-time initial offer handling and the master-package upsell.
- Render public sunflower package pricing and legal/refund copy from the package directory data.

## Validation
- `pnpm --filter @gredice/storage test:node sunflowerPackagesRepo.node.spec.ts`
- `pnpm --filter api test:node processCheckoutSession.node.spec.ts`
- `pnpm --filter api lint`
- `pnpm --filter api build`
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter www lint`
- `pnpm --filter www typecheck`
- `pnpm --filter @gredice/storage lint`
- `pnpm --filter garden lint`
- `pnpm --filter garden typecheck`
- `pnpm --dir apps/garden exec playwright test tests/sunflowers-hud.spec.tsx --project=chromium`
- `git diff --check`

Part of #4033.
Closes #4039.
Closes #3984.
Closes #3993.
Closes #3994.
Closes #3995.
Closes #3996.
Closes #3985.
Closes #3997.
Closes #3998.
Closes #3999.
Closes #4000.
Closes #3986.
Closes #4001.
Closes #4002.
Closes #4003.
Closes #4032.
