### PR TITLE
fix(garden): use completion dates in diary

### DIFF
--- a/apps/garden/tests/GardenOperationsHudStory.tsx
+++ b/apps/garden/tests/GardenOperationsHudStory.tsx
@@ -108,6 +108,7 @@ function buildGarden() {
                             positionIndex: 2,
                             plantSortId: testSorts.tomato.id,
                             plantStatus: 'sprouted',
+                            plantScheduledDate: '2026-05-10T00:00:00.000Z',
                             plantSowDate: now,
                             plantGrowthDate: now,
                         },

--- a/apps/garden/tests/garden-operations-hud.spec.tsx
+++ b/apps/garden/tests/garden-operations-hud.spec.tsx
@@ -177,6 +177,12 @@ test.describe('Garden operations HUD', () => {
         ).toBeVisible();
         await expect(completedSowingCard.getByText('Završeno')).toBeVisible();
         await expect(
+            completedSowingCard.getByText('13. svibnja 2026.'),
+        ).toBeVisible();
+        await expect(
+            completedSowingCard.getByText('10. svibnja 2026.'),
+        ).toHaveCount(0);
+        await expect(
             completedSowingCard.getByLabel('Tijek radnje'),
         ).toHaveCount(0);
         await expect(

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -1895,13 +1895,37 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         ).toBeVisible();
     });
 
