### PR TITLE
feat(garden): enlarge raised bed details modal

### DIFF
--- a/apps/garden/tests/RaisedBedFieldHudStory.tsx
+++ b/apps/garden/tests/RaisedBedFieldHudStory.tsx
@@ -305,7 +305,7 @@ function RaisedBedInfoModalStoryContent() {
             open
             title="Informacije o gredici"
             modal={false}
-            className="overflow-x-hidden md:border-tertiary md:border-b-4"
+            className="overflow-x-hidden md:max-w-4xl md:border-tertiary md:border-b-4"
         >
             <RaisedBedInfo gardenId={garden.id} raisedBed={raisedBed} />
         </Modal>

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -2038,6 +2038,35 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         ).toBeLessThanOrEqual(1);
     });
 
+    test('raised bed details modal uses expanded desktop dimensions', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedCloseupHudStory
+                scenario={raisedBedScrollableOperationHistoryScenario()}
+            />,
+        );
+
+        await page.locator('[data-raised-bed-details-trigger]').click();
+
+        const dialog = page.getByRole('dialog');
+        const diaryViewport = dialog
+            .locator('[data-scroll-view-viewport]')
+            .first();
+        await expect(dialog).toBeVisible();
+        await expect(diaryViewport).toBeVisible();
+
+        const dialogBox = await dialog.boundingBox();
+        const diaryViewportBox = await diaryViewport.boundingBox();
+
+        expect(dialogBox?.width).toBeGreaterThanOrEqual(800);
+        expect(dialogBox?.height).toBeLessThanOrEqual(
+            DESKTOP_VIEWPORT.height - 32,
+        );
+        expect(diaryViewportBox?.height).toBeGreaterThan(384);
+    });
+
     test('raised bed diary scroll view uses modal edge scrollbar and overflow fades', async ({
         mount,
         page,

--- a/packages/game/src/hud/RaisedBedFieldHud.tsx
+++ b/packages/game/src/hud/RaisedBedFieldHud.tsx
@@ -116,7 +116,7 @@ export function RaisedBedFieldHud() {
                             }}
                             title="Informacije o gredici"
                             modal={false}
-                            className="overflow-x-hidden"
+                            className="overflow-x-hidden md:max-w-4xl"
                             trigger={
                                 <ButtonGreen
                                     className="min-w-0 flex-1 justify-between rounded-none px-3 !bg-transparent !bg-none !text-green-950 shadow-none hover:!bg-white/30 hover:!text-green-900 dark:!text-lime-50 dark:hover:!bg-white/10 dark:hover:!text-lime-100"

--- a/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
@@ -233,7 +233,7 @@ export function RaisedBedInfo({
                 <TabsContent value="diary">
                     <ScrollView
                         className="-mx-4 md:-mx-6"
-                        viewportClassName="max-h-96"
+                        viewportClassName="max-h-96 md:max-h-[60dvh]"
                         contentClassName="pl-4 pr-2 md:pl-6 md:pr-2"
                     >
                         <RaisedBedOperationHistoryList


### PR DESCRIPTION
## Summary

- widen the raised bed details modal on desktop
- let the diary viewport use more desktop height so more entries remain visible
- preserve the existing mobile drawer sizing
- add a Chromium component regression test for the expanded desktop dimensions

## Why

The shared modal default constrained the raised bed details view to a narrow desktop width, causing long diary entries to wrap heavily and reducing the number of visible items.

## Validation

- `corepack pnpm --dir packages/game exec biome check src/hud/RaisedBedFieldHud.tsx src/hud/raisedBed/RaisedBedInfo.tsx ../../apps/garden/tests/RaisedBedFieldHudStory.tsx ../../apps/garden/tests/raised-bed-field-hud.spec.tsx`
- `corepack pnpm typecheck --filter @gredice/game --filter garden --filter www`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --dir apps/garden exec playwright test tests/raised-bed-field-hud.spec.tsx --grep "raised bed (diary operation history does not overflow the modal|details modal uses expanded desktop dimensions|diary scroll view uses modal edge scrollbar)"`
- `git diff --check`