### PR TITLE
feat(cjenik): show 30-day minimum prices

### DIFF
--- a/apps/www/app/cjenik/ThirtyDayMinimumPrice.tsx
+++ b/apps/www/app/cjenik/ThirtyDayMinimumPrice.tsx
@@ -1,0 +1,35 @@
+import type { EntityPriceHistorySummary } from '@gredice/storage';
+import { formatPrice } from '../../lib/formatPrice';
+
+const changeDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'Europe/Zagreb',
+});
+
+export function ThirtyDayMinimumPrice({
+    currentPrice,
+    history,
+}: {
+    currentPrice: number;
+    history: EntityPriceHistorySummary | undefined;
+}) {
+    const lowestPrice = history?.lowestPrice ?? currentPrice;
+
+    return (
+        <span className="block whitespace-nowrap">
+            <span className="block font-medium">
+                {formatPrice(lowestPrice)}
+            </span>
+            {history?.lastChangedAt && (
+                <span className="block text-xs font-normal text-muted-foreground">
+                    Promjena:{' '}
+                    <time dateTime={history.lastChangedAt.toISOString()}>
+                        {changeDateFormatter.format(history.lastChangedAt)}
+                    </time>
+                </span>
+            )}
+        </span>
+    );
+}

--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -15,11 +15,13 @@ import { getPlantSortsData } from '../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
 import { getPublicSunflowerPackages } from '../../lib/sunflowerPackages';
 import { KnownPages } from '../../src/KnownPages';
+import { getPricingCatalogHistory, pricingHistoryKey } from './pricingHistory';
 import {
     buildDeliveryPricingRows,
     buildOperationPricingRows,
     buildPlantPricingRows,
 } from './pricingRows';
+import { ThirtyDayMinimumPrice } from './ThirtyDayMinimumPrice';
 
 export const metadata: Metadata = {
     title: 'Cjenik',
@@ -52,6 +54,12 @@ export default async function PricingPage() {
         hqLocations,
         KnownPages.Delivery,
     );
+    const pricingHistory = await getPricingCatalogHistory({
+        sunflowerPackages,
+        plantRows: plantPricingRows,
+        operationRows: operationPricingRows,
+        deliveryRows: deliveryPricingRows,
+    });
 
     return (
         <Container maxWidth="lg">
@@ -92,6 +100,9 @@ export default async function PricingPage() {
                                                 <th className="py-2 text-right">
                                                     Cijena
                                                 </th>
+                                                <th className="py-2 pl-4 text-right">
+                                                    Najniža cijena u 30 dana
+                                                </th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -128,6 +139,21 @@ export default async function PricingPage() {
                                                         {formatPrice(
                                                             pkg.priceEur,
                                                         )}
+                                                    </td>
+                                                    <td className="py-2 pl-4 text-right">
+                                                        <ThirtyDayMinimumPrice
+                                                            currentPrice={
+                                                                pkg.priceEur
+                                                            }
+                                                            history={
+                                                                pricingHistory[
+                                                                    pricingHistoryKey(
+                                                                        'sunflowerPackage',
+                                                                        pkg.entityId,
+                                                                    )
+                                                                ]
+                                                            }
+                                                        />
                                                     </td>
                                                 </tr>
                                             ))}
@@ -171,6 +197,9 @@ export default async function PricingPage() {
                                         </th>
                                         <th className="text-right py-2">
                                             Cijena
+                                        </th>
+                                        <th className="py-2 pl-4 text-right">
+                                            Najniža cijena u 30 dana
                                         </th>
                                     </tr>
                                 </thead>
@@ -220,6 +249,22 @@ export default async function PricingPage() {
                                             <td className="py-2 text-right font-medium">
                                                 {formatPrice(row.price)}
                                             </td>
+                                            <td className="py-2 pl-4 text-right">
+                                                <ThirtyDayMinimumPrice
+                                                    currentPrice={row.price}
+                                                    history={
+                                                        pricingHistory[
+                                                            pricingHistoryKey(
+                                                                row.kind ===
+                                                                    'plant'
+                                                                    ? 'plant'
+                                                                    : 'plantSort',
+                                                                row.entityId,
+                                                            )
+                                                        ]
+                                                    }
+                                                />
+                                            </td>
                                         </tr>
                                     ))}
                                 </tbody>
