### PR TITLE
fix(app): keep raised bed field controls visible

### DIFF
--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldWeedStateSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldWeedStateSelector.tsx
@@ -1,47 +1,123 @@
 'use client';
 
 import type { RaisedBedWeedStateLevel } from '@gredice/storage';
-import { SelectItems } from '@gredice/ui/SelectItems';
-import { setRaisedBedFieldWeedState } from '../../../(actions)/raisedBedFieldsActions';
+import { Chip, type ColorPaletteProp } from '@gredice/ui/Chip';
+import { Check, Leaf, Warning } from '@gredice/ui/icons';
 import {
-    isRaisedBedWeedStateLevel,
-    RaisedBedWeedStateItems,
-} from './RaisedBedWeedStateItems';
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@gredice/ui/Menu';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState, useTransition } from 'react';
+import { setRaisedBedFieldWeedState } from '../../../(actions)/raisedBedFieldsActions';
+import { RaisedBedWeedStateItems } from './RaisedBedWeedStateItems';
+
+const weedStatePresentation: Record<
+    RaisedBedWeedStateLevel,
+    {
+        color: ColorPaletteProp;
+        icon: typeof Check;
+    }
+> = {
+    none: { color: 'success', icon: Check },
+    light: { color: 'warning', icon: Leaf },
+    heavy: { color: 'error', icon: Warning },
+};
 
 export function RaisedBedFieldWeedStateSelector({
     className,
     level,
     positionIndex,
     raisedBedId,
-    variant = 'outlined',
 }: {
     className?: string;
     level: RaisedBedWeedStateLevel;
     positionIndex: number;
     raisedBedId: number;
-    variant?: 'outlined' | 'plain';
 }) {
-    return (
-        <SelectItems
-            className={className}
-            placeholder={`Korov polje ${positionIndex + 1}`}
-            value={level}
-            onValueChange={(newValue) => {
-                if (
-                    !isRaisedBedWeedStateLevel(newValue) ||
-                    newValue === level
-                ) {
-                    return;
-                }
+    const router = useRouter();
+    const [isPending, startTransition] = useTransition();
+    const [optimisticLevel, setOptimisticLevel] = useState(level);
+    const currentItem = RaisedBedWeedStateItems.find(
+        (item) => item.value === optimisticLevel,
+    );
+    const currentPresentation = weedStatePresentation[optimisticLevel];
+    const CurrentIcon = currentPresentation.icon;
 
-                setRaisedBedFieldWeedState({
-                    level: newValue,
+    useEffect(() => {
+        setOptimisticLevel(level);
+    }, [level]);
+
+    const handleSelect = (nextLevel: RaisedBedWeedStateLevel) => {
+        if (nextLevel === optimisticLevel) {
+            return;
+        }
+
+        setOptimisticLevel(nextLevel);
+        startTransition(async () => {
+            try {
+                await setRaisedBedFieldWeedState({
+                    level: nextLevel,
                     positionIndex,
                     raisedBedId,
                 });
-            }}
-            items={RaisedBedWeedStateItems}
-            variant={variant}
-        />
+                router.refresh();
+            } catch (error) {
+                console.error('Error updating field weed state:', error);
+                setOptimisticLevel(level);
+                alert('Promjena stanja korova nije uspjela.');
+            }
+        });
+    };
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild disabled={isPending}>
+                <Chip
+                    size="sm"
+                    variant="solid"
+                    color={currentPresentation.color}
+                    startDecorator={<CurrentIcon aria-hidden />}
+                    title={`Promijeni stanje korova za polje ${positionIndex + 1}`}
+                    className={className}
+                    onClick={() => {}}
+                >
+                    <span className="min-w-0 truncate">
+                        {currentItem?.label ?? optimisticLevel}
+                    </span>
+                </Chip>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+                {RaisedBedWeedStateItems.map((item) => {
+                    const presentation = weedStatePresentation[item.value];
+                    const ItemIcon = presentation.icon;
+
+                    return (
+                        <DropdownMenuItem
+                            key={item.value}
+                            startDecorator={
+                                <span
+                                    aria-hidden
+                                    className="w-4 shrink-0 text-center"
+                                >
+                                    {optimisticLevel === item.value ? (
+                                        <Check className="size-4" />
+                                    ) : null}
+                                </span>
+                            }
+                            onSelect={() => handleSelect(item.value)}
+                        >
+                            <ItemIcon
+                                aria-hidden
+                                className="mr-1 size-4 shrink-0"
+                            />
+                            {item.label}
+                        </DropdownMenuItem>
+                    );
+                })}
+            </DropdownMenuContent>
+        </DropdownMenu>
     );
 }

--- a/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
@@ -8,7 +8,7 @@ type RaisedBedFieldCardGridProps = {
 };
 
 export const raisedBedFieldCardSelectClassName =
-    'w-full min-w-0 [&_[role=combobox]]:h-8 [&_[role=combobox]]:min-w-0 [&_[role=combobox]]:gap-1.5 [&_[role=combobox]]:overflow-hidden [&_[role=combobox]]:border [&_[role=combobox]]:border-input [&_[role=combobox]]:!bg-background [&_[role=combobox]]:px-2 [&_[role=combobox]]:text-foreground [&_[role=combobox]]:shadow-xs [&_[role=combobox]]:hover:!bg-muted [&_[role=combobox]>span]:block [&_[role=combobox]>span]:min-w-0 [&_[role=combobox]>span]:truncate';
+    'w-full min-w-0 [&_[role=combobox]]:h-8 [&_[role=combobox]]:w-full [&_[role=combobox]]:max-w-full [&_[role=combobox]]:min-w-0 [&_[role=combobox]]:gap-1.5 [&_[role=combobox]]:overflow-hidden [&_[role=combobox]]:border [&_[role=combobox]]:border-input [&_[role=combobox]]:!bg-background [&_[role=combobox]]:px-2 [&_[role=combobox]]:text-foreground [&_[role=combobox]]:shadow-xs [&_[role=combobox]]:hover:!bg-muted [&_[role=combobox]>span]:block [&_[role=combobox]>span]:min-w-0 [&_[role=combobox]>span]:truncate';
 
 export const raisedBedFieldCardButtonClassName =
     'max-w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap border border-input !bg-background text-foreground shadow-xs hover:!bg-muted hover:text-foreground [&>span]:min-w-0';
@@ -79,11 +79,11 @@ export function RaisedBedFieldCard({
                     {historyControl}
                 </div>
             )}
-            <div className="relative z-10 mt-auto flex min-w-0 flex-col gap-0.5 px-2 pb-2 pt-8">
+            <div className="relative z-10 mt-auto flex min-w-0 flex-col gap-0.5 px-2 pb-2 pt-2">
                 <div className="min-w-0">{plantSortControl}</div>
                 {weedControl && <div className="min-w-0">{weedControl}</div>}
                 {statusControl && (
-                    <div className="min-w-0">{statusControl}</div>
+                    <div className="w-full min-w-0">{statusControl}</div>
                 )}
             </div>
         </div>

--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -458,8 +458,7 @@ function RaisedBedFieldTile({
             raisedBedId={raisedBedId}
             positionIndex={positionIndex}
             level={field?.weedState?.level ?? 'none'}
-            variant="plain"
-            className={raisedBedFieldCardSelectClassName}
+            className={raisedBedFieldCardChipClassName}
         />
     );
 

--- a/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
+++ b/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
@@ -8,7 +8,7 @@ import {
 import { Button } from '@gredice/ui/Button';
 import { Chip } from '@gredice/ui/Chip';
 import { IconButton } from '@gredice/ui/IconButton';
-import { Calendar, Timer } from '@gredice/ui/icons';
+import { Calendar, Check, Leaf, Timer, Warning } from '@gredice/ui/icons';
 import { SelectItems } from '@gredice/ui/SelectItems';
 import { cx } from '@gredice/ui/utils';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
@@ -22,6 +22,7 @@ type MockField = {
     imageSrc?: string;
     location?: 'greenhouse' | 'raisedBed';
     hasHistory?: boolean;
+    weedLevel?: 'none' | 'light' | 'heavy';
 };
 
 const mockFields: MockField[] = [
@@ -34,6 +35,7 @@ const mockFields: MockField[] = [
         imageSrc: '/assets/plants/tomato_mature.png',
         location: 'greenhouse',
         hasHistory: true,
+        weedLevel: 'heavy',
     },
     {
         id: 'tomato-mini-a',
@@ -43,6 +45,7 @@ const mockFields: MockField[] = [
         date: '22. 05.',
         imageSrc: '/assets/plants/tomato_growing.png',
         location: 'greenhouse',
+        weedLevel: 'light',
     },
     {
         id: 'tomato-mini-b',
@@ -52,6 +55,7 @@ const mockFields: MockField[] = [
         date: '22. 05.',
         imageSrc: '/assets/plants/tomato_growing.png',
         location: 'greenhouse',
+        weedLevel: 'none',
     },
     {
         id: 'chili',
@@ -61,6 +65,7 @@ const mockFields: MockField[] = [
         date: '22. 05.',
         imageSrc: '/assets/plants/bellpepper_mature.png',
         location: 'greenhouse',
+        weedLevel: 'none',
     },
     {
         id: 'bean-yellow',
@@ -70,6 +75,7 @@ const mockFields: MockField[] = [
         date: '29. 05.',
         imageSrc: '/assets/plants/bean_mature.png',
         location: 'raisedBed',
+        weedLevel: 'light',
     },
     {
         id: 'bean-green',
@@ -79,6 +85,7 @@ const mockFields: MockField[] = [
         date: '29. 05.',
         imageSrc: '/assets/plants/greenbean_mature.png',
         location: 'raisedBed',
+        weedLevel: 'none',
     },
 ];
 
@@ -209,6 +216,29 @@ function StatusDateButton({ field }: { field: MockField }) {
     );
 }
 
+function WeedChip({ level = 'none' }: { level?: MockField['weedLevel'] }) {
+    const content = {
+        none: { color: 'success', icon: Check, label: 'Bez korova' },
+        light: { color: 'warning', icon: Leaf, label: 'Lagani korov' },
+        heavy: { color: 'error', icon: Warning, label: 'Jaki korov' },
+    } as const;
+    const current = content[level];
+    const CurrentIcon = current.icon;
+
+    return (
+        <Chip
+            size="sm"
+            variant="solid"
+            color={current.color}
+            startDecorator={<CurrentIcon aria-hidden />}
+            title="Promijeni stanje korova"
+            className={raisedBedFieldCardChipClassName}
+        >
+            <span className="min-w-0 truncate">{current.label}</span>
+        </Chip>
+    );
+}
+
 function MockRaisedBedFieldCard({ field }: { field: MockField }) {
     return (
         <RaisedBedFieldCard
@@ -225,6 +255,7 @@ function MockRaisedBedFieldCard({ field }: { field: MockField }) {
             fieldBadge={<FieldBadge number={field.number} />}
             historyControl={field.hasHistory ? <HistoryButton /> : undefined}
             plantSortControl={<PlantSortSelect field={field} />}
+            weedControl={<WeedChip level={field.weedLevel} />}
             statusControl={
                 field.status ? <StatusDateButton field={field} /> : undefined
             }


### PR DESCRIPTION
## What changed

- Replaced the full-width field weed select with a compact, color-coded badge menu using check, leaf, and warning icons.
- Constrained the plant picker trigger to the field-card width so long plant names truncate instead of overflowing.
- Reduced excess footer spacing so the plant, weed, and status/date controls remain visible inside narrow three-column cards.
- Updated the raised-bed field-card Storybook fixture with all weed states.

## Why

The raised-bed admin grid renders three narrow field cards per row. Full-width weed selects, unconstrained plant-picker triggers, and excess vertical spacing caused controls to extend outside or be clipped by the card.

## Validation

- `corepack pnpm --filter app exec biome check 'app/admin/raised-beds/[raisedBedId]/RaisedBedFieldWeedStateSelector.tsx' components/raised-beds/RaisedBedFieldCard.tsx components/raised-beds/RaisedBedFieldsTable.tsx`
- `corepack pnpm --filter storybook exec biome check stories/apps/app/RaisedBedFieldCard.stories.tsx`
- `corepack pnpm --filter storybook typecheck`
- `corepack pnpm --filter storybook build`
- Rendered the three-column Storybook fixture and measured all plant, weed, and status controls; all 18 controls stayed within their field-card bounds.

The direct app-wide `tsc --noEmit` command still reports existing errors in unrelated admin files; none reference the touched raised-bed files.