### PR TITLE
feat(www): improve delivery slot calendar

### DIFF
--- a/apps/api/app/api/[...route]/deliveryRoutes.ts
+++ b/apps/api/app/api/[...route]/deliveryRoutes.ts
@@ -8,8 +8,11 @@ import {
     getDeliveryAddresses,
     getDeliveryRequestsWithEvents,
     getPickupLocations,
+    getTimeSlotEffectiveClosesAt,
     getTimeSlots,
     type InsertDeliveryAddress,
+    type TimeSlotStatus,
+    TimeSlotStatuses,
     type UpdateDeliveryAddress,
     updateDeliveryAddress,
     validateDeliveryAddress,
@@ -58,6 +61,8 @@ const slotsQuerySchema = z.object({
     from: z.iso.datetime().optional(),
     to: z.iso.datetime().optional(),
     locationId: z.coerce.number().optional(),
+    includeClosed: z.literal('true').optional(),
+    includeArchived: z.literal('true').optional(),
 });
 
 const createRequestSchema = z.object({
@@ -202,28 +207,50 @@ const app = new Hono<{ Variables: AuthVariables }>()
     .get(
         '/slots',
         describeRoute({
-            description: 'Get available time slots for delivery or pickup',
+            description:
+                'Get time slots for delivery or pickup, with optional closed and archived slots',
             security: publicSecurity,
             tags: ['Delivery'],
         }),
         zValidator('query', slotsQuerySchema),
         async (context) => {
-            const { type, from, to, locationId } = context.req.valid('query');
+            const {
+                type,
+                from,
+                to,
+                locationId,
+                includeClosed,
+                includeArchived,
+            } = context.req.valid('query');
 
             // Default to next 14 days if no date range provided
             const fromDate = from ? new Date(from) : new Date();
             const toDate = to
                 ? new Date(to)
                 : new Date(Date.now() + 14 * 24 * 60 * 60 * 1000);
+            const statuses: TimeSlotStatus[] = [TimeSlotStatuses.SCHEDULED];
+
+            if (includeClosed) {
+                statuses.push(TimeSlotStatuses.CLOSED);
+            }
+
+            if (includeArchived) {
+                statuses.push(TimeSlotStatuses.ARCHIVED);
+            }
 
             const slots = await getTimeSlots({
                 type,
                 locationId,
                 fromDate,
                 toDate,
-                status: 'scheduled', // Only return bookable slots
+                status: statuses,
             });
-            return context.json(slots);
+            return context.json(
+                slots.map((slot) => ({
+                    ...slot,
+                    effectiveClosesAt: getTimeSlotEffectiveClosesAt(slot),
+                })),
+            );
         },
     )
     // GET /requests - list user's delivery requests

--- a/apps/www/app/dostava/termini/ClosingSoonIndicator.tsx
+++ b/apps/www/app/dostava/termini/ClosingSoonIndicator.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getClosingSoonHours } from './slotClosingSoon';
+
+const REFRESH_INTERVAL_MS = 60 * 1000;
+
+export function ClosingSoonIndicator({
+    effectiveClosesAt,
+}: {
+    effectiveClosesAt: string;
+}) {
+    const [now, setNow] = useState<number | null>(null);
+
+    useEffect(() => {
+        const refresh = () => setNow(Date.now());
+        refresh();
+        const interval = window.setInterval(refresh, REFRESH_INTERVAL_MS);
+
+        return () => window.clearInterval(interval);
+    }, []);
+
+    if (now === null) {
+        return null;
+    }
+
+    const remainingHours = getClosingSoonHours({ effectiveClosesAt, now });
+
+    if (remainingHours === null) {
+        return null;
+    }
+
+    return (
+        <span className="inline-flex w-full items-center gap-1 border-amber-200/70 border-t bg-amber-50/70 px-2.5 py-1 text-[0.65rem] font-medium text-amber-800 dark:border-amber-500/30 dark:bg-amber-950/40 dark:text-amber-300">
+            <span
+                aria-hidden
+                className="size-1.5 shrink-0 rounded-full bg-amber-500"
+            />
+            <span>Uskoro se zatvara</span>
+            <span aria-hidden>·</span>
+            <span>još {remainingHours} h</span>
+        </span>
+    );
+}

--- a/apps/www/app/dostava/termini/page.tsx
+++ b/apps/www/app/dostava/termini/page.tsx
@@ -68,7 +68,7 @@ interface SlotRange {
 
 function createSlotRange(): SlotRange {
     const referenceDate = new Date();
-    const fromDate = startOfWeek(referenceDate);
+    const fromDate = new Date(referenceDate);
     const toDate = new Date(referenceDate);
     toDate.setDate(toDate.getDate() + SLOT_RANGE_DAYS);
 

--- a/apps/www/app/dostava/termini/page.tsx
+++ b/apps/www/app/dostava/termini/page.tsx
@@ -1,21 +1,24 @@
 import { clientPublic } from '@gredice/client';
 import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
 import { Container } from '@gredice/ui/Container';
-import { Timer } from '@gredice/ui/icons';
+import { MapPin, Truck } from '@gredice/ui/icons';
 import { LocalDateTime, TimeRange } from '@gredice/ui/LocalDateTime';
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { StyledHtml } from '@gredice/ui/StyledHtml';
 import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
 import type { Metadata } from 'next';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { WhatsAppCard } from '../../../components/social/WhatsAppCard';
+import { ClosingSoonIndicator } from './ClosingSoonIndicator';
 
 export const dynamic = 'force-dynamic';
 export const metadata: Metadata = {
     title: 'Termini dostave',
-    description: 'Vidi dostupne termine za dostavu ili osobno preuzimanje.',
+    description:
+        'Vidi raspoložive i zatvorene termine za dostavu ili osobno preuzimanje u sljedećih mjesec dana.',
 };
 
 // Types from API response - these match the type-safe client schema
@@ -25,6 +28,7 @@ interface TimeSlot {
     type: 'delivery' | 'pickup';
     startAt: string;
     endAt: string;
+    effectiveClosesAt: string;
     status: string;
     location?: {
         id: number;
@@ -36,20 +40,52 @@ interface TimeSlot {
     };
 }
 
-// Fetch slots using type-safe client
-async function fetchTimeSlots(
-    type: 'delivery' | 'pickup',
-): Promise<TimeSlot[]> {
-    const fromDate = new Date();
-    const toDate = new Date();
-    toDate.setDate(toDate.getDate() + 14);
+const SLOT_RANGE_DAYS = 30;
+const DELIVERY_TIME_ZONE = 'Europe/Zagreb';
+const deliveryDateKeyFormatter = new Intl.DateTimeFormat('en-US', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    timeZone: DELIVERY_TIME_ZONE,
+});
 
+interface DaySlots {
+    date: Date;
+    slots: TimeSlot[];
+}
+
+interface WeekSlots {
+    startAt: Date;
+    endAt: Date;
+    days: DaySlots[];
+}
+
+interface SlotRange {
+    fromDate: Date;
+    toDate: Date;
+    referenceDate: Date;
+}
+
+function createSlotRange(): SlotRange {
+    const referenceDate = new Date();
+    const fromDate = startOfWeek(referenceDate);
+    const toDate = new Date(referenceDate);
+    toDate.setDate(toDate.getDate() + SLOT_RANGE_DAYS);
+
+    return { fromDate, toDate, referenceDate };
+}
+
+async function fetchTimeSlots({
+    fromDate,
+    toDate,
+}: SlotRange): Promise<TimeSlot[]> {
     try {
         const response = await clientPublic().api.delivery.slots.$get({
             query: {
-                type,
                 from: fromDate.toISOString(),
                 to: toDate.toISOString(),
+                includeClosed: 'true',
+                includeArchived: 'true',
             },
         });
 
@@ -67,41 +103,138 @@ async function fetchTimeSlots(
     }
 }
 
-// Group slots by date for better display
-function groupSlotsByDate(slots: TimeSlot[]) {
-    const grouped = slots.reduce(
-        (acc, slot) => {
-            const date = new Date(slot.startAt).toDateString();
-            if (!acc[date]) {
-                acc[date] = [];
-            }
-            acc[date].push(slot);
-            return acc;
-        },
-        {} as Record<string, TimeSlot[]>,
-    );
+function compareSlots(a: TimeSlot, b: TimeSlot) {
+    const startDifference =
+        new Date(a.startAt).getTime() - new Date(b.startAt).getTime();
 
-    // Sort dates
-    return Object.keys(grouped)
-        .sort((a, b) => new Date(a).getTime() - new Date(b).getTime())
-        .reduce(
-            (acc, date) => {
-                acc[date] = grouped[date].sort(
-                    (a: TimeSlot, b: TimeSlot) =>
-                        new Date(a.startAt).getTime() -
-                        new Date(b.startAt).getTime(),
-                );
-                return acc;
-            },
-            {} as Record<string, TimeSlot[]>,
-        );
+    if (startDifference !== 0) {
+        return startDifference;
+    }
+
+    if (a.type !== b.type) {
+        return a.type === 'delivery' ? -1 : 1;
+    }
+
+    return (a.location?.name ?? '').localeCompare(b.location?.name ?? '');
 }
 
-async function SlotsDisplay({ type }: { type: 'delivery' | 'pickup' }) {
-    const slots = await fetchTimeSlots(type);
-    const groupedSlots = groupSlotsByDate(slots);
+function dateKey(date: Date) {
+    const parts = new Map(
+        deliveryDateKeyFormatter
+            .formatToParts(date)
+            .map(({ type, value }) => [type, value]),
+    );
 
-    if (Object.keys(groupedSlots).length === 0) {
+    return `${parts.get('year')}-${parts.get('month')}-${parts.get('day')}`;
+}
+
+function startOfWeek(date: Date) {
+    const startAt = new Date(`${dateKey(date)}T12:00:00.000Z`);
+    const daysFromMonday = (startAt.getUTCDay() + 6) % 7;
+    startAt.setUTCDate(startAt.getUTCDate() - daysFromMonday);
+    startAt.setUTCHours(0, 0, 0, 0);
+    return startAt;
+}
+
+function groupSlotsByWeek(
+    slots: TimeSlot[],
+    { fromDate, toDate }: SlotRange,
+): WeekSlots[] {
+    const weeks = new Map<number, WeekSlots>();
+    const finalWeekStart = startOfWeek(toDate);
+    let weekStart = startOfWeek(fromDate);
+
+    while (weekStart.getTime() <= finalWeekStart.getTime()) {
+        const weekEnd = new Date(weekStart);
+        weekEnd.setDate(weekEnd.getDate() + 6);
+        weeks.set(weekStart.getTime(), {
+            startAt: weekStart,
+            endAt: weekEnd,
+            days: [],
+        });
+
+        const nextWeekStart = new Date(weekStart);
+        nextWeekStart.setDate(nextWeekStart.getDate() + 7);
+        weekStart = nextWeekStart;
+    }
+
+    const days = new Map<string, DaySlots>();
+
+    for (const slot of [...slots].sort(compareSlots)) {
+        const date = new Date(slot.startAt);
+        const key = dateKey(date);
+        const day = days.get(key);
+
+        if (day) {
+            day.slots.push(slot);
+        } else {
+            days.set(key, { date, slots: [slot] });
+        }
+    }
+
+    for (const day of days.values()) {
+        const weekStart = startOfWeek(day.date);
+        const weekKey = weekStart.getTime();
+        const week = weeks.get(weekKey);
+
+        if (week) {
+            week.days.push(day);
+        }
+    }
+
+    return [...weeks.values()]
+        .sort((a, b) => a.startAt.getTime() - b.startAt.getTime())
+        .map((week) => ({
+            ...week,
+            days: week.days.sort((a, b) => a.date.getTime() - b.date.getTime()),
+        }));
+}
+
+function WeekRange({ startAt, endAt }: Pick<WeekSlots, 'startAt' | 'endAt'>) {
+    const isSameMonth =
+        startAt.getFullYear() === endAt.getFullYear() &&
+        startAt.getMonth() === endAt.getMonth();
+    const isSameYear = startAt.getFullYear() === endAt.getFullYear();
+    const startFormat: Intl.DateTimeFormatOptions = {
+        day: 'numeric',
+        timeZone: DELIVERY_TIME_ZONE,
+    };
+
+    if (!isSameMonth) {
+        startFormat.month = 'long';
+    }
+
+    if (!isSameYear) {
+        startFormat.year = 'numeric';
+    }
+
+    return (
+        <>
+            <LocalDateTime time={false} format={startFormat}>
+                {startAt}
+            </LocalDateTime>{' '}
+            –{' '}
+            <LocalDateTime
+                time={false}
+                format={{
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
+                    timeZone: DELIVERY_TIME_ZONE,
+                }}
+            >
+                {endAt}
+            </LocalDateTime>
+        </>
+    );
+}
+
+async function SlotsDisplay() {
+    const range = createSlotRange();
+    const slots = await fetchTimeSlots(range);
+    const weeks = groupSlotsByWeek(slots, range);
+
+    if (weeks.length === 0) {
         return (
             <Card className="p-6 border-tertiary border-b-4">
                 <CardContent noHeader>
@@ -113,11 +246,8 @@ async function SlotsDisplay({ type }: { type: 'delivery' | 'pickup' }) {
                             level="body2"
                             className="text-muted-foreground"
                         >
-                            Trenutno nema dostupnih termina za{' '}
-                            {type === 'delivery'
-                                ? 'dostavu'
-                                : 'osobno preuzimanje'}{' '}
-                            u sljedećih 14 dana.
+                            Trenutno nema termina za dostavu ili osobno
+                            preuzimanje u sljedećih mjesec dana.
                         </Typography>
                     </Stack>
                 </CardContent>
@@ -126,67 +256,173 @@ async function SlotsDisplay({ type }: { type: 'delivery' | 'pickup' }) {
     }
 
     return (
-        <Stack spacing={4}>
-            {Object.entries(groupedSlots).map(([date, dateSlots]) => (
-                <Card key={date} className="border-tertiary border-b-4">
-                    <CardHeader>
-                        <CardTitle>
-                            <Typography
-                                level="h5"
-                                className="text-xl font-normal"
-                            >
-                                <LocalDateTime
-                                    time={false}
-                                    format={{
-                                        weekday: 'long',
-                                        day: 'numeric',
-                                        month: 'long',
-                                        year: 'numeric',
-                                    }}
+        <Stack spacing={5}>
+            {weeks.map((week, weekIndex) => (
+                <section key={week.startAt.toISOString()}>
+                    <div className="mb-2 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                        <Typography level="h6" component="h5">
+                            <span className="font-normal text-muted-foreground">
+                                Tjedan{' '}
+                            </span>
+                            <WeekRange
+                                startAt={week.startAt}
+                                endAt={week.endAt}
+                            />
+                        </Typography>
+                        {weekIndex === 0 && (
+                            <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground md:ml-auto md:justify-end">
+                                <span className="inline-flex items-center gap-2">
+                                    <Truck
+                                        aria-hidden
+                                        className="size-4 text-primary"
+                                    />
+                                    Dostava na adresu
+                                </span>
+                                <span className="inline-flex items-center gap-2">
+                                    <MapPin
+                                        aria-hidden
+                                        className="size-4 text-tertiary-foreground"
+                                    />
+                                    Osobno preuzimanje
+                                </span>
+                            </div>
+                        )}
+                    </div>
+                    <Card className="overflow-hidden border-tertiary border-b-4 p-0">
+                        {week.days.length === 0 ? (
+                            <div className="flex min-h-20 items-center justify-center p-5 text-center">
+                                <Typography
+                                    level="body2"
+                                    className="text-muted-foreground"
                                 >
-                                    {new Date(date)}
-                                </LocalDateTime>
-                            </Typography>
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent noHeader>
-                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-                            {dateSlots.map((slot) => {
+                                    Nema planiranih ni otvorenih termina dostave
+                                    ili osobnog preuzimanja za ovaj tjedan.
+                                </Typography>
+                            </div>
+                        ) : (
+                            week.days.map((day) => {
+                                const isToday =
+                                    dateKey(day.date) ===
+                                    dateKey(range.referenceDate);
+
                                 return (
                                     <div
-                                        key={slot.id}
-                                        className="border rounded-lg p-3 bg-background"
+                                        key={dateKey(day.date)}
+                                        className="grid grid-cols-[3.25rem_minmax(0,1fr)] gap-3 border-b p-3 last:border-b-0 md:gap-4"
                                     >
-                                        <Stack spacing={4}>
-                                            <Row spacing={2}>
-                                                <Timer className="size-5 shrink-0 text-tertiary-foreground" />
-                                                <Typography
-                                                    level="body2"
-                                                    semiBold
-                                                >
-                                                    <TimeRange
-                                                        startAt={slot.startAt}
-                                                        endAt={slot.endAt}
-                                                        timeOnly
-                                                    />
-                                                </Typography>
-                                            </Row>
-                                            {slot.location &&
-                                                slot.type === 'pickup' && (
-                                                    <Typography
-                                                        level="body3"
-                                                        className="text-muted-foreground"
+                                        <div className="flex min-h-10 flex-col items-start justify-center text-left">
+                                            <LocalDateTime
+                                                className="text-sm font-bold uppercase tracking-wide text-foreground"
+                                                time={false}
+                                                format={{
+                                                    weekday: 'short',
+                                                    timeZone:
+                                                        DELIVERY_TIME_ZONE,
+                                                }}
+                                            >
+                                                {day.date}
+                                            </LocalDateTime>
+                                            <LocalDateTime
+                                                className="whitespace-nowrap text-[0.65rem] font-normal text-muted-foreground"
+                                                time={false}
+                                                format={{
+                                                    day: 'numeric',
+                                                    month: 'short',
+                                                    timeZone:
+                                                        DELIVERY_TIME_ZONE,
+                                                }}
+                                            >
+                                                {day.date}
+                                            </LocalDateTime>
+                                            {isToday && (
+                                                <span className="mt-1 rounded-full bg-primary/10 px-1.5 py-0.5 text-[0.55rem] font-semibold uppercase leading-none tracking-wide text-primary">
+                                                    Danas
+                                                </span>
+                                            )}
+                                        </div>
+
+                                        <div className="flex flex-wrap items-start gap-2">
+                                            {day.slots.map((slot) => {
+                                                const isClosed =
+                                                    slot.status !== 'scheduled';
+                                                const SlotIcon =
+                                                    slot.type === 'delivery'
+                                                        ? Truck
+                                                        : MapPin;
+
+                                                return (
+                                                    <div
+                                                        key={slot.id}
+                                                        className={cx(
+                                                            'inline-flex flex-col overflow-hidden rounded-md border',
+                                                            isClosed
+                                                                ? 'border-dashed bg-muted/60 text-muted-foreground'
+                                                                : 'bg-background text-foreground',
+                                                        )}
                                                     >
-                                                        📍 {slot.location.name}
-                                                    </Typography>
-                                                )}
-                                        </Stack>
+                                                        <div className="inline-flex min-h-9 items-center gap-2 px-2.5 py-1.5 text-sm">
+                                                            <SlotIcon
+                                                                aria-hidden
+                                                                className={cx(
+                                                                    'size-4 shrink-0',
+                                                                    !isClosed &&
+                                                                        slot.type ===
+                                                                            'delivery' &&
+                                                                        'text-primary',
+                                                                    !isClosed &&
+                                                                        slot.type ===
+                                                                            'pickup' &&
+                                                                        'text-tertiary-foreground',
+                                                                )}
+                                                            />
+                                                            <TimeRange
+                                                                className={cx(
+                                                                    'font-medium tabular-nums',
+                                                                    isClosed &&
+                                                                        'line-through',
+                                                                )}
+                                                                startAt={
+                                                                    slot.startAt
+                                                                }
+                                                                endAt={
+                                                                    slot.endAt
+                                                                }
+                                                                timeOnly
+                                                            />
+                                                            {slot.type ===
+                                                                'pickup' &&
+                                                                slot.location && (
+                                                                    <span className="border-l pl-2 text-xs">
+                                                                        {
+                                                                            slot
+                                                                                .location
+                                                                                .name
+                                                                        }
+                                                                    </span>
+                                                                )}
+                                                            {isClosed && (
+                                                                <span className="border-l pl-2 text-[0.65rem] font-semibold uppercase tracking-wide">
+                                                                    zatvoren
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                        {!isClosed && (
+                                                            <ClosingSoonIndicator
+                                                                effectiveClosesAt={
+                                                                    slot.effectiveClosesAt
+                                                                }
+                                                            />
+                                                        )}
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
                                     </div>
                                 );
-                            })}
-                        </div>
-                    </CardContent>
-                </Card>
+                            })
+                        )}
+                    </Card>
+                </section>
             ))}
         </Stack>
     );
@@ -199,14 +435,14 @@ export default async function DeliverySlotsPage() {
                 <PageHeader
                     padded
                     header="📅 Termini dostave"
-                    subHeader="Vidi dostupne termine za dostavu ili osobno preuzimanje."
+                    subHeader="Vidi termine za dostavu ili osobno preuzimanje u sljedećih mjesec dana."
                 />
 
                 <Typography level="body1">
-                    Ovdje možeš vidjeti sve dostupne termine za dostavu ili
-                    osobno preuzimanje u sljedećih 14 dana. Termin možeš
-                    rezervirati u <strong>aplikaciji</strong> tijekom narudžbe
-                    branja.
+                    Ovdje možeš vidjeti raspoložive i zatvorene termine za
+                    dostavu ili osobno preuzimanje u sljedećih mjesec dana.
+                    Raspoloživ termin možeš rezervirati u{' '}
+                    <strong>aplikaciji</strong> tijekom narudžbe branja.
                 </Typography>
 
                 <Typography
@@ -238,22 +474,14 @@ export default async function DeliverySlotsPage() {
 
                 <Stack spacing={4}>
                     <Typography level="h4">
-                        Termini dostave na adresu
+                        Termini dostave i preuzimanja
                     </Typography>
                     <Typography level="body2" className="text-muted-foreground">
-                        Dostava se vrši u 2-satnim blokovima na područje Zagreba
-                        i okolice.
+                        Dostava se vrši u 2-satnim blokovima na području Zagreba
+                        i okolice, a osobno preuzimanje na našim lokacijama u
+                        Zagrebu.
                     </Typography>
-                    <SlotsDisplay type="delivery" />
-                </Stack>
-                <Stack spacing={4}>
-                    <Typography level="h4">
-                        Termini osobnog preuzimanja
-                    </Typography>
-                    <Typography level="body2" className="text-muted-foreground">
-                        Osobno preuzimanje na našim lokacijama u Zagrebu.
-                    </Typography>
-                    <SlotsDisplay type="pickup" />
+                    <SlotsDisplay />
                 </Stack>
 
                 <Stack spacing={4}>

--- a/apps/www/app/dostava/termini/slotClosingSoon.node.spec.ts
+++ b/apps/www/app/dostava/termini/slotClosingSoon.node.spec.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getClosingSoonHours } from './slotClosingSoon.ts';
+
+const HOUR_MS = 60 * 60 * 1000;
+const NOW = Date.parse('2026-07-10T08:00:00.000Z');
+
+test('getClosingSoonHours includes open deadlines within the next 48 hours', () => {
+    assert.equal(
+        getClosingSoonHours({
+            effectiveClosesAt: new Date(NOW + 48 * HOUR_MS).toISOString(),
+            now: NOW,
+        }),
+        48,
+    );
+    assert.equal(
+        getClosingSoonHours({
+            effectiveClosesAt: new Date(NOW + 12.25 * HOUR_MS).toISOString(),
+            now: NOW,
+        }),
+        13,
+    );
+});
+
+test('getClosingSoonHours excludes elapsed and later deadlines', () => {
+    assert.equal(
+        getClosingSoonHours({
+            effectiveClosesAt: new Date(NOW).toISOString(),
+            now: NOW,
+        }),
+        null,
+    );
+    assert.equal(
+        getClosingSoonHours({
+            effectiveClosesAt: new Date(NOW + 48 * HOUR_MS + 1).toISOString(),
+            now: NOW,
+        }),
+        null,
+    );
+    assert.equal(
+        getClosingSoonHours({
+            effectiveClosesAt: 'invalid',
+            now: NOW,
+        }),
+        null,
+    );
+});

--- a/apps/www/app/dostava/termini/slotClosingSoon.ts
+++ b/apps/www/app/dostava/termini/slotClosingSoon.ts
@@ -1,0 +1,24 @@
+const HOUR_MS = 60 * 60 * 1000;
+const CLOSING_SOON_WINDOW_MS = 48 * HOUR_MS;
+
+export function getClosingSoonHours({
+    effectiveClosesAt,
+    now,
+}: {
+    effectiveClosesAt: string;
+    now: number;
+}) {
+    const closesAt = new Date(effectiveClosesAt).getTime();
+
+    if (Number.isNaN(closesAt)) {
+        return null;
+    }
+
+    const remainingMs = closesAt - now;
+
+    if (remainingMs <= 0 || remainingMs > CLOSING_SOON_WINDOW_MS) {
+        return null;
+    }
+
+    return Math.ceil(remainingMs / HOUR_MS);
+}

--- a/packages/storage/src/repositories/timeSlotsRepo.ts
+++ b/packages/storage/src/repositories/timeSlotsRepo.ts
@@ -1,10 +1,11 @@
 import 'server-only';
-import { and, asc, desc, eq, gte, lte } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, lte } from 'drizzle-orm';
 import { bustDeliveryRequestsCache } from '../cache/scheduleCache';
 import { assertTimeSlotClosesBeforeStart } from '../helpers/timeSlotAutomation';
 import {
     type InsertTimeSlot,
     type SelectTimeSlot,
+    type TimeSlotStatus,
     TimeSlotStatuses,
     timeSlots,
     type UpdateTimeSlot,
@@ -200,7 +201,7 @@ export interface GetTimeSlotsParams {
     locationId?: number;
     fromDate?: Date;
     toDate?: Date;
-    status?: string;
+    status?: TimeSlotStatus | TimeSlotStatus[];
 }
 
 export async function getTimeSlots(
@@ -214,7 +215,8 @@ export async function getTimeSlots(
         status = TimeSlotStatuses.SCHEDULED,
     } = params;
 
-    const conditions = [eq(timeSlots.status, status)];
+    const statuses = Array.isArray(status) ? status : [status];
+    const conditions = [inArray(timeSlots.status, statuses)];
 
     if (type) {
         conditions.push(eq(timeSlots.type, type));

--- a/packages/storage/tests/timeSlotAutomation.node.spec.ts
+++ b/packages/storage/tests/timeSlotAutomation.node.spec.ts
@@ -6,6 +6,7 @@ import {
     createPickupLocation,
     createTimeSlot,
     getTimeSlot,
+    getTimeSlots,
     TimeSlotStatuses,
 } from '@gredice/storage';
 import { createTestDb } from './testDb';
@@ -86,4 +87,44 @@ test('autoCloseUpcomingSlots honors explicit close dates', async () => {
 
     assert.equal(keptOpenSlot?.status, TimeSlotStatuses.SCHEDULED);
     assert.equal(customClosedSlot?.status, TimeSlotStatuses.CLOSED);
+});
+
+test('getTimeSlots can include scheduled and closed slots without archived slots', async () => {
+    createTestDb();
+
+    const locationId = await createTestLocation();
+    const startsAt = [
+        new Date('2026-08-03T08:00:00.000Z'),
+        new Date('2026-08-03T10:00:00.000Z'),
+        new Date('2026-08-03T12:00:00.000Z'),
+    ];
+    const statuses = [
+        TimeSlotStatuses.SCHEDULED,
+        TimeSlotStatuses.CLOSED,
+        TimeSlotStatuses.ARCHIVED,
+    ];
+
+    const slotIds = await Promise.all(
+        startsAt.map((startAt, index) =>
+            createTimeSlot({
+                locationId,
+                type: 'delivery',
+                startAt,
+                endAt: new Date(startAt.getTime() + 2 * 60 * 60 * 1000),
+                status: statuses[index],
+            }),
+        ),
+    );
+
+    const visibleSlots = await getTimeSlots({
+        locationId,
+        fromDate: new Date('2026-08-03T00:00:00.000Z'),
+        toDate: new Date('2026-08-04T00:00:00.000Z'),
+        status: [TimeSlotStatuses.SCHEDULED, TimeSlotStatuses.CLOSED],
+    });
+
+    assert.deepEqual(
+        visibleSlots.map((slot) => slot.id),
+        slotIds.slice(0, 2),
+    );
 });


### PR DESCRIPTION
## What changed

- extend the public delivery-slot query to one month and include closed and archived slots
- combine delivery and pickup slots into compact week-based sections with icon differentiation
- show empty weeks with a clear placeholder
- render live “Uskoro se zatvara” countdowns inside affected slots
- include the full active week, render prior slots as closed, and mark today with a green badge only

## Why

The previous page started its query at the current timestamp and only returned scheduled slots. That hid earlier slots from the active week and made it harder to understand the schedule in context. Delivery and pickup were also split into separate, crowded lists.

## Impact

Visitors can now scan the complete active week and the following month, distinguish delivery from pickup at a glance, see closed and closing-soon states, and orient themselves using the current-day badge.

## Validation

- `pnpm --filter www typecheck`
- `pnpm --filter api test:node` (172 tests)
- focused storage slot tests (3 tests)
- closing-soon helper tests (2 tests)
- targeted Biome checks and `git diff --check`
- local desktop and mobile browser verification with no console errors or horizontal overflow