### PR TITLE
fix(garden): refund canceled plantings

### DIFF
--- a/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.node.spec.ts
@@ -1203,7 +1203,7 @@ describe('processItem', () => {
                 },
                 cartId: 100,
                 cartItemId: 1,
-                currency: 'eur',
+                currency: 'sunflower',
                 entityId: '42',
                 entityTypeName: 'plantSort',
                 gardenId: 200,
@@ -1221,6 +1221,11 @@ describe('processItem', () => {
                     plantSortId: '42',
                     scheduledDate: '2026-07-01',
                     sowingLocation: 'greenhouse',
+                    purchase: {
+                        cartItemId: 1,
+                        currency: 'sunflower',
+                        sunflowerAmount: 2500,
+                    },
                 },
             },
         ]);
@@ -1320,6 +1325,11 @@ describe('processItem', () => {
                 plantSortId: '101',
                 scheduledDate: '2026-07-01',
                 sowingLocation: 'greenhouse',
+                purchase: {
+                    cartItemId: 1,
+                    currency: 'eur',
+                    euroAmountCents: 2500,
+                },
             },
         });
     });

--- a/apps/api/lib/stripe/processCheckoutSession.ts
+++ b/apps/api/lib/stripe/processCheckoutSession.ts
@@ -1520,6 +1520,39 @@ function checkoutScheduledDateFromAdditionalData(
     );
 }
 
