### PR TITLE
Add billing rollout reconciliation dashboard

### DIFF
--- a/apps/app/app/admin/billing/reconciliation/page.tsx
+++ b/apps/app/app/admin/billing/reconciliation/page.tsx
@@ -1,0 +1,565 @@
+import {
+    type BillingReconciliationEmailIssue,
+    getBillingReconciliationIssues,
+} from '@gredice/storage';
+import { Breadcrumbs } from '@gredice/ui/Breadcrumbs';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardHeader, CardOverflow, CardTitle } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import { ExternalLink, FileText, Mail, Warning } from '@gredice/ui/icons';
+import { LocalDateTime } from '@gredice/ui/LocalDateTime';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Route } from 'next';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { AdminPageHeader } from '../../../../components/admin/navigation';
+import { AdminBreadcrumbLevelSelector } from '../../../../components/admin/navigation/AdminBreadcrumbLevelSelector';
+import { AdminPageTitle } from '../../../../components/admin/navigation/AdminPageTitle';
+import { NoDataPlaceholder } from '../../../../components/shared/placeholders/NoDataPlaceholder';
+import { auth } from '../../../../lib/auth/auth';
+import { KnownPages } from '../../../../src/KnownPages';
+
+export const dynamic = 'force-dynamic';
+
+const ISSUE_KIND_OPTIONS = [
+    { value: 'all', label: 'Sve' },
+    { value: 'transactions', label: 'Transakcije' },
+    { value: 'invoices', label: 'Ponude' },
+    { value: 'receipts', label: 'Fiskalni računi' },
+    { value: 'emails', label: 'Emailovi' },
+] as const;
+
+const SORT_OPTIONS = [
+    { value: 'newest', label: 'Najnovije' },
+    { value: 'oldest', label: 'Najstarije' },
+] as const;
+
+type IssueKind = (typeof ISSUE_KIND_OPTIONS)[number]['value'];
+type SortOption = (typeof SORT_OPTIONS)[number]['value'];
+
+function isIssueKind(value: string | undefined): value is IssueKind {
+    return ISSUE_KIND_OPTIONS.some((option) => option.value === value);
+}
+
+function isSortOption(value: string | undefined): value is SortOption {
+    return SORT_OPTIONS.some((option) => option.value === value);
+}
+
+function buildHref(kind: IssueKind, sort: SortOption): Route {
+    const params = new URLSearchParams();
+    if (kind !== 'all') {
+        params.set('kind', kind);
+    }
+    if (sort !== 'newest') {
+        params.set('sort', sort);
+    }
+
+    const search = params.toString();
+    return (
+        search
+            ? `${KnownPages.BillingReconciliation}?${search}`
+            : KnownPages.BillingReconciliation
+    ) as Route;
+}
+
+function sortCombinedByDate<T>(
+    rows: T[],
+    sort: SortOption,
+    getDate: (row: T) => Date,
+) {
+    return [...rows].sort((a, b) =>
+        sort === 'oldest'
+            ? getDate(a).getTime() - getDate(b).getTime()
+            : getDate(b).getTime() - getDate(a).getTime(),
+    );
+}
+
+function moneyFromCents(amount: number, currency: string) {
+    const value = (amount / 100).toFixed(2);
+    return `${value}${currency === 'eur' ? '€' : ` ${currency}`}`;
+}
+
+function moneyFromDecimal(amount: string, currency: string) {
+    return `${Number(amount).toFixed(2)}${currency === 'eur' ? '€' : ` ${currency}`}`;
+}
+
+function IssueSection({
+    children,
+    count,
+    emptyLabel,
+    icon,
+    title,
+}: {
+    children: ReactNode;
+    count: number;
+    emptyLabel: string;
+    icon: ReactNode;
+    title: string;
+}) {
+    return (
+        <Card>
+            <CardHeader>
+                <Row spacing={2} className="min-w-0 flex-wrap items-center">
+                    {icon}
+                    <CardTitle>{title}</CardTitle>
+                    <Chip color={count > 0 ? 'warning' : 'success'}>
+                        {count}
+                    </Chip>
+                </Row>
+            </CardHeader>
+            <CardOverflow>
+                {count === 0 ? (
+                    <div className="p-4">
+                        <NoDataPlaceholder>{emptyLabel}</NoDataPlaceholder>
+                    </div>
+                ) : (
+                    <ul className="divide-y">{children}</ul>
+                )}
+            </CardOverflow>
+        </Card>
+    );
+}
+
+function IssueRow({
+    actions,
+    children,
+    title,
+}: {
+    actions: ReactNode;
+    children: ReactNode;
+    title: ReactNode;
+}) {
+    return (
+        <li className="px-3 py-3 transition-colors hover:bg-muted/40 sm:px-4">
+            <div className="flex min-w-0 flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <Stack spacing={1} className="min-w-0">
+                    <Typography component="h3" level="body1" semiBold>
+                        {title}
+                    </Typography>
+                    {children}
+                </Stack>
+                <div className="flex shrink-0 flex-wrap items-center gap-2 lg:justify-end">
+                    {actions}
+                </div>
+            </div>
+        </li>
+    );
+}
+
+function MetadataLine({ children }: { children: ReactNode }) {
+    return (
+        <Typography
+            component="div"
+            level="body3"
+            className="min-w-0 break-words text-muted-foreground [overflow-wrap:anywhere]"
+        >
+            {children}
+        </Typography>
+    );
+}
+
+function EmailIssueStatus({
+    issue,
+}: {
+    issue: BillingReconciliationEmailIssue;
+}) {
+    if (issue.status === 'missing') {
+        return <Chip color="warning">Nedostaje</Chip>;
+    }
+
+    return (
+        <Chip color={issue.status === 'failed' ? 'error' : 'warning'}>
+            {issue.status === 'failed' ? 'Neuspješno' : 'Odbijeno'}
+        </Chip>
+    );
+}
+
+export default async function BillingReconciliationPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+    await auth(['admin']);
+
+    const params = await searchParams;
+    const kindParam = typeof params.kind === 'string' ? params.kind : undefined;
+    const sortParam = typeof params.sort === 'string' ? params.sort : undefined;
+    const selectedKind = isIssueKind(kindParam) ? kindParam : 'all';
+    const selectedSort = isSortOption(sortParam) ? sortParam : 'newest';
+    const issues = await getBillingReconciliationIssues({
+        limit: 50,
+        sort: selectedSort,
+    });
+
+    const transactionsWithoutInvoices = issues.transactionsWithoutInvoices;
+    const paidInvoicesWithoutReceipts = issues.paidInvoicesWithoutReceipts;
+    const receiptsNeedingFiscalization = issues.receiptsNeedingFiscalization;
+    const missingBillingDocumentEmails = issues.missingBillingDocumentEmails;
+    const failedBillingDocumentEmails = issues.failedBillingDocumentEmails;
+    const visibleEmailIssues = sortCombinedByDate(
+        [...missingBillingDocumentEmails, ...failedBillingDocumentEmails],
+        selectedSort,
+        (row) => row.createdAt,
+    );
+    const totalIssueCount =
+        transactionsWithoutInvoices.length +
+        paidInvoicesWithoutReceipts.length +
+        receiptsNeedingFiscalization.length +
+        visibleEmailIssues.length;
+
+    return (
+        <Stack spacing={4}>
+            <AdminPageTitle title="Usklađenje naplate" />
+            <AdminPageHeader
+                breadcrumbs={
+                    <Breadcrumbs
+                        items={[
+                            {
+                                label: <AdminBreadcrumbLevelSelector />,
+                                href: KnownPages.BillingReconciliation,
+                            },
+                            { label: 'Usklađenje naplate' },
+                        ]}
+                    />
+                }
+                heading="Usklađenje naplate"
+            />
+
+            <Row spacing={2} className="flex-wrap">
+                <Chip color={totalIssueCount > 0 ? 'warning' : 'success'}>
+                    {totalIssueCount}
+                </Chip>
+                {ISSUE_KIND_OPTIONS.map((option) => {
+                    const active = selectedKind === option.value;
+                    return (
+                        <Link
+                            key={option.value}
+                            href={buildHref(option.value, selectedSort)}
+                            prefetch={false}
+                        >
+                            <Chip
+                                color={active ? 'primary' : 'neutral'}
+                                className="cursor-pointer"
+                            >
+                                {option.label}
+                            </Chip>
+                        </Link>
+                    );
+                })}
+            </Row>
+
+            <Row spacing={2} className="flex-wrap">
+                {SORT_OPTIONS.map((option) => {
+                    const active = selectedSort === option.value;
+                    return (
+                        <Link
+                            key={option.value}
+                            href={buildHref(selectedKind, option.value)}
+                            prefetch={false}
+                        >
+                            <Chip
+                                color={active ? 'primary' : 'neutral'}
+                                className="cursor-pointer"
+                            >
+                                {option.label}
+                            </Chip>
+                        </Link>
+                    );
+                })}
+            </Row>
+
+            {(selectedKind === 'all' || selectedKind === 'transactions') && (
+                <IssueSection
+                    count={transactionsWithoutInvoices.length}
+                    emptyLabel="Nema dovršenih transakcija bez ponude."
+                    icon={<FileText className="size-4 text-muted-foreground" />}
+                    title="Dovršene transakcije bez ponude"
+                >
+                    {transactionsWithoutInvoices.map((transaction) => (
+                        <IssueRow
+                            key={transaction.id}
+                            title={
+                                <Link
+                                    href={KnownPages.Transaction(
+                                        transaction.id,
+                                    )}
+                                    className="text-primary underline-offset-4 hover:underline"
+                                >
+                                    Transakcija #{transaction.id}
+                                </Link>
+                            }
+                            actions={
+                                <>
+                                    <Button
+                                        href={KnownPages.Transaction(
+                                            transaction.id,
+                                        )}
+                                        size="sm"
+                                        variant="outlined"
+                                    >
+                                        Otvori
+                                    </Button>
+                                    <Button
+                                        href={KnownPages.StripePayment(
+                                            transaction.stripePaymentId,
+                                        )}
+                                        size="sm"
+                                        startDecorator={
+                                            <ExternalLink className="size-4" />
+                                        }
+                                        variant="outlined"
+                                    >
+                                        Stripe
+                                    </Button>
+                                </>
+                            }
+                        >
+                            <MetadataLine>
+                                Račun:{' '}
+                                {transaction.accountId ? (
+                                    <Link
+                                        href={KnownPages.Account(
+                                            transaction.accountId,
+                                        )}
+                                        className="underline-offset-4 hover:text-primary hover:underline"
+                                    >
+                                        {transaction.accountId}
+                                    </Link>
+                                ) : (
+                                    'nema računa'
+                                )}
+                            </MetadataLine>
+                            <MetadataLine>
+                                {moneyFromCents(
+                                    transaction.amount,
+                                    transaction.currency,
+                                )}{' '}
+                                · {transaction.status} ·{' '}
+                                <LocalDateTime>
+                                    {transaction.createdAt}
+                                </LocalDateTime>
+                            </MetadataLine>
+                        </IssueRow>
+                    ))}
+                </IssueSection>
+            )}
+
+            {(selectedKind === 'all' || selectedKind === 'invoices') && (
+                <IssueSection
+                    count={paidInvoicesWithoutReceipts.length}
+                    emptyLabel="Nema plaćenih ponuda bez fiskalnog računa."
+                    icon={<FileText className="size-4 text-muted-foreground" />}
+                    title="Plaćene ponude bez fiskalnog računa"
+                >
+                    {paidInvoicesWithoutReceipts.map((invoice) => (
+                        <IssueRow
+                            key={invoice.id}
+                            title={
+                                <Link
+                                    href={KnownPages.Invoice(invoice.id)}
+                                    className="text-primary underline-offset-4 hover:underline"
+                                >
+                                    {invoice.invoiceNumber}
+                                </Link>
+                            }
+                            actions={
+                                <>
+                                    <Button
+                                        href={KnownPages.Invoice(invoice.id)}
+                                        size="sm"
+                                        variant="outlined"
+                                    >
+                                        Otvori
+                                    </Button>
+                                    <Button
+                                        href={KnownPages.BillingPreviewInvoice(
+                                            invoice.id,
+                                        )}
+                                        size="sm"
+                                        variant="outlined"
+                                    >
+                                        Pregled
+                                    </Button>
+                                </>
+                            }
+                        >
+                            <MetadataLine>
+                                Račun:{' '}
+                                <Link
+                                    href={KnownPages.Account(invoice.accountId)}
+                                    className="underline-offset-4 hover:text-primary hover:underline"
+                                >
+                                    {invoice.accountId}
+                                </Link>{' '}
+                                · {invoice.billToEmail}
+                            </MetadataLine>
+                            <MetadataLine>
+                                {moneyFromDecimal(
+                                    invoice.totalAmount,
+                                    invoice.currency,
+                                )}{' '}
+                                · plaćeno{' '}
+                                {invoice.paidDate ? (
+                                    <LocalDateTime>
+                                        {invoice.paidDate}
+                                    </LocalDateTime>
+                                ) : (
+                                    'bez datuma'
+                                )}
+                            </MetadataLine>
+                        </IssueRow>
+                    ))}
+                </IssueSection>
+            )}
+
+            {(selectedKind === 'all' || selectedKind === 'receipts') && (
+                <IssueSection
+                    count={receiptsNeedingFiscalization.length}
+                    emptyLabel="Nema fiskalnih računa za fiskalizaciju."
+                    icon={<Warning className="size-4 text-muted-foreground" />}
+                    title="Fiskalni računi za fiskalizaciju"
+                >
+                    {receiptsNeedingFiscalization.map((receipt) => (
+                        <IssueRow
+                            key={receipt.id}
+                            title={
+                                <Link
+                                    href={KnownPages.Receipt(receipt.id)}
+                                    className="text-primary underline-offset-4 hover:underline"
+                                >
+                                    {receipt.yearReceiptNumber}
+                                </Link>
+                            }
+                            actions={
+                                <>
+                                    <Button
+                                        href={KnownPages.Receipt(receipt.id)}
+                                        size="sm"
+                                        variant="outlined"
+                                    >
+                                        Otvori
+                                    </Button>
+                                    <Button
+                                        href={KnownPages.BillingPreviewReceipt(
+                                            receipt.id,
+                                        )}
+                                        size="sm"
+                                        variant="outlined"
+                                    >
+                                        Pregled
+                                    </Button>
+                                </>
+                            }
+                        >
+                            <MetadataLine>
+                                Ponuda:{' '}
+                                {receipt.invoiceId ? (
+                                    <Link
+                                        href={KnownPages.Invoice(
+                                            receipt.invoiceId,
+                                        )}
+                                        className="underline-offset-4 hover:text-primary hover:underline"
+                                    >
+                                        {receipt.invoiceNumber ??
+                                            `#${receipt.invoiceId}`}
+                                    </Link>
+                                ) : (
+                                    'nema povezane ponude'
+                                )}
+                            </MetadataLine>
+                            <MetadataLine>
+                                {moneyFromDecimal(
+                                    receipt.totalAmount,
+                                    receipt.currency,
+                                )}{' '}
+                                · CIS {receipt.cisStatus} ·{' '}
+                                <LocalDateTime>
+                                    {receipt.issuedAt}
+                                </LocalDateTime>
+                            </MetadataLine>
+                            {receipt.cisErrorMessage && (
+                                <MetadataLine>
+                                    {receipt.cisErrorMessage}
+                                </MetadataLine>
+                            )}
+                        </IssueRow>
+                    ))}
+                </IssueSection>
+            )}
+
+            {(selectedKind === 'all' || selectedKind === 'emails') && (
+                <IssueSection
+                    count={visibleEmailIssues.length}
+                    emptyLabel="Nema nedostajućih ili neuspješnih emailova za dokumente."
+                    icon={<Mail className="size-4 text-muted-foreground" />}
+                    title="Emailovi dokumenata"
+                >
+                    {visibleEmailIssues.map((issue) => (
+                        <IssueRow
+                            key={`${issue.status}-${issue.id ?? issue.invoiceId}`}
+                            title={
+                                <Link
+                                    href={KnownPages.Invoice(issue.invoiceId)}
+                                    className="text-primary underline-offset-4 hover:underline"
+                                >
+                                    {issue.invoiceNumber}
+                                </Link>
+                            }
+                            actions={
+                                <>
+                                    <EmailIssueStatus issue={issue} />
+                                    {issue.id && (
+                                        <Button
+                                            href={KnownPages.CommunicationEmail(
+                                                issue.id,
+                                            )}
+                                            size="sm"
+                                            variant="outlined"
+                                        >
+                                            Email
+                                        </Button>
+                                    )}
+                                    <Button
+                                        href={KnownPages.Invoice(
+                                            issue.invoiceId,
+                                        )}
+                                        size="sm"
+                                        variant="outlined"
+                                    >
+                                        Ponuda
+                                    </Button>
+                                </>
+                            }
+                        >
+                            <MetadataLine>
+                                Račun:{' '}
+                                <Link
+                                    href={KnownPages.Account(issue.accountId)}
+                                    className="underline-offset-4 hover:text-primary hover:underline"
+                                >
+                                    {issue.accountId}
+                                </Link>{' '}
+                                · {issue.billToEmail}
+                            </MetadataLine>
+                            <MetadataLine>
+                                {moneyFromDecimal(
+                                    issue.totalAmount,
+                                    issue.currency,
+                                )}{' '}
+                                ·{' '}
+                                <LocalDateTime>{issue.createdAt}</LocalDateTime>
+                            </MetadataLine>
+                            {issue.errorMessage && (
+                                <MetadataLine>
+                                    {issue.errorMessage}
+                                </MetadataLine>
+                            )}
+                        </IssueRow>
+                    ))}
+                </IssueSection>
+            )}
+        </Stack>
+    );
+}

