### PR TITLE
fix(game): use gradient bottom in raised bed closeups

### DIFF
--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -29,6 +29,7 @@ import { SunMoon } from './SunMoon';
 import {
     resolveEnvironmentSkyBackgroundColors,
     resolveSkyBackgroundColor,
+    resolveSkyGradientColors,
     resolveThemedSkyBackgroundColors,
 } from './skyGradient';
 import { altAzToScenePosition, timeOfDayToDate } from './sunPosition';
@@ -71,7 +72,6 @@ const DEBUG_WEATHER_BLEND_CONFIG: WeatherBlendConfig = {
 const WEATHER_BLEND_EPSILON = 0.0005;
 const BACKGROUND_COLOR_TRANSITION_SECONDS = 0.55;
 const BACKGROUND_COLOR_EPSILON = 0.001;
-const raisedBedCloseupGroundColor = new Color('#9eb64a');
 
 function dampNumber(
     current: number,
@@ -415,6 +415,24 @@ function useEnvironmentElements({
             weather,
         ],
     );
+    const moonlight = moonlitNightScales.visibleMoonlight;
+    const skyLowerColor = useMemo(
+        () =>
+            resolveSkyGradientColors({
+                backgroundColor,
+                backgroundPaletteIndex,
+                moonlight,
+                timeOfDay,
+                weather,
+            }).lower,
+        [
+            backgroundColor,
+            backgroundPaletteIndex,
+            moonlight,
+            timeOfDay,
+            weather,
+        ],
+    );
 
     const waterColors = resolveWaterColors({
         skyColor: backgroundColor,
@@ -477,7 +495,8 @@ function useEnvironmentElements({
             intensity: directionalLightIntensity,
         },
         sky: {
-            moonlight: moonlitNightScales.visibleMoonlight,
+            lowerColor: skyLowerColor,
+            moonlight,
         },
         waterColors,
     };
@@ -1117,22 +1136,14 @@ export function Environment({
                 <>
                     <SceneBackgroundColor
                         animate
-                        color={
-                            isGroundView
-                                ? raisedBedCloseupGroundColor
-                                : background
-                        }
+                        color={isGroundView ? sky.lowerColor : background}
                     />
                     <SkyGradientBackground
                         animate
                         backgroundColor={background}
                         backgroundPaletteIndex={backgroundPaletteIndex}
                         currentTime={currentTime}
-                        groundColor={
-                            isGroundView
-                                ? raisedBedCloseupGroundColor
-                                : undefined
-                        }
+                        groundView={isGroundView}
                         location={location}
                         moonlight={sky.moonlight}
                         timeOfDay={timeOfDay}

--- a/packages/game/src/scene/SkyGradientBackground.tsx
+++ b/packages/game/src/scene/SkyGradientBackground.tsx
@@ -90,7 +90,7 @@ type SkyGradientBackgroundProps = {
     backgroundColor: Color;
     backgroundPaletteIndex: number;
     currentTime: Date;
-    groundColor?: Color;
+    groundView?: boolean;
     location: { lat: number; lon: number };
     moonlight: number;
     timeOfDay: number;
@@ -138,7 +138,7 @@ export function SkyGradientBackground({
     backgroundColor,
     backgroundPaletteIndex,
     currentTime,
-    groundColor,
+    groundView = false,
     location,
     moonlight,
     timeOfDay,
@@ -196,15 +196,15 @@ export function SkyGradientBackground({
             weather,
         });
 
-        return groundColor
-            ? resolveGroundViewSkyGradientColors(gradient, groundColor)
+        return groundView
+            ? resolveGroundViewSkyGradientColors(gradient)
             : gradient;
     }, [
         backgroundBlue,
         backgroundGreen,
         backgroundPaletteIndex,
         backgroundRed,
-        groundColor,
+        groundView,
         moonlight,
         timeOfDay,
         weather,
@@ -300,10 +300,9 @@ export function SkyGradientBackground({
             const activeGradient = displayed;
             applyGradientUniforms(material, activeGradient);
             material.uniforms.uSunGlowIntensity.value =
-                (groundColor ? 0 : activeGradient.sunGlowIntensity) *
-                sunOpacity;
+                (groundView ? 0 : activeGradient.sunGlowIntensity) * sunOpacity;
             material.uniforms.uMoonGlowIntensity.value =
-                (groundColor ? 0 : activeGradient.moonGlowIntensity) *
+                (groundView ? 0 : activeGradient.moonGlowIntensity) *
                 moonOpacity;
         }
     });

--- a/packages/game/src/scene/skyGradient.ts
+++ b/packages/game/src/scene/skyGradient.ts
@@ -396,8 +396,9 @@ export function cloneSkyGradientColors(
 
 export function resolveGroundViewSkyGradientColors(
     gradient: SkyGradientColors,
-    groundColor: Color,
 ): SkyGradientColors {
+    const groundColor = gradient.lower;
+
     return {
         horizon: groundColor.clone(),
         lower: groundColor.clone(),

--- a/packages/game/src/scene/skyGradient.unit.ts
+++ b/packages/game/src/scene/skyGradient.unit.ts
@@ -130,22 +130,18 @@ test('moonlight and cloud cover tune glow strength at night', () => {
     );
 });
 
-test('ground view collapses the sky to the ground color without celestial glow', () => {
+test('ground view collapses the sky to the gradient lower color without celestial glow', () => {
     const gradient = resolveGradient({
         moonlight: 0.9,
         timeOfDay: 0.5,
     });
-    const groundColor = gradient.lower.clone().set('#9eb64a');
-    const groundView = resolveGroundViewSkyGradientColors(
-        gradient,
-        groundColor,
-    );
+    const groundView = resolveGroundViewSkyGradientColors(gradient);
 
-    assert.ok(colorDistance(groundView.zenith, groundColor) < 0.001);
-    assert.ok(colorDistance(groundView.upper, groundColor) < 0.001);
-    assert.ok(colorDistance(groundView.horizon, groundColor) < 0.001);
-    assert.ok(colorDistance(groundView.lower, groundColor) < 0.001);
+    assert.ok(colorDistance(groundView.zenith, gradient.lower) < 0.001);
+    assert.ok(colorDistance(groundView.upper, gradient.lower) < 0.001);
+    assert.ok(colorDistance(groundView.horizon, gradient.lower) < 0.001);
+    assert.ok(colorDistance(groundView.lower, gradient.lower) < 0.001);
     assert.equal(groundView.sunGlowIntensity, 0);
     assert.equal(groundView.moonGlowIntensity, 0);
-    assert.notEqual(groundView.lower, groundColor);
+    assert.notEqual(groundView.lower, gradient.lower);
 });


### PR DESCRIPTION
## What changed

- remove the fixed green closeup background introduced in #4083
- derive the closeup fill from the active sky gradient's lower color
- use that same lower color for both the shader transition and scene background fallback
- preserve the closeup background through the camera exit animation

## Why

Raised-bed closeups should show the gradient's bottom color behind the floor-facing camera, not a hardcoded grass green. Deriving it from the existing gradient also keeps the result aligned with the active time, palette, and weather.

## Validation

- `corepack pnpm --filter @gredice/game test` (386 passing)
- `corepack pnpm --filter @gredice/game exec biome check src`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter www`
- browser smoke test: closeup and mid-exit use the gradient-bottom tone; normal sky returns after camera completion
- `git diff --check`