@@ -254,6 +299,9 @@ export default async function PricingPage() {
                                         <th className="text-right py-2">
                                             Cijena
                                         </th>
+                                        <th className="py-2 pl-4 text-right">
+                                            Najniža cijena u 30 dana
+                                        </th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -281,6 +329,19 @@ export default async function PricingPage() {
                                             </td>
                                             <td className="py-2 text-right font-medium">
                                                 {formatPrice(row.price)}
+                                            </td>
+                                            <td className="py-2 pl-4 text-right">
+                                                <ThirtyDayMinimumPrice
+                                                    currentPrice={row.price}
+                                                    history={
+                                                        pricingHistory[
+                                                            pricingHistoryKey(
+                                                                'operation',
+                                                                row.entityId,
+                                                            )
+                                                        ]
+                                                    }
+                                                />
                                             </td>
                                         </tr>
                                     ))}
@@ -322,6 +383,9 @@ export default async function PricingPage() {
                                         <th className="text-right py-2">
                                             Cijena po km
                                         </th>
+                                        <th className="py-2 pl-4 text-right">
+                                            Najniža cijena u 30 dana
+                                        </th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -348,6 +412,21 @@ export default async function PricingPage() {
                                                 {formatPrice(
                                                     row.pricePerKilometer,
                                                 )}
+                                            </td>
+                                            <td className="py-2 pl-4 text-right">
+                                                <ThirtyDayMinimumPrice
+                                                    currentPrice={
+                                                        row.pricePerKilometer
+                                                    }
+                                                    history={
+                                                        pricingHistory[
+                                                            pricingHistoryKey(
+                                                                'hqLocations',
+                                                                row.entityId,
+                                                            )
+                                                        ]
+                                                    }
+                                                />
                                             </td>
                                         </tr>
                                     ))}

--- a/apps/www/app/cjenik/pricingHistory.ts
+++ b/apps/www/app/cjenik/pricingHistory.ts
@@ -1,0 +1,120 @@
+import {
+    type EntityPriceHistoryRequest,
+    type EntityPriceHistorySummary,
+    getEntityPriceHistory,
+} from '@gredice/storage';
+import type { PublicSunflowerPackage } from '../../lib/sunflowerPackages';
+import type {
+    DeliveryPricingRow,
+    OperationPricingRow,
+    PlantPricingRow,
+} from './pricingRows';
+
+export function pricingHistoryKey(
+    entityTypeName: string,
+    entityId: number | string,
+) {
+    return `${entityTypeName}:${entityId}`;
+}
+
+function priceHistoryRequest({
+    entityId,
+    entityTypeName,
+    attributeCategory,
+    attributeName,
+    currentPrice,
+}: {
+    entityId: number | string;
+    entityTypeName: string;
+    attributeCategory: string;
+    attributeName: string;
+    currentPrice: number;
+}): EntityPriceHistoryRequest | null {
+    const numericEntityId = Number(entityId);
+    if (!Number.isInteger(numericEntityId) || numericEntityId <= 0) {
+        return null;
+    }
+
+    return {
+        key: pricingHistoryKey(entityTypeName, numericEntityId),
+        entityId: numericEntityId,
+        entityTypeName,
+        attributeCategory,
+        attributeName,
+        currentPrice,
+    };
+}
+
+function currentPriceFallbacks(
+    requests: ReadonlyArray<EntityPriceHistoryRequest>,
+) {
+    return Object.fromEntries(
+        requests.map((request) => [
+            request.key,
+            {
+                lowestPrice: request.currentPrice,
+                lastChangedAt: null,
+            } satisfies EntityPriceHistorySummary,
+        ]),
+    );
+}
+
+export async function getPricingCatalogHistory({
+    sunflowerPackages,
+    plantRows,
+    operationRows,
+    deliveryRows,
+}: {
+    sunflowerPackages: ReadonlyArray<PublicSunflowerPackage>;
+    plantRows: ReadonlyArray<PlantPricingRow>;
+    operationRows: ReadonlyArray<OperationPricingRow>;
+    deliveryRows: ReadonlyArray<DeliveryPricingRow>;
+}) {
+    const requests = [
+        ...sunflowerPackages.map((pkg) =>
+            priceHistoryRequest({
+                entityId: pkg.entityId,
+                entityTypeName: 'sunflowerPackage',
+                attributeCategory: 'pricing',
+                attributeName: 'priceEur',
+                currentPrice: pkg.priceEur,
+            }),
+        ),
+        ...plantRows.map((row) =>
+            priceHistoryRequest({
+                entityId: row.entityId,
+                entityTypeName: row.kind === 'plant' ? 'plant' : 'plantSort',
+                attributeCategory: 'prices',
+                attributeName: 'perPlant',
+                currentPrice: row.price,
+            }),
+        ),
+        ...operationRows.map((row) =>
+            priceHistoryRequest({
+                entityId: row.entityId,
+                entityTypeName: 'operation',
+                attributeCategory: 'prices',
+                attributeName: 'perOperation',
+                currentPrice: row.price,
+            }),
+        ),
+        ...deliveryRows.map((row) =>
+            priceHistoryRequest({
+                entityId: row.entityId,
+                entityTypeName: 'hqLocations',
+                attributeCategory: 'prices',
+                attributeName: 'pricePerKilometer',
+                currentPrice: row.pricePerKilometer,
+            }),
+        ),
+    ].filter(
+        (request): request is EntityPriceHistoryRequest => request !== null,
+    );
+
+    try {
+        return await getEntityPriceHistory(requests);
+    } catch (error) {
+        console.error('Failed to load pricing catalog history', error);
+        return currentPriceFallbacks(requests);
+    }
+}

