### PR TITLE
fix(game): ground raised bed closeup background

### DIFF
--- a/packages/game/src/controls/GameCameraRig.tsx
+++ b/packages/game/src/controls/GameCameraRig.tsx
@@ -51,6 +51,7 @@ type CameraAnimation = {
     startPosition: Vector3;
     startTarget: Vector3;
     startZoom: number;
+    onComplete?: () => void;
 };
 
 type PointerState = {
@@ -172,6 +173,9 @@ export function GameCameraRig({
     const setGameCamera = useGameState((state) => state.setGameCamera);
     const setGameCameraSnapshot = useGameState(
         (state) => state.setGameCameraSnapshot,
+    );
+    const setCloseupCameraActive = useGameState(
+        (state) => state.setCloseupCameraActive,
     );
     const [isAnimating, setIsAnimating] = useState(false);
     const setIsDragging = useGameState((state) => state.setIsDragging);
@@ -418,11 +422,13 @@ export function GameCameraRig({
             endPosition,
             endTarget,
             endZoom,
+            onComplete,
         }: {
             duration: number;
             endPosition: Vector3;
             endTarget: Vector3;
             endZoom: number;
+            onComplete?: () => void;
         }) => {
             if (!isOrthographicCamera) {
                 return;
@@ -435,6 +441,7 @@ export function GameCameraRig({
                 targetRef.current.copy(endTarget);
                 camera.zoom = MathUtils.clamp(endZoom, minZoom, maxZoom);
                 applyCamera();
+                onComplete?.();
                 return;
             }
 
@@ -447,6 +454,7 @@ export function GameCameraRig({
                 startPosition: camera.position.clone(),
                 startTarget: targetRef.current.clone(),
                 startZoom: camera.zoom,
+                onComplete,
             };
             setIsAnimating(true);
         },
@@ -831,6 +839,7 @@ export function GameCameraRig({
         const previousView = previousViewRef.current;
 
         if (view === 'closeup' && closeupTarget) {
+            setCloseupCameraActive(true);
             if (previousView !== 'closeup') {
                 normalCameraRef.current = {
                     position: camera.position.clone(),
@@ -859,10 +868,23 @@ export function GameCameraRig({
                 endPosition: normalCameraRef.current.position,
                 endTarget: normalCameraRef.current.target,
                 endZoom: normalCameraRef.current.zoom,
+                onComplete: () => setCloseupCameraActive(false),
             });
         }
         previousViewRef.current = view;
-    }, [camera, closeupTarget, isOrthographicCamera, startAnimation, view]);
+    }, [
+        camera,
+        closeupTarget,
+        isOrthographicCamera,
+        setCloseupCameraActive,
+        startAnimation,
+        view,
+    ]);
+
+    useEffect(
+        () => () => setCloseupCameraActive(false),
+        [setCloseupCameraActive],
+    );
 
     useFrame((_, delta) => {
         if (!isOrthographicCamera) {
@@ -922,6 +944,7 @@ export function GameCameraRig({
                 setIsAnimating(false);
                 applyCamera();
                 saveNormalCamera();
+                animation.onComplete?.();
             }
             flushSnapshot();
             return;

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -675,7 +675,10 @@ export function Environment({
         (state) => state.backgroundPaletteIndex,
     );
     const view = useGameState((state) => state.view);
-    const isGroundView = view === 'closeup';
+    const closeupCameraActive = useGameState(
+        (state) => state.closeupCameraActive,
+    );
+    const isGroundView = view === 'closeup' || closeupCameraActive;
     const closeupBlockId = useGameState((state) => state.closeupBlock?.id);
     const pickupBlockId = useGameState((state) => state.pickupBlock?.id);
     const winterMode = useGameState((state) => state.winterMode);

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -71,6 +71,7 @@ const DEBUG_WEATHER_BLEND_CONFIG: WeatherBlendConfig = {
 const WEATHER_BLEND_EPSILON = 0.0005;
 const BACKGROUND_COLOR_TRANSITION_SECONDS = 0.55;
 const BACKGROUND_COLOR_EPSILON = 0.001;
+const raisedBedCloseupGroundColor = new Color('#9eb64a');
 
 function dampNumber(
     current: number,
@@ -674,6 +675,7 @@ export function Environment({
         (state) => state.backgroundPaletteIndex,
     );
     const view = useGameState((state) => state.view);
+    const isGroundView = view === 'closeup';
     const closeupBlockId = useGameState((state) => state.closeupBlock?.id);
     const pickupBlockId = useGameState((state) => state.pickupBlock?.id);
     const winterMode = useGameState((state) => state.winterMode);
@@ -1110,12 +1112,24 @@ export function Environment({
             />
             {!noBackground && (
                 <>
-                    <SceneBackgroundColor animate color={background} />
+                    <SceneBackgroundColor
+                        animate
+                        color={
+                            isGroundView
+                                ? raisedBedCloseupGroundColor
+                                : background
+                        }
+                    />
                     <SkyGradientBackground
                         animate
                         backgroundColor={background}
                         backgroundPaletteIndex={backgroundPaletteIndex}
                         currentTime={currentTime}
+                        groundColor={
+                            isGroundView
+                                ? raisedBedCloseupGroundColor
+                                : undefined
+                        }
                         location={location}
                         moonlight={sky.moonlight}
                         timeOfDay={timeOfDay}
@@ -1182,8 +1196,12 @@ export function Environment({
                     windSpeed={windSpeed}
                 />
             )}
-            {showStars && <Stars visibility={starVisibility} />}
-            {!noBackground && <SunMoon visibility={bodyVisibility} />}
+            {showStars && (
+                <Stars visibility={isGroundView ? 0 : starVisibility} />
+            )}
+            {!noBackground && (
+                <SunMoon visibility={isGroundView ? 0 : bodyVisibility} />
+            )}
             {!weatherDisabled && fog > 0 && (
                 <fog attach="fog" args={[fogColor, fogNear, 190]} />
             )}

--- a/packages/game/src/scene/SkyGradientBackground.tsx
+++ b/packages/game/src/scene/SkyGradientBackground.tsx
@@ -7,6 +7,7 @@ import { Color, DoubleSide, type Mesh, ShaderMaterial, Vector2 } from 'three';
 import {
     cloneSkyGradientColors,
     lerpSkyGradientColors,
+    resolveGroundViewSkyGradientColors,
     resolveSkyGradientColors,
     type SkyGradientColors,
     type SkyGradientWeather,
@@ -89,6 +90,7 @@ type SkyGradientBackgroundProps = {
     backgroundColor: Color;
     backgroundPaletteIndex: number;
     currentTime: Date;
+    groundColor?: Color;
     location: { lat: number; lon: number };
     moonlight: number;
     timeOfDay: number;
@@ -136,6 +138,7 @@ export function SkyGradientBackground({
     backgroundColor,
     backgroundPaletteIndex,
     currentTime,
+    groundColor,
     location,
     moonlight,
     timeOfDay,
@@ -180,29 +183,32 @@ export function SkyGradientBackground({
         [],
     );
 
-    const targetGradient = useMemo(
-        () =>
-            resolveSkyGradientColors({
-                backgroundColor: new Color(
-                    backgroundRed,
-                    backgroundGreen,
-                    backgroundBlue,
-                ),
-                backgroundPaletteIndex,
-                moonlight,
-                timeOfDay,
-                weather,
-            }),
-        [
-            backgroundBlue,
-            backgroundGreen,
+    const targetGradient = useMemo(() => {
+        const gradient = resolveSkyGradientColors({
+            backgroundColor: new Color(
+                backgroundRed,
+                backgroundGreen,
+                backgroundBlue,
+            ),
             backgroundPaletteIndex,
-            backgroundRed,
             moonlight,
             timeOfDay,
             weather,
-        ],
-    );
+        });
+
+        return groundColor
+            ? resolveGroundViewSkyGradientColors(gradient, groundColor)
+            : gradient;
+    }, [
+        backgroundBlue,
+        backgroundGreen,
+        backgroundPaletteIndex,
+        backgroundRed,
+        groundColor,
+        moonlight,
+        timeOfDay,
+        weather,
+    ]);
 
     useEffect(() => {
         targetGradientRef.current = targetGradient;
@@ -294,9 +300,11 @@ export function SkyGradientBackground({
             const activeGradient = displayed;
             applyGradientUniforms(material, activeGradient);
             material.uniforms.uSunGlowIntensity.value =
-                activeGradient.sunGlowIntensity * sunOpacity;
+                (groundColor ? 0 : activeGradient.sunGlowIntensity) *
+                sunOpacity;
             material.uniforms.uMoonGlowIntensity.value =
-                activeGradient.moonGlowIntensity * moonOpacity;
+                (groundColor ? 0 : activeGradient.moonGlowIntensity) *
+                moonOpacity;
         }
     });
 

--- a/packages/game/src/scene/skyGradient.ts
+++ b/packages/game/src/scene/skyGradient.ts
@@ -394,6 +394,22 @@ export function cloneSkyGradientColors(
     };
 }
 
+export function resolveGroundViewSkyGradientColors(
+    gradient: SkyGradientColors,
+    groundColor: Color,
+): SkyGradientColors {
+    return {
+        horizon: groundColor.clone(),
+        lower: groundColor.clone(),
+        moonGlow: gradient.moonGlow.clone(),
+        moonGlowIntensity: 0,
+        sunGlow: gradient.sunGlow.clone(),
+        sunGlowIntensity: 0,
+        upper: groundColor.clone(),
+        zenith: groundColor.clone(),
+    };
+}
+
 export function lerpSkyGradientColors(
     current: SkyGradientColors,
     target: SkyGradientColors,

--- a/packages/game/src/scene/skyGradient.unit.ts
+++ b/packages/game/src/scene/skyGradient.unit.ts
@@ -7,6 +7,7 @@ import {
 import { resolveMoonlitNightScales } from './moonlight';
 import {
     resolveEnvironmentSkyBackgroundColors,
+    resolveGroundViewSkyGradientColors,
     resolveSkyBackgroundColor,
     resolveSkyGradientColors,
 } from './skyGradient';
@@ -127,4 +128,24 @@ test('moonlight and cloud cover tune glow strength at night', () => {
     assert.ok(
         overcastGradient.moonGlowIntensity < moonlitGradient.moonGlowIntensity,
     );
+});
+
+test('ground view collapses the sky to the ground color without celestial glow', () => {
+    const gradient = resolveGradient({
+        moonlight: 0.9,
+        timeOfDay: 0.5,
+    });
+    const groundColor = gradient.lower.clone().set('#9eb64a');
+    const groundView = resolveGroundViewSkyGradientColors(
+        gradient,
+        groundColor,
+    );
+
+    assert.ok(colorDistance(groundView.zenith, groundColor) < 0.001);
+    assert.ok(colorDistance(groundView.upper, groundColor) < 0.001);
+    assert.ok(colorDistance(groundView.horizon, groundColor) < 0.001);
+    assert.ok(colorDistance(groundView.lower, groundColor) < 0.001);
+    assert.equal(groundView.sunGlowIntensity, 0);
+    assert.equal(groundView.moonGlowIntensity, 0);
+    assert.notEqual(groundView.lower, groundColor);
 });

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -356,6 +356,8 @@ export type GameState = {
     // Camera
     view: 'normal' | 'closeup';
     closeupBlock: Block | null;
+    closeupCameraActive: boolean;
+    setCloseupCameraActive: (active: boolean) => void;
     setView: (
         options:
             | { view: 'normal'; block?: Block }
@@ -836,6 +838,9 @@ export function createGameState({
         // Camera
         view: 'normal',
         closeupBlock: null,
+        closeupCameraActive: false,
+        setCloseupCameraActive: (closeupCameraActive) =>
+            set({ closeupCameraActive }),
         setView: ({ view, block }) => {
             const currentView = get().view;
 

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -98,6 +98,27 @@ test('setActiveDragPreview skips equivalent drag preview updates', () => {
     }
 });
 
+test('closeup camera stays active while the requested view returns to normal', () => {
+    const store = createGameState({
+        appBaseUrl: '',
+        freezeTime: new Date('2026-01-01T12:00:00.000Z'),
+        isMock: true,
+    });
+
+    try {
+        store.getState().setCloseupCameraActive(true);
+        store.getState().setView({ view: 'normal' });
+
+        assert.equal(store.getState().view, 'normal');
+        assert.equal(store.getState().closeupCameraActive, true);
+
+        store.getState().setCloseupCameraActive(false);
+        assert.equal(store.getState().closeupCameraActive, false);
+    } finally {
+        store.getState().audio.dispose();
+    }
+});
+
 test('addPickupSelectionTarget appends new targets and prevents duplicates', () => {
     const store = createGameState({
         appBaseUrl: '',


### PR DESCRIPTION
## What changed

- transition the sky gradient and scene background to the grass ground tone in raised-bed closeup view
- suppress sun, moon, celestial glow, and stars while the camera is floor-facing
- restore the normal sky and celestial rendering when leaving closeup
- add focused coverage for collapsing the gradient without celestial glow

## Root cause

The camera-relative sky gradient and celestial projections continued rendering while the closeup camera tilted toward the floor. That made the sky and sun/moon move across exposed canvas areas during the transition.

## Validation

- `corepack pnpm --filter @gredice/game test` (385 passing)
- `corepack pnpm --filter @gredice/game exec biome check src`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter www`
- browser smoke test on `/debug/profile/game`: closeup uses a uniform grass background with no celestial bodies; exit restores the normal sky
- `git diff --check`