### PR TITLE
feat(www): show price history on detail cards

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
+++ b/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
@@ -12,6 +12,7 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import { AttributeCard } from '../../../components/attributes/DetailCard';
+import { PriceAttributeCard } from '../../../components/attributes/PriceAttributeCard';
 import { CommunityEditButton } from '../../../components/community-edits/CommunityEditButton';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { KnownPages } from '../../../src/KnownPages';
@@ -115,6 +116,15 @@ export function PlantPageHeader({
     const alternativeNames =
         formatAlternativeNames(sort?.information) ||
         formatAlternativeNames(plant.information);
+    const plantPrice = plant.prices?.perPlant;
+    const price =
+        typeof plantPrice === 'number'
+            ? {
+                  currentPrice: plantPrice,
+                  entityId: plant.id,
+                  entityTypeName: 'plant' as const,
+              }
+            : null;
 
     return (
         <PageHeader
@@ -235,11 +245,13 @@ export function PlantPageHeader({
                         Informacije
                     </Typography>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                        {plant.prices?.perPlant && (
-                            <AttributeCard
+                        {price && (
+                            <PriceAttributeCard
                                 icon={<Sprout />}
                                 header="Cijena sijanja"
-                                value={`${plant.prices.perPlant.toFixed(2)}€`}
+                                entityId={price.entityId}
+                                entityTypeName={price.entityTypeName}
+                                currentPrice={price.currentPrice}
                                 description="Cijena jedne biljke uključuje troškove sjemena, pripreme tla, sjetve i sezonske pogodnosti. Više o samoj sjetvi u gredicama možeš pročitati u nastavku."
                                 navigateHref={KnownPages.Sowing}
                                 navigateLabel="Više o sjetvi"

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -11,7 +11,7 @@ import { Typography } from '@gredice/ui/Typography';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { AttributeCard } from '../../../components/attributes/DetailCard';
+import { PriceAttributeCard } from '../../../components/attributes/PriceAttributeCard';
 import { CommunityEditButton } from '../../../components/community-edits/CommunityEditButton';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { StructuredDataScript } from '../../../components/shared/seo/StructuredDataScript';
@@ -133,10 +133,12 @@ export default async function OperationPage(
                         </Typography>
                         <Stack spacing={2}>
                             <div className="grid grid-cols-2 gap-2">
-                                <AttributeCard
+                                <PriceAttributeCard
                                     icon={<Euro />}
                                     header="Cijena"
-                                    value={`${operation.prices.perOperation.toFixed(2)}€`}
+                                    entityId={operation.id}
+                                    entityTypeName="operation"
+                                    currentPrice={operation.prices.perOperation}
                                 />
                             </div>
                             <Row spacing={1} className="self-end">

--- a/apps/www/components/attributes/PriceAttributeCard.tsx
+++ b/apps/www/components/attributes/PriceAttributeCard.tsx
@@ -1,0 +1,123 @@
+import {
+    type EntityPriceHistorySummary,
+    getEntityPriceHistory,
+} from '@gredice/storage';
+import type { ReactNode } from 'react';
+import { formatPrice } from '../../lib/formatPrice';
+import { AttributeCard } from './DetailCard';
+
+const changeDateFormatter = new Intl.DateTimeFormat('hr-HR', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'Europe/Zagreb',
+});
+
+type PriceEntityTypeName = 'plant' | 'plantSort' | 'operation';
+
+function priceAttributeName(entityTypeName: PriceEntityTypeName) {
+    return entityTypeName === 'operation' ? 'perOperation' : 'perPlant';
+}
+
+async function getPriceHistory({
+    entityId,
+    entityTypeName,
+    currentPrice,
+}: {
+    entityId: number;
+    entityTypeName: PriceEntityTypeName;
+    currentPrice: number;
+}): Promise<EntityPriceHistorySummary> {
+    const key = `${entityTypeName}:${entityId}`;
+    const fallback = {
+        lowestPrice: currentPrice,
+        lastChangedAt: null,
+    };
+
+    if (!process.env.POSTGRES_URL) {
+        return fallback;
+    }
+
+    try {
+        const history = await getEntityPriceHistory([
+            {
+                key,
+                entityId,
+                entityTypeName,
+                attributeCategory: 'prices',
+                attributeName: priceAttributeName(entityTypeName),
+                currentPrice,
+            },
+        ]);
+
+        return history[key] ?? fallback;
+    } catch (error) {
+        console.error('Failed to load detail price history', {
+            entityId,
+            entityTypeName,
+            error,
+        });
+        return fallback;
+    }
+}
+
+export async function PriceAttributeCard({
+    icon,
+    header,
+    entityId,
+    entityTypeName,
+    currentPrice,
+    description,
+    navigateLabel,
+    navigateHref,
+}: {
+    icon: ReactNode;
+    header: string;
+    entityId: number;
+    entityTypeName: PriceEntityTypeName;
+    currentPrice: number;
+    description?: string;
+    navigateLabel?: string;
+    navigateHref?: string;
+}) {
+    const history = await getPriceHistory({
+        entityId,
+        entityTypeName,
+        currentPrice,
+    });
+
+    return (
+        <AttributeCard
+            icon={icon}
+            header={header}
+            description={description}
+            navigateLabel={navigateLabel}
+            navigateHref={navigateHref}
+            value={
+                <span className="block">
+                    <span className="block font-semibold">
+                        {formatPrice(currentPrice)}
+                    </span>
+                    <span className="mt-1 block text-xs font-normal text-muted-foreground">
+                        Najniža cijena u 30 dana:{' '}
+                        <span className="font-medium text-foreground">
+                            {formatPrice(history.lowestPrice)}
+                        </span>
+                    </span>
+                    {history.lastChangedAt && (
+                        <span className="block text-xs font-normal text-muted-foreground">
+                            Zadnja promjena:{' '}
+                            <time
+                                dateTime={history.lastChangedAt.toISOString()}
+                            >
+                                {changeDateFormatter.format(
+                                    history.lastChangedAt,
+                                )}
+                            </time>
+                        </span>
+                    )}
+                </span>
+            }
+        />
+    );
+}


### PR DESCRIPTION
## Summary

- add a reusable audit-backed price attribute card for public detail pages
- show the current price, lowest price in the last 30 days, and latest in-window adjustment date
- use it on plant, plant-sort, and operation detail pages
- keep current-price fallbacks when database history is unavailable

## Detail-page behavior

Plant-sort pages continue to display the parent plant price defined by the current public directory contract, and now use that same plant entity's audit history. Operation pages use the operation per-operation price history.

## Validation

- corepack pnpm --filter www run test:pricing
- corepack pnpm --filter www typecheck
- corepack pnpm --filter www build
- desktop and mobile production-render checks for plant, plant-sort, and operation detail pages