-    test('diary tab shows completed schedule dates as text instead of buttons', async ({
+    test('diary tab shows completed dates as text instead of scheduled dates', async ({
         mount,
         page,
     }) => {
+        const scenario = plantedGrowingWithOperationHistoryScenario();
+        const operation = scenario.operationHistoryItems?.[0];
+
+        if (!operation) {
+            throw new Error('Expected operation history item.');
+        }
+
         await mount(
             <RaisedBedFieldHudStory
-                scenario={plantedGrowingWithOperationHistoryScenario()}
+                scenario={{
+                    ...scenario,
+                    operationHistoryItems: [
+                        {
+                            ...operation,
+                            status: 'completed',
+                            completedAt: '2026-05-12T08:00:00.000Z',
+                            verifiedAt: '2026-05-13T09:00:00.000Z',
+                            statusHistory: [
+                                ...operation.statusHistory,
+                                {
+                                    status: 'completed',
+                                    changedAt: '2026-05-13T09:00:00.000Z',
+                                },
+                            ],
+                        },
+                    ],
+                }}
                 positionIndex={0}
             />,
         );
@@ -1911,9 +1935,10 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         const dialog = page.getByRole('dialog');
         await dialog.getByRole('tab', { name: /Dnevnik/ }).click();
 
-        await expect(dialog.getByText('10. svibnja 2026.')).toBeVisible();
+        await expect(dialog.getByText('12. svibnja 2026.')).toBeVisible();
+        await expect(dialog.getByText('10. svibnja 2026.')).toHaveCount(0);
         await expect(
-            dialog.getByRole('button', { name: '10. svibnja 2026.' }),
+            dialog.getByRole('button', { name: '12. svibnja 2026.' }),
         ).toHaveCount(0);
     });
 

--- a/packages/game/src/hud/GardenOperationsHud.tsx
+++ b/packages/game/src/hud/GardenOperationsHud.tsx
@@ -821,6 +821,10 @@ function isFinishedOperation(operation: GardenOperationHudItem) {
     );
 }
 
+function getOperationTaskDisplayDate(operation: GardenOperationHudItem) {
+    return operation.completedAt ?? operation.scheduledDate;
+}
+
 function OperationScheduleText({ label }: { label: string }) {
     return (
         <Row spacing={1} className="min-w-0 text-muted-foreground">
@@ -843,24 +847,24 @@ export function GardenOperationScheduleAction({
     operation: GardenOperationHudItem;
     referenceDate: Date;
 }) {
-    const scheduledDateLabel = formatDate(operation.scheduledDate);
+    const taskDateLabel = formatDate(getOperationTaskDisplayDate(operation));
 
     if (isFinishedOperation(operation)) {
-        return scheduledDateLabel ? (
-            <OperationScheduleText label={scheduledDateLabel} />
+        return taskDateLabel ? (
+            <OperationScheduleText label={taskDateLabel} />
         ) : null;
     }
 
     if (!garden) {
-        return scheduledDateLabel ? (
-            <OperationScheduleText label={scheduledDateLabel} />
+        return taskDateLabel ? (
+            <OperationScheduleText label={taskDateLabel} />
         ) : null;
     }
 
     const target = getGardenOperationRescheduleTarget(operation, garden);
     if (!target) {
-        return scheduledDateLabel ? (
-            <OperationScheduleText label={scheduledDateLabel} />
+        return taskDateLabel ? (
+            <OperationScheduleText label={taskDateLabel} />
         ) : null;
     }
 
@@ -873,7 +877,7 @@ export function GardenOperationScheduleAction({
             entryName={entryName}
             gardenId={garden.id}
             target={target}
-            triggerLabel={scheduledDateLabel ?? 'Zakaži'}
+            triggerLabel={taskDateLabel ?? 'Zakaži'}
         />
     );
 }
@@ -1325,19 +1329,19 @@ function OperationSchedule({
     cancelAction?: ReactNode;
     scheduleAction?: ReactNode;
 }) {
-    const scheduledDate = formatDate(operation.scheduledDate);
+    const taskDate = formatDate(getOperationTaskDisplayDate(operation));
     const scheduleContent = scheduleAction ? (
         <div className="min-w-0 max-w-full overflow-hidden">
             {scheduleAction}
         </div>
-    ) : scheduledDate ? (
+    ) : taskDate ? (
         <Row
             spacing={1}
             className="min-w-0 max-w-full justify-end text-muted-foreground"
         >
             <Calendar aria-hidden className="size-3.5 shrink-0" />
             <Typography level="body3" secondary noWrap className="min-w-0">
-                {scheduledDate}
+                {taskDate}
             </Typography>
         </Row>
     ) : null;

--- a/packages/game/src/hud/gardenOperationOrdering.ts
+++ b/packages/game/src/hud/gardenOperationOrdering.ts
@@ -30,9 +30,9 @@ function getLatestOperationChangeTime(operation: OperationOrderingItem) {
 
 export function getOperationOrderingTime(operation: OperationOrderingItem) {
     return (
+        getTimestamp(operation.completedAt) ||
         getTimestamp(operation.scheduledDate) ||
         getTimestamp(operation.verifiedAt) ||
-        getTimestamp(operation.completedAt) ||
         getTimestamp(operation.canceledAt) ||
         getLatestOperationChangeTime(operation) ||
         getTimestamp(operation.createdAt)

--- a/packages/game/src/hud/gardenOperationOrdering.unit.ts
+++ b/packages/game/src/hud/gardenOperationOrdering.unit.ts
@@ -30,7 +30,7 @@ function operation({
     };
 }
 
-test('sortOperationTasksNewestFirst prefers scheduled date over status changes', () => {
+test('sortOperationTasksNewestFirst uses completion date after an operation is completed', () => {
     const sorted = sortOperationTasksNewestFirst([
         operation({
             id: 1,
@@ -56,7 +56,7 @@ test('sortOperationTasksNewestFirst prefers scheduled date over status changes',
 
     assert.deepEqual(
         sorted.map((item) => item.id),
-        [3, 1, 2],
+        [3, 2, 1],
     );
 });
 

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -398,6 +398,33 @@ function getOperationScheduledDateExpression() {
     )`;
 }
 
+function getOperationCompletedDateExpression() {
+    return sql<Date | null>`(
+        select ${events.createdAt}
+        from ${events}
+        where ${events.aggregateId} = CAST(${operations.id} as text)
+          and ${events.type} = ${knownEventTypes.operations.complete}
+          and (
+              not exists (
+                  select 1
+                  from ${events}
+                  where ${events.aggregateId} = CAST(${operations.id} as text)
+                    and ${events.type} = ${knownEventTypes.operations.schedule}
+              )
+              or (${events.createdAt}, ${events.id}) > (
+                  select ${events.createdAt}, ${events.id}
+                  from ${events}
+                  where ${events.aggregateId} = CAST(${operations.id} as text)
+                    and ${events.type} = ${knownEventTypes.operations.schedule}
+                  order by ${events.createdAt} desc, ${events.id} desc
+                  limit 1
+                )
+          )
+        order by ${events.createdAt} asc, ${events.id} asc
+        limit 1
+    )`;
+}
+
 function getOperationStatusExpression() {
     const latestStatusTypeExpression = getLatestOperationStatusTypeExpression();
 
@@ -457,11 +484,20 @@ function getOperationLatestStatusChangeDateExpression() {
 }
 
 function getOperationTaskSortExpression() {
+    const statusExpression = getOperationStatusExpression();
+    const completedDateExpression = getOperationCompletedDateExpression();
     const scheduledDateExpression = getOperationScheduledDateExpression();
     const latestStatusChangeDateExpression =
         getOperationLatestStatusChangeDateExpression();
 
-    return sql<Date>`coalesce(${scheduledDateExpression}, ${latestStatusChangeDateExpression}, ${operations.createdAt})`;
+    return sql<Date>`case
+        when ${statusExpression} in (${sql.join(
+            appliedRaisedBedOperationStatuses.map((value) => sql`${value}`),
+            sql`, `,
+        )})
+            then coalesce(${completedDateExpression}, ${scheduledDateExpression}, ${latestStatusChangeDateExpression}, ${operations.createdAt})
+        else coalesce(${scheduledDateExpression}, ${latestStatusChangeDateExpression}, ${operations.createdAt})
+    end`;
 }
 
 export async function getOperations(

--- a/packages/storage/src/repositories/raisedBedDiaryRepo.ts
+++ b/packages/storage/src/repositories/raisedBedDiaryRepo.ts
@@ -317,9 +317,9 @@ const fieldPlantRescheduleStatuses = new Set(['new', 'planned']);
 
 function operationDiaryTimestamp(operation: DiaryOperation) {
     return (
+        operation.completedAt ??
         operation.scheduledDate ??
         operation.verifiedAt ??
-        operation.completedAt ??
         operation.canceledAt ??
         operation.createdAt
     );

--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -917,7 +917,7 @@ test('diary entries can hide unverified operation images', async () => {
     );
 });
 
-test('raised bed diary entries order operations by scheduled or completed dates', async () => {
+test('raised bed diary entries display and order completed operations by completion date', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =
         await createDiaryRescheduleContext();
@@ -935,21 +935,29 @@ test('raised bed diary entries order operations by scheduled or completed dates'
         raisedBedId,
     });
 
-    await createEvent(
-        knownEvents.operations.completedV1(
+    await createEvent({
+        ...knownEvents.operations.completedV1(
             scheduledCompletedOperationId.toString(),
             {
                 completedBy: 'test-user',
             },
         ),
-    );
-    await createEvent(
-        knownEvents.operations.completedV1(completedOperationId.toString(), {
+        createdAt: new Date('2026-07-15T08:00:00.000Z'),
+    });
+    await createEvent({
+        ...knownEvents.operations.completedV1(completedOperationId.toString(), {
             completedBy: 'test-user',
         }),
-    );
+        createdAt: new Date('2026-07-16T08:00:00.000Z'),
+    });
 
     const raisedBedEntries = await getRaisedBedDiaryEntries(raisedBedId);
+    assert.equal(
+        raisedBedEntries
+            .find((entry) => entry.id === scheduledCompletedOperationId)
+            ?.timestamp.toISOString(),
+        '2026-07-15T08:00:00.000Z',
+    );
     const operationEntryIds = raisedBedEntries
         .map((entry) => entry.id)
         .filter((entryId) =>
@@ -959,7 +967,7 @@ test('raised bed diary entries order operations by scheduled or completed dates'
         );
 
     assert.deepEqual(operationEntryIds, [
-        scheduledCompletedOperationId,
         completedOperationId,
+        scheduledCompletedOperationId,
     ]);
 });

--- a/packages/storage/tests/operationsRepo.node.spec.ts
+++ b/packages/storage/tests/operationsRepo.node.spec.ts
@@ -138,7 +138,7 @@ test('farm-targeted operations are visible and assignable for farm users', async
     );
 });
 
-test('getOperationsPage returns operations by newest scheduled or completed task date', async () => {
+test('getOperationsPage uses completion dates for completed operation ordering', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =
         await createOperationsPageTestContext();
@@ -231,9 +231,9 @@ test('getOperationsPage returns operations by newest scheduled or completed task
     assert.deepStrictEqual(
         firstPage.items.map((operation) => operation.id),
         [
-            completedScheduledOperationId,
             scheduledOperationId,
             completedOperationId,
+            completedScheduledOperationId,
         ],
     );
     assert.strictEqual(firstPage.nextCursor, 3);


### PR DESCRIPTION
## Summary

- display `completedAt` instead of `scheduledDate` after garden operations are completed
- order paginated and client-merged diary entries by completion date once available, while retaining scheduled-date ordering for unfinished work
- apply the same behavior to synthetic sowing history and the legacy raised-bed diary endpoint

## Root cause

Diary cards and ordering helpers always preferred `scheduledDate`, even after a completion event had produced `completedAt`. The server pagination query, client merge-sort, and visible card date therefore disagreed with the operation lifecycle users expect.

## User impact

Completed operations and sowing entries now show when the work actually happened and appear in diary order based on that date. Planned and otherwise unfinished entries continue to use their scheduled date.

## Validation

- `pnpm --filter @gredice/game test` (370 passed)
- `pnpm --filter @gredice/storage test:node operationsRepo.node.spec.ts gardenDiaryRescheduleRepo.node.spec.ts` (27 passed)
- `pnpm --filter @gredice/game lint`
- `pnpm --filter @gredice/storage lint`
- `pnpm --filter garden lint`
- `pnpm --filter @gredice/game typecheck`
- `pnpm --filter garden typecheck`
- `pnpm --filter garden build`
- targeted Playwright component regressions for completed sowing and completed operation dates (2 passed)