### PR TITLE
feat(public-gardens): add reliable previews and raised-bed details

### DIFF
--- a/apps/api/lib/garden/publicGardenSerialization.node.spec.ts
+++ b/apps/api/lib/garden/publicGardenSerialization.node.spec.ts
@@ -86,6 +86,30 @@ describe('serializePublicRaisedBedField', () => {
         assert.equal(plantCycle.plantSortId, 7);
     });
 
+    it('preserves public planting state and lifecycle dates', () => {
+        const plantScheduledDate = new Date('2026-05-30T08:00:00.000Z');
+        const plantSowDate = new Date('2026-06-01T08:00:00.000Z');
+        const plantGrowthDate = new Date('2026-06-10T08:00:00.000Z');
+        const plantReadyDate = new Date('2026-07-10T08:00:00.000Z');
+        const field = createField({
+            plantGrowthDate,
+            plantReadyDate,
+            plantScheduledDate,
+            plantSowDate,
+            plantStatus: 'ready',
+            sowingLocation: 'direct',
+        });
+
+        const publicField = serializePublicRaisedBedField(field);
+
+        assert.equal(publicField.plantStatus, 'ready');
+        assert.equal(publicField.sowingLocation, 'direct');
+        assert.equal(publicField.plantScheduledDate, plantScheduledDate);
+        assert.equal(publicField.plantSowDate, plantSowDate);
+        assert.equal(publicField.plantGrowthDate, plantGrowthDate);
+        assert.equal(publicField.plantReadyDate, plantReadyDate);
+    });
+
     it('counts only active planted fields for public garden summaries', () => {
         assert.equal(
             countPublicGardenActivePlants([

--- a/apps/garden/app/vrtovi/[id]/opengraph-image.tsx
+++ b/apps/garden/app/vrtovi/[id]/opengraph-image.tsx
@@ -1,13 +1,15 @@
 import { clientPublic, directoriesClient } from '@gredice/client';
 import { getBlockImageUrl } from '@gredice/ui/BlockImage';
 import { ImageResponse } from 'next/og';
-import sharp from 'sharp';
+import type sharp from 'sharp';
 import {
     GardenDisplay2D,
     type GardenDisplay2DProps,
     getGardenDisplayBlockImageKey,
+    getGardenDisplayProjectedPosition,
     getGardenDisplayRotationSuffix,
     getGardenDisplayViewportOffset,
+    getGardenDisplayViewportPosition,
 } from '../../../components/GardenDisplay2D';
 import { Logotype } from '../../../components/Logotype';
 
@@ -27,6 +29,8 @@ const gardenOgViewportSize = 1200;
 const gardenOgViewportCenter = { x: 576, y: 184 };
 const gardenOgDefaultBlockSize = 128;
 const gardenOgDefaultViewportOffset = { x: 24, y: 630 / 2 + 24 * 2 + 106 / 2 };
+const transparentPngDataUrl =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+4N1vWQAAAABJRU5ErkJggg==';
 
 type GardenOgStacks = GardenDisplay2DProps['garden']['stacks'];
 type GardenOgHomeCamera = {
@@ -35,12 +39,44 @@ type GardenOgHomeCamera = {
 } | null;
 
 const spritePngDataUrlBySrc = new Map<string, Promise<string>>();
+type SharpFactory = typeof sharp;
+let sharpModulePromise: Promise<SharpFactory> | undefined;
 
-export function getGardenOgBlockSpriteRequests(stacks: GardenOgStacks) {
+export function getGardenOgBlockSpriteRequests(
+    stacks: GardenOgStacks,
+    viewport?: {
+        blockSize: number;
+        viewportOffset: { x: number; y: number };
+        viewportSize: number;
+    },
+) {
     const requests = new Map<string, string>();
 
-    for (const rows of Object.values(stacks)) {
-        for (const blocks of Object.values(rows)) {
+    for (const [x, rows] of Object.entries(stacks)) {
+        for (const [y, blocks] of Object.entries(rows)) {
+            if (viewport) {
+                const projectedPosition = getGardenDisplayProjectedPosition({
+                    blockSize: viewport.blockSize,
+                    position: { x: Number(x), y: Number(y) },
+                    viewportSize: viewport.viewportSize,
+                });
+                const viewportPosition = getGardenDisplayViewportPosition({
+                    projectedPosition,
+                    viewportOffset: viewport.viewportOffset,
+                });
+                const visibilityMargin = viewport.blockSize * 1.5;
+                if (
+                    viewportPosition.top + visibilityMargin <= 0 ||
+                    viewportPosition.left + visibilityMargin <= 0 ||
+                    viewportPosition.top - visibilityMargin >=
+                        viewport.viewportSize ||
+                    viewportPosition.left - visibilityMargin >=
+                        viewport.viewportSize
+                ) {
+                    continue;
+                }
+            }
+
             for (const block of blocks) {
                 const rotationSuffix = getGardenDisplayRotationSuffix(
                     block.rotation,
@@ -60,6 +96,46 @@ export function getGardenOgBlockSpriteRequests(stacks: GardenOgStacks) {
     return [...requests].map(([key, src]) => ({ key, src }));
 }
 
+function isSharpFactory(value: unknown): value is SharpFactory {
+    return typeof value === 'function';
+}
+
+function resolveSharpFactory(value: unknown): SharpFactory | undefined {
+    if (isSharpFactory(value)) {
+        return value;
+    }
+
+    if (typeof value !== 'object' || value === null || !('default' in value)) {
+        return undefined;
+    }
+
+    return resolveSharpFactory(value.default);
+}
+
+async function loadSharp() {
+    const sharpModule: unknown = await import('sharp');
+    const sharpFactory = resolveSharpFactory(sharpModule);
+    if (!sharpFactory) {
+        throw new Error('Sharp module does not expose a default factory');
+    }
+
+    return sharpFactory;
+}
+
+async function getSharp() {
+    const currentPromise = sharpModulePromise ?? loadSharp();
+    sharpModulePromise = currentPromise;
+
+    try {
+        return await currentPromise;
+    } catch (error) {
+        if (sharpModulePromise === currentPromise) {
+            sharpModulePromise = undefined;
+        }
+        throw error;
+    }
+}
+
 async function getPngDataUrlForSprite(src: string) {
     const absoluteSrc = new URL(src, gardenOgImageAssetBaseUrl).toString();
 
@@ -67,6 +143,7 @@ async function getPngDataUrlForSprite(src: string) {
         spritePngDataUrlBySrc.set(
             absoluteSrc,
             (async () => {
+                const sharp = await getSharp();
                 const response = await fetch(absoluteSrc);
                 if (!response.ok) {
                     throw new Error(
@@ -91,20 +168,33 @@ async function getPngDataUrlForSprite(src: string) {
     }
 
     return sprite.catch((error: unknown) => {
+        if (spritePngDataUrlBySrc.get(absoluteSrc) === sprite) {
+            spritePngDataUrlBySrc.delete(absoluteSrc);
+        }
         console.error(error);
-        return absoluteSrc;
+        return null;
     });
 }
 
-async function getGardenOgBlockImageSrcByKey(stacks: GardenOgStacks) {
-    return new Map(
-        await Promise.all(
-            getGardenOgBlockSpriteRequests(stacks).map(
-                async ({ key, src }) =>
-                    [key, await getPngDataUrlForSprite(src)] as const,
-            ),
-        ),
+async function getGardenOgBlockImageSrcByKey(
+    requests: ReturnType<typeof getGardenOgBlockSpriteRequests>,
+) {
+    const resolvedSprites = await Promise.all(
+        requests.map(async ({ key, src }) => ({
+            key,
+            src: await getPngDataUrlForSprite(src),
+        })),
     );
+
+    return {
+        failedSpriteCount: resolvedSprites.filter(({ src }) => !src).length,
+        imageSrcByKey: new Map(
+            resolvedSprites.map(({ key, src }) => [
+                key,
+                src ?? transparentPngDataUrl,
+            ]),
+        ),
+    };
 }
 
 function clampGardenOgZoomScale(zoom: number) {
@@ -130,6 +220,101 @@ function getGardenOgViewportOffset(homeCamera: GardenOgHomeCamera) {
     });
 }
 
+function createGardenOgFallbackImage(gardenName: string) {
+    return new ImageResponse(
+        <div
+            style={{
+                alignItems: 'center',
+                background: 'linear-gradient(145deg, #eff3cf, #b9d48d)',
+                color: '#2E6F40',
+                display: 'flex',
+                height: '100%',
+                justifyContent: 'center',
+                overflow: 'hidden',
+                position: 'relative',
+                width: '100%',
+            }}
+        >
+            <div
+                style={{
+                    background: '#79ad64',
+                    borderRadius: 999,
+                    display: 'flex',
+                    height: 260,
+                    position: 'absolute',
+                    right: -40,
+                    top: -70,
+                    width: 260,
+                }}
+            />
+            <div
+                style={{
+                    background: '#593a2a',
+                    border: '24px solid #a86f4d',
+                    borderRadius: 54,
+                    boxShadow: '0 24px 42px rgba(42, 28, 15, 0.18)',
+                    display: 'flex',
+                    height: 250,
+                    left: 170,
+                    position: 'absolute',
+                    top: 120,
+                    transform: 'rotate(-5deg)',
+                    width: 660,
+                }}
+            >
+                <div
+                    style={{
+                        alignItems: 'center',
+                        color: '#8fca62',
+                        display: 'flex',
+                        fontSize: 108,
+                        height: '100%',
+                        justifyContent: 'center',
+                        letterSpacing: 24,
+                        width: '100%',
+                    }}
+                >
+                    • • • • •
+                </div>
+            </div>
+            <div
+                style={{
+                    alignItems: 'center',
+                    background: 'rgba(254, 250, 246, 0.94)',
+                    bottom: 0,
+                    display: 'flex',
+                    height: 116,
+                    justifyContent: 'space-between',
+                    left: 0,
+                    padding: '0 42px',
+                    position: 'absolute',
+                    right: 0,
+                }}
+            >
+                <div
+                    style={{
+                        display: 'flex',
+                        fontSize: 42,
+                        maxWidth: 820,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                    }}
+                >
+                    {gardenName}
+                </div>
+                <Logotype width={220} color="#2E6F40" />
+            </div>
+        </div>,
+        {
+            ...size,
+            headers: {
+                'Cache-Control': gardenOgImageCacheControl,
+            },
+        },
+    );
+}
+
 export default async function GardenOgImage({
     params,
 }: {
@@ -147,22 +332,37 @@ export default async function GardenOgImage({
             gardenId: gardenId.toString(),
         },
     });
-    if (gardenResponse.status === 400 || gardenResponse.status === 404) {
+    if (!gardenResponse.ok) {
         console.error(`Garden with ID ${gardenId} not found`);
-        return null;
+        return new Response('Garden not found', {
+            status:
+                gardenResponse.status === 400 || gardenResponse.status === 404
+                    ? gardenResponse.status
+                    : 502,
+        });
     }
     const garden = await gardenResponse.json();
 
     const blockData = (await directoriesClient().GET('/entities/block')).data;
     if (!blockData) {
         console.error(`Block data not found`);
-        return null;
+        return createGardenOgFallbackImage(garden.name);
     }
-    const blockImageSrcByKey = await getGardenOgBlockImageSrcByKey(
-        garden.stacks,
-    );
     const viewportOffset = getGardenOgViewportOffset(garden.homeCamera);
     const blockSize = getGardenOgBlockSize(garden.homeCamera);
+    const spriteRequests = getGardenOgBlockSpriteRequests(garden.stacks, {
+        blockSize,
+        viewportOffset,
+        viewportSize: gardenOgViewportSize,
+    });
+    const { failedSpriteCount, imageSrcByKey } =
+        await getGardenOgBlockImageSrcByKey(spriteRequests);
+    if (
+        spriteRequests.length === 0 ||
+        failedSpriteCount === spriteRequests.length
+    ) {
+        return createGardenOgFallbackImage(garden.name);
+    }
 
     return new ImageResponse(
         <div
@@ -194,7 +394,7 @@ export default async function GardenOgImage({
                 <GardenDisplay2D
                     garden={garden}
                     blockData={blockData}
-                    blockImageSrcByKey={blockImageSrcByKey}
+                    blockImageSrcByKey={imageSrcByKey}
                     blockSize={blockSize}
                     viewportSize={gardenOgViewportSize}
                     viewportOffset={viewportOffset}

--- a/apps/www/app/vrtovi/PublicGardenPreviewImage.tsx
+++ b/apps/www/app/vrtovi/PublicGardenPreviewImage.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { Sprout } from '@gredice/ui/icons';
+import { cx } from '@gredice/ui/utils';
+import Image from 'next/image';
+import { useState } from 'react';
+import { getPublicGardenOgImageUrl } from './publicGardenUrls';
+
+const gardenPreviewPlantDots = [
+    'dot-1',
+    'dot-2',
+    'dot-3',
+    'dot-4',
+    'dot-5',
+    'dot-6',
+    'dot-7',
+    'dot-8',
+    'dot-9',
+    'dot-10',
+];
+
+export function PublicGardenPreviewImage({
+    gardenId,
+    gardenName,
+    priority = false,
+}: {
+    gardenId: number;
+    gardenName: string;
+    priority?: boolean;
+}) {
+    const [imageFailed, setImageFailed] = useState(false);
+
+    return (
+        <div className="relative aspect-[1200/630] w-full overflow-hidden bg-[#dce8b8]">
+            <div
+                aria-hidden={!imageFailed}
+                aria-label={`Ilustrirani prikaz vrta ${gardenName}`}
+                className="absolute inset-0 overflow-hidden"
+                role="img"
+                style={{
+                    backgroundImage:
+                        'linear-gradient(145deg, #eff3cf 0%, #dce8b8 45%, #b9d48d 100%)',
+                }}
+            >
+                <div className="absolute -top-8 -right-6 size-36 rounded-full bg-[#79ad64]/70 shadow-[inset_-12px_-14px_0_rgba(56,103,56,0.16)]" />
+                <div className="absolute top-[26%] left-[14%] h-[32%] w-[58%] -rotate-6 rounded-[18%] border-[10px] border-[#a86f4d] bg-[#593a2a] shadow-xl">
+                    <div className="grid size-full grid-cols-5 gap-2 overflow-hidden p-3 opacity-90">
+                        {gardenPreviewPlantDots.map((dot) => (
+                            <span
+                                className="rounded-full bg-[#77b255] shadow-sm"
+                                key={dot}
+                            />
+                        ))}
+                    </div>
+                </div>
+                <div className="absolute right-[9%] bottom-[22%] h-[14%] w-[28%] rotate-6 rounded-[20%] border-[7px] border-[#bb805d] bg-[#674533] shadow-lg" />
+                <div className="absolute inset-x-0 bottom-0 flex h-[28%] items-center gap-2 bg-background/92 px-4 text-primary backdrop-blur-sm">
+                    <Sprout aria-hidden className="size-5 shrink-0" />
+                    <span className="truncate text-sm font-semibold">
+                        {gardenName}
+                    </span>
+                </div>
+            </div>
+            {!imageFailed ? (
+                <Image
+                    src={getPublicGardenOgImageUrl(gardenId)}
+                    alt={`Prikaz vrta ${gardenName}`}
+                    fill
+                    sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                    priority={priority}
+                    className={cx(
+                        'object-cover transition-[opacity,transform] duration-300 group-hover:scale-[1.02]',
+                        imageFailed && 'opacity-0',
+                    )}
+                    onError={() => setImageFailed(true)}
+                />
+            ) : null}
+        </div>
+    );
+}

--- a/apps/www/app/vrtovi/page.tsx
+++ b/apps/www/app/vrtovi/page.tsx
@@ -4,13 +4,12 @@ import { PageHeader } from '@gredice/ui/PageHeader';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
-import Image from 'next/image';
 import { KnownPages } from '../../src/KnownPages';
 import { PublicGardenLikeButton } from './PublicGardenLikeButton';
+import { PublicGardenPreviewImage } from './PublicGardenPreviewImage';
 import { PublicGardenTransitionLink } from './PublicGardenTransitionLink';
 import { getPublicGardensForWww } from './publicGardenData';
 import { formatGardenDate, formatGardenNumber } from './publicGardenFormatting';
-import { getPublicGardenOgImageUrl } from './publicGardenUrls';
 import { getPublicGardenCardViewTransitionName } from './publicGardenViewTransition';
 
 const pageDescription =
@@ -65,16 +64,10 @@ export default async function PublicGardensPage() {
                             </PublicGardenTransitionLink>
                             <div className="relative h-full text-card-foreground">
                                 <div className="overflow-hidden bg-muted">
-                                    <Image
-                                        src={getPublicGardenOgImageUrl(
-                                            garden.id,
-                                        )}
-                                        alt={`Prikaz vrta ${garden.name}`}
-                                        width={1200}
-                                        height={630}
-                                        sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                                    <PublicGardenPreviewImage
+                                        gardenId={garden.id}
+                                        gardenName={garden.name}
                                         priority={gardenIndex === 0}
-                                        className="aspect-[1200/630] w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
                                     />
                                 </div>
                                 <div className="grid grid-cols-3 divide-x border-t bg-card">

--- a/packages/game/src/viewers/PublicGardenRaisedBedDetails.tsx
+++ b/packages/game/src/viewers/PublicGardenRaisedBedDetails.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { plantFieldStatusLabel } from '@gredice/js/plants';
+import { Chip } from '@gredice/ui/Chip';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Calendar, Close, Sprout } from '@gredice/ui/icons';
+import { PlantOrSortImage } from '@gredice/ui/plants';
+import { RaisedBedSimpleIcon } from '@gredice/ui/RaisedBedSimpleIcon';
+import { Typography } from '@gredice/ui/Typography';
+import { useEffect, useMemo, useRef } from 'react';
+import { useAllSorts } from '../hooks/usePlantSorts';
+import {
+    getPublicGardenActivePlantFields,
+    getPublicGardenPlantCountLabel,
+    getPublicGardenPlantLocationLabel,
+    getPublicGardenPlantMilestones,
+    getPublicGardenPlantStatusColor,
+    type PublicGardenRaisedBed,
+} from './publicGardenRaisedBedDetailsModel';
+
+export function PublicGardenRaisedBedDetails({
+    onClose,
+    raisedBed,
+}: {
+    onClose: () => void;
+    raisedBed: PublicGardenRaisedBed;
+}) {
+    const panelRef = useRef<HTMLElement>(null);
+    const { data: plantSorts } = useAllSorts();
+    const plantSortById = useMemo(
+        () =>
+            new Map(plantSorts?.map((plantSort) => [plantSort.id, plantSort])),
+        [plantSorts],
+    );
+    const fields = getPublicGardenActivePlantFields(raisedBed);
+    const titleId = `public-raised-bed-${raisedBed.id.toString()}-title`;
+
+    useEffect(() => {
+        const previouslyFocused = document.activeElement;
+        panelRef.current?.focus();
+
+        function handleKeyDown(event: KeyboardEvent) {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        }
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            if (
+                previouslyFocused instanceof HTMLElement &&
+                previouslyFocused !== document.body &&
+                previouslyFocused.isConnected
+            ) {
+                previouslyFocused.focus();
+                return;
+            }
+
+            document
+                .querySelector<HTMLSelectElement>(
+                    '[data-public-garden-raised-bed-picker]',
+                )
+                ?.focus();
+        };
+    }, [onClose]);
+
+    return (
+        <section
+            ref={panelRef}
+            aria-labelledby={titleId}
+            className="absolute inset-x-2 bottom-2 z-30 flex max-h-[72%] min-w-0 flex-col overflow-hidden rounded-2xl border border-black/10 bg-background/95 shadow-2xl backdrop-blur-xl outline-hidden md:inset-y-3 md:right-3 md:left-auto md:max-h-none md:w-[min(420px,calc(100%-1.5rem))]"
+            role="dialog"
+            tabIndex={-1}
+        >
+            <div className="flex shrink-0 items-start gap-3 border-b bg-background/90 p-4 pr-3">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                    <RaisedBedSimpleIcon aria-hidden className="size-6" />
+                </div>
+                <div className="min-w-0 flex-1">
+                    <Typography
+                        id={titleId}
+                        level="h5"
+                        component="h2"
+                        className="truncate"
+                    >
+                        {raisedBed.name}
+                    </Typography>
+                    <div className="mt-1.5 flex flex-wrap gap-1.5">
+                        <Chip
+                            color={fields.length > 0 ? 'success' : 'neutral'}
+                            size="sm"
+                            startDecorator={<Sprout aria-hidden />}
+                            variant="soft"
+                        >
+                            {getPublicGardenPlantCountLabel(fields.length)}
+                        </Chip>
+                        <Chip color="neutral" size="sm" variant="outlined">
+                            Samo za gledanje
+                        </Chip>
+                    </div>
+                </div>
+                <IconButton
+                    aria-label="Zatvori detalje gredice"
+                    className="shrink-0 rounded-full"
+                    onClick={onClose}
+                    size="sm"
+                    variant="plain"
+                >
+                    <Close aria-hidden className="size-4" />
+                </IconButton>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4">
+                {fields.length > 0 ? (
+                    <div className="divide-y overflow-hidden rounded-xl border bg-card">
+                        {fields.map((field) => {
+                            const plantSort =
+                                typeof field.plantSortId === 'number'
+                                    ? plantSortById.get(field.plantSortId)
+                                    : undefined;
+                            const status = plantFieldStatusLabel(
+                                field.plantStatus ?? undefined,
+                            );
+                            const milestones =
+                                getPublicGardenPlantMilestones(field);
+                            const locationLabel =
+                                getPublicGardenPlantLocationLabel(field);
+                            const plantName =
+                                plantSort?.information.plant.information?.name;
+                            const sortName =
+                                plantSort?.information.name ?? 'Biljka';
+
+                            return (
+                                <article
+                                    className="grid min-w-0 grid-cols-[3.5rem_minmax(0,1fr)] gap-3 p-3"
+                                    key={field.id}
+                                >
+                                    <PlantOrSortImage
+                                        plantSort={plantSort}
+                                        alt={sortName}
+                                        className="size-14 rounded-lg border bg-muted object-cover"
+                                        height={56}
+                                        width={56}
+                                    />
+                                    <div className="min-w-0">
+                                        <div className="flex min-w-0 items-start justify-between gap-2">
+                                            <div className="min-w-0">
+                                                <Typography
+                                                    level="body2"
+                                                    semiBold
+                                                    className="truncate"
+                                                >
+                                                    {sortName}
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    secondary
+                                                    className="truncate"
+                                                >
+                                                    {plantName
+                                                        ? `${plantName} · polje ${(field.positionIndex + 1).toString()}`
+                                                        : `Polje ${(field.positionIndex + 1).toString()}`}
+                                                </Typography>
+                                                {locationLabel ? (
+                                                    <Chip
+                                                        className="mt-1"
+                                                        color={
+                                                            locationLabel ===
+                                                            'U plasteniku'
+                                                                ? 'warning'
+                                                                : 'neutral'
+                                                        }
+                                                        size="sm"
+                                                        variant="outlined"
+                                                    >
+                                                        {locationLabel}
+                                                    </Chip>
+                                                ) : null}
+                                            </div>
+                                            <Chip
+                                                color={getPublicGardenPlantStatusColor(
+                                                    field.plantStatus,
+                                                )}
+                                                size="sm"
+                                                variant="soft"
+                                            >
+                                                {status.shortLabel}
+                                            </Chip>
+                                        </div>
+
+                                        {milestones.length > 0 ? (
+                                            <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1.5">
+                                                {milestones.map((milestone) => (
+                                                    <div
+                                                        className="min-w-0"
+                                                        key={milestone.label}
+                                                    >
+                                                        <dt className="flex items-center gap-1 text-[0.7rem] text-muted-foreground">
+                                                            <Calendar
+                                                                aria-hidden
+                                                                className="size-3 shrink-0"
+                                                            />
+                                                            {milestone.label}
+                                                        </dt>
+                                                        <dd className="truncate text-xs font-medium">
+                                                            {milestone.value}
+                                                        </dd>
+                                                    </div>
+                                                ))}
+                                            </dl>
+                                        ) : (
+                                            <Typography
+                                                level="body3"
+                                                secondary
+                                                className="mt-2"
+                                            >
+                                                Datum sadnje još nije
+                                                zabilježen.
+                                            </Typography>
+                                        )}
+                                    </div>
+                                </article>
+                            );
+                        })}
+                    </div>
+                ) : (
+                    <div className="flex min-h-40 flex-col items-center justify-center rounded-xl border border-dashed bg-card/70 p-6 text-center">
+                        <Sprout
+                            aria-hidden
+                            className="mb-3 size-8 text-muted-foreground"
+                        />
+                        <Typography level="body2" semiBold>
+                            Gredica je trenutačno prazna
+                        </Typography>
+                        <Typography
+                            level="body3"
+                            secondary
+                            className="mt-1 max-w-64"
+                        >
+                            U ovoj gredici trenutačno nema aktivnih biljaka.
+                        </Typography>
+                    </div>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/packages/game/src/viewers/PublicGardenRaisedBedInteractions.tsx
+++ b/packages/game/src/viewers/PublicGardenRaisedBedInteractions.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useLayoutEffect, useMemo } from 'react';
+import {
+    createBlockInteractionTargetKey,
+    useBlockInteractionRegistry,
+} from '../controls/BlockInteractionRegistry';
+import { useHoveredBlockStore } from '../controls/useHoveredBlockStore';
+import type { Stack } from '../types/Stack';
+
+export function getPublicGardenRaisedBedInteractionTargets(stacks: Stack[]) {
+    return stacks.flatMap((stack) =>
+        stack.blocks.flatMap((block, blockIndex) =>
+            block.name === 'Raised_Bed'
+                ? [
+                      {
+                          block,
+                          blockIndex,
+                          key: createBlockInteractionTargetKey({
+                              blockId: block.id,
+                              blockIndex,
+                              stackPosition: stack.position,
+                          }),
+                          stack,
+                      },
+                  ]
+                : [],
+        ),
+    );
+}
+
+export function PublicGardenRaisedBedInteractions({
+    onSelect,
+    stacks,
+}: {
+    onSelect: (blockId: string) => void;
+    stacks: Stack[];
+}) {
+    const registry = useBlockInteractionRegistry();
+    const setHoveredBlock = useHoveredBlockStore(
+        (state) => state.setHoveredBlock,
+    );
+    const targets = useMemo(
+        () => getPublicGardenRaisedBedInteractionTargets(stacks),
+        [stacks],
+    );
+
+    useLayoutEffect(() => {
+        if (!registry) {
+            return;
+        }
+
+        let cursorTarget: HTMLElement | null = null;
+        const clearPointerCursor = () => {
+            if (cursorTarget) {
+                cursorTarget.style.cursor = '';
+                cursorTarget = null;
+            }
+        };
+        const unregister = targets.map((target) =>
+            registry.register(target.key, target, {
+                onPointerEnter: (event) => {
+                    event.stopPropagation();
+                    setHoveredBlock(target.block);
+                    if (event.nativeEvent.target instanceof HTMLElement) {
+                        clearPointerCursor();
+                        cursorTarget = event.nativeEvent.target;
+                        cursorTarget.style.cursor = 'pointer';
+                    }
+                },
+                onPointerLeave: (event) => {
+                    event.stopPropagation();
+                    if (
+                        useHoveredBlockStore.getState().hoveredBlock ===
+                        target.block
+                    ) {
+                        setHoveredBlock(null);
+                    }
+                    clearPointerCursor();
+                },
+                onSelectClick: (event) => {
+                    event.stopPropagation();
+                    setHoveredBlock(null);
+                    clearPointerCursor();
+                    onSelect(target.block.id);
+                },
+            }),
+        );
+
+        return () => {
+            for (const unregisterTarget of unregister) {
+                unregisterTarget();
+            }
+            clearPointerCursor();
+            setHoveredBlock(null);
+        };
+    }, [onSelect, registry, setHoveredBlock, targets]);
+
+    return null;
+}

--- a/packages/game/src/viewers/PublicGardenRaisedBedPicker.tsx
+++ b/packages/game/src/viewers/PublicGardenRaisedBedPicker.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { RaisedBedSimpleIcon } from '@gredice/ui/RaisedBedSimpleIcon';
+import { useId } from 'react';
+import type { PublicGardenRaisedBed } from './publicGardenRaisedBedDetailsModel';
+
+export function PublicGardenRaisedBedPicker({
+    onSelect,
+    raisedBeds,
+}: {
+    onSelect: (raisedBedId: number) => void;
+    raisedBeds: PublicGardenRaisedBed[];
+}) {
+    const selectId = useId();
+
+    if (raisedBeds.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="absolute bottom-3 left-3 z-20 flex max-w-[calc(100%-1.5rem)] items-center gap-2 rounded-full border border-black/10 bg-background/90 py-1 pr-1 pl-3 shadow-lg backdrop-blur-md">
+            <RaisedBedSimpleIcon
+                aria-hidden
+                className="size-5 shrink-0 text-primary"
+            />
+            <label className="sr-only" htmlFor={selectId}>
+                Odaberi gredicu za pregled
+            </label>
+            <select
+                className="h-8 min-w-0 max-w-52 cursor-pointer rounded-full border-0 bg-transparent pr-2 text-sm font-medium text-foreground outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                data-public-garden-raised-bed-picker
+                defaultValue=""
+                id={selectId}
+                onChange={(event) => {
+                    const raisedBedId = Number.parseInt(
+                        event.currentTarget.value,
+                        10,
+                    );
+                    if (Number.isFinite(raisedBedId)) {
+                        onSelect(raisedBedId);
+                    }
+                    event.currentTarget.value = '';
+                }}
+            >
+                <option disabled value="">
+                    Pregledaj gredicu
+                </option>
+                {raisedBeds.map((raisedBed) => (
+                    <option key={raisedBed.id} value={raisedBed.id}>
+                        {raisedBed.name}
+                    </option>
+                ))}
+            </select>
+        </div>
+    );
+}

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -11,12 +11,15 @@ import {
     type HTMLAttributes,
     type ReactNode,
     Suspense,
+    useCallback,
     useEffect,
     useMemo,
     useRef,
     useState,
 } from 'react';
 import { Vector3 } from 'three';
+import { BlockInteractionLayer } from '../controls/BlockInteractionLayer';
+import { BlockInteractionRegistryProvider } from '../controls/BlockInteractionRegistry';
 import { GameCameraRig } from '../controls/GameCameraRig';
 import { Bees } from '../entities/bees/Bees';
 import { Birds } from '../entities/birds/Birds';
@@ -44,7 +47,11 @@ import {
     type GameStateStore,
     useDisposeGameStateStore,
 } from '../useGameState';
+import { findRaisedBedByBlockId } from '../utils/raisedBedBlocks';
 import type { GameLocation } from '../utils/timeOfDay';
+import { PublicGardenRaisedBedDetails } from './PublicGardenRaisedBedDetails';
+import { PublicGardenRaisedBedInteractions } from './PublicGardenRaisedBedInteractions';
+import { PublicGardenRaisedBedPicker } from './PublicGardenRaisedBedPicker';
 
 export type PublicGardenBlock = Block;
 
@@ -97,6 +104,20 @@ export function publicGardenStacksFromResponse(
                 variant: block.variant,
             })),
         })),
+    );
+}
+
+export function getPublicGardenRaisedBedsWithBlocks<
+    TRaisedBed extends { blockId?: string | null },
+>(raisedBeds: TRaisedBed[], stacks: Stack[]) {
+    const renderedBlockIds = new Set(
+        stacks.flatMap((stack) => stack.blocks.map((block) => block.id)),
+    );
+
+    return raisedBeds.filter(
+        (raisedBed) =>
+            typeof raisedBed.blockId === 'string' &&
+            renderedBlockIds.has(raisedBed.blockId),
     );
 }
 
@@ -219,6 +240,7 @@ function PublicGardenScene({
     garden,
     gardenCacheReady,
     normalizedStacks,
+    onSelectRaisedBedBlock,
     renderDetails,
 }: {
     enableBlockGeometryMerging: boolean;
@@ -227,6 +249,7 @@ function PublicGardenScene({
     garden?: ReturnType<typeof publicGardenForGameState>;
     gardenCacheReady: boolean;
     normalizedStacks: Stack[];
+    onSelectRaisedBedBlock: (blockId: string) => void;
     renderDetails: boolean;
 }) {
     const blockDataQuery = useBlockData();
@@ -244,80 +267,94 @@ function PublicGardenScene({
                     className="h-full w-full"
                 >
                     <ParticleSystemProvider>
-                        <Environment
-                            noSound
-                            quality={qualityProfile}
-                            weather={undefined}
-                        />
-                        <Suspense fallback={null}>
-                            <group name="PublicGardenScene:Entities">
-                                {normalizedStacks.map((stack) =>
-                                    stack.blocks.map((block) => (
-                                        <EntityFactory
-                                            key={`${stack.position.x}|${stack.position.z}|${block.id}-${block.name}`}
-                                            name={block.name}
-                                            stack={stack}
-                                            block={block}
-                                            stacks={normalizedStacks}
-                                            rotation={block.rotation}
-                                            variant={block.variant}
-                                            noRenderInView={instancedBlockNames}
-                                            noControl
-                                        />
-                                    )),
-                                )}
-                                <EntityInstances
-                                    enableBlockGeometryMerging={
-                                        enableBlockGeometryMerging
-                                    }
-                                    farmId={garden?.farmId}
-                                    quality={qualityProfile}
-                                    renderGroundDecorations={
-                                        renderLivingDetails
-                                    }
-                                    stacks={normalizedStacks}
-                                    renderDetails={renderLivingDetails}
-                                />
-                                {renderLivingDetails && (
-                                    <Suspense fallback={null}>
-                                        <Birds stacks={normalizedStacks} />
-                                    </Suspense>
-                                )}
-                                {renderLivingDetails && (
-                                    <Suspense fallback={null}>
-                                        <Cats
-                                            farmId={garden?.farmId}
-                                            stacks={normalizedStacks}
-                                        />
-                                    </Suspense>
-                                )}
-                                {renderLivingDetails && (
-                                    <Suspense fallback={null}>
-                                        <Dogs
-                                            farmId={garden?.farmId}
-                                            stacks={normalizedStacks}
-                                        />
-                                    </Suspense>
-                                )}
-                                {renderLivingDetails && garden && (
-                                    <Suspense fallback={null}>
-                                        <Bees
-                                            farmId={garden.farmId}
-                                            garden={garden}
-                                            groundDecorationDensity={
-                                                qualityProfile.groundDecorationDensity
-                                            }
-                                        />
-                                    </Suspense>
-                                )}
-                            </group>
-                        </Suspense>
-                        <GameCameraRig
-                            controlsEnabled
-                            initialSnapshot={garden?.homeCamera ?? undefined}
-                            initialTarget={initialView.cameraTarget}
-                            initialViewKey={garden?.id ?? 'stacks'}
-                        />
+                        <BlockInteractionRegistryProvider>
+                            <Environment
+                                noSound
+                                quality={qualityProfile}
+                                weather={undefined}
+                            />
+                            <Suspense fallback={null}>
+                                <group name="PublicGardenScene:Entities">
+                                    {normalizedStacks.map((stack) =>
+                                        stack.blocks.map((block) => (
+                                            <EntityFactory
+                                                key={`${stack.position.x}|${stack.position.z}|${block.id}-${block.name}`}
+                                                name={block.name}
+                                                stack={stack}
+                                                block={block}
+                                                stacks={normalizedStacks}
+                                                rotation={block.rotation}
+                                                variant={block.variant}
+                                                noRenderInView={
+                                                    instancedBlockNames
+                                                }
+                                                noControl
+                                            />
+                                        )),
+                                    )}
+                                    <EntityInstances
+                                        enableBlockGeometryMerging={
+                                            enableBlockGeometryMerging
+                                        }
+                                        farmId={garden?.farmId}
+                                        quality={qualityProfile}
+                                        renderGroundDecorations={
+                                            renderLivingDetails
+                                        }
+                                        stacks={normalizedStacks}
+                                        renderDetails={renderLivingDetails}
+                                    />
+                                    <PublicGardenRaisedBedInteractions
+                                        onSelect={onSelectRaisedBedBlock}
+                                        stacks={normalizedStacks}
+                                    />
+                                    <BlockInteractionLayer
+                                        controlsEnabled
+                                        stacks={normalizedStacks}
+                                    />
+                                    {renderLivingDetails && (
+                                        <Suspense fallback={null}>
+                                            <Birds stacks={normalizedStacks} />
+                                        </Suspense>
+                                    )}
+                                    {renderLivingDetails && (
+                                        <Suspense fallback={null}>
+                                            <Cats
+                                                farmId={garden?.farmId}
+                                                stacks={normalizedStacks}
+                                            />
+                                        </Suspense>
+                                    )}
+                                    {renderLivingDetails && (
+                                        <Suspense fallback={null}>
+                                            <Dogs
+                                                farmId={garden?.farmId}
+                                                stacks={normalizedStacks}
+                                            />
+                                        </Suspense>
+                                    )}
+                                    {renderLivingDetails && garden && (
+                                        <Suspense fallback={null}>
+                                            <Bees
+                                                farmId={garden.farmId}
+                                                garden={garden}
+                                                groundDecorationDensity={
+                                                    qualityProfile.groundDecorationDensity
+                                                }
+                                            />
+                                        </Suspense>
+                                    )}
+                                </group>
+                            </Suspense>
+                            <GameCameraRig
+                                controlsEnabled
+                                initialSnapshot={
+                                    garden?.homeCamera ?? undefined
+                                }
+                                initialTarget={initialView.cameraTarget}
+                                initialViewKey={garden?.id ?? 'stacks'}
+                            />
+                        </BlockInteractionRegistryProvider>
                     </ParticleSystemProvider>
                 </Scene>
             ) : (
@@ -413,6 +450,16 @@ export function PublicGardenViewer({
                 : undefined,
         [garden, normalizedStacks],
     );
+    const selectableRaisedBeds = useMemo(
+        () =>
+            gameGarden
+                ? getPublicGardenRaisedBedsWithBlocks(
+                      gameGarden.raisedBeds,
+                      normalizedStacks,
+                  )
+                : [],
+        [gameGarden, normalizedStacks],
+    );
     const initialView = useMemo(
         () =>
             getPublicGardenInitialView({
@@ -423,12 +470,73 @@ export function PublicGardenViewer({
     );
     const renderDetails = useDeferredSceneDetails(deferDetails);
     const cacheKey = getPublicGardenCacheKey(garden);
+    const [selectedRaisedBedId, setSelectedRaisedBedId] = useState<
+        number | null
+    >(null);
+    const selectedRaisedBed = gameGarden?.raisedBeds.find(
+        (raisedBed) => raisedBed.id === selectedRaisedBedId,
+    );
+
+    const openRaisedBed = useCallback(
+        (raisedBedId: number) => {
+            if (!gameGarden) {
+                return;
+            }
+
+            const raisedBed = gameGarden.raisedBeds.find(
+                (candidate) => candidate.id === raisedBedId,
+            );
+            if (!raisedBed?.blockId) {
+                return;
+            }
+
+            const block = gameGarden.stacks
+                .flatMap((stack) => stack.blocks)
+                .find((candidate) => candidate.id === raisedBed.blockId);
+            if (!block) {
+                return;
+            }
+
+            setSelectedRaisedBedId(raisedBed.id);
+            storeRef.current?.getState().setView({
+                view: 'closeup',
+                block,
+            });
+        },
+        [gameGarden],
+    );
+
+    const openRaisedBedByBlockId = useCallback(
+        (blockId: string) => {
+            const raisedBed = findRaisedBedByBlockId(gameGarden, blockId);
+            if (raisedBed) {
+                openRaisedBed(raisedBed.id);
+            }
+        },
+        [gameGarden, openRaisedBed],
+    );
+
+    const closeRaisedBed = useCallback(() => {
+        setSelectedRaisedBedId(null);
+        storeRef.current?.getState().setView({ view: 'normal' });
+    }, []);
 
     useEffect(() => {
         storeRef.current
             ?.getState()
             .setBackgroundPaletteKey(gameGarden?.backgroundPalette);
     }, [gameGarden?.backgroundPalette]);
+
+    useEffect(() => {
+        if (gameGarden?.id === undefined) {
+            setSelectedRaisedBedId(null);
+            storeRef.current?.getState().setView({ view: 'normal' });
+            return;
+        }
+
+        setSelectedRaisedBedId(null);
+        storeRef.current?.getState().setView({ view: 'normal' });
+    }, [gameGarden?.id]);
 
     return (
         <QueryClientProvider client={clientRef.current}>
@@ -440,17 +548,40 @@ export function PublicGardenViewer({
                         garden={gameGarden}
                     >
                         {(gardenCacheReady) => (
-                            <PublicGardenScene
-                                className={className}
-                                enableBlockGeometryMerging={
-                                    enableBlockGeometryMerging
-                                }
-                                garden={gameGarden}
-                                gardenCacheReady={gardenCacheReady}
-                                initialView={initialView}
-                                normalizedStacks={normalizedStacks}
-                                renderDetails={renderDetails}
-                            />
+                            <div
+                                className={cx(
+                                    'relative h-full w-full',
+                                    className,
+                                )}
+                            >
+                                <PublicGardenScene
+                                    className="size-full"
+                                    enableBlockGeometryMerging={
+                                        enableBlockGeometryMerging
+                                    }
+                                    garden={gameGarden}
+                                    gardenCacheReady={gardenCacheReady}
+                                    initialView={initialView}
+                                    normalizedStacks={normalizedStacks}
+                                    onSelectRaisedBedBlock={
+                                        openRaisedBedByBlockId
+                                    }
+                                    renderDetails={renderDetails}
+                                />
+                                {gameGarden ? (
+                                    <PublicGardenRaisedBedPicker
+                                        onSelect={openRaisedBed}
+                                        raisedBeds={selectableRaisedBeds}
+                                    />
+                                ) : null}
+                                {selectedRaisedBed ? (
+                                    <PublicGardenRaisedBedDetails
+                                        key={selectedRaisedBed.id}
+                                        onClose={closeRaisedBed}
+                                        raisedBed={selectedRaisedBed}
+                                    />
+                                ) : null}
+                            </div>
                         )}
                     </SeedPublicGardenQueryCache>
                 </GameSceneDetailContext.Provider>

--- a/packages/game/src/viewers/PublicGardenViewer.unit.ts
+++ b/packages/game/src/viewers/PublicGardenViewer.unit.ts
@@ -1,11 +1,45 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { getPublicGardenRaisedBedInteractionTargets } from './PublicGardenRaisedBedInteractions';
 import {
     getPublicGardenInitialView,
+    getPublicGardenRaisedBedsWithBlocks,
     getPublicGardenStacksCenter,
     normalizePublicGardenStacks,
     type PublicGardenStack,
 } from './PublicGardenViewer';
+
+describe('getPublicGardenRaisedBedsWithBlocks', () => {
+    it('excludes raised beds that cannot be selected in the rendered garden', () => {
+        const stacks = normalizePublicGardenStacks([
+            {
+                x: 2,
+                y: 5,
+                blocks: [
+                    {
+                        id: 'raised-bed-1',
+                        name: 'Raised_Bed',
+                        rotation: 0,
+                    },
+                ],
+            },
+        ]);
+
+        const raisedBeds = getPublicGardenRaisedBedsWithBlocks(
+            [
+                { id: 1, blockId: 'raised-bed-1' },
+                { id: 2, blockId: 'removed-raised-bed' },
+                { id: 3, blockId: null },
+            ],
+            stacks,
+        );
+
+        assert.deepEqual(
+            raisedBeds.map((raisedBed) => raisedBed.id),
+            [1],
+        );
+    });
+});
 
 describe('normalizePublicGardenStacks', () => {
     it('maps public garden rows onto the game z axis', () => {
@@ -85,5 +119,34 @@ describe('getPublicGardenInitialView', () => {
         assert.equal(view.cameraTarget.y, 0);
         assert.equal(view.cameraTarget.z, 7);
         assert.equal(view.cameraZoom, 90);
+    });
+});
+
+describe('getPublicGardenRaisedBedInteractionTargets', () => {
+    it('registers only raised-bed blocks for public selection', () => {
+        const stacks = normalizePublicGardenStacks([
+            {
+                x: 2,
+                y: 5,
+                blocks: [
+                    {
+                        id: 'raised-bed-1',
+                        name: 'Raised_Bed',
+                        rotation: 0,
+                    },
+                    {
+                        id: 'decoration-1',
+                        name: 'Bucket',
+                        rotation: 0,
+                    },
+                ],
+            },
+        ]);
+
+        const targets = getPublicGardenRaisedBedInteractionTargets(stacks);
+
+        assert.equal(targets.length, 1);
+        assert.equal(targets[0]?.block.id, 'raised-bed-1');
+        assert.equal(targets[0]?.blockIndex, 0);
     });
 });

--- a/packages/game/src/viewers/publicGardenRaisedBedDetails.unit.ts
+++ b/packages/game/src/viewers/publicGardenRaisedBedDetails.unit.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    getPublicGardenActivePlantFields,
+    getPublicGardenPlantCountLabel,
+    getPublicGardenPlantLocationLabel,
+    getPublicGardenPlantMilestones,
+    getPublicGardenPlantStatusColor,
+} from './publicGardenRaisedBedDetailsModel';
+
+describe('getPublicGardenActivePlantFields', () => {
+    it('returns planted active fields in position order', () => {
+        const fields = getPublicGardenActivePlantFields({
+            fields: [
+                { active: true, plantSortId: 8, positionIndex: 4 },
+                { active: false, plantSortId: 9, positionIndex: 1 },
+                { active: true, plantSortId: undefined, positionIndex: 2 },
+                { active: true, plantSortId: 7, positionIndex: 0 },
+            ],
+        });
+
+        assert.deepEqual(
+            fields.map((field) => field.positionIndex),
+            [0, 4],
+        );
+    });
+});
+
+describe('getPublicGardenPlantMilestones', () => {
+    it('shows the planned date until a plant is sown', () => {
+        assert.deepEqual(
+            getPublicGardenPlantMilestones({
+                plantGrowthDate: undefined,
+                plantHarvestedDate: undefined,
+                plantReadyDate: undefined,
+                plantScheduledDate: '2026-07-12T08:00:00.000Z',
+                plantSowDate: undefined,
+            }),
+            [{ label: 'Planirano', value: '12. srp 2026.' }],
+        );
+    });
+
+    it('shows recorded lifecycle dates after sowing', () => {
+        assert.deepEqual(
+            getPublicGardenPlantMilestones({
+                plantGrowthDate: '2026-06-10T08:00:00.000Z',
+                plantHarvestedDate: undefined,
+                plantReadyDate: '2026-07-10T08:00:00.000Z',
+                plantScheduledDate: '2026-06-02T08:00:00.000Z',
+                plantSowDate: '2026-06-03T08:00:00.000Z',
+            }),
+            [
+                { label: 'Posijano', value: '3. lip 2026.' },
+                { label: 'Proklijalo', value: '10. lip 2026.' },
+                { label: 'Spremno za berbu', value: '10. srp 2026.' },
+            ],
+        );
+    });
+
+    it('formats dates in the Croatian garden timezone', () => {
+        assert.deepEqual(
+            getPublicGardenPlantMilestones({
+                plantGrowthDate: undefined,
+                plantHarvestedDate: undefined,
+                plantReadyDate: undefined,
+                plantScheduledDate: '2026-06-14T22:30:00.000Z',
+                plantSowDate: undefined,
+            }),
+            [{ label: 'Planirano', value: '15. lip 2026.' }],
+        );
+    });
+});
+
+describe('public garden plant labels', () => {
+    it('localizes counts and status colors', () => {
+        assert.equal(getPublicGardenPlantCountLabel(1), '1 biljka');
+        assert.equal(getPublicGardenPlantCountLabel(4), '4 biljke');
+        assert.equal(getPublicGardenPlantCountLabel(11), '11 biljaka');
+        assert.equal(getPublicGardenPlantCountLabel(14), '14 biljaka');
+        assert.equal(getPublicGardenPlantCountLabel(21), '21 biljka');
+        assert.equal(getPublicGardenPlantStatusColor('ready'), 'info');
+        assert.equal(getPublicGardenPlantStatusColor('died'), 'error');
+        assert.equal(getPublicGardenPlantStatusColor('sprouted'), 'success');
+    });
+
+    it('distinguishes seedlings that are not physically in the raised bed', () => {
+        assert.equal(
+            getPublicGardenPlantLocationLabel({
+                plantStatus: 'sprouted',
+                sowingLocation: 'greenhouse',
+            }),
+            'U plasteniku',
+        );
+        assert.equal(
+            getPublicGardenPlantLocationLabel({
+                plantStatus: 'firstFlowers',
+                sowingLocation: 'greenhouse',
+            }),
+            'Presadnica iz plastenika',
+        );
+        assert.equal(
+            getPublicGardenPlantLocationLabel({
+                plantStatus: 'sowed',
+                sowingLocation: 'direct',
+            }),
+            'Izravna sjetva',
+        );
+    });
+});

--- a/packages/game/src/viewers/publicGardenRaisedBedDetailsModel.ts
+++ b/packages/game/src/viewers/publicGardenRaisedBedDetailsModel.ts
@@ -1,0 +1,138 @@
+import type { PublicGardenDetail } from './PublicGardenViewer';
+
+export type PublicGardenRaisedBed = PublicGardenDetail['raisedBeds'][number];
+export type PublicGardenRaisedBedField =
+    PublicGardenRaisedBed['fields'][number];
+
+export type PublicGardenPlantMilestone = {
+    label: string;
+    value: string;
+};
+
+const publicGardenPlantDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'Europe/Zagreb',
+});
+
+export function getPublicGardenActivePlantFields<
+    TField extends {
+        active?: boolean | null;
+        plantSortId?: number | null;
+        positionIndex: number;
+    },
+>(raisedBed: { fields: TField[] }) {
+    return raisedBed.fields
+        .filter(
+            (field) => field.active && typeof field.plantSortId === 'number',
+        )
+        .sort((left, right) => left.positionIndex - right.positionIndex);
+}
+
+function formatPublicGardenPlantDate(value: Date | string | null | undefined) {
+    if (!value) {
+        return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    return publicGardenPlantDateFormatter.format(date);
+}
+
+export function getPublicGardenPlantMilestones(
+    field: Pick<
+        PublicGardenRaisedBedField,
+        | 'plantGrowthDate'
+        | 'plantHarvestedDate'
+        | 'plantReadyDate'
+        | 'plantScheduledDate'
+        | 'plantSowDate'
+    >,
+): PublicGardenPlantMilestone[] {
+    const milestones: Array<{
+        label: string;
+        value: Date | string | null | undefined;
+    }> = [
+        ...(!field.plantSowDate
+            ? [
+                  {
+                      label: 'Planirano',
+                      value: field.plantScheduledDate,
+                  },
+              ]
+            : []),
+        { label: 'Posijano', value: field.plantSowDate },
+        { label: 'Proklijalo', value: field.plantGrowthDate },
+        { label: 'Spremno za berbu', value: field.plantReadyDate },
+        { label: 'Ubrano', value: field.plantHarvestedDate },
+    ];
+
+    return milestones.flatMap((milestone) => {
+        const value = formatPublicGardenPlantDate(milestone.value);
+        return value ? [{ label: milestone.label, value }] : [];
+    });
+}
+
+export function getPublicGardenPlantStatusColor(
+    status: string | null | undefined,
+): 'error' | 'info' | 'neutral' | 'success' | 'warning' {
+    switch (status) {
+        case 'notSprouted':
+        case 'died':
+            return 'error';
+        case 'ready':
+            return 'info';
+        case 'sprouted':
+        case 'firstFlowers':
+        case 'firstFruitSet':
+            return 'success';
+        case 'new':
+        case 'planned':
+        case 'sowed':
+        case 'pendingVerification':
+            return 'warning';
+        default:
+            return 'neutral';
+    }
+}
+
+export function getPublicGardenPlantLocationLabel(
+    field: Pick<PublicGardenRaisedBedField, 'plantStatus' | 'sowingLocation'>,
+) {
+    if (field.sowingLocation === 'direct') {
+        return 'Izravna sjetva';
+    }
+
+    if (field.sowingLocation !== 'greenhouse') {
+        return null;
+    }
+
+    if (
+        ['new', 'planned', 'pendingVerification', 'sowed', 'sprouted'].includes(
+            field.plantStatus ?? '',
+        )
+    ) {
+        return 'U plasteniku';
+    }
+
+    return 'Presadnica iz plastenika';
+}
+
+export function getPublicGardenPlantCountLabel(count: number) {
+    const modulo100 = count % 100;
+    const modulo10 = count % 10;
+    const noun =
+        modulo10 === 1 && modulo100 !== 11
+            ? 'biljka'
+            : modulo10 >= 2 &&
+                modulo10 <= 4 &&
+                (modulo100 < 12 || modulo100 > 14)
+              ? 'biljke'
+              : 'biljaka';
+
+    return `${count.toString()} ${noun}`;
+}


### PR DESCRIPTION
## Summary

- restore public garden card previews with resilient OG rendering and a branded client fallback
- make raised beds selectable in public gardens and show read-only plant status, sowing location, and lifecycle dates
- preserve the garden's saved home-camera position, target, and zoom as the authoritative initial public framing

## Why

Public garden OG image requests were failing while loading Sharp/libvips, which left the `/vrtovi` cards broken or empty. The route now lazy-loads Sharp, tolerates individual sprite failures, culls off-screen work, and returns a branded image instead of a 500 when rendering cannot complete.

User testing also showed that visitors naturally click raised beds. Public previews now support that interaction without exposing private actions or assignment data.

## User impact

Visitors get a useful garden image even during an image-rendering failure. In the public 3D garden they can click or keyboard-select a raised bed, inspect its plants and dates, and close the read-only panel back to the previously configured garden view.

## Validation

- `corepack pnpm --filter @gredice/game test` — 384 passed
- `corepack pnpm --filter api test:node` — 185 passed
- `corepack pnpm typecheck --filter @gredice/game --filter garden --filter www`
- production builds for `apps/garden` and `apps/www`
- built OG route returned `200 image/png`, 1200×630
- browser verification covered fallback cards, direct 3D hover/click, keyboard selection, Escape close, camera/focus restoration, and error overlays
- `git diff --check`
