### PR TITLE
fix(app): show raised-bed milestone dates

### DIFF
--- a/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
+++ b/apps/app/components/raised-beds/RaisedBedFieldsTable.tsx
@@ -103,9 +103,11 @@ function getCurrentDateKey(status?: string | null) {
         case 'sowed':
             return 'plantSowDate';
         case 'sprouted':
-        case 'firstFlowers':
-        case 'firstFruitSet':
             return 'plantGrowthDate';
+        case 'firstFlowers':
+            return 'plantFirstFlowersDate';
+        case 'firstFruitSet':
+            return 'plantFirstFruitSetDate';
         case 'ready':
             return 'plantReadyDate';
         case 'harvested':
@@ -132,6 +134,21 @@ function normalizeDate(value?: Date | string | null) {
     }
 
     return value;
+}
+
+function getPlantStatusDate(
+    plantCycle: RaisedBedFieldPlantCycle | undefined,
+    status: string,
+) {
+    const statusChanges = plantCycle?.statusChanges ?? [];
+    for (let index = statusChanges.length - 1; index >= 0; index -= 1) {
+        const statusChange = statusChanges[index];
+        if (statusChange?.status === status) {
+            return statusChange.occurredAt;
+        }
+    }
+
+    return null;
 }
 
 interface RaisedBedFieldsTableProps {
@@ -260,6 +277,18 @@ export async function RaisedBedFieldsTable({
                                 plantGrowthDate: normalizeDate(
                                     plantCycle.plantGrowthDate,
                                 ),
+                                plantFirstFlowersDate: normalizeDate(
+                                    getPlantStatusDate(
+                                        plantCycle,
+                                        'firstFlowers',
+                                    ),
+                                ),
+                                plantFirstFruitSetDate: normalizeDate(
+                                    getPlantStatusDate(
+                                        plantCycle,
+                                        'firstFruitSet',
+                                    ),
+                                ),
                                 plantReadyDate: normalizeDate(
                                     plantCycle.plantReadyDate,
                                 ),
@@ -356,6 +385,22 @@ function RaisedBedFieldTile({
             label: 'Proklijalo',
             value: normalizeDate(field?.plantGrowthDate),
             current: currentDateKey === 'plantGrowthDate',
+        },
+        {
+            key: 'plantFirstFlowersDate',
+            label: 'Prvi cvjetovi',
+            value: normalizeDate(
+                getPlantStatusDate(activePlantCycle, 'firstFlowers'),
+            ),
+            current: currentDateKey === 'plantFirstFlowersDate',
+        },
+        {
+            key: 'plantFirstFruitSetDate',
+            label: 'Prvi plodovi',
+            value: normalizeDate(
+                getPlantStatusDate(activePlantCycle, 'firstFruitSet'),
+            ),
+            current: currentDateKey === 'plantFirstFruitSetDate',
         },
         {
             key: 'plantReadyDate',

--- a/apps/app/components/raised-beds/RaisedBedRemovedFieldsModal.tsx
+++ b/apps/app/components/raised-beds/RaisedBedRemovedFieldsModal.tsx
@@ -25,6 +25,8 @@ export type RemovedFieldDetails = {
     plantScheduledDate?: string | null;
     plantSowDate?: string | null;
     plantGrowthDate?: string | null;
+    plantFirstFlowersDate?: string | null;
+    plantFirstFruitSetDate?: string | null;
     plantReadyDate?: string | null;
     plantHarvestedDate?: string | null;
     plantDeadDate?: string | null;
@@ -48,6 +50,8 @@ const dateEntries: {
     { key: 'plantScheduledDate', label: 'Planirano' },
     { key: 'plantSowDate', label: 'Sijano' },
     { key: 'plantGrowthDate', label: 'Proklijalo' },
+    { key: 'plantFirstFlowersDate', label: 'Prvi cvjetovi' },
+    { key: 'plantFirstFruitSetDate', label: 'Prvi plodovi' },
     { key: 'plantReadyDate', label: 'Spremno' },
     { key: 'plantHarvestedDate', label: 'Ubrano' },
     { key: 'plantDeadDate', label: 'Uginulo' },


### PR DESCRIPTION
## What changed

- show separate dates for the `firstFlowers` and `firstFruitSet` plant milestones in raised-bed field details
- use the exact status event date for the currently selected milestone instead of reusing the sprouting date
- include the same milestone dates in removed-field history

## Why

The admin status dialog only rendered the older lifecycle date fields. Newer statuses such as first flowers and first fruit set were mapped to `plantGrowthDate`, so their own dates were missing and the editable current date could incorrectly show the sprouting date.

## Validation

- `pnpm lint --filter app`
- `pnpm --filter app exec biome check components/raised-beds/RaisedBedFieldsTable.tsx components/raised-beds/RaisedBedRemovedFieldsModal.tsx`
- `git diff --check origin/main...HEAD`

Direct `tsc -p apps/app/tsconfig.json --noEmit` remains blocked by unrelated existing type errors outside the changed files.
