### PR TITLE
feat(www): refresh development resource links

### DIFF
--- a/apps/www/app/development/page.tsx
+++ b/apps/www/app/development/page.tsx
@@ -42,7 +42,7 @@ type EnvironmentHosts = {
     app: string;
     api: string;
     farm: string;
-    farmDebug: string;
+    farmDebug: string | null;
     garden: string;
     news: string;
     status: string;
@@ -51,7 +51,10 @@ type EnvironmentHosts = {
 };
 
 function getEnvironmentHosts(): EnvironmentHosts {
-    const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production';
+    const vercelEnvironment = process.env.NEXT_PUBLIC_VERCEL_ENV;
+    const isProduction = vercelEnvironment === 'production';
+    const isLocalDevelopment =
+        !vercelEnvironment || vercelEnvironment === 'development';
     const domain = isProduction ? 'gredice.com' : 'gredice.test';
     const storybookDomain = isProduction
         ? 'dev.gredice.com'
@@ -61,9 +64,7 @@ function getEnvironmentHosts(): EnvironmentHosts {
         app: `https://app.${domain}`,
         api: `https://api.${domain}`,
         farm: `https://farma.${domain}`,
-        farmDebug: isProduction
-            ? 'https://farma.gredice.test'
-            : `https://farma.${domain}`,
+        farmDebug: isLocalDevelopment ? `https://farma.${domain}` : null,
         garden: `https://vrt.${domain}`,
         news: isProduction
             ? `https://www.${domain}/novosti`
@@ -75,6 +76,48 @@ function getEnvironmentHosts(): EnvironmentHosts {
 }
 
 function getDevelopmentSections(hosts: EnvironmentHosts): DevelopmentSection[] {
+    const operationalDebugResources: DevelopmentResource[] = [
+        ...(hosts.farmDebug
+            ? [
+                  {
+                      title: 'Farma debug indeks',
+                      description:
+                          'Lokalni razvojni indeks za farm debug alate i operativne provjere.',
+                      href: `${hosts.farmDebug}/debug`,
+                      icon: '🛠️',
+                  },
+                  {
+                      title: 'Etikete berbe',
+                      description:
+                          'Lokalni pregled generiranih harvest etiketa s reprezentativnim podacima.',
+                      href: `${hosts.farmDebug}/debug/labels`,
+                      icon: '🏷️',
+                  },
+              ]
+            : []),
+        {
+            title: 'Aplikacija debug indeks',
+            description:
+                'Pregled internog debug alata za dijeljene admin i aplikacijske komponente.',
+            href: `${hosts.app}/debug`,
+            icon: '🧰',
+        },
+        {
+            title: 'SelectItems mobile debug',
+            description:
+                'Ručna mobilna provjera otvaranja i zatvaranja SelectItems kontrole.',
+            href: `${hosts.app}/debug/select-items`,
+            icon: '📱',
+        },
+        {
+            title: 'MCP test konzola',
+            description:
+                'Sigurna JSON-RPC konzola za provjeru MCP alata, resursa i autorizacije.',
+            href: `${hosts.api}/test`,
+            icon: '🧾',
+        },
+    ];
+
     return [
         {
             title: 'Vrt debug i učinkovitost',
@@ -143,43 +186,7 @@ function getDevelopmentSections(hosts: EnvironmentHosts): DevelopmentSection[] {
             title: 'Operativni debug',
             description:
                 'Interni debug alati za farmu, admin aplikaciju i provjeru platformnih integracija.',
-            resources: [
-                {
-                    title: 'Farma debug indeks',
-                    description:
-                        'Lokalni razvojni indeks za farm debug alate i operativne provjere.',
-                    href: `${hosts.farmDebug}/debug`,
-                    icon: '🛠️',
-                },
-                {
-                    title: 'Etikete berbe',
-                    description:
-                        'Lokalni pregled generiranih harvest etiketa s reprezentativnim podacima.',
-                    href: `${hosts.farmDebug}/debug/labels`,
-                    icon: '🏷️',
-                },
-                {
-                    title: 'Aplikacija debug indeks',
-                    description:
-                        'Pregled internog debug alata za dijeljene admin i aplikacijske komponente.',
-                    href: `${hosts.app}/debug`,
-                    icon: '🧰',
-                },
-                {
-                    title: 'SelectItems mobile debug',
-                    description:
-                        'Ručna mobilna provjera otvaranja i zatvaranja SelectItems kontrole.',
-                    href: `${hosts.app}/debug/select-items`,
-                    icon: '📱',
-                },
-                {
-                    title: 'MCP test konzola',
-                    description:
-                        'Sigurna JSON-RPC konzola za provjeru MCP alata, resursa i autorizacije.',
-                    href: `${hosts.api}/test`,
-                    icon: '🧾',
-                },
-            ],
+            resources: operationalDebugResources,
         },
         {
             title: 'Sučelja proizvoda',

--- a/apps/www/app/development/page.tsx
+++ b/apps/www/app/development/page.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from '@gredice/ui/Card';
 import { Container } from '@gredice/ui/Container';
+import { CompanyGitHub } from '@gredice/ui/icons';
 import { NavigatingButton } from '@gredice/ui/NavigatingButton';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
@@ -14,11 +15,21 @@ export const metadata: Metadata = {
         'Središnje mjesto za razvojne alate, dijagnostiku, API i timsku suradnju u Gredicama.',
 };
 
+type DevelopmentResourceIcon =
+    | string
+    | {
+          type: 'github';
+      }
+    | {
+          type: 'image';
+          src: string;
+      };
+
 type DevelopmentResource = {
     title: string;
     description: string;
     href: string;
-    icon: string;
+    icon: DevelopmentResourceIcon;
 };
 
 type DevelopmentSection = {
@@ -31,27 +42,32 @@ type EnvironmentHosts = {
     app: string;
     api: string;
     farm: string;
+    farmDebug: string;
     garden: string;
+    news: string;
     status: string;
     storybook: string;
     www: string;
 };
 
 function getEnvironmentHosts(): EnvironmentHosts {
-    const domain =
-        process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
-            ? 'gredice.com'
-            : 'gredice.test';
-    const storybookDomain =
-        process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
-            ? 'dev.gredice.com'
-            : 'dev.gredice.test';
+    const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production';
+    const domain = isProduction ? 'gredice.com' : 'gredice.test';
+    const storybookDomain = isProduction
+        ? 'dev.gredice.com'
+        : 'dev.gredice.test';
 
     return {
         app: `https://app.${domain}`,
         api: `https://api.${domain}`,
         farm: `https://farma.${domain}`,
+        farmDebug: isProduction
+            ? 'https://farma.gredice.test'
+            : `https://farma.${domain}`,
         garden: `https://vrt.${domain}`,
+        news: isProduction
+            ? `https://www.${domain}/novosti`
+            : `https://novosti.${domain}`,
         status: `https://status.${domain}`,
         storybook: `https://storybook.${storybookDomain}`,
         www: `https://www.${domain}`,
@@ -61,10 +77,17 @@ function getEnvironmentHosts(): EnvironmentHosts {
 function getDevelopmentSections(hosts: EnvironmentHosts): DevelopmentSection[] {
     return [
         {
-            title: 'Dijagnostika i učinkovitost',
+            title: 'Vrt debug i učinkovitost',
             description:
-                'Brzi pristup vrtnim alatima za pregled elemenata i provjeru učinkovitosti iscrtavanja.',
+                'Brzi pristup vrtnim debug scenama, pregledima elemenata i provjerama učinkovitosti iscrtavanja.',
             resources: [
+                {
+                    title: 'Vrt debug indeks',
+                    description:
+                        'Početni pregled svih dostupnih debug scena i pomoćnih alata u Vrt aplikaciji.',
+                    href: `${hosts.garden}/debug`,
+                    icon: '🧪',
+                },
                 {
                     title: 'Dijagnostika vrtnih elemenata',
                     description:
@@ -73,11 +96,88 @@ function getDevelopmentSections(hosts: EnvironmentHosts): DevelopmentSection[] {
                     icon: '🐞',
                 },
                 {
+                    title: 'Jedan vrtni element',
+                    description:
+                        'Izolirani prikaz jednog elementa kroz standardnu sandbox scenu.',
+                    href: `${hosts.garden}/debug/entities/FireflyJar`,
+                    icon: '🔎',
+                },
+                {
                     title: 'Učinkovitost prikaza biljaka',
                     description:
                         'Gusti prikaz biljnih predložaka za uočavanje zastoja pri iscrtavanju i pada učinkovitosti.',
                     href: `${hosts.garden}/debug/plants`,
                     icon: '📈',
+                },
+                {
+                    title: 'Lokalni sandbox igre',
+                    description:
+                        'Igriva scena s lokalnom pohranom za brzu provjeru stanja vrta.',
+                    href: `${hosts.garden}/debug/sandbox`,
+                    icon: '🎮',
+                },
+                {
+                    title: 'Ponašanje životinja',
+                    description:
+                        'Scena za provjeru ponašanja, postavljanja i kontrola životinja u vrtu.',
+                    href: `${hosts.garden}/debug/animals`,
+                    icon: '🐾',
+                },
+                {
+                    title: 'Profili igre',
+                    description:
+                        'Mock profili vrta za vrijeme, sezonu, kvalitetu prikaza i HUD provjere.',
+                    href: `${hosts.garden}/debug/profile/game`,
+                    icon: '🧬',
+                },
+                {
+                    title: 'Matrica nagrada radnji',
+                    description:
+                        'Before/after prikaz podignutih gredica za vizualne nagrade radnji.',
+                    href: `${hosts.garden}/debug/profile/game?profile=operation-rewards&details=1&quality=medium`,
+                    icon: '✨',
+                },
+            ],
+        },
+        {
+            title: 'Operativni debug',
+            description:
+                'Interni debug alati za farmu, admin aplikaciju i provjeru platformnih integracija.',
+            resources: [
+                {
+                    title: 'Farma debug indeks',
+                    description:
+                        'Lokalni razvojni indeks za farm debug alate i operativne provjere.',
+                    href: `${hosts.farmDebug}/debug`,
+                    icon: '🛠️',
+                },
+                {
+                    title: 'Etikete berbe',
+                    description:
+                        'Lokalni pregled generiranih harvest etiketa s reprezentativnim podacima.',
+                    href: `${hosts.farmDebug}/debug/labels`,
+                    icon: '🏷️',
+                },
+                {
+                    title: 'Aplikacija debug indeks',
+                    description:
+                        'Pregled internog debug alata za dijeljene admin i aplikacijske komponente.',
+                    href: `${hosts.app}/debug`,
+                    icon: '🧰',
+                },
+                {
+                    title: 'SelectItems mobile debug',
+                    description:
+                        'Ručna mobilna provjera otvaranja i zatvaranja SelectItems kontrole.',
+                    href: `${hosts.app}/debug/select-items`,
+                    icon: '📱',
+                },
+                {
+                    title: 'MCP test konzola',
+                    description:
+                        'Sigurna JSON-RPC konzola za provjeru MCP alata, resursa i autorizacije.',
+                    href: `${hosts.api}/test`,
+                    icon: '🧾',
                 },
             ],
         },
@@ -92,6 +192,13 @@ function getDevelopmentSections(hosts: EnvironmentHosts): DevelopmentSection[] {
                         'Marketinška web-stranica za odredišne, SEO i javne stranice.',
                     href: hosts.www,
                     icon: '🌐',
+                },
+                {
+                    title: 'Novosti',
+                    description:
+                        'Aplikacija za novosti, changelog i javne CMS objave.',
+                    href: hosts.news,
+                    icon: '📰',
                 },
                 {
                     title: 'Vrt',
@@ -154,18 +261,80 @@ function getDevelopmentSections(hosts: EnvironmentHosts): DevelopmentSection[] {
                     description:
                         'Analitika proizvoda i uvidi u oznake značajki na cijeloj platformi.',
                     href: 'https://eu.posthog.com',
-                    icon: '📊',
+                    icon: {
+                        type: 'image',
+                        src: 'https://posthog.com/favicon-32x32.png',
+                    },
                 },
                 {
                     title: 'GitHub',
                     description:
                         'Kontrola izvornog koda, pregledi promjena, praćenje zadataka i CI provjere.',
                     href: 'https://github.com/gredice',
-                    icon: '🐙',
+                    icon: {
+                        type: 'github',
+                    },
                 },
             ],
         },
     ];
+}
+
+function ResourceIcon({
+    icon,
+    title,
+}: {
+    icon: DevelopmentResourceIcon;
+    title: string;
+}) {
+    const label = `${title} ikona`;
+
+    if (typeof icon === 'string') {
+        return (
+            <span
+                className="flex size-8 items-center justify-center text-3xl"
+                role="img"
+                aria-label={label}
+            >
+                {icon}
+            </span>
+        );
+    }
+
+    if (icon.type === 'github') {
+        return (
+            <span
+                className="flex size-8 items-center justify-center text-foreground"
+                role="img"
+                aria-label={label}
+            >
+                <CompanyGitHub
+                    aria-hidden="true"
+                    className="size-8"
+                    focusable="false"
+                />
+            </span>
+        );
+    }
+
+    return (
+        <span
+            className="flex size-8 items-center justify-center"
+            role="img"
+            aria-label={label}
+        >
+            {/** biome-ignore lint/performance/noImgElement: Third-party tool logo is a small favicon outside the Next image config. */}
+            <img
+                alt=""
+                className="size-7 rounded-xs object-contain"
+                height={28}
+                loading="lazy"
+                referrerPolicy="no-referrer"
+                src={icon.src}
+                width={28}
+            />
+        </span>
+    );
 }
 
 function DeploymentStatsSection() {
@@ -228,13 +397,10 @@ export default function DevelopmentPage() {
                                             className="h-full justify-between"
                                         >
                                             <Stack spacing={4}>
-                                                <span
-                                                    className="text-3xl"
-                                                    role="img"
-                                                    aria-label={`${resource.title} ikona`}
-                                                >
-                                                    {resource.icon}
-                                                </span>
+                                                <ResourceIcon
+                                                    icon={resource.icon}
+                                                    title={resource.title}
+                                                />
                                                 <Typography
                                                     level="h5"
                                                     component="h3"


### PR DESCRIPTION
## Summary
- add current garden, farm, app, and API debug/test resources to the development page
- add the News app to product interface links
- replace GitHub and PostHog emoji cards with logo-style icons

## Validation
- corepack pnpm --filter www lint
- corepack pnpm --filter www typecheck
- corepack pnpm --filter www build