### PR TITLE
fix(vercel): install pnpm workspaces

### DIFF
--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://openapi.vercel.sh/vercel.json",
+    "installCommand": "pnpm install --frozen-lockfile",
     "crons": [
         {
             "path": "/api/stripe/cron",

--- a/apps/app/vercel.json
+++ b/apps/app/vercel.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "installCommand": "pnpm install --frozen-lockfile"
+}

--- a/apps/farm/vercel.json
+++ b/apps/farm/vercel.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "installCommand": "pnpm install --frozen-lockfile"
+}

--- a/apps/garden/vercel.json
+++ b/apps/garden/vercel.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "installCommand": "pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
## What changed

- configure the `app`, `farm`, and `garden` Vercel projects to install the pnpm workspace
- add the same install command to the existing `api` Vercel configuration without changing its cron definitions

## Why

Vercel CLI 55 ran `npm install --prefix=../..` for these projects. That installed only the monorepo root dependencies, so fresh builds could not detect the app-local Next.js dependency and failed with `NEXT_NO_VERSION`. Cached builds had previously masked the configuration issue.

The affected projects now use the same source-controlled command already working for `www`, `news`, and `status`:

```sh
pnpm install --frozen-lockfile
```

## Validation

- `corepack pnpm install --frozen-lockfile`
- per-app `biome check vercel.json` for `app`, `farm`, `garden`, and `api`
- JSON parsing for all four files
- `git diff --check`