### PR TITLE
fix(admin): keep future tasks out of today's schedule

### DIFF
--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -61,7 +61,7 @@ type FarmSummary = {
 };
 
 interface FarmOperationsScheduleSectionProps {
-    date: Date;
+    dateKey: string;
     timeZone: string;
     farm: FarmSummary;
     scheduledOperations: Operation[];
@@ -85,7 +85,7 @@ function getOperationLabel(
 }
 
 export function FarmOperationsScheduleSection({
-    date,
+    dateKey,
     timeZone,
     farm,
     scheduledOperations,
@@ -421,7 +421,7 @@ export function FarmOperationsScheduleSection({
                         !!operation.scheduledDate &&
                         !isSameScheduleDay(
                             operation.scheduledDate,
-                            date,
+                            dateKey,
                             timeZone,
                         );
 

--- a/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/FarmOperationsScheduleSection.tsx
@@ -62,6 +62,7 @@ type FarmSummary = {
 
 interface FarmOperationsScheduleSectionProps {
     date: Date;
+    timeZone: string;
     farm: FarmSummary;
     scheduledOperations: Operation[];
     operationsData: EntityStandardized[] | null | undefined;
@@ -85,6 +86,7 @@ function getOperationLabel(
 
 export function FarmOperationsScheduleSection({
     date,
+    timeZone,
     farm,
     scheduledOperations,
     operationsData,
@@ -417,7 +419,11 @@ export function FarmOperationsScheduleSection({
                               : 'text-muted-foreground';
                     const showScheduledDate =
                         !!operation.scheduledDate &&
-                        !isSameScheduleDay(operation.scheduledDate, date);
+                        !isSameScheduleDay(
+                            operation.scheduledDate,
+                            date,
+                            timeZone,
+                        );
 
                     return (
                         <Row
@@ -560,7 +566,15 @@ export function FarmOperationsScheduleSection({
                                         className="shrink-0 select-none"
                                     >
                                         {showScheduledDate ? (
-                                            <LocalDateTime time={false}>
+                                            <LocalDateTime
+                                                time={false}
+                                                format={{
+                                                    year: 'numeric',
+                                                    month: 'numeric',
+                                                    day: 'numeric',
+                                                    timeZone,
+                                                }}
+                                            >
                                                 {operation.scheduledDate}
                                             </LocalDateTime>
                                         ) : (

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -59,6 +59,7 @@ import { VerifyOperationModal } from './VerifyOperationModal';
 
 interface RaisedBedOperationsScheduleSectionProps {
     date: Date;
+    timeZone: string;
     physicalId: string;
     raisedBeds: RaisedBed[];
     scheduledOperations: Operation[];
@@ -72,6 +73,7 @@ interface RaisedBedOperationsScheduleSectionProps {
 
 export function RaisedBedOperationsScheduleSection({
     date,
+    timeZone,
     physicalId,
     raisedBeds,
     scheduledOperations,
@@ -500,7 +502,11 @@ export function RaisedBedOperationsScheduleSection({
                     );
                     const showScheduledDate =
                         !!operation.scheduledDate &&
-                        !isSameScheduleDay(operation.scheduledDate, date);
+                        !isSameScheduleDay(
+                            operation.scheduledDate,
+                            date,
+                            timeZone,
+                        );
 
                     return (
                         <div key={operation.id}>
@@ -648,7 +654,15 @@ export function RaisedBedOperationsScheduleSection({
                                             className="shrink-0 select-none"
                                         >
                                             {showScheduledDate ? (
-                                                <LocalDateTime time={false}>
+                                                <LocalDateTime
+                                                    time={false}
+                                                    format={{
+                                                        year: 'numeric',
+                                                        month: 'numeric',
+                                                        day: 'numeric',
+                                                        timeZone,
+                                                    }}
+                                                >
                                                     {operation.scheduledDate}
                                                 </LocalDateTime>
                                             ) : (

--- a/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedOperationsScheduleSection.tsx
@@ -58,7 +58,7 @@ import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
 import { VerifyOperationModal } from './VerifyOperationModal';
 
 interface RaisedBedOperationsScheduleSectionProps {
-    date: Date;
+    dateKey: string;
     timeZone: string;
     physicalId: string;
     raisedBeds: RaisedBed[];
@@ -72,7 +72,7 @@ interface RaisedBedOperationsScheduleSectionProps {
 }
 
 export function RaisedBedOperationsScheduleSection({
-    date,
+    dateKey,
     timeZone,
     physicalId,
     raisedBeds,
@@ -504,7 +504,7 @@ export function RaisedBedOperationsScheduleSection({
                         !!operation.scheduledDate &&
                         !isSameScheduleDay(
                             operation.scheduledDate,
-                            date,
+                            dateKey,
                             timeZone,
                         );
 

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -53,7 +53,7 @@ import { useOptimisticScheduleActions } from './useOptimisticScheduleActions';
 import { VerifyPlantingModal } from './VerifyPlantingModal';
 
 interface RaisedBedPlantingScheduleSectionProps {
-    date: Date;
+    dateKey: string;
     timeZone: string;
     physicalId: string;
     raisedBeds: RaisedBed[];
@@ -84,7 +84,7 @@ function getSowingTaskLabel({
 }
 
 export function RaisedBedPlantingScheduleSection({
-    date,
+    dateKey,
     timeZone,
     physicalId,
     raisedBeds,
@@ -480,7 +480,7 @@ export function RaisedBedPlantingScheduleSection({
                         !!field.plantScheduledDate &&
                         !isSameScheduleDay(
                             field.plantScheduledDate,
-                            date,
+                            dateKey,
                             timeZone,
                         );
 

--- a/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
+++ b/apps/app/app/admin/schedule/RaisedBedPlantingScheduleSection.tsx
@@ -54,6 +54,7 @@ import { VerifyPlantingModal } from './VerifyPlantingModal';
 
 interface RaisedBedPlantingScheduleSectionProps {
     date: Date;
+    timeZone: string;
     physicalId: string;
     raisedBeds: RaisedBed[];
     scheduledFields: RaisedBedField[];
@@ -84,6 +85,7 @@ function getSowingTaskLabel({
 
 export function RaisedBedPlantingScheduleSection({
     date,
+    timeZone,
     physicalId,
     raisedBeds,
     scheduledFields,
@@ -476,7 +478,11 @@ export function RaisedBedPlantingScheduleSection({
                         !fieldApproved && !fieldLocked;
                     const showScheduledDate =
                         !!field.plantScheduledDate &&
-                        !isSameScheduleDay(field.plantScheduledDate, date);
+                        !isSameScheduleDay(
+                            field.plantScheduledDate,
+                            date,
+                            timeZone,
+                        );
 
                     return (
                         <div key={field.id}>
@@ -586,7 +592,15 @@ export function RaisedBedPlantingScheduleSection({
                                             className="shrink-0 select-none"
                                         >
                                             {showScheduledDate ? (
-                                                <LocalDateTime time={false}>
+                                                <LocalDateTime
+                                                    time={false}
+                                                    format={{
+                                                        year: 'numeric',
+                                                        month: 'numeric',
+                                                        day: 'numeric',
+                                                        timeZone,
+                                                    }}
+                                                >
                                                     {field.plantScheduledDate}
                                                 </LocalDateTime>
                                             ) : (

--- a/apps/app/app/admin/schedule/ScheduleDayDeliveriesSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayDeliveriesSection.tsx
@@ -10,10 +10,7 @@ export async function ScheduleDayDeliveriesSection({
     isToday,
     date,
 }: ScheduleDayDeliveriesSectionProps) {
-    const { todaysDeliveryRequests } = await getScheduleDayData(
-        date.toISOString(),
-        isToday,
-    );
+    const { todaysDeliveryRequests } = await getScheduleDayData(date, isToday);
 
     return <DeliveryRequestsSection requests={todaysDeliveryRequests} />;
 }

--- a/apps/app/app/admin/schedule/ScheduleDayEmptyState.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayEmptyState.tsx
@@ -11,7 +11,7 @@ export async function ScheduleDayEmptyState({
     date,
 }: ScheduleDayEmptyStateProps) {
     const { scheduledFields, scheduledOperations, todaysDeliveryRequests } =
-        await getScheduleDayData(date.toISOString(), isToday);
+        await getScheduleDayData(date, isToday);
 
     if (
         scheduledFields.length +

--- a/apps/app/app/admin/schedule/ScheduleDayHeaderSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayHeaderSection.tsx
@@ -20,9 +20,9 @@ export async function ScheduleDayHeaderSection({
     isToday,
     date,
 }: ScheduleDayHeaderSectionProps) {
-    const [{ scheduledFields, scheduledOperations, timeZone }, operationsData] =
+    const [{ dateKey, scheduledFields, scheduledOperations }, operationsData] =
         await Promise.all([
-            getScheduleDayData(date.toISOString(), isToday),
+            getScheduleDayData(date, isToday),
             getScheduleOperationsData(),
         ]);
 
@@ -77,8 +77,8 @@ export async function ScheduleDayHeaderSection({
     const summaryCopyText = [
         `Sažetak za ${new Intl.DateTimeFormat('hr-HR', {
             dateStyle: 'full',
-            timeZone,
-        }).format(date)}`,
+            timeZone: 'UTC',
+        }).format(new Date(`${dateKey}T00:00:00.000Z`))}`,
         `Odobreni zadaci: ${approvedTasksCount}`,
         `Odobreno vrijeme: ${formatMinutes(approvedDuration)}`,
     ].join('\n');

--- a/apps/app/app/admin/schedule/ScheduleDayHeaderSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayHeaderSection.tsx
@@ -20,7 +20,7 @@ export async function ScheduleDayHeaderSection({
     isToday,
     date,
 }: ScheduleDayHeaderSectionProps) {
-    const [{ scheduledFields, scheduledOperations }, operationsData] =
+    const [{ scheduledFields, scheduledOperations, timeZone }, operationsData] =
         await Promise.all([
             getScheduleDayData(date.toISOString(), isToday),
             getScheduleOperationsData(),
@@ -77,6 +77,7 @@ export async function ScheduleDayHeaderSection({
     const summaryCopyText = [
         `Sažetak za ${new Intl.DateTimeFormat('hr-HR', {
             dateStyle: 'full',
+            timeZone,
         }).format(date)}`,
         `Odobreni zadaci: ${approvedTasksCount}`,
         `Odobreno vrijeme: ${formatMinutes(approvedDuration)}`,

--- a/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
@@ -31,11 +31,11 @@ export async function ScheduleDayOperationsSection({
     date,
 }: ScheduleDayOperationsSectionProps) {
     const [
-        { raisedBeds, scheduledOperations, timeZone },
+        { dateKey, raisedBeds, scheduledOperations, timeZone },
         plantSorts,
         operationsData,
     ] = await Promise.all([
-        getScheduleDayData(date.toISOString(), isToday),
+        getScheduleDayData(date, isToday),
         getSchedulePlantSorts(),
         getScheduleOperationsData(),
     ]);
@@ -133,7 +133,7 @@ export async function ScheduleDayOperationsSection({
                         return (
                             <RaisedBedOperationsScheduleSection
                                 key={key}
-                                date={date}
+                                dateKey={dateKey}
                                 timeZone={timeZone}
                                 physicalId={physicalId}
                                 raisedBeds={beds}
@@ -150,7 +150,7 @@ export async function ScheduleDayOperationsSection({
                 {operationFarms.map((farm) => (
                     <FarmOperationsScheduleSection
                         key={farm.id}
-                        date={date}
+                        dateKey={dateKey}
                         timeZone={timeZone}
                         farm={farm}
                         scheduledOperations={scheduledOperations}

--- a/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayOperationsSection.tsx
@@ -30,12 +30,15 @@ export async function ScheduleDayOperationsSection({
     isToday,
     date,
 }: ScheduleDayOperationsSectionProps) {
-    const [{ raisedBeds, scheduledOperations }, plantSorts, operationsData] =
-        await Promise.all([
-            getScheduleDayData(date.toISOString(), isToday),
-            getSchedulePlantSorts(),
-            getScheduleOperationsData(),
-        ]);
+    const [
+        { raisedBeds, scheduledOperations, timeZone },
+        plantSorts,
+        operationsData,
+    ] = await Promise.all([
+        getScheduleDayData(date.toISOString(), isToday),
+        getSchedulePlantSorts(),
+        getScheduleOperationsData(),
+    ]);
     if (scheduledOperations.length === 0) {
         return null;
     }
@@ -131,6 +134,7 @@ export async function ScheduleDayOperationsSection({
                             <RaisedBedOperationsScheduleSection
                                 key={key}
                                 date={date}
+                                timeZone={timeZone}
                                 physicalId={physicalId}
                                 raisedBeds={beds}
                                 scheduledOperations={scheduledOperations}
@@ -147,6 +151,7 @@ export async function ScheduleDayOperationsSection({
                     <FarmOperationsScheduleSection
                         key={farm.id}
                         date={date}
+                        timeZone={timeZone}
                         farm={farm}
                         scheduledOperations={scheduledOperations}
                         operationsData={operationsData}

--- a/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
@@ -22,10 +22,11 @@ export async function ScheduleDayPlantingsSection({
     isToday,
     date,
 }: ScheduleDayPlantingsSectionProps) {
-    const [{ raisedBeds, scheduledFields }, plantSorts] = await Promise.all([
-        getScheduleDayData(date.toISOString(), isToday),
-        getSchedulePlantSorts(),
-    ]);
+    const [{ raisedBeds, scheduledFields, timeZone }, plantSorts] =
+        await Promise.all([
+            getScheduleDayData(date.toISOString(), isToday),
+            getSchedulePlantSorts(),
+        ]);
     if (scheduledFields.length === 0) {
         return null;
     }
@@ -102,6 +103,7 @@ export async function ScheduleDayPlantingsSection({
                             <RaisedBedPlantingScheduleSection
                                 key={key}
                                 date={date}
+                                timeZone={timeZone}
                                 physicalId={physicalId}
                                 raisedBeds={beds}
                                 scheduledFields={scheduledFields}

--- a/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
+++ b/apps/app/app/admin/schedule/ScheduleDayPlantingsSection.tsx
@@ -22,9 +22,9 @@ export async function ScheduleDayPlantingsSection({
     isToday,
     date,
 }: ScheduleDayPlantingsSectionProps) {
-    const [{ raisedBeds, scheduledFields, timeZone }, plantSorts] =
+    const [{ dateKey, raisedBeds, scheduledFields, timeZone }, plantSorts] =
         await Promise.all([
-            getScheduleDayData(date.toISOString(), isToday),
+            getScheduleDayData(date, isToday),
             getSchedulePlantSorts(),
         ]);
     if (scheduledFields.length === 0) {
@@ -102,7 +102,7 @@ export async function ScheduleDayPlantingsSection({
                         return (
                             <RaisedBedPlantingScheduleSection
                                 key={key}
-                                date={date}
+                                dateKey={dateKey}
                                 timeZone={timeZone}
                                 physicalId={physicalId}
                                 raisedBeds={beds}

--- a/apps/app/app/admin/schedule/scheduleData.ts
+++ b/apps/app/app/admin/schedule/scheduleData.ts
@@ -20,6 +20,7 @@ import {
     getScheduledFieldsForDay,
     getScheduledOperationsForDay,
 } from './scheduleDayFilters';
+import { getScheduleCalendarDateKey } from './scheduleTimeZone';
 
 const operationsBackDays = 90;
 
@@ -101,14 +102,13 @@ export const getScheduleDeliveryRequests = cache(async () => {
     return getDeliveryRequestsSummary();
 });
 
-export const getScheduleDayData = cache(
+const getScheduleDayDataByDateKey = cache(
     async (dateKey: string, isToday: boolean) => {
         const timeZone = await getScheduleTimeZone();
 
         return cacheScheduleRead(
             `${scheduleCacheKeys.adminDay(dateKey, isToday)}:timeZone:${encodeURIComponent(timeZone)}`,
             async () => {
-                const date = new Date(dateKey);
                 const [raisedBeds, operations, deliveryRequests] =
                     await Promise.all([
                         getScheduleRaisedBeds(),
@@ -117,23 +117,24 @@ export const getScheduleDayData = cache(
                     ]);
 
                 return {
+                    dateKey,
                     raisedBeds,
                     timeZone,
                     scheduledFields: getScheduledFieldsForDay(
                         isToday,
-                        date,
+                        dateKey,
                         raisedBeds,
                         timeZone,
                     ),
                     scheduledOperations: getScheduledOperationsForDay(
                         isToday,
-                        date,
+                        dateKey,
                         operations,
                         timeZone,
                     ),
                     todaysDeliveryRequests: getDayDeliveryRequests(
                         isToday,
-                        date,
+                        dateKey,
                         deliveryRequests,
                         timeZone,
                     ),
@@ -143,3 +144,10 @@ export const getScheduleDayData = cache(
         );
     },
 );
+
+export function getScheduleDayData(date: Date, isToday: boolean) {
+    return getScheduleDayDataByDateKey(
+        getScheduleCalendarDateKey(date),
+        isToday,
+    );
+}

--- a/apps/app/app/admin/schedule/scheduleData.ts
+++ b/apps/app/app/admin/schedule/scheduleData.ts
@@ -2,10 +2,14 @@ import 'server-only';
 
 import {
     cacheScheduleRead,
+    DEFAULT_ADMIN_TIME_ZONE,
     getAllOperations,
     getAllRaisedBeds,
     getDeliveryRequestsSummary,
     getEntitiesFormatted,
+    getSetting,
+    isAdminGeneralSettingValue,
+    SettingsKeys,
     scheduleCacheKeys,
     scheduleCacheTtls,
 } from '@gredice/storage';
@@ -45,6 +49,14 @@ export const getSchedulePlantSorts = cache(async () => {
 
 export const getScheduleOperationsData = cache(async () => {
     return getEntitiesFormatted<EntityStandardized>('operation');
+});
+
+export const getScheduleTimeZone = cache(async () => {
+    const setting = await getSetting(SettingsKeys.AdminGeneral);
+
+    return isAdminGeneralSettingValue(setting?.value)
+        ? setting.value.timeZone
+        : DEFAULT_ADMIN_TIME_ZONE;
 });
 
 export const getScheduleOperations = cache(async () => {
@@ -91,8 +103,10 @@ export const getScheduleDeliveryRequests = cache(async () => {
 
 export const getScheduleDayData = cache(
     async (dateKey: string, isToday: boolean) => {
+        const timeZone = await getScheduleTimeZone();
+
         return cacheScheduleRead(
-            scheduleCacheKeys.adminDay(dateKey, isToday),
+            `${scheduleCacheKeys.adminDay(dateKey, isToday)}:timeZone:${encodeURIComponent(timeZone)}`,
             async () => {
                 const date = new Date(dateKey);
                 const [raisedBeds, operations, deliveryRequests] =
@@ -104,20 +118,24 @@ export const getScheduleDayData = cache(
 
                 return {
                     raisedBeds,
+                    timeZone,
                     scheduledFields: getScheduledFieldsForDay(
                         isToday,
                         date,
                         raisedBeds,
+                        timeZone,
                     ),
                     scheduledOperations: getScheduledOperationsForDay(
                         isToday,
                         date,
                         operations,
+                        timeZone,
                     ),
                     todaysDeliveryRequests: getDayDeliveryRequests(
                         isToday,
                         date,
                         deliveryRequests,
+                        timeZone,
                     ),
                 };
             },

--- a/apps/app/app/admin/schedule/scheduleDayFilters.ts
+++ b/apps/app/app/admin/schedule/scheduleDayFilters.ts
@@ -6,15 +6,16 @@ import {
     isOperationPendingVerification,
     OPERATION_STATUSES_TO_INCLUDE,
 } from './scheduleShared';
+import { getScheduleDateKey } from './scheduleTimeZone';
 import type { DeliveryRequest, Operation, RaisedBed } from './types';
 
 export function getScheduledFieldsForDay(
     isToday: boolean,
     date: Date,
     raisedBeds: RaisedBed[],
+    timeZone: string,
 ) {
-    const normalizedDate = new Date(date);
-    normalizedDate.setHours(0, 0, 0, 0);
+    const dateKey = getScheduleDateKey(date, timeZone);
 
     return raisedBeds
         .filter((raisedBed) => Boolean(raisedBed.physicalId))
@@ -35,28 +36,36 @@ export function getScheduledFieldsForDay(
                     return isToday;
                 }
 
-                const sowDate = new Date(field.plantSowDate);
+                const sowDateKey = getScheduleDateKey(
+                    new Date(field.plantSowDate),
+                    timeZone,
+                );
                 return (
-                    sowDate.toDateString() === normalizedDate.toDateString() ||
-                    (isToday && normalizedDate > sowDate)
+                    sowDateKey === dateKey || (isToday && sowDateKey < dateKey)
                 );
             }
 
             if (field.plantStatus === 'sowed' && field.plantSowDate) {
-                const sowDate = new Date(field.plantSowDate);
-                return sowDate.toDateString() === normalizedDate.toDateString();
+                return (
+                    getScheduleDateKey(
+                        new Date(field.plantSowDate),
+                        timeZone,
+                    ) === dateKey
+                );
             }
 
             if (!field.plantScheduledDate) {
                 return isToday;
             }
 
-            const scheduledDate = new Date(field.plantScheduledDate);
+            const scheduledDateKey = getScheduleDateKey(
+                new Date(field.plantScheduledDate),
+                timeZone,
+            );
 
             return (
-                normalizedDate.toDateString() ===
-                    scheduledDate.toDateString() ||
-                (isToday && normalizedDate > scheduledDate)
+                scheduledDateKey === dateKey ||
+                (isToday && scheduledDateKey < dateKey)
             );
         });
 }
@@ -65,9 +74,9 @@ export function getScheduledOperationsForDay(
     isToday: boolean,
     date: Date,
     operations: Operation[],
+    timeZone: string,
 ) {
-    const normalizedDate = new Date(date);
-    normalizedDate.setHours(0, 0, 0, 0);
+    const dateKey = getScheduleDateKey(date, timeZone);
 
     return operations.filter((operation) => {
         if (!OPERATION_STATUSES_TO_INCLUDE.has(operation.status)) {
@@ -86,32 +95,35 @@ export function getScheduledOperationsForDay(
                 return isToday;
             }
 
-            const completedDate = new Date(operation.completedAt);
+            const completedDateKey = getScheduleDateKey(
+                new Date(operation.completedAt),
+                timeZone,
+            );
             return (
-                completedDate.toDateString() ===
-                    normalizedDate.toDateString() ||
-                (isToday && normalizedDate > completedDate)
+                completedDateKey === dateKey ||
+                (isToday && completedDateKey < dateKey)
             );
         }
 
         if (isOperationCompleted(operation.status) && operation.completedAt) {
-            const completedDate = new Date(operation.completedAt);
             return (
-                completedDate.toDateString() === normalizedDate.toDateString()
+                getScheduleDateKey(
+                    new Date(operation.completedAt),
+                    timeZone,
+                ) === dateKey
             );
         }
 
-        const scheduledDate = operation.scheduledDate
-            ? new Date(operation.scheduledDate)
+        const scheduledDateKey = operation.scheduledDate
+            ? getScheduleDateKey(new Date(operation.scheduledDate), timeZone)
             : undefined;
         const sameDay =
-            scheduledDate !== undefined &&
-            normalizedDate.toDateString() === scheduledDate.toDateString();
-        const isUnscheduledToday = scheduledDate === undefined && isToday;
+            scheduledDateKey !== undefined && scheduledDateKey === dateKey;
+        const isUnscheduledToday = scheduledDateKey === undefined && isToday;
         const isOverdueToday =
-            scheduledDate !== undefined &&
+            scheduledDateKey !== undefined &&
             isToday &&
-            normalizedDate > scheduledDate &&
+            scheduledDateKey < dateKey &&
             !isOperationCompleted(operation.status) &&
             !isOperationPendingVerification(operation.status) &&
             !isOperationCancelled(operation.status);
@@ -124,10 +136,9 @@ export function getDayDeliveryRequests(
     isToday: boolean,
     date: Date,
     deliveryRequests: DeliveryRequest[],
+    timeZone: string,
 ) {
-    const normalizedDate = new Date(date);
-    normalizedDate.setHours(0, 0, 0, 0);
-    const dateString = normalizedDate.toDateString();
+    const dateKey = getScheduleDateKey(date, timeZone);
 
     return deliveryRequests
         .filter((request) => {
@@ -136,10 +147,11 @@ export function getDayDeliveryRequests(
                 : undefined;
 
             if (slotStart) {
-                const sameDay = slotStart.toDateString() === dateString;
+                const slotDateKey = getScheduleDateKey(slotStart, timeZone);
+                const sameDay = slotDateKey === dateKey;
                 const overdueToday =
                     isToday &&
-                    slotStart < normalizedDate &&
+                    slotDateKey < dateKey &&
                     request.state !== 'fulfilled' &&
                     request.state !== 'cancelled';
                 return sameDay || overdueToday;

--- a/apps/app/app/admin/schedule/scheduleDayFilters.ts
+++ b/apps/app/app/admin/schedule/scheduleDayFilters.ts
@@ -11,12 +11,10 @@ import type { DeliveryRequest, Operation, RaisedBed } from './types';
 
 export function getScheduledFieldsForDay(
     isToday: boolean,
-    date: Date,
+    dateKey: string,
     raisedBeds: RaisedBed[],
     timeZone: string,
 ) {
-    const dateKey = getScheduleDateKey(date, timeZone);
-
     return raisedBeds
         .filter((raisedBed) => Boolean(raisedBed.physicalId))
         .flatMap((raisedBed) => raisedBed.fields)
@@ -72,12 +70,10 @@ export function getScheduledFieldsForDay(
 
 export function getScheduledOperationsForDay(
     isToday: boolean,
-    date: Date,
+    dateKey: string,
     operations: Operation[],
     timeZone: string,
 ) {
-    const dateKey = getScheduleDateKey(date, timeZone);
-
     return operations.filter((operation) => {
         if (!OPERATION_STATUSES_TO_INCLUDE.has(operation.status)) {
             return false;
@@ -134,12 +130,10 @@ export function getScheduledOperationsForDay(
 
 export function getDayDeliveryRequests(
     isToday: boolean,
-    date: Date,
+    dateKey: string,
     deliveryRequests: DeliveryRequest[],
     timeZone: string,
 ) {
-    const dateKey = getScheduleDateKey(date, timeZone);
-
     return deliveryRequests
         .filter((request) => {
             const slotStart = request.slot?.startAt

--- a/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
+++ b/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
@@ -15,6 +15,7 @@ import type { Operation, RaisedBed, RaisedBedField } from './types.ts';
 
 const today = new Date(2026, 4, 14);
 const yesterdayNoon = new Date(2026, 4, 13, 12);
+const scheduleTimeZone = 'Europe/Zagreb';
 
 function buildField(overrides: Partial<RaisedBedField>): RaisedBedField {
     return {
@@ -90,10 +91,12 @@ test('pending verification sowing remains visible today until verified', () => {
     });
 
     assert.deepEqual(
-        getScheduledFieldsForDay(true, today, [
-            buildRaisedBed(pendingField),
-            buildRaisedBed(verifiedField),
-        ]).map((field) => field.id),
+        getScheduledFieldsForDay(
+            true,
+            today,
+            [buildRaisedBed(pendingField), buildRaisedBed(verifiedField)],
+            scheduleTimeZone,
+        ).map((field) => field.id),
         [1],
     );
 });
@@ -110,11 +113,54 @@ test('pending verification operation remains visible today until verified', () =
     });
 
     assert.deepEqual(
-        getScheduledOperationsForDay(true, today, [
-            pendingOperation,
-            verifiedOperation,
-        ]).map((operation) => operation.id),
+        getScheduledOperationsForDay(
+            true,
+            today,
+            [pendingOperation, verifiedOperation],
+            scheduleTimeZone,
+        ).map((operation) => operation.id),
         [1],
+    );
+});
+
+test('tomorrow tasks stay out of today when local midnight is the previous UTC day', () => {
+    const july11 = new Date('2026-07-11T00:00:00.000Z');
+    const july12 = new Date('2026-07-12T00:00:00.000Z');
+    const july12InZagreb = new Date('2026-07-11T22:00:56.865Z');
+    const operation = buildOperation({ scheduledDate: july12InZagreb });
+    const field = buildField({ plantScheduledDate: july12InZagreb });
+    const raisedBeds = [buildRaisedBed(field)];
+
+    assert.deepEqual(
+        getScheduledOperationsForDay(
+            true,
+            july11,
+            [operation],
+            scheduleTimeZone,
+        ),
+        [],
+    );
+    assert.deepEqual(
+        getScheduledFieldsForDay(true, july11, raisedBeds, scheduleTimeZone),
+        [],
+    );
+    assert.deepEqual(
+        getScheduledOperationsForDay(
+            false,
+            july12,
+            [operation],
+            scheduleTimeZone,
+        ).map((item) => item.id),
+        [operation.id],
+    );
+    assert.deepEqual(
+        getScheduledFieldsForDay(
+            false,
+            july12,
+            raisedBeds,
+            scheduleTimeZone,
+        ).map((item) => item.id),
+        [field.id],
     );
 });
 

--- a/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
+++ b/apps/app/app/admin/schedule/scheduleDayFilters.unit.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    getDayDeliveryRequests,
     getScheduledFieldsForDay,
     getScheduledOperationsForDay,
 } from './scheduleDayFilters.ts';
@@ -11,9 +12,15 @@ import {
     isDayBulkOperationApprovalTargetVisible,
     isDayBulkOperationAssignmentTargetVisible,
 } from './scheduleOptimisticHelpers.ts';
-import type { Operation, RaisedBed, RaisedBedField } from './types.ts';
+import { isSameScheduleDay } from './scheduleShared.ts';
+import type {
+    DeliveryRequest,
+    Operation,
+    RaisedBed,
+    RaisedBedField,
+} from './types.ts';
 
-const today = new Date(2026, 4, 14);
+const todayKey = '2026-05-14';
 const yesterdayNoon = new Date(2026, 4, 13, 12);
 const scheduleTimeZone = 'Europe/Zagreb';
 
@@ -93,7 +100,7 @@ test('pending verification sowing remains visible today until verified', () => {
     assert.deepEqual(
         getScheduledFieldsForDay(
             true,
-            today,
+            todayKey,
             [buildRaisedBed(pendingField), buildRaisedBed(verifiedField)],
             scheduleTimeZone,
         ).map((field) => field.id),
@@ -115,7 +122,7 @@ test('pending verification operation remains visible today until verified', () =
     assert.deepEqual(
         getScheduledOperationsForDay(
             true,
-            today,
+            todayKey,
             [pendingOperation, verifiedOperation],
             scheduleTimeZone,
         ).map((operation) => operation.id),
@@ -124,8 +131,8 @@ test('pending verification operation remains visible today until verified', () =
 });
 
 test('tomorrow tasks stay out of today when local midnight is the previous UTC day', () => {
-    const july11 = new Date('2026-07-11T00:00:00.000Z');
-    const july12 = new Date('2026-07-12T00:00:00.000Z');
+    const july11 = '2026-07-11';
+    const july12 = '2026-07-12';
     const july12InZagreb = new Date('2026-07-11T22:00:56.865Z');
     const operation = buildOperation({ scheduledDate: july12InZagreb });
     const field = buildField({ plantScheduledDate: july12InZagreb });
@@ -161,6 +168,72 @@ test('tomorrow tasks stay out of today when local midnight is the previous UTC d
             scheduleTimeZone,
         ).map((item) => item.id),
         [field.id],
+    );
+});
+
+test('selected calendar day does not shift in a time zone west of UTC', () => {
+    const newYorkTimeZone = 'America/New_York';
+    const selectedDateKey = '2026-07-11';
+    const operation = buildOperation({
+        scheduledDate: new Date('2026-07-11T12:00:00.000Z'),
+    });
+    const field = buildField({
+        plantScheduledDate: new Date('2026-07-11T12:00:00.000Z'),
+    });
+    const slotDate = new Date('2026-07-11T12:00:00.000Z');
+    const deliveryRequest: DeliveryRequest = {
+        id: 'delivery-1',
+        state: 'scheduled',
+        slot: {
+            id: 1,
+            locationId: 1,
+            type: 'delivery',
+            startAt: slotDate,
+            endAt: new Date('2026-07-11T14:00:00.000Z'),
+            closesAt: null,
+            status: 'scheduled',
+            createdAt: slotDate,
+            updatedAt: slotDate,
+        },
+        surveySent: false,
+        createdAt: slotDate,
+        updatedAt: slotDate,
+    };
+
+    assert.deepEqual(
+        getScheduledOperationsForDay(
+            false,
+            selectedDateKey,
+            [operation],
+            newYorkTimeZone,
+        ).map((item) => item.id),
+        [operation.id],
+    );
+    assert.deepEqual(
+        getScheduledFieldsForDay(
+            false,
+            selectedDateKey,
+            [buildRaisedBed(field)],
+            newYorkTimeZone,
+        ).map((item) => item.id),
+        [field.id],
+    );
+    assert.deepEqual(
+        getDayDeliveryRequests(
+            false,
+            selectedDateKey,
+            [deliveryRequest],
+            newYorkTimeZone,
+        ).map((item) => item.id),
+        [deliveryRequest.id],
+    );
+    assert.equal(
+        isSameScheduleDay(
+            operation.scheduledDate,
+            selectedDateKey,
+            newYorkTimeZone,
+        ),
+        true,
     );
 });
 

--- a/apps/app/app/admin/schedule/scheduleShared.ts
+++ b/apps/app/app/admin/schedule/scheduleShared.ts
@@ -1,4 +1,5 @@
 import type { EntityStandardized } from '../../../lib/@types/EntityStandardized';
+import { getScheduleDateKey } from './scheduleTimeZone';
 import type { RaisedBed } from './types';
 
 export type RaisedBedScheduleGroup = {
@@ -138,6 +139,7 @@ export function getScheduleTaskRowClassName({
 export function isSameScheduleDay(
     left: Date | string | null | undefined,
     right: Date | string | null | undefined,
+    timeZone: string,
 ) {
     if (!left || !right) {
         return false;
@@ -154,9 +156,8 @@ export function isSameScheduleDay(
     }
 
     return (
-        leftDate.getFullYear() === rightDate.getFullYear() &&
-        leftDate.getMonth() === rightDate.getMonth() &&
-        leftDate.getDate() === rightDate.getDate()
+        getScheduleDateKey(leftDate, timeZone) ===
+        getScheduleDateKey(rightDate, timeZone)
     );
 }
 

--- a/apps/app/app/admin/schedule/scheduleShared.ts
+++ b/apps/app/app/admin/schedule/scheduleShared.ts
@@ -138,27 +138,20 @@ export function getScheduleTaskRowClassName({
 
 export function isSameScheduleDay(
     left: Date | string | null | undefined,
-    right: Date | string | null | undefined,
+    rightDateKey: string,
     timeZone: string,
 ) {
-    if (!left || !right) {
+    if (!left) {
         return false;
     }
 
     const leftDate = typeof left === 'string' ? new Date(left) : left;
-    const rightDate = typeof right === 'string' ? new Date(right) : right;
 
-    if (
-        !Number.isFinite(leftDate.getTime()) ||
-        !Number.isFinite(rightDate.getTime())
-    ) {
+    if (!Number.isFinite(leftDate.getTime())) {
         return false;
     }
 
-    return (
-        getScheduleDateKey(leftDate, timeZone) ===
-        getScheduleDateKey(rightDate, timeZone)
-    );
+    return getScheduleDateKey(leftDate, timeZone) === rightDateKey;
 }
 
 export function isTaskDateBeforeToday(date: Date | undefined) {

--- a/apps/app/app/admin/schedule/scheduleTimeZone.ts
+++ b/apps/app/app/admin/schedule/scheduleTimeZone.ts
@@ -1,0 +1,13 @@
+export function getScheduleDateKey(date: Date, timeZone: string) {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+        timeZone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    }).formatToParts(date);
+    const values = Object.fromEntries(
+        parts.map((part) => [part.type, part.value]),
+    );
+
+    return `${values.year}-${values.month}-${values.day}`;
+}

--- a/apps/app/app/admin/schedule/scheduleTimeZone.ts
+++ b/apps/app/app/admin/schedule/scheduleTimeZone.ts
@@ -1,3 +1,11 @@
+export function getScheduleCalendarDateKey(date: Date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+
+    return `${year}-${month}-${day}`;
+}
+
 export function getScheduleDateKey(date: Date, timeZone: string) {
     const parts = new Intl.DateTimeFormat('en-CA', {
         timeZone,


### PR DESCRIPTION
## What changed

- compare schedule day keys in the configured backoffice timezone
- apply the same timezone to operation, planting, delivery, and overdue matching
- keep displayed scheduled dates and copied day summaries aligned with that timezone
- add regression coverage for a Zagreb midnight stored on the previous UTC day

## Root cause

The admin schedule grouped tasks with the server process calendar day, while dates were displayed in the browser timezone. For example, a task shown as `12. 07. 2026.` was stored as `2026-07-11T22:00:56.865Z`, so the UTC server comparison incorrectly included it in July 11.

## Validation

- `corepack pnpm --filter app test:unit` (95 tests passed)
- Biome check on all changed files
- `git diff --check`
- direct app TypeScript check was also run; it remains blocked by pre-existing errors outside this diff