### PR TITLE
fix(game): reset camera when switching gardens

### DIFF
--- a/packages/game/src/GameScene.tsx
+++ b/packages/game/src/GameScene.tsx
@@ -252,7 +252,10 @@ export function GameScene({
     }
     const gardenHomeCamera =
         gardenInitialHomeCameraRef.current.homeCamera ?? undefined;
-    const sceneCameraPosition = gardenHomeCamera?.position ?? cameraPosition;
+    const sceneCameraPosition = useMemo(
+        () => new Vector3(...(gardenHomeCamera?.position ?? cameraPosition)),
+        [cameraPosition, gardenHomeCamera],
+    );
     const sceneCameraTarget = useMemo(
         () =>
             gardenHomeCamera
@@ -451,9 +454,11 @@ export function GameScene({
                             </group>
                             <GameCameraRig
                                 controlsEnabled={!noControls}
+                                initialPosition={sceneCameraPosition}
                                 initialSnapshot={gardenHomeCamera}
                                 initialTarget={sceneCameraTarget}
                                 initialViewKey={gardenInitialViewKey}
+                                initialZoom={sceneCameraZoom}
                             />
                         </BlockInteractionRegistryProvider>
                     </ParticleSystemProvider>

--- a/packages/game/src/controls/GameCameraRig.tsx
+++ b/packages/game/src/controls/GameCameraRig.tsx
@@ -3,10 +3,6 @@
 import { useFrame, useThree } from '@react-three/fiber';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MathUtils, OrthographicCamera, Vector2, Vector3 } from 'three';
-import {
-    defaultGameCameraPosition,
-    defaultGameCameraTarget,
-} from '../gameCamera';
 import { useCurrentGarden } from '../hooks/useCurrentGarden';
 import { useGameState } from '../useGameState';
 import {
@@ -18,6 +14,7 @@ import {
     hasDragEdgeAutopanDelta,
 } from './dragEdgeAutopan';
 import type { GameCameraRigApi, GameCameraSnapshot } from './GameCameraRigApi';
+import { resolveGameCameraInitialView } from './gameCameraInitialView';
 
 const closeupZoom = 300;
 const animationDurationSeconds = 1;
@@ -159,14 +156,18 @@ function toSnapshot({
 
 export function GameCameraRig({
     controlsEnabled,
+    initialPosition,
     initialSnapshot,
     initialTarget,
     initialViewKey,
+    initialZoom,
 }: {
     controlsEnabled: boolean;
+    initialPosition?: Vector3;
     initialSnapshot?: Pick<GameCameraSnapshot, 'position' | 'target' | 'zoom'>;
     initialTarget?: Vector3;
     initialViewKey?: string | number | null;
+    initialZoom?: number;
 }) {
     const { camera, gl, size } = useThree();
     const isOrthographicCamera = camera instanceof OrthographicCamera;
@@ -185,6 +186,7 @@ export function GameCameraRig({
     const worldRotation = useGameState((state) => state.worldRotation);
     const worldRotate = useGameState((state) => state.worldRotate);
     const view = useGameState((state) => state.view);
+    const setView = useGameState((state) => state.setView);
     const closeupBlock = useGameState((state) => state.closeupBlock);
     const isBlockPlacementActive = useGameState(
         (state) =>
@@ -192,22 +194,17 @@ export function GameCameraRig({
     );
     const { data: garden } = useCurrentGarden();
 
-    const resolvedInitialTarget = useMemo(
+    const resolvedInitialView = useMemo(
         () =>
-            initialSnapshot
-                ? new Vector3(...initialSnapshot.target)
-                : (initialTarget?.clone() ??
-                  new Vector3(...defaultGameCameraTarget)),
-        [initialSnapshot, initialTarget],
+            resolveGameCameraInitialView({
+                initialPosition,
+                initialSnapshot,
+                initialTarget,
+                initialZoom,
+            }),
+        [initialPosition, initialSnapshot, initialTarget, initialZoom],
     );
-    const resolvedInitialPosition = useMemo(
-        () =>
-            initialSnapshot
-                ? new Vector3(...initialSnapshot.position)
-                : undefined,
-        [initialSnapshot],
-    );
-    const targetRef = useRef(resolvedInitialTarget.clone());
+    const targetRef = useRef(resolvedInitialView.target.clone());
     const animationRef = useRef<CameraAnimation | null>(null);
     const apiRef = useRef<GameCameraRigApi | null>(null);
     const cameraListenersRef = useRef(
@@ -224,10 +221,11 @@ export function GameCameraRig({
     const initialViewKeyRef = useRef<string | number | null | undefined>(
         undefined,
     );
+    const skipCloseupTransitionRef = useRef(false);
     const normalCameraRef = useRef<NormalCameraSnapshot>({
-        position: new Vector3(...defaultGameCameraPosition),
-        target: new Vector3(...defaultGameCameraTarget),
-        zoom: camera instanceof OrthographicCamera ? camera.zoom : 100,
+        position: resolvedInitialView.position.clone(),
+        target: resolvedInitialView.target.clone(),
+        zoom: resolvedInitialView.zoom,
     });
     const scratchForwardRef = useRef(new Vector3());
     const scratchRightRef = useRef(new Vector3());
@@ -566,15 +564,23 @@ export function GameCameraRig({
             !initializedRef.current ||
             initialViewKeyRef.current !== initialViewKey;
         if (shouldApplyInitialView) {
-            if (resolvedInitialPosition) {
-                camera.position.copy(resolvedInitialPosition);
-                camera.zoom = MathUtils.clamp(
-                    initialSnapshot?.zoom ?? camera.zoom,
-                    minZoom,
-                    maxZoom,
-                );
+            const initialViewChanged = initializedRef.current;
+            animationRef.current = null;
+            setIsAnimating(false);
+            camera.position.copy(resolvedInitialView.position);
+            camera.zoom = MathUtils.clamp(
+                resolvedInitialView.zoom,
+                minZoom,
+                maxZoom,
+            );
+            targetRef.current.copy(resolvedInitialView.target);
+            if (initialViewChanged) {
+                skipCloseupTransitionRef.current = true;
+                previousViewRef.current = 'normal';
+                setCloseupCameraActive(false);
+                setCloseupCameraSettled(false);
+                setView({ view: 'normal' });
             }
-            targetRef.current.copy(resolvedInitialTarget);
             normalCameraRef.current = {
                 position: camera.position.clone(),
                 target: targetRef.current.clone(),
@@ -593,12 +599,13 @@ export function GameCameraRig({
         applyCamera,
         camera,
         flushSnapshot,
-        initialSnapshot?.zoom,
         initialViewKey,
         isOrthographicCamera,
-        resolvedInitialPosition,
-        resolvedInitialTarget,
+        resolvedInitialView,
+        setCloseupCameraActive,
+        setCloseupCameraSettled,
         setGameCamera,
+        setView,
     ]);
 
     useEffect(() => {
@@ -836,6 +843,12 @@ export function GameCameraRig({
 
     useEffect(() => {
         if (!initializedRef.current || !isOrthographicCamera) {
+            return;
+        }
+
+        if (skipCloseupTransitionRef.current) {
+            skipCloseupTransitionRef.current = false;
+            previousViewRef.current = 'normal';
             return;
         }
 

--- a/packages/game/src/controls/gameCameraInitialView.ts
+++ b/packages/game/src/controls/gameCameraInitialView.ts
@@ -1,0 +1,33 @@
+import { Vector3 } from 'three';
+import {
+    defaultGameCameraPosition,
+    defaultGameCameraTarget,
+    defaultGameCameraZoom,
+} from '../gameCamera';
+import type { GameCameraSnapshot } from './GameCameraRigApi';
+
+type GameCameraInitialViewOptions = {
+    initialPosition?: Vector3;
+    initialSnapshot?: Pick<GameCameraSnapshot, 'position' | 'target' | 'zoom'>;
+    initialTarget?: Vector3;
+    initialZoom?: number;
+};
+
+export function resolveGameCameraInitialView({
+    initialPosition,
+    initialSnapshot,
+    initialTarget,
+    initialZoom,
+}: GameCameraInitialViewOptions) {
+    return {
+        position: initialSnapshot
+            ? new Vector3(...initialSnapshot.position)
+            : (initialPosition?.clone() ??
+              new Vector3(...defaultGameCameraPosition)),
+        target: initialSnapshot
+            ? new Vector3(...initialSnapshot.target)
+            : (initialTarget?.clone() ??
+              new Vector3(...defaultGameCameraTarget)),
+        zoom: initialSnapshot?.zoom ?? initialZoom ?? defaultGameCameraZoom,
+    };
+}

--- a/packages/game/src/controls/gameCameraInitialView.unit.ts
+++ b/packages/game/src/controls/gameCameraInitialView.unit.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { Vector3 } from 'three';
+import { resolveGameCameraInitialView } from './gameCameraInitialView';
+
+describe('resolveGameCameraInitialView', () => {
+    it('uses the garden scene defaults when there is no saved home camera', () => {
+        const initialPosition = new Vector3(-80, 90, -70);
+        const initialTarget = new Vector3(4, 0, 6);
+
+        const view = resolveGameCameraInitialView({
+            initialPosition,
+            initialTarget,
+            initialZoom: 75,
+        });
+
+        assert.deepEqual(view.position.toArray(), [-80, 90, -70]);
+        assert.deepEqual(view.target.toArray(), [4, 0, 6]);
+        assert.equal(view.zoom, 75);
+        assert.notEqual(view.position, initialPosition);
+        assert.notEqual(view.target, initialTarget);
+    });
+
+    it('prefers the saved garden home camera', () => {
+        const view = resolveGameCameraInitialView({
+            initialPosition: new Vector3(-100, 100, -100),
+            initialSnapshot: {
+                position: [12, 80, -18],
+                target: [4, 0, -6],
+                zoom: 140,
+            },
+            initialTarget: new Vector3(0, 0, 0),
+            initialZoom: 100,
+        });
+
+        assert.deepEqual(view.position.toArray(), [12, 80, -18]);
+        assert.deepEqual(view.target.toArray(), [4, 0, -6]);
+        assert.equal(view.zoom, 140);
+    });
+});

--- a/packages/game/src/useRaisedBedCloseup.tsx
+++ b/packages/game/src/useRaisedBedCloseup.tsx
@@ -1,12 +1,8 @@
 import { decodeUriComponentSafe } from '@gredice/js/uri';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useCurrentGarden } from './hooks/useCurrentGarden';
 import { useGameState } from './useGameState';
-import {
-    useRaisedBedCloseupParam,
-    useRaisedBedCloseupParams,
-    useRaisedBedFieldDetailsParam,
-} from './useUrlState';
+import { useRaisedBedCloseupParams } from './useUrlState';
 
 export function useRemoveRaisedBedCloseupParam() {
     const [, setRaisedBedCloseupParams] = useRaisedBedCloseupParams();
@@ -31,11 +27,12 @@ export function useSetRaisedBedCloseupParam() {
 
 export function useRaisedBedCloseup() {
     const { data: garden } = useCurrentGarden();
-    const [raisedBedParam, setRaisedBedParam] = useRaisedBedCloseupParam();
-    const [, setFieldDetailsParam] = useRaisedBedFieldDetailsParam();
+    const [{ gredica: raisedBedParam }, setRaisedBedCloseupParams] =
+        useRaisedBedCloseupParams();
     const setView = useGameState((state) => state.setView);
     const closeupBlock = useGameState((state) => state.closeupBlock);
     const view = useGameState((state) => state.view);
+    const previousGardenIdRef = useRef(garden?.id);
 
     const blocks = useMemo(
         () => garden?.stacks.flatMap((stack) => stack.blocks) ?? [],
@@ -43,6 +40,26 @@ export function useRaisedBedCloseup() {
     );
 
     useEffect(() => {
+        const previousGardenId = previousGardenIdRef.current;
+        if (garden?.id !== undefined) {
+            previousGardenIdRef.current = garden.id;
+        }
+
+        if (
+            garden?.id !== undefined &&
+            previousGardenId !== undefined &&
+            previousGardenId !== garden.id
+        ) {
+            if (view === 'closeup') {
+                setView({ view: 'normal' });
+            }
+            void setRaisedBedCloseupParams({
+                gredica: null,
+                polje: null,
+            });
+            return;
+        }
+
         if (!garden || !raisedBedParam) {
             // No raised bed param, reset view if needed
             if (view === 'closeup') {
@@ -68,8 +85,10 @@ export function useRaisedBedCloseup() {
             if (view === 'closeup') {
                 setView({ view: 'normal' });
             }
-            setRaisedBedParam(null);
-            setFieldDetailsParam(null);
+            void setRaisedBedCloseupParams({
+                gredica: null,
+                polje: null,
+            });
             return;
         }
 
@@ -81,8 +100,10 @@ export function useRaisedBedCloseup() {
             if (view === 'closeup') {
                 setView({ view: 'normal' });
             }
-            setRaisedBedParam(null);
-            setFieldDetailsParam(null);
+            void setRaisedBedCloseupParams({
+                gredica: null,
+                polje: null,
+            });
             return;
         }
 
@@ -98,8 +119,7 @@ export function useRaisedBedCloseup() {
         closeupBlock?.id,
         garden,
         raisedBedParam,
-        setFieldDetailsParam,
-        setRaisedBedParam,
+        setRaisedBedCloseupParams,
         setView,
         view,
     ]);

--- a/packages/game/src/viewers/PublicGardenViewer.tsx
+++ b/packages/game/src/viewers/PublicGardenViewer.tsx
@@ -440,11 +440,13 @@ function PublicGardenScene({
                             </Suspense>
                             <GameCameraRig
                                 controlsEnabled={!capture}
+                                initialPosition={initialView.cameraPosition}
                                 initialSnapshot={
                                     garden?.homeCamera ?? undefined
                                 }
                                 initialTarget={initialView.cameraTarget}
                                 initialViewKey={garden?.id ?? 'stacks'}
+                                initialZoom={initialView.cameraZoom}
                             />
                             {capture ? (
                                 <PublicGardenCaptureProbe


### PR DESCRIPTION
## Summary

- reset the camera to the selected garden's saved home view or scene defaults whenever the garden changes
- cancel raised-bed closeup camera state and clear closeup URL parameters during the switch
- apply the same initial-view contract to authenticated and public garden scenes
- add regression coverage for saved and default garden camera resolution

## Testing

- `corepack pnpm --filter @gredice/game test` (396 tests passed)
- `corepack pnpm --filter @gredice/game typecheck`
- `corepack pnpm --filter @gredice/game exec biome check src/controls/GameCameraRig.tsx src/controls/gameCameraInitialView.ts src/controls/gameCameraInitialView.unit.ts src/GameScene.tsx src/viewers/PublicGardenViewer.tsx src/useRaisedBedCloseup.tsx`
- `git diff --check`