### PR TITLE
fix(garden): align outlet and inventory badge colors

### DIFF
--- a/apps/garden/tests/outlet-hud.spec.tsx
+++ b/apps/garden/tests/outlet-hud.spec.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/experimental-ct-react';
 import { OutletHudStory } from './OutletHudStory';
 
-test('outlet HUD uses a neutral badge for the available item count', async ({
+test('outlet HUD matches the inventory badge colors', async ({
     mount,
     page,
 }) => {
@@ -17,8 +17,11 @@ test('outlet HUD uses a neutral badge for the available item count', async ({
     await expect(outletButton).toBeVisible();
     await expect(outletButton).toHaveAccessibleName('Outlet sadnica');
     await expect(availabilityBadge).toHaveText('4');
-    await expect(availabilityBadge).toHaveClass(/bg-muted/u);
-    await expect(availabilityBadge).toHaveClass(/text-muted-foreground/u);
+    await expect(availabilityBadge).toHaveClass(/bg-tertiary/u);
+    await expect(availabilityBadge).toHaveClass(/text-tertiary-foreground/u);
+    await expect(availabilityBadge).toHaveClass(
+        /border-tertiary-foreground\/30/u,
+    );
     await expect(outletButton.getByText('Outlet', { exact: true })).toHaveCount(
         0,
     );

--- a/packages/game/src/hud/OutletHud.tsx
+++ b/packages/game/src/hud/OutletHud.tsx
@@ -159,7 +159,7 @@ export function OutletHud() {
                                 <div
                                     aria-hidden="true"
                                     className={cx(
-                                        'absolute -top-4 -right-4 flex size-6 items-center justify-center rounded-full border border-border bg-muted px-1.5 text-sm font-semibold leading-none text-muted-foreground shadow-sm',
+                                        'absolute -top-4 -right-4 flex size-6 items-center justify-center rounded-full border border-tertiary-foreground/30 bg-tertiary px-1.5 text-sm font-semibold leading-none text-tertiary-foreground shadow-md',
                                         availableItemsCount > 99 &&
                                             'text-[10px]',
                                     )}


### PR DESCRIPTION
## Summary

- align the outlet availability badge with the inventory badge color treatment
- reuse the same tertiary background, foreground, border, and shadow tokens
- update the outlet component regression test to lock the matching badge colors

## Why

The outlet badge introduced in #4091 used muted tokens while the neighboring inventory badge used the tertiary palette, which made the two otherwise matching HUD counters look inconsistent.

## Validation

- `corepack pnpm lint --filter @gredice/game`
- `corepack pnpm lint --filter garden`
- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter garden`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/outlet-hud.spec.tsx`
- `git diff --check`