### PR TITLE
fix(game): slide celestial bodies into raised bed closeups

### DIFF
--- a/packages/game/src/controls/GameCameraRig.tsx
+++ b/packages/game/src/controls/GameCameraRig.tsx
@@ -177,6 +177,9 @@ export function GameCameraRig({
     const setCloseupCameraActive = useGameState(
         (state) => state.setCloseupCameraActive,
     );
+    const setCloseupCameraSettled = useGameState(
+        (state) => state.setCloseupCameraSettled,
+    );
     const [isAnimating, setIsAnimating] = useState(false);
     const setIsDragging = useGameState((state) => state.setIsDragging);
     const worldRotation = useGameState((state) => state.worldRotation);
@@ -840,6 +843,7 @@ export function GameCameraRig({
 
         if (view === 'closeup' && closeupTarget) {
             setCloseupCameraActive(true);
+            setCloseupCameraSettled(false);
             if (previousView !== 'closeup') {
                 normalCameraRef.current = {
                     position: camera.position.clone(),
@@ -857,6 +861,7 @@ export function GameCameraRig({
                 }),
                 endTarget: closeupTarget.target,
                 endZoom: closeupZoom,
+                onComplete: () => setCloseupCameraSettled(true),
             });
             previousViewRef.current = view;
             return;
@@ -868,7 +873,10 @@ export function GameCameraRig({
                 endPosition: normalCameraRef.current.position,
                 endTarget: normalCameraRef.current.target,
                 endZoom: normalCameraRef.current.zoom,
-                onComplete: () => setCloseupCameraActive(false),
+                onComplete: () => {
+                    setCloseupCameraActive(false);
+                    setCloseupCameraSettled(false);
+                },
             });
         }
         previousViewRef.current = view;
@@ -877,14 +885,17 @@ export function GameCameraRig({
         closeupTarget,
         isOrthographicCamera,
         setCloseupCameraActive,
+        setCloseupCameraSettled,
         startAnimation,
         view,
     ]);
 
-    useEffect(
-        () => () => setCloseupCameraActive(false),
-        [setCloseupCameraActive],
-    );
+    useEffect(() => {
+        return () => {
+            setCloseupCameraActive(false);
+            setCloseupCameraSettled(false);
+        };
+    }, [setCloseupCameraActive, setCloseupCameraSettled]);
 
     useFrame((_, delta) => {
         if (!isOrthographicCamera) {

--- a/packages/game/src/scene/Environment.tsx
+++ b/packages/game/src/scene/Environment.tsx
@@ -697,6 +697,9 @@ export function Environment({
     const closeupCameraActive = useGameState(
         (state) => state.closeupCameraActive,
     );
+    const closeupCameraSettled = useGameState(
+        (state) => state.closeupCameraSettled,
+    );
     const isGroundView = view === 'closeup' || closeupCameraActive;
     const closeupBlockId = useGameState((state) => state.closeupBlock?.id);
     const pickupBlockId = useGameState((state) => state.pickupBlock?.id);
@@ -1144,6 +1147,7 @@ export function Environment({
                         backgroundPaletteIndex={backgroundPaletteIndex}
                         currentTime={currentTime}
                         groundView={isGroundView}
+                        hideCelestialGlow={closeupCameraSettled}
                         location={location}
                         moonlight={sky.moonlight}
                         timeOfDay={timeOfDay}
@@ -1211,10 +1215,12 @@ export function Environment({
                 />
             )}
             {showStars && (
-                <Stars visibility={isGroundView ? 0 : starVisibility} />
+                <Stars visibility={closeupCameraSettled ? 0 : starVisibility} />
             )}
             {!noBackground && (
-                <SunMoon visibility={isGroundView ? 0 : bodyVisibility} />
+                <SunMoon
+                    visibility={closeupCameraSettled ? 0 : bodyVisibility}
+                />
             )}
             {!weatherDisabled && fog > 0 && (
                 <fog attach="fog" args={[fogColor, fogNear, 190]} />

--- a/packages/game/src/scene/SkyGradientBackground.tsx
+++ b/packages/game/src/scene/SkyGradientBackground.tsx
@@ -91,6 +91,7 @@ type SkyGradientBackgroundProps = {
     backgroundPaletteIndex: number;
     currentTime: Date;
     groundView?: boolean;
+    hideCelestialGlow?: boolean;
     location: { lat: number; lon: number };
     moonlight: number;
     timeOfDay: number;
@@ -139,6 +140,7 @@ export function SkyGradientBackground({
     backgroundPaletteIndex,
     currentTime,
     groundView = false,
+    hideCelestialGlow = false,
     location,
     moonlight,
     timeOfDay,
@@ -300,9 +302,10 @@ export function SkyGradientBackground({
             const activeGradient = displayed;
             applyGradientUniforms(material, activeGradient);
             material.uniforms.uSunGlowIntensity.value =
-                (groundView ? 0 : activeGradient.sunGlowIntensity) * sunOpacity;
+                (hideCelestialGlow ? 0 : activeGradient.sunGlowIntensity) *
+                sunOpacity;
             material.uniforms.uMoonGlowIntensity.value =
-                (groundView ? 0 : activeGradient.moonGlowIntensity) *
+                (hideCelestialGlow ? 0 : activeGradient.moonGlowIntensity) *
                 moonOpacity;
         }
     });

--- a/packages/game/src/useGameState.ts
+++ b/packages/game/src/useGameState.ts
@@ -357,7 +357,9 @@ export type GameState = {
     view: 'normal' | 'closeup';
     closeupBlock: Block | null;
     closeupCameraActive: boolean;
+    closeupCameraSettled: boolean;
     setCloseupCameraActive: (active: boolean) => void;
+    setCloseupCameraSettled: (settled: boolean) => void;
     setView: (
         options:
             | { view: 'normal'; block?: Block }
@@ -839,8 +841,11 @@ export function createGameState({
         view: 'normal',
         closeupBlock: null,
         closeupCameraActive: false,
+        closeupCameraSettled: false,
         setCloseupCameraActive: (closeupCameraActive) =>
             set({ closeupCameraActive }),
+        setCloseupCameraSettled: (closeupCameraSettled) =>
+            set({ closeupCameraSettled }),
         setView: ({ view, block }) => {
             const currentView = get().view;
 

--- a/packages/game/src/useGameState.unit.ts
+++ b/packages/game/src/useGameState.unit.ts
@@ -107,13 +107,17 @@ test('closeup camera stays active while the requested view returns to normal', (
 
     try {
         store.getState().setCloseupCameraActive(true);
+        store.getState().setCloseupCameraSettled(true);
         store.getState().setView({ view: 'normal' });
 
         assert.equal(store.getState().view, 'normal');
         assert.equal(store.getState().closeupCameraActive, true);
+        assert.equal(store.getState().closeupCameraSettled, true);
 
         store.getState().setCloseupCameraActive(false);
+        store.getState().setCloseupCameraSettled(false);
         assert.equal(store.getState().closeupCameraActive, false);
+        assert.equal(store.getState().closeupCameraSettled, false);
     } finally {
         store.getState().audio.dispose();
     }


### PR DESCRIPTION
## Summary

- keep the sun, moon, stars, and celestial glow active while the closeup camera begins moving so they slide naturally with the scene
- hide celestial elements only after the raised-bed camera settles
- preserve the ground background and hidden celestial state throughout the return animation

## Validation

- `corepack pnpm --filter @gredice/game test` (394 passed)
- `corepack pnpm --filter @gredice/game exec biome check src`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm typecheck --filter www`
- browser-verified entry at 250 ms and 500 ms, settled closeup, mid-exit, and settled normal view