### PR TITLE
feat(delivery): support multi-slot routes

### DIFF
--- a/apps/delivery/app/api/driver/runs/route.ts
+++ b/apps/delivery/app/api/driver/runs/route.ts
@@ -1,20 +1,23 @@
 import { withAuth } from '../../../../lib/auth/auth';
-import { startDeliveryRun } from '../../../../lib/deliveryDashboard';
+import {
+    deliveryRunStartErrorMessage,
+    startDeliveryRun,
+} from '../../../../lib/deliveryDashboard';
+import { maximumDeliveryRouteStops } from '../../../../lib/deliveryRouting';
+import { parseDeliveryRunRequestBody } from '../../../../lib/deliveryRunRequest';
 
 export async function POST(request: Request) {
     return await withAuth(['driver', 'admin'], async ({ userId }) => {
         const body: unknown = await request.json().catch(() => null);
-        const slotId =
-            typeof body === 'object' &&
-            body !== null &&
-            'slotId' in body &&
-            typeof body.slotId === 'number' &&
-            Number.isInteger(body.slotId)
-                ? body.slotId
-                : null;
-        if (!slotId) {
+        const deliveryRequestIds = parseDeliveryRunRequestBody(
+            body,
+            maximumDeliveryRouteStops,
+        );
+        if (!deliveryRequestIds) {
             return Response.json(
-                { error: 'Odaberi valjani termin dostave.' },
+                {
+                    error: `Odaberi između 1 i ${maximumDeliveryRouteStops} valjanih dostava.`,
+                },
                 { status: 400 },
             );
         }
@@ -22,18 +25,20 @@ export async function POST(request: Request) {
         try {
             const run = await startDeliveryRun({
                 driverUserId: userId,
-                slotId,
+                deliveryRequestIds,
             });
             return Response.json({ id: run.id }, { status: 201 });
         } catch (error) {
             console.error('Failed to start delivery run', {
                 error,
-                slotId,
+                requestCount: deliveryRequestIds.length,
                 userId,
             });
             return Response.json(
                 {
-                    error: 'Rutu nije moguće pokrenuti. Provjeri adrese i pokušaj ponovno.',
+                    error:
+                        deliveryRunStartErrorMessage(error) ??
+                        'Rutu nije moguće pokrenuti. Provjeri adrese i pokušaj ponovno.',
                 },
                 { status: 409 },
             );

--- a/apps/delivery/components/DeliveryBatchCard.tsx
+++ b/apps/delivery/components/DeliveryBatchCard.tsx
@@ -1,56 +1,116 @@
 'use client';
 
-import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
-import { Calendar, Play, Truck } from '@gredice/ui/icons';
+import { Checkbox } from '@gredice/ui/Checkbox';
+import { Calendar, MapPin, Truck } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import type { DeliveryBatchSummary } from '../lib/deliveryDashboardTypes';
-import { formatDeliveryDateTime } from '../lib/deliveryFormatting';
+import {
+    formatDeliveryDateTime,
+    formatDeliveryTime,
+} from '../lib/deliveryFormatting';
+import { DeliverySelectionItem } from './DeliverySelectionItem';
 
 export function DeliveryBatchCard({
     batch,
-    loading,
     disabled,
-    onStart,
+    selectionLimitReached,
+    selectedRequestIds,
+    onToggleBatch,
+    onToggleOrder,
 }: {
     batch: DeliveryBatchSummary;
-    loading: boolean;
     disabled: boolean;
-    onStart: () => void;
+    selectionLimitReached: boolean;
+    selectedRequestIds: ReadonlySet<string>;
+    onToggleBatch: (checked: boolean) => void;
+    onToggleOrder: (requestId: string, checked: boolean) => void;
 }) {
+    const selectedCount = batch.orders.filter((order) =>
+        selectedRequestIds.has(order.requestId),
+    ).length;
+    const allSelected = selectedCount === batch.orders.length;
+    const batchSelectionState = allSelected
+        ? true
+        : selectedCount > 0
+          ? 'indeterminate'
+          : false;
+
     return (
         <Card>
-            <CardContent
-                noHeader
-                className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between"
-            >
-                <div className="flex min-w-0 items-start gap-3">
-                    <div className="rounded-lg bg-secondary p-2 text-secondary-foreground">
-                        <Calendar className="size-5" />
+            <CardContent noHeader className="p-0">
+                <div className="flex flex-col gap-3 p-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <div className="rounded-lg bg-secondary p-2 text-secondary-foreground">
+                            <Calendar className="size-5" />
+                        </div>
+                        <div className="min-w-0">
+                            <Typography level="body1" semiBold>
+                                {formatDeliveryDateTime(batch.startAt)} –{' '}
+                                {formatDeliveryTime(batch.endAt)}
+                            </Typography>
+                            <Typography
+                                level="body3"
+                                className="mt-1 flex items-center gap-1 text-muted-foreground"
+                            >
+                                <Truck className="size-4" />
+                                {batch.deliveryCount}{' '}
+                                {batch.deliveryCount === 1
+                                    ? 'dostava'
+                                    : batch.deliveryCount < 5
+                                      ? 'dostave'
+                                      : 'dostava'}
+                            </Typography>
+                            {batch.pickupLocationName ? (
+                                <Typography
+                                    level="body3"
+                                    className="mt-1 flex items-start gap-1 text-muted-foreground"
+                                >
+                                    <MapPin className="mt-0.5 size-4 shrink-0" />
+                                    <span>
+                                        {batch.pickupLocationName}
+                                        {batch.pickupAddress
+                                            ? ` · ${batch.pickupAddress}`
+                                            : ''}
+                                    </span>
+                                </Typography>
+                            ) : null}
+                        </div>
                     </div>
-                    <div className="min-w-0">
-                        <Typography level="body1" semiBold>
-                            {formatDeliveryDateTime(batch.startAt)}
-                        </Typography>
-                        <Typography
-                            level="body3"
-                            className="mt-1 flex items-center gap-1 text-muted-foreground"
-                        >
-                            <Truck className="size-4" />
-                            {batch.deliveryCount}{' '}
-                            {batch.deliveryCount === 1 ? 'dostava' : 'dostava'}
-                        </Typography>
-                    </div>
+                    <Checkbox
+                        checked={batchSelectionState}
+                        disabled={
+                            disabled || (selectionLimitReached && !allSelected)
+                        }
+                        onCheckedChange={(value) =>
+                            onToggleBatch(value === true)
+                        }
+                        label={
+                            allSelected
+                                ? 'Poništi termin'
+                                : 'Odaberi cijeli termin'
+                        }
+                    />
                 </div>
-                <Button
-                    loading={loading}
-                    disabled={disabled}
-                    onClick={onStart}
-                    startDecorator={<Play className="size-4" />}
-                    className="sm:min-w-48"
-                >
-                    Preuzmi i pokreni rutu
-                </Button>
+                <div className="divide-y border-t">
+                    {batch.orders.map((order) => {
+                        const checked = selectedRequestIds.has(order.requestId);
+                        return (
+                            <DeliverySelectionItem
+                                key={order.requestId}
+                                order={order}
+                                checked={checked}
+                                disabled={
+                                    disabled ||
+                                    (selectionLimitReached && !checked)
+                                }
+                                onCheckedChange={(value) =>
+                                    onToggleOrder(order.requestId, value)
+                                }
+                            />
+                        );
+                    })}
+                </div>
             </CardContent>
         </Card>
     );

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -45,7 +45,12 @@ function isDeliveryDashboard(value: unknown): value is DeliveryDashboardData {
     }
 
     return value.kind === 'driver'
-        ? 'batches' in value && Array.isArray(value.batches)
+        ? 'batches' in value &&
+              Array.isArray(value.batches) &&
+              'maximumRouteDeliveries' in value &&
+              typeof value.maximumRouteDeliveries === 'number' &&
+              'maximumRouteWindowHours' in value &&
+              typeof value.maximumRouteWindowHours === 'number'
         : value.kind === 'customer' &&
               'deliveries' in value &&
               Array.isArray(value.deliveries);
@@ -156,9 +161,9 @@ export function DeliveryDashboard() {
                     dashboard={dashboard}
                     trackingState={trackingState}
                     pendingAction={pendingAction}
-                    onStartRun={(slotId) =>
-                        void perform(`start:${slotId}`, '/api/driver/runs', {
-                            slotId,
+                    onStartRun={(deliveryRequestIds) =>
+                        void perform('start-route', '/api/driver/runs', {
+                            deliveryRequestIds,
                         })
                     }
                     onArrive={(runId, stopId) =>

--- a/apps/delivery/components/DeliverySelectionItem.tsx
+++ b/apps/delivery/components/DeliverySelectionItem.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Checkbox } from '@gredice/ui/Checkbox';
+import { Leaf, MapPin } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import type { DeliveryRouteOrderSummary } from '../lib/deliveryDashboardTypes';
+
+export function DeliverySelectionItem({
+    order,
+    checked,
+    disabled,
+    onCheckedChange,
+}: {
+    order: DeliveryRouteOrderSummary;
+    checked: boolean;
+    disabled: boolean;
+    onCheckedChange: (checked: boolean) => void;
+}) {
+    return (
+        <div
+            className={
+                checked
+                    ? 'bg-primary/5 px-4 py-3'
+                    : 'px-4 py-3 transition-colors hover:bg-muted/50'
+            }
+        >
+            <Checkbox
+                id={`delivery-order-${order.requestId}`}
+                checked={checked}
+                disabled={disabled}
+                onCheckedChange={(value) => onCheckedChange(value === true)}
+                className="mt-1 size-5"
+                label={
+                    <span className="block min-w-0 space-y-1 pl-1">
+                        <span className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                            <Typography component="span" level="body2" semiBold>
+                                {order.contactName}
+                            </Typography>
+                            <Typography
+                                component="span"
+                                level="body3"
+                                className="text-muted-foreground"
+                            >
+                                {order.harvest.plantName}
+                            </Typography>
+                        </span>
+                        <span className="flex items-start gap-2 text-sm font-normal text-muted-foreground">
+                            <MapPin className="mt-0.5 size-4 shrink-0" />
+                            <span>{order.address}</span>
+                        </span>
+                        {order.requestNotes ? (
+                            <span className="flex items-start gap-2 text-sm font-normal text-amber-800 dark:text-amber-200">
+                                <Leaf className="mt-0.5 size-4 shrink-0" />
+                                <span>{order.requestNotes}</span>
+                            </span>
+                        ) : null}
+                    </span>
+                }
+            />
+        </div>
+    );
+}

--- a/apps/delivery/components/DeliveryStopCard.tsx
+++ b/apps/delivery/components/DeliveryStopCard.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
 import {
     Approved,
+    Calendar,
     ExternalLink,
     Leaf,
     MapPin,
@@ -13,6 +14,7 @@ import {
     Navigate,
     Timer,
     User,
+    Warning,
 } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
@@ -53,6 +55,11 @@ export function DeliveryStopCard({
     const navigationUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(stop.address)}`;
     const driverMode = mode === 'driver';
     const delivered = stop.statusLabel === 'Dostavljeno';
+    const estimatedOutsideWindow = Boolean(
+        stop.estimatedArrivalAt &&
+            stop.slotEndAt &&
+            new Date(stop.estimatedArrivalAt) > new Date(stop.slotEndAt),
+    );
 
     return (
         <Card
@@ -140,6 +147,16 @@ export function DeliveryStopCard({
                 ) : null}
 
                 <div className="space-y-2 text-sm">
+                    {driverMode && stop.slotStartAt && stop.slotEndAt ? (
+                        <div className="flex items-start gap-2">
+                            <Calendar className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                            <span>
+                                Termin:{' '}
+                                {formatDeliveryDateTime(stop.slotStartAt)} –{' '}
+                                {formatDeliveryTime(stop.slotEndAt)}
+                            </span>
+                        </div>
+                    ) : null}
                     {driverMode ? (
                         <div className="flex items-start gap-2">
                             <MapPin className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
@@ -170,6 +187,15 @@ export function DeliveryStopCard({
                     {stop.requestNotes ? (
                         <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950">
                             <strong>Napomena:</strong> {stop.requestNotes}
+                        </div>
+                    ) : null}
+                    {estimatedOutsideWindow && !delivered ? (
+                        <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                            <Warning className="mt-0.5 size-4 shrink-0" />
+                            <span>
+                                Trenutačna procjena dolaska je nakon završetka
+                                termina. Obavijesti korisnika o kašnjenju.
+                            </span>
                         </div>
                     ) : null}
                     {driverMode && stop.accountContacts.length > 0 ? (

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -1,17 +1,21 @@
 'use client';
 
 import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
 import {
     Map as MapIcon,
     MapPin,
     MyLocation,
+    Play,
+    Reset,
     Timer,
     Truck,
     Warning,
 } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
+import { useState } from 'react';
 import type { DriverTrackingState } from '../hooks/useDriverTracking';
 import type { DriverDeliveryDashboard } from '../lib/deliveryDashboardTypes';
 import {
@@ -52,12 +56,80 @@ export function DriverDashboard({
     dashboard: DriverDeliveryDashboard;
     trackingState: DriverTrackingState;
     pendingAction: string | null;
-    onStartRun: (slotId: number) => void;
+    onStartRun: (deliveryRequestIds: string[]) => void;
     onArrive: (runId: string, stopId: number) => void;
     onDeliver: (runId: string, stopId: number, notes?: string) => void;
 }) {
     const run = dashboard.activeRun;
     const locationMessage = trackingMessage(trackingState);
+    const [selectedRequestIds, setSelectedRequestIds] = useState<string[]>([]);
+    const availableRequestIds = dashboard.batches.flatMap((batch) =>
+        batch.orders.map((order) => order.requestId),
+    );
+    const availableRequestIdSet = new Set(availableRequestIds);
+    const effectiveSelectedRequestIds = selectedRequestIds.filter((requestId) =>
+        availableRequestIdSet.has(requestId),
+    );
+    const selectedRequestIdSet = new Set(effectiveSelectedRequestIds);
+    const selectionLimitReached =
+        effectiveSelectedRequestIds.length >= dashboard.maximumRouteDeliveries;
+    const selectedSlotCount = dashboard.batches.filter((batch) =>
+        batch.orders.some((order) => selectedRequestIdSet.has(order.requestId)),
+    ).length;
+    const selectedLocationCount = new Set(
+        dashboard.batches.flatMap((batch) =>
+            batch.orders.flatMap((order) =>
+                selectedRequestIdSet.has(order.requestId)
+                    ? [order.address]
+                    : [],
+            ),
+        ),
+    ).size;
+
+    const toggleOrder = (requestId: string, checked: boolean) => {
+        setSelectedRequestIds((current) => {
+            const availableCurrent = current.filter((id) =>
+                availableRequestIdSet.has(id),
+            );
+            if (!checked) {
+                return availableCurrent.filter((id) => id !== requestId);
+            }
+            if (
+                availableCurrent.includes(requestId) ||
+                availableCurrent.length >= dashboard.maximumRouteDeliveries
+            ) {
+                return availableCurrent;
+            }
+            return [...availableCurrent, requestId];
+        });
+    };
+
+    const toggleBatch = (
+        batch: DriverDeliveryDashboard['batches'][number],
+        checked: boolean,
+    ) => {
+        const batchIds = new Set(batch.orders.map((order) => order.requestId));
+        setSelectedRequestIds((current) => {
+            const availableCurrent = current.filter((id) =>
+                availableRequestIdSet.has(id),
+            );
+            if (!checked) {
+                return availableCurrent.filter((id) => !batchIds.has(id));
+            }
+
+            const next = [...availableCurrent];
+            for (const requestId of batchIds) {
+                if (
+                    next.length >= dashboard.maximumRouteDeliveries ||
+                    next.includes(requestId)
+                ) {
+                    continue;
+                }
+                next.push(requestId);
+            }
+            return next;
+        });
+    };
 
     return (
         <div className="min-h-[100dvh] bg-background">
@@ -73,7 +145,7 @@ export function DriverDashboard({
                     <Typography className="mt-1 text-muted-foreground">
                         {run
                             ? 'Slijedi redoslijed stanica, potvrdi dolazak i nastavi nakon svake dostave.'
-                            : 'Odaberi termin. Preuzimanjem se urod označava spremnim i računa optimalna ruta.'}
+                            : 'Odaberi narudžbe iz jednog ili više termina. Preuzimanjem se urodi označavaju spremnima i računa povezana ruta kroz sve lokacije.'}
                     </Typography>
                 </div>
 
@@ -148,7 +220,7 @@ export function DriverDashboard({
                                                 level="body3"
                                                 className="text-muted-foreground"
                                             >
-                                                Preuzeto
+                                                Dostavljeno
                                             </Typography>
                                             <Chip color="success" size="sm">
                                                 {
@@ -213,18 +285,151 @@ export function DriverDashboard({
                 ) : (
                     <section className="space-y-3">
                         {dashboard.batches.length > 0 ? (
-                            dashboard.batches.map((batch) => (
-                                <DeliveryBatchCard
-                                    key={batch.slotId}
-                                    batch={batch}
-                                    loading={
-                                        pendingAction ===
-                                        `start:${batch.slotId}`
-                                    }
-                                    disabled={Boolean(pendingAction)}
-                                    onStart={() => onStartRun(batch.slotId)}
-                                />
-                            ))
+                            <>
+                                <Card className="shadow-md">
+                                    <CardContent
+                                        noHeader
+                                        className="flex flex-col gap-4 p-4 lg:flex-row lg:items-center lg:justify-between"
+                                    >
+                                        <div>
+                                            <Typography level="body1" semiBold>
+                                                Plan povezane rute
+                                            </Typography>
+                                            <div className="mt-2 flex flex-wrap gap-2">
+                                                <Chip color="info" size="sm">
+                                                    {
+                                                        effectiveSelectedRequestIds.length
+                                                    }{' '}
+                                                    odabrano
+                                                </Chip>
+                                                <Chip color="neutral" size="sm">
+                                                    {selectedSlotCount}{' '}
+                                                    {selectedSlotCount === 1
+                                                        ? 'termin'
+                                                        : 'termina'}
+                                                </Chip>
+                                                <Chip color="neutral" size="sm">
+                                                    {selectedLocationCount}{' '}
+                                                    {selectedLocationCount === 1
+                                                        ? 'lokacija'
+                                                        : selectedLocationCount <
+                                                            5
+                                                          ? 'lokacije'
+                                                          : 'lokacija'}
+                                                </Chip>
+                                            </div>
+                                            <Typography
+                                                level="body3"
+                                                className="mt-2 text-muted-foreground"
+                                            >
+                                                Najviše{' '}
+                                                {
+                                                    dashboard.maximumRouteDeliveries
+                                                }{' '}
+                                                dostava po ruti i termini unutar
+                                                najviše{' '}
+                                                {
+                                                    dashboard.maximumRouteWindowHours
+                                                }{' '}
+                                                sata. Termini se poštuju pri
+                                                izračunu dolazaka.
+                                            </Typography>
+                                        </div>
+                                        <div className="flex flex-wrap gap-2">
+                                            <Button
+                                                variant="outlined"
+                                                disabled={Boolean(
+                                                    pendingAction,
+                                                )}
+                                                onClick={() =>
+                                                    setSelectedRequestIds(
+                                                        availableRequestIds.slice(
+                                                            0,
+                                                            dashboard.maximumRouteDeliveries,
+                                                        ),
+                                                    )
+                                                }
+                                            >
+                                                Odaberi sve
+                                            </Button>
+                                            <Button
+                                                variant="plain"
+                                                disabled={
+                                                    Boolean(pendingAction) ||
+                                                    effectiveSelectedRequestIds.length ===
+                                                        0
+                                                }
+                                                onClick={() =>
+                                                    setSelectedRequestIds([])
+                                                }
+                                                startDecorator={
+                                                    <Reset className="size-4" />
+                                                }
+                                            >
+                                                Poništi
+                                            </Button>
+                                            <Button
+                                                loading={
+                                                    pendingAction ===
+                                                    'start-route'
+                                                }
+                                                disabled={
+                                                    Boolean(pendingAction) ||
+                                                    effectiveSelectedRequestIds.length ===
+                                                        0
+                                                }
+                                                onClick={() =>
+                                                    onStartRun(
+                                                        effectiveSelectedRequestIds,
+                                                    )
+                                                }
+                                                startDecorator={
+                                                    <Play className="size-4" />
+                                                }
+                                            >
+                                                Preuzmi{' '}
+                                                {
+                                                    effectiveSelectedRequestIds.length
+                                                }{' '}
+                                                i pokreni rutu
+                                            </Button>
+                                        </div>
+                                    </CardContent>
+                                </Card>
+
+                                {selectionLimitReached &&
+                                availableRequestIds.length >
+                                    dashboard.maximumRouteDeliveries ? (
+                                    <Alert
+                                        color="info"
+                                        startDecorator={
+                                            <Warning className="size-5" />
+                                        }
+                                    >
+                                        Dosegnut je najveći broj dostava za
+                                        jednu rutu. Poništi neku dostavu kako bi
+                                        odabrao drugu.
+                                    </Alert>
+                                ) : null}
+
+                                {dashboard.batches.map((batch) => (
+                                    <DeliveryBatchCard
+                                        key={batch.slotId}
+                                        batch={batch}
+                                        disabled={Boolean(pendingAction)}
+                                        selectionLimitReached={
+                                            selectionLimitReached
+                                        }
+                                        selectedRequestIds={
+                                            selectedRequestIdSet
+                                        }
+                                        onToggleBatch={(checked) =>
+                                            toggleBatch(batch, checked)
+                                        }
+                                        onToggleOrder={toggleOrder}
+                                    />
+                                ))}
+                            </>
                         ) : (
                             <Card>
                                 <CardContent

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -23,11 +23,16 @@ import type {
     ActiveDeliveryRunSummary,
     DeliveryContactSummary,
     DeliveryDashboard,
+    DeliveryHarvestSummary,
+    DeliveryRouteOrderSummary,
     DeliveryStopSummary,
     DeliveryTrackingLocation,
 } from './deliveryDashboardTypes';
 import {
+    DeliveryRoutePlanningError,
     formatDeliveryDestinationAddress,
+    maximumDeliveryRouteStops,
+    maximumDeliveryRouteWindowHours,
     planDeliveryRoute,
     recalculateDeliveryRoute,
 } from './deliveryRouting';
@@ -51,6 +56,10 @@ const batchStates: ReadonlySet<string> = new Set([
     DeliveryRequestStates.READY,
 ]);
 const etaRefreshIntervalMs = 2 * 60 * 1000;
+
+export class DeliveryRunStartError extends Error {
+    override name = 'DeliveryRunStartError';
+}
 
 function iso(value?: Date | null) {
     return value?.toISOString() ?? null;
@@ -119,6 +128,16 @@ function fieldName(request: DeliveryRequest) {
     return typeof positionIndex === 'number'
         ? `Polje ${positionIndex + 1}`
         : null;
+}
+
+function harvestSummary(request: DeliveryRequest): DeliveryHarvestSummary {
+    return {
+        plantName: plantName(request),
+        operationName: request.operationData?.information?.label ?? null,
+        raisedBedName: raisedBedName(request),
+        fieldName: fieldName(request),
+        tracePath: request.trace?.publicPath ?? null,
+    };
 }
 
 function statusLabel({
@@ -220,13 +239,7 @@ function deliveryStopSummary({
         estimatedDistanceMeters: stop?.estimatedDistanceMeters ?? null,
         arrivedAt: iso(stop?.arrivedAt),
         deliveredAt: iso(stop?.deliveredAt),
-        harvest: {
-            plantName: plantName(request),
-            operationName: request.operationData?.information?.label ?? null,
-            raisedBedName: raisedBedName(request),
-            fieldName: fieldName(request),
-            tracePath: request.trace?.publicPath ?? null,
-        },
+        harvest: harvestSummary(request),
         accountContacts: accountContacts(request.accountId, contacts),
         tracking: includeTracking ? runLocation : null,
         runId: run?.id ?? null,
@@ -303,7 +316,7 @@ async function driverDashboard({
             request.address &&
             request.slot &&
             batchStates.has(request.state) &&
-            request.slot.endAt.getTime() >= now - 6 * 60 * 60 * 1000 &&
+            request.slot.endAt.getTime() >= now &&
             request.slot.startAt.getTime() <= now + 14 * 24 * 60 * 60 * 1000,
     );
     const assigned = await getDeliveryRunStopsForRequestIds(
@@ -314,20 +327,43 @@ async function driverDashboard({
     );
     const batchesBySlot = new Map<
         number,
-        { startAt: Date; endAt: Date; deliveryCount: number }
+        {
+            startAt: Date;
+            endAt: Date;
+            pickupLocationName: string | null;
+            pickupAddress: string | null;
+            orders: DeliveryRouteOrderSummary[];
+        }
     >();
     for (const request of candidateRequests) {
-        if (!request.slot || assignedRequestIds.has(request.id)) {
+        if (
+            !request.slot ||
+            !request.address ||
+            assignedRequestIds.has(request.id)
+        ) {
             continue;
         }
+        const order = {
+            requestId: request.id,
+            contactName: request.address.contactName,
+            address: formatDeliveryDestinationAddress(request.address),
+            addressLabel: request.address.label,
+            requestNotes: request.requestNotes ?? null,
+            harvest: harvestSummary(request),
+        } satisfies DeliveryRouteOrderSummary;
         const batch = batchesBySlot.get(request.slot.id);
         if (batch) {
-            batch.deliveryCount += 1;
+            batch.orders.push(order);
         } else {
+            const pickupLocation = request.slot.location;
             batchesBySlot.set(request.slot.id, {
                 startAt: request.slot.startAt,
                 endAt: request.slot.endAt,
-                deliveryCount: 1,
+                pickupLocationName: pickupLocation?.name ?? null,
+                pickupAddress: pickupLocation
+                    ? formatDeliveryDestinationAddress(pickupLocation)
+                    : null,
+                orders: [order],
             });
         }
     }
@@ -344,10 +380,17 @@ async function driverDashboard({
             slotId,
             startAt: batch.startAt.toISOString(),
             endAt: batch.endAt.toISOString(),
-            deliveryCount: batch.deliveryCount,
+            pickupLocationName: batch.pickupLocationName,
+            pickupAddress: batch.pickupAddress,
+            deliveryCount: batch.orders.length,
+            orders: batch.orders.sort((first, second) =>
+                first.address.localeCompare(second.address, 'hr'),
+            ),
         })).sort((first, second) =>
             first.startAt.localeCompare(second.startAt),
         ),
+        maximumRouteDeliveries: maximumDeliveryRouteStops,
+        maximumRouteWindowHours: maximumDeliveryRouteWindowHours,
         refreshedAt: new Date().toISOString(),
     };
 }
@@ -376,17 +419,21 @@ async function customerDashboard({
         runRows.map((row) => [row.stop.deliveryRequestId, row]),
     );
     const contacts = await getDeliveryAccountContacts([accountId]);
-    const activeStops = runRows
-        .filter(
-            ({ run, stop }) =>
-                run.state === DeliveryRunStates.ACTIVE &&
-                stop.state !== DeliveryRunStopStates.DELIVERED,
-        )
-        .sort((first, second) => first.stop.sequence - second.stop.sequence);
+    const activeRunIds = Array.from(
+        new Set(
+            runRows.flatMap(({ run }) =>
+                run.state === DeliveryRunStates.ACTIVE ? [run.id] : [],
+            ),
+        ),
+    );
+    const activeRuns = await Promise.all(activeRunIds.map(getDeliveryRun));
     const currentByRunId = new Map<string, number>();
-    for (const row of activeStops) {
-        if (!currentByRunId.has(row.run.id)) {
-            currentByRunId.set(row.run.id, row.stop.id);
+    for (const run of activeRuns) {
+        const currentStop = run?.stops.find(
+            (stop) => stop.state !== DeliveryRunStopStates.DELIVERED,
+        );
+        if (run && currentStop) {
+            currentByRunId.set(run.id, currentStop.id);
         }
     }
 
@@ -404,7 +451,8 @@ async function customerDashboard({
                 contacts,
                 includeTracking:
                     row?.run.state === DeliveryRunStates.ACTIVE &&
-                    row.stop.state !== DeliveryRunStopStates.DELIVERED,
+                    row.stop.state !== DeliveryRunStopStates.DELIVERED &&
+                    isCurrent,
             });
         })
         .sort((first, second) => {
@@ -468,57 +516,88 @@ async function ensureRunRequestsReady(run: DeliveryRun) {
 
 export async function startDeliveryRun({
     driverUserId,
-    slotId,
+    deliveryRequestIds,
 }: {
     driverUserId: string;
-    slotId: number;
+    deliveryRequestIds: string[];
 }) {
     const existingRun = await getActiveDeliveryRunForDriver(driverUserId);
     if (existingRun) {
         await ensureRunRequestsReady(existingRun);
         return existingRun;
     }
+    if (
+        deliveryRequestIds.length === 0 ||
+        deliveryRequestIds.length > maximumDeliveryRouteStops
+    ) {
+        throw new DeliveryRunStartError(
+            `Odaberi između 1 i ${maximumDeliveryRouteStops} dostava.`,
+        );
+    }
 
-    const requests = await getDeliveryRequestsWithEvents(
-        undefined,
-        undefined,
-        slotId,
+    const requests = await getDeliveryRequestsWithEvents();
+    const requestsById = new Map(
+        requests.map((request) => [request.id, request]),
     );
-    const candidates = requests.filter(
-        (request) =>
-            request.mode === 'delivery' &&
-            request.address &&
-            batchStates.has(request.state),
-    );
+    const candidates: ListedDeliveryRequest[] = [];
+    const now = new Date();
+    for (const requestId of deliveryRequestIds) {
+        const request = requestsById.get(requestId);
+        if (
+            request?.mode !== 'delivery' ||
+            !request.address ||
+            !request.slot ||
+            !batchStates.has(request.state) ||
+            request.slot.endAt < now
+        ) {
+            throw new DeliveryRunStartError(
+                'Jedna ili više odabranih dostava više nije dostupna za preuzimanje. Osvježi popis i pokušaj ponovno.',
+            );
+        }
+        candidates.push(request);
+    }
+
     const existingStops = await getDeliveryRunStopsForRequestIds(
         candidates.map((request) => request.id),
     );
-    const assignedIds = new Set(
-        existingStops.map(({ stop }) => stop.deliveryRequestId),
-    );
-    const unassigned = candidates.filter(
-        (request) => !assignedIds.has(request.id) && request.address,
-    );
-    if (unassigned.length === 0) {
-        throw new Error('U odabranom terminu nema dostava za preuzimanje.');
+    if (existingStops.length > 0) {
+        throw new DeliveryRunStartError(
+            'Jedna ili više odabranih dostava već je dodijeljena drugoj ruti. Osvježi popis i odaberi ponovno.',
+        );
     }
 
     const plan = await planDeliveryRoute({
-        candidates: unassigned.map((request) => {
-            if (!request.address) {
-                throw new Error('Dostava nema valjanu adresu.');
+        candidates: candidates.map((request) => {
+            if (!request.address || !request.slot) {
+                throw new DeliveryRunStartError(
+                    'Odabrana dostava nema valjanu adresu ili termin.',
+                );
             }
             return {
                 deliveryRequestId: request.id,
                 formattedAddress: formatDeliveryDestinationAddress(
                     request.address,
                 ),
+                windowStartAt: request.slot.startAt,
+                windowEndAt: request.slot.endAt,
             };
         }),
     });
+    const primarySlot = candidates
+        .map((request) => request.slot)
+        .filter((slot): slot is NonNullable<typeof slot> => Boolean(slot))
+        .sort(
+            (first, second) =>
+                first.startAt.getTime() - second.startAt.getTime(),
+        )[0];
+    if (!primarySlot) {
+        throw new DeliveryRunStartError(
+            'Odabrane dostave nemaju valjani termin.',
+        );
+    }
     const run = await createDeliveryRun({
         driverUserId,
-        timeSlotId: slotId,
+        timeSlotId: primarySlot.id,
         encodedPolyline: plan.encodedPolyline,
         totalDistanceMeters: plan.totalDistanceMeters,
         totalDurationSeconds: plan.totalDurationSeconds,
@@ -623,14 +702,29 @@ export async function recordDriverLocation({
     const remainingStops = run.stops.filter(
         (stop) => stop.state !== DeliveryRunStopStates.DELIVERED,
     );
+    const requests = await Promise.all(
+        remainingStops.map((stop) =>
+            getDeliveryRequest(stop.deliveryRequestId),
+        ),
+    );
+    const requestsById = new Map(
+        requests.flatMap((request) =>
+            request ? [[request.id, request] as const] : [],
+        ),
+    );
     const plan = await recalculateDeliveryRoute({
         origin: { latitude, longitude },
-        stops: remainingStops.map((stop) => ({
-            deliveryRequestId: stop.deliveryRequestId,
-            formattedAddress: stop.formattedAddress,
-            latitude: stop.latitude,
-            longitude: stop.longitude,
-        })),
+        stops: remainingStops.map((stop) => {
+            const request = requestsById.get(stop.deliveryRequestId);
+            return {
+                deliveryRequestId: stop.deliveryRequestId,
+                formattedAddress: stop.formattedAddress,
+                latitude: stop.latitude,
+                longitude: stop.longitude,
+                windowStartAt: request?.slot?.startAt,
+                windowEndAt: request?.slot?.endAt,
+            };
+        }),
     });
     await updateDeliveryRunEstimates({
         runId,
@@ -639,4 +733,11 @@ export async function recordDriverLocation({
         totalDurationSeconds: plan.totalDurationSeconds,
         estimates: plan.stops,
     });
+}
+
+export function deliveryRunStartErrorMessage(error: unknown) {
+    return error instanceof DeliveryRunStartError ||
+        error instanceof DeliveryRoutePlanningError
+        ? error.message
+        : null;
 }

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -53,7 +53,19 @@ export type DeliveryBatchSummary = {
     slotId: number;
     startAt: string;
     endAt: string;
+    pickupLocationName: string | null;
+    pickupAddress: string | null;
     deliveryCount: number;
+    orders: DeliveryRouteOrderSummary[];
+};
+
+export type DeliveryRouteOrderSummary = {
+    requestId: string;
+    contactName: string;
+    address: string;
+    addressLabel: string | null;
+    requestNotes: string | null;
+    harvest: DeliveryHarvestSummary;
 };
 
 export type ActiveDeliveryRunSummary = {
@@ -78,6 +90,8 @@ export type DriverDeliveryDashboard = {
     };
     activeRun: ActiveDeliveryRunSummary | null;
     batches: DeliveryBatchSummary[];
+    maximumRouteDeliveries: number;
+    maximumRouteWindowHours: number;
     refreshedAt: string;
 };
 

--- a/apps/delivery/lib/deliveryRouting.node.spec.ts
+++ b/apps/delivery/lib/deliveryRouting.node.spec.ts
@@ -69,33 +69,86 @@ test('orders earlier delivery windows first and optimizes within a window', () =
         windowEndAt: new Date('2026-07-13T11:00:00.000Z'),
     };
 
-    const ordered = orderDeliveryStopsByTimeWindow(origin, [
-        {
-            deliveryRequestId: 'later',
-            formattedAddress: 'Later',
-            latitude: 45.7805,
-            longitude: 15.9805,
-            ...laterWindow,
-        },
-        {
-            deliveryRequestId: 'early-far',
-            formattedAddress: 'Early far',
-            latitude: 45.82,
-            longitude: 16.02,
-            ...earlyWindow,
-        },
-        {
-            deliveryRequestId: 'early-near',
-            formattedAddress: 'Early near',
-            latitude: 45.781,
-            longitude: 15.981,
-            ...earlyWindow,
-        },
-    ]);
+    const ordered = orderDeliveryStopsByTimeWindow(
+        origin,
+        [
+            {
+                deliveryRequestId: 'later',
+                formattedAddress: 'Later',
+                latitude: 45.7805,
+                longitude: 15.9805,
+                ...laterWindow,
+            },
+            {
+                deliveryRequestId: 'early-far',
+                formattedAddress: 'Early far',
+                latitude: 45.82,
+                longitude: 16.02,
+                ...earlyWindow,
+            },
+            {
+                deliveryRequestId: 'early-near',
+                formattedAddress: 'Early near',
+                latitude: 45.781,
+                longitude: 15.981,
+                ...earlyWindow,
+            },
+        ],
+        new Date('2026-07-13T07:55:00.000Z'),
+    );
 
     assert.deepEqual(
         ordered.map((stop) => stop.deliveryRequestId),
         ['early-near', 'early-far', 'later'],
+    );
+});
+
+test('serves an available stop before waiting for an overlapping window', () => {
+    const origin = { latitude: 45.78, longitude: 15.98 };
+    const departureTime = new Date('2026-07-13T08:00:00.000Z');
+    const futureNarrowStop = {
+        deliveryRequestId: 'future-narrow',
+        formattedAddress: 'Future narrow',
+        latitude: 45.781,
+        longitude: 15.981,
+        windowStartAt: new Date('2026-07-13T09:00:00.000Z'),
+        windowEndAt: new Date('2026-07-13T09:04:00.000Z'),
+    };
+    const availableStop = {
+        deliveryRequestId: 'available-now',
+        formattedAddress: 'Available now',
+        latitude: 45.7805,
+        longitude: 15.9805,
+        windowStartAt: new Date('2026-07-13T08:00:00.000Z'),
+        windowEndAt: new Date('2026-07-13T09:05:00.000Z'),
+    };
+    const ordered = orderDeliveryStopsByTimeWindow(
+        origin,
+        [futureNarrowStop, availableStop],
+        departureTime,
+    );
+
+    assert.deepEqual(
+        ordered.map((stop) => stop.deliveryRequestId),
+        ['available-now', 'future-narrow'],
+    );
+    assert.throws(
+        () =>
+            estimateDeliveryRoute({
+                origin,
+                stops: [futureNarrowStop, availableStop],
+                departureTime,
+                optimize: false,
+            }),
+        DeliveryRoutePlanningError,
+    );
+    assert.doesNotThrow(() =>
+        estimateDeliveryRoute({
+            origin,
+            stops: ordered,
+            departureTime,
+            optimize: false,
+        }),
     );
 });
 

--- a/apps/delivery/lib/deliveryRouting.node.spec.ts
+++ b/apps/delivery/lib/deliveryRouting.node.spec.ts
@@ -1,9 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    DeliveryRoutePlanningError,
+    estimateDeliveryRoute,
     formatDeliveryDestinationAddress,
     haversineDistanceMeters,
     nearestNeighborStopOrder,
+    orderDeliveryStopsByTimeWindow,
+    planDeliveryRoute,
 } from './deliveryRouting';
 
 test('formats a Croatian delivery address without empty lines', () => {
@@ -52,4 +56,100 @@ test('haversine distance returns a stable non-zero city distance', () => {
 
     assert.ok(distance > 2_000);
     assert.ok(distance < 4_000);
+});
+
+test('orders earlier delivery windows first and optimizes within a window', () => {
+    const origin = { latitude: 45.78, longitude: 15.98 };
+    const earlyWindow = {
+        windowStartAt: new Date('2026-07-13T08:00:00.000Z'),
+        windowEndAt: new Date('2026-07-13T09:00:00.000Z'),
+    };
+    const laterWindow = {
+        windowStartAt: new Date('2026-07-13T10:00:00.000Z'),
+        windowEndAt: new Date('2026-07-13T11:00:00.000Z'),
+    };
+
+    const ordered = orderDeliveryStopsByTimeWindow(origin, [
+        {
+            deliveryRequestId: 'later',
+            formattedAddress: 'Later',
+            latitude: 45.7805,
+            longitude: 15.9805,
+            ...laterWindow,
+        },
+        {
+            deliveryRequestId: 'early-far',
+            formattedAddress: 'Early far',
+            latitude: 45.82,
+            longitude: 16.02,
+            ...earlyWindow,
+        },
+        {
+            deliveryRequestId: 'early-near',
+            formattedAddress: 'Early near',
+            latitude: 45.781,
+            longitude: 15.981,
+            ...earlyWindow,
+        },
+    ]);
+
+    assert.deepEqual(
+        ordered.map((stop) => stop.deliveryRequestId),
+        ['early-near', 'early-far', 'later'],
+    );
+});
+
+test('waits for a future delivery window and rejects an expired one', () => {
+    const origin = { latitude: 45.78, longitude: 15.98 };
+    const stop = {
+        deliveryRequestId: 'scheduled',
+        formattedAddress: 'Scheduled',
+        latitude: 45.781,
+        longitude: 15.981,
+        windowStartAt: new Date('2026-07-13T09:00:00.000Z'),
+        windowEndAt: new Date('2026-07-13T10:00:00.000Z'),
+    };
+    const plan = estimateDeliveryRoute({
+        origin,
+        stops: [stop],
+        departureTime: new Date('2026-07-13T08:00:00.000Z'),
+        optimize: false,
+    });
+
+    assert.equal(
+        plan.stops[0]?.estimatedArrivalAt.toISOString(),
+        '2026-07-13T09:00:00.000Z',
+    );
+    assert.throws(
+        () =>
+            estimateDeliveryRoute({
+                origin,
+                stops: [stop],
+                departureTime: new Date('2026-07-13T10:01:00.000Z'),
+                optimize: false,
+            }),
+        DeliveryRoutePlanningError,
+    );
+});
+
+test('rejects selected time windows that span more than one route day', async () => {
+    await assert.rejects(
+        planDeliveryRoute({
+            candidates: [
+                {
+                    deliveryRequestId: 'first',
+                    formattedAddress: 'First',
+                    windowStartAt: new Date('2026-07-13T08:00:00.000Z'),
+                    windowEndAt: new Date('2026-07-13T10:00:00.000Z'),
+                },
+                {
+                    deliveryRequestId: 'second',
+                    formattedAddress: 'Second',
+                    windowStartAt: new Date('2026-07-14T10:00:01.000Z'),
+                    windowEndAt: new Date('2026-07-14T12:00:01.000Z'),
+                },
+            ],
+        }),
+        DeliveryRoutePlanningError,
+    );
 });

--- a/apps/delivery/lib/deliveryRouting.ts
+++ b/apps/delivery/lib/deliveryRouting.ts
@@ -8,6 +8,8 @@ export type DeliveryCoordinates = {
 export type DeliveryRouteCandidate = {
     deliveryRequestId: string;
     formattedAddress: string;
+    windowStartAt?: Date;
+    windowEndAt?: Date;
 };
 
 export type GeocodedDeliveryRouteCandidate = DeliveryRouteCandidate &
@@ -41,8 +43,13 @@ type GoogleRoute = {
 };
 
 const deliveryStopServiceSeconds = 5 * 60;
-const maximumRouteStops = 26;
+export const maximumDeliveryRouteStops = 26;
+export const maximumDeliveryRouteWindowHours = 24;
 const defaultHqAddress = 'Ulica Julija Knifera 3, 10000 Zagreb, Hrvatska';
+
+export class DeliveryRoutePlanningError extends Error {
+    override name = 'DeliveryRoutePlanningError';
+}
 
 function googleMapsApiKey() {
     const apiKey = process.env.GREDICE_GOOGLE_MAPS_API_KEY?.trim();
@@ -159,6 +166,105 @@ export function nearestNeighborStopOrder(
     return ordered;
 }
 
+function windowTimestamp(value: Date | undefined, fallback: number) {
+    return value?.getTime() ?? fallback;
+}
+
+function deliveryWindowKey(stop: GeocodedDeliveryRouteCandidate) {
+    return `${windowTimestamp(stop.windowStartAt, 0)}:${windowTimestamp(stop.windowEndAt, 0)}`;
+}
+
+export function orderDeliveryStopsByTimeWindow(
+    origin: DeliveryCoordinates,
+    stops: GeocodedDeliveryRouteCandidate[],
+) {
+    const groups = new Map<string, GeocodedDeliveryRouteCandidate[]>();
+    for (const stop of stops) {
+        const key = deliveryWindowKey(stop);
+        const group = groups.get(key);
+        if (group) {
+            group.push(stop);
+        } else {
+            groups.set(key, [stop]);
+        }
+    }
+
+    const orderedGroups = Array.from(groups.values()).sort((first, second) => {
+        const firstStop = first[0];
+        const secondStop = second[0];
+        if (!firstStop || !secondStop) return 0;
+
+        const endDifference =
+            windowTimestamp(firstStop.windowEndAt, Number.POSITIVE_INFINITY) -
+            windowTimestamp(secondStop.windowEndAt, Number.POSITIVE_INFINITY);
+        if (endDifference !== 0) return endDifference;
+
+        return (
+            windowTimestamp(firstStop.windowStartAt, 0) -
+            windowTimestamp(secondStop.windowStartAt, 0)
+        );
+    });
+
+    const ordered: GeocodedDeliveryRouteCandidate[] = [];
+    let current = origin;
+    for (const group of orderedGroups) {
+        const orderedGroup = nearestNeighborStopOrder(current, group);
+        ordered.push(...orderedGroup);
+        const last = orderedGroup.at(-1);
+        if (last) current = last;
+    }
+
+    return ordered;
+}
+
+function stopsShareDeliveryWindow(stops: GeocodedDeliveryRouteCandidate[]) {
+    const first = stops[0];
+    return Boolean(
+        first &&
+            stops.every(
+                (stop) => deliveryWindowKey(stop) === deliveryWindowKey(first),
+            ),
+    );
+}
+
+function scheduledArrival({
+    departureTime,
+    elapsedSeconds,
+    travelSeconds,
+    stop,
+    enforceTimeWindows,
+}: {
+    departureTime: Date;
+    elapsedSeconds: number;
+    travelSeconds: number;
+    stop: GeocodedDeliveryRouteCandidate;
+    enforceTimeWindows: boolean;
+}) {
+    const physicalArrivalTime =
+        departureTime.getTime() + (elapsedSeconds + travelSeconds) * 1_000;
+    const arrivalTime = Math.max(
+        physicalArrivalTime,
+        windowTimestamp(stop.windowStartAt, physicalArrivalTime),
+    );
+    const windowEndTime = stop.windowEndAt?.getTime();
+    if (
+        enforceTimeWindows &&
+        windowEndTime !== undefined &&
+        arrivalTime > windowEndTime
+    ) {
+        throw new DeliveryRoutePlanningError(
+            'Odabrane dostave nije moguće obaviti unutar svih termina. Ukloni dio dostava ili izradi zasebnu rutu.',
+        );
+    }
+
+    return {
+        estimatedArrivalAt: new Date(arrivalTime),
+        elapsedSeconds: Math.round(
+            (arrivalTime - departureTime.getTime()) / 1_000,
+        ),
+    };
+}
+
 async function geocodeAddress(
     formattedAddress: string,
 ): Promise<DeliveryCoordinates> {
@@ -172,7 +278,7 @@ async function geocodeAddress(
     const response = await fetch(url, { cache: 'no-store' });
     const body: unknown = await response.json().catch(() => null);
     if (!response.ok || !isRecord(body) || body.status !== 'OK') {
-        throw new Error(`Adresa se ne može pronaći: ${formattedAddress}`);
+        throw new Error('Jednu od adresa nije moguće pronaći.');
     }
 
     const firstResult = Array.isArray(body.results) ? body.results[0] : null;
@@ -184,7 +290,7 @@ async function geocodeAddress(
         : undefined;
 
     if (latitude === undefined || longitude === undefined) {
-        throw new Error(`Adresa nema valjane koordinate: ${formattedAddress}`);
+        throw new Error('Jedna od adresa nema valjane koordinate.');
     }
 
     return { latitude, longitude };
@@ -222,15 +328,17 @@ async function computeGoogleRoute({
     stops,
     optimize,
     departureTime,
+    enforceTimeWindows,
 }: {
     origin: DeliveryCoordinates;
     stops: GeocodedDeliveryRouteCandidate[];
     optimize: boolean;
     departureTime: Date;
+    enforceTimeWindows: boolean;
 }): Promise<DeliveryRoutePlan> {
-    if (stops.length > maximumRouteStops) {
+    if (stops.length > maximumDeliveryRouteStops) {
         throw new Error(
-            `Jedna ruta može sadržavati najviše ${maximumRouteStops} dostava.`,
+            `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} dostava.`,
         );
     }
 
@@ -294,10 +402,14 @@ async function computeGoogleRoute({
         const leg = legs[index];
         const estimatedTravelSeconds = durationSeconds(leg?.duration) ?? 0;
         const estimatedDistanceMeters = numberField(leg?.distanceMeters) ?? 0;
-        elapsedSeconds += estimatedTravelSeconds;
-        const estimatedArrivalAt = new Date(
-            departureTime.getTime() + elapsedSeconds * 1000,
-        );
+        const scheduled = scheduledArrival({
+            departureTime,
+            elapsedSeconds,
+            travelSeconds: estimatedTravelSeconds,
+            stop,
+            enforceTimeWindows,
+        });
+        elapsedSeconds = scheduled.elapsedSeconds;
         if (index < orderedStops.length - 1) {
             elapsedSeconds += deliveryStopServiceSeconds;
         }
@@ -305,7 +417,7 @@ async function computeGoogleRoute({
         return {
             ...stop,
             sequence: index + 1,
-            estimatedArrivalAt,
+            estimatedArrivalAt: scheduled.estimatedArrivalAt,
             estimatedTravelSeconds,
             estimatedDistanceMeters,
         };
@@ -327,16 +439,18 @@ async function computeGoogleRoute({
     };
 }
 
-function computeFallbackRoute({
+export function estimateDeliveryRoute({
     origin,
     stops,
     departureTime,
     optimize = true,
+    enforceTimeWindows = true,
 }: {
     origin: DeliveryCoordinates;
     stops: GeocodedDeliveryRouteCandidate[];
     departureTime: Date;
     optimize?: boolean;
+    enforceTimeWindows?: boolean;
 }): DeliveryRoutePlan {
     const orderedStops = optimize
         ? nearestNeighborStopOrder(origin, stops)
@@ -352,10 +466,14 @@ function computeFallbackRoute({
             Math.round(estimatedDistanceMeters / (25_000 / 3600)),
         );
         totalDistanceMeters += estimatedDistanceMeters;
-        elapsedSeconds += estimatedTravelSeconds;
-        const estimatedArrivalAt = new Date(
-            departureTime.getTime() + elapsedSeconds * 1000,
-        );
+        const scheduled = scheduledArrival({
+            departureTime,
+            elapsedSeconds,
+            travelSeconds: estimatedTravelSeconds,
+            stop,
+            enforceTimeWindows,
+        });
+        elapsedSeconds = scheduled.elapsedSeconds;
         if (index < orderedStops.length - 1) {
             elapsedSeconds += deliveryStopServiceSeconds;
         }
@@ -364,7 +482,7 @@ function computeFallbackRoute({
         return {
             ...stop,
             sequence: index + 1,
-            estimatedArrivalAt,
+            estimatedArrivalAt: scheduled.estimatedArrivalAt,
             estimatedTravelSeconds,
             estimatedDistanceMeters,
         };
@@ -387,9 +505,38 @@ export async function planDeliveryRoute({
     if (candidates.length === 0) {
         throw new Error('Nema dostava za planiranje rute.');
     }
-    if (candidates.length > maximumRouteStops) {
+    if (candidates.length > maximumDeliveryRouteStops) {
         throw new Error(
-            `Jedna ruta može sadržavati najviše ${maximumRouteStops} dostava.`,
+            `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} dostava.`,
+        );
+    }
+    for (const candidate of candidates) {
+        if (
+            !candidate.windowStartAt ||
+            !candidate.windowEndAt ||
+            !Number.isFinite(candidate.windowStartAt.getTime()) ||
+            !Number.isFinite(candidate.windowEndAt.getTime()) ||
+            candidate.windowStartAt >= candidate.windowEndAt
+        ) {
+            throw new DeliveryRoutePlanningError(
+                'Jedna ili više odabranih dostava nema valjani termin.',
+            );
+        }
+    }
+    const earliestWindowStart = Math.min(
+        ...candidates.map(
+            (candidate) => candidate.windowStartAt?.getTime() ?? 0,
+        ),
+    );
+    const latestWindowEnd = Math.max(
+        ...candidates.map((candidate) => candidate.windowEndAt?.getTime() ?? 0),
+    );
+    if (
+        latestWindowEnd - earliestWindowStart >
+        maximumDeliveryRouteWindowHours * 60 * 60 * 1_000
+    ) {
+        throw new DeliveryRoutePlanningError(
+            `Jedna ruta može povezati termine unutar najviše ${maximumDeliveryRouteWindowHours} sata. Za udaljenije termine izradi zasebne rute.`,
         );
     }
 
@@ -404,23 +551,33 @@ export async function planDeliveryRoute({
             })),
         ),
     ]);
+    const optimizeAsOneWindow = stopsShareDeliveryWindow(geocodedStops);
+    const orderedStops = optimizeAsOneWindow
+        ? geocodedStops
+        : orderDeliveryStopsByTimeWindow(origin, geocodedStops);
 
     try {
         return await computeGoogleRoute({
             origin,
-            stops: geocodedStops,
-            optimize: true,
+            stops: orderedStops,
+            optimize: optimizeAsOneWindow,
             departureTime,
+            enforceTimeWindows: true,
         });
     } catch (error) {
+        if (error instanceof DeliveryRoutePlanningError) {
+            throw error;
+        }
         console.warn('Google route optimization failed; using local fallback', {
             error,
-            stopCount: geocodedStops.length,
+            stopCount: orderedStops.length,
         });
-        return computeFallbackRoute({
+        return estimateDeliveryRoute({
             origin,
-            stops: geocodedStops,
+            stops: orderedStops,
             departureTime,
+            optimize: optimizeAsOneWindow,
+            enforceTimeWindows: true,
         });
     }
 }
@@ -448,17 +605,19 @@ export async function recalculateDeliveryRoute({
             stops,
             optimize: false,
             departureTime,
+            enforceTimeWindows: false,
         });
     } catch (error) {
         console.warn('Google ETA refresh failed; using local estimate', {
             error,
             stopCount: stops.length,
         });
-        return computeFallbackRoute({
+        return estimateDeliveryRoute({
             origin,
             stops,
             departureTime,
             optimize: false,
+            enforceTimeWindows: false,
         });
     }
 }

--- a/apps/delivery/lib/deliveryRouting.ts
+++ b/apps/delivery/lib/deliveryRouting.ts
@@ -166,6 +166,22 @@ export function nearestNeighborStopOrder(
     return ordered;
 }
 
+function estimatedRoadLeg(
+    first: DeliveryCoordinates,
+    second: DeliveryCoordinates,
+) {
+    const estimatedDistanceMeters = Math.round(
+        haversineDistanceMeters(first, second) * 1.25,
+    );
+    return {
+        estimatedDistanceMeters,
+        estimatedTravelSeconds: Math.max(
+            60,
+            Math.round(estimatedDistanceMeters / (25_000 / 3600)),
+        ),
+    };
+}
+
 function windowTimestamp(value: Date | undefined, fallback: number) {
     return value?.getTime() ?? fallback;
 }
@@ -177,41 +193,90 @@ function deliveryWindowKey(stop: GeocodedDeliveryRouteCandidate) {
 export function orderDeliveryStopsByTimeWindow(
     origin: DeliveryCoordinates,
     stops: GeocodedDeliveryRouteCandidate[],
+    departureTime = new Date(),
 ) {
-    const groups = new Map<string, GeocodedDeliveryRouteCandidate[]>();
-    for (const stop of stops) {
-        const key = deliveryWindowKey(stop);
-        const group = groups.get(key);
-        if (group) {
-            group.push(stop);
-        } else {
-            groups.set(key, [stop]);
-        }
-    }
-
-    const orderedGroups = Array.from(groups.values()).sort((first, second) => {
-        const firstStop = first[0];
-        const secondStop = second[0];
-        if (!firstStop || !secondStop) return 0;
-
-        const endDifference =
-            windowTimestamp(firstStop.windowEndAt, Number.POSITIVE_INFINITY) -
-            windowTimestamp(secondStop.windowEndAt, Number.POSITIVE_INFINITY);
-        if (endDifference !== 0) return endDifference;
-
-        return (
-            windowTimestamp(firstStop.windowStartAt, 0) -
-            windowTimestamp(secondStop.windowStartAt, 0)
-        );
-    });
-
+    const remaining = [...stops];
     const ordered: GeocodedDeliveryRouteCandidate[] = [];
     let current = origin;
-    for (const group of orderedGroups) {
-        const orderedGroup = nearestNeighborStopOrder(current, group);
-        ordered.push(...orderedGroup);
-        const last = orderedGroup.at(-1);
-        if (last) current = last;
+    let currentTime = departureTime.getTime();
+
+    while (remaining.length > 0) {
+        const candidates = remaining.map((stop, index) => {
+            const { estimatedTravelSeconds } = estimatedRoadLeg(current, stop);
+            const physicalArrivalTime =
+                currentTime + estimatedTravelSeconds * 1_000;
+            const scheduledArrivalTime = Math.max(
+                physicalArrivalTime,
+                windowTimestamp(stop.windowStartAt, physicalArrivalTime),
+            );
+            const windowEndTime = windowTimestamp(
+                stop.windowEndAt,
+                Number.POSITIVE_INFINITY,
+            );
+            const departureAfterService =
+                scheduledArrivalTime + deliveryStopServiceSeconds * 1_000;
+            const leavesRemainingReachable = remaining.every(
+                (other, otherIndex) => {
+                    if (otherIndex === index) return true;
+                    const nextLeg = estimatedRoadLeg(stop, other);
+                    const nextPhysicalArrival =
+                        departureAfterService +
+                        nextLeg.estimatedTravelSeconds * 1_000;
+                    const nextScheduledArrival = Math.max(
+                        nextPhysicalArrival,
+                        windowTimestamp(
+                            other.windowStartAt,
+                            nextPhysicalArrival,
+                        ),
+                    );
+                    return (
+                        nextScheduledArrival <=
+                        windowTimestamp(
+                            other.windowEndAt,
+                            Number.POSITIVE_INFINITY,
+                        )
+                    );
+                },
+            );
+
+            return {
+                index,
+                stop,
+                estimatedTravelSeconds,
+                scheduledArrivalTime,
+                windowEndTime,
+                feasible: scheduledArrivalTime <= windowEndTime,
+                leavesRemainingReachable,
+            };
+        });
+        const feasibleCandidates = candidates.filter(
+            (candidate) => candidate.feasible,
+        );
+        const candidatesKeepingOptionsOpen = feasibleCandidates.filter(
+            (candidate) => candidate.leavesRemainingReachable,
+        );
+        const viableCandidates =
+            candidatesKeepingOptionsOpen.length > 0
+                ? candidatesKeepingOptionsOpen
+                : feasibleCandidates.length > 0
+                  ? feasibleCandidates
+                  : candidates;
+        const rankedCandidates = viableCandidates.sort(
+            (first, second) =>
+                first.scheduledArrivalTime - second.scheduledArrivalTime ||
+                first.windowEndTime - second.windowEndTime ||
+                first.estimatedTravelSeconds - second.estimatedTravelSeconds,
+        );
+        const nextCandidate = rankedCandidates[0];
+        if (!nextCandidate) break;
+
+        const [next] = remaining.splice(nextCandidate.index, 1);
+        if (!next) break;
+        ordered.push(next);
+        current = next;
+        currentTime =
+            nextCandidate.scheduledArrivalTime +
+            (remaining.length > 0 ? deliveryStopServiceSeconds * 1_000 : 0);
     }
 
     return ordered;
@@ -459,12 +524,8 @@ export function estimateDeliveryRoute({
     let elapsedSeconds = 0;
     let totalDistanceMeters = 0;
     const plannedStops = orderedStops.map((stop, index) => {
-        const directDistance = haversineDistanceMeters(current, stop);
-        const estimatedDistanceMeters = Math.round(directDistance * 1.25);
-        const estimatedTravelSeconds = Math.max(
-            60,
-            Math.round(estimatedDistanceMeters / (25_000 / 3600)),
-        );
+        const { estimatedDistanceMeters, estimatedTravelSeconds } =
+            estimatedRoadLeg(current, stop);
         totalDistanceMeters += estimatedDistanceMeters;
         const scheduled = scheduledArrival({
             departureTime,
@@ -554,7 +615,7 @@ export async function planDeliveryRoute({
     const optimizeAsOneWindow = stopsShareDeliveryWindow(geocodedStops);
     const orderedStops = optimizeAsOneWindow
         ? geocodedStops
-        : orderDeliveryStopsByTimeWindow(origin, geocodedStops);
+        : orderDeliveryStopsByTimeWindow(origin, geocodedStops, departureTime);
 
     try {
         return await computeGoogleRoute({

--- a/apps/delivery/lib/deliveryRunRequest.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunRequest.node.spec.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseDeliveryRunRequestBody } from './deliveryRunRequest';
+
+const firstRequestId = '0f325da1-df30-4a22-8db1-93bcdb245f68';
+const secondRequestId = 'c724532a-79fe-4c77-93e3-e92dc0aeb143';
+
+test('accepts multiple unique delivery request IDs', () => {
+    assert.deepEqual(
+        parseDeliveryRunRequestBody(
+            { deliveryRequestIds: [firstRequestId, secondRequestId] },
+            26,
+        ),
+        [firstRequestId, secondRequestId],
+    );
+});
+
+test('rejects duplicate, malformed, empty, and oversized selections', () => {
+    assert.equal(
+        parseDeliveryRunRequestBody(
+            { deliveryRequestIds: [firstRequestId, firstRequestId] },
+            26,
+        ),
+        null,
+    );
+    assert.equal(
+        parseDeliveryRunRequestBody({ deliveryRequestIds: ['invalid'] }, 26),
+        null,
+    );
+    assert.equal(
+        parseDeliveryRunRequestBody({ deliveryRequestIds: [] }, 26),
+        null,
+    );
+    assert.equal(
+        parseDeliveryRunRequestBody(
+            { deliveryRequestIds: [firstRequestId, secondRequestId] },
+            1,
+        ),
+        null,
+    );
+});

--- a/apps/delivery/lib/deliveryRunRequest.ts
+++ b/apps/delivery/lib/deliveryRunRequest.ts
@@ -1,0 +1,34 @@
+const deliveryRequestIdPattern =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function parseDeliveryRunRequestBody(
+    value: unknown,
+    maximumRequestCount: number,
+) {
+    if (
+        typeof value !== 'object' ||
+        value === null ||
+        !('deliveryRequestIds' in value) ||
+        !Array.isArray(value.deliveryRequestIds) ||
+        value.deliveryRequestIds.length === 0 ||
+        value.deliveryRequestIds.length > maximumRequestCount
+    ) {
+        return null;
+    }
+
+    const requestIds = value.deliveryRequestIds;
+    if (
+        !requestIds.every(
+            (requestId): requestId is string =>
+                typeof requestId === 'string' &&
+                deliveryRequestIdPattern.test(requestId),
+        )
+    ) {
+        return null;
+    }
+
+    const uniqueRequestIds = Array.from(new Set(requestIds));
+    return uniqueRequestIds.length === requestIds.length
+        ? uniqueRequestIds
+        : null;
+}

--- a/apps/delivery/package.json
+++ b/apps/delivery/package.json
@@ -11,7 +11,7 @@
         "dev": "node ../../scripts/run-app-command.mjs dev",
         "build": "next build",
         "start": "node ../../scripts/run-app-command.mjs start",
-        "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test lib/deliveryRouting.node.spec.ts"
+        "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test lib/*.node.spec.ts"
     },
     "dependencies": {
         "next": "16.2.10",

--- a/packages/storage/src/repositories/deliveryRunsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunsRepo.ts
@@ -193,8 +193,8 @@ export async function accountCanTrackDeliveryRun({
     accountId: string;
     runId: string;
 }) {
-    const row = await storage()
-        .select({ id: deliveryRunStops.id })
+    const rows = await storage()
+        .select({ accountId: operations.accountId })
         .from(deliveryRunStops)
         .innerJoin(deliveryRuns, eq(deliveryRunStops.runId, deliveryRuns.id))
         .innerJoin(
@@ -207,12 +207,12 @@ export async function accountCanTrackDeliveryRun({
                 eq(deliveryRunStops.runId, runId),
                 eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
                 ne(deliveryRunStops.state, DeliveryRunStopStates.DELIVERED),
-                eq(operations.accountId, accountId),
             ),
         )
+        .orderBy(asc(deliveryRunStops.sequence))
         .limit(1);
 
-    return row.length > 0;
+    return rows[0]?.accountId === accountId;
 }
 
 export async function updateDeliveryRunLocation({

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -19,7 +19,7 @@ import {
 import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
-test('delivery run enforces stop order and limits live tracking to active deliveries', async () => {
+test('delivery run enforces stop order and limits tracking to the current delivery', async () => {
     createTestDb();
     const accountId = await createTestAccount();
     const otherAccountId = await createTestAccount();
@@ -65,7 +65,7 @@ test('delivery run enforces stop order and limits live tracking to active delive
             {
                 entityId: 2,
                 entityTypeName: 'operation',
-                accountId,
+                accountId: otherAccountId,
             },
         ])
         .returning({ id: operations.id });
@@ -147,6 +147,17 @@ test('delivery run enforces stop order and limits live tracking to active delive
         runId: run.id,
         stopId: firstStop.id,
     });
+    assert.equal(
+        await accountCanTrackDeliveryRun({ accountId, runId: run.id }),
+        false,
+    );
+    assert.equal(
+        await accountCanTrackDeliveryRun({
+            accountId: otherAccountId,
+            runId: run.id,
+        }),
+        true,
+    );
     await fulfillDeliveryRunStop({
         driverUserId,
         runId: run.id,
@@ -159,6 +170,13 @@ test('delivery run enforces stop order and limits live tracking to active delive
     assert.equal(completedRun?.currentLongitude, null);
     assert.equal(
         await accountCanTrackDeliveryRun({ accountId, runId: run.id }),
+        false,
+    );
+    assert.equal(
+        await accountCanTrackDeliveryRun({
+            accountId: otherAccountId,
+            runId: run.id,
+        }),
         false,
     );
 });


### PR DESCRIPTION
## What changed

- let drivers select individual deliveries or whole time slots and start one connected route across multiple pickup groups, addresses, and delivery windows
- validate route size, request ownership/state, time-window span, expired windows, and route feasibility before marking harvests ready
- calculate ordered stops, travel/arrival estimates, future-window waiting time, and late-delivery warnings with Google routing plus a local fallback
- limit live GPS visibility to the customer whose delivery is the current stop

## Why

Drivers need to collect and deliver several orders in one run even when those orders come from different locations and time slots, while customers should only see live tracking when their own delivery is currently being served.

## Impact

The delivery dashboard now supports up to 26 selected deliveries across a maximum 24-hour window. Drivers can select, start, and complete the combined route; customers retain their delivery/status list and only the current recipient can view the active driver's location.

## Validation

- `corepack pnpm --filter delivery lint`
- `corepack pnpm --filter @gredice/storage lint`
- `corepack pnpm --filter delivery test`
- `corepack pnpm --filter @gredice/storage exec bash ./tests/runNodeTests.sh deliveryRunsRepo.node.spec.ts`
- `corepack pnpm --filter delivery typecheck`
- `corepack pnpm --filter delivery build`
- responsive browser checks at 1280x720, 768x1024, and 390x844
- `git diff --check`