--- a/apps/www/app/cjenik/pricingRows.node.spec.ts
+++ b/apps/www/app/cjenik/pricingRows.node.spec.ts
@@ -181,6 +181,7 @@ test('buildDeliveryPricingRows links delivery rows to the delivery page', () => 
                 id: 'delivery-31',
                 label: 'Zagreb',
                 href: '/dostava',
+                entityId: 31,
                 freeRadius: 10,
                 zoneRadius: 60,
                 pricePerKilometer: 0.2,

--- a/apps/www/app/cjenik/pricingRows.ts
+++ b/apps/www/app/cjenik/pricingRows.ts
@@ -81,6 +81,7 @@ export type PlantPricingRow<
           kind: 'plant';
           label: string;
           href: Route;
+          entityId: EntityId;
           price: number;
           plant: TPlant;
       }
@@ -90,6 +91,7 @@ export type PlantPricingRow<
           label: string;
           parentLabel: string;
           href: Route;
+          entityId: EntityId;
           price: number;
           plantSort: TPlantSort;
       };
@@ -100,6 +102,7 @@ export type OperationPricingRow<
     id: string;
     label: string;
     href: Route;
+    entityId: EntityId;
     price: number;
     operation: TOperation;
 };
@@ -108,6 +111,7 @@ export type DeliveryPricingRow = {
     id: string;
     label: string;
     href: Route;
+    entityId: EntityId;
     freeRadius: number;
     zoneRadius: number;
     pricePerKilometer: number;
@@ -158,6 +162,7 @@ export function buildPlantPricingRows<
             kind: 'plant',
             label: plant.information.name,
             href: toRoute(PublicDirectoryPaths.Plant(plant.information.name)),
+            entityId: plant.id,
             price: plant.prices.perPlant,
             plant,
         }),
@@ -185,6 +190,7 @@ export function buildPlantPricingRows<
                         sort.information.name,
                     ),
                 ),
+                entityId: sort.id,
                 price: sort.prices.perPlant,
                 plantSort: sort,
             };
@@ -204,6 +210,7 @@ export function buildOperationPricingRows<TOperation extends NamedOperation>(
             href: toRoute(
                 PublicDirectoryPaths.Operation(operation.information.label),
             ),
+            entityId: operation.id,
             price: operation.prices.perOperation,
             operation,
         }))
