### PR TITLE
feat(garden): move raised bed abandonment to settings

### DIFF
--- a/apps/api/app/api/[...route]/gardensRoutes.ts
+++ b/apps/api/app/api/[...route]/gardensRoutes.ts
@@ -2719,6 +2719,12 @@ const app = new Hono<{ Variables: AuthVariables }>()
                     409,
                 );
             }
+            if (raisedBed.status !== 'active') {
+                return context.json(
+                    { error: 'Only active raised beds can be abandoned' },
+                    409,
+                );
+            }
 
             const operationId = await abandonRaisedBed({
                 accountId,

--- a/apps/garden/tests/garden-tab.spec.tsx
+++ b/apps/garden/tests/garden-tab.spec.tsx
@@ -69,6 +69,114 @@ test.describe('Garden tab', () => {
         ).toBeDisabled();
     });
 
+    test('requires an active raised bed selection and confirmation before abandonment', async ({
+        mount,
+        page,
+    }) => {
+        const abandonRequests: string[] = [];
+        await page.route(
+            '**/api/gredice/api/gardens/1/raised-beds/*/abandon',
+            async (route) => {
+                if (route.request().method() === 'POST') {
+                    abandonRequests.push(route.request().url());
+                    await route.fulfill({
+                        contentType: 'application/json',
+                        status: 201,
+                        body: JSON.stringify({ id: 99 }),
+                    });
+                    return;
+                }
+
+                await route.fallback();
+            },
+        );
+
+        await mount(<GardenTabStory activeRaisedBedCount={2} />);
+
+        const abandonButton = page.getByRole('button', {
+            name: 'Napusti gredicu',
+        });
+        await expect(abandonButton).toBeDisabled();
+
+        await page.getByLabel('Aktivna gredica').click();
+        await expect(
+            page.getByRole('option', { name: 'Gredica 3' }),
+        ).toHaveCount(0);
+        await page.getByRole('option', { name: 'Gredica 2' }).click();
+        await expect(abandonButton).toBeEnabled();
+
+        await abandonButton.click();
+        const dialog = page.getByRole('alertdialog', {
+            name: 'Napuštanje gredice',
+        });
+        await expect(dialog).toBeVisible();
+        expect(abandonRequests).toHaveLength(0);
+
+        await dialog.getByRole('button', { name: 'Napusti gredicu' }).click();
+
+        await expect.poll(() => abandonRequests.length).toBe(1);
+        expect(abandonRequests[0]).toContain(
+            '/gardens/1/raised-beds/2/abandon',
+        );
+        await expect(
+            page.getByText(
+                'Postupak napuštanja gredice „Gredica 2” je pokrenut.',
+            ),
+        ).toBeVisible();
+    });
+
+    test('disables raised bed abandonment when the garden has no active beds', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<GardenTabStory activeRaisedBedCount={0} />);
+
+        await expect(page.getByLabel('Aktivna gredica')).toBeDisabled();
+        await expect(
+            page.getByText('Vrt nema aktivnih gredica za napuštanje.'),
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Napusti gredicu' }),
+        ).toBeDisabled();
+    });
+
+    test('shows a recoverable error when raised bed eligibility changes before confirmation', async ({
+        mount,
+        page,
+    }) => {
+        await page.route(
+            '**/api/gredice/api/gardens/1/raised-beds/*/abandon',
+            async (route) => {
+                await route.fulfill({
+                    contentType: 'application/json',
+                    status: 409,
+                    body: JSON.stringify({
+                        error: 'Only active raised beds can be abandoned',
+                    }),
+                });
+            },
+        );
+
+        await mount(<GardenTabStory activeRaisedBedCount={1} />);
+
+        await page.getByLabel('Aktivna gredica').click();
+        await page.getByRole('option', { name: 'Gredica 1' }).click();
+        await page.getByRole('button', { name: 'Napusti gredicu' }).click();
+        await page
+            .getByRole('alertdialog', { name: 'Napuštanje gredice' })
+            .getByRole('button', { name: 'Napusti gredicu' })
+            .click();
+
+        await expect(
+            page.getByText(
+                'Odabrana gredica više nije aktivna. Osvježi popis i odaberi drugu gredicu.',
+            ),
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Napusti gredicu' }),
+        ).toBeEnabled();
+    });
+
     test('requires typed confirmation before deleting a garden', async ({
         mount,
         page,

--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -2325,7 +2325,7 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
         ).toHaveCount(1);
     });
 
