### PR TITLE
fix(api): harden birthday sunflower rewards

### DIFF
--- a/apps/api/app/api/internal/cron/birthday-rewards/route.ts
+++ b/apps/api/app/api/internal/cron/birthday-rewards/route.ts
@@ -110,7 +110,7 @@ export async function GET(request: NextRequest) {
                 daysLate: daysSinceBirthday,
             });
         } else {
-            skipped.push({ userId: user.id, reason: 'no_account' });
+            skipped.push({ userId: user.id, reason: result.reason });
         }
     }
 

--- a/apps/api/lib/users/birthdayRewards.node.spec.ts
+++ b/apps/api/lib/users/birthdayRewards.node.spec.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    BIRTHDAY_REWARD_MIN_ACCOUNT_AGE_DAYS,
+    isBirthdayRewardPrimaryAccountEligible,
+} from './birthdayRewards';
+
+test('birthday rewards require the primary account to predate the reward by the minimum age', () => {
+    const rewardDate = new Date(Date.UTC(2026, 6, 8));
+
+    assert.equal(
+        isBirthdayRewardPrimaryAccountEligible({
+            accountCreatedAt: new Date(Date.UTC(2026, 5, 9)),
+            rewardDate,
+        }),
+        false,
+    );
+    assert.equal(
+        isBirthdayRewardPrimaryAccountEligible({
+            accountCreatedAt: new Date(
+                Date.UTC(2026, 6, 8 - BIRTHDAY_REWARD_MIN_ACCOUNT_AGE_DAYS),
+            ),
+            rewardDate,
+        }),
+        true,
+    );
+    assert.equal(
+        isBirthdayRewardPrimaryAccountEligible({
+            accountCreatedAt: new Date(Date.UTC(2026, 6, 8)),
+            rewardDate,
+        }),
+        false,
+    );
+});

--- a/apps/api/lib/users/birthdayRewards.ts
+++ b/apps/api/lib/users/birthdayRewards.ts
@@ -1,14 +1,13 @@
 import {
-    createEvent,
     createNotification,
-    earnSunflowers,
-    knownEvents,
+    grantBirthdaySunflowers,
     type SelectUser,
 } from '@gredice/storage';
 import { sendBirthdayGreeting } from '../email/transactional';
 import { differenceInCalendarDays, startOfUtcDay } from './birthdayUtils';
 
 export const BIRTHDAY_REWARD_AMOUNT = 9999;
