### PR TITLE
feat(www): rename public gardens title

### DIFF
--- a/apps/www/app/vrtovi/page.tsx
+++ b/apps/www/app/vrtovi/page.tsx
@@ -19,13 +19,13 @@ const pageDescription =
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-    title: 'Vidljivi vrtovi',
+    title: 'Vrtovi',
     description: pageDescription,
     alternates: {
         canonical: KnownPages.PublicGardens,
     },
     openGraph: {
-        title: 'Vidljivi vrtovi',
+        title: 'Vrtovi',
         description: pageDescription,
         url: KnownPages.PublicGardens,
     },
@@ -40,11 +40,7 @@ export default async function PublicGardensPage() {
             {publicGardenIds.length > 0 ? (
                 <PublicGardenPreviewBackfill gardenIds={publicGardenIds} />
             ) : null}
-            <PageHeader
-                padded
-                header="Vidljivi vrtovi"
-                subHeader={pageDescription}
-            />
+            <PageHeader padded header="Vrtovi" subHeader={pageDescription} />
             {gardens.items.length > 0 ? (
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                     {gardens.items.map((garden, gardenIndex) => (


### PR DESCRIPTION
## Summary

- rename the `/vrtovi` page heading from "Vidljivi vrtovi" to "Vrtovi"
- align the browser and Open Graph titles with the visible heading

## Why

The shorter title matches the requested public page naming while preserving the existing description and garden listing behavior.

## Validation

- `corepack pnpm --filter www exec biome check app/vrtovi/page.tsx`
- `git diff --check`