-    test('raised bed more action sits in the header above the tabs', async ({
+    test('raised bed header no longer exposes the abandonment action', async ({
         mount,
         page,
     }) => {
@@ -2337,14 +2337,10 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
 
         const dialog = page.getByRole('dialog');
         await expect(dialog).toBeVisible();
-        const moreButton = dialog.getByRole('button', {
-            name: 'Prikaži dodatne opcije gredice',
-        });
         const photoButton = dialog.getByRole('button', {
             name: /Fotografije gredice Raised Bed 1/u,
         });
         const tabList = dialog.getByRole('tablist');
-        await expect(moreButton).toBeVisible();
         await expect(photoButton).toBeVisible();
         await expect(photoButton.locator('img')).toBeVisible();
         await expect(
@@ -2354,21 +2350,25 @@ test.describe('RaisedBedFieldItem HUD (mobile)', () => {
 
         await expect
             .poll(async () => {
-                const moreBox = await moreButton.boundingBox();
+                const photoBox = await photoButton.boundingBox();
                 const tabListBox = await tabList.boundingBox();
 
-                if (!moreBox || !tabListBox) {
+                if (!photoBox || !tabListBox) {
                     return Number.POSITIVE_INFINITY;
                 }
 
-                return moreBox.y + moreBox.height - tabListBox.y;
+                return photoBox.y + photoBox.height - tabListBox.y;
             })
             .toBeLessThanOrEqual(0);
 
-        await moreButton.click();
+        await expect(
+            dialog.getByRole('button', {
+                name: 'Prikaži dodatne opcije gredice',
+            }),
+        ).toHaveCount(0);
         await expect(
             dialog.getByRole('button', { name: 'Napusti gredicu' }),
-        ).toBeVisible();
+        ).toHaveCount(0);
     });
 
     test('raised bed info modal cover searches older history pages', async ({

--- a/packages/game/src/hooks/useAbandonRaisedBed.ts
+++ b/packages/game/src/hooks/useAbandonRaisedBed.ts
@@ -18,6 +18,15 @@ async function getAbandonErrorMessage(response: Response) {
         if (typeof body === 'object' && body !== null && 'error' in body) {
             const { error } = body;
             if (typeof error === 'string' && error.trim()) {
+                if (error === 'Raised bed is already abandoned') {
+                    return 'Odabrana gredica je već napuštena. Odaberi drugu aktivnu gredicu.';
+                }
+                if (error === 'Only active raised beds can be abandoned') {
+                    return 'Odabrana gredica više nije aktivna. Osvježi popis i odaberi drugu gredicu.';
+                }
+                if (error === 'Raised bed not found') {
+                    return 'Odabrana gredica više nije dostupna. Osvježi popis i pokušaj ponovno.';
+                }
                 return error;
             }
         }
@@ -28,7 +37,7 @@ async function getAbandonErrorMessage(response: Response) {
     return RAISED_BED_ABANDON_FAILED_MESSAGE;
 }
 
-export function useAbandonRaisedBed(gardenId: number, raisedBedId: number) {
+export function useAbandonRaisedBed(gardenId: number) {
     const queryClient = useQueryClient();
     const { data: garden } = useCurrentGarden();
     const winterMode = useGameState((state) => state.winterMode);
@@ -36,7 +45,7 @@ export function useAbandonRaisedBed(gardenId: number, raisedBedId: number) {
 
     return useMutation({
         mutationKey,
-        mutationFn: async () => {
+        mutationFn: async (raisedBedId: number) => {
             const response = await clientAuthenticated().api.gardens[
                 ':gardenId'
             ]['raised-beds'][':raisedBedId'].abandon.$post({
@@ -54,7 +63,7 @@ export function useAbandonRaisedBed(gardenId: number, raisedBedId: number) {
                 throw new Error(await getAbandonErrorMessage(response));
             }
         },
-        onMutate: async () => {
+        onMutate: async (raisedBedId) => {
             if (!garden) {
                 return;
             }

--- a/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedInfo.tsx
@@ -1,29 +1,19 @@
-import { Alert } from '@gredice/ui/Alert';
-import { Button } from '@gredice/ui/Button';
 import { EditableInput } from '@gredice/ui/EditableInput';
-import { Book, Hammer, Info, MoreHorizontal, Warning } from '@gredice/ui/icons';
-import { ModalConfirm } from '@gredice/ui/ModalConfirm';
+import { Book, Hammer, Info } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@gredice/ui/Tabs';
 import { Typography } from '@gredice/ui/Typography';
-import { cx } from '@gredice/ui/utils';
 import { useState } from 'react';
-import { useAbandonRaisedBed } from '../../hooks/useAbandonRaisedBed';
 import type { useCurrentGarden } from '../../hooks/useCurrentGarden';
 import { useUpdateRaisedBed } from '../../hooks/useUpdateRaisedBed';
-import {
-    RAISED_BED_ABANDON_FAILED_MESSAGE,
-    RAISED_BED_STATUS_ABANDONED,
-} from '../../raisedBedConstants';
 import { ScrollView } from '../../shared-ui/ScrollView';
-import { useGameState } from '../../useGameState';
 import { RaisedBedInfoTab } from './RaisedBedInfoTab';
 import { RaisedBedOperationHistoryList } from './RaisedBedOperationHistoryList';
 import { RaisedBedOperationsTab } from './RaisedBedOperationsTab';
 import { RaisedBedPhotosModal } from './RaisedBedPhotosModal';
 
-type RaisedBedTab = 'diary' | 'operations' | 'info' | 'more';
+type RaisedBedTab = 'diary' | 'operations' | 'info';
 
 export function RaisedBedInfo({
     gardenId,
@@ -35,40 +25,15 @@ export function RaisedBedInfo({
     >['raisedBeds'][0];
 }) {
     const updateRaisedBed = useUpdateRaisedBed(gardenId, raisedBed.id);
-    const abandonRaisedBed = useAbandonRaisedBed(gardenId, raisedBed.id);
-    const setView = useGameState((state) => state.setView);
     const [activeTab, setActiveTab] = useState<RaisedBedTab>('diary');
-    const [abandonError, setAbandonError] = useState<string | null>(null);
-    const isAbandoned = raisedBed.status === RAISED_BED_STATUS_ABANDONED;
 
     function handleNameChange(newName: string) {
         updateRaisedBed.mutate({ name: newName });
     }
 
-    function handleAbandonRaisedBed() {
-        if (abandonRaisedBed.isPending || isAbandoned) {
-            return;
-        }
-
-        setAbandonError(null);
-        abandonRaisedBed.mutate(undefined, {
-            onSuccess: () => {
-                setView({ view: 'normal' });
-            },
-            onError: (error) => {
-                console.error('Failed to abandon raised bed:', error);
-                if (error instanceof Error) {
-                    setAbandonError(error.message);
-                } else {
-                    setAbandonError(RAISED_BED_ABANDON_FAILED_MESSAGE);
-                }
-            },
-        });
-    }
-
     return (
         <Stack spacing={4} className="min-w-0 max-w-full">
-            <div className="grid min-w-0 max-w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 pr-8">
+            <div className="min-w-0 max-w-full pr-8">
                 <Row spacing={4} className="min-w-0 flex-1 items-start">
                     <RaisedBedPhotosModal
                         gardenId={gardenId}
@@ -84,23 +49,6 @@ export function RaisedBedInfo({
                             className="w-full"
                         />
                     </Stack>
-                </Row>
-                <Row spacing={2} className="items-start">
-                    <Button
-                        type="button"
-                        variant="plain"
-                        size="sm"
-                        aria-label="Prikaži dodatne opcije gredice"
-                        className={cx(
-                            'size-8 min-w-8 shrink-0 rounded-full p-0',
-                            activeTab === 'more'
-                                ? 'bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-300'
-                                : undefined,
-                        )}
-                        onClick={() => setActiveTab('more')}
-                    >
-                        <MoreHorizontal className="size-4" />
-                    </Button>
                 </Row>
             </div>
             <Tabs
@@ -137,98 +85,6 @@ export function RaisedBedInfo({
                         gardenId={gardenId}
                         raisedBedId={raisedBed.id}
                     />
-                </TabsContent>
-                <TabsContent value="more">
-                    <Stack spacing={4}>
-                        {isAbandoned ? (
-                            <Alert
-                                color="danger"
-                                startDecorator={
-                                    <Warning className="size-4 shrink-0" />
-                                }
-                            >
-                                <Typography level="body2">
-                                    Gredica je označena kao napuštena.
-                                </Typography>
-                            </Alert>
-                        ) : (
-                            <Stack
-                                spacing={3}
-                                className="rounded-xl border border-red-200 bg-red-50/90 p-4 shadow-xs dark:border-red-900/60 dark:bg-red-950/90"
-                            >
-                                <Row spacing={4} alignItems="center">
-                                    <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-red-100 text-red-700 ring-4 ring-red-200/70 dark:bg-red-900/70 dark:text-red-100 dark:ring-red-800/70">
-                                        <Warning className="size-5 shrink-0" />
-                                    </div>
-                                    <Stack spacing={1}>
-                                        <Typography level="body1" semiBold>
-                                            Napusti gredicu
-                                        </Typography>
-                                        <Typography level="body2" secondary>
-                                            Ova radnja pokreće napuštanje
-                                            gredice.
-                                        </Typography>
-                                    </Stack>
-                                </Row>
-                                <Typography level="body2">
-                                    Napuštanjem gredice uklanjaju se sve biljke,
-                                    senzori i povezani podaci, baš kao prilikom
-                                    brisanja računa. Ova radnja je nepovratna.
-                                </Typography>
-                                <Typography level="body2" secondary>
-                                    Nakon napuštanja, gredica će biti odspojena
-                                    od tvog vrta i morat ćeš je ponovno
-                                    zatražiti želiš li je ponovno koristiti.
-                                </Typography>
-                                {abandonError && (
-                                    <Alert
-                                        color="danger"
-                                        startDecorator={
-                                            <Warning className="size-4 shrink-0" />
-                                        }
-                                    >
-                                        <Typography level="body2">
-                                            {abandonError}
-                                        </Typography>
-                                    </Alert>
-                                )}
-                                <ModalConfirm
-                                    title="Potvrdi napuštanje gredice"
-                                    header="Napuštanje gredice"
-                                    onConfirm={handleAbandonRaisedBed}
-                                    trigger={
-                                        <Button
-                                            type="button"
-                                            variant="solid"
-                                            className="bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-600 dark:bg-red-700 dark:hover:bg-red-600"
-                                            disabled={
-                                                abandonRaisedBed.isPending
-                                            }
-                                            loading={abandonRaisedBed.isPending}
-                                        >
-                                            Napusti gredicu
-                                        </Button>
-                                    }
-                                >
-                                    <Stack spacing={4}>
-                                        <Typography>
-                                            Napuštanjem gredice{' '}
-                                            <strong>{raisedBed.name}</strong>{' '}
-                                            uklonit će se sve biljke, senzori i
-                                            povezani podaci. Postupak je jednak
-                                            onome koji provodimo pri brisanju
-                                            računa i ne može se poništiti.
-                                        </Typography>
-                                        <Typography level="body2">
-                                            Ako se predomisliš, gredicu će biti
-                                            potrebno ponovno zatražiti i
-                                            postaviti u vrtu.
-                                        </Typography>
-                                    </Stack>
-                                </ModalConfirm>
-                            </Stack>
-                        )}
-                    </Stack>
                 </TabsContent>
                 <TabsContent value="diary">
                     <ScrollView

--- a/packages/game/src/modals/components/GardenTab.tsx
+++ b/packages/game/src/modals/components/GardenTab.tsx
@@ -23,6 +23,7 @@ import { GardenDangerCard } from './GardenDangerCard';
 import { GardenHomeCameraCard } from './GardenHomeCameraCard';
 import { GardenNameCard } from './GardenNameCard';
 import { GardenVisibilityCard } from './GardenVisibilityCard';
+import { RaisedBedAbandonCard } from './RaisedBedAbandonCard';
 
 function NoGardensCard() {
     const [createGardenModalOpen, setCreateGardenModalOpen] = useState(false);
@@ -156,6 +157,9 @@ export function GardenTab() {
                                     gardenId={selectedGarden.id}
                                     gardenName={selectedGarden.name}
                                     isPublic={selectedGarden.isPublic}
+                                />
+                                <RaisedBedAbandonCard
+                                    gardenId={selectedGarden.id}
                                 />
                                 <GardenDangerCard
                                     gardenId={selectedGarden.id}

--- a/packages/game/src/modals/components/RaisedBedAbandonCard.tsx
+++ b/packages/game/src/modals/components/RaisedBedAbandonCard.tsx
@@ -1,0 +1,168 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent } from '@gredice/ui/Card';
+import { Warning } from '@gredice/ui/icons';
+import { ModalConfirm } from '@gredice/ui/ModalConfirm';
+import { Row } from '@gredice/ui/Row';
+import { SelectItems } from '@gredice/ui/SelectItems';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useState } from 'react';
+import { useAbandonRaisedBed } from '../../hooks/useAbandonRaisedBed';
+import { useCurrentGarden } from '../../hooks/useCurrentGarden';
+import { RAISED_BED_ABANDON_FAILED_MESSAGE } from '../../raisedBedConstants';
+
+type RaisedBedAbandonCardProps = {
+    gardenId: number;
+};
+
+export function RaisedBedAbandonCard({ gardenId }: RaisedBedAbandonCardProps) {
+    const { data: currentGarden } = useCurrentGarden();
+    const abandonRaisedBed = useAbandonRaisedBed(gardenId);
+    const [selectedRaisedBedId, setSelectedRaisedBedId] = useState<string>();
+    const [abandonError, setAbandonError] = useState<string | null>(null);
+    const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    const activeRaisedBeds =
+        currentGarden?.id === gardenId
+            ? currentGarden.raisedBeds.filter(
+                  (raisedBed) => raisedBed.status === 'active',
+              )
+            : undefined;
+    const selectedRaisedBed = activeRaisedBeds?.find(
+        (raisedBed) => raisedBed.id.toString() === selectedRaisedBedId,
+    );
+    const isSelectionValid = selectedRaisedBed?.status === 'active';
+    const isActionDisabled = !isSelectionValid || abandonRaisedBed.isPending;
+
+    function handleSelectionChange(raisedBedId: string) {
+        setSelectedRaisedBedId(raisedBedId);
+        setAbandonError(null);
+        setSuccessMessage(null);
+    }
+
+    function handleAbandonRaisedBed() {
+        if (!selectedRaisedBed || isActionDisabled) {
+            return;
+        }
+
+        const raisedBedName = selectedRaisedBed.name;
+        setAbandonError(null);
+        setSuccessMessage(null);
+        abandonRaisedBed.mutate(selectedRaisedBed.id, {
+            onSuccess: () => {
+                setSelectedRaisedBedId(undefined);
+                setSuccessMessage(
+                    `Postupak napuštanja gredice „${raisedBedName}” je pokrenut.`,
+                );
+            },
+            onError: (error) => {
+                setAbandonError(
+                    error instanceof Error
+                        ? error.message
+                        : RAISED_BED_ABANDON_FAILED_MESSAGE,
+                );
+            },
+        });
+    }
+
+    return (
+        <Card className="border-red-200 bg-red-50/80 shadow-xs dark:border-red-900/60 dark:bg-red-950/80">
+            <CardContent noHeader>
+                <Stack spacing={4}>
+                    <Row spacing={4} alignItems="start">
+                        <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-red-100 text-red-700 ring-4 ring-red-200/70 dark:bg-red-900/70 dark:text-red-100 dark:ring-red-800/70">
+                            <Warning className="size-5 shrink-0" />
+                        </div>
+                        <Stack spacing={1} className="min-w-0">
+                            <Typography level="body1" semiBold>
+                                Napuštanje gredice
+                            </Typography>
+                            <Typography level="body2">
+                                Odaberi aktivnu gredicu koju želiš odspojiti od
+                                vrta.
+                            </Typography>
+                        </Stack>
+                    </Row>
+                    <Typography level="body2">
+                        Napuštanjem se uklanjaju sve biljke, senzori i povezani
+                        podaci. Radnja se ne može poništiti, a gredicu će biti
+                        potrebno ponovno zatražiti želiš li je opet koristiti.
+                    </Typography>
+                    <SelectItems
+                        disabled={
+                            activeRaisedBeds === undefined ||
+                            activeRaisedBeds.length === 0 ||
+                            abandonRaisedBed.isPending
+                        }
+                        items={(activeRaisedBeds ?? []).map((raisedBed) => ({
+                            label: raisedBed.name,
+                            value: raisedBed.id.toString(),
+                        }))}
+                        label="Aktivna gredica"
+                        onValueChange={handleSelectionChange}
+                        placeholder="Odaberi gredicu"
+                        value={selectedRaisedBedId}
+                    />
+                    {activeRaisedBeds === undefined ? (
+                        <Typography level="body2" secondary>
+                            Provjeravamo status gredica.
+                        </Typography>
+                    ) : activeRaisedBeds.length === 0 ? (
+                        <Typography level="body2" secondary>
+                            Vrt nema aktivnih gredica za napuštanje.
+                        </Typography>
+                    ) : null}
+                    {abandonError ? (
+                        <Alert
+                            color="danger"
+                            startDecorator={
+                                <Warning className="size-4 shrink-0" />
+                            }
+                        >
+                            <Typography level="body2">
+                                {abandonError}
+                            </Typography>
+                        </Alert>
+                    ) : null}
+                    {successMessage ? (
+                        <Alert color="success">
+                            <Typography level="body2">
+                                {successMessage}
+                            </Typography>
+                        </Alert>
+                    ) : null}
+                    <ModalConfirm
+                        title="Potvrdi napuštanje gredice"
+                        header="Napuštanje gredice"
+                        confirmLabel="Napusti gredicu"
+                        onConfirm={handleAbandonRaisedBed}
+                        trigger={
+                            <Button
+                                type="button"
+                                variant="solid"
+                                color="danger"
+                                disabled={isActionDisabled}
+                                loading={abandonRaisedBed.isPending}
+                            >
+                                Napusti gredicu
+                            </Button>
+                        }
+                    >
+                        <Stack spacing={4}>
+                            <Typography>
+                                Napuštanjem gredice{' '}
+                                <strong>{selectedRaisedBed?.name}</strong>{' '}
+                                uklonit će se sve biljke, senzori i povezani
+                                podaci.
+                            </Typography>
+                            <Typography level="body2">
+                                Potvrdom će se pokrenuti postupak napuštanja.
+                                Ova se radnja ne može poništiti.
+                            </Typography>
+                        </Stack>
+                    </ModalConfirm>
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+}


### PR DESCRIPTION
## Summary

- remove raised-bed abandonment from the per-bed details modal
- add a guarded raised-bed selector to Garden settings with loading, empty, success, and recoverable error states
- require an explicit confirmation before queuing abandonment and revalidate active status on the API
- cover the relocated flow and the removed modal action with Playwright component tests

## Validation

- `corepack pnpm --filter game typecheck`
- `corepack pnpm --filter garden typecheck`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/garden-tab.spec.tsx`
- `corepack pnpm --filter garden exec playwright test tests/garden-tab.spec.tsx tests/raised-bed-field-hud.spec.tsx --grep 'Garden tab|raised bed header no longer exposes the abandonment action'`
- `corepack pnpm --filter api build`