### PR TITLE
feat(game): improve delivery slot selection

### DIFF
--- a/apps/status/vercel.json
+++ b/apps/status/vercel.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "installCommand": "pnpm install --frozen-lockfile"
+}

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -32,6 +32,7 @@ const config: StorybookConfig = {
             include: [
                 '../../packages/ui/src/**/*.tsx',
                 '../../packages/game/src/hud/**/*.tsx',
+                '../../packages/game/src/shared-ui/delivery/DeliverySlotPicker.tsx',
                 '../app/components/admin/cards/FactCard.tsx',
                 '../app/components/raised-beds/RaisedBedFieldCard.tsx',
                 '../app/components/shared/ServerActionButton.tsx',

--- a/apps/storybook/stories/packages/game/shared-ui/DeliverySlotPicker.stories.tsx
+++ b/apps/storybook/stories/packages/game/shared-ui/DeliverySlotPicker.stories.tsx
@@ -1,0 +1,204 @@
+import {
+    DeliverySlotPicker,
+    type DeliverySlotPickerProps,
+    type DeliverySlotPickerSlot,
+} from '@packages/game/shared-ui/delivery/DeliverySlotPicker';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+
+const deliveryDates = [
+    '2026-07-06',
+    '2026-07-07',
+    '2026-07-08',
+    '2026-07-09',
+    '2026-07-10',
+    '2026-07-11',
+    '2026-07-13',
+    '2026-07-14',
+    '2026-07-15',
+    '2026-07-16',
+    '2026-07-17',
+    '2026-07-20',
+    '2026-07-21',
+    '2026-07-22',
+    '2026-07-23',
+    '2026-07-24',
+    '2026-07-27',
+    '2026-07-28',
+    '2026-07-29',
+    '2026-07-30',
+    '2026-07-31',
+    '2026-08-03',
+    '2026-08-04',
+    '2026-08-05',
+    '2026-08-06',
+    '2026-08-07',
+];
+
+const pickupDates = [
+    '2026-07-08',
+    '2026-07-11',
+    '2026-07-13',
+    '2026-07-15',
+    '2026-07-20',
+    '2026-07-22',
+    '2026-07-27',
+    '2026-07-29',
+    '2026-08-03',
+    '2026-08-05',
+];
+
+const deliveryTimes = [
+    ['15:00:00.000Z', '17:00:00.000Z'],
+    ['17:00:00.000Z', '19:00:00.000Z'],
+] satisfies ReadonlyArray<readonly [string, string]>;
+
+const pickupTimes = [
+    ['15:00:00.000Z', '17:00:00.000Z'],
+] satisfies ReadonlyArray<readonly [string, string]>;
+
+function createMockSlots(
+    dates: readonly string[],
+    times: ReadonlyArray<readonly [string, string]>,
+    initialId: number,
+    fulfillment: DeliverySlotPickerSlot['fulfillment'],
+): DeliverySlotPickerSlot[] {
+    return dates.flatMap((date, dateIndex) =>
+        times.map(([startTime, endTime], timeIndex) => ({
+            id: initialId + dateIndex * 10 + timeIndex + 1,
+            startAt: `${date}T${startTime}`,
+            endAt: `${date}T${endTime}`,
+            fulfillment,
+        })),
+    );
+}
+
+const deliverySlots = createMockSlots(
+    deliveryDates,
+    deliveryTimes,
+    100,
+    'delivery',
+);
+const pickupSlots = createMockSlots(pickupDates, pickupTimes, 600, 'pickup');
+const mixedSlots = [...deliverySlots, ...pickupSlots].sort(
+    (first, second) =>
+        new Date(first.startAt).getTime() - new Date(second.startAt).getTime(),
+);
+const slotsWithoutCurrentWeekAvailability = mixedSlots.filter(
+    (slot) => !new Date(slot.startAt).toISOString().startsWith('2026-07-11'),
+);
+const slotsWithEmptyWeek = mixedSlots.filter((slot) => {
+    const startAt = new Date(slot.startAt).toISOString();
+    return startAt < '2026-07-20' || startAt >= '2026-07-27';
+});
+
+const meta = {
+    title: 'packages/game/shared-ui/delivery/DeliverySlotPicker',
+    component: DeliverySlotPicker,
+    tags: ['autodocs'],
+    args: {
+        slots: mixedSlots,
+        value: undefined,
+        onValueChange: () => {},
+        referenceDate: '2026-07-10T10:00:00.000Z',
+    },
+    argTypes: {
+        onValueChange: { control: false },
+        value: { control: false },
+    },
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'Interactive date and time picker for in-game delivery or pickup checkout, with week navigation for longer availability windows.',
+            },
+        },
+    },
+    render: (args) => (
+        <div className="w-[40rem] max-w-full rounded-xl border border-border bg-card p-5 shadow-sm">
+            <ControlledDeliverySlotPicker {...args} />
+        </div>
+    ),
+} satisfies Meta<typeof DeliverySlotPicker>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Interactive: Story = {};
+
+export const FourWeeks: Story = {
+    args: {
+        value: 161,
+    },
+};
+
+export const NoSelection: Story = {
+    args: {
+        autoSelectFirstDeliverySlot: false,
+        slots: slotsWithoutCurrentWeekAvailability,
+        value: undefined,
+    },
+};
+
+export const EmptyWeek: Story = {
+    args: {
+        slots: slotsWithEmptyWeek,
+        value: 161,
+    },
+};
+
+export const Pickup: Story = {
+    args: {
+        slots: pickupSlots,
+        value: 611,
+        label: 'Termin preuzimanja',
+        description:
+            'Odaberi dan i vrijeme osobnog preuzimanja na lokaciji Gredice HQ.',
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        loading: true,
+        slots: [],
+        value: undefined,
+    },
+};
+
+export const Empty: Story = {
+    args: {
+        slots: [],
+        value: undefined,
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        disabled: true,
+    },
+};
+
+export const MobileWidth: Story = {
+    args: {
+        value: 151,
+    },
+    parameters: {
+        layout: 'fullscreen',
+    },
+    render: (args) => (
+        <div className="min-h-screen w-full bg-background p-4">
+            <div className="mx-auto w-full max-w-[21rem] rounded-xl border border-border bg-card p-4 shadow-sm">
+                <ControlledDeliverySlotPicker {...args} />
+            </div>
+        </div>
+    ),
+};
+
+function ControlledDeliverySlotPicker(args: DeliverySlotPickerProps) {
+    const [value, setValue] = useState(args.value);
+
+    return (
+        <DeliverySlotPicker {...args} value={value} onValueChange={setValue} />
+    );
+}

--- a/apps/storybook/stories/packages/ui/EventCalendar.stories.tsx
+++ b/apps/storybook/stories/packages/ui/EventCalendar.stories.tsx
@@ -52,6 +52,27 @@ const entries: EventCalendarEntry[] = [
     },
 ];
 
