### PR TITLE
fix(game): animate rain and snow particles

### DIFF
--- a/packages/game/src/scene/PrecipitationMaterial.ts
+++ b/packages/game/src/scene/PrecipitationMaterial.ts
@@ -1,0 +1,34 @@
+import {
+    DoubleSide,
+    type IUniform,
+    ShaderMaterial,
+    type ShaderMaterialParameters,
+} from 'three';
+
+type PrecipitationMaterialOptions = Pick<
+    ShaderMaterialParameters,
+    'fragmentShader' | 'vertexShader'
+> & {
+    timeUniform: IUniform<number>;
+    uniforms: Record<string, IUniform<unknown>>;
+};
+
+export function createPrecipitationMaterial({
+    fragmentShader,
+    timeUniform,
+    uniforms,
+    vertexShader,
+}: PrecipitationMaterialOptions) {
+    return new ShaderMaterial({
+        depthTest: false,
+        depthWrite: false,
+        fragmentShader,
+        side: DoubleSide,
+        transparent: true,
+        uniforms: {
+            ...uniforms,
+            uTime: timeUniform,
+        },
+        vertexShader,
+    });
+}

--- a/packages/game/src/scene/PrecipitationMaterial.unit.ts
+++ b/packages/game/src/scene/PrecipitationMaterial.unit.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createPrecipitationMaterial } from './PrecipitationMaterial';
+
+test('keeps the scene time uniform attached to precipitation materials', () => {
+    const timeUniform = { value: 0 };
+    const material = createPrecipitationMaterial({
+        fragmentShader: 'void main() { gl_FragColor = vec4(1.0); }',
+        timeUniform,
+        uniforms: {},
+        vertexShader: 'void main() { gl_Position = vec4(position, 1.0); }',
+    });
+
+    assert.equal(material.uniforms.uTime, timeUniform);
+
+    timeUniform.value = 2.5;
+
+    assert.equal(material.uniforms.uTime.value, 2.5);
+    material.dispose();
+});

--- a/packages/game/src/scene/Rain/Drops.tsx
+++ b/packages/game/src/scene/Rain/Drops.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import * as THREE from 'three';
 import { useGameState } from '../../useGameState';
+import { createPrecipitationMaterial } from '../PrecipitationMaterial';
 import { useSceneTimeInvalidation, useSceneTimeUniform } from '../SceneTime';
 
 interface DropsProps {
@@ -194,14 +195,21 @@ export const Drops = ({ count = 2000 }: DropsProps) => {
         [],
     );
 
-    const uniforms = useMemo(
-        () => ({
-            uTime: timeUniform,
-            uRainFieldSize: { value: size },
-            uRainProgress: { value: 1 },
-        }),
-        [timeUniform],
+    const material = useMemo(
+        () =>
+            createPrecipitationMaterial({
+                fragmentShader,
+                timeUniform,
+                uniforms: {
+                    uRainFieldSize: { value: size },
+                    uRainProgress: { value: 1 },
+                },
+                vertexShader,
+            }),
+        [fragmentShader, timeUniform, vertexShader],
     );
+
+    useEffect(() => () => material.dispose(), [material]);
 
     return (
         <group ref={fref} name="Weather:Rain">
@@ -211,16 +219,7 @@ export const Drops = ({ count = 2000 }: DropsProps) => {
                 frustumCulled={false}
                 renderOrder={35}
             >
-                <shaderMaterial
-                    key={vertexShader + fragmentShader}
-                    depthTest={false}
-                    depthWrite={false}
-                    vertexShader={vertexShader}
-                    fragmentShader={fragmentShader}
-                    side={THREE.DoubleSide}
-                    uniforms={uniforms}
-                    transparent
-                />
+                <primitive attach="material" object={material} />
             </instancedMesh>
         </group>
     );

--- a/packages/game/src/scene/Snow/Snow.tsx
+++ b/packages/game/src/scene/Snow/Snow.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import * as THREE from 'three';
 import { useGameState } from '../../useGameState';
+import { createPrecipitationMaterial } from '../PrecipitationMaterial';
 import { useSceneTimeInvalidation, useSceneTimeUniform } from '../SceneTime';
 
 const DEFAULT_FLAKE_SIZE = 0.07;
@@ -228,15 +229,22 @@ const Snow = ({
         });
     }, [camera, gameCamera, updateSnowFieldPosition]);
 
-    const uniforms = useMemo(
-        () => ({
-            uTime: timeUniform,
-            uSize: { value: size },
-            uHeightRange: { value: heightRange },
-            uGroundLevel: { value: groundLevel },
-        }),
+    const material = useMemo(
+        () =>
+            createPrecipitationMaterial({
+                fragmentShader: snowFragmentShader,
+                timeUniform,
+                uniforms: {
+                    uSize: { value: size },
+                    uHeightRange: { value: heightRange },
+                    uGroundLevel: { value: groundLevel },
+                },
+                vertexShader: snowVertexShader,
+            }),
         [groundLevel, heightRange, size, timeUniform],
     );
+
+    useEffect(() => () => material.dispose(), [material]);
 
     return (
         <group ref={fref} name="Weather:Snow">
@@ -246,15 +254,7 @@ const Snow = ({
                 frustumCulled={false}
                 renderOrder={36}
             >
-                <shaderMaterial
-                    depthTest={false}
-                    depthWrite={false}
-                    vertexShader={snowVertexShader}
-                    fragmentShader={snowFragmentShader}
-                    side={THREE.DoubleSide}
-                    transparent
-                    uniforms={uniforms}
-                />
+                <primitive attach="material" object={material} />
             </instancedMesh>
         </group>
     );


### PR DESCRIPTION
## What changed

- attach rain and snow shader materials imperatively so both retain the shared scene time uniform
- dispose precipitation materials when their owning component changes or unmounts
- add a regression test for the shared time-uniform reference

## Root cause

React Three Fiber preserves declarative ShaderMaterial uniform targets by copying incoming uniform objects. That disconnected the precipitation materials from the shared scene clock, leaving their GPU uTime value at 0 even while frames continued to render.

## Validation

- `pnpm --filter @gredice/game test`
- `pnpm --filter @gredice/game typecheck`
- `pnpm typecheck --filter garden --filter www`
- scoped Biome check for all changed files
- local debug profiles for snow and rain: no error overlay and 25 distinct GPU uTime samples across 25 consecutive frames for each effect