### PR TITLE
fix(app): move weed badge to field header

### DIFF
--- a/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldWeedStateSelector.tsx
+++ b/apps/app/app/admin/raised-beds/[raisedBedId]/RaisedBedFieldWeedStateSelector.tsx
@@ -9,6 +9,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@gredice/ui/Menu';
+import { cx } from '@gredice/ui/utils';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, useTransition } from 'react';
 import { setRaisedBedFieldWeedState } from '../../../(actions)/raisedBedFieldsActions';
@@ -81,10 +82,11 @@ export function RaisedBedFieldWeedStateSelector({
                     color={currentPresentation.color}
                     startDecorator={<CurrentIcon aria-hidden />}
                     title={`Promijeni stanje korova za polje ${positionIndex + 1}`}
-                    className={className}
+                    aria-label={`${currentItem?.label ?? optimisticLevel}. Promijeni stanje korova za polje ${positionIndex + 1}`}
+                    className={cx('size-6 justify-center !p-0', className)}
                     onClick={() => {}}
                 >
-                    <span className="min-w-0 truncate">
+                    <span className="sr-only">
                         {currentItem?.label ?? optimisticLevel}
                     </span>
                 </Chip>

--- a/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldCard.tsx
@@ -72,16 +72,18 @@ export function RaisedBedFieldCard({
             <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-background/55 via-background/10 to-background/70" />
             <div className="relative z-10 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-1.5 p-2">
                 <div className="min-w-0">{locationControl}</div>
-                <div className="shrink-0">{fieldBadge}</div>
+                <div className="flex shrink-0 items-center gap-1">
+                    {weedControl}
+                    {fieldBadge}
+                </div>
             </div>
             {historyControl && (
                 <div className="absolute left-2 top-11 z-10">
                     {historyControl}
                 </div>
             )}
-            <div className="relative z-10 mt-auto flex min-w-0 flex-col gap-0.5 px-2 pb-2 pt-2">
+            <div className="relative z-10 mt-auto flex min-w-0 flex-col gap-0.5 px-2 pb-2 pt-8">
                 <div className="min-w-0">{plantSortControl}</div>
-                {weedControl && <div className="min-w-0">{weedControl}</div>}
                 {statusControl && (
                     <div className="w-full min-w-0">{statusControl}</div>
                 )}

--- a/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
+++ b/apps/storybook/stories/apps/app/RaisedBedFieldCard.stories.tsx
@@ -232,9 +232,10 @@ function WeedChip({ level = 'none' }: { level?: MockField['weedLevel'] }) {
             color={current.color}
             startDecorator={<CurrentIcon aria-hidden />}
             title="Promijeni stanje korova"
-            className={raisedBedFieldCardChipClassName}
+            aria-label={`${current.label}. Promijeni stanje korova`}
+            className="size-6 justify-center !p-0"
         >
-            <span className="min-w-0 truncate">{current.label}</span>
+            <span className="sr-only">{current.label}</span>
         </Chip>
     );
 }


### PR DESCRIPTION
## What
- move the compact weed-state badge into the field card header beside the field number
- render the weed state as an icon-only 24px badge while preserving its dropdown interaction and accessible label
- restore footer spacing now that the weed control no longer competes with the plant and status inputs
- update the matching Storybook grid story

## Why
The weed selector in the footer made the compact raised-bed field cards overflow and hide parts of their inputs. The header already contains compact metadata badges, so the weed state fits there without reducing the usable input width.

## Validation
- `corepack pnpm --filter app exec biome check 'app/admin/raised-beds/[raisedBedId]/RaisedBedFieldWeedStateSelector.tsx' components/raised-beds/RaisedBedFieldCard.tsx`
- `corepack pnpm --filter storybook exec biome check stories/apps/app/RaisedBedFieldCard.stories.tsx`
- `corepack pnpm --filter storybook typecheck`
- `corepack pnpm --filter storybook build`
- `git diff --check`
- rendered the six-card Storybook field grid and verified the location, weed, and field-number badges stay inside every card without overlap; footer controls also remain within bounds