### PR TITLE
fix(game): render diary notes as markdown

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -502,6 +502,28 @@ function plantedGrowingWithOperationHistoryScenario(): RaisedBedScenario {
     };
 }
 
+function plantedGrowingWithMarkdownOperationNotesScenario(): RaisedBedScenario {
+    const scenario = plantedGrowingWithOperationHistoryScenario();
+    const [operation, ...remainingOperations] =
+        scenario.operationHistoryItems ?? [];
+
+    if (!operation) {
+        return scenario;
+    }
+
+    return {
+        ...scenario,
+        operationHistoryItems: [
+            {
+                ...operation,
+                completionNotes:
+                    '**Pregled**\nPolje 1\nPolje 2\n\n- Ukloni korov\n- Provjeri kupus',
+            },
+            ...remainingOperations,
+        ],
+    };
+}
+
 function plantedGrowingWithPendingOperationHistoryScenario(): RaisedBedScenario {
     const scenario = plantedGrowingWithOperationHistoryScenario();
     const operation = scenario.operations?.[0];
@@ -1423,6 +1445,43 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
                 (element) => element.scrollWidth - element.clientWidth,
             ),
         ).toBeLessThanOrEqual(1);
+    });
+
+    test('diary tab renders operation notes as markdown with visible line breaks', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldHudStory
+                scenario={plantedGrowingWithMarkdownOperationNotesScenario()}
+                positionIndex={0}
+            />,
+        );
+
+        await page.getByRole('button').first().click();
+
+        const dialog = page.getByRole('dialog');
+        await dialog.getByRole('tab', { name: /Dnevnik/ }).click();
+
+        const notes = dialog.locator('[data-operation-notes]');
+        const paragraph = notes.locator('p');
+        await expect(notes.locator('strong')).toHaveText('Pregled');
+        await expect(notes.locator('li')).toHaveText([
+            'Ukloni korov',
+            'Provjeri kupus',
+        ]);
+        await expect(paragraph).toHaveCSS('white-space', 'pre-line');
+
+        const paragraphLineCount = await paragraph.evaluate((element) => {
+            const range = document.createRange();
+            range.selectNodeContents(element);
+            return new Set(
+                Array.from(range.getClientRects(), (rect) =>
+                    Math.round(rect.top),
+                ),
+            ).size;
+        });
+        expect(paragraphLineCount).toBeGreaterThanOrEqual(3);
     });
 
     test('closeup HUD photo shortcut opens the raised bed photos modal', async ({

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -15,6 +15,7 @@ import {
     Navigate,
     ShoppingCart,
 } from '@gredice/ui/icons';
+import { Markdown } from '@gredice/ui/Markdown';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { Popper } from '@gredice/ui/Popper';
 import { PlantOrSortImage } from '@gredice/ui/plants';
@@ -1385,13 +1386,12 @@ function OperationEvidence({ operation }: { operation: GardenOperationItem }) {
                 </div>
             )}
             {completionNotes && (
-                <Typography
-                    level="body2"
-                    className="break-words"
+                <Markdown
+                    className="min-w-0 break-words text-sm prose-headings:my-1 prose-headings:text-sm prose-li:my-0 prose-ol:my-1 prose-p:my-1 prose-p:whitespace-pre-line prose-ul:my-1"
                     data-operation-notes
                 >
                     {completionNotes}
-                </Typography>
+                </Markdown>
             )}
         </Stack>
     );


### PR DESCRIPTION
## Summary

- render operation completion notes with the shared Markdown component in diary cards
- preserve single newlines while supporting Markdown emphasis, headings, and lists
- cover the rendered Markdown structure and visible line breaks with a Playwright component test

## Root cause

Diary completion notes were rendered through the plain typography component. Browser whitespace collapsing therefore displayed multiline notes as one inline paragraph.

## Validation

- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter @gredice/game test` (370 passed)
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter www typecheck`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/raised-bed-field-hud.spec.tsx --project=chromium --grep "diary tab (shows filtered operation history|renders operation notes)"` (2 passed)
- focused Biome check
- `git diff --check`