### PR TITLE
fix(www): balance navbar CTA spacing

### DIFF
--- a/apps/www/tests/landing.spec.ts
+++ b/apps/www/tests/landing.spec.ts
@@ -229,11 +229,34 @@ test('navbar floats on scroll and landing game frame is rounded', async ({
         .toBeGreaterThanOrEqual(7);
 });
 
-test('desktop floating navbar keeps container width', async ({ page }) => {
+test('desktop floating navbar keeps its width and balanced CTA spacing', async ({
+    page,
+}) => {
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto('/');
 
     const header = page.locator('header');
+    const gardenCta = page.getByRole('link', { name: 'Moj novi vrt' });
+    const gardenCtaIcon = gardenCta.locator('svg:visible').last();
+
+    await expect
+        .poll(async () => {
+            const [buttonBox, iconBox] = await Promise.all([
+                gardenCta.boundingBox(),
+                gardenCtaIcon.boundingBox(),
+            ]);
+            if (!buttonBox || !iconBox) {
+                return Number.POSITIVE_INFINITY;
+            }
+
+            const trailingSpace =
+                buttonBox.x + buttonBox.width - (iconBox.x + iconBox.width);
+            const verticalSpace = (buttonBox.height - iconBox.height) / 2;
+
+            return Math.abs(trailingSpace - verticalSpace);
+        })
+        .toBeLessThanOrEqual(0.5);
+
     await page.evaluate(() => window.scrollTo(0, 160));
     await expectPillBorderRadius(header);
 

--- a/packages/ui/src/PublicChrome/NavUserButton.tsx
+++ b/packages/ui/src/PublicChrome/NavUserButton.tsx
@@ -17,7 +17,7 @@ export function NavUserButton({
     return (
         <NavigatingButton
             href={href}
-            className="shrink-0 whitespace-nowrap rounded-full bg-green-800 px-3 hover:bg-green-700 dark:bg-green-700 dark:text-white dark:hover:bg-green-600 sm:px-4"
+            className="shrink-0 whitespace-nowrap rounded-full bg-green-800 px-3 hover:bg-green-700 dark:bg-green-700 dark:text-white dark:hover:bg-green-600 sm:pl-4"
             endDecorator={
                 <span className="hidden pl-1 sm:inline-flex">
                     <SquareArrowRightEnter aria-hidden className="size-4" />


### PR DESCRIPTION
## Summary

- keep the CTA's existing avatar-side inset while reducing the trailing inset from 16px to 12px
- match the trailing space beside the 16px icon to the 12px vertical inset of the 40px button
- add a Playwright geometry assertion to guard the balanced spacing

## Root cause

The desktop breakpoint applied `px-4`, leaving 16px after the trailing icon while the button's height and icon size produced 12px above and below it.

## Validation

- `corepack pnpm lint --filter @gredice/ui --filter www`
- `corepack pnpm typecheck --filter @gredice/ui --filter www`
- `corepack pnpm build --filter www`
- `corepack pnpm --filter www exec playwright test --project=chromium tests/landing.spec.ts --grep "desktop floating navbar keeps its width and balanced CTA spacing"`
- `git diff --check`