--- a/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
+++ b/apps/app/components/admin/navigation/AdminBreadcrumbLevelSelector.tsx
@@ -26,6 +26,7 @@ import {
     Tally3,
     Truck,
     User,
+    Warning,
 } from '@gredice/ui/icons';
 import {
     DropdownMenu,
@@ -126,6 +127,10 @@ const breadcrumbSections: {
                 icon: <Euro className="size-4" />,
             },
             { ...adminPages.Sunflowers, icon: <Success className="size-4" /> },
+            {
+                ...adminPages.BillingReconciliation,
+                icon: <Warning className="size-4" />,
+            },
             { ...adminPages.Receipts, icon: <File className="size-4" /> },
             { ...adminPages.Outlet, icon: <Discount className="size-4" /> },
         ],

--- a/apps/app/components/admin/navigation/Nav.tsx
+++ b/apps/app/components/admin/navigation/Nav.tsx
@@ -43,6 +43,7 @@ import {
     Tally3,
     Truck,
     User,
+    Warning,
 } from '@gredice/ui/icons';
 import { RaisedBedIcon } from '@gredice/ui/RaisedBedIcon';
 import { usePathname } from 'next/navigation';
@@ -84,6 +85,8 @@ function quickActionIcon(quickAction: { href: string; icon?: string | null }) {
             return <Success className="size-5" />;
         case KnownPages.AiAnalytics:
             return <AI className="size-5" />;
+        case KnownPages.BillingReconciliation:
+            return <Warning className="size-5" />;
         case KnownPages.Approvals:
         case KnownPages.CommunicationInbox:
             return <Inbox className="size-5" />;
@@ -458,6 +461,7 @@ export function Nav({
                         adminPages.Invoices.href,
                         adminPages.Transactions.href,
                         adminPages.Sunflowers.href,
+                        adminPages.BillingReconciliation.href,
                         adminPages.BillingPreviews.href,
                         adminPages.Receipts.href,
                         adminPages.Outlet.href,
@@ -492,6 +496,14 @@ export function Nav({
                         href={adminPages.Sunflowers.href}
                         label={adminPages.Sunflowers.label}
                         icon={<Success className="size-5" />}
+                        onClick={onItemClick}
+                        compact={compact}
+                        nested
+                    />
+                    <NavItem
+                        href={adminPages.BillingReconciliation.href}
+                        label={adminPages.BillingReconciliation.label}
+                        icon={<Warning className="size-5" />}
                         onClick={onItemClick}
                         compact={compact}
                         nested

--- a/apps/app/components/admin/navigation/adminPages.ts
+++ b/apps/app/components/admin/navigation/adminPages.ts
@@ -18,6 +18,10 @@ export const adminPages = {
     Invoices: { href: KnownPages.Invoices, label: 'Ponude' },
     Transactions: { href: KnownPages.Transactions, label: 'Transakcije' },
     Sunflowers: { href: KnownPages.Sunflowers, label: 'Suncokreti' },
+    BillingReconciliation: {
+        href: KnownPages.BillingReconciliation,
+        label: 'Usklađenje naplate',
+    },
     BillingPreviews: {
         href: KnownPages.BillingPreviews,
         label: 'Pregledi dokumenata',
@@ -89,6 +93,7 @@ export const adminBreadcrumbPages = [
     adminPages.Invoices,
     adminPages.Transactions,
     adminPages.Sunflowers,
+    adminPages.BillingReconciliation,
     adminPages.BillingPreviews,
     adminPages.Receipts,
     adminPages.Outlet,

--- a/apps/app/components/admin/navigation/adminRouteTitle.ts
+++ b/apps/app/components/admin/navigation/adminRouteTitle.ts
@@ -4,6 +4,7 @@ import type { NavContextType } from './NavContext';
 const idRouteTitlePrefixes = new Map([
     ['/admin/accounts', 'Račun'],
     ['/admin/automations', 'Automatizacija'],
+    ['/admin/billing/reconciliation', 'Usklađenje naplate'],
     ['/admin/billing/previews', 'Pregled dokumenta'],
     ['/admin/cms/pages', 'Stranica'],
     ['/admin/community-edits', 'Prijedlog zajednice'],

--- a/apps/app/src/KnownPages.ts
+++ b/apps/app/src/KnownPages.ts
@@ -82,6 +82,7 @@ export const KnownPages = {
     Transaction: (transactionId: number) =>
         `/admin/transactions/${transactionId}` as Route,
     Sunflowers: '/admin/sunflowers',
+    BillingReconciliation: '/admin/billing/reconciliation',
     BillingPreviews: '/admin/billing/previews',
     BillingPreviewInvoice: (invoiceId: number) =>
         `/admin/billing/previews?source=invoice&invoiceId=${invoiceId}` as Route,

--- a/docs/billing-automation.md
+++ b/docs/billing-automation.md
@@ -1,37 +1,123 @@
 # Billing Automation
 
 Billing document automation is guarded by `GREDICE_BILLING_AUTOMATION_ENABLED`.
+The flag controls automatic checkout-driven invoice creation, receipt issuing,
+receipt fiscalization, and billing document email delivery. Manual admin
+workflows stay available while automation is disabled.
 
-## Default
+## Actors
 
-Unset, blank, false, off, zero, and unknown values are treated as disabled. This
-keeps local, preview, and production environments safe until invoice generation,
-receipt issuing, fiscalization, and billing email delivery are ready.
+- Customer: completes Stripe checkout or sunflower package checkout.
+- API: handles the Stripe checkout session webhook in
+  `apps/api/lib/stripe/processCheckoutSession.ts`.
+- Storage: creates transactions, invoices, receipts, email logs, and sunflower
+  ledger entries.
+- Admin: reconciles failed or skipped billing states in `apps/app`.
+- Fiscalization provider: confirms Croatian receipt fiscalization.
+- Email provider: sends `commerce-billing-documents` and records delivery state.
 
-## Enable
+## Configuration
 
-Set the server-side environment variable on the API project:
+Unset, blank, `false`, `off`, `0`, and unknown values are disabled. Accepted
+enabled values are `1`, `true`, `yes`, `on`, and `enabled`.
+
+Enable automation only on the API project:
 
 ```bash
 GREDICE_BILLING_AUTOMATION_ENABLED=true
 ```
 
-Accepted enabled values are `1`, `true`, `yes`, `on`, and `enabled`.
-
-## Disable
-
-Remove the variable or set it to `false`:
+Disable or roll back with:
 
 ```bash
 GREDICE_BILLING_AUTOMATION_ENABLED=false
 ```
 
-Manual admin preview and generation workflows are not blocked by this flag. The
-flag is only for automatic checkout-driven invoice, receipt, fiscalization, and
-billing email mutations.
+The parser lives in `apps/api/lib/billing/automationFlag.ts`. Keep production
+disabled until the launch checklist in `docs/sunflower-billing-rollout.md` is
+green.
 
-## Verify
+## Entry Points
 
-Before enabling production automation, verify the current state through the
-central helper in `apps/api/lib/billing/automationFlag.ts` and keep rollout
-checks documented on the Billing/Receipts rollout issues.
+- Checkout webhook: `apps/api/lib/stripe/processCheckoutSession.ts`.
+- Invoice creation: `ensureInvoiceForTransaction` in
+  `packages/storage/src/repositories/invoicesRepo.ts`.
+- Receipt issuing and fiscalization:
+  `packages/fiscalization/src/server.ts`.
+- Billing document email:
+  `apps/api/lib/billing/billingDocumentEmail.ts`.
+- Admin reconciliation: `/admin/billing/reconciliation`.
+- Manual previews: `/admin/billing/previews`.
+
+## State Model
+
+- Transaction: Stripe payment captured and stored with `status = completed`.
+- Invoice: generated for a completed transaction and marked `paid`.
+- Receipt: generated from a paid invoice.
+- Fiscalization: receipt `cisStatus` moves through `pending`, `failed`, or
+  `confirmed`.
+- Billing email: `commerce-billing-documents` log uses
+  `metadata.billingDeliveryKey = billing-documents:invoice:{invoiceId}`.
+
+## Happy Path
+
+1. Stripe checkout completes.
+2. API creates or reuses a completed transaction.
+3. If automation is enabled, API generates a paid invoice from trusted checkout
+   line items and billing snapshot.
+4. API issues a receipt for the paid invoice.
+5. API fiscalizes the receipt.
+6. API sends the billing document email with invoice and, when fiscalized,
+   receipt links.
+7. API sends the order confirmation email for the purchased items.
+
+## Recovery
+
+Use `/admin/billing/reconciliation` first. It lists bounded, newest-first rows
+and links to the existing manual recovery page for each issue:
+
+- Completed transactions without invoices: open the transaction and use
+  `Generiraj ponudu`.
+- Paid invoices without receipts: open the invoice and use `Stvori račun`.
+- Receipts with `pending` or `failed` fiscalization: open the receipt and use
+  `Fiskaliziraj račun`.
+- Missing or failed billing document emails: open the invoice and email log,
+  then retry through the delivery path after the underlying failure is fixed.
+
+The page is backed by
+`packages/storage/src/repositories/billingReconciliationRepo.ts`, so support
+queries and admin UI use the same state rules.
+
+## Rollout
+
+1. Keep `GREDICE_BILLING_AUTOMATION_ENABLED=false`.
+2. Open `/admin/billing/reconciliation` and clear any pre-existing production
+   rows that would hide launch regressions.
+3. Run a preview checkout and confirm transaction, invoice, receipt,
+   fiscalization, billing email, and order confirmation behavior.
+4. Enable the flag on the API project.
+5. Complete one low-risk production checkout.
+6. Re-open `/admin/billing/reconciliation` and confirm no new rows remain.
+7. Monitor API logs for `Checkout invoice generation skipped`,
+   `Checkout receipt issuing skipped`, `Checkout receipt fiscalization failed`,
+   and `Checkout billing document automation failed`.
+
+## Rollback
+
+Set `GREDICE_BILLING_AUTOMATION_ENABLED=false` on the API project. Existing
+manual admin workflows continue to work, and checkout processing continues
+without automatic document mutations. Reconcile any captured payments through
+the admin reconciliation page before re-enabling.
+
+## Validation
+
+Run the narrowest relevant checks from the repo root:
+
+```bash
+pnpm --filter api test:node processCheckoutSession.node.spec.ts
+pnpm --filter @gredice/storage test:node billingReconciliationRepo.node.spec.ts
+pnpm --filter app build
+pnpm --filter app lint
+pnpm --filter @gredice/storage lint
+git diff --check
+```

--- a/docs/sunflower-billing-rollout.md
+++ b/docs/sunflower-billing-rollout.md
@@ -1,0 +1,117 @@
+# Sunflower Billing Rollout
+
+This checklist covers the first production rollout for sunflower package
+purchases, order confirmation email, billing automation, and prepaid sunflower
+ledger reconciliation.
+
+## Entry Points
+
+- Package catalog and eligibility:
+  `packages/storage/src/repositories/sunflowerPackagesRepo.ts`.
+- Package checkout and fulfillment:
+  `apps/api/lib/stripe/processCheckoutSession.ts`.
+- Package UI funnel:
+  `packages/game/src/shared-ui/sunflowers/SunflowerPackagesPanel.tsx`.
+- Ledger lifecycle:
+  `packages/storage/src/repositories/sunflowerLedgerRepo.ts`.
+- Admin sunflowers ledger view: `/admin/sunflowers`.
+- Billing reconciliation: `/admin/billing/reconciliation`.
+
+## Analytics
+
+Client funnel events:
+
+- `sunflower_package_catalog_viewed`: `package_count`,
+  `initial_offer_count`, `main_package_count`.
+- `sunflower_package_selected`: `package_code`, `package_role`,
+  `price_cents`, `source`, `sunflowers`.
+- `sunflower_package_upsell_shown`: `package_code`,
+  `trigger_package_code`.
+- `sunflower_package_upsell_accepted`: `package_code`,
+  `trigger_package_code`.
+- `sunflower_package_upsell_declined`: `package_code`,
+  `upsell_package_code`.
+
+Server fulfillment events:
+
+- `sunflower_package_fulfilled`: `checkout_session_id`, `transaction_id`,
+  `package_code`, `package_role`, `price_cents`, `paid_amount_cents`,
+  `sunflowers`, `bonus_sunflowers`, `duplicate_one_time_purchase`,
+  `ledger_entry_ids`.
+- `sunflower_package_fulfillment_failed`: `checkout_session_id`,
+  `package_code`, `reason`.
+- `purchase_completed`: `amount_total`, `currency`, `item_count`,
+  `checkout_session_id`.
+
+## Ledger States
+
+Sunflower ledger entry types are append-only:
+
+- `top_up` and `top_up_bonus`: package purchase credit.
+- `reservation`: prepaid operation or checkout reservation.
+- `reservation_release`: unused reserved balance returned to available.
+- `daily_capture`: daily prepaid capture.
+- `refund`: support or automated refund.
+- `correction` and `manual_adjustment`: support correction.
+- `expiry`: expiration adjustment.
+
+Every package fulfillment should connect the Stripe checkout session,
+transaction, package code, price, credited sunflowers, and ledger entry IDs.
+
+## Launch Order
+
+1. Seed or verify the package catalog:
+
+   ```bash
+   pnpm --filter @gredice/storage sunflower-packages:seed
+   ```
+
+2. Keep `GREDICE_BILLING_AUTOMATION_ENABLED=false` and clear current rows in
+   `/admin/billing/reconciliation`.
+3. In preview, buy one normal package and one upsell path package.
+4. Confirm `commerce-order-confirmation` is logged for the checkout.
+5. Confirm the account sunflower balance changes in `/admin/sunflowers`.
+6. Enable billing automation and repeat one low-risk checkout.
+7. Confirm invoice document link, receipt document link, fiscalization status,
+   and `commerce-billing-documents` delivery.
+8. Confirm PostHog has the funnel and fulfillment events above.
+
+## Reconciliation Checks
+
+- Paid not credited: Stripe checkout completed and transaction exists, but no
+  `top_up` ledger entry with the package code or checkout session metadata.
+- Credited not documented: package `top_up` exists, but billing reconciliation
+  shows missing invoice, receipt, fiscalization, or billing email.
+- Reserved not captured: old `reservation` balance remains without matching
+  `daily_capture` or `reservation_release`.
+- Captured not documented: `daily_capture` exists but related operation,
+  invoice, receipt, or billing metadata is missing.
+- Refund or correction: `refund`, `correction`, `manual_adjustment`, and
+  `expiry` entries have a support reason and idempotency key.
+
+Use these admin pages first:
+
+- `/admin/sunflowers` for account/user/time-filtered ledger events.
+- `/admin/accounts/{accountId}` for customer balance and transaction context.
+- `/admin/transactions` for payment records and invoice generation.
+- `/admin/billing/reconciliation` for missing invoice, receipt,
+  fiscalization, and billing email states.
+- `/admin/communication/emails?status=failed` for failed email delivery.
+
+## Rollback
+
+Set `GREDICE_BILLING_AUTOMATION_ENABLED=false` to stop automatic billing
+mutations. If package purchasing itself must pause, deactivate the sunflower
+package entities or remove their Stripe lookup keys before re-enabling the
+surface. Reconcile captured payments manually through the admin pages above.
+
+## Validation
+
+```bash
+pnpm --filter api test:node processCheckoutSession.node.spec.ts
+pnpm --filter @gredice/storage test:node sunflowerLedgerRepo.node.spec.ts billingReconciliationRepo.node.spec.ts
+pnpm --filter app build
+pnpm --filter app lint
+pnpm --filter @gredice/storage lint
+git diff --check
+```

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -30,6 +30,7 @@ export * from './repositories/approvalRequestsRepo';
 export * from './repositories/attributeDefinitionsRepo';
 export * from './repositories/attributeValuesRepo';
 export * from './repositories/automationsRepo';
+export * from './repositories/billingReconciliationRepo';
 export * from './repositories/cmsPagesRepo';
 export * from './repositories/communityEditRequestsRepo';
 export * from './repositories/deliveryAddressesRepo';

--- a/packages/storage/src/repositories/billingReconciliationRepo.ts
+++ b/packages/storage/src/repositories/billingReconciliationRepo.ts
@@ -1,0 +1,377 @@
+import 'server-only';
+
+import {
+    and,
+    asc,
+    desc,
+    eq,
+    gt,
+    inArray,
+    notExists,
+    or,
+    sql,
+} from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import {
+    type EmailStatus,
+    emailMessages,
+    invoices,
+    receipts,
+    transactions,
+} from '../schema';
+import { storage } from '../storage';
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+const BILLING_DOCUMENTS_TEMPLATE_NAME = 'commerce-billing-documents';
+const BILLING_DELIVERY_KEY_PREFIX = 'billing-documents:invoice:';
+
+const failedBillingEmailStatuses = [
+    'failed',
+    'bounced',
+] satisfies EmailStatus[];
+const activeBillingEmailStatuses = [
+    'queued',
+    'sending',
+    'sent',
+] satisfies EmailStatus[];
+
+export type BillingReconciliationSort = 'newest' | 'oldest';
+
+function clampLimit(limit: number | undefined) {
+    if (limit === undefined || !Number.isFinite(limit)) {
+        return DEFAULT_LIMIT;
+    }
+
+    return Math.min(MAX_LIMIT, Math.max(1, Math.trunc(limit)));
+}
+
+function normalizeSort(
+    sort: BillingReconciliationSort | undefined,
+): BillingReconciliationSort {
+    return sort === 'oldest' ? 'oldest' : 'newest';
+}
+
+export type BillingReconciliationTransactionIssue = {
+    id: number;
+    accountId: string | null;
+    stripePaymentId: string;
+    amount: number;
+    currency: string;
+    status: string;
+    createdAt: Date;
+};
+
+export type BillingReconciliationInvoiceIssue = {
+    id: number;
+    invoiceNumber: string;
+    accountId: string;
+    transactionId: number | null;
+    billToEmail: string;
+    totalAmount: string;
+    currency: string;
+    status: string;
+    issueDate: Date;
+    paidDate: Date | null;
+    createdAt: Date;
+};
+
+export type BillingReconciliationReceiptIssue = {
+    id: number;
+    receiptNumber: string;
+    yearReceiptNumber: string;
+    invoiceId: number | null;
+    invoiceNumber: string | null;
+    accountId: string | null;
+    totalAmount: string;
+    currency: string;
+    cisStatus: string;
+    cisErrorMessage: string | null;
+    issuedAt: Date;
+    createdAt: Date;
+};
+
+export type BillingReconciliationEmailIssue = {
+    id: number | null;
+    invoiceId: number;
+    invoiceNumber: string;
+    accountId: string;
+    billToEmail: string;
+    totalAmount: string;
+    currency: string;
+    status: EmailStatus | 'missing';
+    errorMessage: string | null;
+    createdAt: Date;
+};
+
+export type BillingReconciliationIssues = {
+    transactionsWithoutInvoices: BillingReconciliationTransactionIssue[];
+    paidInvoicesWithoutReceipts: BillingReconciliationInvoiceIssue[];
+    receiptsNeedingFiscalization: BillingReconciliationReceiptIssue[];
+    missingBillingDocumentEmails: BillingReconciliationEmailIssue[];
+    failedBillingDocumentEmails: BillingReconciliationEmailIssue[];
+};
+
+export async function getBillingReconciliationIssues({
+    limit,
+    sort,
+}: {
+    limit?: number;
+    sort?: BillingReconciliationSort;
+} = {}): Promise<BillingReconciliationIssues> {
+    const rowLimit = clampLimit(limit);
+    const rowSort = normalizeSort(sort);
+    const resolvedBillingEmailMessages = alias(
+        emailMessages,
+        'resolved_billing_email_messages',
+    );
+
+    const [
+        transactionsWithoutInvoices,
+        paidInvoicesWithoutReceipts,
+        receiptsNeedingFiscalization,
+        missingBillingDocumentEmails,
+        failedBillingDocumentEmails,
+    ] = await Promise.all([
+        storage()
+            .select({
+                id: transactions.id,
+                accountId: transactions.accountId,
+                stripePaymentId: transactions.stripePaymentId,
+                amount: transactions.amount,
+                currency: transactions.currency,
+                status: transactions.status,
+                createdAt: transactions.createdAt,
+            })
+            .from(transactions)
+            .where(
+                and(
+                    eq(transactions.status, 'completed'),
+                    eq(transactions.isDeleted, false),
+                    notExists(
+                        storage()
+                            .select({ id: invoices.id })
+                            .from(invoices)
+                            .where(
+                                and(
+                                    eq(invoices.transactionId, transactions.id),
+                                    eq(invoices.isDeleted, false),
+                                ),
+                            ),
+                    ),
+                ),
+            )
+            .orderBy(
+                rowSort === 'oldest'
+                    ? asc(transactions.createdAt)
+                    : desc(transactions.createdAt),
+            )
+            .limit(rowLimit),
+        storage()
+            .select({
+                id: invoices.id,
+                invoiceNumber: invoices.invoiceNumber,
+                accountId: invoices.accountId,
+                transactionId: invoices.transactionId,
+                billToEmail: invoices.billToEmail,
+                totalAmount: invoices.totalAmount,
+                currency: invoices.currency,
+                status: invoices.status,
+                issueDate: invoices.issueDate,
+                paidDate: invoices.paidDate,
+                createdAt: invoices.createdAt,
+            })
+            .from(invoices)
+            .where(
+                and(
+                    eq(invoices.status, 'paid'),
+                    eq(invoices.isDeleted, false),
+                    notExists(
+                        storage()
+                            .select({ id: receipts.id })
+                            .from(receipts)
+                            .where(
+                                and(
+                                    eq(receipts.invoiceId, invoices.id),
+                                    eq(receipts.isDeleted, false),
+                                ),
+                            ),
+                    ),
+                ),
+            )
+            .orderBy(
+                rowSort === 'oldest'
+                    ? asc(
+                          sql<Date>`coalesce(${invoices.paidDate}, ${invoices.issueDate})`,
+                      )
+                    : desc(
+                          sql<Date>`coalesce(${invoices.paidDate}, ${invoices.issueDate})`,
+                      ),
+            )
+            .limit(rowLimit),
+        storage()
+            .select({
+                id: receipts.id,
+                receiptNumber: receipts.receiptNumber,
+                yearReceiptNumber: receipts.yearReceiptNumber,
+                invoiceId: receipts.invoiceId,
+                invoiceNumber: invoices.invoiceNumber,
+                accountId: invoices.accountId,
+                totalAmount: receipts.totalAmount,
+                currency: receipts.currency,
+                cisStatus: receipts.cisStatus,
+                cisErrorMessage: receipts.cisErrorMessage,
+                issuedAt: receipts.issuedAt,
+                createdAt: receipts.createdAt,
+            })
+            .from(receipts)
+            .leftJoin(
+                invoices,
+                and(
+                    eq(receipts.invoiceId, invoices.id),
+                    eq(invoices.isDeleted, false),
+                ),
+            )
+            .where(
+                and(
+                    inArray(receipts.cisStatus, ['pending', 'failed']),
+                    eq(receipts.isDeleted, false),
+                ),
+            )
+            .orderBy(
+                rowSort === 'oldest'
+                    ? asc(receipts.issuedAt)
+                    : desc(receipts.issuedAt),
+                rowSort === 'oldest'
+                    ? asc(receipts.createdAt)
+                    : desc(receipts.createdAt),
+            )
+            .limit(rowLimit),
+        storage()
+            .select({
+                id: sql<null>`null`,
+                invoiceId: invoices.id,
+                invoiceNumber: invoices.invoiceNumber,
+                accountId: invoices.accountId,
+                billToEmail: invoices.billToEmail,
+                totalAmount: invoices.totalAmount,
+                currency: invoices.currency,
+                status: sql<'missing'>`'missing'`,
+                errorMessage: sql<null>`null`,
+                createdAt: invoices.createdAt,
+            })
+            .from(invoices)
+            .where(
+                and(
+                    eq(invoices.status, 'paid'),
+                    eq(invoices.isDeleted, false),
+                    notExists(
+                        storage()
+                            .select({ id: emailMessages.id })
+                            .from(emailMessages)
+                            .where(
+                                and(
+                                    eq(
+                                        emailMessages.templateName,
+                                        BILLING_DOCUMENTS_TEMPLATE_NAME,
+                                    ),
+                                    sql<boolean>`${emailMessages.metadata}->>'billingDeliveryKey' = ${BILLING_DELIVERY_KEY_PREFIX} || ${invoices.id}::text`,
+                                ),
+                            ),
+                    ),
+                ),
+            )
+            .orderBy(
+                rowSort === 'oldest'
+                    ? asc(
+                          sql<Date>`coalesce(${invoices.paidDate}, ${invoices.issueDate})`,
+                      )
+                    : desc(
+                          sql<Date>`coalesce(${invoices.paidDate}, ${invoices.issueDate})`,
+                      ),
+            )
+            .limit(rowLimit),
+        storage()
+            .select({
+                id: emailMessages.id,
+                invoiceId: invoices.id,
+                invoiceNumber: invoices.invoiceNumber,
+                accountId: invoices.accountId,
+                billToEmail: invoices.billToEmail,
+                totalAmount: invoices.totalAmount,
+                currency: invoices.currency,
+                status: emailMessages.status,
+                errorMessage: emailMessages.errorMessage,
+                createdAt: emailMessages.createdAt,
+            })
+            .from(emailMessages)
+            .innerJoin(
+                invoices,
+                and(
+                    eq(
+                        invoices.id,
+                        sql<number>`nullif(${emailMessages.metadata}->>'invoiceId', '')::int`,
+                    ),
+                    eq(invoices.isDeleted, false),
+                ),
+            )
+            .where(
+                and(
+                    eq(
+                        emailMessages.templateName,
+                        BILLING_DOCUMENTS_TEMPLATE_NAME,
+                    ),
+                    inArray(emailMessages.status, failedBillingEmailStatuses),
+                    sql<boolean>`${emailMessages.metadata}->>'billingDeliveryKey' like ${`${BILLING_DELIVERY_KEY_PREFIX}%`}`,
+                    notExists(
+                        storage()
+                            .select({ id: resolvedBillingEmailMessages.id })
+                            .from(resolvedBillingEmailMessages)
+                            .where(
+                                and(
+                                    eq(
+                                        resolvedBillingEmailMessages.templateName,
+                                        BILLING_DOCUMENTS_TEMPLATE_NAME,
+                                    ),
+                                    inArray(
+                                        resolvedBillingEmailMessages.status,
+                                        activeBillingEmailStatuses,
+                                    ),
+                                    sql<boolean>`${resolvedBillingEmailMessages.metadata}->>'billingDeliveryKey' = ${emailMessages.metadata}->>'billingDeliveryKey'`,
+                                    or(
+                                        gt(
+                                            resolvedBillingEmailMessages.createdAt,
+                                            emailMessages.createdAt,
+                                        ),
+                                        and(
+                                            eq(
+                                                resolvedBillingEmailMessages.createdAt,
+                                                emailMessages.createdAt,
+                                            ),
+                                            gt(
+                                                resolvedBillingEmailMessages.id,
+                                                emailMessages.id,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                    ),
+                ),
+            )
+            .orderBy(
+                rowSort === 'oldest'
+                    ? asc(emailMessages.createdAt)
+                    : desc(emailMessages.createdAt),
+            )
+            .limit(rowLimit),
+    ]);
+
+    return {
+        failedBillingDocumentEmails,
+        missingBillingDocumentEmails,
+        paidInvoicesWithoutReceipts,
+        receiptsNeedingFiscalization,
+        transactionsWithoutInvoices,
+    };
+}

--- a/packages/storage/tests/billingReconciliationRepo.node.spec.ts
+++ b/packages/storage/tests/billingReconciliationRepo.node.spec.ts
@@ -1,0 +1,283 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    createEmailMessageLog,
+    createInvoice,
+    createReceipt,
+    createTransaction,
+    getBillingReconciliationIssues,
+    updateEmailMessageLog,
+    updateReceiptFiscalization,
+} from '@gredice/storage';
+import { createTestAccount } from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+function date() {
+    return new Date();
+}
+
+async function createPaidInvoice({
+    accountId,
+    transactionId,
+}: {
+    accountId: string;
+    transactionId?: number;
+}) {
+    const now = date();
+    return createInvoice({
+        accountId,
+        transactionId,
+        subtotal: '10.00',
+        taxAmount: '0.00',
+        totalAmount: '10.00',
+        currency: 'eur',
+        status: 'paid',
+        issueDate: now,
+        dueDate: now,
+        paidDate: now,
+        billToName: 'Kupac Test',
+        billToEmail: `kupac-${randomUUID()}@example.test`,
+        billToCountry: 'HR',
+    });
+}
+
+async function createPendingReceipt(invoiceId: number) {
+    return createReceipt({
+        invoiceId,
+        subtotal: '10.00',
+        taxAmount: '0.00',
+        totalAmount: '10.00',
+        currency: 'eur',
+        paymentMethod: 'card',
+        paymentReference: `pi_${randomUUID()}`,
+        issuedAt: date(),
+    });
+}
+
+test('getBillingReconciliationIssues returns recoverable billing gaps', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+
+    const transactionWithoutInvoiceId = await createTransaction({
+        accountId,
+        amount: 1000,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId: `pi_${randomUUID()}`,
+    });
+
+    const transactionWithInvoiceId = await createTransaction({
+        accountId,
+        amount: 1000,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId: `pi_${randomUUID()}`,
+    });
+    await createPaidInvoice({
+        accountId,
+        transactionId: transactionWithInvoiceId,
+    });
+
+    const invoiceWithoutReceiptId = await createPaidInvoice({ accountId });
+    const invoiceWithPendingReceiptId = await createPaidInvoice({ accountId });
+    const pendingReceiptId = await createPendingReceipt(
+        invoiceWithPendingReceiptId,
+    );
+
+    const invoiceWithConfirmedReceiptId = await createPaidInvoice({
+        accountId,
+    });
+    const confirmedReceiptId = await createPendingReceipt(
+        invoiceWithConfirmedReceiptId,
+    );
+    await updateReceiptFiscalization(confirmedReceiptId, {
+        cisStatus: 'confirmed',
+        jir: `jir-${randomUUID()}`,
+        zki: `zki-${randomUUID()}`,
+        cisTimestamp: date(),
+    });
+
+    const invoiceWithoutBillingEmailId = await createPaidInvoice({ accountId });
+    const invoiceWithSentBillingEmailId = await createPaidInvoice({
+        accountId,
+    });
+    await createEmailMessageLog({
+        fromAddress: 'suncokret@obavijesti.gredice.com',
+        subject: 'Gredice - dokumenti narudžbe',
+        templateName: 'commerce-billing-documents',
+        messageType: 'commerce',
+        recipients: { to: [{ address: 'kupac@example.test' }] },
+        metadata: {
+            billingDeliveryKey: `billing-documents:invoice:${invoiceWithSentBillingEmailId}`,
+            invoiceId: invoiceWithSentBillingEmailId,
+        },
+        status: 'sent',
+    });
+
+    const invoiceWithFailedBillingEmailId = await createPaidInvoice({
+        accountId,
+    });
+    const failedEmail = await createEmailMessageLog({
+        fromAddress: 'suncokret@obavijesti.gredice.com',
+        subject: 'Gredice - dokumenti narudžbe',
+        templateName: 'commerce-billing-documents',
+        messageType: 'commerce',
+        recipients: { to: [{ address: 'kupac@example.test' }] },
+        metadata: {
+            billingDeliveryKey: `billing-documents:invoice:${invoiceWithFailedBillingEmailId}`,
+            invoiceId: invoiceWithFailedBillingEmailId,
+        },
+        status: 'failed',
+    });
+    await updateEmailMessageLog(failedEmail.id, {
+        errorMessage: 'ACS unavailable',
+    });
+
+    const issues = await getBillingReconciliationIssues({ limit: 100 });
+
+    assert.ok(
+        issues.transactionsWithoutInvoices.some(
+            (transaction) => transaction.id === transactionWithoutInvoiceId,
+        ),
+    );
+    assert.equal(
+        issues.transactionsWithoutInvoices.some(
+            (transaction) => transaction.id === transactionWithInvoiceId,
+        ),
+        false,
+    );
+    assert.ok(
+        issues.paidInvoicesWithoutReceipts.some(
+            (invoice) => invoice.id === invoiceWithoutReceiptId,
+        ),
+    );
+    assert.ok(
+        issues.receiptsNeedingFiscalization.some(
+            (receipt) => receipt.id === pendingReceiptId,
+        ),
+    );
+    assert.equal(
+        issues.receiptsNeedingFiscalization.some(
+            (receipt) => receipt.id === confirmedReceiptId,
+        ),
+        false,
+    );
+    assert.ok(
+        issues.missingBillingDocumentEmails.some(
+            (emailIssue) =>
+                emailIssue.invoiceId === invoiceWithoutBillingEmailId,
+        ),
+    );
+    assert.equal(
+        issues.missingBillingDocumentEmails.some(
+            (emailIssue) =>
+                emailIssue.invoiceId === invoiceWithSentBillingEmailId,
+        ),
+        false,
+    );
+    assert.ok(
+        issues.failedBillingDocumentEmails.some(
+            (emailIssue) =>
+                emailIssue.id === failedEmail.id &&
+                emailIssue.invoiceId === invoiceWithFailedBillingEmailId &&
+                emailIssue.errorMessage === 'ACS unavailable',
+        ),
+    );
+});
+
+test('getBillingReconciliationIssues applies sort before limiting', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+
+    const oldestTransactionId = await createTransaction({
+        accountId,
+        amount: 1000,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId: `pi_${randomUUID()}`,
+        createdAt: new Date('2020-07-01T10:00:00.000Z'),
+    });
+    const newestTransactionId = await createTransaction({
+        accountId,
+        amount: 1000,
+        currency: 'eur',
+        status: 'completed',
+        stripePaymentId: `pi_${randomUUID()}`,
+        createdAt: new Date('2030-07-02T10:00:00.000Z'),
+    });
+
+    const oldestIssues = await getBillingReconciliationIssues({
+        limit: 1,
+        sort: 'oldest',
+    });
+    const newestIssues = await getBillingReconciliationIssues({
+        limit: 1,
+        sort: 'newest',
+    });
+
+    assert.equal(
+        oldestIssues.transactionsWithoutInvoices[0]?.id,
+        oldestTransactionId,
+    );
+    assert.equal(
+        newestIssues.transactionsWithoutInvoices[0]?.id,
+        newestTransactionId,
+    );
+});
+
+test('getBillingReconciliationIssues suppresses failed email logs after a later active retry', async () => {
+    createTestDb();
+    const accountId = await createTestAccount();
+    const invoiceId = await createPaidInvoice({ accountId });
+    const deliveryKey = `billing-documents:invoice:${invoiceId}`;
+
+    const failedEmail = await createEmailMessageLog({
+        fromAddress: 'suncokret@obavijesti.gredice.com',
+        subject: 'Gredice - dokumenti narudžbe',
+        templateName: 'commerce-billing-documents',
+        messageType: 'commerce',
+        recipients: { to: [{ address: 'kupac@example.test' }] },
+        metadata: {
+            billingDeliveryKey: deliveryKey,
+            invoiceId,
+        },
+        status: 'failed',
+    });
+    await updateEmailMessageLog(failedEmail.id, {
+        createdAt: new Date('2026-07-01T10:00:00.000Z'),
+        errorMessage: 'Temporary ACS outage',
+    });
+
+    const sentEmail = await createEmailMessageLog({
+        fromAddress: 'suncokret@obavijesti.gredice.com',
+        subject: 'Gredice - dokumenti narudžbe',
+        templateName: 'commerce-billing-documents',
+        messageType: 'commerce',
+        recipients: { to: [{ address: 'kupac@example.test' }] },
+        metadata: {
+            billingDeliveryKey: deliveryKey,
+            invoiceId,
+        },
+        status: 'sent',
+    });
+    await updateEmailMessageLog(sentEmail.id, {
+        createdAt: new Date('2026-07-01T10:05:00.000Z'),
+        sentAt: new Date('2026-07-01T10:05:00.000Z'),
+    });
+
+    const issues = await getBillingReconciliationIssues({ limit: 100 });
+
+    assert.equal(
+        issues.failedBillingDocumentEmails.some(
+            (emailIssue) => emailIssue.invoiceId === invoiceId,
+        ),
+        false,
+    );
+    assert.equal(
+        issues.missingBillingDocumentEmails.some(
+            (emailIssue) => emailIssue.invoiceId === invoiceId,
+        ),
+        false,
+    );
+});


### PR DESCRIPTION
## Summary
- add bounded storage reconciliation queries for missing invoices, receipts, fiscalization, and billing document emails
- add /admin/billing/reconciliation with filters, sorting, and links to existing recovery pages
- document billing automation rollout, rollback, sunflower package analytics, and ledger reconciliation checks

## Validation
- pnpm --filter @gredice/storage test:node sunflowerLedgerRepo.node.spec.ts billingReconciliationRepo.node.spec.ts
- pnpm --filter api test:node processCheckoutSession.node.spec.ts
- pnpm --filter app build
- pnpm --filter @gredice/storage lint
- pnpm --filter app lint
- targeted app/storage biome checks on changed files
- git diff --check

## Typecheck note
- pnpm exec tsc --project apps/app/tsconfig.json --noEmit --pretty false still fails on pre-existing repo-wide issues outside this PR; no errors reference the new reconciliation files after the typed-route fix.
- pnpm exec tsc --project packages/storage/tsconfig.json --noEmit --pretty false still fails on pre-existing script/test typing issues outside this PR; no errors reference billingReconciliation.

Closes #4040
Closes #4007
Closes #4024
Closes #4025
Closes #3988