@@ -221,6 +228,7 @@ export function buildDeliveryPricingRows(
             id: `delivery-${location.id}`,
             label: location.information.label,
             href: deliveryHref,
+            entityId: location.id,
             freeRadius: location.delivery.freeRadius,
             zoneRadius: location.delivery.zoneRadius,
             pricePerKilometer: location.prices.pricePerKilometer,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -39,6 +39,7 @@ export * from './repositories/deliveryUtilsRepo';
 export * from './repositories/emailsRepo';
 export * from './repositories/entitiesRepo';
 export * from './repositories/entityHierarchyRepo';
+export * from './repositories/entityPriceHistoryRepo';
 export * from './repositories/entitySearchRepo';
 export * from './repositories/entityTypeCategoriesRepo';
 export * from './repositories/entityTypesRepo';

--- a/packages/storage/src/repositories/entityPriceHistoryRepo.ts
+++ b/packages/storage/src/repositories/entityPriceHistoryRepo.ts
@@ -1,0 +1,238 @@
+import 'server-only';
+import { and, desc, eq, gte, inArray } from 'drizzle-orm';
+import { storage } from '..';
+import {
+    attributeDefinitions,
+    entityRevisions,
+    type SelectEntityRevision,
+} from '../schema';
+
+const DEFAULT_HISTORY_DAYS = 30;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type EntityPriceHistoryRequest = {
+    key: string;
+    entityId: number;
+    entityTypeName: string;
+    attributeCategory: string;
+    attributeName: string;
+    currentPrice: number;
+};
+
+export type EntityPriceHistorySummary = {
+    lowestPrice: number;
+    lastChangedAt: Date | null;
+};
+
+type PriceRevision = Pick<
+    SelectEntityRevision,
+    | 'entityId'
+    | 'attributeDefinitionId'
+    | 'action'
+    | 'previousValue'
+    | 'nextValue'
+    | 'createdAt'
+>;
+
+function attributePath(entityTypeName: string, category: string, name: string) {
+    return `${entityTypeName}:${category}.${name}`;
+}
+
+function revisionPath(entityId: number, attributeDefinitionId: number) {
+    return `${entityId}:${attributeDefinitionId}`;
+}
+
+function parsePrice(value: string | null) {
+    if (value === null || value.trim().length === 0) {
+        return null;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function isActualPriceChange(revision: PriceRevision) {
+    if (revision.action !== 'attribute.updated') {
+        return false;
+    }
+
+    const previousPrice = parsePrice(revision.previousValue);
+    const nextPrice = parsePrice(revision.nextValue);
+    return (
+        previousPrice !== null &&
+        nextPrice !== null &&
+        previousPrice !== nextPrice
+    );
+}
+
+export function summarizeEntityPriceHistory(
+    request: EntityPriceHistoryRequest,
+    attributeDefinitionId: number | undefined,
+    revisions: ReadonlyArray<PriceRevision>,
+): EntityPriceHistorySummary {
+    if (attributeDefinitionId === undefined) {
+        return {
+            lowestPrice: request.currentPrice,
+            lastChangedAt: null,
+        };
+    }
+
+    const matchingRevisions = revisions.filter(
+        (revision) =>
+            revision.entityId === request.entityId &&
+            revision.attributeDefinitionId === attributeDefinitionId,
+    );
+    const recordedPrices = matchingRevisions.flatMap((revision) =>
+        [revision.previousValue, revision.nextValue]
+            .map(parsePrice)
+            .filter((price): price is number => price !== null),
+    );
+    const lastChange = matchingRevisions.find(isActualPriceChange);
+
+    return {
+        lowestPrice: Math.min(request.currentPrice, ...recordedPrices),
+        lastChangedAt: lastChange?.createdAt ?? null,
+    };
+}
+
+export async function getEntityPriceHistory(
+    requests: ReadonlyArray<EntityPriceHistoryRequest>,
+    options?: { now?: Date; historyDays?: number },
+): Promise<Record<string, EntityPriceHistorySummary>> {
+    if (requests.length === 0) {
+        return {};
+    }
+
+    const now = options?.now ?? new Date();
+    const historyDays = options?.historyDays ?? DEFAULT_HISTORY_DAYS;
+    const since = new Date(now.getTime() - historyDays * MILLISECONDS_PER_DAY);
+    const entityTypeNames = Array.from(
+        new Set(requests.map((request) => request.entityTypeName)),
+    );
+    const categories = Array.from(
+        new Set(requests.map((request) => request.attributeCategory)),
+    );
+    const names = Array.from(
+        new Set(requests.map((request) => request.attributeName)),
+    );
+
+    const definitions = await storage()
+        .select({
+            id: attributeDefinitions.id,
+            entityTypeName: attributeDefinitions.entityTypeName,
+            category: attributeDefinitions.category,
+            name: attributeDefinitions.name,
+        })
+        .from(attributeDefinitions)
+        .where(
+            and(
+                inArray(attributeDefinitions.entityTypeName, entityTypeNames),
+                inArray(attributeDefinitions.category, categories),
+                inArray(attributeDefinitions.name, names),
+                eq(attributeDefinitions.isDeleted, false),
+            ),
+        );
+    const requestedPaths = new Set(
+        requests.map((request) =>
+            attributePath(
+                request.entityTypeName,
+                request.attributeCategory,
+                request.attributeName,
+            ),
+        ),
+    );
+    const matchingDefinitions = definitions.filter((definition) =>
+        requestedPaths.has(
+            attributePath(
+                definition.entityTypeName,
+                definition.category,
+                definition.name,
+            ),
+        ),
+    );
+    const definitionIds = matchingDefinitions.map(
+        (definition) => definition.id,
+    );
+    const entityIds = Array.from(
+        new Set(requests.map((request) => request.entityId)),
+    );
+    const revisions =
+        definitionIds.length === 0
+            ? []
+            : await storage()
+                  .select({
+                      entityId: entityRevisions.entityId,
+                      attributeDefinitionId:
+                          entityRevisions.attributeDefinitionId,
+                      action: entityRevisions.action,
+                      previousValue: entityRevisions.previousValue,
+                      nextValue: entityRevisions.nextValue,
+                      createdAt: entityRevisions.createdAt,
+                  })
+                  .from(entityRevisions)
+                  .where(
+                      and(
+                          inArray(entityRevisions.entityId, entityIds),
+                          inArray(
+                              entityRevisions.attributeDefinitionId,
+                              definitionIds,
+                          ),
+                          gte(entityRevisions.createdAt, since),
+                      ),
+                  )
+                  .orderBy(
+                      desc(entityRevisions.createdAt),
+                      desc(entityRevisions.id),
+                  );
+    const definitionIdsByPath = new Map(
+        matchingDefinitions.map((definition) => [
+            attributePath(
+                definition.entityTypeName,
+                definition.category,
+                definition.name,
+            ),
+            definition.id,
+        ]),
+    );
+    const revisionsByPath = new Map<string, PriceRevision[]>();
+
+    for (const revision of revisions) {
+        if (revision.attributeDefinitionId === null) {
+            continue;
+        }
+        const path = revisionPath(
+            revision.entityId,
+            revision.attributeDefinitionId,
+        );
+        const pathRevisions = revisionsByPath.get(path) ?? [];
+        pathRevisions.push(revision);
+        revisionsByPath.set(path, pathRevisions);
+    }
+
+    return Object.fromEntries(
+        requests.map((request) => {
+            const definitionId = definitionIdsByPath.get(
+                attributePath(
+                    request.entityTypeName,
+                    request.attributeCategory,
+                    request.attributeName,
+                ),
+            );
+            const requestRevisions =
+                definitionId === undefined
+                    ? []
+                    : (revisionsByPath.get(
+                          revisionPath(request.entityId, definitionId),
+                      ) ?? []);
+
+            return [
+                request.key,
+                summarizeEntityPriceHistory(
+                    request,
+                    definitionId,
+                    requestRevisions,
+                ),
+            ];
+        }),
+    );
+}

--- a/packages/storage/tests/entityPriceHistoryRepo.node.spec.ts
+++ b/packages/storage/tests/entityPriceHistoryRepo.node.spec.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    attributeDefinitions,
+    entities,
+    entityRevisions,
+    entityTypes,
+    getEntityPriceHistory,
+    storage,
+} from '@gredice/storage';
+import { createTestDb } from './testDb';
+
+test('getEntityPriceHistory derives the 30-day minimum and latest adjustment from entity revisions', async () => {
+    createTestDb();
+    const now = new Date('2026-07-11T10:00:00.000Z');
+    const [entityType] = await storage()
+        .insert(entityTypes)
+        .values({
+            name: 'priceHistoryTest',
+            label: 'Price history test',
+        })
+        .returning({ name: entityTypes.name });
+    const [priceDefinition] = await storage()
+        .insert(attributeDefinitions)
+        .values({
+            entityTypeName: entityType.name,
+            category: 'prices',
+            name: 'amount',
+            label: 'Price',
+            dataType: 'number',
+        })
+        .returning({ id: attributeDefinitions.id });
+    const [entity] = await storage()
+        .insert(entities)
+        .values({ entityTypeName: entityType.name })
+        .returning({ id: entities.id });
+
+    await storage()
+        .insert(entityRevisions)
+        .values([
+            {
+                entityId: entity.id,
+                entityTypeName: entityType.name,
+                action: 'attribute.updated',
+                attributeDefinitionId: priceDefinition.id,
+                previousValue: '20',
+                nextValue: '17',
+                createdAt: new Date('2026-05-01T10:00:00.000Z'),
+            },
+            {
+                entityId: entity.id,
+                entityTypeName: entityType.name,
+                action: 'attribute.updated',
+                attributeDefinitionId: priceDefinition.id,
+                previousValue: '17',
+                nextValue: '12.5',
+                createdAt: new Date('2026-06-20T10:00:00.000Z'),
+            },
+            {
+                entityId: entity.id,
+                entityTypeName: entityType.name,
+                action: 'attribute.updated',
+                attributeDefinitionId: priceDefinition.id,
+                previousValue: '12.5',
+                nextValue: '15',
+                createdAt: new Date('2026-07-05T10:00:00.000Z'),
+            },
+        ]);
+
+    const result = await getEntityPriceHistory(
+        [
+            {
+                key: 'test-price',
+                entityId: entity.id,
+                entityTypeName: entityType.name,
+                attributeCategory: 'prices',
+                attributeName: 'amount',
+                currentPrice: 15,
+            },
+        ],
+        { now },
+    );
+
+    assert.deepEqual(result['test-price'], {
+        lowestPrice: 12.5,
+        lastChangedAt: new Date('2026-07-05T10:00:00.000Z'),
+    });
+});
+
+test('getEntityPriceHistory falls back to the current price without a matching definition', async () => {
+    createTestDb();
+
+    const result = await getEntityPriceHistory([
+        {
+            key: 'missing-price',
+            entityId: 999_999,
+            entityTypeName: 'missingEntityType',
+            attributeCategory: 'prices',
+            attributeName: 'amount',
+            currentPrice: 8.75,
+        },
+    ]);
+
+    assert.deepEqual(result['missing-price'], {
+        lowestPrice: 8.75,
+        lastChangedAt: null,
+    });
+});


### PR DESCRIPTION
## Summary

- derive the lowest price in the last 30 days from existing entity revision history
- show the 30-day minimum for sunflower packages, plants and sorts, operations, and delivery pricing
- show the most recent in-window price adjustment date and retain current-price fallbacks when history is unavailable

## Why

The public pricing catalog currently shows only the current price. Entity attribute changes are already audited with previous and next values, so the catalog can expose useful price context without introducing another history table or migration.

## Validation

- corepack pnpm --filter www run test:pricing
- corepack pnpm --filter @gredice/storage test -- entityPriceHistoryRepo.node.spec.ts
- corepack pnpm --filter www typecheck
- corepack pnpm --filter www build
- desktop and mobile local render check with Playwright