+export const BIRTHDAY_REWARD_MIN_ACCOUNT_AGE_DAYS = 30;
 
 export type BirthdayRewardUser = SelectUser & {
     accounts: {
@@ -16,6 +15,33 @@ export type BirthdayRewardUser = SelectUser & {
         createdAt: Date;
     }[];
 };
+
+export type BirthdayRewardResult =
+    | {
+          rewarded: true;
+          accountId: string;
+          daysLate: number;
+      }
+    | {
+          rewarded: false;
+          reason: 'account_too_new' | 'already_rewarded' | 'no_account';
+          accountId?: string;
+      };
+
+export function isBirthdayRewardPrimaryAccountEligible({
+    accountCreatedAt,
+    rewardDate,
+}: {
+    accountCreatedAt: Date;
+    rewardDate: Date;
+}) {
+    const accountCreatedDay = startOfUtcDay(accountCreatedAt);
+    const rewardDay = startOfUtcDay(rewardDate);
+    return (
+        differenceInCalendarDays(rewardDay, accountCreatedDay) >=
+        BIRTHDAY_REWARD_MIN_ACCOUNT_AGE_DAYS
+    );
+}
 
 export async function grantBirthdayReward({
     user,
@@ -25,7 +51,7 @@ export async function grantBirthdayReward({
     user: BirthdayRewardUser;
     rewardDate: Date;
     isLate: boolean;
-}) {
+}): Promise<BirthdayRewardResult> {
     const accounts = [...user.accounts].sort(
         (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
     );
@@ -34,16 +60,37 @@ export async function grantBirthdayReward({
         console.warn('Skipping birthday reward for user without account', {
             userId: user.id,
         });
-        return { rewarded: false };
+        return { rewarded: false, reason: 'no_account' as const };
     }
 
-    const rewardReason = `birthday:${rewardDate.getUTCFullYear()}`;
+    if (
+        !isBirthdayRewardPrimaryAccountEligible({
+            accountCreatedAt: primaryAccount.createdAt,
+            rewardDate,
+        })
+    ) {
+        return {
+            rewarded: false,
+            reason: 'account_too_new' as const,
+            accountId: primaryAccount.accountId,
+        };
+    }
 
-    await earnSunflowers(
-        primaryAccount.accountId,
-        BIRTHDAY_REWARD_AMOUNT,
-        rewardReason,
-    );
+    const grantResult = await grantBirthdaySunflowers({
+        accountId: primaryAccount.accountId,
+        amount: BIRTHDAY_REWARD_AMOUNT,
+        isLate,
+        rewardDate,
+        userId: user.id,
+    });
+
+    if (grantResult.status === 'existing') {
+        return {
+            rewarded: false,
+            reason: 'already_rewarded' as const,
+            accountId: primaryAccount.accountId,
+        };
+    }
 
     const header = isLate
         ? 'Sretan rođendan (uz malo zakašnjenje)!'
@@ -58,14 +105,22 @@ export async function grantBirthdayReward({
         'Hvala ti što si dio Gredica - uživaj u slavlju! 🌼',
     ].join('\n\n');
 
-    await createNotification({
-        accountId: primaryAccount.accountId,
-        userId: user.id,
-        header,
-        content,
-        iconUrl: 'https://cdn.gredice.com/sunflower-large.svg',
-        timestamp: new Date(),
-    });
+    try {
+        await createNotification({
+            accountId: primaryAccount.accountId,
+            userId: user.id,
+            header,
+            content,
+            iconUrl: 'https://cdn.gredice.com/sunflower-large.svg',
+            timestamp: new Date(),
+        });
+    } catch (error) {
+        console.error('Failed to create birthday reward notification', {
+            userId: user.id,
+            accountId: primaryAccount.accountId,
+            error,
+        });
+    }
 
     const userEmail = user.userName.includes('@') ? user.userName : null;
     if (userEmail) {
@@ -82,16 +137,6 @@ export async function grantBirthdayReward({
             });
         }
     }
-
-    const normalizedRewardDate = startOfUtcDay(rewardDate);
-    await createEvent(
-        knownEvents.users.birthdayRewardV1(user.id, {
-            rewardDate: normalizedRewardDate.toISOString(),
-            accountId: primaryAccount.accountId,
-            amount: BIRTHDAY_REWARD_AMOUNT,
-            late: isLate,
-        }),
-    );
 
     const daysDifference = differenceInCalendarDays(new Date(), rewardDate);
     return {

--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -195,7 +195,7 @@ export async function grantBirthdaySunflowers({
         const lastRewardDate = lastRewardEvent
             ? startOfUtcDay(new Date(lastRewardEvent.data.rewardDate))
             : null;
-        if (lastRewardDate && lastRewardDate >= normalizedRewardDate) {
+        if (lastRewardDate?.getUTCFullYear() === rewardYear) {
             return {
                 status: 'existing',
                 accountId,

--- a/packages/storage/src/repositories/accountsRepo.ts
+++ b/packages/storage/src/repositories/accountsRepo.ts
@@ -5,6 +5,7 @@ import { accounts, accountUsers, ensureAccountAchievement, storage } from '..';
 import {
     createEvent,
     getAllEvents,
+    getLastBirthdayRewardEvent,
     getLatestEvents,
     knownEvents,
     knownEventTypes,
@@ -14,6 +15,16 @@ interface SunflowerEventData {
     amount: number;
     reason?: string;
 }
+
+export type BirthdaySunflowerGrantResult =
+    | {
+          status: 'created';
+          accountId: string;
+      }
+    | {
+          status: 'existing';
+          accountId: string;
+      };
 
 function parseSunflowerEventData(data: unknown): SunflowerEventData {
     if (!data || typeof data !== 'object') {
@@ -144,6 +155,69 @@ export async function getSunflowers(
                 : amount;
     }
     return currentSunflowers;
+}
+
+function startOfUtcDay(date: Date) {
+    return new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+}
+
+export async function grantBirthdaySunflowers({
+    accountId,
+    amount,
+    isLate,
+    rewardDate,
+    userId,
+}: {
+    accountId: string;
+    amount: number;
+    isLate: boolean;
+    rewardDate: Date;
+    userId: string;
+}): Promise<BirthdaySunflowerGrantResult> {
+    if (!Number.isInteger(amount) || amount <= 0) {
+        throw new Error(
+            'Birthday sunflower amount must be a positive integer.',
+        );
+    }
+
+    const normalizedRewardDate = startOfUtcDay(rewardDate);
+    const rewardYear = normalizedRewardDate.getUTCFullYear();
+    const reason = `birthday:${rewardYear.toString()}`;
+
+    return storage().transaction(async (tx) => {
+        await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtext(${`birthday-reward:${userId}:${rewardYear.toString()}`}));`,
+        );
+
+        const lastRewardEvent = await getLastBirthdayRewardEvent(userId, tx);
+        const lastRewardDate = lastRewardEvent
+            ? startOfUtcDay(new Date(lastRewardEvent.data.rewardDate))
+            : null;
+        if (lastRewardDate && lastRewardDate >= normalizedRewardDate) {
+            return {
+                status: 'existing',
+                accountId,
+            };
+        }
+
+        await earnSunflowers(accountId, amount, reason, tx);
+        await createEvent(
+            knownEvents.users.birthdayRewardV1(userId, {
+                rewardDate: normalizedRewardDate.toISOString(),
+                accountId,
+                amount,
+                late: isLate,
+            }),
+            tx,
+        );
+
+        return {
+            status: 'created',
+            accountId,
+        };
+    });
 }
 
 export async function getSunflowersHistory(

--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -708,8 +708,11 @@ export async function updateEventCreatedAt(eventId: number, createdAt: Date) {
     await bustReadModelCachesForEvent(event);
 }
 
-export async function getLastBirthdayRewardEvent(userId: string) {
-    const event = await storage().query.events.findFirst({
+export async function getLastBirthdayRewardEvent(
+    userId: string,
+    db: DatabaseClient = storage(),
+) {
+    const event = await db.query.events.findFirst({
         where: and(
             eq(events.aggregateId, userId),
             eq(events.type, knownEventTypes.users.birthdayReward),

--- a/packages/storage/tests/accountsRepo.node.spec.ts
+++ b/packages/storage/tests/accountsRepo.node.spec.ts
@@ -1,14 +1,20 @@
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
+    accountUsers,
     assignStripeCustomerId,
     earnSunflowers,
     getAccount,
     getAccounts,
     getAccountUsers,
+    getLastBirthdayRewardEvent,
     getSunflowers,
     getSunflowersHistory,
+    grantBirthdaySunflowers,
     spendSunflowers,
+    storage,
+    users,
 } from '@gredice/storage';
 import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
@@ -168,6 +174,55 @@ test('earnSunflowers increases sunflowers', async () => {
     await earnSunflowers(accountId, 500, 'bonus');
     const sunflowers = await getSunflowers(accountId);
     assert.strictEqual(sunflowers, 1500);
+});
+
+test('grantBirthdaySunflowers is idempotent for a user reward year', async () => {
+    createTestDb();
+    const db = storage();
+    const accountId = await createTestAccount();
+    const userId = randomUUID();
+    const userCreatedAt = new Date(Date.UTC(2026, 4, 1));
+    const rewardDate = new Date(Date.UTC(2026, 6, 8));
+
+    await db.insert(users).values({
+        id: userId,
+        userName: `${userId}@example.com`,
+        displayName: 'Birthday Test',
+        role: 'user',
+        createdAt: userCreatedAt,
+        updatedAt: userCreatedAt,
+    });
+    await db.insert(accountUsers).values({
+        accountId,
+        userId,
+        createdAt: userCreatedAt,
+        updatedAt: userCreatedAt,
+    });
+
+    const firstGrant = await grantBirthdaySunflowers({
+        accountId,
+        amount: 9999,
+        isLate: false,
+        rewardDate,
+        userId,
+    });
+    const secondGrant = await grantBirthdaySunflowers({
+        accountId,
+        amount: 9999,
+        isLate: false,
+        rewardDate,
+        userId,
+    });
+
+    assert.strictEqual(firstGrant.status, 'created');
+    assert.strictEqual(secondGrant.status, 'existing');
+    assert.strictEqual(await getSunflowers(accountId), 10999);
+
+    const rewardEvent = await getLastBirthdayRewardEvent(userId);
+    assert.ok(rewardEvent);
+    assert.strictEqual(rewardEvent.data.accountId, accountId);
+    assert.strictEqual(rewardEvent.data.amount, 9999);
+    assert.strictEqual(rewardEvent.data.rewardDate, rewardDate.toISOString());
 });
 
 test('spendSunflowers decreases sunflowers', async () => {

--- a/packages/storage/tests/accountsRepo.node.spec.ts
+++ b/packages/storage/tests/accountsRepo.node.spec.ts
@@ -182,7 +182,8 @@ test('grantBirthdaySunflowers is idempotent for a user reward year', async () =>
     const accountId = await createTestAccount();
     const userId = randomUUID();
     const userCreatedAt = new Date(Date.UTC(2026, 4, 1));
-    const rewardDate = new Date(Date.UTC(2026, 6, 8));
+    const firstRewardDate = new Date(Date.UTC(2026, 5, 8));
+    const laterRewardDate = new Date(Date.UTC(2026, 6, 8));
 
     await db.insert(users).values({
         id: userId,
@@ -203,14 +204,14 @@ test('grantBirthdaySunflowers is idempotent for a user reward year', async () =>
         accountId,
         amount: 9999,
         isLate: false,
-        rewardDate,
+        rewardDate: firstRewardDate,
         userId,
     });
     const secondGrant = await grantBirthdaySunflowers({
         accountId,
         amount: 9999,
         isLate: false,
-        rewardDate,
+        rewardDate: laterRewardDate,
         userId,
     });
 
@@ -222,7 +223,10 @@ test('grantBirthdaySunflowers is idempotent for a user reward year', async () =>
     assert.ok(rewardEvent);
     assert.strictEqual(rewardEvent.data.accountId, accountId);
     assert.strictEqual(rewardEvent.data.amount, 9999);
-    assert.strictEqual(rewardEvent.data.rewardDate, rewardDate.toISOString());
+    assert.strictEqual(
+        rewardEvent.data.rewardDate,
+        firstRewardDate.toISOString(),
+    );
 });
 
 test('spendSunflowers decreases sunflowers', async () => {


### PR DESCRIPTION
## Summary
- make birthday sunflower grants atomic and idempotent per user/reward year
- require the primary account membership to predate the birthday by 30 days before granting the reward
- keep birthday notification/email side effects best-effort after the currency/event transaction

## Validation
- pnpm --filter @gredice/storage test:node accountsRepo.node.spec.ts
- pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/users/birthdayRewards.node.spec.ts
- pnpm --filter api exec biome check --write lib/users/birthdayRewards.ts lib/users/birthdayRewards.node.spec.ts app/api/internal/cron/birthday-rewards/route.ts
- pnpm --filter @gredice/storage exec biome check --write src/repositories/accountsRepo.ts src/repositories/events/queries.ts tests/accountsRepo.node.spec.ts
- pnpm typecheck --filter api --filter @gredice/storage

Note: direct package-level tsc still reports unrelated existing spec/script errors; filtered output contained no errors for the touched birthday/storage files.