### PR TITLE
feat(ai): update default models and pricing for GPT-5.6

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -8,7 +8,7 @@ POSTHOG_PROXY_HOST=
 GREDICE_JWT_SIGN_SECRET=local-dev-sign-secret
 GREDICE_GARDEN_APP_URL=https://vrt.gredice.test
 GREDICE_ADMIN_APP_URL=https://app.gredice.test
-AI_GATEWAY_MODEL=openai/gpt-5
+AI_GATEWAY_MODEL=openai/gpt-5.6-terra
 CMS_PAGES_PREVIEW_SECRET=local-preview-secret
 
 # Test-safe defaults for nonessential services

--- a/apps/api/lib/ai/suncokretModels.node.spec.ts
+++ b/apps/api/lib/ai/suncokretModels.node.spec.ts
@@ -41,10 +41,14 @@ test('getSuncokretModel defaults to DeepSeek V4 Flash', () => {
 test('getSuncokretModel falls back to the first enabled model for automatic selection', () => {
     withModelEnv(
         {
-            allowlist: 'openai/gpt-5.5',
+            allowlist: 'openai/gpt-5.6-luna',
         },
         () => {
-            assert.equal(getSuncokretModel()?.id, 'openai/gpt-5.5');
+            const model = getSuncokretModel();
+
+            assert.equal(model?.id, 'openai/gpt-5.6-luna');
+            assert.equal(model?.inputUsdPerMillionTokens, 1);
+            assert.equal(model?.outputUsdPerMillionTokens, 6);
         },
     );
 });
@@ -52,7 +56,7 @@ test('getSuncokretModel falls back to the first enabled model for automatic sele
 test('getSuncokretModel keeps explicit unavailable model requests invalid', () => {
     withModelEnv(
         {
-            allowlist: 'openai/gpt-5.5',
+            allowlist: 'openai/gpt-5.6-luna',
         },
         () => {
             assert.equal(getSuncokretModel('deepseek/deepseek-v4-flash'), null);

--- a/apps/api/lib/ai/suncokretModels.ts
+++ b/apps/api/lib/ai/suncokretModels.ts
@@ -13,10 +13,10 @@ const DEFAULT_MODEL_ID = 'deepseek/deepseek-v4-flash';
 
 const MODEL_REGISTRY: SuncokretModelConfig[] = [
     {
-        id: 'openai/gpt-5.5',
-        label: 'OpenAI GPT-5.5',
-        inputUsdPerMillionTokens: 5,
-        outputUsdPerMillionTokens: 30,
+        id: 'openai/gpt-5.6-luna',
+        label: 'OpenAI GPT-5.6 Luna',
+        inputUsdPerMillionTokens: 1,
+        outputUsdPerMillionTokens: 6,
         enabled: true,
     },
     {

--- a/apps/api/lib/garden/raisedBedAiAnalysisService.ts
+++ b/apps/api/lib/garden/raisedBedAiAnalysisService.ts
@@ -23,7 +23,7 @@ const GREENHOUSE_SEEDLING_STATUSES = new Set([
     'sprouted',
 ]);
 
-const AI_MODEL = process.env.AI_GATEWAY_MODEL ?? 'openai/gpt-5.5';
+const AI_MODEL = process.env.AI_GATEWAY_MODEL ?? 'openai/gpt-5.6-terra';
 
 export const AI_REQUEST_QUOTA_WINDOW_DAYS = 7;
 export const AI_REQUEST_QUOTA_WINDOW_MS =

--- a/apps/app/src/ai/aiAnalyticsCost.ts
+++ b/apps/app/src/ai/aiAnalyticsCost.ts
@@ -21,6 +21,15 @@ type AiModelPricing = {
 const TOKENS_PER_MILLION = 1_000_000;
 
 const AI_MODEL_PRICING_USD: Record<string, AiModelPricing> = {
+    'gpt-5.6-terra': {
+        inputUsdPerMillionTokens: 2.5,
+        outputUsdPerMillionTokens: 15,
+        longContext: {
+            inputTokenThreshold: 272_000,
+            inputRateMultiplier: 2,
+            outputRateMultiplier: 1.5,
+        },
+    },
     'gpt-5.5': {
         inputUsdPerMillionTokens: 5,
         outputUsdPerMillionTokens: 30,

--- a/apps/app/src/ai/aiAnalyticsCost.unit.ts
+++ b/apps/app/src/ai/aiAnalyticsCost.unit.ts
@@ -5,6 +5,26 @@ import {
     sumAiAnalysisCostUsd,
 } from './aiAnalyticsCost';
 
+test('estimateAiAnalysisCostUsd calculates standard GPT-5.6 Terra usage cost', () => {
+    const cost = estimateAiAnalysisCostUsd({
+        model: 'openai/gpt-5.6-terra',
+        inputTokens: 200_000,
+        outputTokens: 100_000,
+    });
+
+    assert.strictEqual(cost, 2);
+});
+
+test('estimateAiAnalysisCostUsd applies GPT-5.6 Terra long-context multipliers', () => {
+    const cost = estimateAiAnalysisCostUsd({
+        model: 'gpt-5.6-terra',
+        inputTokens: 300_000,
+        outputTokens: 100_000,
+    });
+
+    assert.strictEqual(cost, 3.75);
+});
+
 test('estimateAiAnalysisCostUsd calculates standard GPT-5.5 usage cost', () => {
     const cost = estimateAiAnalysisCostUsd({
         model: 'openai/gpt-5.5',

--- a/packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts
+++ b/packages/storage/src/automations/raisedBedImagePlantStatusAnalysis.ts
@@ -24,7 +24,7 @@ import type { AutomationJsonObject } from '../schema';
 import { buildPreviousPlantNames } from './raisedBedImagePlantContext';
 import type { AutomationSourceEvent } from './types';
 
-const AI_MODEL = process.env.AI_GATEWAY_MODEL ?? 'openai/gpt-5.5';
+const AI_MODEL = process.env.AI_GATEWAY_MODEL ?? 'openai/gpt-5.6-terra';
 const RAISED_BED_COLUMNS = 3;
 const REVIEW_REQUESTER = 'automation:raised-bed-image-status-review';
 const MAX_AI_DEBUG_TEXT_LENGTH = 8_000;


### PR DESCRIPTION
## Summary
- Switch API and automation defaults from GPT-5.5 to GPT-5.6 Terra
- Replace the Suncokret allowlisted model with GPT-5.6 Luna and update its pricing metadata
- Add GPT-5.6 Terra analytics pricing, including long-context multipliers
- Extend unit coverage for the new pricing behavior

## Testing
- Not run (not requested)