+const selectedTodayEntries: EventCalendarEntry[] = [
+    {
+        id: 'today-completed',
+        date: referenceDate,
+        label: 'Obavljeno zalijevanje',
+        tone: 'completed',
+    },
+    {
+        id: 'today-scheduled',
+        date: referenceDate,
+        label: 'Planirano zalijevanje',
+        tone: 'scheduled',
+    },
+    {
+        id: 'today-cart',
+        date: referenceDate,
+        label: 'Zalijevanje u košari',
+        tone: 'cart',
+    },
+];
+
 function SelectableScheduleStory(args: ComponentProps<typeof EventCalendar>) {
     const [selectedDate, setSelectedDate] = useState(
         new Date('2026-06-20T00:00:00.000Z'),
@@ -110,4 +131,14 @@ export const Timeline: Story = {
 export const SelectableSchedule: Story = {
     name: 'Selectable schedule',
     render: SelectableScheduleStory,
+};
+
+export const SelectedTodayWithEntries: Story = {
+    name: 'Selected today with entries',
+    args: {
+        entries: selectedTodayEntries,
+        selectedDate: referenceDate,
+        visibleFrom: new Date('2026-06-01T00:00:00.000Z'),
+        visibleTo: new Date('2026-06-30T23:59:59.999Z'),
+    },
 };

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -40,6 +40,7 @@
         "../../packages/ui/src/**/*.tsx",
         "../../packages/game/src/hud/**/*.ts",
         "../../packages/game/src/hud/**/*.tsx",
+        "../../packages/game/src/shared-ui/delivery/DeliverySlotPicker.tsx",
         "../../packages/game/src/utils/raisedBedFields.ts",
         "../app/components/admin/cards/FactCard.tsx",
         "../app/components/raised-beds/RaisedBedFieldCard.tsx",

--- a/packages/game/src/hud/ShoppingCartHud.tsx
+++ b/packages/game/src/hud/ShoppingCartHud.tsx
@@ -6,6 +6,7 @@ import {
     Info,
     Navigate,
     ShoppingCart as ShoppingCartIcon,
+    Truck,
 } from '@gredice/ui/icons';
 import { ModalConfirm } from '@gredice/ui/ModalConfirm';
 import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
@@ -34,7 +35,15 @@ import { HudCard } from './components/HudCard';
 import { ButtonConfirmPayment } from './components/shopping-cart/ButtonConfirmPayment';
 import { ShoppingCartItem } from './components/shopping-cart/ShoppingCartItem';
 
-export function ShoppingCart() {
+interface ShoppingCartProps {
+    showDeliveryStep: boolean;
+    onShowDeliveryStepChange: (showDeliveryStep: boolean) => void;
+}
+
+export function ShoppingCart({
+    showDeliveryStep,
+    onShowDeliveryStepChange,
+}: ShoppingCartProps) {
     const { data: account } = useCurrentAccount();
     const { data: cart, isLoading, isError } = useShoppingCart();
     const { track } = useGameAnalytics();
@@ -42,7 +51,6 @@ export function ShoppingCart() {
     const checkout = useCheckout();
 
     // State for delivery flow
-    const [showDeliveryStep, setShowDeliveryStep] = useState(false);
     const [deliverySelection, setDeliverySelection] =
         useState<DeliverySelectionData | null>(null);
 
@@ -69,7 +77,7 @@ export function ShoppingCart() {
                 item_count: cart.items.length,
                 total: cart.total,
             });
-            setShowDeliveryStep(true);
+            onShowDeliveryStepChange(true);
             return;
         }
 
@@ -100,7 +108,7 @@ export function ShoppingCart() {
     }
 
     function handleBackToCart() {
-        setShowDeliveryStep(false);
+        onShowDeliveryStepChange(false);
     }
 
     function handleDelivery() {
@@ -108,7 +116,7 @@ export function ShoppingCart() {
             item_count: cart?.items.length,
             total: cart?.total,
         });
-        setShowDeliveryStep(true);
+        onShowDeliveryStepChange(true);
     }
 
     function handleDeliveryProceed() {
@@ -284,6 +292,7 @@ export function ShoppingCartHud() {
     const { data: cart } = useShoppingCart();
     const { track } = useGameAnalytics();
     const [isOpen, setIsOpen] = useShoppingCartOpenParam();
+    const [showDeliveryStep, setShowDeliveryStep] = useState(false);
     const showTransientHub = useShoppingCartTransientHub(isOpen);
 
     if (!cart?.items.length && !showTransientHub) {
@@ -304,10 +313,14 @@ export function ShoppingCartHud() {
                         }
                         setIsOpen(open);
                     }}
-                    title="Košara"
+                    title={showDeliveryStep ? 'Dostava' : 'Košara'}
                     className="md:max-w-2xl"
                     headerIcon={
-                        <ShoppingCartIcon className="size-7 shrink-0" />
+                        showDeliveryStep ? (
+                            <Truck className="size-7 shrink-0" />
+                        ) : (
+                            <ShoppingCartIcon className="size-7 shrink-0" />
+                        )
                     }
                     hudLayer
                     trigger={
@@ -341,7 +354,10 @@ export function ShoppingCartHud() {
                         </Button>
                     }
                 >
-                    <ShoppingCart />
+                    <ShoppingCart
+                        showDeliveryStep={showDeliveryStep}
+                        onShowDeliveryStepChange={setShowDeliveryStep}
+                    />
                 </GameModal>
             </Row>
         </HudCard>

--- a/packages/game/src/shared-ui/delivery/DeliverySlotPicker.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliverySlotPicker.tsx
@@ -1,0 +1,636 @@
+'use client';
+
+import { IconButton } from '@gredice/ui/IconButton';
+import {
+    ArrowLeft,
+    ArrowRight,
+    Calendar,
+    Check,
+    MapPin,
+    Truck,
+} from '@gredice/ui/icons';
+import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
+import { Skeleton } from '@gredice/ui/Skeleton';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+
+const LOADING_DAY_KEYS = ['first', 'second', 'third', 'fourth'];
+
+export interface DeliverySlotPickerSlot {
+    id: number;
+    startAt: Date | string;
+    endAt: Date | string;
+    fulfillment: 'delivery' | 'pickup';
+}
+
+export interface DeliverySlotPickerProps {
+    slots: readonly DeliverySlotPickerSlot[];
+    value?: number;
+    onValueChange: (slotId: number | undefined) => void;
+    label?: string | null;
+    description?: string;
+    emptyMessage?: string;
+    locale?: string;
+    timeZone?: string;
+    referenceDate?: Date | string;
+    autoFocus?: boolean;
+    autoSelectFirstDeliverySlot?: boolean;
+    loading?: boolean;
+    disabled?: boolean;
+    className?: string;
+}
+
+interface SlotDay {
+    key: string;
+    date: Date;
+    slots: DeliverySlotPickerSlot[];
+}
+
+interface SlotWeek {
+    key: string;
+    startAt: Date;
+    endAt: Date;
+    days: SlotDay[];
+}
+
+function dateKey(formatter: Intl.DateTimeFormat, date: Date) {
+    const parts = new Map(
+        formatter.formatToParts(date).map(({ type, value }) => [type, value]),
+    );
+
+    return `${parts.get('year')}-${parts.get('month')}-${parts.get('day')}`;
+}
+
+function startOfWeek(formatter: Intl.DateTimeFormat, date: Date) {
+    const weekStart = new Date(`${dateKey(formatter, date)}T12:00:00.000Z`);
+    const daysFromMonday = (weekStart.getUTCDay() + 6) % 7;
+    weekStart.setUTCDate(weekStart.getUTCDate() - daysFromMonday);
+    return weekStart;
+}
+
+function weekKey(formatter: Intl.DateTimeFormat, date: Date) {
+    return dateKey(formatter, startOfWeek(formatter, date));
+}
+
+function slotCountLabel(count: number) {
+    return count === 1 ? '1 termin' : `${count.toString()} termina`;
+}
+
+export function DeliverySlotPicker({
+    slots,
+    value,
+    onValueChange,
+    label = 'Termin dostave',
+    description = 'Prvo odaberi dan, a zatim vrijeme koje ti najviše odgovara.',
+    emptyMessage = 'Trenutno nema dostupnih termina za odabrani način dostave.',
+    locale = 'hr-HR',
+    timeZone = 'Europe/Zagreb',
+    referenceDate,
+    autoFocus = true,
+    autoSelectFirstDeliverySlot = true,
+    loading = false,
+    disabled = false,
+    className,
+}: DeliverySlotPickerProps) {
+    const labelId = useId();
+    const [initialDate] = useState(() => new Date());
+    const formatters = useMemo(
+        () => ({
+            dateKey: new Intl.DateTimeFormat('en-US', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric',
+                timeZone,
+            }),
+            dayNumber: new Intl.DateTimeFormat(locale, {
+                day: 'numeric',
+                timeZone,
+            }),
+            fullDate: new Intl.DateTimeFormat(locale, {
+                day: 'numeric',
+                month: 'long',
+                weekday: 'long',
+                timeZone,
+            }),
+            month: new Intl.DateTimeFormat(locale, {
+                month: 'short',
+                timeZone,
+            }),
+            time: new Intl.DateTimeFormat(locale, {
+                hour: '2-digit',
+                hour12: false,
+                minute: '2-digit',
+                timeZone,
+            }),
+            weekEnd: new Intl.DateTimeFormat(locale, {
+                day: 'numeric',
+                month: 'short',
+                year: 'numeric',
+                timeZone,
+            }),
+            weekStart: new Intl.DateTimeFormat(locale, {
+                day: 'numeric',
+                month: 'short',
+                timeZone,
+            }),
+            weekday: new Intl.DateTimeFormat(locale, {
+                weekday: 'short',
+                timeZone,
+            }),
+        }),
+        [locale, timeZone],
+    );
+    const todayKey = dateKey(
+        formatters.dateKey,
+        referenceDate ? new Date(referenceDate) : initialDate,
+    );
+    const days = useMemo(() => {
+        const groupedDays = new Map<string, SlotDay>();
+
+        for (const slot of [...slots].sort(
+            (first, second) =>
+                new Date(first.startAt).getTime() -
+                new Date(second.startAt).getTime(),
+        )) {
+            const date = new Date(slot.startAt);
+            const key = dateKey(formatters.dateKey, date);
+            const existingDay = groupedDays.get(key);
+
+            if (existingDay) {
+                existingDay.slots.push(slot);
+            } else {
+                groupedDays.set(key, { key, date, slots: [slot] });
+            }
+        }
+
+        return [...groupedDays.values()];
+    }, [formatters.dateKey, slots]);
+    const weeks = useMemo(() => {
+        const groupedWeeks = new Map<string, SlotWeek>();
+
+        for (const day of days) {
+            const weekStart = startOfWeek(formatters.dateKey, day.date);
+            const key = dateKey(formatters.dateKey, weekStart);
+            const existingWeek = groupedWeeks.get(key);
+
+            if (existingWeek) {
+                existingWeek.days.push(day);
+            } else {
+                const weekEnd = new Date(weekStart);
+                weekEnd.setUTCDate(weekEnd.getUTCDate() + 6);
+                groupedWeeks.set(key, {
+                    key,
+                    startAt: weekStart,
+                    endAt: weekEnd,
+                    days: [day],
+                });
+            }
+        }
+
+        const populatedWeeks = [...groupedWeeks.values()];
+        const firstWeek = populatedWeeks[0];
+        const lastWeek = populatedWeeks[populatedWeeks.length - 1];
+
+        if (!firstWeek || !lastWeek) {
+            return [];
+        }
+
+        const continuousWeeks: SlotWeek[] = [];
+        const cursor = new Date(firstWeek.startAt);
+
+        while (cursor.getTime() <= lastWeek.startAt.getTime()) {
+            const key = dateKey(formatters.dateKey, cursor);
+            const populatedWeek = groupedWeeks.get(key);
+
+            if (populatedWeek) {
+                continuousWeeks.push(populatedWeek);
+            } else {
+                const startAt = new Date(cursor);
+                const endAt = new Date(cursor);
+                endAt.setUTCDate(endAt.getUTCDate() + 6);
+                continuousWeeks.push({ key, startAt, endAt, days: [] });
+            }
+
+            cursor.setUTCDate(cursor.getUTCDate() + 7);
+        }
+
+        return continuousWeeks;
+    }, [days, formatters.dateKey]);
+    const selectedSlot = slots.find((slot) => slot.id === value);
+    const selectedSlotDate = selectedSlot
+        ? new Date(selectedSlot.startAt)
+        : undefined;
+    const selectedSlotDayKey = selectedSlotDate
+        ? dateKey(formatters.dateKey, selectedSlotDate)
+        : undefined;
+    const availableSelectedSlotDayKey =
+        selectedSlotDayKey && selectedSlotDayKey > todayKey
+            ? selectedSlotDayKey
+            : undefined;
+    const selectedSlotWeekKey =
+        selectedSlotDate && availableSelectedSlotDayKey
+            ? weekKey(formatters.dateKey, selectedSlotDate)
+            : undefined;
+    const [preferredWeekKey, setPreferredWeekKey] = useState<string>();
+    const [preferredDayKey, setPreferredDayKey] = useState<string>();
+    const firstAvailableWeekKey = weeks.find((week) =>
+        week.days.some(
+            (day) =>
+                day.key > todayKey &&
+                day.slots.some((slot) => slot.fulfillment === 'delivery'),
+        ),
+    )?.key;
+    const firstFutureWeekKey = weeks.find((week) =>
+        week.days.some((day) => day.key > todayKey),
+    )?.key;
+    const selectedWeekKey =
+        selectedSlotWeekKey ??
+        weeks.find((week) => week.key === preferredWeekKey)?.key ??
+        (autoSelectFirstDeliverySlot
+            ? firstAvailableWeekKey
+            : firstFutureWeekKey) ??
+        firstFutureWeekKey ??
+        weeks[0]?.key;
+    const selectedWeekIndex = Math.max(
+        weeks.findIndex((week) => week.key === selectedWeekKey),
+        0,
+    );
+    const selectedWeek = weeks[selectedWeekIndex];
+    const selectedDayKey =
+        availableSelectedSlotDayKey ??
+        selectedWeek?.days.find(
+            (day) => day.key === preferredDayKey && day.key > todayKey,
+        )?.key ??
+        (autoSelectFirstDeliverySlot
+            ? selectedWeek?.days.find(
+                  (day) =>
+                      day.key > todayKey &&
+                      day.slots.some((slot) => slot.fulfillment === 'delivery'),
+              )?.key
+            : undefined) ??
+        selectedWeek?.days.find((day) => day.key > todayKey)?.key;
+    const selectedDay = selectedWeek?.days.find(
+        (day) => day.key === selectedDayKey,
+    );
+    const focusTargetKey = availableSelectedSlotDayKey
+        ? `slot-${value?.toString()}`
+        : selectedDayKey
+          ? `day-${selectedDayKey}`
+          : undefined;
+    const focusTargetRef = useRef<HTMLButtonElement>(null);
+    const autoSelectedSlotRef = useRef<number | undefined>(undefined);
+    const firstAvailableDeliverySlotId = selectedDay?.slots.find(
+        (slot) => slot.fulfillment === 'delivery',
+    )?.id;
+
+    useEffect(() => {
+        if (value !== undefined) {
+            autoSelectedSlotRef.current = undefined;
+            return;
+        }
+
+        if (
+            !autoSelectFirstDeliverySlot ||
+            disabled ||
+            firstAvailableDeliverySlotId === undefined ||
+            autoSelectedSlotRef.current === firstAvailableDeliverySlotId
+        ) {
+            return;
+        }
+
+        autoSelectedSlotRef.current = firstAvailableDeliverySlotId;
+        onValueChange(firstAvailableDeliverySlotId);
+    }, [
+        autoSelectFirstDeliverySlot,
+        disabled,
+        firstAvailableDeliverySlotId,
+        onValueChange,
+        value,
+    ]);
+
+    useEffect(() => {
+        if (autoFocus && !disabled && focusTargetKey) {
+            focusTargetRef.current?.focus();
+        }
+    }, [autoFocus, disabled, focusTargetKey]);
+
+    function selectWeek(nextWeekIndex: number) {
+        const nextWeek = weeks[nextWeekIndex];
+
+        if (!nextWeek) {
+            return;
+        }
+
+        setPreferredWeekKey(nextWeek.key);
+        setPreferredDayKey(
+            (autoSelectFirstDeliverySlot
+                ? nextWeek.days.find(
+                      (day) =>
+                          day.key > todayKey &&
+                          day.slots.some(
+                              (slot) => slot.fulfillment === 'delivery',
+                          ),
+                  )?.key
+                : undefined) ??
+                nextWeek.days.find((day) => day.key > todayKey)?.key,
+        );
+
+        if (selectedSlotWeekKey && selectedSlotWeekKey !== nextWeek.key) {
+            onValueChange(undefined);
+        }
+    }
+
+    return (
+        <section
+            aria-label={label ? undefined : description}
+            aria-labelledby={label ? labelId : undefined}
+            className={cx('w-full min-w-0', className)}
+        >
+            <div className="mb-3">
+                {label && (
+                    <Typography id={labelId} level="h6" semiBold>
+                        {label}
+                    </Typography>
+                )}
+                <Typography level="body2" className="text-foreground/70">
+                    {description}
+                </Typography>
+            </div>
+
+            {loading ? (
+                <div
+                    aria-label="Učitavanje termina"
+                    className="space-y-4"
+                    role="status"
+                >
+                    <Skeleton className="mx-auto h-9 w-56" />
+                    <div className="flex gap-2 overflow-hidden">
+                        {LOADING_DAY_KEYS.map((key) => (
+                            <Skeleton
+                                key={key}
+                                className="h-[5.5rem] min-w-[5rem] grow"
+                            />
+                        ))}
+                    </div>
+                    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                        <Skeleton className="h-12" />
+                        <Skeleton className="h-12" />
+                        <Skeleton className="h-12" />
+                    </div>
+                </div>
+            ) : weeks.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border bg-muted/30 px-5 py-8">
+                    <Calendar
+                        aria-hidden
+                        className="mx-auto mb-3 size-6 text-muted-foreground"
+                    />
+                    <NoDataPlaceholder>{emptyMessage}</NoDataPlaceholder>
+                </div>
+            ) : (
+                <div className="space-y-5">
+                    {weeks.length > 1 && selectedWeek && (
+                        <nav
+                            aria-label="Tjedni termini"
+                            className="flex items-center justify-between gap-3 rounded-lg bg-muted/40 px-1.5 py-1"
+                        >
+                            <IconButton
+                                aria-label="Prikaži prethodni tjedan"
+                                disabled={disabled || selectedWeekIndex === 0}
+                                onClick={() =>
+                                    selectWeek(selectedWeekIndex - 1)
+                                }
+                                size="sm"
+                                variant="plain"
+                            >
+                                <ArrowLeft className="size-4" />
+                            </IconButton>
+                            <div className="min-w-0 text-center">
+                                <p className="m-0 truncate text-sm font-semibold text-foreground">
+                                    Tjedan{' '}
+                                    {formatters.weekStart.format(
+                                        selectedWeek.startAt,
+                                    )}{' '}
+                                    –{' '}
+                                    {formatters.weekEnd.format(
+                                        selectedWeek.endAt,
+                                    )}
+                                </p>
+                                <p className="m-0 text-[0.65rem] text-foreground/70">
+                                    {(selectedWeekIndex + 1).toString()} od{' '}
+                                    {weeks.length.toString()}
+                                </p>
+                            </div>
+                            <IconButton
+                                aria-label="Prikaži sljedeći tjedan"
+                                disabled={
+                                    disabled ||
+                                    selectedWeekIndex === weeks.length - 1
+                                }
+                                onClick={() =>
+                                    selectWeek(selectedWeekIndex + 1)
+                                }
+                                size="sm"
+                                variant="plain"
+                            >
+                                <ArrowRight className="size-4" />
+                            </IconButton>
+                        </nav>
+                    )}
+
+                    {selectedWeek && selectedWeek.days.length > 0 ? (
+                        <fieldset
+                            className="m-0 flex min-w-0 gap-2 overflow-x-auto border-0 p-0 pb-1"
+                            disabled={disabled}
+                        >
+                            <legend className="sr-only">Odaberi dan</legend>
+                            {selectedWeek.days.map((day) => {
+                                const isSelected = day.key === selectedDay?.key;
+                                const isToday = day.key === todayKey;
+                                const isUnavailable = day.key <= todayKey;
+
+                                return (
+                                    <button
+                                        key={day.key}
+                                        aria-current={
+                                            isToday ? 'date' : undefined
+                                        }
+                                        aria-label={`${formatters.fullDate.format(day.date)}, ${slotCountLabel(day.slots.length)}${isToday ? ', danas' : ''}${isUnavailable ? ', nije dostupno' : ''}`}
+                                        aria-pressed={isSelected}
+                                        className={cx(
+                                            'relative flex min-h-[5.5rem] min-w-[5rem] flex-1 flex-col items-center justify-center rounded-lg border px-2.5 py-2 text-center transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed',
+                                            isSelected
+                                                ? 'border-primary bg-primary/10 text-primary ring-1 ring-inset ring-primary/40'
+                                                : 'border-border bg-background text-foreground hover:border-primary/50 hover:bg-muted/50',
+                                            isUnavailable &&
+                                                'border-border/60 bg-muted/30 text-foreground/50 hover:border-border/60 hover:bg-muted/30',
+                                        )}
+                                        disabled={disabled || isUnavailable}
+                                        ref={
+                                            !availableSelectedSlotDayKey &&
+                                            isSelected
+                                                ? focusTargetRef
+                                                : undefined
+                                        }
+                                        onClick={() => {
+                                            setPreferredDayKey(day.key);
+
+                                            if (
+                                                selectedSlotDayKey &&
+                                                selectedSlotDayKey !== day.key
+                                            ) {
+                                                onValueChange(undefined);
+                                            }
+                                        }}
+                                        type="button"
+                                    >
+                                        {isToday && (
+                                            <span className="absolute left-1.5 top-1.5 rounded-full bg-primary px-1.5 py-0.5 text-[0.5rem] font-bold uppercase tracking-wide text-primary-foreground">
+                                                Danas
+                                            </span>
+                                        )}
+                                        <span
+                                            aria-hidden
+                                            className={cx(
+                                                'absolute right-1.5 top-1.5 flex size-5 items-center justify-center rounded-full bg-muted text-[0.6rem] font-bold text-foreground/70',
+                                                isSelected &&
+                                                    'bg-primary text-primary-foreground',
+                                                isUnavailable &&
+                                                    'bg-muted-foreground/10 text-foreground/50',
+                                            )}
+                                        >
+                                            {day.slots.length}
+                                        </span>
+                                        <span className="text-[0.65rem] font-bold uppercase tracking-wide">
+                                            {formatters.weekday.format(
+                                                day.date,
+                                            )}
+                                        </span>
+                                        <span className="text-xl font-bold leading-tight">
+                                            {formatters.dayNumber.format(
+                                                day.date,
+                                            )}
+                                        </span>
+                                        <span className="text-[0.65rem] text-foreground/70">
+                                            {formatters.month.format(day.date)}
+                                        </span>
+                                    </button>
+                                );
+                            })}
+                        </fieldset>
+                    ) : (
+                        <div className="rounded-lg border border-dashed border-border bg-muted/30 px-5 py-7 text-center">
+                            <Calendar
+                                aria-hidden
+                                className="mx-auto mb-3 size-6 text-muted-foreground"
+                            />
+                            <NoDataPlaceholder>
+                                Nema planiranih ni otvorenih termina dostave ili
+                                osobnog preuzimanja za ovaj tjedan.
+                            </NoDataPlaceholder>
+                        </div>
+                    )}
+
+                    {selectedDay && (
+                        <div className="pt-1">
+                            <div className="mb-3 flex items-center justify-between gap-3">
+                                <Typography level="body2" semiBold>
+                                    Dostupna vremena
+                                </Typography>
+                                <Typography
+                                    level="body3"
+                                    className="text-right capitalize text-foreground/70"
+                                >
+                                    {formatters.fullDate.format(
+                                        selectedDay.date,
+                                    )}
+                                </Typography>
+                            </div>
+                            <fieldset
+                                className="m-0 grid min-w-0 grid-cols-2 gap-2 border-0 p-0 sm:grid-cols-3"
+                                disabled={disabled}
+                            >
+                                <legend className="sr-only">
+                                    Odaberi vrijeme za{' '}
+                                    {formatters.fullDate.format(
+                                        selectedDay.date,
+                                    )}
+                                </legend>
+                                {selectedDay.slots.map((slot) => {
+                                    const isSelected = slot.id === value;
+                                    const FulfillmentIcon =
+                                        slot.fulfillment === 'delivery'
+                                            ? Truck
+                                            : MapPin;
+                                    const fulfillmentLabel =
+                                        slot.fulfillment === 'delivery'
+                                            ? 'Dostava'
+                                            : 'Preuzimanje';
+
+                                    return (
+                                        <button
+                                            key={slot.id}
+                                            aria-pressed={isSelected}
+                                            className={cx(
+                                                'flex min-h-14 items-center gap-2 rounded-lg border px-3 py-2 text-sm tabular-nums transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+                                                isSelected
+                                                    ? 'border-primary bg-primary/10 text-primary ring-1 ring-inset ring-primary/40'
+                                                    : 'border-border bg-background text-foreground hover:border-primary/60 hover:bg-primary/5',
+                                            )}
+                                            disabled={disabled}
+                                            ref={
+                                                isSelected
+                                                    ? focusTargetRef
+                                                    : undefined
+                                            }
+                                            onClick={() =>
+                                                onValueChange(slot.id)
+                                            }
+                                            type="button"
+                                        >
+                                            <FulfillmentIcon
+                                                aria-hidden
+                                                className={cx(
+                                                    'size-4 shrink-0',
+                                                    !isSelected &&
+                                                        'text-muted-foreground',
+                                                )}
+                                            />
+                                            <span className="min-w-0 flex-1 text-left">
+                                                <span className="block whitespace-nowrap font-semibold">
+                                                    {formatters.time.format(
+                                                        new Date(slot.startAt),
+                                                    )}{' '}
+                                                    –{' '}
+                                                    {formatters.time.format(
+                                                        new Date(slot.endAt),
+                                                    )}
+                                                </span>
+                                                <span
+                                                    className={cx(
+                                                        'block text-[0.65rem] font-medium',
+                                                        isSelected
+                                                            ? 'text-primary/80'
+                                                            : 'text-foreground/70',
+                                                    )}
+                                                >
+                                                    {fulfillmentLabel}
+                                                </span>
+                                            </span>
+                                            {isSelected && (
+                                                <Check
+                                                    aria-hidden
+                                                    className="size-4 shrink-0"
+                                                />
+                                            )}
+                                        </button>
+                                    );
+                                })}
+                            </fieldset>
+                        </div>
+                    )}
+                </div>
+            )}
+        </section>
+    );
+}

--- a/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryStep.tsx
@@ -1,33 +1,24 @@
 import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
-import { Card, CardContent } from '@gredice/ui/Card';
 import { IconButton } from '@gredice/ui/IconButton';
-import {
-    Edit,
-    Map as MapIcon,
-    Navigate,
-    ShoppingCart,
-    Truck,
-} from '@gredice/ui/icons';
+import { Edit, Info, Navigate } from '@gredice/ui/icons';
 import { NoDataPlaceholder } from '@gredice/ui/NoDataPlaceholder';
 import { Row } from '@gredice/ui/Row';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Typography } from '@gredice/ui/Typography';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { useCheckout } from '../../hooks/useCheckout';
 import { useDeliveryAddresses } from '../../hooks/useDeliveryAddresses';
-import { usePickupLocations } from '../../hooks/usePickupLocations';
 import { useShoppingCart } from '../../hooks/useShoppingCart';
-import { type TimeSlotData, useTimeSlots } from '../../hooks/useTimeSlots';
+import { useTimeSlots } from '../../hooks/useTimeSlots';
 import { ButtonConfirmPayment } from '../../hud/components/shopping-cart/ButtonConfirmPayment';
-import { KnownPages } from '../../knownPages';
+import { DeliveryAddressesSection } from './DeliveryAddressesSection';
 import {
-    AddressCard,
-    DeliveryAddressesSection,
-} from './DeliveryAddressesSection';
+    DeliverySlotPicker,
+    type DeliverySlotPickerSlot,
+} from './DeliverySlotPicker';
 
 export interface DeliverySelectionData {
     mode: 'delivery' | 'pickup';
@@ -56,93 +47,121 @@ export function DeliveryStep({
         mode: 'delivery',
     });
     const [manageAddresses, setManageAddresses] = useState(false);
-    const { data: cart } = useShoppingCart();
+    const [slotRange] = useState(() => {
+        const from = new Date();
+        const daysFromMonday = (from.getDay() + 6) % 7;
+        from.setDate(from.getDate() - daysFromMonday);
+        from.setHours(0, 0, 0, 0);
 
+        const to = new Date();
+        to.setMonth(to.getMonth() + 1);
+
+        return {
+            from: from.toISOString(),
+            to: to.toISOString(),
+        };
+    });
+    const { data: cart } = useShoppingCart();
     const { data: addresses, isLoading: isLoadingAddresses } =
         useDeliveryAddresses();
-    const { data: pickupLocations } = usePickupLocations();
+    const { data: timeSlots, isLoading: slotsLoading } =
+        useTimeSlots(slotRange);
+    const pickerSlots = useMemo<DeliverySlotPickerSlot[]>(
+        () =>
+            (timeSlots ?? []).flatMap((slot) => {
+                if (slot.type !== 'delivery' && slot.type !== 'pickup') {
+                    return [];
+                }
 
-    // Get available slots based on current selection
-    const { data: timeSlots, isLoading: slotsLoading } = useTimeSlots({
-        type: selection.mode,
-        locationId:
-            selection.mode === 'pickup' ? selection.locationId : undefined,
-        from: new Date().toISOString(),
-        to: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString(), // Next 14 days
-    });
+                return [
+                    {
+                        id: slot.id,
+                        startAt: slot.startAt,
+                        endAt: slot.endAt,
+                        fulfillment: slot.type,
+                    },
+                ];
+            }),
+        [timeSlots],
+    );
+    const selectedTimeSlot = timeSlots?.find(
+        (slot) => slot.id === selection.slotId,
+    );
 
     useEffect(() => {
         if (
-            !isLoadingAddresses &&
-            addresses &&
-            addresses.length > 0 &&
-            !selection.addressId
+            selectedTimeSlot?.type !== 'delivery' ||
+            isLoadingAddresses ||
+            !addresses?.length ||
+            addresses.some((address) => address.id === selection.addressId)
         ) {
-            const defaultAddress =
-                addresses.find((a) => a.isDefault) || addresses[0];
-            setSelection((prev) => ({
-                ...prev,
-                addressId: defaultAddress.id,
-            }));
+            return;
         }
-    }, [addresses, isLoadingAddresses, selection.addressId]);
 
-    // Update parent component when selection changes
+        const defaultAddress =
+            addresses.find((address) => address.isDefault) ?? addresses[0];
+
+        setSelection((previous) => ({
+            ...previous,
+            addressId: defaultAddress.id,
+        }));
+    }, [
+        addresses,
+        isLoadingAddresses,
+        selectedTimeSlot?.type,
+        selection.addressId,
+    ]);
+
     useEffect(() => {
         const isComplete =
-            selection.slotId &&
+            typeof selection.slotId === 'number' &&
             (selection.mode === 'delivery'
-                ? selection.addressId
-                : selection.locationId);
+                ? typeof selection.addressId === 'number'
+                : typeof selection.locationId === 'number');
 
         onSelectionChange(isComplete ? selection : null);
     }, [selection, onSelectionChange]);
 