+function plantingPurchaseFromCheckoutItem(itemData: {
+    amount_total: number;
+    cartItemId?: number | null;
+    currency: string | null;
+}) {
+    if (!itemData.cartItemId) {
+        return undefined;
+    }
+
+    if (itemData.currency === 'sunflower') {
+        return {
+            cartItemId: itemData.cartItemId,
+            currency: 'sunflower' as const,
+            sunflowerAmount: itemData.amount_total,
+        };
+    }
+    if (itemData.currency === 'eur') {
+        return {
+            cartItemId: itemData.cartItemId,
+            currency: 'eur' as const,
+            euroAmountCents: itemData.amount_total,
+        };
+    }
+    if (itemData.currency === 'inventory') {
+        return {
+            cartItemId: itemData.cartItemId,
+            currency: 'inventory' as const,
+        };
+    }
+
+    return undefined;
+}
+
 export async function processItem(
     itemData: {
         entityId: string | null | undefined;
@@ -1777,6 +1810,7 @@ export async function processItem(
             dependencies,
         );
         const aggregateId = `${itemData.raisedBedId}|${itemData.positionIndex}`;
+        const purchase = plantingPurchaseFromCheckoutItem(itemData);
 
         await dependencies.upsertRaisedBedField({
             positionIndex: itemData.positionIndex,
@@ -1796,6 +1830,7 @@ export async function processItem(
                     : greenhouseSowingLocationFromAdditionalData(
                           itemData.additionalData,
                       ),
+                ...(purchase ? { purchase } : {}),
             }),
         );
         if (outletReservation) {

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -12,6 +12,7 @@ import {
     getFarmUserRaisedBeds,
     getRaisedBed,
     getRaisedBedFieldContext,
+    getRaisedBedFieldSunflowerRefundAmount,
     getRaisedBedFieldsWithEvents,
     knownEvents,
     moveRaisedBedFieldPlantHistory,
@@ -550,9 +551,24 @@ export async function cancelRaisedBedFieldAction(formData: FormData) {
             field.plantSortId,
         );
         plantName = sortData?.information?.name ?? plantName;
-        refundAmount = sortData?.prices?.perPlant
-            ? Math.round(sortData.prices.perPlant * 1000)
-            : 0;
+        const activePlantCycle = field.plantCycles.find(
+            (cycle) => cycle.active,
+        );
+        const perPlantPrice =
+            sortData?.prices?.perPlant ??
+            sortData?.information?.plant?.prices?.perPlant;
+        if (raisedBed.accountId && activePlantCycle) {
+            refundAmount = await getRaisedBedFieldSunflowerRefundAmount({
+                accountId: raisedBed.accountId,
+                fallbackAmount:
+                    typeof perPlantPrice === 'number' && perPlantPrice > 0
+                        ? Math.round(perPlantPrice * 1000)
+                        : 0,
+                plantCycleStartedAt: activePlantCycle.startedAt,
+                positionIndex,
+                raisedBedId,
+            });
+        }
     }
 
     const header = 'Sijanje biljke je otkazano';

--- a/apps/app/app/(actions)/raisedBedFieldsActions.ts
+++ b/apps/app/app/(actions)/raisedBedFieldsActions.ts
@@ -566,6 +566,7 @@ export async function cancelRaisedBedFieldAction(formData: FormData) {
                         : 0,
                 plantCycleStartedAt: activePlantCycle.startedAt,
                 positionIndex,
+                purchase: activePlantCycle.purchase,
                 raisedBedId,
             });
         }

--- a/packages/storage/src/repositories/events/index.ts
+++ b/packages/storage/src/repositories/events/index.ts
@@ -81,6 +81,7 @@ export type {
     RaisedBedFieldPlantEventsAnyPayload,
     RaisedBedFieldPlantEventsPayload,
     RaisedBedFieldPlantPlacePayload,
+    RaisedBedFieldPlantPurchase,
     RaisedBedFieldPlantReplaceSortPayload,
     RaisedBedFieldPlantSchedulePayload,
     RaisedBedFieldPlantUpdatePayload,

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -191,10 +191,27 @@ export type RaisedBedFieldDeletePayload = {
 
 export type RaisedBedFieldSowingLocation = 'direct' | 'greenhouse';
 
+export type RaisedBedFieldPlantPurchase =
+    | {
+          cartItemId: number;
+          currency: 'sunflower';
+          sunflowerAmount: number;
+      }
+    | {
+          cartItemId: number;
+          currency: 'eur';
+          euroAmountCents: number;
+      }
+    | {
+          cartItemId: number;
+          currency: 'inventory';
+      };
+
 export type RaisedBedFieldPlantPlacePayload = {
     plantSortId: string;
     scheduledDate: string | null | undefined;
     sowingLocation?: RaisedBedFieldSowingLocation;
+    purchase?: RaisedBedFieldPlantPurchase;
 };
 
 export type RaisedBedFieldPlantSchedulePayload = {

--- a/packages/storage/src/repositories/gardenDiaryCancelRepo.ts
+++ b/packages/storage/src/repositories/gardenDiaryCancelRepo.ts
@@ -13,6 +13,7 @@ import {
 import { deleteRaisedBedField, getRaisedBed } from './gardensRepo';
 import { createNotification } from './notificationsRepo';
 import { getOperationsByIds } from './operationsRepo';
+import { getRaisedBedFieldSunflowerRefundAmount } from './shoppingCartRepo';
 
 export type GardenDiaryCancelStatusCode = 400 | 404 | 409;
 
@@ -255,9 +256,19 @@ export async function cancelGardenDiaryRaisedBedField({
     );
     const plantName =
         plantSortData?.information?.name ?? `Biljka #${field.plantSortId}`;
-    const refundAmount = calculateSunflowerRefund(
-        plantSortData?.prices?.perPlant,
-    );
+    const activePlantCycle = field.plantCycles.find((cycle) => cycle.active);
+    const refundAmount = activePlantCycle
+        ? await getRaisedBedFieldSunflowerRefundAmount({
+              accountId,
+              fallbackAmount: calculateSunflowerRefund(
+                  plantSortData?.prices?.perPlant ??
+                      plantSortData?.information?.plant?.prices?.perPlant,
+              ),
+              plantCycleStartedAt: activePlantCycle.startedAt,
+              positionIndex,
+              raisedBedId,
+          })
+        : 0;
     let content = `Sijanje biljke **${plantName}** na gredici **${raisedBed.name}** za polje **${positionIndex + 1}** je otkazano.`;
 
     if (refundAmount > 0) {

--- a/packages/storage/src/repositories/gardenDiaryCancelRepo.ts
+++ b/packages/storage/src/repositories/gardenDiaryCancelRepo.ts
@@ -266,6 +266,7 @@ export async function cancelGardenDiaryRaisedBedField({
               ),
               plantCycleStartedAt: activePlantCycle.startedAt,
               positionIndex,
+              purchase: activePlantCycle.purchase,
               raisedBedId,
           })
         : 0;

--- a/packages/storage/src/repositories/raisedBedFieldsRepo.ts
+++ b/packages/storage/src/repositories/raisedBedFieldsRepo.ts
@@ -21,6 +21,7 @@ import {
     getAllEvents,
     knownEvents,
     knownEventTypes,
+    type RaisedBedFieldPlantPurchase,
     type RaisedBedFieldSowingLocation,
     type RaisedBedWeedStateLevel,
     type RaisedBedWeedStateSetPayload,
@@ -83,6 +84,7 @@ export type RaisedBedFieldPlantCycle = {
     plantSortId?: number;
     plantScheduledDate?: Date;
     sowingLocation: RaisedBedFieldSowingLocation;
+    purchase?: RaisedBedFieldPlantPurchase;
     plantSowDate?: Date;
     plantGrowthDate?: Date;
     plantReadyDate?: Date;
@@ -605,6 +607,44 @@ function parseSowingLocation(
     return value === 'direct' || value === 'greenhouse' ? value : undefined;
 }
 
+function parseNonNegativeInteger(value: unknown) {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0
+        ? value
+        : undefined;
+}
+
+function parsePlantPurchase(
+    value: unknown,
+): RaisedBedFieldPlantPurchase | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return undefined;
+    }
+
+    const record = value as Record<string, unknown>;
+    const cartItemId = parseNonNegativeInteger(record.cartItemId);
+    if (!cartItemId || cartItemId < 1) {
+        return undefined;
+    }
+
+    if (record.currency === 'inventory') {
+        return { cartItemId, currency: 'inventory' };
+    }
+    if (record.currency === 'sunflower') {
+        const sunflowerAmount = parseNonNegativeInteger(record.sunflowerAmount);
+        return typeof sunflowerAmount === 'number'
+            ? { cartItemId, currency: 'sunflower', sunflowerAmount }
+            : undefined;
+    }
+    if (record.currency === 'eur') {
+        const euroAmountCents = parseNonNegativeInteger(record.euroAmountCents);
+        return typeof euroAmountCents === 'number'
+            ? { cartItemId, currency: 'eur', euroAmountCents }
+            : undefined;
+    }
+
+    return undefined;
+}
+
 function parseWeedStateLevel(value: unknown): RaisedBedWeedStateLevel | null {
     switch (value) {
         case 'none':
@@ -711,6 +751,7 @@ function summarizePlantCycle(
     let plantSortId: number | undefined;
     let plantScheduledDate: Date | undefined;
     let sowingLocation: RaisedBedFieldSowingLocation = 'direct';
+    let purchase: RaisedBedFieldPlantPurchase | undefined;
     let plantSowDate: Date | undefined;
     let plantGrowthDate: Date | undefined;
     let plantReadyDate: Date | undefined;
@@ -742,6 +783,7 @@ function summarizePlantCycle(
             plantSortId = parsePlantSortId(data?.plantSortId);
             sowingLocation =
                 parseSowingLocation(data?.sowingLocation) ?? 'direct';
+            purchase = parsePlantPurchase(data?.purchase);
 
             if (data?.scheduledDate && typeof data.scheduledDate === 'string') {
                 plantScheduledDate = new Date(data.scheduledDate);
@@ -931,6 +973,7 @@ function summarizePlantCycle(
         plantSortId,
         plantScheduledDate,
         sowingLocation,
+        purchase,
         plantSowDate,
         plantGrowthDate,
         plantReadyDate,

--- a/packages/storage/src/repositories/shoppingCartRepo.ts
+++ b/packages/storage/src/repositories/shoppingCartRepo.ts
@@ -1,6 +1,7 @@
-import { and, asc, eq } from 'drizzle-orm';
-import { shoppingCartItems, shoppingCarts } from '../schema';
+import { and, asc, desc, eq, gte, lte, sql } from 'drizzle-orm';
+import { events, shoppingCartItems, shoppingCarts } from '../schema';
 import { storage } from '../storage';
+import { knownEventTypes } from './eventsRepo';
 import { getInventory } from './inventoryRepo';
 import {
     releaseOutletReservationForCartItem,
@@ -13,6 +14,99 @@ type TransactionClient = Parameters<
     Parameters<StorageClient['transaction']>[0]
 >[0];
 type DatabaseClient = StorageClient | TransactionClient;
+
+const raisedBedFieldPurchaseMatchWindowMs = 10 * 60 * 1000;
+
+function parsePositiveInteger(value: unknown) {
+    if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+        return value;
+    }
+    if (typeof value === 'string') {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    }
+    return null;
+}
+
+/**
+ * Resolve the sunflower amount actually paid for the plant purchase that
+ * started the current raised-bed field cycle.
+ *
+ * Older immediate sunflower checkouts recorded one spend event per cart item.
+ * Euro purchases and legacy aggregate-cart sunflower checkouts use the
+ * catalog-derived sunflower equivalent after confirming the matched cart item
+ * was paid rather than sourced from inventory.
+ */
+export async function getRaisedBedFieldSunflowerRefundAmount({
+    accountId,
+    fallbackAmount = 0,
+    plantCycleStartedAt,
+    positionIndex,
+    raisedBedId,
+}: {
+    accountId: string;
+    fallbackAmount?: number;
+    plantCycleStartedAt: Date;
+    positionIndex: number;
+    raisedBedId: number;
+}) {
+    const windowStart = new Date(
+        plantCycleStartedAt.getTime() - raisedBedFieldPurchaseMatchWindowMs,
+    );
+    const windowEnd = new Date(
+        plantCycleStartedAt.getTime() + raisedBedFieldPurchaseMatchWindowMs,
+    );
+    const [purchase] = await storage()
+        .select({
+            cartItemId: shoppingCartItems.id,
+            currency: shoppingCartItems.currency,
+        })
+        .from(shoppingCartItems)
+        .innerJoin(
+            shoppingCarts,
+            eq(shoppingCarts.id, shoppingCartItems.cartId),
+        )
+        .where(
+            and(
+                eq(shoppingCarts.accountId, accountId),
+                eq(shoppingCarts.isDeleted, false),
+                eq(shoppingCartItems.entityTypeName, 'plantSort'),
+                eq(shoppingCartItems.raisedBedId, raisedBedId),
+                eq(shoppingCartItems.positionIndex, positionIndex),
+                eq(shoppingCartItems.status, 'paid'),
+                eq(shoppingCartItems.isDeleted, false),
+                gte(shoppingCartItems.updatedAt, windowStart),
+                lte(shoppingCartItems.updatedAt, windowEnd),
+            ),
+        )
+        .orderBy(desc(shoppingCartItems.updatedAt), desc(shoppingCartItems.id))
+        .limit(1);
+
+    if (!purchase || purchase.currency === 'inventory') {
+        return 0;
+    }
+
+    if (purchase.currency === 'sunflower') {
+        const paymentEvent = await storage().query.events.findFirst({
+            where: and(
+                eq(events.aggregateId, accountId),
+                eq(events.type, knownEventTypes.accounts.spendSunflowers),
+                sql`${events.data}->>'reason' = ${`shoppingCartItem:${purchase.cartItemId.toString()}`}`,
+            ),
+            orderBy: [desc(events.createdAt), desc(events.id)],
+        });
+        const eventData = paymentEvent?.data as
+            | Record<string, unknown>
+            | null
+            | undefined;
+        const paidAmount = parsePositiveInteger(eventData?.amount);
+        if (paidAmount) {
+            return paidAmount;
+        }
+    }
+
+    return parsePositiveInteger(fallbackAmount) ?? 0;
+}
 
 function startOfUtcDay(date: Date) {
     return new Date(

--- a/packages/storage/src/repositories/shoppingCartRepo.ts
+++ b/packages/storage/src/repositories/shoppingCartRepo.ts
@@ -1,7 +1,10 @@
 import { and, asc, desc, eq, gte, lte, sql } from 'drizzle-orm';
 import { events, shoppingCartItems, shoppingCarts } from '../schema';
 import { storage } from '../storage';
-import { knownEventTypes } from './eventsRepo';
+import {
+    knownEventTypes,
+    type RaisedBedFieldPlantPurchase,
+} from './eventsRepo';
 import { getInventory } from './inventoryRepo';
 import {
     releaseOutletReservationForCartItem,
@@ -32,31 +35,43 @@ function parsePositiveInteger(value: unknown) {
  * Resolve the sunflower amount actually paid for the plant purchase that
  * started the current raised-bed field cycle.
  *
- * Older immediate sunflower checkouts recorded one spend event per cart item.
- * Euro purchases and legacy aggregate-cart sunflower checkouts use the
- * catalog-derived sunflower equivalent after confirming the matched cart item
- * was paid rather than sourced from inventory.
+ * New planting events carry their cart item, currency, and paid amount. Older
+ * events fall back to matching the paid cart item around the cycle start;
+ * immediate sunflower checkouts can still recover the exact spend event while
+ * euro and aggregate-cart purchases use the catalog-derived equivalent.
  */
 export async function getRaisedBedFieldSunflowerRefundAmount({
     accountId,
     fallbackAmount = 0,
     plantCycleStartedAt,
     positionIndex,
+    purchase,
     raisedBedId,
 }: {
     accountId: string;
     fallbackAmount?: number;
     plantCycleStartedAt: Date;
     positionIndex: number;
+    purchase?: RaisedBedFieldPlantPurchase;
     raisedBedId: number;
 }) {
+    if (purchase?.currency === 'inventory') {
+        return 0;
+    }
+    if (purchase?.currency === 'sunflower') {
+        return parsePositiveInteger(purchase.sunflowerAmount) ?? 0;
+    }
+    if (purchase?.currency === 'eur') {
+        return parsePositiveInteger(purchase.euroAmountCents * 10) ?? 0;
+    }
+
     const windowStart = new Date(
         plantCycleStartedAt.getTime() - raisedBedFieldPurchaseMatchWindowMs,
     );
     const windowEnd = new Date(
         plantCycleStartedAt.getTime() + raisedBedFieldPurchaseMatchWindowMs,
     );
-    const [purchase] = await storage()
+    const [matchedCartItem] = await storage()
         .select({
             cartItemId: shoppingCartItems.id,
             currency: shoppingCartItems.currency,
@@ -82,16 +97,16 @@ export async function getRaisedBedFieldSunflowerRefundAmount({
         .orderBy(desc(shoppingCartItems.updatedAt), desc(shoppingCartItems.id))
         .limit(1);
 
-    if (!purchase || purchase.currency === 'inventory') {
+    if (!matchedCartItem || matchedCartItem.currency === 'inventory') {
         return 0;
     }
 
-    if (purchase.currency === 'sunflower') {
+    if (matchedCartItem.currency === 'sunflower') {
         const paymentEvent = await storage().query.events.findFirst({
             where: and(
                 eq(events.aggregateId, accountId),
                 eq(events.type, knownEventTypes.accounts.spendSunflowers),
-                sql`${events.data}->>'reason' = ${`shoppingCartItem:${purchase.cartItemId.toString()}`}`,
+                sql`${events.data}->>'reason' = ${`shoppingCartItem:${matchedCartItem.cartItemId.toString()}`}`,
             ),
             orderBy: [desc(events.createdAt), desc(events.id)],
         });

--- a/packages/storage/src/repositories/shoppingCartRepo.ts
+++ b/packages/storage/src/repositories/shoppingCartRepo.ts
@@ -7,6 +7,7 @@ import {
 } from './eventsRepo';
 import { getInventory } from './inventoryRepo';
 import {
+    getOutletOfferReservationForCartItem,
     releaseOutletReservationForCartItem,
     releaseOutletReservationsForCart,
     reserveOutletOffer,
@@ -38,7 +39,8 @@ function parsePositiveInteger(value: unknown) {
  * New planting events carry their cart item, currency, and paid amount. Older
  * events fall back to matching the paid cart item around the cycle start;
  * immediate sunflower checkouts can still recover the exact spend event while
- * euro and aggregate-cart purchases use the catalog-derived equivalent.
+ * euro and aggregate-cart purchases use an outlet reservation snapshot when
+ * available, then the catalog-derived equivalent as a final fallback.
  */
 export async function getRaisedBedFieldSunflowerRefundAmount({
     accountId,
@@ -99,6 +101,16 @@ export async function getRaisedBedFieldSunflowerRefundAmount({
 
     if (!matchedCartItem || matchedCartItem.currency === 'inventory') {
         return 0;
+    }
+
+    const outletReservation = await getOutletOfferReservationForCartItem(
+        matchedCartItem.cartItemId,
+    );
+    const outletAmount = parsePositiveInteger(
+        (outletReservation?.heldOutletPriceCents ?? 0) * 10,
+    );
+    if (outletAmount) {
+        return outletAmount;
     }
 
     if (matchedCartItem.currency === 'sunflower') {

--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -4,11 +4,13 @@ import {
     acceptOperation,
     cancelGardenDiaryOperation,
     cancelGardenDiaryRaisedBedField,
+    convertOutletReservationForCartItem,
     createAccount,
     createAttributeDefinition,
     createEntity,
     createEvent,
     createOperation,
+    createOutletOffer,
     earnSunflowers,
     GardenDiaryCancelError,
     GardenDiaryRescheduleError,
@@ -25,6 +27,7 @@ import {
     type RaisedBedFieldPlantPurchase,
     rescheduleGardenDiaryOperation,
     rescheduleGardenDiaryRaisedBedField,
+    reserveOutletOffer,
     setCartItemPaid,
     spendSunflowers,
     updateEntity,
@@ -917,6 +920,66 @@ test('cancelGardenDiaryRaisedBedField refunds euro plant purchases in sunflowers
 
     assert.equal(result.refundAmount, 1500);
     assert.equal(await getSunflowers(accountId), balanceBeforeCancel + 1500);
+});
+
+test('cancelGardenDiaryRaisedBedField refunds the legacy outlet price', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const plantSortId = await createPricedPlantSortEntity();
+    const balanceBeforeCancel = await getSunflowers(accountId);
+    const now = new Date();
+
+    const cartItemId = await createPaidPlantCartItem({
+        accountId,
+        amount: 1500,
+        currency: 'eur',
+        gardenId,
+        plantSortId,
+        positionIndex: 0,
+        raisedBedId,
+    });
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart);
+    const outletOfferId = await createOutletOffer({
+        plantSortId,
+        sowingDate: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+        initialPlantStatus: 'sprouted',
+        imageUrls: [],
+        outletPriceCents: 75,
+        comparePriceCents: 150,
+        quantity: 1,
+        startAt: new Date(now.getTime() - 60 * 60 * 1000),
+        endAt: new Date(now.getTime() + 60 * 60 * 1000),
+        status: 'published',
+        adminNotes: null,
+    });
+    await reserveOutletOffer({
+        offerId: outletOfferId,
+        accountId,
+        cartId: cart.id,
+        cartItemId,
+        now,
+    });
+    await convertOutletReservationForCartItem(cartItemId, now);
+    await createScheduledField({
+        plantSortId,
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    const result = await cancelGardenDiaryRaisedBedField({
+        accountId,
+        canceledBy: 'user-1',
+        gardenId,
+        raisedBedId,
+        positionIndex: 0,
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    assert.equal(result.refundAmount, 750);
+    assert.equal(await getSunflowers(accountId), balanceBeforeCancel + 750);
 });
 
 test('cancelGardenDiaryRaisedBedField does not refund inventory plantings', async () => {

--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -9,11 +9,13 @@ import {
     createEntity,
     createEvent,
     createOperation,
+    earnSunflowers,
     GardenDiaryCancelError,
     GardenDiaryRescheduleError,
     getAttributeDefinitions,
     getNotificationsByAccount,
     getOperationById,
+    getOrCreateShoppingCart,
     getRaisedBed,
     getRaisedBedDiaryEntries,
     getRaisedBedFieldDiaryEntries,
@@ -22,9 +24,12 @@ import {
     knownEvents,
     rescheduleGardenDiaryOperation,
     rescheduleGardenDiaryRaisedBedField,
+    setCartItemPaid,
+    spendSunflowers,
     updateEntity,
     upsertAttributeValue,
     upsertEntityType,
+    upsertOrRemoveCartItem,
     upsertRaisedBedField,
 } from '@gredice/storage';
 import {
@@ -123,10 +128,28 @@ async function createPricedOperationEntity() {
 
 async function createPricedPlantSortEntity() {
     await upsertEntityType({
+        name: 'plant',
+        label: 'Biljka',
+    });
+    await upsertEntityType({
         name: 'plantSort',
         label: 'Sorta biljke',
     });
 
+    const plantNameDefinitionId = await ensureAttributeDefinition({
+        category: 'information',
+        dataType: 'text',
+        entityTypeName: 'plant',
+        label: 'Name',
+        name: 'name',
+    });
+    const priceDefinitionId = await ensureAttributeDefinition({
+        category: 'prices',
+        dataType: 'number',
+        entityTypeName: 'plant',
+        label: 'Price per plant',
+        name: 'perPlant',
+    });
     const nameDefinitionId = await ensureAttributeDefinition({
         category: 'information',
         dataType: 'text',
@@ -134,16 +157,24 @@ async function createPricedPlantSortEntity() {
         label: 'Name',
         name: 'name',
     });
-    const priceDefinitionId = await ensureAttributeDefinition({
-        category: 'prices',
-        dataType: 'number',
+    const plantDefinitionId = await ensureAttributeDefinition({
+        category: 'information',
+        dataType: 'ref:plant',
         entityTypeName: 'plantSort',
-        label: 'Price per plant',
-        name: 'perPlant',
+        label: 'Plant',
+        name: 'plant',
     });
+    const plantId = await createEntity('plant');
     const entityId = await createEntity('plantSort');
 
+    await updateEntity({ id: plantId, state: 'published' });
     await updateEntity({ id: entityId, state: 'published' });
+    await upsertAttributeValue({
+        attributeDefinitionId: plantNameDefinitionId,
+        entityTypeName: 'plant',
+        entityId: plantId,
+        value: 'Rajčica',
+    });
     await upsertAttributeValue({
         attributeDefinitionId: nameDefinitionId,
         entityTypeName: 'plantSort',
@@ -152,12 +183,65 @@ async function createPricedPlantSortEntity() {
     });
     await upsertAttributeValue({
         attributeDefinitionId: priceDefinitionId,
+        entityTypeName: 'plant',
+        entityId: plantId,
+        value: '1.5',
+    });
+    await upsertAttributeValue({
+        attributeDefinitionId: plantDefinitionId,
         entityTypeName: 'plantSort',
         entityId,
-        value: '1.5',
+        value: plantId.toString(),
     });
 
     return entityId;
+}
+
+async function createPaidPlantCartItem({
+    accountId,
+    amount,
+    currency = 'sunflower',
+    gardenId,
+    plantSortId,
+    positionIndex,
+    raisedBedId,
+}: {
+    accountId: string;
+    amount: number;
+    currency?: 'eur' | 'sunflower';
+    gardenId: number;
+    plantSortId: number;
+    positionIndex: number;
+    raisedBedId: number;
+}) {
+    const cart = await getOrCreateShoppingCart(accountId);
+    assert.ok(cart);
+    const cartItemId = await upsertOrRemoveCartItem(
+        undefined,
+        cart.id,
+        plantSortId.toString(),
+        'plantSort',
+        1,
+        gardenId,
+        raisedBedId,
+        positionIndex,
+        undefined,
+        currency,
+        true,
+    );
+    assert.ok(cartItemId);
+
+    if (currency === 'sunflower') {
+        await earnSunflowers(accountId, amount, 'test-funding');
+        await spendSunflowers(
+            accountId,
+            amount,
+            `shoppingCartItem:${cartItemId.toString()}`,
+        );
+    }
+    await setCartItemPaid(cartItemId);
+
+    return cartItemId;
 }
 
 async function createScheduledOperation({
@@ -666,6 +750,17 @@ test('cancelGardenDiaryRaisedBedField removes future planned sowing with refund 
     const { accountId, gardenId, raisedBedId } =
         await createDiaryRescheduleContext();
     const plantSortId = await createPricedPlantSortEntity();
+    const paidAmount = 1750;
+    const balanceBeforePurchase = await getSunflowers(accountId);
+
+    await createPaidPlantCartItem({
+        accountId,
+        amount: paidAmount,
+        gardenId,
+        plantSortId,
+        positionIndex: 0,
+        raisedBedId,
+    });
 
     await createScheduledField({
         plantSortId,
@@ -695,7 +790,7 @@ test('cancelGardenDiaryRaisedBedField removes future planned sowing with refund 
         10,
     );
 
-    assert.equal(result.refundAmount, 1500);
+    assert.equal(result.refundAmount, paidAmount);
     assert.equal(field?.active, false);
     assert.equal(field?.plantStatus, 'deleted');
     assert.equal(field?.plantSortId, undefined);
@@ -713,10 +808,13 @@ test('cancelGardenDiaryRaisedBedField removes future planned sowing with refund 
         cancelDiaryEntry?.description,
         'Razlog otkazivanja: Korisnik je otkazao.',
     );
-    assert.equal(await getSunflowers(accountId), 2500);
+    assert.equal(
+        await getSunflowers(accountId),
+        balanceBeforePurchase + paidAmount,
+    );
     assert.equal(notifications.length, 1);
     assert.equal(notifications[0]?.header, 'Sijanje je otkazano');
-    assert.match(notifications[0]?.content ?? '', /1500 🌻/);
+    assert.match(notifications[0]?.content ?? '', /1750 🌻/);
 });
 
 test('cancelGardenDiaryRaisedBedField removes future confirmed sowing', async () => {
@@ -725,6 +823,15 @@ test('cancelGardenDiaryRaisedBedField removes future confirmed sowing', async ()
         await createDiaryRescheduleContext();
     const plantSortId = await createPricedPlantSortEntity();
     const aggregateId = `${raisedBedId.toString()}|0`;
+
+    await createPaidPlantCartItem({
+        accountId,
+        amount: 1500,
+        gardenId,
+        plantSortId,
+        positionIndex: 0,
+        raisedBedId,
+    });
 
     await createScheduledField({
         plantSortId,
@@ -755,6 +862,42 @@ test('cancelGardenDiaryRaisedBedField removes future confirmed sowing', async ()
     assert.equal(field?.active, false);
     assert.equal(field?.plantStatus, 'deleted');
     assert.equal(field?.cancellationReason, 'Korisnik je otkazao.');
+});
+
+test('cancelGardenDiaryRaisedBedField refunds euro plant purchases in sunflowers', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const plantSortId = await createPricedPlantSortEntity();
+    const balanceBeforeCancel = await getSunflowers(accountId);
+
+    await createPaidPlantCartItem({
+        accountId,
+        amount: 1500,
+        currency: 'eur',
+        gardenId,
+        plantSortId,
+        positionIndex: 0,
+        raisedBedId,
+    });
+    await createScheduledField({
+        plantSortId,
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    const result = await cancelGardenDiaryRaisedBedField({
+        accountId,
+        canceledBy: 'user-1',
+        gardenId,
+        raisedBedId,
+        positionIndex: 0,
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    assert.equal(result.refundAmount, 1500);
+    assert.equal(await getSunflowers(accountId), balanceBeforeCancel + 1500);
 });
 
 test('cancelGardenDiaryRaisedBedField rejects sowing scheduled for today', async () => {

--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -22,6 +22,7 @@ import {
     getRaisedBedFieldPlantCycles,
     getSunflowers,
     knownEvents,
+    type RaisedBedFieldPlantPurchase,
     rescheduleGardenDiaryOperation,
     rescheduleGardenDiaryRaisedBedField,
     setCartItemPaid,
@@ -208,7 +209,7 @@ async function createPaidPlantCartItem({
 }: {
     accountId: string;
     amount: number;
-    currency?: 'eur' | 'sunflower';
+    currency?: 'eur' | 'inventory' | 'sunflower';
     gardenId: number;
     plantSortId: number;
     positionIndex: number;
@@ -305,11 +306,13 @@ async function createUnscheduledPlannedOperation({
 
 async function createScheduledField({
     plantSortId = 101,
+    purchase,
     raisedBedId,
     positionIndex,
     scheduledDate,
 }: {
     plantSortId?: number;
+    purchase?: RaisedBedFieldPlantPurchase;
     raisedBedId: number;
     positionIndex: number;
     scheduledDate: string;
@@ -324,6 +327,7 @@ async function createScheduledField({
             `${raisedBedId.toString()}|${positionIndex.toString()}`,
             {
                 plantSortId: plantSortId.toString(),
+                ...(purchase ? { purchase } : {}),
                 scheduledDate,
             },
         ),
@@ -753,7 +757,7 @@ test('cancelGardenDiaryRaisedBedField removes future planned sowing with refund 
     const paidAmount = 1750;
     const balanceBeforePurchase = await getSunflowers(accountId);
 
-    await createPaidPlantCartItem({
+    const cartItemId = await createPaidPlantCartItem({
         accountId,
         amount: paidAmount,
         gardenId,
@@ -764,6 +768,11 @@ test('cancelGardenDiaryRaisedBedField removes future planned sowing with refund 
 
     await createScheduledField({
         plantSortId,
+        purchase: {
+            cartItemId,
+            currency: 'sunflower',
+            sunflowerAmount: paidAmount,
+        },
         raisedBedId,
         positionIndex: 0,
         scheduledDate: '2026-06-04T00:00:00.000Z',
@@ -798,6 +807,11 @@ test('cancelGardenDiaryRaisedBedField removes future planned sowing with refund 
     assert.equal(plantCycle?.active, false);
     assert.equal(plantCycle?.plantStatus, 'deleted');
     assert.equal(plantCycle?.plantSortId, plantSortId);
+    assert.deepEqual(plantCycle?.purchase, {
+        cartItemId,
+        currency: 'sunflower',
+        sunflowerAmount: paidAmount,
+    });
     assert.equal(plantCycle?.cancellationReason, 'Korisnik je otkazao.');
     const [cancelDiaryEntry] = await getRaisedBedFieldDiaryEntries(
         raisedBedId,
@@ -871,7 +885,7 @@ test('cancelGardenDiaryRaisedBedField refunds euro plant purchases in sunflowers
     const plantSortId = await createPricedPlantSortEntity();
     const balanceBeforeCancel = await getSunflowers(accountId);
 
-    await createPaidPlantCartItem({
+    const cartItemId = await createPaidPlantCartItem({
         accountId,
         amount: 1500,
         currency: 'eur',
@@ -882,6 +896,11 @@ test('cancelGardenDiaryRaisedBedField refunds euro plant purchases in sunflowers
     });
     await createScheduledField({
         plantSortId,
+        purchase: {
+            cartItemId,
+            currency: 'eur',
+            euroAmountCents: 150,
+        },
         raisedBedId,
         positionIndex: 0,
         scheduledDate: '2026-06-04T00:00:00.000Z',
@@ -898,6 +917,46 @@ test('cancelGardenDiaryRaisedBedField refunds euro plant purchases in sunflowers
 
     assert.equal(result.refundAmount, 1500);
     assert.equal(await getSunflowers(accountId), balanceBeforeCancel + 1500);
+});
+
+test('cancelGardenDiaryRaisedBedField does not refund inventory plantings', async () => {
+    createTestDb();
+    const { accountId, gardenId, raisedBedId } =
+        await createDiaryRescheduleContext();
+    const plantSortId = await createPricedPlantSortEntity();
+    const balanceBeforeCancel = await getSunflowers(accountId);
+
+    const cartItemId = await createPaidPlantCartItem({
+        accountId,
+        amount: 0,
+        currency: 'inventory',
+        gardenId,
+        plantSortId,
+        positionIndex: 0,
+        raisedBedId,
+    });
+    await createScheduledField({
+        plantSortId,
+        purchase: {
+            cartItemId,
+            currency: 'inventory',
+        },
+        raisedBedId,
+        positionIndex: 0,
+        scheduledDate: '2026-06-04T00:00:00.000Z',
+    });
+
+    const result = await cancelGardenDiaryRaisedBedField({
+        accountId,
+        canceledBy: 'user-1',
+        gardenId,
+        raisedBedId,
+        positionIndex: 0,
+        referenceDate: new Date('2026-06-03T12:00:00.000Z'),
+    });
+
+    assert.equal(result.refundAmount, 0);
+    assert.equal(await getSunflowers(accountId), balanceBeforeCancel);
 });
 
 test('cancelGardenDiaryRaisedBedField rejects sowing scheduled for today', async () => {


### PR DESCRIPTION
## What changed

- store the originating cart item, payment currency, and exact paid amount on new planting events
- resolve new cancellation refunds directly from durable planting-event metadata
- refund sunflower-paid plantings using the exact paid sunflower amount
- refund euro-paid plantings at 1 EUR = 1,000 sunflowers using the exact paid euro cents
- keep inventory-sourced plantings non-refundable
- retain the time-window cart lookup only for legacy planting events without payment metadata
- apply the shared resolver to both user and admin cancellation paths
- update regression fixtures to mirror the production plant-sort to plant pricing relationship

## Why

Planting cancellation previously read `prices.perPlant` directly from the plant-sort entity, while production pricing is inherited from the linked plant. The first fix recovered purchases by matching cart activity near the planting time, but that temporal association was not durable. New planting events now carry the payment reference and amount needed for an exact future refund.

## Impact

Users receive the correct sunflower credit when a paid planting is canceled, regardless of whether the planting was paid with euros or sunflowers. Inventory plantings do not create a monetary refund. Existing plantings remain compatible through the legacy lookup.

## Validation

- `corepack pnpm --filter @gredice/storage test:node -- gardenDiaryRescheduleRepo.node.spec.ts` (20 passed)
- `corepack pnpm --filter api exec node --import tsx --test --conditions=react-server ./lib/stripe/processCheckoutSession.node.spec.ts` (17 passed)
- package-local Biome checks for all changed files
- `git diff --check`