### PR TITLE
feat(game): refresh Suncokret chat UI

### DIFF
--- a/apps/storybook/stories/packages/ui/Chat.stories.tsx
+++ b/apps/storybook/stories/packages/ui/Chat.stories.tsx
@@ -1,0 +1,264 @@
+import {
+    ChatBubble,
+    ChatMarker,
+    ChatMessage,
+    ChatMessageScroller,
+    type ChatMessageScrollerProps,
+} from '@gredice/ui/Chat';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Check, LoaderSpinner, Send, Sun } from '@gredice/ui/icons';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const assistantAvatar = (
+    <span className="grid size-full place-items-center bg-amber-50 dark:bg-amber-950">
+        <Sun className="size-4 text-amber-500" />
+    </span>
+);
+
+const conversationItems: ChatMessageScrollerProps['items'] = [
+    {
+        id: 'today',
+        content: <ChatMarker variant="separator">Danas</ChatMarker>,
+    },
+    {
+        id: 'question',
+        scrollAnchor: true,
+        content: (
+            <ChatMessage align="end">
+                <ChatBubble align="end" variant="sunflower">
+                    Koje radnje su najvažnije ovaj tjedan?
+                </ChatBubble>
+            </ChatMessage>
+        ),
+    },
+    {
+        id: 'status',
+        content: (
+            <ChatMarker icon={<Check />} role="status">
+                Provjereni su vrt, gredice i zadnje radnje.
+            </ChatMarker>
+        ),
+    },
+    {
+        id: 'answer',
+        content: (
+            <ChatMessage avatar={assistantAvatar} header="Suncokret">
+                <ChatBubble className="grid gap-2" variant="ghost">
+                    <p>
+                        Ovaj tjedan kreni sa zalijevanjem rajčice i pregledom
+                        mladih listova.
+                    </p>
+                    <ol className="list-decimal space-y-1 pl-5">
+                        <li>Zalij rano ujutro.</li>
+                        <li>Ukloni suhe listove.</li>
+                        <li>Provjeri potporu uz stabljiku.</li>
+                    </ol>
+                </ChatBubble>
+            </ChatMessage>
+        ),
+    },
+];
+
+const longConversationItems: ChatMessageScrollerProps['items'] = [
+    ...conversationItems,
+    {
+        id: 'follow-up-question',
+        scrollAnchor: true,
+        content: (
+            <ChatMessage align="end">
+                <ChatBubble align="end" variant="sunflower">
+                    Trebam li danas ponovno zalijevati?
+                </ChatBubble>
+            </ChatMessage>
+        ),
+    },
+    {
+        id: 'follow-up-answer',
+        content: (
+            <ChatMessage avatar={assistantAvatar} header="Suncokret">
+                <ChatBubble className="grid gap-2" variant="ghost">
+                    <p>
+                        Pričekaj večer i prvo provjeri vlagu nekoliko
+                        centimetara ispod površine zemlje.
+                    </p>
+                    <p>
+                        Ako je zemlja još vlažna, preskoči zalijevanje i
+                        provjeri ponovno sutra ujutro.
+                    </p>
+                </ChatBubble>
+            </ChatMessage>
+        ),
+    },
+    {
+        id: 'second-follow-up-question',
+        scrollAnchor: true,
+        content: (
+            <ChatMessage align="end">
+                <ChatBubble align="end" variant="sunflower">
+                    Što mogu pripremiti za vikend?
+                </ChatBubble>
+            </ChatMessage>
+        ),
+    },
+    {
+        id: 'second-follow-up-answer',
+        content: (
+            <ChatMessage avatar={assistantAvatar} header="Suncokret">
+                <ChatBubble variant="ghost">
+                    Pripremi vezice za rajčicu i malo malča za zadržavanje
+                    vlage.
+                </ChatBubble>
+            </ChatMessage>
+        ),
+    },
+];
+
+function ChatPanel(props: ChatMessageScrollerProps) {
+    return (
+        <div className="grid min-h-screen place-items-center p-4">
+            <div className="flex h-[36rem] w-full max-w-[27.5rem] flex-col overflow-hidden rounded-2xl border border-amber-200/80 border-b-4 border-b-emerald-700 bg-background shadow-2xl dark:border-amber-900/80">
+                <Row
+                    justifyContent="space-between"
+                    className="border-b border-amber-200/70 bg-amber-50/80 px-3.5 py-3 dark:border-amber-900/70 dark:bg-amber-950/30"
+                >
+                    <Row spacing={2}>
+                        <span className="grid size-10 place-items-center rounded-full border border-amber-200 bg-background">
+                            <Sun className="size-5 text-amber-500" />
+                        </span>
+                        <Stack spacing={0}>
+                            <Typography level="body2" semiBold>
+                                Suncokret
+                            </Typography>
+                            <Typography
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                <span className="mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle" />
+                                Razgovor za Gredicu A12
+                            </Typography>
+                        </Stack>
+                    </Row>
+                    <span className="rounded-full bg-emerald-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200">
+                        AI pomoćnik
+                    </span>
+                </Row>
+
+                <ChatMessageScroller className="flex-1" {...props} />
+
+                <div className="border-t bg-background p-3">
+                    <div className="overflow-hidden rounded-2xl border bg-card shadow-sm">
+                        <textarea
+                            aria-label="Pitaj Suncokret"
+                            className="min-h-14 w-full resize-none border-0 bg-transparent px-4 py-3 text-sm outline-hidden placeholder:text-muted-foreground"
+                            placeholder="Pitaj Suncokret..."
+                        />
+                        <Row
+                            justifyContent="space-between"
+                            className="border-t border-border/60 px-2 py-2"
+                        >
+                            <Typography
+                                level="body3"
+                                className="px-1 text-muted-foreground"
+                            >
+                                Enter šalje poruku
+                            </Typography>
+                            <IconButton
+                                disabled
+                                title="Pošalji"
+                                className="size-9 rounded-full bg-emerald-700 text-white"
+                            >
+                                <Send className="size-4" />
+                            </IconButton>
+                        </Row>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+const meta = {
+    title: 'packages/ui/Chat',
+    component: ChatMessageScroller,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Composable chat rows, bubbles, markers, and a streaming-safe message scroller adapted from the shadcn chat primitives for Gredice surfaces.',
+            },
+        },
+    },
+} satisfies Meta<typeof ChatMessageScroller>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Conversation: Story = {
+    args: {
+        ariaLabel: 'Razgovor sa Suncokretom',
+        items: conversationItems,
+    },
+    render: (args) => <ChatPanel {...args} />,
+};
+
+export const LongConversation: Story = {
+    args: {
+        ariaLabel: 'Dugi razgovor sa Suncokretom',
+        items: longConversationItems,
+    },
+    render: (args) => <ChatPanel {...args} />,
+};
+
+export const Empty: Story = {
+    args: {
+        items: [],
+        emptyContent: (
+            <Stack alignItems="center" spacing={3} className="px-6 text-center">
+                <span className="grid size-14 place-items-center rounded-full border border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950">
+                    <Sun className="size-7 text-amber-500" />
+                </span>
+                <Stack spacing={1} alignItems="center">
+                    <Typography level="h6" semiBold>
+                        Kako ti mogu pomoći?
+                    </Typography>
+                    <Typography
+                        level="body3"
+                        className="max-w-72 text-muted-foreground"
+                    >
+                        Pitaj o stanju vrta, sadnji ili radnjama koje slijede.
+                    </Typography>
+                </Stack>
+            </Stack>
+        ),
+    },
+    render: (args) => <ChatPanel {...args} />,
+};
+
+export const Streaming: Story = {
+    args: {
+        ariaBusy: true,
+        items: [
+            ...conversationItems,
+            {
+                id: 'streaming',
+                content: (
+                    <ChatMarker
+                        className="px-10"
+                        icon={<LoaderSpinner className="animate-spin" />}
+                        role="status"
+                    >
+                        <span className="chat-shimmer">
+                            Suncokret razmišlja...
+                        </span>
+                    </ChatMarker>
+                ),
+            },
+        ],
+    },
+    render: (args) => <ChatPanel {...args} />,
+};

