### PR TITLE
fix(public-gardens): package OG image runtime

### DIFF
--- a/apps/garden/app/vrtovi/[id]/opengraph-image.tsx
+++ b/apps/garden/app/vrtovi/[id]/opengraph-image.tsx
@@ -24,6 +24,8 @@ export const runtime = 'nodejs';
 
 const gardenOgImageCacheControl =
     'public, max-age=86400, s-maxage=86400, stale-while-revalidate=86400';
+const gardenOgFallbackCacheControl = 'no-store';
+const gardenOgRenderHeader = 'X-Gredice-Garden-Preview';
 const gardenOgImageAssetBaseUrl = 'https://vrt.gredice.com';
 const gardenOgViewportSize = 1200;
 const gardenOgViewportCenter = { x: 576, y: 184 };
@@ -309,7 +311,8 @@ function createGardenOgFallbackImage(gardenName: string) {
         {
             ...size,
             headers: {
-                'Cache-Control': gardenOgImageCacheControl,
+                'Cache-Control': gardenOgFallbackCacheControl,
+                [gardenOgRenderHeader]: 'fallback',
             },
         },
     );
@@ -361,6 +364,11 @@ export default async function GardenOgImage({
         spriteRequests.length === 0 ||
         failedSpriteCount === spriteRequests.length
     ) {
+        console.error('Garden OG preview could not render any block sprites', {
+            failedSpriteCount,
+            gardenId,
+            spriteRequestCount: spriteRequests.length,
+        });
         return createGardenOgFallbackImage(garden.name);
     }
 
@@ -436,6 +444,7 @@ export default async function GardenOgImage({
             height: 630,
             headers: {
                 'Cache-Control': gardenOgImageCacheControl,
+                [gardenOgRenderHeader]: 'rendered',
             },
         },
     );

--- a/apps/garden/next.config.ts
+++ b/apps/garden/next.config.ts
@@ -1,3 +1,5 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import vercelToolbar from '@vercel/toolbar/plugins/next';
 import type { NextConfig } from 'next';
 import {
@@ -9,6 +11,13 @@ import {
 
 const app = getAppByName('garden');
 const apiApp = getAppByName('api');
+const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const gardenOgImageRoute = '/vrtovi/*/opengraph-image';
+const gardenOgSharpRuntimeFiles = [
+    '../../node_modules/.pnpm/sharp@*/node_modules/sharp/**/*',
+    '../../node_modules/.pnpm/@img+sharp-linux-x64@*/node_modules/@img/sharp-linux-x64/**/*',
+    '../../node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/node_modules/@img/sharp-libvips-linux-x64/**/*',
+];
 // Use the Vercel deployment ID (or git commit SHA) as a cache-busting tag.
 // Assets are not truly immutable – they change when game models or sprites are updated.
 // CDN (s-maxage) is purged automatically by Vercel on each deployment.
@@ -31,6 +40,10 @@ const assetCacheHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+    outputFileTracingRoot: workspaceRoot,
+    outputFileTracingIncludes: {
+        [gardenOgImageRoute]: gardenOgSharpRuntimeFiles,
+    },
     reactStrictMode: true,
     typedRoutes: true,
     reactCompiler: true,

--- a/apps/www/app/vrtovi/publicGardenUrls.ts
+++ b/apps/www/app/vrtovi/publicGardenUrls.ts
@@ -1,5 +1,11 @@
 import { KnownPages } from '../../src/KnownPages';
 
+const publicGardenOgImageVersion = '2';
+
 export function getPublicGardenOgImageUrl(gardenId: number) {
-    return `${KnownPages.GardenApp}${KnownPages.PublicGarden(gardenId)}/opengraph-image`;
+    const url = new URL(
+        `${KnownPages.GardenApp}${KnownPages.PublicGarden(gardenId)}/opengraph-image`,
+    );
+    url.searchParams.set('v', publicGardenOgImageVersion);
+    return url.toString();
 }


### PR DESCRIPTION
## Summary

- include Sharp and its Linux libvips runtime in the public-garden OG function trace
- expose whether an OG response rendered the garden or used the fallback
- prevent fallback images from being cached and version the public preview URL to bypass stale optimized placeholders

## Root cause

The Vercel function contained Sharp's JavaScript and native addon but omitted `libvips-cpp.so.8.18.3`. Every sprite conversion therefore failed, and the OG route returned its successful generic fallback for every garden.

## Impact

Public garden cards can render their actual garden-specific OG previews in production. If rendering regresses, fallbacks are observable through `X-Gredice-Garden-Preview: fallback` and are not cached.

## Validation

- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter www`
- `corepack pnpm build --filter garden`
- `corepack pnpm build --filter www`
- targeted Biome checks
- built local OG request returned `200 image/png`, 1200x630, and `X-Gredice-Garden-Preview: rendered`

The Vercel preview will be checked for the same `rendered` header before merge.