-    const handleModeChange = (mode: 'delivery' | 'pickup') => {
-        setSelection({
-            mode,
-            // Reset mode-specific selections
-            addressId: undefined,
+    function handleSlotChange(slotId: number | undefined) {
+        if (slotId === undefined) {
+            setSelection((previous) => ({
+                ...previous,
+                slotId: undefined,
+            }));
+            return;
+        }
+
+        const slot = timeSlots?.find((candidate) => candidate.id === slotId);
+
+        if (!slot || (slot.type !== 'delivery' && slot.type !== 'pickup')) {
+            return;
+        }
+
+        setSelection((previous) =>
+            slot.type === 'delivery'
+                ? {
+                      ...previous,
+                      mode: 'delivery',
+                      slotId,
+                      locationId: undefined,
+                  }
+                : {
+                      ...previous,
+                      mode: 'pickup',
+                      slotId,
+                      addressId: undefined,
+                      locationId: slot.locationId,
+                  },
+        );
+    }
+
+    function handleAddressChange(addressId: number) {
+        setSelection((previous) => ({
+            ...previous,
+            addressId,
             locationId: undefined,
-            slotId: undefined,
-            notes: selection.notes,
-        });
-    };
-
-    const handleAddressChange = (addressId: number) => {
-        setSelection((prev) => ({ ...prev, addressId, locationId: undefined }));
-    };
-
-    const handleLocationChange = (locationId: number) => {
-        setSelection((prev) => ({ ...prev, locationId, addressId: undefined }));
-    };
-
-    const handleSlotChange = (slotId: number) => {
-        setSelection((prev) => ({ ...prev, slotId }));
-    };
-
-    const formatSlotTime = (slot: TimeSlotData) => {
-        const start = new Date(slot.startAt);
-        const end = new Date(slot.endAt);
-
-        const dayOfWeek = start.toLocaleDateString('hr-HR', {
-            weekday: 'long',
-        });
-        const capitalizedDayOfWeek =
-            dayOfWeek.charAt(0).toUpperCase() + dayOfWeek.slice(1);
-
-        const datePart = start.toLocaleDateString('hr-HR');
-        const timePartStart = start.toLocaleTimeString('hr-HR', {
-            hour: '2-digit',
-            minute: '2-digit',
-        });
-        const timePartEnd = end.toLocaleTimeString('hr-HR', {
-            hour: '2-digit',
-            minute: '2-digit',
-        });
-
-        return `${capitalizedDayOfWeek}, ${datePart} ${timePartStart} - ${timePartEnd}`;
-    };
+        }));
+    }
 
     if (manageAddresses) {
         return (
@@ -153,262 +172,83 @@ export function DeliveryStep({
                         variant="plain"
                         onClick={() => setManageAddresses(false)}
                     >
-                        <Navigate className="size-5 rotate-180 shrink-0" />
+                        <Navigate className="size-5 shrink-0 rotate-180" />
                     </IconButton>
                     <Typography level="h3">Upravljanje adresama</Typography>
                 </Row>
-                <div className="overflow-y-auto max-h-[50vh]">
+                <div className="max-h-[50vh] overflow-y-auto">
                     <DeliveryAddressesSection />
                 </div>
             </Stack>
         );
     }
 
-    const selectedAddress = addresses?.find(
-        (a) => a.id === selection.addressId,
-    );
-
     return (
-        <Stack spacing={4}>
-            <Typography level="h3">Način dostave</Typography>
+        <Stack spacing={6}>
+            <DeliverySlotPicker
+                description="Odaberi termin dostave ili osobnog preuzimanja."
+                emptyMessage="Trenutno nema dostupnih termina dostave ili osobnog preuzimanja."
+                label={null}
+                loading={slotsLoading}
+                slots={pickerSlots}
+                value={selection.slotId}
+                onValueChange={handleSlotChange}
+            />
 
-            <Alert color="info">
-                Tvoja košara sadrži radnje koje zahtijevaju dostavu ili
-                preuzimanje.
-            </Alert>
-
-            {/* Mode Selection */}
-            <Stack spacing={4}>
-                <Tabs
-                    value={selection.mode}
-                    onValueChange={(value: string) =>
-                        handleModeChange(value as 'delivery' | 'pickup')
-                    }
+            {selectedTimeSlot?.type === 'pickup' && (
+                <Alert
+                    color="warning"
+                    startDecorator={<Info className="size-5 shrink-0" />}
                 >
-                    <TabsList className="grid w-full grid-cols-2 border">
-                        <TabsTrigger
-                            value="delivery"
-                            className="flex items-center gap-2"
-                        >
-                            <Truck className="size-4" />
-                            Dostava
-                        </TabsTrigger>
-                        <TabsTrigger
-                            value="pickup"
-                            className="flex items-center gap-2"
-                        >
-                            <ShoppingCart className="size-4" />
-                            Preuzimanje
-                        </TabsTrigger>
-                    </TabsList>
-
-                    <TabsContent value="delivery" className="mt-4">
-                        <Stack spacing={6}>
-                            <Stack spacing={4}>
-                                <Stack spacing={2}>
-                                    <Row spacing={2}>
-                                        {isLoadingAddresses ? (
-                                            <Skeleton className="h-10 w-full rounded-md" />
-                                        ) : addresses &&
-                                          addresses.length > 0 ? (
-                                            <SelectItems
-                                                label="Adresa za dostavu"
-                                                placeholder="Odaberi adresu..."
-                                                className="w-full"
-                                                defaultValue={
-                                                    addresses
-                                                        .find(
-                                                            (a) => a.isDefault,
-                                                        )
-                                                        ?.id.toString() || ''
-                                                }
-                                                value={
-                                                    selection.addressId?.toString() ||
-                                                    ''
-                                                }
-                                                onValueChange={(
-                                                    value: string,
-                                                ) =>
-                                                    handleAddressChange(
-                                                        parseInt(value, 10),
-                                                    )
-                                                }
-                                                items={addresses.map(
-                                                    (address) => ({
-                                                        label: `${address.label} - ${address.street1}, ${address.city}`,
-                                                        value: address.id.toString(),
-                                                    }),
-                                                )}
-                                            />
-                                        ) : (
-                                            <NoDataPlaceholder className="grow">
-                                                Dodajte adresu za dostavu da
-                                                biste nastavili s dostavom...
-                                            </NoDataPlaceholder>
-                                        )}
-                                        <Button
-                                            variant={
-                                                !isLoadingAddresses &&
-                                                !addresses?.length
-                                                    ? 'solid'
-                                                    : 'outlined'
-                                            }
-                                            size="sm"
-                                            onClick={() =>
-                                                setManageAddresses(true)
-                                            }
-                                            className="h-10 whitespace-nowrap self-end"
-                                            startDecorator={
-                                                <Edit className="size-4 shrink-0" />
-                                            }
-                                        >
-                                            Moje adrese
-                                        </Button>
-                                    </Row>
-                                </Stack>
-                                {/* Show selected address details */}
-                                {selectedAddress && (
-                                    <AddressCard
-                                        address={selectedAddress}
-                                        key={selection.addressId}
-                                        readonly
-                                    />
-                                )}
-                            </Stack>
-                        </Stack>
-                    </TabsContent>
-                    <TabsContent value="pickup" className="mt-4">
-                        <Stack spacing={6}>
-                            {pickupLocations && pickupLocations.length > 0 ? (
-                                <Stack spacing={4}>
-                                    <SelectItems
-                                        label="Lokacija dostave"
-                                        placeholder="Odaberi lokaciju za preuzimanje..."
-                                        value={
-                                            selection.locationId?.toString() ||
-                                            ''
-                                        }
-                                        onValueChange={(value: string) =>
-                                            handleLocationChange(
-                                                parseInt(value, 10),
-                                            )
-                                        }
-                                        items={pickupLocations.map(
-                                            (location) => ({
-                                                label: `${location.name} - ${location.street1}, ${location.city}`,
-                                                value: location.id.toString(),
-                                            }),
-                                        )}
-                                    />
-                                    {/* Show selected location details */}
-                                    {selection.locationId &&
-                                        pickupLocations.map(
-                                            (location) =>
-                                                selection.locationId ===
-                                                    location.id && (
-                                                    <Card
-                                                        key={location.id}
-                                                        className="bg-background/50"
-                                                    >
-                                                        <CardContent className="p-3">
-                                                            <Row
-                                                                spacing={4}
-                                                                justifyContent="space-between"
-                                                            >
-                                                                <Stack
-                                                                    spacing={2}
-                                                                >
-                                                                    <Typography
-                                                                        level="body1"
-                                                                        bold
-                                                                    >
-                                                                        {
-                                                                            location.name
-                                                                        }
-                                                                    </Typography>
-                                                                    <Typography
-                                                                        level="body3"
-                                                                        secondary
-                                                                    >
-                                                                        {
-                                                                            location.street1
-                                                                        }
-                                                                        {location.street2 &&
-                                                                            `, ${location.street2}`}
-                                                                        <br />
-                                                                        {
-                                                                            location.postalCode
-                                                                        }{' '}
-                                                                        {
-                                                                            location.city
-                                                                        }
-                                                                    </Typography>
-                                                                </Stack>
-                                                                <a
-                                                                    href={
-                                                                        KnownPages.GoogleMapsGrediceHQ
-                                                                    }
-                                                                    target="_blank"
-                                                                    rel="noopener noreferrer"
-                                                                >
-                                                                    <MapIcon className="size-6 shrink-0" />
-                                                                </a>
-                                                            </Row>
-                                                        </CardContent>
-                                                    </Card>
-                                                ),
-                                        )}
-                                </Stack>
-                            ) : (
-                                <NoDataPlaceholder>
-                                    Trenutno nema dostupnih lokacija za
-                                    preuzimanje
-                                </NoDataPlaceholder>
-                            )}
-                        </Stack>
-                    </TabsContent>
-                </Tabs>
-            </Stack>
-
-            {/* Time Slot Selection */}
-            {(selection.addressId || selection.locationId) && (
-                <Stack spacing={6}>
-                    {slotsLoading ? (
-                        <Typography>Učitavanje termina...</Typography>
-                    ) : timeSlots && timeSlots.length > 0 ? (
-                        <Stack spacing={4}>
-                            <SelectItems
-                                label="Termin dostave"
-                                placeholder="Odaberi termin dostave..."
-                                value={selection.slotId?.toString() || ''}
-                                onValueChange={(value: string) =>
-                                    handleSlotChange(parseInt(value, 10))
-                                }
-                                items={timeSlots.map((slot) => ({
-                                    label: formatSlotTime(slot),
-                                    value: slot.id.toString(),
-                                }))}
-                            />
-                        </Stack>
-                    ) : (
-                        <NoDataPlaceholder className="mb-4">
-                            Trenutno nema dostupnih termina za odabrani način
-                            dostave
-                        </NoDataPlaceholder>
-                    )}
-                </Stack>
+                    <strong>Odabrano je osobno preuzimanje.</strong> Narudžbu
+                    preuzimaš na lokaciji Gredice HQ; neće biti dostavljena na
+                    tvoju adresu.
+                </Alert>
             )}
 
-            {/* Action Buttons */}
+            {selectedTimeSlot?.type === 'delivery' && (
+                <Row alignItems="end" className="min-w-0" spacing={2}>
+                    {isLoadingAddresses ? (
+                        <Skeleton className="h-10 min-w-0 flex-1 rounded-md" />
+                    ) : addresses?.length ? (
+                        <SelectItems
+                            className="min-w-0 flex-1"
+                            items={addresses.map((address) => ({
+                                label: `${address.label} - ${address.street1}, ${address.city}`,
+                                value: address.id.toString(),
+                            }))}
+                            label="Adresa za dostavu"
+                            placeholder="Odaberi adresu..."
+                            value={selection.addressId?.toString() ?? ''}
+                            onValueChange={(value) =>
+                                handleAddressChange(Number.parseInt(value, 10))
+                            }
+                        />
+                    ) : (
+                        <NoDataPlaceholder className="min-w-0 flex-1">
+                            Dodaj adresu za dostavu kako bi mogao nastaviti.
+                        </NoDataPlaceholder>
+                    )}
+                    <Button
+                        className="shrink-0"
+                        onClick={() => setManageAddresses(true)}
+                        startDecorator={<Edit className="size-4 shrink-0" />}
+                        variant={addresses?.length ? 'outlined' : 'solid'}
+                    >
+                        Moje adrese
+                    </Button>
+                </Row>
+            )}
+
             <Row spacing={4} justifyContent="end">
                 <Button variant="outlined" onClick={onBack}>
                     Natrag
                 </Button>
                 <ButtonConfirmPayment
-                    onConfirm={onProceed}
-                    checkout={checkout}
                     cart={cart}
+                    checkout={checkout}
                     disabled={!isValid}
+                    onConfirm={onProceed}
                 />
             </Row>
         </Stack>

--- a/packages/ui/src/EventCalendar/EventCalendar.tsx
+++ b/packages/ui/src/EventCalendar/EventCalendar.tsx
@@ -494,7 +494,7 @@ function EventCalendarDayView({
             {visibleEntries.length > 0 ? (
                 <span
                     aria-hidden
-                    className="absolute top-0.5 left-1/2 flex -translate-x-1/2 gap-0.5"
+                    className="absolute top-0.5 left-1/2 z-20 flex -translate-x-1/2 gap-0.5"
                     data-event-calendar-markers
                 >
                     {visibleEntries.map((entry) => {

--- a/packages/ui/src/SelectItems/SelectItems.tsx
+++ b/packages/ui/src/SelectItems/SelectItems.tsx
@@ -232,9 +232,11 @@ export function SelectItems<T extends string>({
                     aria-label={label ?? placeholder}
                     aria-labelledby={labelId}
                     className={cx(
-                        'flex h-10 w-full items-center justify-between rounded-md bg-transparent px-3 py-2 text-left text-sm ring-offset-background focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+                        'flex h-10 w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm ring-offset-background focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
                         '[&>span]:line-clamp-1 data-[placeholder]:text-muted-foreground',
-                        variant === 'outlined' && 'border border-input',
+                        variant === 'outlined' &&
+                            'border border-input bg-background',
+                        variant === 'plain' && 'bg-transparent',
                     )}
                     id={inputId}
                 >


### PR DESCRIPTION
## What changed

- replace the basic delivery-time select with a reusable, week-based slot picker
- show delivery and pickup options directly on time slots, including pickup warnings and conditional address selection
- auto-select the first available delivery slot while keeping today and past dates disabled
- preserve empty weeks with a clear placeholder instead of skipping them
- simplify the delivery checkout step and improve address-select styling
- add Storybook coverage for interactive slot-picker states
- keep calendar operation dots above today and selected-date indicators

## Why

The previous select made it difficult to compare days, times, and fulfillment methods. Calendar event markers could also be partially covered by today or selected-date indicators.

## Validation

- `pnpm --filter @gredice/ui exec biome check src/EventCalendar/EventCalendar.tsx`
- `pnpm --filter storybook exec biome check stories/packages/ui/EventCalendar.stories.tsx`
- `pnpm --filter @gredice/ui typecheck`
- `pnpm --filter storybook typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter storybook build`
- `git diff --check`
