### PR TITLE
feat(garden): add neutral outlet availability badge

### DIFF
--- a/apps/garden/tests/outlet-hud.spec.tsx
+++ b/apps/garden/tests/outlet-hud.spec.tsx
@@ -1,6 +1,26 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import { OutletHudStory } from './OutletHudStory';
 
+test('outlet HUD uses a neutral badge for the available item count', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OutletHudStory searchParams="vrt=1" />);
+
+    const outletButton = page.locator('button[title="Outlet sadnica"]');
+    const availabilityBadge = outletButton.locator(
+        '[data-outlet-availability-badge]',
+    );
+
+    await expect(outletButton).toBeVisible();
+    await expect(availabilityBadge).toHaveText('4');
+    await expect(availabilityBadge).toHaveClass(/bg-muted/u);
+    await expect(availabilityBadge).toHaveClass(/text-muted-foreground/u);
+    await expect(outletButton.getByText('Outlet', { exact: true })).toHaveCount(
+        0,
+    );
+});
+
 test('outlet modal collapses offers and lets user pick a not-yet-active raised bed', async ({
     mount,
     page,

--- a/apps/garden/tests/outlet-hud.spec.tsx
+++ b/apps/garden/tests/outlet-hud.spec.tsx
@@ -7,12 +7,15 @@ test('outlet HUD uses a neutral badge for the available item count', async ({
 }) => {
     await mount(<OutletHudStory searchParams="vrt=1" />);
 
-    const outletButton = page.locator('button[title="Outlet sadnica"]');
+    const outletButton = page.getByRole('button', {
+        name: 'Outlet sadnica',
+    });
     const availabilityBadge = outletButton.locator(
         '[data-outlet-availability-badge]',
     );
 
     await expect(outletButton).toBeVisible();
+    await expect(outletButton).toHaveAccessibleName('Outlet sadnica');
     await expect(availabilityBadge).toHaveText('4');
     await expect(availabilityBadge).toHaveClass(/bg-muted/u);
     await expect(availabilityBadge).toHaveClass(/text-muted-foreground/u);

--- a/packages/game/src/hud/OutletHud.tsx
+++ b/packages/game/src/hud/OutletHud.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@gredice/ui/Button';
+import { IconButton } from '@gredice/ui/IconButton';
 import { Check, Discount, Navigate } from '@gredice/ui/icons';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -61,6 +62,14 @@ export function OutletHud() {
     const selectedOffer =
         offers?.find((offer) => offer.id === highlightedOfferId) ?? null;
     const selectedOfferId = selectedOffer?.id ?? null;
+    const availableItemsCount = useMemo(
+        () =>
+            offers?.reduce(
+                (total, offer) => total + offer.remainingQuantity,
+                0,
+            ) ?? 0,
+        [offers],
+    );
     const emptyFieldTargets = useMemo(
         () =>
             findEmptyRaisedBedFieldTargets(currentGarden, cart?.items, {
@@ -138,20 +147,29 @@ export function OutletHud() {
                 headerIcon={<Discount className="size-7 shrink-0" />}
                 hudLayer
                 trigger={
-                    <Button
+                    <IconButton
                         title="Outlet sadnica"
                         variant="plain"
-                        className="relative rounded-full p-2 gap-2"
+                        className="size-10 rounded-full"
                     >
-                        <Discount className="size-6 shrink-0" />
-                        <Typography
-                            level="body2"
-                            semiBold
-                            className="text-foreground"
-                        >
-                            Outlet
-                        </Typography>
-                    </Button>
+                        <div className="relative flex items-center justify-center">
+                            <Discount className="size-6" />
+                            {availableItemsCount > 0 && (
+                                <div
+                                    className={cx(
+                                        'absolute -top-4 -right-4 flex size-6 items-center justify-center rounded-full border border-border bg-muted px-1.5 text-sm font-semibold leading-none text-muted-foreground shadow-sm',
+                                        availableItemsCount > 99 &&
+                                            'text-[10px]',
+                                    )}
+                                    data-outlet-availability-badge
+                                >
+                                    {availableItemsCount > 99
+                                        ? '99+'
+                                        : availableItemsCount}
+                                </div>
+                            )}
+                        </div>
+                    </IconButton>
                 }
             >
                 <Stack spacing={4}>

--- a/packages/game/src/hud/OutletHud.tsx
+++ b/packages/game/src/hud/OutletHud.tsx
@@ -148,6 +148,7 @@ export function OutletHud() {
                 hudLayer
                 trigger={
                     <IconButton
+                        aria-label="Outlet sadnica"
                         title="Outlet sadnica"
                         variant="plain"
                         className="size-10 rounded-full"
@@ -156,6 +157,7 @@ export function OutletHud() {
                             <Discount className="size-6" />
                             {availableItemsCount > 0 && (
                                 <div
+                                    aria-hidden="true"
                                     className={cx(
                                         'absolute -top-4 -right-4 flex size-6 items-center justify-center rounded-full border border-border bg-muted px-1.5 text-sm font-semibold leading-none text-muted-foreground shadow-sm',
                                         availableItemsCount > 99 &&


### PR DESCRIPTION
## Summary

- replace the outlet HUD text trigger with the compact discount icon
- show a neutral badge with the total remaining outlet seedling quantity
- cap large badge values at `99+`
- add component coverage for the count, neutral styling, and icon-only trigger

## Why

The outlet action occupied more visual space than the neighboring inventory action and did not expose current availability at a glance. Matching the inventory trigger shape keeps the HUD compact, while muted tokens prevent the outlet counter from competing with higher-priority HUD indicators.

## Validation

- `corepack pnpm lint --filter @gredice/game`
- `corepack pnpm lint --filter garden`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/outlet-hud.spec.tsx`
- `git diff --check`