### PR TITLE
fix(farm): keep schedule tasks on Zagreb day

### DIFF
--- a/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
+++ b/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState, useTransition } from 'react';
 import { HomeButton } from '../../components/HomeButton';
 import { FarmScheduleSectionSkeleton } from './FarmScheduleSectionSkeleton';
 import { ScheduleDaySummarySkeleton } from './ScheduleDaySummarySkeleton';
+import { getFarmScheduleDateKey } from './scheduleShared';
 
 interface FarmScheduleNavigationFrameProps {
     children: ReactNode;
@@ -91,7 +92,7 @@ export function FarmScheduleNavigationFrame({
         month: 'long',
         year: 'numeric',
     }).format(date);
-    const isToday = new Date().toDateString() === date.toDateString();
+    const isToday = getFarmScheduleDateKey(new Date()) === optimisticDateKey;
 
     const prevDateKey = formatDateParam(getOffsetDate(date, -1));
     const nextDateKey = formatDateParam(getOffsetDate(date, 1));

--- a/apps/farm/app/schedule/ScheduleLabelPrintSection.tsx
+++ b/apps/farm/app/schedule/ScheduleLabelPrintSection.tsx
@@ -14,7 +14,7 @@ interface ScheduleLabelPrintSectionProps {
     dayDataPromise: Promise<FarmScheduleDayData>;
     operationsDataPromise: ReturnType<typeof getFarmScheduleOperationsData>;
     plantSortsPromise: ReturnType<typeof getFarmSchedulePlantSorts>;
-    date: Date;
+    dateKey: string;
 }
 
 function formatLabelCount(count: number) {
@@ -52,7 +52,7 @@ export async function ScheduleLabelPrintSection({
     dayDataPromise,
     operationsDataPromise,
     plantSortsPromise,
-    date,
+    dateKey,
 }: ScheduleLabelPrintSectionProps) {
     const [dayData, operationsData, plantSorts] = await Promise.all([
         dayDataPromise,
@@ -63,7 +63,7 @@ export async function ScheduleLabelPrintSection({
         dayData,
         plantSorts,
         operationsData,
-        date,
+        dateKey,
     );
 
     if (printData.labels.length === 0) {

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -1,3 +1,8 @@
+import {
+    calendarDateKeyToUtcDate,
+    getTimeZoneDateKey,
+    isCalendarDateKey,
+} from '@gredice/storage';
 import { Suspense } from 'react';
 import LoginDialog from '../../components/auth/LoginDialog';
 import { auth } from '../../lib/auth/auth';
@@ -13,48 +18,14 @@ import {
     getFarmSchedulePlantingsDayData,
     getFarmSchedulePlantSorts,
 } from './scheduleData';
+import { FARM_SCHEDULE_TIME_ZONE } from './scheduleShared';
 
 export const dynamic = 'force-dynamic';
 
-function formatDateParam(date: Date) {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
-}
-
 function parseDateParam(dateParam?: string) {
-    if (!dateParam) {
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-        return today;
-    }
-
-    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateParam);
-    if (!match) {
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-        return today;
-    }
-
-    const year = Number.parseInt(match[1], 10);
-    const monthIndex = Number.parseInt(match[2], 10) - 1;
-    const day = Number.parseInt(match[3], 10);
-    const date = new Date(year, monthIndex, day);
-    date.setHours(0, 0, 0, 0);
-
-    if (
-        Number.isNaN(date.getTime()) ||
-        date.getFullYear() !== year ||
-        date.getMonth() !== monthIndex ||
-        date.getDate() !== day
-    ) {
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-        return today;
-    }
-
-    return date;
+    return dateParam && isCalendarDateKey(dateParam)
+        ? dateParam
+        : getTimeZoneDateKey(new Date(), FARM_SCHEDULE_TIME_ZONE);
 }
 
 async function getFarmAuth() {
@@ -65,19 +36,30 @@ async function getFarmAuth() {
     }
 }
 
-function FarmScheduleContent({ date, userId }: { date: Date; userId: string }) {
-    const isToday = new Date().toDateString() === date.toDateString();
-    const dateKey = date.toISOString();
-    const selectedDateKey = formatDateParam(date);
-    const dayDataPromise = getFarmScheduleDayData(userId, dateKey, isToday);
+function FarmScheduleContent({
+    selectedDateKey,
+    userId,
+}: {
+    selectedDateKey: string;
+    userId: string;
+}) {
+    const isToday =
+        getTimeZoneDateKey(new Date(), FARM_SCHEDULE_TIME_ZONE) ===
+        selectedDateKey;
+    const printDate = calendarDateKeyToUtcDate(selectedDateKey);
+    const dayDataPromise = getFarmScheduleDayData(
+        userId,
+        selectedDateKey,
+        isToday,
+    );
     const plantingsDayDataPromise = getFarmSchedulePlantingsDayData(
         userId,
-        dateKey,
+        selectedDateKey,
         isToday,
     );
     const operationsDayDataPromise = getFarmScheduleOperationsDayData(
         userId,
-        dateKey,
+        selectedDateKey,
         isToday,
     );
     const operationsDataPromise = getFarmScheduleOperationsData();
@@ -100,7 +82,7 @@ function FarmScheduleContent({ date, userId }: { date: Date; userId: string }) {
                         dayDataPromise={dayDataPromise}
                         operationsDataPromise={operationsDataPromise}
                         plantSortsPromise={plantSortsPromise}
-                        date={date}
+                        date={printDate}
                     />
                 </Suspense>
             }
@@ -124,13 +106,16 @@ export default async function FarmSchedulePage({
     searchParams: Promise<{ date?: string }>;
 }) {
     const { date: dateParam } = await searchParams;
-    const date = parseDateParam(dateParam);
+    const selectedDateKey = parseDateParam(dateParam);
     const authContext = await getFarmAuth();
 
     return (
         <div className="min-h-[100dvh] w-full bg-background">
             {authContext ? (
-                <FarmScheduleContent date={date} userId={authContext.userId} />
+                <FarmScheduleContent
+                    selectedDateKey={selectedDateKey}
+                    userId={authContext.userId}
+                />
             ) : (
                 <LoginDialog />
             )}

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -1,8 +1,4 @@
-import {
-    calendarDateKeyToUtcDate,
-    getTimeZoneDateKey,
-    isCalendarDateKey,
-} from '@gredice/storage';
+import { getTimeZoneDateKey, isCalendarDateKey } from '@gredice/storage';
 import { Suspense } from 'react';
 import LoginDialog from '../../components/auth/LoginDialog';
 import { auth } from '../../lib/auth/auth';
@@ -46,7 +42,6 @@ function FarmScheduleContent({
     const isToday =
         getTimeZoneDateKey(new Date(), FARM_SCHEDULE_TIME_ZONE) ===
         selectedDateKey;
-    const printDate = calendarDateKeyToUtcDate(selectedDateKey);
     const dayDataPromise = getFarmScheduleDayData(
         userId,
         selectedDateKey,
@@ -82,7 +77,7 @@ function FarmScheduleContent({
                         dayDataPromise={dayDataPromise}
                         operationsDataPromise={operationsDataPromise}
                         plantSortsPromise={plantSortsPromise}
-                        date={printDate}
+                        dateKey={selectedDateKey}
                     />
                 </Suspense>
             }

--- a/apps/farm/app/schedule/scheduleData.ts
+++ b/apps/farm/app/schedule/scheduleData.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import {
+    addCalendarDays,
     cacheScheduleRead,
     type EntityStandardized,
     getEntitiesFormatted,
@@ -8,10 +9,13 @@ import {
     getFarmUserAcceptedOperationsByScheduleRange,
     getFarmUserRaisedBeds,
     getRaisedBedPhotoPreviews,
+    getTimeZoneDateKey,
+    getTimeZoneDayRange,
     scheduleCacheKeys,
     scheduleCacheTtls,
 } from '@gredice/storage';
 import { cache } from 'react';
+import { FARM_SCHEDULE_TIME_ZONE } from './scheduleShared';
 
 const operationsBackDays = 90;
 const raisedBedPhotoPreviewImageLimit = 3;
@@ -27,26 +31,12 @@ const SCHEDULE_OPERATION_STATUSES = new Set([
     'completed',
 ]);
 
-function startOfToday() {
-    const date = new Date();
-    date.setHours(0, 0, 0, 0);
-    return date;
-}
-
 function startOfDaysAgo(days: number) {
-    const date = startOfToday();
-    date.setDate(date.getDate() - days);
-    return date;
-}
-
-function getDayRange(date: Date) {
-    const from = new Date(date);
-    from.setHours(0, 0, 0, 0);
-
-    const to = new Date(date);
-    to.setHours(23, 59, 59, 999);
-
-    return { from, to };
+    const todayKey = getTimeZoneDateKey(new Date(), FARM_SCHEDULE_TIME_ZONE);
+    return getTimeZoneDayRange(
+        addCalendarDays(todayKey, -days),
+        FARM_SCHEDULE_TIME_ZONE,
+    ).from;
 }
 
 function dedupeById<T extends { id: number }>(items: T[]) {
@@ -63,12 +53,9 @@ function isFieldCompleted(status?: string) {
 
 function getScheduledFieldsForDay(
     isToday: boolean,
-    date: Date,
+    dateKey: string,
     raisedBeds: FarmScheduleRaisedBed[],
 ) {
-    const normalizedDate = new Date(date);
-    normalizedDate.setHours(0, 0, 0, 0);
-
     return raisedBeds
         .filter((raisedBed) => Boolean(raisedBed.physicalId))
         .flatMap((raisedBed) => raisedBed.fields)
@@ -83,7 +70,10 @@ function getScheduledFieldsForDay(
 
             if (isFieldCompleted(field.plantStatus) && field.plantSowDate) {
                 const sowDate = new Date(field.plantSowDate);
-                return sowDate.toDateString() === normalizedDate.toDateString();
+                return (
+                    getTimeZoneDateKey(sowDate, FARM_SCHEDULE_TIME_ZONE) ===
+                    dateKey
+                );
             }
 
             if (!field.plantScheduledDate) {
@@ -91,22 +81,22 @@ function getScheduledFieldsForDay(
             }
 
             const scheduledDate = new Date(field.plantScheduledDate);
+            const scheduledDateKey = getTimeZoneDateKey(
+                scheduledDate,
+                FARM_SCHEDULE_TIME_ZONE,
+            );
 
             return (
-                normalizedDate.toDateString() ===
-                    scheduledDate.toDateString() ||
-                (isToday && normalizedDate > scheduledDate)
+                scheduledDateKey === dateKey ||
+                (isToday && scheduledDateKey < dateKey)
             );
         });
 }
 
 function getSelectedDateOperationsForDay(
-    date: Date,
+    dateKey: string,
     operations: FarmScheduleOperation[],
 ) {
-    const normalizedDate = new Date(date);
-    normalizedDate.setHours(0, 0, 0, 0);
-
     return operations.filter((operation) => {
         if (!SCHEDULE_OPERATION_STATUSES.has(operation.status)) {
             return false;
@@ -122,7 +112,8 @@ function getSelectedDateOperationsForDay(
         if (isOperationCompleted(operation.status) && operation.completedAt) {
             const completedDate = new Date(operation.completedAt);
             return (
-                completedDate.toDateString() === normalizedDate.toDateString()
+                getTimeZoneDateKey(completedDate, FARM_SCHEDULE_TIME_ZONE) ===
+                dateKey
             );
         }
 
@@ -132,22 +123,20 @@ function getSelectedDateOperationsForDay(
 
         return (
             scheduledDate !== undefined &&
-            normalizedDate.toDateString() === scheduledDate.toDateString()
+            getTimeZoneDateKey(scheduledDate, FARM_SCHEDULE_TIME_ZONE) ===
+                dateKey
         );
     });
 }
 
 function getCarryoverOperationsForToday(
     isToday: boolean,
-    date: Date,
+    dateKey: string,
     operations: FarmScheduleOperation[],
 ) {
     if (!isToday) {
         return [];
     }
-
-    const normalizedDate = new Date(date);
-    normalizedDate.setHours(0, 0, 0, 0);
 
     return operations.filter((operation) => {
         if (!SCHEDULE_OPERATION_STATUSES.has(operation.status)) {
@@ -169,7 +158,12 @@ function getCarryoverOperationsForToday(
             return true;
         }
 
-        return normalizedDate > new Date(operation.scheduledDate);
+        return (
+            getTimeZoneDateKey(
+                new Date(operation.scheduledDate),
+                FARM_SCHEDULE_TIME_ZONE,
+            ) < dateKey
+        );
     });
 }
 
@@ -328,8 +322,10 @@ export const getFarmScheduleOperationsForDay = cache(
 
 export const getFarmScheduleSelectedDateOperationsForDay = cache(
     async (userId: string, dateKey: string) => {
-        const date = new Date(dateKey);
-        const { from, to } = getDayRange(date);
+        const { from, to } = getTimeZoneDayRange(
+            dateKey,
+            FARM_SCHEDULE_TIME_ZONE,
+        );
         const [scheduledOperations, completedOperations] = await Promise.all([
             getFarmUserAcceptedOperationsByScheduleRange({
                 userId,
@@ -344,7 +340,7 @@ export const getFarmScheduleSelectedDateOperationsForDay = cache(
         ]);
 
         return getSelectedDateOperationsForDay(
-            date,
+            dateKey,
             sortOperationsNewestFirst(
                 dedupeById([...scheduledOperations, ...completedOperations]),
             ),
@@ -358,10 +354,9 @@ export const getFarmScheduleCarryoverOperationsForDay = cache(
             return [];
         }
 
-        const date = new Date(dateKey);
         const operations = await getFarmScheduleOperations(userId);
 
-        return getCarryoverOperationsForToday(isToday, date, operations);
+        return getCarryoverOperationsForToday(isToday, dateKey, operations);
     },
 );
 
@@ -371,14 +366,13 @@ export const getFarmSchedulePlantingsDayData = cache(
         dateKey: string,
         isToday: boolean,
     ): Promise<FarmSchedulePlantingsDayData> => {
-        const date = new Date(dateKey);
         const raisedBeds = await getFarmScheduleRaisedBeds(userId);
 
         return {
             raisedBeds,
             scheduledFields: getScheduledFieldsForDay(
                 isToday,
-                date,
+                dateKey,
                 raisedBeds,
             ),
         };

--- a/apps/farm/app/schedule/scheduleLabelDate.spec.ts
+++ b/apps/farm/app/schedule/scheduleLabelDate.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+import { formatScheduleLabelDate } from './scheduleLabelDate';
+
+test('keeps printed label dates independent of the runtime timezone', () => {
+    expect(formatScheduleLabelDate('2026-07-10')).toBe('10.07.2026.');
+});
+
+test('rejects invalid schedule date keys', () => {
+    expect(() => formatScheduleLabelDate('10.07.2026')).toThrow(
+        'Invalid schedule date key.',
+    );
+});

--- a/apps/farm/app/schedule/scheduleLabelDate.ts
+++ b/apps/farm/app/schedule/scheduleLabelDate.ts
@@ -1,0 +1,12 @@
+export function formatScheduleLabelDate(dateKey: string) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateKey);
+    const year = match?.at(1);
+    const month = match?.at(2);
+    const day = match?.at(3);
+
+    if (!year || !month || !day) {
+        throw new Error('Invalid schedule date key.');
+    }
+
+    return `${day}.${month}.${year}.`;
+}

--- a/apps/farm/app/schedule/scheduleLabels.ts
+++ b/apps/farm/app/schedule/scheduleLabels.ts
@@ -6,6 +6,7 @@ import {
     type EntityStandardized,
 } from '@gredice/storage';
 import type { FarmScheduleDayData } from './scheduleData';
+import { formatScheduleLabelDate } from './scheduleLabelDate';
 import {
     getFieldPhysicalPositionIndex,
     groupRaisedBedsForSchedule,
@@ -46,12 +47,6 @@ function getPlantsPerFieldCount(
 
 function formatPieceCountLabel(count: number) {
     return `${count} ${count === 1 ? 'KOMAD' : 'KOMADA'}`;
-}
-
-function formatScheduleLabelDate(date: Date) {
-    const day = date.getDate().toString().padStart(2, '0');
-    const month = (date.getMonth() + 1).toString().padStart(2, '0');
-    return `${day}.${month}.${date.getFullYear()}.`;
 }
 
 function formatFieldRange(fields: SowingLabelField[]) {
@@ -501,11 +496,11 @@ export async function buildScheduleLabelPrintData(
     dayData: FarmScheduleDayData,
     plantSorts: EntityStandardized[] | null | undefined,
     operationsData: EntityStandardized[] | null | undefined,
-    date: Date,
+    dateKey: string,
 ) {
     const plantSortById = getEntityById(plantSorts);
     const operationDataById = getEntityById(operationsData);
-    const dateLabel = formatScheduleLabelDate(date);
+    const dateLabel = formatScheduleLabelDate(dateKey);
     const sowingLabels = buildSowingLabels(dayData, plantSortById, dateLabel);
     const harvestLabels = await buildHarvestLabels(
         dayData,

--- a/apps/farm/app/schedule/scheduleShared.ts
+++ b/apps/farm/app/schedule/scheduleShared.ts
@@ -6,6 +6,7 @@ type FarmRaisedBedField = FarmRaisedBed['fields'][number];
 type ScheduleTaskAgeIndicatorLevel = 'warning' | 'critical';
 
 const RAISED_BED_FIELDS_PER_BLOCK = 9;
+export const FARM_SCHEDULE_TIME_ZONE = 'Europe/Zagreb';
 
 export type RaisedBedScheduleGroup = {
     key: string;
@@ -22,6 +23,20 @@ export type ScheduleTaskAgeIndicator = {
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 const WARNING_TASK_AGE_DAYS = 2;
 const CRITICAL_TASK_AGE_DAYS = 3;
+
+export function getFarmScheduleDateKey(date: Date) {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+        timeZone: FARM_SCHEDULE_TIME_ZONE,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    }).formatToParts(date);
+    const values = Object.fromEntries(
+        parts.map((part) => [part.type, part.value]),
+    );
+
+    return `${values.year}-${values.month}-${values.day}`;
+}
 
 function comparePhysicalIds(left: string | null, right: string | null) {
     if (!left && !right) {
@@ -107,19 +122,23 @@ export function getScheduleDateFormat(
     referenceDate = new Date(),
 ): Intl.DateTimeFormatOptions {
     const parsedScheduledDate = parseScheduleDate(scheduledDate);
-    const includeYear =
-        !parsedScheduledDate ||
-        parsedScheduledDate.getFullYear() !== referenceDate.getFullYear();
+    const scheduledYear = parsedScheduledDate
+        ? getFarmScheduleDateKey(parsedScheduledDate).slice(0, 4)
+        : null;
+    const referenceYear = getFarmScheduleDateKey(referenceDate).slice(0, 4);
+    const includeYear = !parsedScheduledDate || scheduledYear !== referenceYear;
 
     return includeYear
         ? {
               day: '2-digit',
               month: '2-digit',
               year: 'numeric',
+              timeZone: FARM_SCHEDULE_TIME_ZONE,
           }
         : {
               day: '2-digit',
               month: '2-digit',
+              timeZone: FARM_SCHEDULE_TIME_ZONE,
           };
 }
 
@@ -196,10 +215,11 @@ export function getFieldPhysicalPositionIndex(
 }
 
 function getLocalDayNumber(date: Date) {
-    return (
-        Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) /
-        MILLISECONDS_PER_DAY
-    );
+    const [year, month, day] = getFarmScheduleDateKey(date)
+        .split('-')
+        .map(Number);
+
+    return Date.UTC(year, month - 1, day) / MILLISECONDS_PER_DAY;
 }
 
 function parseScheduleDate(date: Date | string | null | undefined) {

--- a/packages/storage/src/helpers/timezoneUtils.ts
+++ b/packages/storage/src/helpers/timezoneUtils.ts
@@ -51,15 +51,6 @@ export function addCalendarDays(dateKey: string, days: number) {
     return date.toISOString().slice(0, 10);
 }
 
-export function calendarDateKeyToUtcDate(dateKey: string) {
-    const parts = calendarDateParts(dateKey);
-    if (!parts) {
-        throw new Error('Invalid calendar date.');
-    }
-
-    return new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
-}
-
 export function zonedCalendarDateStart(dateKey: string, timeZone: string) {
     const parts = calendarDateParts(dateKey);
     if (!parts) {

--- a/packages/storage/src/helpers/timezoneUtils.ts
+++ b/packages/storage/src/helpers/timezoneUtils.ts
@@ -1,3 +1,121 @@
+const calendarDateKeyPattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+function calendarDateParts(dateKey: string) {
+    const match = calendarDateKeyPattern.exec(dateKey);
+    if (!match) {
+        return null;
+    }
+
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const date = new Date(Date.UTC(year, month - 1, day));
+
+    if (
+        date.getUTCFullYear() !== year ||
+        date.getUTCMonth() !== month - 1 ||
+        date.getUTCDate() !== day
+    ) {
+        return null;
+    }
+
+    return { day, month, year };
+}
+
+export function isCalendarDateKey(dateKey: string) {
+    return calendarDateParts(dateKey) !== null;
+}
+
+export function getTimeZoneDateKey(date: Date, timeZone: string) {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+        timeZone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    }).formatToParts(date);
+    const values = Object.fromEntries(
+        parts.map((part) => [part.type, part.value]),
+    );
+
+    return `${values.year}-${values.month}-${values.day}`;
+}
+
+export function addCalendarDays(dateKey: string, days: number) {
+    const parts = calendarDateParts(dateKey);
+    if (!parts || !Number.isInteger(days)) {
+        throw new Error('Invalid calendar date or day offset.');
+    }
+
+    const date = new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
+    date.setUTCDate(date.getUTCDate() + days);
+    return date.toISOString().slice(0, 10);
+}
+
+export function calendarDateKeyToUtcDate(dateKey: string) {
+    const parts = calendarDateParts(dateKey);
+    if (!parts) {
+        throw new Error('Invalid calendar date.');
+    }
+
+    return new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
+}
+
+export function zonedCalendarDateStart(dateKey: string, timeZone: string) {
+    const parts = calendarDateParts(dateKey);
+    if (!parts) {
+        throw new Error('Invalid calendar date.');
+    }
+
+    const targetUtc = Date.UTC(parts.year, parts.month - 1, parts.day);
+    let utc = targetUtc;
+
+    for (let index = 0; index < 4; index += 1) {
+        const formattedParts = new Intl.DateTimeFormat('en-US', {
+            timeZone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hourCycle: 'h23',
+        }).formatToParts(new Date(utc));
+        const values = Object.fromEntries(
+            formattedParts.map((part) => [part.type, part.value]),
+        );
+        const renderedUtc = Date.UTC(
+            Number(values.year),
+            Number(values.month) - 1,
+            Number(values.day),
+            Number(values.hour),
+            Number(values.minute),
+            Number(values.second),
+        );
+        const difference = targetUtc - renderedUtc;
+
+        if (difference === 0) {
+            break;
+        }
+
+        utc += difference;
+    }
+
+    return new Date(utc);
+}
+
+export function getTimeZoneDayRange(dateKey: string, timeZone: string) {
+    const from = zonedCalendarDateStart(dateKey, timeZone);
+    const nextDayStart = zonedCalendarDateStart(
+        addCalendarDays(dateKey, 1),
+        timeZone,
+    );
+
+    return {
+        from,
+        to: new Date(nextDayStart.getTime() - 1),
+    };
+}
+
 /**
  * Check if the current hour in a timezone matches the target hour.
  * @param timeZone - IANA timezone string (e.g., 'Europe/Paris')

--- a/packages/storage/tests/timezoneUtils.node.spec.ts
+++ b/packages/storage/tests/timezoneUtils.node.spec.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     addCalendarDays,
-    calendarDateKeyToUtcDate,
     getTimeZoneDateKey,
     getTimeZoneDayRange,
     isCalendarDateKey,
@@ -19,10 +18,6 @@ test('validates calendar date keys', () => {
 test('adds calendar days without depending on the runtime time zone', () => {
     assert.equal(addCalendarDays('2026-12-31', 1), '2027-01-01');
     assert.equal(addCalendarDays('2026-03-01', -1), '2026-02-28');
-    assert.equal(
-        calendarDateKeyToUtcDate('2026-07-10').toISOString(),
-        '2026-07-10T00:00:00.000Z',
-    );
 });
 
 test('uses the Zagreb calendar date across the summer UTC rollover', () => {

--- a/packages/storage/tests/timezoneUtils.node.spec.ts
+++ b/packages/storage/tests/timezoneUtils.node.spec.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    addCalendarDays,
+    calendarDateKeyToUtcDate,
+    getTimeZoneDateKey,
+    getTimeZoneDayRange,
+    isCalendarDateKey,
+} from '../src/helpers/timezoneUtils';
+
+const ZAGREB_TIME_ZONE = 'Europe/Zagreb';
+
+test('validates calendar date keys', () => {
+    assert.equal(isCalendarDateKey('2026-07-10'), true);
+    assert.equal(isCalendarDateKey('2026-02-29'), false);
+    assert.equal(isCalendarDateKey('2026-7-10'), false);
+});
+
+test('adds calendar days without depending on the runtime time zone', () => {
+    assert.equal(addCalendarDays('2026-12-31', 1), '2027-01-01');
+    assert.equal(addCalendarDays('2026-03-01', -1), '2026-02-28');
+    assert.equal(
+        calendarDateKeyToUtcDate('2026-07-10').toISOString(),
+        '2026-07-10T00:00:00.000Z',
+    );
+});
+
+test('uses the Zagreb calendar date across the summer UTC rollover', () => {
+    assert.equal(
+        getTimeZoneDateKey(
+            new Date('2026-07-10T21:59:59.999Z'),
+            ZAGREB_TIME_ZONE,
+        ),
+        '2026-07-10',
+    );
+    assert.equal(
+        getTimeZoneDateKey(
+            new Date('2026-07-10T22:00:00.000Z'),
+            ZAGREB_TIME_ZONE,
+        ),
+        '2026-07-11',
+    );
+});
+
+test('builds Zagreb day ranges that exclude the following local day', () => {
+    const julyTenth = getTimeZoneDayRange('2026-07-10', ZAGREB_TIME_ZONE);
+    const julyEleventh = getTimeZoneDayRange('2026-07-11', ZAGREB_TIME_ZONE);
+
+    assert.equal(julyTenth.from.toISOString(), '2026-07-09T22:00:00.000Z');
+    assert.equal(julyTenth.to.toISOString(), '2026-07-10T21:59:59.999Z');
+    assert.equal(julyEleventh.from.toISOString(), '2026-07-10T22:00:00.000Z');
+    assert.equal(
+        new Date('2026-07-10T22:00:00.000Z').getTime() <=
+            julyTenth.to.getTime(),
+        false,
+    );
+    assert.equal(
+        new Date('2026-07-10T22:00:00.000Z').getTime() >=
+            julyEleventh.from.getTime(),
+        true,
+    );
+});
+
+test('builds DST-aware Zagreb day ranges', () => {
+    const springForwardDay = getTimeZoneDayRange(
+        '2026-03-29',
+        ZAGREB_TIME_ZONE,
+    );
+
+    assert.equal(
+        springForwardDay.to.getTime() - springForwardDay.from.getTime() + 1,
+        23 * 60 * 60 * 1000,
+    );
+});


### PR DESCRIPTION
## Summary

- define farm schedule days explicitly in `Europe/Zagreb`
- use Zagreb-aware day boundaries for operation queries, carryover checks, planting grouping, and today detection
- render task date chips with the same schedule timezone
- add regression coverage for the July UTC rollover and DST day length

## Root cause

Production grouped tasks using the server's UTC calendar day while the date chip formatted the same timestamp in the browser's Zagreb timezone. A task at `2026-07-10T22:00:00Z` was therefore selected for July 10 but displayed as July 11.

## Impact

Tasks now appear only on their intended Zagreb calendar day. Existing scheduled timestamps require no migration.

## Validation

- `corepack pnpm --filter @gredice/storage exec node --import tsx --test tests/timezoneUtils.node.spec.ts`
- `corepack pnpm exec tsc --noEmit -p tsconfig.json` in `apps/farm`
- `corepack pnpm build --filter farm`
- scoped Biome checks and `git diff --check`

The full storage TypeScript project still reports unrelated existing errors in maintenance scripts and older tests; the new helper and regression test pass independently.