### PR TITLE
fix(www): cache deployment stats for 12 hours

### DIFF
--- a/apps/www/app/development/DeploymentStatsCard.tsx
+++ b/apps/www/app/development/DeploymentStatsCard.tsx
@@ -139,7 +139,6 @@ async function fetchDeploymentStats(
     signal: AbortSignal,
 ) {
     const response = await fetch(deploymentStatsUrl(period), {
-        cache: 'no-store',
         signal,
     });
 

--- a/apps/www/app/development/deploymentStats.ts
+++ b/apps/www/app/development/deploymentStats.ts
@@ -13,7 +13,7 @@ const VERCEL_API_BASE_URL = 'https://api.vercel.com/v7/deployments';
 const VERCEL_PAGE_LIMIT = 100;
 const LIVE_WINDOW_DAYS = 30;
 const MAX_PAGES_PER_PROJECT = 25;
-const DEPLOYMENT_STATS_REVALIDATE_SECONDS = 300;
+export const DEPLOYMENT_STATS_CACHE_SECONDS = 12 * 60 * 60;
 
 type VercelProject = {
     name: string;
@@ -191,7 +191,7 @@ async function fetchProjectDeployments({
                 Authorization: `Bearer ${token}`,
             },
             next: {
-                revalidate: DEPLOYMENT_STATS_REVALIDATE_SECONDS,
+                revalidate: DEPLOYMENT_STATS_CACHE_SECONDS,
             },
         });
 

--- a/apps/www/app/development/deployments/route.ts
+++ b/apps/www/app/development/deployments/route.ts
@@ -7,7 +7,8 @@ import {
 
 export const dynamic = 'force-dynamic';
 
-const cacheControl = `public, max-age=0, s-maxage=${DEPLOYMENT_STATS_CACHE_SECONDS}`;
+const readyCacheControl = `public, max-age=0, s-maxage=${DEPLOYMENT_STATS_CACHE_SECONDS}`;
+const unavailableCacheControl = 'private, no-store';
 
 export async function GET(request: NextRequest) {
     const period = getDeploymentStatsPeriodFromSearchParams(
@@ -17,7 +18,10 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(snapshot, {
         headers: {
-            'Cache-Control': cacheControl,
+            'Cache-Control':
+                snapshot.status === 'ready'
+                    ? readyCacheControl
+                    : unavailableCacheControl,
         },
     });
 }

--- a/apps/www/app/development/deployments/route.ts
+++ b/apps/www/app/development/deployments/route.ts
@@ -1,10 +1,13 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import {
+    DEPLOYMENT_STATS_CACHE_SECONDS,
     getDeploymentStats,
     getDeploymentStatsPeriodFromSearchParams,
 } from '../deploymentStats';
 
 export const dynamic = 'force-dynamic';
+
+const cacheControl = `public, max-age=0, s-maxage=${DEPLOYMENT_STATS_CACHE_SECONDS}`;
 
 export async function GET(request: NextRequest) {
     const period = getDeploymentStatsPeriodFromSearchParams(
@@ -14,7 +17,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(snapshot, {
         headers: {
-            'Cache-Control': 'private, no-store',
+            'Cache-Control': cacheControl,
         },
     });
 }


### PR DESCRIPTION
## Summary

- Cache ready `/development/deployments` responses at the shared/CDN layer for 12 hours.
- Align the upstream Vercel deployments fetch revalidation window to 12 hours.
- Stop the client request from forcing `no-store`, so cached route responses can be reused between page visits.
- Keep unavailable deployment-stat responses private and `no-store` so transient token/API failures are not cached for visitors.

## Validation

- `corepack pnpm --filter www lint`
- `corepack pnpm --filter www typecheck`
- `git diff --check`
- `corepack pnpm --filter www build`
- Verified built missing-token route response locally: `cache-control: private, no-store`