### PR TITLE
fix(game): remove cross-account garden switch delay

### DIFF
--- a/apps/garden/tests/GardenAccountMenuItemsStory.tsx
+++ b/apps/garden/tests/GardenAccountMenuItemsStory.tsx
@@ -15,6 +15,7 @@ import {
     createGameState,
     GameStateContext,
 } from '../../../packages/game/src/useGameState';
+import { useCurrentGardenIdParam } from '../../../packages/game/src/useUrlState';
 
 const currentGarden = {
     id: 1,
@@ -27,6 +28,13 @@ const sandboxGarden = {
     id: 2,
     name: 'Vrt za igru 1',
     isSandbox: true,
+    createdAt: '2026-06-01T00:00:00.000Z',
+};
+
+const otherAccountGarden = {
+    id: 3,
+    name: 'Drugi vrt',
+    isSandbox: false,
     createdAt: '2026-06-01T00:00:00.000Z',
 };
 
@@ -44,6 +52,12 @@ function createGardenAccountMenuQueryClient() {
             name: 'test@example.com račun',
             isCurrent: true,
             gardens: [currentGarden, sandboxGarden],
+        },
+        {
+            accountId: 'other-account',
+            name: 'other@example.com račun',
+            isCurrent: false,
+            gardens: [otherAccountGarden],
         },
     ]);
     queryClient.setQueryData(currentGardenKeys('summer', currentGarden.id), {
@@ -71,13 +85,40 @@ function GardenAccountMenuItemsTestProviders({ children }: PropsWithChildren) {
     );
 
     return (
-        <ReactQuery.QueryClientProvider client={queryClient}>
-            <NuqsTestingAdapter>
-                <GameStateContext.Provider value={gameState}>
+        <NuqsTestingAdapter hasMemory>
+            <ReactQuery.QueryClientProvider client={queryClient}>
+                <GardenAccountMenuItemsTestContent gameState={gameState}>
                     {children}
-                </GameStateContext.Provider>
-            </NuqsTestingAdapter>
-        </ReactQuery.QueryClientProvider>
+                </GardenAccountMenuItemsTestContent>
+            </ReactQuery.QueryClientProvider>
+        </NuqsTestingAdapter>
+    );
+}
+
+function GardenAccountMenuItemsTestContent({
+    children,
+    gameState,
+}: PropsWithChildren<{
+    gameState: ReturnType<typeof createGameState>;
+}>) {
+    const [selectedGardenId] = useCurrentGardenIdParam();
+
+    // Keep one active refetch pending so the switcher test can prove that URL
+    // selection no longer waits for every invalidated query to settle.
+    ReactQuery.useQuery({
+        queryKey: ['accounts', 'current', 'switch-delay-probe'],
+        queryFn: () => new Promise<never>(() => undefined),
+        initialData: 'ready',
+        staleTime: Number.POSITIVE_INFINITY,
+    });
+
+    return (
+        <GameStateContext.Provider value={gameState}>
+            {children}
+            <output className="sr-only" data-testid="selected-garden-id">
+                {selectedGardenId ?? 'default'}
+            </output>
+        </GameStateContext.Provider>
     );
 }
 

--- a/apps/garden/tests/garden-account-menu-items.spec.tsx
+++ b/apps/garden/tests/garden-account-menu-items.spec.tsx
@@ -2,6 +2,32 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import { GardenAccountMenuItemsStory } from './GardenAccountMenuItemsStory';
 
 test.describe('Garden account menu items', () => {
+    test('selects a garden before refreshing account-scoped queries', async ({
+        mount,
+        page,
+    }) => {
+        await page.route(
+            '**/api/gredice/api/accounts/switch',
+            async (route) => {
+                await route.fulfill({
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        success: true,
+                        accountId: 'other-account',
+                    }),
+                });
+            },
+        );
+        await mount(<GardenAccountMenuItemsStory />);
+
+        await page.getByRole('button', { name: 'Otvori izbornik' }).click();
+        await page.getByRole('menuitem', { name: /Drugi vrt/ }).click();
+
+        await expect(page.getByTestId('selected-garden-id')).toHaveText('3', {
+            timeout: 1_000,
+        });
+    });
+
     test('shows sandbox gardens inline on mobile', async ({ mount, page }) => {
         await page.setViewportSize({ width: 600, height: 800 });
         await mount(<GardenAccountMenuItemsStory />);

--- a/apps/garden/tests/garden-account-menu-items.spec.tsx
+++ b/apps/garden/tests/garden-account-menu-items.spec.tsx
@@ -2,13 +2,15 @@ import { expect, test } from '@playwright/experimental-ct-react';
 import { GardenAccountMenuItemsStory } from './GardenAccountMenuItemsStory';
 
 test.describe('Garden account menu items', () => {
-    test('selects a garden before refreshing account-scoped queries', async ({
+    test('switches gardens in both directions before account queries refresh', async ({
         mount,
         page,
     }) => {
+        const accountSwitchRequests: string[] = [];
         await page.route(
             '**/api/gredice/api/accounts/switch',
             async (route) => {
+                accountSwitchRequests.push(route.request().postData() ?? '');
                 await route.fulfill({
                     contentType: 'application/json',
                     body: JSON.stringify({
@@ -26,6 +28,17 @@ test.describe('Garden account menu items', () => {
         await expect(page.getByTestId('selected-garden-id')).toHaveText('3', {
             timeout: 1_000,
         });
+
+        await page.getByRole('button', { name: 'Otvori izbornik' }).click();
+        await page.getByRole('menuitem', { name: /Test/ }).click();
+
+        await expect(page.getByTestId('selected-garden-id')).toHaveText('1', {
+            timeout: 1_000,
+        });
+        expect(accountSwitchRequests).toEqual([
+            JSON.stringify({ accountId: 'other-account' }),
+            JSON.stringify({ accountId: 'test-account' }),
+        ]);
     });
 
     test('shows sandbox gardens inline on mobile', async ({ mount, page }) => {

--- a/packages/game/src/hud/GardenAccountMenuItems.tsx
+++ b/packages/game/src/hud/GardenAccountMenuItems.tsx
@@ -24,7 +24,10 @@ import { useGameAnalytics } from '../analytics/GameAnalyticsContext';
 import { useCreateGarden } from '../hooks/useCreateGarden';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useDeleteSandboxGarden } from '../hooks/useDeleteSandboxGarden';
-import { useGardenAccountGroups } from '../hooks/useGardenAccountGroups';
+import {
+    gardenAccountGroupsKeys,
+    useGardenAccountGroups,
+} from '../hooks/useGardenAccountGroups';
 import { useGardens } from '../hooks/useGardens';
 import { useSwitchGardenAccount } from '../hooks/useSwitchGardenAccount';
 import { useCurrentGardenIdParam } from '../useUrlState';
@@ -130,12 +133,21 @@ export function GardenAccountMenuItems({
                 await switchGardenAccount.mutateAsync({
                     accountId: accountGroup.accountId,
                 });
+                queryClient.setQueryData<typeof accountGroups>(
+                    gardenAccountGroupsKeys,
+                    (groups) =>
+                        groups?.map((group) => ({
+                            ...group,
+                            isCurrent:
+                                group.accountId === accountGroup.accountId,
+                        })) ?? groups,
+                );
                 await setSelectedGardenId(garden.id);
                 void queryClient.invalidateQueries();
                 return;
             }
 
-            const isDefault = currentAccountGardens?.[0]?.id === garden.id;
+            const isDefault = accountGroup.gardens[0]?.id === garden.id;
             await setSelectedGardenId(isDefault ? null : garden.id);
         } catch (error) {
             console.error('Failed to switch garden account:', error);

--- a/packages/game/src/hud/GardenAccountMenuItems.tsx
+++ b/packages/game/src/hud/GardenAccountMenuItems.tsx
@@ -130,8 +130,8 @@ export function GardenAccountMenuItems({
                 await switchGardenAccount.mutateAsync({
                     accountId: accountGroup.accountId,
                 });
-                await queryClient.invalidateQueries();
                 await setSelectedGardenId(garden.id);
+                void queryClient.invalidateQueries();
                 return;
             }
 


### PR DESCRIPTION
## Summary

- select the target garden as soon as the account-switch request succeeds
- refresh account-scoped React Query data in the background instead of blocking the scene transition
- add component coverage proving garden selection completes while an unrelated active refetch is still pending

## Root cause

The cross-account switch handler awaited a global query invalidation before updating the `vrt` URL state. React Query waits for all active refetches to settle, so unrelated account, inventory, weather, notification, and garden requests delayed the new garden from beginning to load.

## Validation

- `corepack pnpm lint --filter @gredice/game`
- `corepack pnpm lint --filter garden`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm test --filter @gredice/game` (394 passed)
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm exec playwright test tests/garden-account-menu-items.spec.tsx` (2 passed)
- `git diff --check`