--- a/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
+++ b/apps/storybook/stories/packages/ui/ComponentShowcases.stories.tsx
@@ -25,6 +25,12 @@ import {
     CardOverflow,
     CardTitle,
 } from '@gredice/ui/Card';
+import {
+    ChatBubble,
+    ChatMarker,
+    ChatMessage,
+    ChatMessageScroller,
+} from '@gredice/ui/Chat';
 import { Checkbox } from '@gredice/ui/Checkbox';
 import { Chip } from '@gredice/ui/Chip';
 import { Collapse } from '@gredice/ui/Collapse';
@@ -71,6 +77,7 @@ import { ImageViewer } from '@gredice/ui/ImageViewer';
 import { Input } from '@gredice/ui/Input';
 import {
     Add,
+    AI,
     Approved,
     Calendar,
     Check,
@@ -91,6 +98,7 @@ import {
     Settings,
     Sprout,
     Store,
+    Sun,
     Truck,
     Upload,
     User,
@@ -1569,6 +1577,71 @@ function GardenWorkspaceShowcase() {
                                         </Row>
                                     </Stack>
                                 </GentleSlide>
+                            </div>
+                            <div className="absolute right-4 bottom-4 hidden h-72 w-80 flex-col overflow-hidden rounded-2xl border border-amber-200/80 border-b-4 border-b-emerald-700 bg-background shadow-xl xl:flex dark:border-amber-900/80">
+                                <Row className="border-b border-amber-200/70 bg-amber-50/90 px-3 py-2 dark:border-amber-900/70 dark:bg-amber-950/40">
+                                    <span className="grid size-8 place-items-center rounded-full bg-background">
+                                        <Sun className="size-4 text-amber-500" />
+                                    </span>
+                                    <Stack spacing={0}>
+                                        <Typography level="body3" semiBold>
+                                            Suncokret
+                                        </Typography>
+                                        <Typography
+                                            level="body3"
+                                            className="text-muted-foreground"
+                                        >
+                                            Gredica A12
+                                        </Typography>
+                                    </Stack>
+                                </Row>
+                                <ChatMessageScroller
+                                    className="flex-1"
+                                    contentClassName="gap-3 px-3 py-3"
+                                    items={[
+                                        {
+                                            id: 'showcase-question',
+                                            scrollAnchor: true,
+                                            content: (
+                                                <ChatMessage align="end">
+                                                    <ChatBubble
+                                                        align="end"
+                                                        variant="sunflower"
+                                                    >
+                                                        Što prvo trebam
+                                                        napraviti?
+                                                    </ChatBubble>
+                                                </ChatMessage>
+                                            ),
+                                        },
+                                        {
+                                            id: 'showcase-status',
+                                            content: (
+                                                <ChatMarker icon={<AI />}>
+                                                    Provjereno stanje gredice
+                                                </ChatMarker>
+                                            ),
+                                        },
+                                        {
+                                            id: 'showcase-answer',
+                                            content: (
+                                                <ChatMessage
+                                                    avatar={
+                                                        <Sun className="size-4 text-amber-500" />
+                                                    }
+                                                    header="Suncokret"
+                                                >
+                                                    <ChatBubble variant="ghost">
+                                                        Kreni sa zalijevanjem
+                                                        rajčice, zatim provjeri
+                                                        mlade listove.
+                                                    </ChatBubble>
+                                                </ChatMessage>
+                                            ),
+                                        },
+                                    ]}
+                                    scrollButtonLabel="Najnovije"
+                                />
                             </div>
                         </div>
                     </SplitView>

--- a/packages/game/src/hud/SuncokretChatHud.tsx
+++ b/packages/game/src/hud/SuncokretChatHud.tsx
@@ -3,6 +3,12 @@
 import { useChat } from '@ai-sdk/react';
 import { getBrowserGrediceAppOrigin } from '@gredice/client';
 import { Button } from '@gredice/ui/Button';
+import {
+    ChatBubble,
+    ChatMarker,
+    ChatMessage as ChatMessageLayout,
+    ChatMessageScroller,
+} from '@gredice/ui/Chat';
 import { IconButton } from '@gredice/ui/IconButton';
 import {
     AI,
@@ -20,7 +26,7 @@ import { Typography } from '@gredice/ui/Typography';
 import { cx } from '@gredice/ui/utils';
 import { DefaultChatTransport, type UIMessage } from 'ai';
 import Image from 'next/image';
-import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { type FormEvent, useEffect, useMemo, useState } from 'react';
 import { useGameFlags } from '../GameFlagsContext';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useGameState } from '../useGameState';
@@ -243,7 +249,7 @@ function ToolPart({
     const name = toolName(part);
 
     return (
-        <div className="rounded-md border bg-muted/30 p-2 text-xs">
+        <div className="rounded-xl border bg-muted/30 p-3 text-xs">
             <Row justifyContent="space-between" className="gap-2">
                 <Stack spacing={0} className="min-w-0">
                     <Typography level="body3" semiBold>
@@ -451,20 +457,25 @@ function ChatMessage({
     );
 
     return (
-        <div
-            className={cx(
-                'flex w-full',
-                isUser ? 'justify-end' : 'justify-start',
-            )}
+        <ChatMessageLayout
+            align={isUser ? 'end' : 'start'}
+            avatar={
+                isUser ? undefined : (
+                    <Image
+                        src="https://cdn.gredice.com/sunflower-large.svg"
+                        alt=""
+                        width={32}
+                        height={32}
+                        className="size-full bg-amber-50 p-1 dark:bg-amber-950"
+                    />
+                )
+            }
+            header={isUser ? undefined : 'Suncokret'}
         >
-            <Stack
-                spacing={1}
-                className={cx(
-                    'max-w-[88%] rounded-md border px-3 py-2',
-                    isUser
-                        ? 'border-primary/30 bg-primary/10'
-                        : 'border-border bg-background/95',
-                )}
+            <ChatBubble
+                align={isUser ? 'end' : 'start'}
+                className={cx('flex flex-col gap-2', !isUser && 'w-full')}
+                variant={isUser ? 'sunflower' : 'ghost'}
             >
                 {message.parts.map((part) => {
                     const baseKey = messagePartKey(part);
@@ -507,32 +518,32 @@ function ChatMessage({
                     ) : null;
                 })}
                 {showToolActivity && (
-                    <Row
-                        spacing={2}
+                    <ChatMarker
                         className={cx(
-                            'rounded-md border border-dashed px-2 py-1.5 text-muted-foreground',
+                            'w-fit rounded-full bg-muted/60 px-2.5 py-1',
                             hasToolError
-                                ? 'border-amber-300 bg-amber-50 text-amber-900'
-                                : 'bg-muted/30',
+                                ? 'bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-100'
+                                : 'text-muted-foreground',
                         )}
+                        icon={
+                            hasToolError ? (
+                                <Warning />
+                            ) : hasDeniedTool ? (
+                                <Close />
+                            ) : hasRunningTool ||
+                              (isStreaming && !hasApprovalRespondedTool) ? (
+                                <LoaderSpinner className="animate-spin" />
+                            ) : (
+                                <AI />
+                            )
+                        }
+                        role="status"
                     >
-                        {hasToolError ? (
-                            <Warning className="size-3.5 shrink-0" />
-                        ) : hasDeniedTool ? (
-                            <Close className="size-3.5 shrink-0" />
-                        ) : hasRunningTool ||
-                          (isStreaming && !hasApprovalRespondedTool) ? (
-                            <LoaderSpinner className="size-3.5 shrink-0 animate-spin" />
-                        ) : (
-                            <AI className="size-3.5 shrink-0" />
-                        )}
-                        <Typography level="body3">
-                            {toolActivitySummary({
-                                isStreaming,
-                                parts: passiveToolParts,
-                            })}
-                        </Typography>
-                    </Row>
+                        {toolActivitySummary({
+                            isStreaming,
+                            parts: passiveToolParts,
+                        })}
+                    </ChatMarker>
                 )}
                 {debug && Boolean(message.metadata) && (
                     <details>
@@ -544,8 +555,8 @@ function ChatMessage({
                         </pre>
                     </details>
                 )}
-            </Stack>
-        </div>
+            </ChatBubble>
+        </ChatMessageLayout>
     );
 }
 
@@ -559,7 +570,6 @@ export function SuncokretChatHud() {
     const [models, setModels] = useState<SuncokretModel[]>([]);
     const [modelId, setModelId] = useState<string | null>(null);
     const chatId = useMemo(randomChatId, []);
-    const scrollRef = useRef<HTMLDivElement>(null);
     const apiOrigin = getBrowserGrediceAppOrigin('api');
     const featureFlags = useMemo(
         () => ({
@@ -649,13 +659,6 @@ export function SuncokretChatHud() {
         };
     }, [apiOrigin, enabled, featureFlagQuery, open]);
 
-    useEffect(() => {
-        scrollRef.current?.scrollTo({
-            top: scrollRef.current.scrollHeight,
-            behavior: 'smooth',
-        });
-    });
-
     if (!enabled) {
         return null;
     }
@@ -685,8 +688,8 @@ export function SuncokretChatHud() {
                     variant="plain"
                     onClick={() => setOpen((current) => !current)}
                     className={cx(
-                        'bg-background/90 hover:bg-muted shadow-sm',
-                        open && 'bg-muted',
+                        'rounded-full border border-amber-200 bg-background/95 shadow-lg hover:bg-amber-50 dark:border-amber-900 dark:hover:bg-amber-950',
+                        open && 'bg-amber-50 dark:bg-amber-950',
                     )}
                 >
                     <Sun className="size-5 text-amber-500" />
@@ -694,32 +697,45 @@ export function SuncokretChatHud() {
             </div>
             {open && (
                 <div className="pointer-events-auto fixed inset-x-2 bottom-2 z-50 flex justify-center md:inset-auto md:right-2 md:bottom-14 md:block">
-                    <div className="flex h-[min(680px,calc(100dvh-1rem))] w-full max-w-[430px] flex-col overflow-hidden rounded-md border border-tertiary border-b-4 bg-background shadow-xl md:h-[min(720px,calc(100dvh-5rem))]">
+                    <div className="flex h-[min(680px,calc(100dvh-1rem))] w-full max-w-[440px] flex-col overflow-hidden rounded-2xl border border-amber-200/80 border-b-4 border-b-emerald-700 bg-background/98 shadow-2xl shadow-foreground/15 backdrop-blur-sm dark:border-amber-900/80 md:h-[min(720px,calc(100dvh-5rem))]">
                         <Row
                             justifyContent="space-between"
-                            className="border-b bg-muted/40 px-3 py-2"
+                            className="border-b border-amber-200/70 bg-amber-50/80 px-3.5 py-3 dark:border-amber-900/70 dark:bg-amber-950/30"
                         >
                             <Row spacing={2} className="min-w-0">
-                                <Image
-                                    src="https://cdn.gredice.com/sunflower-large.svg"
-                                    alt=""
-                                    width={32}
-                                    height={32}
-                                    className="size-8 shrink-0"
-                                />
+                                <span className="grid size-10 shrink-0 place-items-center rounded-full border border-amber-200 bg-white shadow-sm dark:border-amber-900 dark:bg-amber-950">
+                                    <Image
+                                        src="https://cdn.gredice.com/sunflower-large.svg"
+                                        alt=""
+                                        width={32}
+                                        height={32}
+                                        className="size-8"
+                                    />
+                                </span>
                                 <Stack spacing={0} className="min-w-0">
-                                    <Typography level="body2" semiBold noWrap>
-                                        Suncokret
-                                    </Typography>
+                                    <Row spacing={1.5}>
+                                        <Typography
+                                            level="body2"
+                                            semiBold
+                                            noWrap
+                                        >
+                                            Suncokret
+                                        </Typography>
+                                        <span className="rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200">
+                                            AI vrtni pomoćnik
+                                        </span>
+                                    </Row>
                                     <Typography
                                         level="body3"
                                         className="text-muted-foreground"
                                         noWrap
                                     >
+                                        <span className="mr-1.5 inline-block size-1.5 rounded-full bg-emerald-500 align-middle" />
+                                        Razgovor za{' '}
                                         {raisedBed
                                             ? raisedBed.name
                                             : (currentGarden?.name ??
-                                              'Moj vrt')}
+                                              'moj vrt')}
                                     </Typography>
                                 </Stack>
                             </Row>
@@ -733,7 +749,7 @@ export function SuncokretChatHud() {
                                                 event.target.value || null,
                                             )
                                         }
-                                        className="h-8 max-w-36 rounded-md border bg-background px-2 text-xs"
+                                        className="h-8 max-w-32 rounded-full border bg-background px-2.5 text-xs"
                                     >
                                         {models.map((model) => (
                                             <option
@@ -755,23 +771,37 @@ export function SuncokretChatHud() {
                             </Row>
                         </Row>
 
-                        <div
-                            ref={scrollRef}
-                            className="flex-1 space-y-3 overflow-y-auto px-3 py-3"
-                        >
-                            {messages.length === 0 && (
-                                <Stack spacing={3} className="items-start">
-                                    <Row spacing={2}>
-                                        <AI className="mt-0.5 size-5 shrink-0 text-primary" />
-                                        <Typography level="body2">
-                                            Pitaj za stanje vrta, gredice,
-                                            sijanje ili radnje.
+                        <ChatMessageScroller
+                            ariaBusy={loading}
+                            ariaLabel="Razgovor sa Suncokretom"
+                            className="flex-1"
+                            emptyContent={
+                                <Stack
+                                    alignItems="center"
+                                    spacing={4}
+                                    className="w-full px-3 text-center"
+                                >
+                                    <span className="grid size-14 place-items-center rounded-full border border-amber-200 bg-amber-50 shadow-sm dark:border-amber-900 dark:bg-amber-950">
+                                        <Sun className="size-7 text-amber-500" />
+                                    </span>
+                                    <Stack spacing={1} alignItems="center">
+                                        <Typography level="h6" semiBold>
+                                            Kako ti mogu pomoći?
                                         </Typography>
-                                    </Row>
-                                    <div className="flex flex-wrap gap-2">
+                                        <Typography
+                                            level="body3"
+                                            className="max-w-72 text-muted-foreground"
+                                        >
+                                            Pitaj me o stanju vrta, sadnji ili
+                                            radnjama koje slijede.
+                                        </Typography>
+                                    </Stack>
+                                    <Stack spacing={2} className="w-full">
                                         <Button
-                                            size="xs"
-                                            variant="soft"
+                                            fullWidth
+                                            size="sm"
+                                            variant="outlined"
+                                            className="rounded-full border-amber-200 bg-amber-50/60 hover:bg-amber-100 dark:border-amber-900 dark:bg-amber-950/40 dark:hover:bg-amber-950"
                                             onClick={() =>
                                                 sendPrompt(
                                                     raisedBed
@@ -780,89 +810,103 @@ export function SuncokretChatHud() {
                                                 )
                                             }
                                         >
-                                            Stanje gredice
+                                            Sažmi stanje gredice
                                         </Button>
                                         <Button
-                                            size="xs"
-                                            variant="soft"
+                                            fullWidth
+                                            size="sm"
+                                            variant="outlined"
+                                            className="rounded-full"
                                             onClick={() =>
                                                 sendPrompt(
                                                     'Koje radnje su najvažnije ovaj tjedan?',
                                                 )
                                             }
                                         >
-                                            Plan za tjedan
+                                            Složi plan za ovaj tjedan
                                         </Button>
                                         <Button
-                                            size="xs"
-                                            variant="soft"
+                                            fullWidth
+                                            size="sm"
+                                            variant="outlined"
+                                            className="rounded-full"
                                             onClick={() =>
                                                 sendPrompt(
                                                     'Što mogu posaditi sljedeće?',
                                                 )
                                             }
                                         >
-                                            Što posaditi
+                                            Predloži što posaditi
                                         </Button>
-                                    </div>
+                                    </Stack>
                                 </Stack>
-                            )}
-                            {messages.map((message) => (
-                                <ChatMessage
-                                    key={message.id}
-                                    addToolApprovalResponse={
-                                        addToolApprovalResponse
-                                    }
-                                    debug={debug}
-                                    isStreaming={
-                                        loading &&
-                                        message.role === 'assistant' &&
-                                        message.id ===
-                                            messages[messages.length - 1]?.id
-                                    }
-                                    message={message}
-                                />
-                            ))}
-                            {loading && (
-                                <Row
-                                    spacing={2}
-                                    className="text-muted-foreground"
-                                >
-                                    <LoaderSpinner className="size-4 animate-spin" />
-                                    <Typography level="body3">
-                                        Suncokret razmišlja...
-                                    </Typography>
-                                </Row>
-                            )}
-                        </div>
+                            }
+                            items={[
+                                ...messages.map((message) => ({
+                                    id: message.id,
+                                    scrollAnchor: message.role === 'user',
+                                    content: (
+                                        <ChatMessage
+                                            addToolApprovalResponse={
+                                                addToolApprovalResponse
+                                            }
+                                            debug={debug}
+                                            isStreaming={
+                                                loading &&
+                                                message.role === 'assistant' &&
+                                                message.id ===
+                                                    messages[
+                                                        messages.length - 1
+                                                    ]?.id
+                                            }
+                                            message={message}
+                                        />
+                                    ),
+                                })),
+                                ...(loading
+                                    ? [
+                                          {
+                                              id: 'suncokret-loading',
+                                              content: (
+                                                  <ChatMarker
+                                                      className="px-10"
+                                                      icon={
+                                                          <LoaderSpinner className="animate-spin" />
+                                                      }
+                                                      role="status"
+                                                  >
+                                                      <span className="chat-shimmer">
+                                                          Suncokret razmišlja...
+                                                      </span>
+                                                  </ChatMarker>
+                                              ),
+                                          },
+                                      ]
+                                    : []),
+                            ]}
+                        />
 
-                        <Stack spacing={1} className="border-t p-2">
-                            {limit && (
-                                <Row
-                                    justifyContent="space-between"
-                                    className="text-muted-foreground"
-                                >
-                                    <Typography level="body3">
-                                        Preostalo danas
-                                    </Typography>
-                                    <Typography level="body3">
-                                        {formatUsd(limit.remainingUsd)}
-                                    </Typography>
-                                </Row>
-                            )}
+                        <Stack
+                            spacing={2}
+                            className="border-t bg-background/95 p-3"
+                        >
                             {blocked && (
-                                <div className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs text-amber-900">
+                                <div className="rounded-xl border border-amber-300 bg-amber-50 p-2.5 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
                                     Dnevni limit je iskorišten. Nastavak je
                                     moguć {formatRetryAt(limit?.retryAt)}.
                                 </div>
                             )}
                             {error && (
-                                <div className="rounded-md border border-red-300 bg-red-50 p-2 text-xs text-red-900">
+                                <div className="rounded-xl border border-red-300 bg-red-50 p-2.5 text-xs text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-100">
                                     {error.message}
                                 </div>
                             )}
-                            <form onSubmit={onSubmit} className="flex gap-2">
+                            <form
+                                onSubmit={onSubmit}
+                                className="overflow-hidden rounded-2xl border bg-card shadow-sm transition-shadow focus-within:ring-2 focus-within:ring-ring"
+                            >
                                 <textarea
+                                    aria-label="Pitaj Suncokret"
                                     value={input}
                                     disabled={loading || blocked}
                                     onChange={(event) =>
@@ -877,25 +921,42 @@ export function SuncokretChatHud() {
                                             sendPrompt(input);
                                         }
                                     }}
-                                    className="min-h-10 max-h-28 flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm outline-hidden focus:ring-2 focus:ring-ring"
+                                    className="min-h-14 max-h-28 w-full resize-none border-0 bg-transparent px-4 py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed"
                                     placeholder="Pitaj Suncokret..."
                                 />
-                                <IconButton
-                                    title="Pošalji"
-                                    type="submit"
-                                    disabled={
-                                        loading ||
-                                        blocked ||
-                                        input.trim().length === 0
-                                    }
-                                    className="h-10 w-10 shrink-0 bg-primary text-primary-foreground hover:bg-primary/90"
+                                <Row
+                                    justifyContent="space-between"
+                                    className="border-t border-border/60 px-2 py-2"
                                 >
-                                    {loading ? (
-                                        <LoaderSpinner className="size-4 animate-spin" />
-                                    ) : (
-                                        <Send className="size-4" />
-                                    )}
-                                </IconButton>
+                                    <Typography
+                                        level="body3"
+                                        className="px-1 text-muted-foreground"
+                                    >
+                                        {limit
+                                            ? `Danas preostalo ${formatUsd(limit.remainingUsd)}`
+                                            : 'Enter šalje poruku'}
+                                    </Typography>
+                                    <IconButton
+                                        title={
+                                            loading
+                                                ? 'Suncokret odgovara'
+                                                : 'Pošalji'
+                                        }
+                                        type="submit"
+                                        disabled={
+                                            loading ||
+                                            blocked ||
+                                            input.trim().length === 0
+                                        }
+                                        className="size-9 shrink-0 rounded-full bg-emerald-700 text-white shadow-sm hover:bg-emerald-800 dark:bg-emerald-600 dark:hover:bg-emerald-500"
+                                    >
+                                        {loading ? (
+                                            <LoaderSpinner className="size-4 animate-spin" />
+                                        ) : (
+                                            <Send className="size-4" />
+                                        )}
+                                    </IconButton>
+                                </Row>
                             </form>
                             {debug && statusInfo && (
                                 <details className="text-xs text-muted-foreground">

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,6 +29,7 @@
     "dependencies": {
         "@gredice/js": "workspace:*",
         "@posthog/next": "0.7.0",
+        "@shadcn/react": "0.2.1",
         "@radix-ui/react-alert-dialog": "1.1.18",
         "@radix-ui/react-checkbox": "1.3.6",
         "@radix-ui/react-dialog": "1.1.18",

--- a/packages/ui/src/Chat/ChatBubble.tsx
+++ b/packages/ui/src/Chat/ChatBubble.tsx
@@ -1,0 +1,53 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type { HTMLAttributes } from 'react';
+import { cx } from '../utils';
+
+const chatBubbleVariants = cva(
+    'w-fit max-w-[82%] min-w-0 overflow-hidden rounded-2xl border px-3.5 py-2.5 text-sm leading-relaxed wrap-break-word',
+    {
+        variants: {
+            variant: {
+                default:
+                    'border-transparent bg-primary text-primary-foreground',
+                secondary:
+                    'border-transparent bg-secondary text-secondary-foreground',
+                muted: 'border-transparent bg-muted text-foreground',
+                sunflower:
+                    'border-amber-200/80 bg-amber-100/90 text-amber-950 dark:border-amber-800/70 dark:bg-amber-950/60 dark:text-amber-100',
+                outline: 'border-border bg-background text-foreground',
+                ghost: 'max-w-full rounded-none border-transparent bg-transparent p-0 text-foreground',
+                destructive:
+                    'border-red-200 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950/60 dark:text-red-100',
+            },
+        },
+        defaultVariants: {
+            variant: 'default',
+        },
+    },
+);
+
+export type ChatBubbleProps = HTMLAttributes<HTMLDivElement> &
+    VariantProps<typeof chatBubbleVariants> & {
+        align?: 'start' | 'end';
+    };
+
+export function ChatBubble({
+    align = 'start',
+    className,
+    variant = 'default',
+    ...props
+}: ChatBubbleProps) {
+    return (
+        <div
+            className={cx(
+                chatBubbleVariants({ variant }),
+                align === 'end' && 'self-end',
+                className,
+            )}
+            data-align={align}
+            data-chat-bubble=""
+            data-variant={variant}
+            {...props}
+        />
+    );
+}

--- a/packages/ui/src/Chat/ChatMarker.tsx
+++ b/packages/ui/src/Chat/ChatMarker.tsx
@@ -1,0 +1,47 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from '../utils';
+
+export type ChatMarkerProps = HTMLAttributes<HTMLDivElement> & {
+    icon?: ReactNode;
+    variant?: 'default' | 'border' | 'separator';
+};
+
+export function ChatMarker({
+    children,
+    className,
+    icon,
+    variant = 'default',
+    ...props
+}: ChatMarkerProps) {
+    return (
+        <div
+            className={cx(
+                'flex min-h-4 w-full items-center gap-2 text-left text-xs text-muted-foreground',
+                variant === 'border' && 'border-b border-border pb-2',
+                variant === 'separator' &&
+                    'before:mr-1 before:h-px before:min-w-0 before:flex-1 before:bg-border after:ml-1 after:h-px after:min-w-0 after:flex-1 after:bg-border',
+                className,
+            )}
+            data-chat-marker=""
+            data-variant={variant}
+            {...props}
+        >
+            {icon && (
+                <span
+                    aria-hidden="true"
+                    className="flex size-4 shrink-0 items-center justify-center [&_svg]:size-4"
+                >
+                    {icon}
+                </span>
+            )}
+            <span
+                className={cx(
+                    'min-w-0 wrap-break-word',
+                    variant === 'separator' && 'flex-none text-center',
+                )}
+            >
+                {children}
+            </span>
+        </div>
+    );
+}

--- a/packages/ui/src/Chat/ChatMessage.tsx
+++ b/packages/ui/src/Chat/ChatMessage.tsx
@@ -1,0 +1,56 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from '../utils';
+
+export type ChatMessageProps = HTMLAttributes<HTMLDivElement> & {
+    align?: 'start' | 'end';
+    avatar?: ReactNode;
+    footer?: ReactNode;
+    header?: ReactNode;
+};
+
+export function ChatMessage({
+    align = 'start',
+    avatar,
+    children,
+    className,
+    footer,
+    header,
+    ...props
+}: ChatMessageProps) {
+    return (
+        <div
+            className={cx(
+                'flex w-full min-w-0 gap-2 text-sm',
+                align === 'end' && 'flex-row-reverse',
+                className,
+            )}
+            data-align={align}
+            data-chat-message=""
+            {...props}
+        >
+            {avatar && (
+                <div className="flex size-8 shrink-0 items-center justify-center self-end overflow-hidden rounded-full border border-border bg-muted">
+                    {avatar}
+                </div>
+            )}
+            <div
+                className={cx(
+                    'flex min-w-0 flex-1 flex-col gap-1.5',
+                    align === 'end' ? 'items-end' : 'items-start',
+                )}
+            >
+                {header && (
+                    <div className="max-w-full min-w-0 px-1 text-xs font-medium text-muted-foreground">
+                        {header}
+                    </div>
+                )}
+                {children}
+                {footer && (
+                    <div className="max-w-full min-w-0 px-1 text-xs text-muted-foreground">
+                        {footer}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/Chat/ChatMessageScroller.tsx
+++ b/packages/ui/src/Chat/ChatMessageScroller.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { MessageScroller } from '@shadcn/react/message-scroller';
+import type { HTMLAttributes, ReactNode } from 'react';
+import { Down } from '../icons';
+import { cx } from '../utils';
+
+export type ChatMessageScrollerItem = {
+    content: ReactNode;
+    id: string;
+    scrollAnchor?: boolean;
+};
+
+export type ChatMessageScrollerProps = Omit<
+    HTMLAttributes<HTMLDivElement>,
+    'children'
+> & {
+    ariaBusy?: boolean;
+    ariaLabel?: string;
+    contentClassName?: string;
+    emptyContent?: ReactNode;
+    items: ChatMessageScrollerItem[];
+    scrollButtonLabel?: string;
+};
+
+export function ChatMessageScroller({
+    ariaBusy = false,
+    ariaLabel = 'Razgovor',
+    className,
+    contentClassName,
+    emptyContent,
+    items,
+    scrollButtonLabel = 'Najnovije poruke',
+    ...props
+}: ChatMessageScrollerProps) {
+    return (
+        <MessageScroller.Provider
+            autoScroll
+            defaultScrollPosition="end"
+            scrollPreviousItemPeek={48}
+        >
+            <MessageScroller.Root
+                className={cx(
+                    'relative flex size-full min-h-0 flex-col overflow-hidden',
+                    className,
+                )}
+                data-chat-message-scroller=""
+                {...props}
+            >
+                <MessageScroller.Viewport
+                    aria-label={ariaLabel}
+                    className="size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain"
+                    data-chat-message-scroller-viewport=""
+                >
+                    <MessageScroller.Content
+                        aria-busy={ariaBusy}
+                        className={cx(
+                            'flex h-max min-h-full flex-col gap-5 px-4 py-5',
+                            contentClassName,
+                        )}
+                    >
+                        {items.length > 0
+                            ? items.map((item) => (
+                                  <MessageScroller.Item
+                                      className="min-w-0 shrink-0 [contain-intrinsic-size:auto_8rem] [content-visibility:auto]"
+                                      key={item.id}
+                                      messageId={item.id}
+                                      scrollAnchor={item.scrollAnchor}
+                                  >
+                                      {item.content}
+                                  </MessageScroller.Item>
+                              ))
+                            : emptyContent && (
+                                  <MessageScroller.Item
+                                      className="flex min-h-full min-w-0 flex-1 items-center justify-center"
+                                      messageId="chat-empty-state"
+                                  >
+                                      {emptyContent}
+                                  </MessageScroller.Item>
+                              )}
+                    </MessageScroller.Content>
+                </MessageScroller.Viewport>
+                <MessageScroller.Button
+                    className="absolute bottom-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-border bg-background/95 px-3 py-1.5 text-xs font-medium text-foreground shadow-md backdrop-blur-sm transition-[transform,opacity] duration-200 hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring data-[active=false]:pointer-events-none data-[active=false]:translate-y-3 data-[active=false]:scale-95 data-[active=false]:opacity-0 data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100"
+                    direction="end"
+                    type="button"
+                >
+                    <Down className="size-3.5" />
+                    <span>{scrollButtonLabel}</span>
+                </MessageScroller.Button>
+            </MessageScroller.Root>
+        </MessageScroller.Provider>
+    );
+}

--- a/packages/ui/src/Chat/index.ts
+++ b/packages/ui/src/Chat/index.ts
@@ -1,0 +1,8 @@
+export { ChatBubble, type ChatBubbleProps } from './ChatBubble';
+export { ChatMarker, type ChatMarkerProps } from './ChatMarker';
+export { ChatMessage, type ChatMessageProps } from './ChatMessage';
+export {
+    ChatMessageScroller,
+    type ChatMessageScrollerItem,
+    type ChatMessageScrollerProps,
+} from './ChatMessageScroller';

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -122,3 +122,53 @@
 svg.lucide {
     stroke-width: 1.75px;
 }
+
+@keyframes chat-shimmer {
+    to {
+        background-position: -200% center;
+    }
+}
+
+[data-chat-message-scroller] [data-chat-message-scroller-viewport] {
+    --chat-scroll-fade-top: 1;
+    --chat-scroll-fade-bottom: 1;
+    mask-image: linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, var(--chat-scroll-fade-top)) 0,
+        #000 1.5rem,
+        #000 calc(100% - 1.5rem),
+        rgba(0, 0, 0, var(--chat-scroll-fade-bottom)) 100%
+    );
+}
+
+[data-chat-message-scroller][data-scrollable~="start"]
+    [data-chat-message-scroller-viewport] {
+    --chat-scroll-fade-top: 0;
+}
+
+[data-chat-message-scroller][data-scrollable~="end"]
+    [data-chat-message-scroller-viewport] {
+    --chat-scroll-fade-bottom: 0;
+}
+
+.chat-shimmer {
+    animation: chat-shimmer 1.8s linear infinite;
+    background-image: linear-gradient(
+        90deg,
+        hsl(var(--muted-foreground)) 35%,
+        hsl(var(--foreground)) 50%,
+        hsl(var(--muted-foreground)) 65%
+    );
+    background-position: 200% center;
+    background-size: 200% 100%;
+    background-clip: text;
+    color: transparent;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .chat-shimmer {
+        animation: none;
+        background: none;
+        color: inherit;
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1512,6 +1512,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.2.11
         version: 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@shadcn/react':
+        specifier: 0.2.1
+        version: 0.2.1(@types/react@19.2.17)(react@19.2.7)
       '@tanstack/react-query':
         specifier: ~5.101.2
         version: 5.101.2(react@19.2.7)
@@ -4941,6 +4944,17 @@ packages:
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@shadcn/react@0.2.1':
+    resolution: {integrity: sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ==}
+    peerDependencies:
+      '@types/react': 19.2.17
+      react: '>=19'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -13698,6 +13712,11 @@ snapshots:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.11.0
+
+  '@shadcn/react@0.2.1(@types/react@19.2.17)(react@19.2.7)':
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   '@sindresorhus/is@4.6.0': {}
 


### PR DESCRIPTION
## What changed

- add reusable Gredice chat primitives for messages, bubbles, markers, and streaming-safe scrolling
- adopt the new shadcn MessageScroller behavior for anchored turns, auto-follow, edge fades, and jump-to-latest
- redesign the Suncokret HUD with Gredice sunflower and garden colors, improved empty/loading/error states, and a richer composer
- add Storybook conversation, long-thread, empty, streaming, and garden-workspace coverage

## Why

The existing Suncokret chat used a basic scroll container and visually generic message cards. This update brings the interaction and presentation closer to the recently released shadcn chat patterns while keeping the existing Gredice AI transport, limits, approvals, and debugging behavior intact.

## Impact

Users get a calmer, more recognizable in-game assistant with stable streaming scroll behavior, clearer tool activity, responsive mobile layout, and easier access to the latest message in long conversations.

## Validation

- `pnpm typecheck --filter @gredice/ui`
- `pnpm typecheck --filter @gredice/game`
- `pnpm typecheck --filter storybook`
- `pnpm typecheck --filter garden`
- `pnpm typecheck --filter www`
- `pnpm test --filter @gredice/game` — 370 tests passed
- targeted Biome checks
- Storybook browser verification at desktop and 390 × 844 widths
- verified empty, streaming, long-thread, and jump-to-latest behavior with no console errors or overflow
