### PR TITLE
feat(garden): collapse destructive settings

### DIFF
--- a/apps/garden/tests/garden-tab.spec.tsx
+++ b/apps/garden/tests/garden-tab.spec.tsx
@@ -60,11 +60,12 @@ test.describe('Garden tab', () => {
         mount,
         page,
     }) => {
-        await mount(<GardenTabStory activeRaisedBedCount={2} />);
+        await mount(<GardenTabStory activeRaisedBedCount={0} />);
 
-        await expect(
-            page.getByRole('button', { name: /Zona opasnosti/ }),
-        ).toBeVisible();
+        const dangerZoneButton = page.getByRole('button', {
+            name: /Zona opasnosti/,
+        });
+        await expect(dangerZoneButton).toBeVisible();
         await expect(
             page.getByText('Napuštanje gredice', { exact: true }),
         ).toHaveCount(0);
@@ -80,6 +81,21 @@ test.describe('Garden tab', () => {
         await expect(
             page.getByText('Brisanje vrta', { exact: true }),
         ).toBeVisible();
+        const deleteButton = page.getByRole('button', {
+            name: 'Obriši vrt',
+        });
+        const [dangerZoneBackground, deleteButtonBackground] =
+            await Promise.all([
+                dangerZoneButton.evaluate(
+                    (element) => getComputedStyle(element).backgroundColor,
+                ),
+                deleteButton.evaluate(
+                    (element) => getComputedStyle(element).backgroundColor,
+                ),
+            ]);
+        expect(deleteButtonBackground).not.toBe(dangerZoneBackground);
+        await expect(deleteButton).toHaveCSS('border-top-width', '0px');
+        await expect(deleteButton).toHaveCSS('padding-top', '0px');
     });
 
     test('disables garden deletion while raised beds are active', async ({

--- a/apps/garden/tests/garden-tab.spec.tsx
+++ b/apps/garden/tests/garden-tab.spec.tsx
@@ -1,5 +1,9 @@
-import { expect, test } from '@playwright/experimental-ct-react';
+import { expect, type Page, test } from '@playwright/experimental-ct-react';
 import { GardenTabStory } from './GardenTabStory';
+
+async function openDangerZone(page: Page) {
+    await page.getByRole('button', { name: /Zona opasnosti/ }).click();
+}
 
 test.describe('Garden tab', () => {
     test('saves the current camera snapshot as the garden home position', async ({
@@ -52,13 +56,42 @@ test.describe('Garden tab', () => {
         ).toBeVisible();
     });
 
-    test('disables garden deletion while raised beds are active', async ({
+    test('keeps destructive actions collapsed under the danger zone by default', async ({
         mount,
         page,
     }) => {
         await mount(<GardenTabStory activeRaisedBedCount={2} />);
 
-        await expect(page.getByText('Brisanje vrta')).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: /Zona opasnosti/ }),
+        ).toBeVisible();
+        await expect(
+            page.getByText('Napuštanje gredice', { exact: true }),
+        ).toHaveCount(0);
+        await expect(
+            page.getByText('Brisanje vrta', { exact: true }),
+        ).toHaveCount(0);
+
+        await openDangerZone(page);
+
+        await expect(
+            page.getByText('Napuštanje gredice', { exact: true }),
+        ).toBeVisible();
+        await expect(
+            page.getByText('Brisanje vrta', { exact: true }),
+        ).toBeVisible();
+    });
+
+    test('disables garden deletion while raised beds are active', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<GardenTabStory activeRaisedBedCount={2} />);
+        await openDangerZone(page);
+
+        await expect(
+            page.getByText('Brisanje vrta', { exact: true }),
+        ).toBeVisible();
         await expect(
             page.getByText(
                 'Vrt ima 2 aktivnih gredica. Prvo napusti aktivne gredice, zatim obriši vrt.',
@@ -92,6 +125,7 @@ test.describe('Garden tab', () => {
         );
 
         await mount(<GardenTabStory activeRaisedBedCount={2} />);
+        await openDangerZone(page);
 
         const abandonButton = page.getByRole('button', {
             name: 'Napusti gredicu',
@@ -130,6 +164,7 @@ test.describe('Garden tab', () => {
         page,
     }) => {
         await mount(<GardenTabStory activeRaisedBedCount={0} />);
+        await openDangerZone(page);
 
         await expect(page.getByLabel('Aktivna gredica')).toBeDisabled();
         await expect(
@@ -158,6 +193,7 @@ test.describe('Garden tab', () => {
         );
 
         await mount(<GardenTabStory activeRaisedBedCount={1} />);
+        await openDangerZone(page);
 
         await page.getByLabel('Aktivna gredica').click();
         await page.getByRole('option', { name: 'Gredica 1' }).click();
@@ -197,6 +233,7 @@ test.describe('Garden tab', () => {
         });
 
         await mount(<GardenTabStory activeRaisedBedCount={0} />);
+        await openDangerZone(page);
 
         await page.getByRole('button', { name: 'Obriši vrt' }).click();
         const dialog = page.getByRole('alertdialog', {
@@ -237,6 +274,7 @@ test.describe('Garden tab', () => {
         });
 
         await mount(<GardenTabStory activeRaisedBedCount={0} isSandbox />);
+        await openDangerZone(page);
 
         await page.getByRole('button', { name: 'Obriši vrt' }).click();
         const dialog = page.getByRole('alertdialog', {
@@ -269,6 +307,7 @@ test.describe('Garden tab', () => {
         });
 
         await mount(<GardenTabStory activeRaisedBedCount={0} />);
+        await openDangerZone(page);
 
         await page.getByRole('button', { name: 'Obriši vrt' }).click();
         const dialog = page.getByRole('alertdialog', {

--- a/packages/game/src/modals/components/GardenTab.tsx
+++ b/packages/game/src/modals/components/GardenTab.tsx
@@ -1,7 +1,8 @@
+import { Accordion } from '@gredice/ui/Accordion';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { IconButton } from '@gredice/ui/IconButton';
-import { Add } from '@gredice/ui/icons';
+import { Add, Warning } from '@gredice/ui/icons';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -158,13 +159,39 @@ export function GardenTab() {
                                     gardenName={selectedGarden.name}
                                     isPublic={selectedGarden.isPublic}
                                 />
-                                <RaisedBedAbandonCard
-                                    gardenId={selectedGarden.id}
-                                />
-                                <GardenDangerCard
-                                    gardenId={selectedGarden.id}
-                                    gardenName={selectedGarden.name}
-                                />
+                                <Accordion
+                                    className="[&_button]:rounded-lg [&_button]:border [&_button]:border-red-200 [&_button]:bg-red-50/80 [&_button]:p-4 [&_button]:shadow-xs [&_button]:hover:bg-red-100/80 dark:[&_button]:border-red-900/60 dark:[&_button]:bg-red-950/80 dark:[&_button]:hover:bg-red-950"
+                                    unmountOnExit
+                                    variant="plain"
+                                >
+                                    <Row
+                                        alignItems="start"
+                                        className="min-w-0"
+                                        spacing={4}
+                                    >
+                                        <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-red-100 text-red-700 ring-4 ring-red-200/70 dark:bg-red-900/70 dark:text-red-100 dark:ring-red-800/70">
+                                            <Warning className="size-5 shrink-0" />
+                                        </div>
+                                        <Stack className="min-w-0" spacing={1}>
+                                            <Typography level="body1" semiBold>
+                                                Zona opasnosti
+                                            </Typography>
+                                            <Typography level="body2">
+                                                Napuštanje gredice i brisanje
+                                                vrta
+                                            </Typography>
+                                        </Stack>
+                                    </Row>
+                                    <Stack spacing={2}>
+                                        <RaisedBedAbandonCard
+                                            gardenId={selectedGarden.id}
+                                        />
+                                        <GardenDangerCard
+                                            gardenId={selectedGarden.id}
+                                            gardenName={selectedGarden.name}
+                                        />
+                                    </Stack>
+                                </Accordion>
                             </>
                         )}
                     </>

--- a/packages/game/src/modals/components/GardenTab.tsx
+++ b/packages/game/src/modals/components/GardenTab.tsx
@@ -160,7 +160,7 @@ export function GardenTab() {
                                     isPublic={selectedGarden.isPublic}
                                 />
                                 <Accordion
-                                    className="[&_button]:rounded-lg [&_button]:border [&_button]:border-red-200 [&_button]:bg-red-50/80 [&_button]:p-4 [&_button]:shadow-xs [&_button]:hover:bg-red-100/80 dark:[&_button]:border-red-900/60 dark:[&_button]:bg-red-950/80 dark:[&_button]:hover:bg-red-950"
+                                    className="[&>div:first-child>button]:rounded-lg [&>div:first-child>button]:border [&>div:first-child>button]:border-red-200 [&>div:first-child>button]:bg-red-50/80 [&>div:first-child>button]:p-4 [&>div:first-child>button]:shadow-xs [&>div:first-child>button]:hover:bg-red-100/80 dark:[&>div:first-child>button]:border-red-900/60 dark:[&>div:first-child>button]:bg-red-950/80 dark:[&>div:first-child>button]:hover:bg-red-950"
                                     unmountOnExit
                                     variant="plain"
                                 >


### PR DESCRIPTION
## Summary

- group raised-bed abandonment and garden deletion under a single danger-zone disclosure
- keep the danger zone collapsed by default so destructive actions are less prominent
- preserve the existing eligibility and confirmation safeguards when expanded
- cover the collapsed default and update the focused destructive-action component tests

## Validation

- `corepack pnpm lint --filter @gredice/game --filter garden`
- `corepack pnpm typecheck --filter @gredice/game --filter garden --filter www`
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm --filter garden exec playwright test tests/garden-tab.spec.tsx` (9 passed)
- `git diff --check`