### PR TITLE
feat(www): use pill radius for public navbar

### DIFF
--- a/apps/www/tests/landing.spec.ts
+++ b/apps/www/tests/landing.spec.ts
@@ -1,7 +1,26 @@
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { expect, test } from './fixtures';
 
 test.describe.configure({ mode: 'default' });
+
+async function expectPillBorderRadius(locator: Locator) {
+    await expect
+        .poll(async () =>
+            locator.evaluate((element) => {
+                const styles = window.getComputedStyle(element);
+                const radii = [
+                    styles.borderTopLeftRadius,
+                    styles.borderTopRightRadius,
+                    styles.borderBottomRightRadius,
+                    styles.borderBottomLeftRadius,
+                ].map((radius) => Number.parseFloat(radius));
+                const { height } = element.getBoundingClientRect();
+
+                return Math.min(...radii) - height / 2;
+            }),
+        )
+        .toBeGreaterThanOrEqual(0);
+}
 
 async function expectMobileNavActionsDoNotOverlap(page: Page) {
     const cta = page.getByRole('link', { name: 'Moj novi vrt' });
@@ -192,7 +211,7 @@ test('navbar floats on scroll and landing game frame is rounded', async ({
         .toBeGreaterThan(10);
 
     await page.evaluate(() => window.scrollTo(0, 160));
-    await expect(header).toHaveCSS('border-radius', '16px');
+    await expectPillBorderRadius(header);
     await expect(header).toHaveCSS('border-bottom-width', '1px');
     await expectMobileNavActionsDoNotOverlap(page);
 
@@ -216,7 +235,7 @@ test('desktop floating navbar keeps container width', async ({ page }) => {
 
     const header = page.locator('header');
     await page.evaluate(() => window.scrollTo(0, 160));
-    await expect(header).toHaveCSS('border-radius', '16px');
+    await expectPillBorderRadius(header);
 
     const headerBox = await header.boundingBox();
     expect(headerBox).not.toBeNull();

--- a/packages/ui/src/Nav/Nav.tsx
+++ b/packages/ui/src/Nav/Nav.tsx
@@ -117,7 +117,7 @@ export function PageNav({
                     className={cx(
                         'pointer-events-auto relative flex h-16 items-center border-transparent bg-background/75 backdrop-blur-md transition-[height,border-color,background-color,box-shadow] duration-300 ease-out',
                         isFloating &&
-                            'h-14 rounded-2xl border border-border/70 bg-background/80 shadow-lg shadow-foreground/10 backdrop-blur-xl',
+                            'h-14 rounded-full border border-border/70 bg-background/80 shadow-lg shadow-foreground/10 backdrop-blur-xl',
                     )}
                 >
                     <div className="relative flex h-full w-full min-w-0 items-center justify-between gap-1 px-2 sm:gap-2 sm:px-3 md:px-4">


### PR DESCRIPTION
## Summary

- change the floating public navbar from a fixed 2xl radius to a full pill radius
- match the navbar silhouette to the Moj vrt CTA on the right
- keep the mobile navigation panel geometry unchanged

## Root cause

The shared PageNav header used rounded-2xl while the adjacent user CTA used rounded-full, producing visibly different corner shapes.

## Impact

Public pages now show a consistent pill-shaped floating navbar across desktop and mobile header states.

## Validation

- corepack pnpm lint --filter @gredice/ui
- corepack pnpm typecheck --filter @gredice/ui --filter www
- corepack pnpm build --filter www
- git diff --check