### PR TITLE
feat(cjenik): redesign pricing catalog

### DIFF
--- a/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
+++ b/apps/www/app/biljke/[alias]/PlantPageHeader.tsx
@@ -1,4 +1,4 @@
-import type { PlantData, PlantSortData } from '@gredice/client';
+import type { PlantData } from '@gredice/client';
 import { calculatePlantsPerField, FIELD_SIZE_LABEL } from '@gredice/js/plants';
 import { slug } from '@gredice/js/slug';
 import { Chip } from '@gredice/ui/Chip';
@@ -15,6 +15,7 @@ import { AttributeCard } from '../../../components/attributes/DetailCard';
 import { PriceAttributeCard } from '../../../components/attributes/PriceAttributeCard';
 import { CommunityEditButton } from '../../../components/community-edits/CommunityEditButton';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
+import type { PlantSortDataWithRelationships } from '../../../lib/plants/getPlantSortsData';
 import { KnownPages } from '../../../src/KnownPages';
 import { getPlantImageViewTransitionName } from '../plantViewTransition';
 import { getPlantInforationSections } from './getPlantInforationSections';
@@ -27,10 +28,6 @@ type InformationWithAlternativeName = {
     name?: unknown;
     alternativeName?: unknown;
 };
-type PlantSortWithRelationships = PlantSortData & {
-    relationships?: PlantData['relationships'];
-};
-
 type OverviewEditTarget = {
     entityTypeName: 'plant' | 'plantSort';
     entityId: number;
@@ -71,7 +68,7 @@ export function PlantPageHeader({
 }: {
     overviewEditTarget?: OverviewEditTarget;
     plant: PlantData & { isRecommended: boolean | null | undefined };
-    sort?: PlantSortWithRelationships;
+    sort?: PlantSortDataWithRelationships;
 }) {
     const informationSections = getPlantInforationSections(plant, sort);
     const { totalPlants } = calculatePlantsPerField(
@@ -116,13 +113,15 @@ export function PlantPageHeader({
     const alternativeNames =
         formatAlternativeNames(sort?.information) ||
         formatAlternativeNames(plant.information);
-    const plantPrice = plant.prices?.perPlant;
+    const plantPrice = sort ? sort.prices?.perPlant : plant.prices?.perPlant;
     const price =
         typeof plantPrice === 'number'
             ? {
                   currentPrice: plantPrice,
-                  entityId: plant.id,
-                  entityTypeName: 'plant' as const,
+                  entityId: sort?.id ?? plant.id,
+                  entityTypeName: sort
+                      ? ('plantSort' as const)
+                      : ('plant' as const),
               }
             : null;
 

--- a/apps/www/app/biljke/[alias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/page.tsx
@@ -111,7 +111,8 @@ export default async function PlantPage(props: PageProps<'/biljke/[alias]'>) {
                     },
                     url: `https://www.gredice.com${KnownPages.Plant(alias)}`,
                     offers:
-                        typeof plant.prices?.perPlant === 'number'
+                        typeof plant.prices?.perPlant === 'number' &&
+                        plant.prices.perPlant > 0
                             ? {
                                   '@type': 'Offer',
                                   price: plant.prices.perPlant.toFixed(2),

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -178,25 +178,13 @@ export default async function PlantSortPage(
 
     const sortPath = KnownPages.PlantSort(alias, sortData.information.name);
     const sortUrl = `https://www.gredice.com${sortPath}`;
-    const hasPerPlantPrice = typeof basePlantData.prices?.perPlant === 'number';
-    const hasPricedOffer =
-        hasPerPlantPrice && basePlantData.prices.perPlant > 0;
+    const sortPrice = sortData.prices?.perPlant;
+    const hasPerPlantPrice = typeof sortPrice === 'number';
+    const hasPricedOffer = hasPerPlantPrice && sortPrice > 0;
     const relationships = hasPlantRelationships(sortData.relationships)
         ? sortData.relationships
         : basePlantData.relationships;
     const health = basePlantData.health;
-
-    if (!hasPerPlantPrice) {
-        console.error('Missing per-plant price for plant sort product schema', {
-            alias,
-            plantId: basePlantData.id,
-            plantName: basePlantData.information.name,
-            sortAlias: sort,
-            sortId: sortData.id,
-            sortName: sortData.information.name,
-            sortUrl,
-        });
-    }
 
     return (
         <div className="py-8">
@@ -229,9 +217,7 @@ export default async function PlantSortPage(
                                   ? {
                                         offers: {
                                             '@type': 'Offer',
-                                            price: basePlantData.prices.perPlant.toFixed(
-                                                2,
-                                            ),
+                                            price: sortPrice.toFixed(2),
                                             priceCurrency: 'EUR',
                                             availability:
                                                 sortData.store

--- a/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
+++ b/apps/www/app/biljke/[alias]/sorte/[sortAlias]/page.tsx
@@ -179,6 +179,8 @@ export default async function PlantSortPage(
     const sortPath = KnownPages.PlantSort(alias, sortData.information.name);
     const sortUrl = `https://www.gredice.com${sortPath}`;
     const hasPerPlantPrice = typeof basePlantData.prices?.perPlant === 'number';
+    const hasPricedOffer =
+        hasPerPlantPrice && basePlantData.prices.perPlant > 0;
     const relationships = hasPlantRelationships(sortData.relationships)
         ? sortData.relationships
         : basePlantData.relationships;
@@ -223,19 +225,25 @@ export default async function PlantSortPage(
                                   url: `https://www.gredice.com${KnownPages.Plant(alias)}`,
                               },
                               url: sortUrl,
-                              offers: {
-                                  '@type': 'Offer',
-                                  price: basePlantData.prices.perPlant.toFixed(
-                                      2,
-                                  ),
-                                  priceCurrency: 'EUR',
-                                  availability:
-                                      sortData.store?.availableInStore === false
-                                          ? 'https://schema.org/OutOfStock'
-                                          : 'https://schema.org/InStock',
-                                  url: sortUrl,
-                                  hasMerchantReturnPolicy: merchantReturnPolicy,
-                              },
+                              ...(hasPricedOffer
+                                  ? {
+                                        offers: {
+                                            '@type': 'Offer',
+                                            price: basePlantData.prices.perPlant.toFixed(
+                                                2,
+                                            ),
+                                            priceCurrency: 'EUR',
+                                            availability:
+                                                sortData.store
+                                                    ?.availableInStore === false
+                                                    ? 'https://schema.org/OutOfStock'
+                                                    : 'https://schema.org/InStock',
+                                            url: sortUrl,
+                                            hasMerchantReturnPolicy:
+                                                merchantReturnPolicy,
+                                        },
+                                    }
+                                  : {}),
                           }
                         : {
                               '@context': 'https://schema.org',

--- a/apps/www/app/biljke/page.tsx
+++ b/apps/www/app/biljke/page.tsx
@@ -66,7 +66,8 @@ export default async function PlantsPage({
                                 url: `https://www.gredice.com${KnownPages.Plant(plant.information.name)}`,
                                 image: plant.image?.cover?.url,
                                 offers:
-                                    typeof plant.prices?.perPlant === 'number'
+                                    typeof plant.prices?.perPlant ===
+                                        'number' && plant.prices.perPlant > 0
                                         ? {
                                               '@type': 'Offer',
                                               price: plant.prices.perPlant.toFixed(

--- a/apps/www/app/cjenik/PricingCatalogList.tsx
+++ b/apps/www/app/cjenik/PricingCatalogList.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Close, Search } from '@gredice/ui/icons';
+import type { ReactNode } from 'react';
+import { useMemo, useState } from 'react';
+import { normalizeSearchText } from '../../lib/search/normalizeSearchText';
+
+const INITIAL_VISIBLE_ITEMS = 16;
+
+export type PricingCatalogItem = {
+    content: ReactNode;
+    filter: string;
+    id: string;
+    searchText: string;
+};
+
+export type PricingCatalogFilter = {
+    label: string;
+    value: string;
+};
+
+export function PricingCatalogList({
+    columnHeader,
+    emptyMessage,
+    filters,
+    items,
+    searchLabel,
+}: {
+    columnHeader?: ReactNode;
+    emptyMessage: string;
+    filters: PricingCatalogFilter[];
+    items: PricingCatalogItem[];
+    searchLabel: string;
+}) {
+    const [activeFilter, setActiveFilter] = useState(filters[0]?.value ?? '');
+    const [search, setSearch] = useState('');
+    const [visibleItems, setVisibleItems] = useState(INITIAL_VISIBLE_ITEMS);
+    const normalizedSearch = normalizeSearchText(search);
+
+    const filteredItems = useMemo(
+        () =>
+            items.filter(
+                (item) =>
+                    (activeFilter === 'all' || item.filter === activeFilter) &&
+                    (!normalizedSearch ||
+                        normalizeSearchText(item.searchText).includes(
+                            normalizedSearch,
+                        )),
+            ),
+        [activeFilter, items, normalizedSearch],
+    );
+
+    const shownItems = filteredItems.slice(0, visibleItems);
+    const remainingItems = filteredItems.length - shownItems.length;
+
+    function updateSearch(value: string) {
+        setSearch(value);
+        setVisibleItems(INITIAL_VISIBLE_ITEMS);
+    }
+
+    function updateFilter(value: string) {
+        setActiveFilter(value);
+        setVisibleItems(INITIAL_VISIBLE_ITEMS);
+    }
+
+    return (
+        <div>
+            <div className="mb-3 flex flex-col gap-3 rounded-lg border border-primary/15 bg-primary/5 p-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex min-w-0 flex-wrap gap-2">
+                    {filters.map((filter) => (
+                        <Chip
+                            aria-pressed={activeFilter === filter.value}
+                            color={
+                                activeFilter === filter.value
+                                    ? 'primary'
+                                    : 'neutral'
+                            }
+                            key={filter.value}
+                            onClick={() => updateFilter(filter.value)}
+                            variant={
+                                activeFilter === filter.value
+                                    ? 'soft'
+                                    : 'outlined'
+                            }
+                        >
+                            {filter.label}
+                        </Chip>
+                    ))}
+                </div>
+                <div className="flex h-10 w-full min-w-0 items-center rounded-md border border-border bg-background shadow-xs focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 sm:max-w-80">
+                    <Search className="ml-3 size-4 shrink-0 text-muted-foreground" />
+                    <input
+                        aria-label={searchLabel}
+                        className="h-full min-w-0 flex-1 bg-transparent px-3 text-sm outline-hidden placeholder:text-muted-foreground"
+                        onChange={(event) => updateSearch(event.target.value)}
+                        placeholder={searchLabel}
+                        type="search"
+                        value={search}
+                    />
+                    <IconButton
+                        aria-label="Očisti pretragu"
+                        className={search ? 'visible mr-1' : 'invisible mr-1'}
+                        onClick={() => updateSearch('')}
+                        size="sm"
+                        type="button"
+                        variant="plain"
+                    >
+                        <Close className="size-4" />
+                    </IconButton>
+                </div>
+            </div>
+
+            <p className="mb-2 text-xs text-muted-foreground" role="status">
+                {filteredItems.length === 1
+                    ? 'Prikazana je 1 stavka.'
+                    : `Prikazano stavki: ${filteredItems.length}.`}
+            </p>
+
+            {shownItems.length > 0 ? (
+                <div className="overflow-hidden rounded-lg border">
+                    {columnHeader}
+                    {shownItems.map((item) => (
+                        <div className="border-b last:border-b-0" key={item.id}>
+                            {item.content}
+                        </div>
+                    ))}
+                </div>
+            ) : (
+                <div className="rounded-lg border border-dashed bg-muted/30 px-4 py-10 text-center text-sm text-muted-foreground">
+                    {emptyMessage}
+                </div>
+            )}
+
+            {remainingItems > 0 ? (
+                <div className="mt-4 flex justify-center">
+                    <Button
+                        color="neutral"
+                        onClick={() =>
+                            setVisibleItems(
+                                (current) => current + INITIAL_VISIBLE_ITEMS,
+                            )
+                        }
+                        variant="outlined"
+                    >
+                        Prikaži još ({remainingItems})
+                    </Button>
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/www/app/cjenik/page.tsx
+++ b/apps/www/app/cjenik/page.tsx
@@ -1,12 +1,24 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
 import { Container } from '@gredice/ui/Container';
+import {
+    Hammer,
+    Navigate,
+    Sprout,
+    Sun,
+    Truck,
+    Warning,
+} from '@gredice/ui/icons';
 import { OperationImage } from '@gredice/ui/OperationImage';
 import { PageHeader } from '@gredice/ui/PageHeader';
 import { PlantOrSortImage } from '@gredice/ui/plants';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import type { Metadata } from 'next';
+import type { Metadata, Route } from 'next';
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { formatPrice } from '../../lib/formatPrice';
 import { getHqLocationsData } from '../../lib/getHqLocationsData';
@@ -15,6 +27,10 @@ import { getPlantSortsData } from '../../lib/plants/getPlantSortsData';
 import { getPlantsData } from '../../lib/plants/getPlantsData';
 import { getPublicSunflowerPackages } from '../../lib/sunflowerPackages';
 import { KnownPages } from '../../src/KnownPages';
+import {
+    type PricingCatalogItem,
+    PricingCatalogList,
+} from './PricingCatalogList';
 import { getPricingCatalogHistory, pricingHistoryKey } from './pricingHistory';
 import {
     buildDeliveryPricingRows,
@@ -26,12 +42,125 @@ import { ThirtyDayMinimumPrice } from './ThirtyDayMinimumPrice';
 export const metadata: Metadata = {
     title: 'Cjenik',
     description:
-        'Pregled svih cijena: paketi suncokreta, biljke, radnje i dostava na jednom mjestu.',
+        'Pregled cijena i dostupnosti paketa suncokreta, biljaka, sorti, radnji i dostave.',
 };
 
 const sunflowerFormatter = new Intl.NumberFormat('hr-HR', {
     maximumFractionDigits: 0,
 });
+
+function itemCountLabel(count: number) {
+    return count === 1 ? '1 stavka' : `${count} stavki`;
+}
+
+function CatalogSectionHeader({
+    count,
+    description,
+    headingId,
+    icon,
+    title,
+}: {
+    count: number;
+    description: string;
+    headingId: string;
+    icon: ReactNode;
+    title: string;
+}) {
+    return (
+        <CardHeader className="flex-row items-start justify-between gap-4 p-4 pb-2">
+            <div className="flex min-w-0 items-start gap-3">
+                <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary [&>svg]:size-5">
+                    {icon}
+                </span>
+                <div className="min-w-0">
+                    <CardTitle className="text-xl" id={headingId}>
+                        {title}
+                    </CardTitle>
+                    <Typography level="body2" secondary className="mt-1">
+                        {description}
+                    </Typography>
+                </div>
+            </div>
+            <Chip color="neutral" size="sm" variant="soft">
+                {itemCountLabel(count)}
+            </Chip>
+        </CardHeader>
+    );
+}
+
+function CatalogColumnHeader({ itemLabel }: { itemLabel: string }) {
+    return (
+        <div
+            aria-hidden="true"
+            className="hidden grid-cols-[minmax(0,1fr)_20rem_1.25rem] gap-3 border-b bg-muted/30 px-3 py-2 text-xs font-medium text-muted-foreground md:grid"
+        >
+            <span>{itemLabel}</span>
+            <span className="grid grid-cols-2 gap-6 text-right">
+                <span>Cijena</span>
+                <span>Najniža u 30 dana</span>
+            </span>
+            <span />
+        </div>
+    );
+}
+
+function CatalogRow({
+    badge,
+    currentValue,
+    href,
+    minimumValue,
+    subtitle,
+    title,
+    visual,
+}: {
+    badge?: ReactNode;
+    currentValue: ReactNode;
+    href: Route;
+    minimumValue?: ReactNode;
+    subtitle: string;
+    title: string;
+    visual: ReactNode;
+}) {
+    return (
+        <Link
+            className="group grid grid-cols-[minmax(0,1fr)_minmax(7rem,auto)] items-center gap-3 bg-card p-3 transition-colors hover:bg-primary/5 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring md:grid-cols-[minmax(0,1fr)_20rem_1.25rem]"
+            href={href}
+        >
+            <span className="flex min-w-0 items-center gap-3">
+                <span className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-muted-foreground">
+                    {visual}
+                </span>
+                <span className="min-w-0">
+                    <span className="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2">
+                        <span className="line-clamp-2 min-w-0 font-medium group-hover:underline group-hover:underline-offset-2 md:truncate">
+                            {title}
+                        </span>
+                        {badge}
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                        {subtitle}
+                    </span>
+                </span>
+            </span>
+            <span className="grid min-w-0 gap-1 text-right md:grid-cols-2 md:items-center md:gap-6">
+                <span className="font-medium tabular-nums">{currentValue}</span>
+                {minimumValue ? (
+                    <span>
+                        <span className="block text-[11px] font-normal text-muted-foreground md:hidden">
+                            Najniža u 30 dana
+                        </span>
+                        {minimumValue}
+                    </span>
+                ) : (
+                    <span className="hidden text-muted-foreground md:block">
+                        —
+                    </span>
+                )}
+            </span>
+            <Navigate className="hidden size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground md:block" />
+        </Link>
+    );
+}
 
 export default async function PricingPage() {
     const [
@@ -61,219 +190,304 @@ export default async function PricingPage() {
         deliveryRows: deliveryPricingRows,
     });
 
+    const plantItems: PricingCatalogItem[] = plantPricingRows.map((row) => {
+        const isAvailable = row.price > 0;
+        return {
+            id: row.id,
+            filter: row.kind,
+            searchText: `${row.label} ${row.kind === 'sort' ? row.parentLabel : 'biljka'}`,
+            content: (
+                <CatalogRow
+                    badge={
+                        isAvailable ? undefined : (
+                            <Chip color="neutral" size="sm" variant="outlined">
+                                Nije dostupno
+                            </Chip>
+                        )
+                    }
+                    currentValue={
+                        isAvailable ? formatPrice(row.price) : 'Nije dostupno'
+                    }
+                    href={row.href}
+                    minimumValue={
+                        isAvailable ? (
+                            <ThirtyDayMinimumPrice
+                                currentPrice={row.price}
+                                history={
+                                    pricingHistory[
+                                        pricingHistoryKey(
+                                            row.kind === 'plant'
+                                                ? 'plant'
+                                                : 'plantSort',
+                                            row.entityId,
+                                        )
+                                    ]
+                                }
+                            />
+                        ) : undefined
+                    }
+                    subtitle={
+                        row.kind === 'plant'
+                            ? 'Biljka'
+                            : `Sorta · ${row.parentLabel}`
+                    }
+                    title={row.label}
+                    visual={
+                        row.kind === 'plant' ? (
+                            <PlantOrSortImage
+                                alt={`Slika biljke ${row.label}`}
+                                className="size-10 object-cover"
+                                height={40}
+                                plant={row.plant}
+                                width={40}
+                            />
+                        ) : (
+                            <PlantOrSortImage
+                                alt={`Slika sorte ${row.label}`}
+                                className="size-10 object-cover"
+                                height={40}
+                                plantSort={row.plantSort}
+                                width={40}
+                            />
+                        )
+                    }
+                />
+            ),
+        };
+    });
+
+    const operationItems: PricingCatalogItem[] = operationPricingRows.map(
+        (row) => {
+            const isAvailable = row.availability === 'available';
+            const isInternal = row.availability === 'internal';
+            return {
+                id: row.id,
+                filter: row.availability,
+                searchText: `${row.label} ${row.stageLabel} ${
+                    isInternal
+                        ? 'interna radnja bez naplate OPG partneri'
+                        : isAvailable
+                          ? 'dostupno'
+                          : 'nije dostupno'
+                }`,
+                content: (
+                    <CatalogRow
+                        badge={
+                            isInternal ? (
+                                <Chip color="warning" size="sm" variant="soft">
+                                    Interna radnja
+                                </Chip>
+                            ) : isAvailable ? undefined : (
+                                <Chip
+                                    color="neutral"
+                                    size="sm"
+                                    variant="outlined"
+                                >
+                                    Nije dostupno
+                                </Chip>
+                            )
+                        }
+                        currentValue={
+                            isInternal
+                                ? 'Bez naplate'
+                                : isAvailable
+                                  ? formatPrice(row.price)
+                                  : 'Nije dostupno'
+                        }
+                        href={row.href}
+                        minimumValue={
+                            isAvailable ? (
+                                <ThirtyDayMinimumPrice
+                                    currentPrice={row.price}
+                                    history={
+                                        pricingHistory[
+                                            pricingHistoryKey(
+                                                'operation',
+                                                row.entityId,
+                                            )
+                                        ]
+                                    }
+                                />
+                            ) : undefined
+                        }
+                        subtitle={
+                            isInternal
+                                ? `${row.stageLabel} · Za OPG partnere`
+                                : row.stageLabel
+                        }
+                        title={row.label}
+                        visual={
+                            <OperationImage
+                                className="rounded-md bg-muted text-muted-foreground"
+                                operation={row.operation}
+                                size={40}
+                            />
+                        }
+                    />
+                ),
+            };
+        },
+    );
+
     return (
-        <Container maxWidth="lg">
-            <Stack spacing={4}>
+        <Container className="pb-12" maxWidth="lg">
+            <Stack spacing={6}>
                 <PageHeader
-                    padded
                     header="💶 Cjenik"
-                    subHeader="Sve cijene na jednom mjestu: paketi suncokreta, biljke, sorte, radnje i dostava"
+                    subHeader="Jasan pregled cijena i dostupnosti paketa suncokreta, biljaka, sorti, radnji i dostave."
+                    headerChildren={
+                        <div className="space-y-2">
+                            <div className="flex flex-wrap gap-2">
+                                <Chip color="warning" size="sm" variant="soft">
+                                    Interna radnja
+                                </Chip>
+                                <Chip
+                                    color="neutral"
+                                    size="sm"
+                                    variant="outlined"
+                                >
+                                    Nije dostupno
+                                </Chip>
+                            </div>
+                            <Typography level="body3" secondary>
+                                Interne radnje namijenjene su OPG partnerima i
+                                ne naplaćuju se. Cijena 0 € za biljku, sortu ili
+                                javnu radnju znači da trenutačno nije dostupna.
+                            </Typography>
+                        </div>
+                    }
                 />
 
-                <Card>
-                    <CardHeader className="flex-row items-center justify-between">
-                        <CardTitle>Paketi suncokreta</CardTitle>
-                        <FeedbackModal topic="www/pricing/sunflowers" />
-                    </CardHeader>
-                    <CardContent>
-                        <Stack spacing={3}>
-                            <Typography level="body2" secondary>
-                                Suncokreti su prepaid Gredice bodovi za vrtne
-                                akcije. Kod korištenja salda vrijedi
-                                orijentacijski odnos 1 EUR ≈ 1.000 suncokreta, a
-                                bonus se dodaje kao dodatni broj suncokreta.
-                            </Typography>
-                            {sunflowerPackages.length > 0 ? (
-                                <div className="overflow-x-auto">
-                                    <table className="w-full border-collapse">
-                                        <thead>
-                                            <tr className="border-b">
-                                                <th className="py-2 pr-4 text-left">
-                                                    Paket
-                                                </th>
-                                                <th className="py-2 pr-4 text-right">
-                                                    Suncokreti
-                                                </th>
-                                                <th className="py-2 pr-4 text-right">
-                                                    Bonus
-                                                </th>
-                                                <th className="py-2 text-right">
-                                                    Cijena
-                                                </th>
-                                                <th className="py-2 pl-4 text-right">
-                                                    Najniža cijena u 30 dana
-                                                </th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {sunflowerPackages.map((pkg) => (
-                                                <tr
-                                                    key={pkg.code}
-                                                    className="border-b last:border-b-0"
-                                                >
-                                                    <td className="py-2 pr-4 align-middle">
-                                                        <span className="block font-medium">
-                                                            {pkg.name}
-                                                        </span>
-                                                        <span className="block text-xs text-muted-foreground">
-                                                            {pkg.isOneTime
-                                                                ? 'Jednokratna ponuda'
-                                                                : pkg.role ===
-                                                                    'upsell'
-                                                                  ? 'Najveći paket'
-                                                                  : (pkg.tag ??
-                                                                    'Glavni paket')}
-                                                        </span>
-                                                    </td>
-                                                    <td className="py-2 pr-4 text-right font-medium tabular-nums">
-                                                        {sunflowerFormatter.format(
-                                                            pkg.sunflowers,
-                                                        )}
-                                                    </td>
-                                                    <td className="py-2 pr-4 text-right tabular-nums">
-                                                        {pkg.bonusSunflowers > 0
-                                                            ? `+${sunflowerFormatter.format(pkg.bonusSunflowers)}`
-                                                            : '-'}
-                                                    </td>
-                                                    <td className="py-2 text-right font-medium">
-                                                        {formatPrice(
-                                                            pkg.priceEur,
-                                                        )}
-                                                    </td>
-                                                    <td className="py-2 pl-4 text-right">
-                                                        <ThirtyDayMinimumPrice
-                                                            currentPrice={
-                                                                pkg.priceEur
-                                                            }
-                                                            history={
-                                                                pricingHistory[
-                                                                    pricingHistoryKey(
-                                                                        'sunflowerPackage',
-                                                                        pkg.entityId,
-                                                                    )
-                                                                ]
-                                                            }
-                                                        />
-                                                    </td>
-                                                </tr>
-                                            ))}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            ) : (
-                                <Typography level="body2" secondary>
-                                    Paketi se trenutno ne mogu učitati. Aktualni
-                                    saldo i kupnja dostupni su u vrtu.
-                                </Typography>
-                            )}
-                            <Typography level="body2" secondary>
-                                Detalje o korištenju salda pročitaj na stranici{' '}
-                                <Link
-                                    className="underline"
-                                    href={KnownPages.Sunflowers}
-                                >
-                                    Suncokreti
-                                </Link>
-                                .
-                            </Typography>
-                        </Stack>
-                    </CardContent>
-                </Card>
+                <nav
+                    aria-label="Dijelovi cjenika"
+                    className="sticky top-16 z-20 -mx-2 flex gap-2 overflow-x-auto rounded-lg border bg-background/95 p-2 shadow-xs backdrop-blur-sm"
+                >
+                    <Chip color="neutral" href="#suncokreti" variant="soft">
+                        Suncokreti
+                    </Chip>
+                    <Chip color="neutral" href="#biljke-i-sorte" variant="soft">
+                        Biljke i sorte
+                    </Chip>
+                    <Chip color="neutral" href="#radnje" variant="soft">
+                        Radnje
+                    </Chip>
+                    <Chip color="neutral" href="#dostava" variant="soft">
+                        Dostava
+                    </Chip>
+                </nav>
 
-                <Card>
-                    <CardHeader className="flex-row items-center justify-between">
-                        <CardTitle>
-                            Cijene biljaka i sorti (po biljci)
-                        </CardTitle>
-                        <FeedbackModal topic="www/pricing/plants" />
-                    </CardHeader>
-                    <CardContent>
-                        <div className="overflow-x-auto">
-                            <table className="w-full border-collapse">
-                                <thead>
-                                    <tr className="border-b">
-                                        <th className="text-left py-2 pr-4">
-                                            Biljka ili sorta
-                                        </th>
-                                        <th className="text-right py-2">
-                                            Cijena
-                                        </th>
-                                        <th className="py-2 pl-4 text-right">
-                                            Najniža cijena u 30 dana
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {plantPricingRows.map((row) => (
-                                        <tr
-                                            key={row.id}
-                                            className="border-b last:border-b-0"
-                                        >
-                                            <td className="py-2 pr-4 align-middle">
-                                                <div className="flex min-w-56 items-center gap-3">
-                                                    {row.kind === 'plant' ? (
-                                                        <PlantOrSortImage
-                                                            plant={row.plant}
-                                                            alt={`Slika biljke ${row.label}`}
-                                                            width={40}
-                                                            height={40}
-                                                            className="size-10 rounded-md object-cover"
-                                                        />
-                                                    ) : (
-                                                        <PlantOrSortImage
-                                                            plantSort={
-                                                                row.plantSort
-                                                            }
-                                                            alt={`Slika sorte ${row.label}`}
-                                                            width={40}
-                                                            height={40}
-                                                            className="size-10 rounded-md object-cover"
-                                                        />
-                                                    )}
-                                                    <span className="min-w-0">
-                                                        <Link
-                                                            className="block truncate font-medium underline underline-offset-2"
-                                                            href={row.href}
-                                                        >
-                                                            {row.label}
-                                                        </Link>
-                                                        <span className="block truncate text-xs text-muted-foreground">
-                                                            {row.kind ===
-                                                            'plant'
-                                                                ? 'Biljka'
-                                                                : `Sorta - ${row.parentLabel}`}
-                                                        </span>
-                                                    </span>
-                                                </div>
-                                            </td>
-                                            <td className="py-2 text-right font-medium">
-                                                {formatPrice(row.price)}
-                                            </td>
-                                            <td className="py-2 pl-4 text-right">
+                <Card className="scroll-mt-28" id="suncokreti">
+                    <CatalogSectionHeader
+                        count={sunflowerPackages.length}
+                        description="Prepaid Gredice bodovi za radnje u vrtu. Orijentacijski odnos je 1 EUR ≈ 1.000 suncokreta."
+                        headingId="suncokreti-naslov"
+                        icon={<Sun />}
+                        title="Paketi suncokreta"
+                    />
+                    <CardContent className="p-4 pt-2">
+                        {sunflowerPackages.length > 0 ? (
+                            <div className="overflow-hidden rounded-lg border">
+                                <CatalogColumnHeader itemLabel="Paket" />
+                                {sunflowerPackages.map((pkg) => (
+                                    <div
+                                        className="border-b last:border-b-0"
+                                        key={pkg.code}
+                                    >
+                                        <CatalogRow
+                                            currentValue={formatPrice(
+                                                pkg.priceEur,
+                                            )}
+                                            href={KnownPages.Sunflowers}
+                                            minimumValue={
                                                 <ThirtyDayMinimumPrice
-                                                    currentPrice={row.price}
+                                                    currentPrice={pkg.priceEur}
                                                     history={
                                                         pricingHistory[
                                                             pricingHistoryKey(
-                                                                row.kind ===
-                                                                    'plant'
-                                                                    ? 'plant'
-                                                                    : 'plantSort',
-                                                                row.entityId,
+                                                                'sunflowerPackage',
+                                                                pkg.entityId,
                                                             )
                                                         ]
                                                     }
                                                 />
-                                            </td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                        </div>
+                                            }
+                                            subtitle={`${sunflowerFormatter.format(pkg.sunflowers)} suncokreta${
+                                                pkg.bonusSunflowers > 0
+                                                    ? ` + ${sunflowerFormatter.format(pkg.bonusSunflowers)} bonus`
+                                                    : ''
+                                            } · ${
+                                                pkg.isOneTime
+                                                    ? 'Jednokratna ponuda'
+                                                    : (pkg.tag ??
+                                                      'Paket suncokreta')
+                                            }`}
+                                            title={pkg.name}
+                                            visual={
+                                                <Sun className="size-5 text-primary" />
+                                            }
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <Alert color="neutral" startDecorator={<Warning />}>
+                                <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                    <span>
+                                        Paketi se trenutačno ne mogu učitati.
+                                        Aktualni saldo i kupnja dostupni su u
+                                        vrtu.
+                                    </span>
+                                    <Button
+                                        className="shrink-0"
+                                        href={KnownPages.GardenApp}
+                                        size="sm"
+                                        variant="outlined"
+                                    >
+                                        Moj vrt
+                                    </Button>
+                                </div>
+                            </Alert>
+                        )}
+                        <Typography level="body2" secondary className="mt-3">
+                            Detalje o saldu, bonusima i korištenju pročitaj na
+                            stranici{' '}
+                            <Link
+                                className="underline underline-offset-2"
+                                href={KnownPages.Sunflowers}
+                            >
+                                Suncokreti
+                            </Link>
+                            .
+                        </Typography>
+                    </CardContent>
+                </Card>
+
+                <Card className="scroll-mt-28" id="biljke-i-sorte">
+                    <CatalogSectionHeader
+                        count={plantPricingRows.length}
+                        description="Cijena po posađenoj biljci, uz zasebne cijene sorti kada su definirane."
+                        headingId="biljke-i-sorte-naslov"
+                        icon={<Sprout />}
+                        title="Biljke i sorte"
+                    />
+                    <CardContent className="p-4 pt-2">
+                        <PricingCatalogList
+                            columnHeader={
+                                <CatalogColumnHeader itemLabel="Biljka ili sorta" />
+                            }
+                            emptyMessage="Nema biljaka ili sorti koje odgovaraju pretrazi."
+                            filters={[
+                                { label: 'Sve', value: 'all' },
+                                { label: 'Biljke', value: 'plant' },
+                                { label: 'Sorte', value: 'sort' },
+                            ]}
+                            items={plantItems}
+                            searchLabel="Pretraži biljke i sorte"
+                        />
                         <Typography level="body2" secondary className="mt-3">
                             Za biljke i sorte vrijedi{' '}
                             <Link
-                                className="underline"
+                                className="underline underline-offset-2"
                                 href={KnownPages.Refunds}
                             >
                                 30-dnevna politika povrata novca
@@ -283,75 +497,36 @@ export default async function PricingPage() {
                     </CardContent>
                 </Card>
 
-                <Card>
-                    <CardHeader className="flex-row items-center justify-between">
-                        <CardTitle>Cijene radnji (po radnji)</CardTitle>
-                        <FeedbackModal topic="www/pricing/operations" />
-                    </CardHeader>
-                    <CardContent>
-                        <div className="overflow-x-auto">
-                            <table className="w-full border-collapse">
-                                <thead>
-                                    <tr className="border-b">
-                                        <th className="text-left py-2 pr-4">
-                                            Radnja
-                                        </th>
-                                        <th className="text-right py-2">
-                                            Cijena
-                                        </th>
-                                        <th className="py-2 pl-4 text-right">
-                                            Najniža cijena u 30 dana
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {operationPricingRows.map((row) => (
-                                        <tr
-                                            key={row.id}
-                                            className="border-b last:border-b-0"
-                                        >
-                                            <td className="py-2 pr-4 align-middle">
-                                                <div className="flex min-w-56 items-center gap-3">
-                                                    <OperationImage
-                                                        operation={
-                                                            row.operation
-                                                        }
-                                                        size={40}
-                                                        className="rounded-md bg-muted text-muted-foreground"
-                                                    />
-                                                    <Link
-                                                        className="block min-w-0 truncate font-medium underline underline-offset-2"
-                                                        href={row.href}
-                                                    >
-                                                        {row.label}
-                                                    </Link>
-                                                </div>
-                                            </td>
-                                            <td className="py-2 text-right font-medium">
-                                                {formatPrice(row.price)}
-                                            </td>
-                                            <td className="py-2 pl-4 text-right">
-                                                <ThirtyDayMinimumPrice
-                                                    currentPrice={row.price}
-                                                    history={
-                                                        pricingHistory[
-                                                            pricingHistoryKey(
-                                                                'operation',
-                                                                row.entityId,
-                                                            )
-                                                        ]
-                                                    }
-                                                />
-                                            </td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                        </div>
+                <Card className="scroll-mt-28" id="radnje">
+                    <CatalogSectionHeader
+                        count={operationPricingRows.length}
+                        description="Cijene po radnji, uključujući jasno označene interne i trenutačno nedostupne radnje."
+                        headingId="radnje-naslov"
+                        icon={<Hammer />}
+                        title="Radnje"
+                    />
+                    <CardContent className="p-4 pt-2">
+                        <PricingCatalogList
+                            columnHeader={
+                                <CatalogColumnHeader itemLabel="Radnja" />
+                            }
+                            emptyMessage="Nema radnji koje odgovaraju pretrazi."
+                            filters={[
+                                { label: 'Sve', value: 'all' },
+                                { label: 'Dostupne', value: 'available' },
+                                { label: 'Interne', value: 'internal' },
+                                {
+                                    label: 'Nije dostupno',
+                                    value: 'unavailable',
+                                },
+                            ]}
+                            items={operationItems}
+                            searchLabel="Pretraži radnje"
+                        />
                         <Typography level="body2" secondary className="mt-3">
-                            Za radnje vrijedi{' '}
+                            Za dostupne radnje koje se naplaćuju vrijedi{' '}
                             <Link
-                                className="underline"
+                                className="underline underline-offset-2"
                                 href={KnownPages.Refunds}
                             >
                                 30-dnevna politika povrata novca
@@ -361,90 +536,79 @@ export default async function PricingPage() {
                     </CardContent>
                 </Card>
 
-                <Card>
-                    <CardHeader className="flex-row items-center justify-between">
-                        <CardTitle>Cijene dostave</CardTitle>
-                        <FeedbackModal topic="www/pricing/delivery" />
-                    </CardHeader>
-                    <CardContent>
-                        <div className="overflow-x-auto">
-                            <table className="w-full border-collapse">
-                                <thead>
-                                    <tr className="border-b">
-                                        <th className="text-left py-2 pr-4">
-                                            Lokacija
-                                        </th>
-                                        <th className="text-right py-2 pr-4">
-                                            Besplatna zona
-                                        </th>
-                                        <th className="text-right py-2 pr-4">
-                                            Maks. zona
-                                        </th>
-                                        <th className="text-right py-2">
-                                            Cijena po km
-                                        </th>
-                                        <th className="py-2 pl-4 text-right">
-                                            Najniža cijena u 30 dana
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {deliveryPricingRows.map((row) => (
-                                        <tr
-                                            key={row.id}
-                                            className="border-b last:border-b-0"
-                                        >
-                                            <td className="py-2 pr-4">
-                                                <Link
-                                                    className="font-medium underline underline-offset-2"
-                                                    href={row.href}
-                                                >
-                                                    {row.label}
-                                                </Link>
-                                            </td>
-                                            <td className="py-2 text-right pr-4">
-                                                {row.freeRadius} km
-                                            </td>
-                                            <td className="py-2 text-right pr-4">
-                                                {row.zoneRadius} km
-                                            </td>
-                                            <td className="py-2 text-right font-medium">
-                                                {formatPrice(
-                                                    row.pricePerKilometer,
-                                                )}
-                                            </td>
-                                            <td className="py-2 pl-4 text-right">
-                                                <ThirtyDayMinimumPrice
-                                                    currentPrice={
-                                                        row.pricePerKilometer
-                                                    }
-                                                    history={
-                                                        pricingHistory[
-                                                            pricingHistoryKey(
-                                                                'hqLocations',
-                                                                row.entityId,
-                                                            )
-                                                        ]
-                                                    }
-                                                />
-                                            </td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
+                <Card className="scroll-mt-28" id="dostava">
+                    <CatalogSectionHeader
+                        count={deliveryPricingRows.length}
+                        description="Za svaku lokaciju prikazane su besplatna zona, maksimalna zona i cijena po kilometru."
+                        headingId="dostava-naslov"
+                        icon={<Truck />}
+                        title="Dostava"
+                    />
+                    <CardContent className="p-4 pt-2">
+                        <div className="overflow-hidden rounded-lg border">
+                            <CatalogColumnHeader itemLabel="Lokacija" />
+                            {deliveryPricingRows.map((row) => (
+                                <div
+                                    className="border-b last:border-b-0"
+                                    key={row.id}
+                                >
+                                    <CatalogRow
+                                        currentValue={`${formatPrice(row.pricePerKilometer)} / km`}
+                                        href={row.href}
+                                        minimumValue={
+                                            <ThirtyDayMinimumPrice
+                                                currentPrice={
+                                                    row.pricePerKilometer
+                                                }
+                                                history={
+                                                    pricingHistory[
+                                                        pricingHistoryKey(
+                                                            'hqLocations',
+                                                            row.entityId,
+                                                        )
+                                                    ]
+                                                }
+                                            />
+                                        }
+                                        subtitle={`Prvih ${row.freeRadius} km bez naknade · dostupno do ${row.zoneRadius} km`}
+                                        title={row.label}
+                                        visual={
+                                            <Truck className="size-5 text-primary" />
+                                        }
+                                    />
+                                </div>
+                            ))}
+                        </div>
+                        <div className="mt-3 flex justify-end">
+                            <Button
+                                endDecorator={<Navigate className="size-4" />}
+                                href={KnownPages.Delivery}
+                                variant="outlined"
+                            >
+                                Više o dostavi
+                            </Button>
                         </div>
                     </CardContent>
                 </Card>
 
                 <Card>
-                    <CardHeader>
-                        <CardTitle>Podijeli povratnu informaciju</CardTitle>
-                    </CardHeader>
-                    <CardContent className="flex items-center justify-between gap-4">
-                        <Typography level="body2" secondary>
-                            Nedostaje li cijena ili želiš predložiti poboljšanje
-                            cjenika?
-                        </Typography>
+                    <CardContent
+                        className="flex flex-col items-start justify-between gap-4 p-4 sm:flex-row sm:items-center"
+                        noHeader
+                    >
+                        <div>
+                            <Typography level="h5" component="h2">
+                                Podijeli povratnu informaciju
+                            </Typography>
+                            <Typography
+                                level="body2"
+                                secondary
+                                className="mt-1"
+                            >
+                                Nedostaje li cijena ili želiš predložiti
+                                poboljšanje cjenika?
+                            </Typography>
+                        </div>
                         <FeedbackModal topic="www/pricing" />
                     </CardContent>
                 </Card>

--- a/apps/www/app/cjenik/pricingHistory.ts
+++ b/apps/www/app/cjenik/pricingHistory.ts
@@ -80,24 +80,29 @@ export async function getPricingCatalogHistory({
                 currentPrice: pkg.priceEur,
             }),
         ),
-        ...plantRows.map((row) =>
-            priceHistoryRequest({
-                entityId: row.entityId,
-                entityTypeName: row.kind === 'plant' ? 'plant' : 'plantSort',
-                attributeCategory: 'prices',
-                attributeName: 'perPlant',
-                currentPrice: row.price,
-            }),
-        ),
-        ...operationRows.map((row) =>
-            priceHistoryRequest({
-                entityId: row.entityId,
-                entityTypeName: 'operation',
-                attributeCategory: 'prices',
-                attributeName: 'perOperation',
-                currentPrice: row.price,
-            }),
-        ),
+        ...plantRows
+            .filter((row) => row.price > 0)
+            .map((row) =>
+                priceHistoryRequest({
+                    entityId: row.entityId,
+                    entityTypeName:
+                        row.kind === 'plant' ? 'plant' : 'plantSort',
+                    attributeCategory: 'prices',
+                    attributeName: 'perPlant',
+                    currentPrice: row.price,
+                }),
+            ),
+        ...operationRows
+            .filter((row) => row.availability === 'available')
+            .map((row) =>
+                priceHistoryRequest({
+                    entityId: row.entityId,
+                    entityTypeName: 'operation',
+                    attributeCategory: 'prices',
+                    attributeName: 'perOperation',
+                    currentPrice: row.price,
+                }),
+            ),
         ...deliveryRows.map((row) =>
             priceHistoryRequest({
                 entityId: row.entityId,

--- a/apps/www/app/cjenik/pricingRows.node.spec.ts
+++ b/apps/www/app/cjenik/pricingRows.node.spec.ts
@@ -129,7 +129,7 @@ test('buildPlantPricingRows includes plant sorts with their own numeric price an
     );
 });
 
-test('buildPlantPricingRows keeps zero-price entries so they can be marked unavailable', () => {
+test('buildPlantPricingRows keeps zero-price plants and sorts so they can be marked unavailable', () => {
     const rows = buildPlantPricingRows(
         [
             {
@@ -138,11 +138,28 @@ test('buildPlantPricingRows keeps zero-price entries so they can be marked unava
                 prices: { perPlant: 0 },
             },
         ],
-        [],
+        [
+            {
+                id: 15,
+                information: {
+                    name: 'Nedostupna sorta',
+                    plant: {
+                        id: 14,
+                        information: { name: 'Nedostupna biljka' },
+                    },
+                },
+                prices: { perPlant: 0 },
+            },
+        ],
     );
 
-    assert.equal(rows.length, 1);
-    assert.equal(rows[0]?.price, 0);
+    assert.deepEqual(
+        rows.map(({ kind, price }) => ({ kind, price })),
+        [
+            { kind: 'plant', price: 0 },
+            { kind: 'sort', price: 0 },
+        ],
+    );
 });
 
 test('buildOperationPricingRows includes operations only when numeric prices exist and links public operation pages', () => {

--- a/apps/www/app/cjenik/pricingRows.node.spec.ts
+++ b/apps/www/app/cjenik/pricingRows.node.spec.ts
@@ -129,6 +129,22 @@ test('buildPlantPricingRows includes plant sorts with their own numeric price an
     );
 });
 
+test('buildPlantPricingRows keeps zero-price entries so they can be marked unavailable', () => {
+    const rows = buildPlantPricingRows(
+        [
+            {
+                id: 14,
+                information: { name: 'Nedostupna biljka' },
+                prices: { perPlant: 0 },
+            },
+        ],
+        [],
+    );
+
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]?.price, 0);
+});
+
 test('buildOperationPricingRows includes operations only when numeric prices exist and links public operation pages', () => {
     const rows = buildOperationPricingRows([
         {
@@ -159,6 +175,63 @@ test('buildOperationPricingRows includes operations only when numeric prices exi
                 price: 4,
             },
             { href: '/radnje/zalijevanje', label: 'Zalijevanje', price: 1.25 },
+        ],
+    );
+});
+
+test('buildOperationPricingRows distinguishes paid, internal, and unavailable operations', () => {
+    const rows = buildOperationPricingRows([
+        {
+            id: 24,
+            information: { label: 'Plaćena radnja' },
+            attributes: {
+                internal: false,
+                stage: { information: { label: 'Održavanje' } },
+            },
+            prices: { perOperation: 0.5 },
+        },
+        {
+            id: 25,
+            information: { label: 'Interna radnja' },
+            attributes: {
+                internal: true,
+                stage: { information: { label: 'Evidencija' } },
+            },
+            prices: { perOperation: 99 },
+        },
+        {
+            id: 26,
+            information: { label: 'Nedostupna radnja' },
+            attributes: {
+                internal: false,
+                stage: { information: { label: 'Berba' } },
+            },
+            prices: { perOperation: 0 },
+        },
+    ]);
+
+    assert.deepEqual(
+        rows.map(({ availability, label, stageLabel }) => ({
+            availability,
+            label,
+            stageLabel,
+        })),
+        [
+            {
+                availability: 'internal',
+                label: 'Interna radnja',
+                stageLabel: 'Evidencija',
+            },
+            {
+                availability: 'unavailable',
+                label: 'Nedostupna radnja',
+                stageLabel: 'Berba',
+            },
+            {
+                availability: 'available',
+                label: 'Plaćena radnja',
+                stageLabel: 'Održavanje',
+            },
         ],
     );
 });

--- a/apps/www/app/cjenik/pricingRows.ts
+++ b/apps/www/app/cjenik/pricingRows.ts
@@ -1,5 +1,9 @@
 import type { Route } from 'next';
 import { PublicDirectoryPaths } from '../../../../packages/directory-types/src/publicUrls.ts';
+import {
+    getOperationPriceAvailability,
+    type OperationPriceAvailability,
+} from '../../lib/operationPricing.ts';
 
 type EntityId = number | string;
 
@@ -53,6 +57,14 @@ type NamedPlantSort = PerPlantPrice & {
 type NamedOperation = PerOperationPrice & {
     id: EntityId;
     slug?: string | null;
+    attributes?: {
+        internal?: boolean;
+        stage?: {
+            information?: {
+                label?: string | null;
+            } | null;
+        } | null;
+    } | null;
     information: {
         label: string;
     };
@@ -104,6 +116,8 @@ export type OperationPricingRow<
     href: Route;
     entityId: EntityId;
     price: number;
+    availability: OperationPriceAvailability;
+    stageLabel: string;
     operation: TOperation;
 };
 
@@ -212,6 +226,9 @@ export function buildOperationPricingRows<TOperation extends NamedOperation>(
             ),
             entityId: operation.id,
             price: operation.prices.perOperation,
+            availability: getOperationPriceAvailability(operation),
+            stageLabel:
+                operation.attributes?.stage?.information?.label ?? 'Radnja',
             operation,
         }))
         .sort((first, second) =>

--- a/apps/www/app/radnje/[alias]/page.tsx
+++ b/apps/www/app/radnje/[alias]/page.tsx
@@ -15,6 +15,7 @@ import { PriceAttributeCard } from '../../../components/attributes/PriceAttribut
 import { CommunityEditButton } from '../../../components/community-edits/CommunityEditButton';
 import { FeedbackModal } from '../../../components/shared/feedback/FeedbackModal';
 import { StructuredDataScript } from '../../../components/shared/seo/StructuredDataScript';
+import { getOperationPriceAvailability } from '../../../lib/operationPricing';
 import { getOperationsData } from '../../../lib/plants/getOperationsData';
 import { KnownPages } from '../../../src/KnownPages';
 import { merchantReturnPolicy } from '../../../src/merchantReturnPolicy';
@@ -75,6 +76,7 @@ export default async function OperationPage(
     const operationPath = KnownPages.Operation(
         operation.slug || operation.information.label,
     );
+    const priceAvailability = getOperationPriceAvailability(operation);
 
     return (
         <div className="operation-page py-8">
@@ -93,14 +95,20 @@ export default async function OperationPage(
                         name: 'Gredice',
                     },
                     url: `https://www.gredice.com${operationPath}`,
-                    offers: {
-                        '@type': 'Offer',
-                        price: operation.prices.perOperation.toFixed(2),
-                        priceCurrency: 'EUR',
-                        availability: 'https://schema.org/InStock',
-                        url: `https://www.gredice.com${operationPath}`,
-                        hasMerchantReturnPolicy: merchantReturnPolicy,
-                    },
+                    ...(priceAvailability === 'available'
+                        ? {
+                              offers: {
+                                  '@type': 'Offer',
+                                  price: operation.prices.perOperation.toFixed(
+                                      2,
+                                  ),
+                                  priceCurrency: 'EUR',
+                                  availability: 'https://schema.org/InStock',
+                                  url: `https://www.gredice.com${operationPath}`,
+                                  hasMerchantReturnPolicy: merchantReturnPolicy,
+                              },
+                          }
+                        : {}),
                 }}
             />
             <Stack spacing={8}>
@@ -139,6 +147,7 @@ export default async function OperationPage(
                                     entityId={operation.id}
                                     entityTypeName="operation"
                                     currentPrice={operation.prices.perOperation}
+                                    availability={priceAvailability}
                                 />
                             </div>
                             <Row spacing={1} className="self-end">
@@ -157,16 +166,18 @@ export default async function OperationPage(
                                     }}
                                 />
                             </Row>
-                            <Typography level="body2" secondary>
-                                Nisi zadovoljan uslugom? Dostupan je{' '}
-                                <Link
-                                    className="underline"
-                                    href={KnownPages.Refunds}
-                                >
-                                    povrat novca do 30 dana
-                                </Link>
-                                .
-                            </Typography>
+                            {priceAvailability === 'available' && (
+                                <Typography level="body2" secondary>
+                                    Nisi zadovoljan uslugom? Dostupan je{' '}
+                                    <Link
+                                        className="underline"
+                                        href={KnownPages.Refunds}
+                                    >
+                                        povrat novca do 30 dana
+                                    </Link>
+                                    .
+                                </Typography>
+                            )}
                             {harvestPlantRemovalDescription && (
                                 <Typography level="body2" secondary>
                                     {harvestPlantRemovalDescription}

--- a/apps/www/app/radnje/page.tsx
+++ b/apps/www/app/radnje/page.tsx
@@ -7,6 +7,7 @@ import { Suspense } from 'react';
 import { FeedbackModal } from '../../components/shared/feedback/FeedbackModal';
 import { PageFilterInput } from '../../components/shared/PageFilterInput';
 import { StructuredDataScript } from '../../components/shared/seo/StructuredDataScript';
+import { getOperationPriceAvailability } from '../../lib/operationPricing';
 import { getOperationsData } from '../../lib/plants/getOperationsData';
 import { KnownPages } from '../../src/KnownPages';
 import { merchantReturnPolicy } from '../../src/merchantReturnPolicy';
@@ -66,15 +67,20 @@ export default async function OperationsPage({
                                 name: operation.information.label,
                                 url: `https://www.gredice.com${KnownPages.Operation(operation.information.label)}`,
                                 image: operation.image?.cover?.url,
-                                offers: {
-                                    '@type': 'Offer',
-                                    price: operation.prices.perOperation.toFixed(
-                                        2,
-                                    ),
-                                    priceCurrency: 'EUR',
-                                    hasMerchantReturnPolicy:
-                                        merchantReturnPolicy,
-                                },
+                                ...(getOperationPriceAvailability(operation) ===
+                                'available'
+                                    ? {
+                                          offers: {
+                                              '@type': 'Offer',
+                                              price: operation.prices.perOperation.toFixed(
+                                                  2,
+                                              ),
+                                              priceCurrency: 'EUR',
+                                              hasMerchantReturnPolicy:
+                                                  merchantReturnPolicy,
+                                          },
+                                      }
+                                    : {}),
                             },
                         }),
                     ),

--- a/apps/www/components/attributes/PriceAttributeCard.tsx
+++ b/apps/www/components/attributes/PriceAttributeCard.tsx
@@ -2,8 +2,10 @@ import {
     type EntityPriceHistorySummary,
     getEntityPriceHistory,
 } from '@gredice/storage';
+import { Chip } from '@gredice/ui/Chip';
 import type { ReactNode } from 'react';
 import { formatPrice } from '../../lib/formatPrice';
+import type { OperationPriceAvailability } from '../../lib/operationPricing';
 import { AttributeCard } from './DetailCard';
 
 const changeDateFormatter = new Intl.DateTimeFormat('hr-HR', {
@@ -67,6 +69,7 @@ export async function PriceAttributeCard({
     entityId,
     entityTypeName,
     currentPrice,
+    availability,
     description,
     navigateLabel,
     navigateHref,
@@ -76,10 +79,42 @@ export async function PriceAttributeCard({
     entityId: number;
     entityTypeName: PriceEntityTypeName;
     currentPrice: number;
+    availability?: OperationPriceAvailability;
     description?: string;
     navigateLabel?: string;
     navigateHref?: string;
 }) {
+    const resolvedAvailability =
+        availability ?? (currentPrice > 0 ? 'available' : 'unavailable');
+
+    if (resolvedAvailability !== 'available') {
+        return (
+            <AttributeCard
+                icon={icon}
+                header={header}
+                description={description}
+                navigateLabel={navigateLabel}
+                navigateHref={navigateHref}
+                value={
+                    resolvedAvailability === 'internal' ? (
+                        <span className="block">
+                            <Chip color="warning" size="sm" variant="soft">
+                                Interna radnja
+                            </Chip>
+                            <span className="mt-1 block font-semibold">
+                                Bez naplate
+                            </span>
+                        </span>
+                    ) : (
+                        <Chip color="neutral" size="sm" variant="outlined">
+                            Nije dostupno
+                        </Chip>
+                    )
+                }
+            />
+        );
+    }
+
     const history = await getPriceHistory({
         entityId,
         entityTypeName,

--- a/apps/www/lib/operationPricing.ts
+++ b/apps/www/lib/operationPricing.ts
@@ -1,0 +1,24 @@
+export type OperationPriceAvailability =
+    | 'available'
+    | 'internal'
+    | 'unavailable';
+
+type OperationPricingData = {
+    attributes?: {
+        internal?: boolean;
+    } | null;
+    prices?: {
+        perOperation?: number | null;
+    } | null;
+};
+
+export function getOperationPriceAvailability(
+    operation: OperationPricingData,
+): OperationPriceAvailability {
+    if (operation.attributes?.internal === true) {
+        return 'internal';
+    }
+
+    const price = operation.prices?.perOperation;
+    return typeof price === 'number' && price > 0 ? 'available' : 'unavailable';
+}

--- a/apps/www/lib/plants/getPlantSortsData.ts
+++ b/apps/www/lib/plants/getPlantSortsData.ts
@@ -6,6 +6,7 @@ import {
 import { cache } from 'react';
 
 export type PlantSortDataWithRelationships = PlantSortData & {
+    prices?: PlantData['prices'];
     relationships?: PlantData['relationships'];
 };
 


### PR DESCRIPTION
## Summary

- redesign `/cjenik` as a compact, responsive pricing catalog with sticky section navigation, search, filters, result counts, and incremental loading
- distinguish internal operations from unavailable public items: internal work is labeled and shown as `Bez naplate`, while zero-priced public plants, sorts, and operations are shown as `Nije dostupno`
- keep 30-day minimum prices only for available paid items and align operation/plant detail cards plus structured data with the same availability rules
- improve sunflower-package, delivery, feedback, empty, and mobile states while preserving existing public routes and price-history behavior

## Validation

- `corepack pnpm --filter www run test:pricing` (6 tests)
- `corepack pnpm --filter www typecheck`
- `corepack pnpm --filter www build`
- production browser verification at desktop and mobile widths, including search/filter interaction, internal-operation detail state, structured-data offer omission, error overlays, and horizontal overflow
