### PR TITLE
feat(delivery): group bulk delivery stops

### DIFF
--- a/apps/delivery/app/api/driver/runs/route.ts
+++ b/apps/delivery/app/api/driver/runs/route.ts
@@ -3,20 +3,16 @@ import {
     deliveryRunStartErrorMessage,
     startDeliveryRun,
 } from '../../../../lib/deliveryDashboard';
-import { maximumDeliveryRouteStops } from '../../../../lib/deliveryRouting';
 import { parseDeliveryRunRequestBody } from '../../../../lib/deliveryRunRequest';
 
 export async function POST(request: Request) {
     return await withAuth(['driver', 'admin'], async ({ userId }) => {
         const body: unknown = await request.json().catch(() => null);
-        const deliveryRequestIds = parseDeliveryRunRequestBody(
-            body,
-            maximumDeliveryRouteStops,
-        );
+        const deliveryRequestIds = parseDeliveryRunRequestBody(body);
         if (!deliveryRequestIds) {
             return Response.json(
                 {
-                    error: `Odaberi između 1 i ${maximumDeliveryRouteStops} valjanih dostava.`,
+                    error: 'Odaberi barem jednu valjanu dostavu.',
                 },
                 { status: 400 },
             );

--- a/apps/delivery/app/api/map/[runId]/route.ts
+++ b/apps/delivery/app/api/map/[runId]/route.ts
@@ -1,10 +1,9 @@
+import { DeliveryRunStopStates, getDeliveryRun } from '@gredice/storage';
+import { withAuth } from '../../../../lib/auth/auth';
 import {
     accountCanTrackDeliveryRun,
-    DeliveryRunStopStates,
-    getDeliveryRequest,
-    getDeliveryRun,
-} from '@gredice/storage';
-import { withAuth } from '../../../../lib/auth/auth';
+    resolveDeliveryRunStopGroups,
+} from '../../../../lib/deliveryDashboard';
 import {
     buildGoogleStaticMapUrl,
     unavailableMapSvg,
@@ -42,20 +41,31 @@ export async function GET(
                 return new Response(null, { status: 403 });
             }
 
-            const stops = driverView
-                ? run.stops
-                : (
-                      await Promise.all(
-                          run.stops.map(async (stop) => ({
-                              request: await getDeliveryRequest(
-                                  stop.deliveryRequestId,
-                              ),
-                              stop,
-                          })),
-                      )
-                  )
-                      .filter(({ request }) => request?.accountId === accountId)
-                      .map(({ stop }) => stop);
+            const groups = await resolveDeliveryRunStopGroups(run);
+            const stops = groups.flatMap((group, index) => {
+                const customerOwnsStop = group.items.some(
+                    ({ request }) => request?.accountId === accountId,
+                );
+                const delivered = group.items.every(
+                    ({ stop }) =>
+                        stop.state === DeliveryRunStopStates.DELIVERED,
+                );
+                const representative = group.items[0]?.stop;
+                if (
+                    !representative ||
+                    (!driverView && !customerOwnsStop) ||
+                    (driverView && delivered)
+                ) {
+                    return [];
+                }
+                return [
+                    {
+                        latitude: representative.latitude,
+                        longitude: representative.longitude,
+                        sequence: index + 1,
+                    },
+                ];
+            });
             const url = buildGoogleStaticMapUrl({
                 driverLocation:
                     run.currentLatitude !== null &&
@@ -65,17 +75,7 @@ export async function GET(
                               longitude: run.currentLongitude,
                           }
                         : null,
-                stops: stops
-                    .filter(
-                        (stop) =>
-                            stop.state !== DeliveryRunStopStates.DELIVERED ||
-                            customerView,
-                    )
-                    .map((stop) => ({
-                        latitude: stop.latitude,
-                        longitude: stop.longitude,
-                        sequence: stop.sequence,
-                    })),
+                stops,
                 encodedPolyline: run.encodedPolyline,
                 customerView,
             });

--- a/apps/delivery/components/DeliveryBatchCard.tsx
+++ b/apps/delivery/components/DeliveryBatchCard.tsx
@@ -9,6 +9,7 @@ import {
     formatDeliveryDateTime,
     formatDeliveryTime,
 } from '../lib/deliveryFormatting';
+import { groupByDeliveryStop } from '../lib/deliveryStopGrouping';
 import { DeliverySelectionItem } from './DeliverySelectionItem';
 
 export function DeliveryBatchCard({
@@ -16,6 +17,7 @@ export function DeliveryBatchCard({
     disabled,
     selectionLimitReached,
     selectedRequestIds,
+    selectedStopKeys,
     onToggleBatch,
     onToggleOrder,
 }: {
@@ -23,9 +25,11 @@ export function DeliveryBatchCard({
     disabled: boolean;
     selectionLimitReached: boolean;
     selectedRequestIds: ReadonlySet<string>;
+    selectedStopKeys: ReadonlySet<string>;
     onToggleBatch: (checked: boolean) => void;
     onToggleOrder: (requestId: string, checked: boolean) => void;
 }) {
+    const stopGroups = groupByDeliveryStop(batch.orders);
     const selectedCount = batch.orders.filter((order) =>
         selectedRequestIds.has(order.requestId),
     ).length;
@@ -55,11 +59,13 @@ export function DeliveryBatchCard({
                             >
                                 <Truck className="size-4" />
                                 {batch.deliveryCount}{' '}
-                                {batch.deliveryCount === 1
-                                    ? 'dostava'
-                                    : batch.deliveryCount < 5
-                                      ? 'dostave'
-                                      : 'dostava'}
+                                {batch.deliveryCount === 1 ? 'urod' : 'uroda'} ·{' '}
+                                {batch.stopCount}{' '}
+                                {batch.stopCount === 1
+                                    ? 'stanica'
+                                    : batch.stopCount < 5
+                                      ? 'stanice'
+                                      : 'stanica'}
                             </Typography>
                             {batch.pickupLocationName ? (
                                 <Typography
@@ -93,22 +99,27 @@ export function DeliveryBatchCard({
                     />
                 </div>
                 <div className="divide-y border-t">
-                    {batch.orders.map((order) => {
-                        const checked = selectedRequestIds.has(order.requestId);
-                        return (
+                    {stopGroups.flatMap((group) => {
+                        const firstOrder = group.items[0];
+                        if (!firstOrder) return [];
+                        const checked = group.items.every((order) =>
+                            selectedRequestIds.has(order.requestId),
+                        );
+                        return [
                             <DeliverySelectionItem
-                                key={order.requestId}
-                                order={order}
+                                key={group.stopKey}
+                                orders={group.items}
                                 checked={checked}
                                 disabled={
                                     disabled ||
-                                    (selectionLimitReached && !checked)
+                                    (selectionLimitReached &&
+                                        !selectedStopKeys.has(group.stopKey))
                                 }
                                 onCheckedChange={(value) =>
-                                    onToggleOrder(order.requestId, value)
+                                    onToggleOrder(firstOrder.requestId, value)
                                 }
-                            />
-                        );
+                            />,
+                        ];
                     })}
                 </div>
             </CardContent>

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -47,8 +47,8 @@ function isDeliveryDashboard(value: unknown): value is DeliveryDashboardData {
     return value.kind === 'driver'
         ? 'batches' in value &&
               Array.isArray(value.batches) &&
-              'maximumRouteDeliveries' in value &&
-              typeof value.maximumRouteDeliveries === 'number' &&
+              'maximumRouteStops' in value &&
+              typeof value.maximumRouteStops === 'number' &&
               'maximumRouteWindowHours' in value &&
               typeof value.maximumRouteWindowHours === 'number'
         : value.kind === 'customer' &&

--- a/apps/delivery/components/DeliverySelectionItem.tsx
+++ b/apps/delivery/components/DeliverySelectionItem.tsx
@@ -6,16 +6,19 @@ import { Typography } from '@gredice/ui/Typography';
 import type { DeliveryRouteOrderSummary } from '../lib/deliveryDashboardTypes';
 
 export function DeliverySelectionItem({
-    order,
+    orders,
     checked,
     disabled,
     onCheckedChange,
 }: {
-    order: DeliveryRouteOrderSummary;
+    orders: DeliveryRouteOrderSummary[];
     checked: boolean;
     disabled: boolean;
     onCheckedChange: (checked: boolean) => void;
 }) {
+    const firstOrder = orders[0];
+    if (!firstOrder) return null;
+
     return (
         <div
             className={
@@ -25,35 +28,57 @@ export function DeliverySelectionItem({
             }
         >
             <Checkbox
-                id={`delivery-order-${order.requestId}`}
+                id={`delivery-stop-${firstOrder.requestId}`}
                 checked={checked}
                 disabled={disabled}
                 onCheckedChange={(value) => onCheckedChange(value === true)}
                 className="mt-1 size-5"
                 label={
                     <span className="block min-w-0 space-y-1 pl-1">
-                        <span className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-                            <Typography component="span" level="body2" semiBold>
-                                {order.contactName}
-                            </Typography>
-                            <Typography
-                                component="span"
-                                level="body3"
-                                className="text-muted-foreground"
-                            >
-                                {order.harvest.plantName}
-                            </Typography>
-                        </span>
                         <span className="flex items-start gap-2 text-sm font-normal text-muted-foreground">
                             <MapPin className="mt-0.5 size-4 shrink-0" />
-                            <span>{order.address}</span>
+                            <span>{firstOrder.address}</span>
                         </span>
-                        {order.requestNotes ? (
-                            <span className="flex items-start gap-2 text-sm font-normal text-amber-800 dark:text-amber-200">
-                                <Leaf className="mt-0.5 size-4 shrink-0" />
-                                <span>{order.requestNotes}</span>
-                            </span>
-                        ) : null}
+                        <Typography
+                            component="span"
+                            level="body3"
+                            className="block text-muted-foreground"
+                        >
+                            {orders.length}{' '}
+                            {orders.length === 1 ? 'urod' : 'uroda'} na ovoj
+                            stanici
+                        </Typography>
+                        <span className="block space-y-2 pt-1">
+                            {orders.map((order) => (
+                                <span
+                                    key={order.requestId}
+                                    className="block rounded-md border bg-background/70 p-2"
+                                >
+                                    <span className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                                        <Typography
+                                            component="span"
+                                            level="body2"
+                                            semiBold
+                                        >
+                                            {order.contactName}
+                                        </Typography>
+                                        <Typography
+                                            component="span"
+                                            level="body3"
+                                            className="text-muted-foreground"
+                                        >
+                                            {order.harvest.plantName}
+                                        </Typography>
+                                    </span>
+                                    {order.requestNotes ? (
+                                        <span className="mt-1 flex items-start gap-2 text-sm font-normal text-amber-800 dark:text-amber-200">
+                                            <Leaf className="mt-0.5 size-4 shrink-0" />
+                                            <span>{order.requestNotes}</span>
+                                        </span>
+                                    ) : null}
+                                </span>
+                            ))}
+                        </span>
                     </span>
                 }
             />

--- a/apps/delivery/components/DeliveryStopCard.tsx
+++ b/apps/delivery/components/DeliveryStopCard.tsx
@@ -88,7 +88,9 @@ export function DeliveryStopCard({
                                 className="truncate"
                             >
                                 {driverMode
-                                    ? stop.contactName
+                                    ? stop.deliveryCount > 1
+                                        ? `${stop.deliveryCount} uroda · skupna dostava`
+                                        : stop.contactName
                                     : stop.harvest.plantName}
                             </Typography>
                             <Typography
@@ -96,7 +98,9 @@ export function DeliveryStopCard({
                                 className="mt-0.5 text-muted-foreground"
                             >
                                 {driverMode
-                                    ? stop.harvest.plantName
+                                    ? stop.deliveryCount > 1
+                                        ? 'Ista adresa i termin'
+                                        : stop.harvest.plantName
                                     : formatDeliveryDateTime(stop.slotStartAt)}
                             </Typography>
                         </div>
@@ -163,32 +167,113 @@ export function DeliveryStopCard({
                             <span>{stop.address}</span>
                         </div>
                     ) : null}
-                    {driverMode && stop.phone ? (
-                        <a
-                            href={`tel:${stop.phone}`}
-                            className="flex items-center gap-2 text-primary hover:underline"
-                        >
-                            <Mobile className="size-4" />
-                            {stop.phone}
-                        </a>
-                    ) : null}
-                    <div className="flex items-start gap-2">
-                        <Leaf className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                        <span>
-                            {[
-                                stop.harvest.plantName,
-                                stop.harvest.raisedBedName,
-                                stop.harvest.fieldName,
-                            ]
-                                .filter(Boolean)
-                                .join(' · ')}
-                        </span>
-                    </div>
-                    {stop.requestNotes ? (
-                        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950">
-                            <strong>Napomena:</strong> {stop.requestNotes}
+                    {driverMode ? (
+                        <div className="space-y-2">
+                            {stop.deliveries.map((delivery) => (
+                                <div
+                                    key={delivery.requestId}
+                                    className="space-y-2 rounded-md border p-3"
+                                >
+                                    <Typography
+                                        level="body3"
+                                        semiBold
+                                        className="flex items-center gap-2"
+                                    >
+                                        <User className="size-4" />
+                                        {delivery.contactName}
+                                    </Typography>
+                                    {delivery.phone ? (
+                                        <a
+                                            href={`tel:${delivery.phone}`}
+                                            className="flex items-center gap-2 text-primary hover:underline"
+                                        >
+                                            <Mobile className="size-4" />
+                                            {delivery.phone}
+                                        </a>
+                                    ) : null}
+                                    <div className="flex items-start gap-2">
+                                        <Leaf className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                                        <span>
+                                            {[
+                                                delivery.harvest.plantName,
+                                                delivery.harvest.raisedBedName,
+                                                delivery.harvest.fieldName,
+                                            ]
+                                                .filter(Boolean)
+                                                .join(' · ')}
+                                        </span>
+                                    </div>
+                                    {delivery.requestNotes ? (
+                                        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                                            <strong>Napomena:</strong>{' '}
+                                            {delivery.requestNotes}
+                                        </div>
+                                    ) : null}
+                                    {delivery.accountContacts.length > 0 ? (
+                                        <div className="border-t pt-2">
+                                            <Typography
+                                                level="body3"
+                                                semiBold
+                                                className="mb-1"
+                                            >
+                                                Korisnici računa
+                                            </Typography>
+                                            {delivery.accountContacts.map(
+                                                (contact) => (
+                                                    <div
+                                                        key={contact.id}
+                                                        className="text-sm"
+                                                    >
+                                                        {contact.displayName} ·{' '}
+                                                        <a
+                                                            href={`mailto:${contact.email}`}
+                                                            className="text-primary hover:underline"
+                                                        >
+                                                            {contact.email}
+                                                        </a>
+                                                    </div>
+                                                ),
+                                            )}
+                                        </div>
+                                    ) : null}
+                                    {delivery.harvest.tracePath ? (
+                                        <Button
+                                            href={`https://www.gredice.com${delivery.harvest.tracePath}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            variant="plain"
+                                            startDecorator={
+                                                <ExternalLink className="size-4" />
+                                            }
+                                        >
+                                            Trag uroda
+                                        </Button>
+                                    ) : null}
+                                </div>
+                            ))}
                         </div>
-                    ) : null}
+                    ) : (
+                        <>
+                            <div className="flex items-start gap-2">
+                                <Leaf className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                                <span>
+                                    {[
+                                        stop.harvest.plantName,
+                                        stop.harvest.raisedBedName,
+                                        stop.harvest.fieldName,
+                                    ]
+                                        .filter(Boolean)
+                                        .join(' · ')}
+                                </span>
+                            </div>
+                            {stop.requestNotes ? (
+                                <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                                    <strong>Napomena:</strong>{' '}
+                                    {stop.requestNotes}
+                                </div>
+                            ) : null}
+                        </>
+                    )}
                     {estimatedOutsideWindow && !delivered ? (
                         <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
                             <Warning className="mt-0.5 size-4 shrink-0" />
@@ -196,28 +281,6 @@ export function DeliveryStopCard({
                                 Trenutačna procjena dolaska je nakon završetka
                                 termina. Obavijesti korisnika o kašnjenju.
                             </span>
-                        </div>
-                    ) : null}
-                    {driverMode && stop.accountContacts.length > 0 ? (
-                        <div className="rounded-md border p-3">
-                            <Typography
-                                level="body3"
-                                semiBold
-                                className="mb-2 flex items-center gap-2"
-                            >
-                                <User className="size-4" /> Korisnici računa
-                            </Typography>
-                            {stop.accountContacts.map((contact) => (
-                                <div key={contact.id} className="text-sm">
-                                    {contact.displayName} ·{' '}
-                                    <a
-                                        href={`mailto:${contact.email}`}
-                                        className="text-primary hover:underline"
-                                    >
-                                        {contact.email}
-                                    </a>
-                                </div>
-                            ))}
                         </div>
                     ) : null}
                 </div>
@@ -234,7 +297,7 @@ export function DeliveryStopCard({
                             Navigacija
                         </Button>
                     ) : null}
-                    {stop.harvest.tracePath ? (
+                    {!driverMode && stop.harvest.tracePath ? (
                         <Button
                             href={`https://www.gredice.com${stop.harvest.tracePath}`}
                             target="_blank"
@@ -253,7 +316,9 @@ export function DeliveryStopCard({
                             className="block text-sm font-medium"
                             htmlFor={`notes-${stop.id}`}
                         >
-                            Napomena o dostavi
+                            {stop.deliveryCount > 1
+                                ? 'Napomena za skupnu dostavu'
+                                : 'Napomena o dostavi'}
                         </label>
                         <textarea
                             id={`notes-${stop.id}`}
@@ -284,7 +349,9 @@ export function DeliveryStopCard({
                                 onClick={() => onDeliver?.(notes || undefined)}
                                 startDecorator={<Approved className="size-4" />}
                             >
-                                Dostavljeno · dalje
+                                {stop.deliveryCount > 1
+                                    ? `Dostavi ${stop.deliveryCount} uroda · dalje`
+                                    : 'Dostavljeno · dalje'}
                             </Button>
                         </div>
                     </div>

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -23,6 +23,7 @@ import {
     formatDistance,
     formatTravelDuration,
 } from '../lib/deliveryFormatting';
+import { groupByDeliveryStop } from '../lib/deliveryStopGrouping';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
 import { DeliveryBatchCard } from './DeliveryBatchCard';
 import { DeliveryMap } from './DeliveryMap';
@@ -63,44 +64,60 @@ export function DriverDashboard({
     const run = dashboard.activeRun;
     const locationMessage = trackingMessage(trackingState);
     const [selectedRequestIds, setSelectedRequestIds] = useState<string[]>([]);
-    const availableRequestIds = dashboard.batches.flatMap((batch) =>
-        batch.orders.map((order) => order.requestId),
-    );
+    const availableOrders = dashboard.batches.flatMap((batch) => batch.orders);
+    const availableRequestIds = availableOrders.map((order) => order.requestId);
     const availableRequestIdSet = new Set(availableRequestIds);
+    const ordersByRequestId = new Map(
+        availableOrders.map((order) => [order.requestId, order]),
+    );
+    const availableStopGroups = groupByDeliveryStop(availableOrders);
     const effectiveSelectedRequestIds = selectedRequestIds.filter((requestId) =>
         availableRequestIdSet.has(requestId),
     );
     const selectedRequestIdSet = new Set(effectiveSelectedRequestIds);
+    const selectedStopKeys = new Set(
+        effectiveSelectedRequestIds.flatMap((requestId) => {
+            const order = ordersByRequestId.get(requestId);
+            return order ? [order.stopKey] : [];
+        }),
+    );
     const selectionLimitReached =
-        effectiveSelectedRequestIds.length >= dashboard.maximumRouteDeliveries;
+        selectedStopKeys.size >= dashboard.maximumRouteStops;
     const selectedSlotCount = dashboard.batches.filter((batch) =>
         batch.orders.some((order) => selectedRequestIdSet.has(order.requestId)),
     ).length;
-    const selectedLocationCount = new Set(
-        dashboard.batches.flatMap((batch) =>
-            batch.orders.flatMap((order) =>
-                selectedRequestIdSet.has(order.requestId)
-                    ? [order.address]
-                    : [],
-            ),
-        ),
-    ).size;
 
     const toggleOrder = (requestId: string, checked: boolean) => {
+        const order = ordersByRequestId.get(requestId);
+        if (!order) return;
+        const groupedRequestIds = availableOrders.flatMap((candidate) =>
+            candidate.stopKey === order.stopKey ? [candidate.requestId] : [],
+        );
+        const groupedRequestIdSet = new Set(groupedRequestIds);
         setSelectedRequestIds((current) => {
             const availableCurrent = current.filter((id) =>
                 availableRequestIdSet.has(id),
             );
             if (!checked) {
-                return availableCurrent.filter((id) => id !== requestId);
+                return availableCurrent.filter(
+                    (id) => !groupedRequestIdSet.has(id),
+                );
             }
+            const currentStopKeys = new Set(
+                availableCurrent.flatMap((id) => {
+                    const currentOrder = ordersByRequestId.get(id);
+                    return currentOrder ? [currentOrder.stopKey] : [];
+                }),
+            );
             if (
-                availableCurrent.includes(requestId) ||
-                availableCurrent.length >= dashboard.maximumRouteDeliveries
+                !currentStopKeys.has(order.stopKey) &&
+                currentStopKeys.size >= dashboard.maximumRouteStops
             ) {
                 return availableCurrent;
             }
-            return [...availableCurrent, requestId];
+            return Array.from(
+                new Set([...availableCurrent, ...groupedRequestIds]),
+            );
         });
     };
 
@@ -117,18 +134,36 @@ export function DriverDashboard({
                 return availableCurrent.filter((id) => !batchIds.has(id));
             }
 
-            const next = [...availableCurrent];
-            for (const requestId of batchIds) {
-                if (
-                    next.length >= dashboard.maximumRouteDeliveries ||
-                    next.includes(requestId)
-                ) {
-                    continue;
+            const next = new Set(availableCurrent);
+            const nextStopKeys = new Set(
+                availableCurrent.flatMap((id) => {
+                    const order = ordersByRequestId.get(id);
+                    return order ? [order.stopKey] : [];
+                }),
+            );
+            for (const group of groupByDeliveryStop(batch.orders)) {
+                if (!nextStopKeys.has(group.stopKey)) {
+                    if (nextStopKeys.size >= dashboard.maximumRouteStops) {
+                        continue;
+                    }
+                    nextStopKeys.add(group.stopKey);
                 }
-                next.push(requestId);
+                for (const order of group.items) {
+                    next.add(order.requestId);
+                }
             }
-            return next;
+            return Array.from(next);
         });
+    };
+
+    const selectAllAvailable = () => {
+        setSelectedRequestIds(
+            availableStopGroups
+                .slice(0, dashboard.maximumRouteStops)
+                .flatMap((group) =>
+                    group.items.map((order) => order.requestId),
+                ),
+        );
     };
 
     return (
@@ -234,6 +269,19 @@ export function DriverDashboard({
                                             </Chip>
                                         </div>
                                         <Typography
+                                            level="body3"
+                                            className="mt-1 text-muted-foreground"
+                                        >
+                                            {run.deliveryCount}{' '}
+                                            {run.deliveryCount === 1
+                                                ? 'urod'
+                                                : 'uroda'}{' '}
+                                            na {run.stops.length}{' '}
+                                            {run.stops.length === 1
+                                                ? 'stanici'
+                                                : 'stanica'}
+                                        </Typography>
+                                        <Typography
                                             level="body2"
                                             className="mt-1"
                                         >
@@ -256,7 +304,7 @@ export function DriverDashboard({
                             <div className="grid gap-3 lg:grid-cols-2">
                                 {run.stops.map((stop) => (
                                     <DeliveryStopCard
-                                        key={stop.requestId}
+                                        key={stop.id ?? stop.requestId}
                                         stop={stop}
                                         mode="driver"
                                         pendingAction={
@@ -300,7 +348,19 @@ export function DriverDashboard({
                                                     {
                                                         effectiveSelectedRequestIds.length
                                                     }{' '}
-                                                    odabrano
+                                                    {effectiveSelectedRequestIds.length ===
+                                                    1
+                                                        ? 'urod'
+                                                        : 'uroda'}
+                                                </Chip>
+                                                <Chip color="neutral" size="sm">
+                                                    {selectedStopKeys.size}{' '}
+                                                    {selectedStopKeys.size === 1
+                                                        ? 'stanica'
+                                                        : selectedStopKeys.size <
+                                                            5
+                                                          ? 'stanice'
+                                                          : 'stanica'}
                                                 </Chip>
                                                 <Chip color="neutral" size="sm">
                                                     {selectedSlotCount}{' '}
@@ -308,31 +368,23 @@ export function DriverDashboard({
                                                         ? 'termin'
                                                         : 'termina'}
                                                 </Chip>
-                                                <Chip color="neutral" size="sm">
-                                                    {selectedLocationCount}{' '}
-                                                    {selectedLocationCount === 1
-                                                        ? 'lokacija'
-                                                        : selectedLocationCount <
-                                                            5
-                                                          ? 'lokacije'
-                                                          : 'lokacija'}
-                                                </Chip>
                                             </div>
                                             <Typography
                                                 level="body3"
                                                 className="mt-2 text-muted-foreground"
                                             >
                                                 Najviše{' '}
-                                                {
-                                                    dashboard.maximumRouteDeliveries
-                                                }{' '}
-                                                dostava po ruti i termini unutar
-                                                najviše{' '}
+                                                {dashboard.maximumRouteStops}{' '}
+                                                fizičkih stanica po ruti. Svi
+                                                urodi za istu adresu u istom
+                                                terminu računaju se kao jedna
+                                                skupna stanica. Termini moraju
+                                                biti unutar najviše{' '}
                                                 {
                                                     dashboard.maximumRouteWindowHours
                                                 }{' '}
-                                                sata. Termini se poštuju pri
-                                                izračunu dolazaka.
+                                                sata i poštuju se pri izračunu
+                                                dolazaka.
                                             </Typography>
                                         </div>
                                         <div className="flex flex-wrap gap-2">
@@ -341,14 +393,7 @@ export function DriverDashboard({
                                                 disabled={Boolean(
                                                     pendingAction,
                                                 )}
-                                                onClick={() =>
-                                                    setSelectedRequestIds(
-                                                        availableRequestIds.slice(
-                                                            0,
-                                                            dashboard.maximumRouteDeliveries,
-                                                        ),
-                                                    )
-                                                }
+                                                onClick={selectAllAvailable}
                                             >
                                                 Odaberi sve
                                             </Button>
@@ -391,6 +436,10 @@ export function DriverDashboard({
                                                 {
                                                     effectiveSelectedRequestIds.length
                                                 }{' '}
+                                                {effectiveSelectedRequestIds.length ===
+                                                1
+                                                    ? 'urod'
+                                                    : 'uroda'}{' '}
                                                 i pokreni rutu
                                             </Button>
                                         </div>
@@ -398,17 +447,18 @@ export function DriverDashboard({
                                 </Card>
 
                                 {selectionLimitReached &&
-                                availableRequestIds.length >
-                                    dashboard.maximumRouteDeliveries ? (
+                                availableStopGroups.length >
+                                    dashboard.maximumRouteStops ? (
                                     <Alert
                                         color="info"
                                         startDecorator={
                                             <Warning className="size-5" />
                                         }
                                     >
-                                        Dosegnut je najveći broj dostava za
-                                        jednu rutu. Poništi neku dostavu kako bi
-                                        odabrao drugu.
+                                        Dosegnut je najveći broj fizičkih
+                                        stanica za jednu rutu. Urodi na već
+                                        odabranoj adresi i u istom terminu i
+                                        dalje se dodaju skupno.
                                     </Alert>
                                 ) : null}
 
@@ -423,6 +473,7 @@ export function DriverDashboard({
                                         selectedRequestIds={
                                             selectedRequestIdSet
                                         }
+                                        selectedStopKeys={selectedStopKeys}
                                         onToggleBatch={(checked) =>
                                             toggleBatch(batch, checked)
                                         }

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -4,16 +4,15 @@ import {
     DeliveryRequestStates,
     DeliveryRunStates,
     DeliveryRunStopStates,
-    fulfillDeliveryRunStop,
+    fulfillDeliveryRunStops,
     getActiveDeliveryRunForDriver,
     getDeliveryAccountContacts,
     getDeliveryRequest,
     getDeliveryRequestsWithEvents,
     getDeliveryRun,
-    getDeliveryRunStop,
     getDeliveryRunStopsForRequestIds,
     getUser,
-    markDeliveryRunStopArrived,
+    markDeliveryRunStopsArrived,
     readyDeliveryRequest,
     updateDeliveryRunEstimates,
     updateDeliveryRunLocation,
@@ -25,6 +24,7 @@ import type {
     DeliveryDashboard,
     DeliveryHarvestSummary,
     DeliveryRouteOrderSummary,
+    DeliveryStopDeliverySummary,
     DeliveryStopSummary,
     DeliveryTrackingLocation,
 } from './deliveryDashboardTypes';
@@ -36,6 +36,10 @@ import {
     planDeliveryRoute,
     recalculateDeliveryRoute,
 } from './deliveryRouting';
+import {
+    buildDeliveryStopKey,
+    groupByDeliveryStop,
+} from './deliveryStopGrouping';
 
 type ListedDeliveryRequest = Awaited<
     ReturnType<typeof getDeliveryRequestsWithEvents>
@@ -43,7 +47,9 @@ type ListedDeliveryRequest = Awaited<
 type DeliveryRequest =
     | ListedDeliveryRequest
     | NonNullable<Awaited<ReturnType<typeof getDeliveryRequest>>>;
-type DeliveryRun = NonNullable<Awaited<ReturnType<typeof getDeliveryRun>>>;
+export type DeliveryRun = NonNullable<
+    Awaited<ReturnType<typeof getDeliveryRun>>
+>;
 type DeliveryRunStop = DeliveryRun['stops'][number];
 type DeliveryAccountContact = Awaited<
     ReturnType<typeof getDeliveryAccountContacts>
@@ -140,6 +146,49 @@ function harvestSummary(request: DeliveryRequest): DeliveryHarvestSummary {
     };
 }
 
+function deliveryRequestStopKey(request: DeliveryRequest) {
+    if (!request.slot || !request.address) {
+        return `request:${request.id}`;
+    }
+
+    return buildDeliveryStopKey(
+        request.slot.id,
+        formatDeliveryDestinationAddress(request.address),
+    );
+}
+
+export type ResolvedDeliveryRunStop = {
+    stop: DeliveryRunStop;
+    request: DeliveryRequest | undefined;
+    stopKey: string;
+};
+
+export type ResolvedDeliveryRunStopGroup = {
+    stopKey: string;
+    items: ResolvedDeliveryRunStop[];
+};
+
+export async function resolveDeliveryRunStopGroups(
+    run: DeliveryRun,
+): Promise<ResolvedDeliveryRunStopGroup[]> {
+    const requests = await Promise.all(
+        run.stops.map((stop) => getDeliveryRequest(stop.deliveryRequestId)),
+    );
+
+    return groupByDeliveryStop(
+        run.stops.map((stop, index) => {
+            const request = requests[index];
+            return {
+                stop,
+                request,
+                stopKey: request
+                    ? deliveryRequestStopKey(request)
+                    : `request:${stop.deliveryRequestId}`,
+            };
+        }),
+    );
+}
+
 function statusLabel({
     requestState,
     stopState,
@@ -192,21 +241,55 @@ type DeliveryRunSnapshot = Pick<
     | 'currentLocationRecordedAt'
 >;
 
+function deliverySummaryItem(
+    request: DeliveryRequest,
+    contacts: DeliveryAccountContact[],
+): DeliveryStopDeliverySummary {
+    const address = request.address;
+    return {
+        requestId: request.id,
+        requestState: request.state,
+        contactName: address?.contactName ?? 'Nepoznat kontakt',
+        phone: address?.phone ?? null,
+        addressLabel: address?.label ?? null,
+        requestNotes: request.requestNotes ?? null,
+        deliveryNotes: request.deliveryNotes ?? null,
+        harvest: harvestSummary(request),
+        accountContacts: accountContacts(request.accountId, contacts),
+    };
+}
+
 function deliveryStopSummary({
-    request,
-    stop,
+    items,
     run,
     isCurrent,
     contacts,
     includeTracking,
+    sequence,
 }: {
-    request: DeliveryRequest;
-    stop?: DeliveryRunStop | null;
+    items: { request: DeliveryRequest; stop?: DeliveryRunStop | null }[];
     run?: DeliveryRunSnapshot | null;
     isCurrent: boolean;
     contacts: DeliveryAccountContact[];
     includeTracking: boolean;
+    sequence?: number | null;
 }): DeliveryStopSummary {
+    const primary = items[0];
+    if (!primary) {
+        throw new Error('Dostavna stanica nema nijednu dostavu.');
+    }
+    const request = primary.request;
+    const stops = items.flatMap((item) => (item.stop ? [item.stop] : []));
+    const representativeStop =
+        stops.find((stop) => stop.state !== DeliveryRunStopStates.DELIVERED) ??
+        stops[0];
+    const stopState =
+        stops.length > 0 &&
+        stops.every((stop) => stop.state === DeliveryRunStopStates.DELIVERED)
+            ? DeliveryRunStopStates.DELIVERED
+            : stops.some((stop) => stop.state === DeliveryRunStopStates.ARRIVED)
+              ? DeliveryRunStopStates.ARRIVED
+              : (representativeStop?.state ?? null);
     const address = request.address;
     const formattedAddress = address
         ? formatDeliveryDestinationAddress(address)
@@ -214,14 +297,14 @@ function deliveryStopSummary({
     const runLocation = run ? trackingLocation(run) : null;
 
     return {
-        id: stop?.id ?? null,
+        id: representativeStop?.id ?? null,
         requestId: request.id,
-        sequence: stop?.sequence ?? null,
-        stopState: stop?.state ?? null,
+        sequence: sequence ?? representativeStop?.sequence ?? null,
+        stopState,
         requestState: request.state,
         statusLabel: statusLabel({
             requestState: request.state,
-            stopState: stop?.state,
+            stopState,
             isCurrent,
             runState: run?.state,
         }),
@@ -234,23 +317,30 @@ function deliveryStopSummary({
         deliveryNotes: request.deliveryNotes ?? null,
         slotStartAt: iso(request.slot?.startAt),
         slotEndAt: iso(request.slot?.endAt),
-        estimatedArrivalAt: iso(stop?.estimatedArrivalAt),
-        estimatedTravelSeconds: stop?.estimatedTravelSeconds ?? null,
-        estimatedDistanceMeters: stop?.estimatedDistanceMeters ?? null,
-        arrivedAt: iso(stop?.arrivedAt),
-        deliveredAt: iso(stop?.deliveredAt),
+        estimatedArrivalAt: iso(representativeStop?.estimatedArrivalAt),
+        estimatedTravelSeconds:
+            representativeStop?.estimatedTravelSeconds ?? null,
+        estimatedDistanceMeters:
+            representativeStop?.estimatedDistanceMeters ?? null,
+        arrivedAt: iso(stops.find((stop) => stop.arrivedAt)?.arrivedAt),
+        deliveredAt: iso(stops.find((stop) => stop.deliveredAt)?.deliveredAt),
         harvest: harvestSummary(request),
         accountContacts: accountContacts(request.accountId, contacts),
         tracking: includeTracking ? runLocation : null,
         runId: run?.id ?? null,
+        deliveryCount: items.length,
+        deliveries: items.map((item) =>
+            deliverySummaryItem(item.request, contacts),
+        ),
     };
 }
 
 async function activeRunSummary(
     run: DeliveryRun,
 ): Promise<ActiveDeliveryRunSummary> {
-    const requests = await Promise.all(
-        run.stops.map((stop) => getDeliveryRequest(stop.deliveryRequestId)),
+    const groups = await resolveDeliveryRunStopGroups(run);
+    const requests = groups.flatMap((group) =>
+        group.items.flatMap((item) => (item.request ? [item.request] : [])),
     );
     const accountIds = Array.from(
         new Set(
@@ -260,24 +350,28 @@ async function activeRunSummary(
         ),
     );
     const contacts = await getDeliveryAccountContacts(accountIds);
-    const currentStop = run.stops.find(
-        (stop) => stop.state !== DeliveryRunStopStates.DELIVERED,
+    const currentGroup = groups.find((group) =>
+        group.items.some(
+            ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,
+        ),
     );
-    const stops = run.stops.flatMap((stop, index) => {
-        const request = requests[index];
-        return request
-            ? [
-                  deliveryStopSummary({
-                      request,
-                      stop,
-                      run,
-                      isCurrent: currentStop?.id === stop.id,
-                      contacts,
-                      includeTracking: true,
-                  }),
-              ]
-            : [];
-    });
+    const stops: DeliveryStopSummary[] = [];
+    for (const group of groups) {
+        const items = group.items.flatMap(({ request, stop }) =>
+            request ? [{ request, stop }] : [],
+        );
+        if (items.length === 0) continue;
+        stops.push(
+            deliveryStopSummary({
+                items,
+                run,
+                isCurrent: currentGroup?.stopKey === group.stopKey,
+                contacts,
+                includeTracking: true,
+                sequence: stops.length + 1,
+            }),
+        );
+    }
 
     return {
         id: run.id,
@@ -289,6 +383,10 @@ async function activeRunSummary(
         location: trackingLocation(run),
         estimatesUpdatedAt: iso(run.estimatesUpdatedAt),
         mapUrl: `/api/map/${run.id}`,
+        deliveryCount: stops.reduce(
+            (count, stop) => count + stop.deliveryCount,
+            0,
+        ),
         stops,
     };
 }
@@ -345,6 +443,7 @@ async function driverDashboard({
         }
         const order = {
             requestId: request.id,
+            stopKey: deliveryRequestStopKey(request),
             contactName: request.address.contactName,
             address: formatDeliveryDestinationAddress(request.address),
             addressLabel: request.address.label,
@@ -383,13 +482,14 @@ async function driverDashboard({
             pickupLocationName: batch.pickupLocationName,
             pickupAddress: batch.pickupAddress,
             deliveryCount: batch.orders.length,
+            stopCount: new Set(batch.orders.map((order) => order.stopKey)).size,
             orders: batch.orders.sort((first, second) =>
                 first.address.localeCompare(second.address, 'hr'),
             ),
         })).sort((first, second) =>
             first.startAt.localeCompare(second.startAt),
         ),
-        maximumRouteDeliveries: maximumDeliveryRouteStops,
+        maximumRouteStops: maximumDeliveryRouteStops,
         maximumRouteWindowHours: maximumDeliveryRouteWindowHours,
         refreshedAt: new Date().toISOString(),
     };
@@ -427,13 +527,20 @@ async function customerDashboard({
         ),
     );
     const activeRuns = await Promise.all(activeRunIds.map(getDeliveryRun));
-    const currentByRunId = new Map<string, number>();
+    const currentStopIdsByRunId = new Map<string, Set<number>>();
     for (const run of activeRuns) {
-        const currentStop = run?.stops.find(
-            (stop) => stop.state !== DeliveryRunStopStates.DELIVERED,
+        if (!run) continue;
+        const groups = await resolveDeliveryRunStopGroups(run);
+        const currentGroup = groups.find((group) =>
+            group.items.some(
+                ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,
+            ),
         );
-        if (run && currentStop) {
-            currentByRunId.set(run.id, currentStop.id);
+        if (currentGroup) {
+            currentStopIdsByRunId.set(
+                run.id,
+                new Set(currentGroup.items.map(({ stop }) => stop.id)),
+            );
         }
     }
 
@@ -441,11 +548,11 @@ async function customerDashboard({
         .map((request) => {
             const row = rowsByRequestId.get(request.id);
             const isCurrent = row
-                ? currentByRunId.get(row.run.id) === row.stop.id
+                ? (currentStopIdsByRunId.get(row.run.id)?.has(row.stop.id) ??
+                  false)
                 : false;
             return deliveryStopSummary({
-                request,
-                stop: row?.stop,
+                items: [{ request, stop: row?.stop }],
                 run: row?.run,
                 isCurrent,
                 contacts,
@@ -526,20 +633,15 @@ export async function startDeliveryRun({
         await ensureRunRequestsReady(existingRun);
         return existingRun;
     }
-    if (
-        deliveryRequestIds.length === 0 ||
-        deliveryRequestIds.length > maximumDeliveryRouteStops
-    ) {
-        throw new DeliveryRunStartError(
-            `Odaberi između 1 i ${maximumDeliveryRouteStops} dostava.`,
-        );
+    if (deliveryRequestIds.length === 0) {
+        throw new DeliveryRunStartError('Odaberi barem jednu dostavu.');
     }
 
     const requests = await getDeliveryRequestsWithEvents();
     const requestsById = new Map(
         requests.map((request) => [request.id, request]),
     );
-    const candidates: ListedDeliveryRequest[] = [];
+    const selectedStopKeys = new Set<string>();
     const now = new Date();
     for (const requestId of deliveryRequestIds) {
         const request = requestsById.get(requestId);
@@ -554,8 +656,23 @@ export async function startDeliveryRun({
                 'Jedna ili više odabranih dostava više nije dostupna za preuzimanje. Osvježi popis i pokušaj ponovno.',
             );
         }
-        candidates.push(request);
+        selectedStopKeys.add(deliveryRequestStopKey(request));
     }
+    if (selectedStopKeys.size > maximumDeliveryRouteStops) {
+        throw new DeliveryRunStartError(
+            `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} fizičkih stanica. Dostave na istoj adresi u istom terminu računaju se kao jedna stanica.`,
+        );
+    }
+
+    const candidates = requests.filter(
+        (request) =>
+            request.mode === 'delivery' &&
+            request.address &&
+            request.slot &&
+            batchStates.has(request.state) &&
+            request.slot.endAt >= now &&
+            selectedStopKeys.has(deliveryRequestStopKey(request)),
+    );
 
     const existingStops = await getDeliveryRunStopsForRequestIds(
         candidates.map((request) => request.id),
@@ -566,20 +683,32 @@ export async function startDeliveryRun({
         );
     }
 
+    const candidateGroups = groupByDeliveryStop(
+        candidates.map((request) => ({
+            request,
+            stopKey: deliveryRequestStopKey(request),
+        })),
+    );
+    const candidateGroupsByRepresentativeId = new Map<
+        string,
+        (typeof candidateGroups)[number]
+    >();
     const plan = await planDeliveryRoute({
-        candidates: candidates.map((request) => {
-            if (!request.address || !request.slot) {
+        candidates: candidateGroups.map((group) => {
+            const representative = group.items[0]?.request;
+            if (!representative?.address || !representative.slot) {
                 throw new DeliveryRunStartError(
                     'Odabrana dostava nema valjanu adresu ili termin.',
                 );
             }
+            candidateGroupsByRepresentativeId.set(representative.id, group);
             return {
-                deliveryRequestId: request.id,
+                deliveryRequestId: representative.id,
                 formattedAddress: formatDeliveryDestinationAddress(
-                    request.address,
+                    representative.address,
                 ),
-                windowStartAt: request.slot.startAt,
-                windowEndAt: request.slot.endAt,
+                windowStartAt: representative.slot.startAt,
+                windowEndAt: representative.slot.endAt,
             };
         }),
     });
@@ -595,13 +724,38 @@ export async function startDeliveryRun({
             'Odabrane dostave nemaju valjani termin.',
         );
     }
+    let storedSequence = 0;
+    const storedStops = plan.stops.flatMap((plannedStop) => {
+        const group = candidateGroupsByRepresentativeId.get(
+            plannedStop.deliveryRequestId,
+        );
+        if (!group) {
+            throw new DeliveryRunStartError(
+                'Planirana dostavna stanica nije pronađena.',
+            );
+        }
+
+        return group.items.map(({ request }) => {
+            storedSequence += 1;
+            return {
+                deliveryRequestId: request.id,
+                sequence: storedSequence,
+                latitude: plannedStop.latitude,
+                longitude: plannedStop.longitude,
+                formattedAddress: plannedStop.formattedAddress,
+                estimatedArrivalAt: plannedStop.estimatedArrivalAt,
+                estimatedTravelSeconds: plannedStop.estimatedTravelSeconds,
+                estimatedDistanceMeters: plannedStop.estimatedDistanceMeters,
+            };
+        });
+    });
     const run = await createDeliveryRun({
         driverUserId,
         timeSlotId: primarySlot.id,
         encodedPolyline: plan.encodedPolyline,
         totalDistanceMeters: plan.totalDistanceMeters,
         totalDurationSeconds: plan.totalDurationSeconds,
-        stops: plan.stops,
+        stops: storedStops,
     });
 
     await ensureRunRequestsReady(run);
@@ -618,11 +772,60 @@ export async function arriveAtDeliveryStop({
     runId: string;
     stopId: number;
 }) {
-    return await markDeliveryRunStopArrived({
+    const group = await getOwnedDeliveryRunStopGroup({
         driverUserId,
         runId,
         stopId,
     });
+    return await markDeliveryRunStopsArrived({
+        driverUserId,
+        runId,
+        stopIds: group.items.map(({ stop }) => stop.id),
+    });
+}
+
+async function getOwnedDeliveryRunStopGroup({
+    driverUserId,
+    runId,
+    stopId,
+}: {
+    driverUserId: string;
+    runId: string;
+    stopId: number;
+}) {
+    const run = await getDeliveryRun(runId);
+    if (!run || run.driverUserId !== driverUserId) {
+        throw new Error('Aktivna dostava nije pronađena.');
+    }
+    const groups = await resolveDeliveryRunStopGroups(run);
+    const targetGroup = groups.find((group) =>
+        group.items.some(({ stop }) => stop.id === stopId),
+    );
+    if (!targetGroup) {
+        throw new Error('Aktivna dostava nije pronađena.');
+    }
+    const targetIsDelivered = targetGroup.items.every(
+        ({ stop }) => stop.state === DeliveryRunStopStates.DELIVERED,
+    );
+    if (targetIsDelivered) {
+        return targetGroup;
+    }
+    if (run.state !== DeliveryRunStates.ACTIVE) {
+        throw new Error('Aktivna dostava nije pronađena.');
+    }
+    const currentGroup = groups.find((group) =>
+        group.items.some(
+            ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,
+        ),
+    );
+    if (currentGroup?.stopKey !== targetGroup.stopKey) {
+        throw new Error('Dostave se moraju završiti redoslijedom rute.');
+    }
+    if (targetGroup.items.some(({ request }) => !request)) {
+        throw new Error('Dostava u ruti nije pronađena.');
+    }
+
+    return targetGroup;
 }
 
 export async function deliverDeliveryStop({
@@ -636,26 +839,50 @@ export async function deliverDeliveryStop({
     stopId: number;
     notes?: string;
 }) {
-    const stop = await getDeliveryRunStop(stopId);
-    if (
-        !stop ||
-        stop.run.id !== runId ||
-        stop.run.driverUserId !== driverUserId ||
-        stop.run.state !== DeliveryRunStates.ACTIVE
-    ) {
-        throw new Error('Aktivna dostava nije pronađena.');
-    }
-
-    await fulfillDeliveryRunStop({
+    const group = await getOwnedDeliveryRunStopGroup({
         driverUserId,
         runId,
         stopId,
+    });
+    const requestIds = await fulfillDeliveryRunStops({
+        driverUserId,
+        runId,
+        stopIds: group.items.map(({ stop }) => stop.id),
         deliveryNotes: notes,
     });
-    await notifyDeliveryRequestEvent(stop.deliveryRequestId, 'updated', {
-        status: DeliveryRequestStates.FULFILLED,
-        note: notes,
-    });
+    await Promise.all(
+        requestIds.map((requestId) =>
+            notifyDeliveryRequestEvent(requestId, 'updated', {
+                status: DeliveryRequestStates.FULFILLED,
+                note: notes,
+            }),
+        ),
+    );
+}
+
+export async function accountCanTrackDeliveryRun({
+    accountId,
+    runId,
+}: {
+    accountId: string;
+    runId: string;
+}) {
+    const run = await getDeliveryRun(runId);
+    if (!run || run.state !== DeliveryRunStates.ACTIVE) {
+        return false;
+    }
+    const groups = await resolveDeliveryRunStopGroups(run);
+    const currentGroup = groups.find((group) =>
+        group.items.some(
+            ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,
+        ),
+    );
+
+    return Boolean(
+        currentGroup?.items.some(
+            ({ request }) => request?.accountId === accountId,
+        ),
+    );
 }
 
 export async function recordDriverLocation({
@@ -699,39 +926,56 @@ export async function recordDriverLocation({
         return;
     }
 
-    const remainingStops = run.stops.filter(
-        (stop) => stop.state !== DeliveryRunStopStates.DELIVERED,
-    );
-    const requests = await Promise.all(
-        remainingStops.map((stop) =>
-            getDeliveryRequest(stop.deliveryRequestId),
-        ),
-    );
-    const requestsById = new Map(
-        requests.flatMap((request) =>
-            request ? [[request.id, request] as const] : [],
-        ),
-    );
+    const groups = await resolveDeliveryRunStopGroups(run);
+    const remainingGroups = groups.flatMap((group) => {
+        const items = group.items.filter(
+            ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,
+        );
+        return items.length > 0 ? [{ ...group, items }] : [];
+    });
+    const groupsByRepresentativeId = new Map<
+        string,
+        (typeof remainingGroups)[number]
+    >();
+    const routeStops = remainingGroups.flatMap((group) => {
+        const representative = group.items.find(({ request }) => request);
+        if (!representative) return [];
+        groupsByRepresentativeId.set(
+            representative.stop.deliveryRequestId,
+            group,
+        );
+        return [
+            {
+                deliveryRequestId: representative.stop.deliveryRequestId,
+                formattedAddress: representative.stop.formattedAddress,
+                latitude: representative.stop.latitude,
+                longitude: representative.stop.longitude,
+                windowStartAt: representative.request?.slot?.startAt,
+                windowEndAt: representative.request?.slot?.endAt,
+            },
+        ];
+    });
     const plan = await recalculateDeliveryRoute({
         origin: { latitude, longitude },
-        stops: remainingStops.map((stop) => {
-            const request = requestsById.get(stop.deliveryRequestId);
-            return {
+        stops: routeStops,
+    });
+    const estimates = plan.stops.flatMap((estimate) => {
+        const group = groupsByRepresentativeId.get(estimate.deliveryRequestId);
+        return (
+            group?.items.map(({ stop }) => ({
                 deliveryRequestId: stop.deliveryRequestId,
-                formattedAddress: stop.formattedAddress,
-                latitude: stop.latitude,
-                longitude: stop.longitude,
-                windowStartAt: request?.slot?.startAt,
-                windowEndAt: request?.slot?.endAt,
-            };
-        }),
+                estimatedArrivalAt: estimate.estimatedArrivalAt,
+                estimatedTravelSeconds: estimate.estimatedTravelSeconds,
+                estimatedDistanceMeters: estimate.estimatedDistanceMeters,
+            })) ?? []
+        );
     });
     await updateDeliveryRunEstimates({
         runId,
         encodedPolyline: plan.encodedPolyline,
         totalDistanceMeters: plan.totalDistanceMeters,
         totalDurationSeconds: plan.totalDurationSeconds,
-        estimates: plan.stops,
+        estimates,
     });
 }
 

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -22,6 +22,18 @@ export type DeliveryContactSummary = {
     avatarUrl: string | null;
 };
 
+export type DeliveryStopDeliverySummary = {
+    requestId: string;
+    requestState: string;
+    contactName: string;
+    phone: string | null;
+    addressLabel: string | null;
+    requestNotes: string | null;
+    deliveryNotes: string | null;
+    harvest: DeliveryHarvestSummary;
+    accountContacts: DeliveryContactSummary[];
+};
+
 export type DeliveryStopSummary = {
     id: number | null;
     requestId: string;
@@ -47,6 +59,8 @@ export type DeliveryStopSummary = {
     accountContacts: DeliveryContactSummary[];
     tracking: DeliveryTrackingLocation | null;
     runId: string | null;
+    deliveryCount: number;
+    deliveries: DeliveryStopDeliverySummary[];
 };
 
 export type DeliveryBatchSummary = {
@@ -56,11 +70,13 @@ export type DeliveryBatchSummary = {
     pickupLocationName: string | null;
     pickupAddress: string | null;
     deliveryCount: number;
+    stopCount: number;
     orders: DeliveryRouteOrderSummary[];
 };
 
 export type DeliveryRouteOrderSummary = {
     requestId: string;
+    stopKey: string;
     contactName: string;
     address: string;
     addressLabel: string | null;
@@ -78,6 +94,7 @@ export type ActiveDeliveryRunSummary = {
     location: DeliveryTrackingLocation | null;
     estimatesUpdatedAt: string | null;
     mapUrl: string;
+    deliveryCount: number;
     stops: DeliveryStopSummary[];
 };
 
@@ -90,7 +107,7 @@ export type DriverDeliveryDashboard = {
     };
     activeRun: ActiveDeliveryRunSummary | null;
     batches: DeliveryBatchSummary[];
-    maximumRouteDeliveries: number;
+    maximumRouteStops: number;
     maximumRouteWindowHours: number;
     refreshedAt: string;
 };

--- a/apps/delivery/lib/deliveryRouting.ts
+++ b/apps/delivery/lib/deliveryRouting.ts
@@ -403,7 +403,7 @@ async function computeGoogleRoute({
 }): Promise<DeliveryRoutePlan> {
     if (stops.length > maximumDeliveryRouteStops) {
         throw new Error(
-            `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} dostava.`,
+            `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} fizičkih stanica.`,
         );
     }
 
@@ -568,7 +568,7 @@ export async function planDeliveryRoute({
     }
     if (candidates.length > maximumDeliveryRouteStops) {
         throw new Error(
-            `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} dostava.`,
+            `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} fizičkih stanica.`,
         );
     }
     for (const candidate of candidates) {

--- a/apps/delivery/lib/deliveryRunRequest.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunRequest.node.spec.ts
@@ -7,35 +7,23 @@ const secondRequestId = 'c724532a-79fe-4c77-93e3-e92dc0aeb143';
 
 test('accepts multiple unique delivery request IDs', () => {
     assert.deepEqual(
-        parseDeliveryRunRequestBody(
-            { deliveryRequestIds: [firstRequestId, secondRequestId] },
-            26,
-        ),
+        parseDeliveryRunRequestBody({
+            deliveryRequestIds: [firstRequestId, secondRequestId],
+        }),
         [firstRequestId, secondRequestId],
     );
 });
 
-test('rejects duplicate, malformed, empty, and oversized selections', () => {
+test('rejects duplicate, malformed, and empty selections', () => {
     assert.equal(
-        parseDeliveryRunRequestBody(
-            { deliveryRequestIds: [firstRequestId, firstRequestId] },
-            26,
-        ),
+        parseDeliveryRunRequestBody({
+            deliveryRequestIds: [firstRequestId, firstRequestId],
+        }),
         null,
     );
     assert.equal(
-        parseDeliveryRunRequestBody({ deliveryRequestIds: ['invalid'] }, 26),
+        parseDeliveryRunRequestBody({ deliveryRequestIds: ['invalid'] }),
         null,
     );
-    assert.equal(
-        parseDeliveryRunRequestBody({ deliveryRequestIds: [] }, 26),
-        null,
-    );
-    assert.equal(
-        parseDeliveryRunRequestBody(
-            { deliveryRequestIds: [firstRequestId, secondRequestId] },
-            1,
-        ),
-        null,
-    );
+    assert.equal(parseDeliveryRunRequestBody({ deliveryRequestIds: [] }), null);
 });

--- a/apps/delivery/lib/deliveryRunRequest.ts
+++ b/apps/delivery/lib/deliveryRunRequest.ts
@@ -1,17 +1,13 @@
 const deliveryRequestIdPattern =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-export function parseDeliveryRunRequestBody(
-    value: unknown,
-    maximumRequestCount: number,
-) {
+export function parseDeliveryRunRequestBody(value: unknown) {
     if (
         typeof value !== 'object' ||
         value === null ||
         !('deliveryRequestIds' in value) ||
         !Array.isArray(value.deliveryRequestIds) ||
-        value.deliveryRequestIds.length === 0 ||
-        value.deliveryRequestIds.length > maximumRequestCount
+        value.deliveryRequestIds.length === 0
     ) {
         return null;
     }

--- a/apps/delivery/lib/deliveryStopGrouping.node.spec.ts
+++ b/apps/delivery/lib/deliveryStopGrouping.node.spec.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    buildDeliveryStopKey,
+    groupByDeliveryStop,
+} from './deliveryStopGrouping';
+
+test('groups deliveries at the same normalized address in the same slot', () => {
+    const firstStopKey = buildDeliveryStopKey(12, 'Ilica 1, 10000 Zagreb, HR');
+    const secondStopKey = buildDeliveryStopKey(
+        12,
+        '  ILICA 1 ,  10000 Zagreb, HR  ',
+    );
+    const otherSlotKey = buildDeliveryStopKey(13, 'Ilica 1, 10000 Zagreb, HR');
+    const groups = groupByDeliveryStop([
+        { requestId: 'first', stopKey: firstStopKey },
+        { requestId: 'second', stopKey: secondStopKey },
+        { requestId: 'later', stopKey: otherSlotKey },
+    ]);
+
+    assert.equal(firstStopKey, secondStopKey);
+    assert.equal(groups.length, 2);
+    assert.deepEqual(
+        groups.map((group) =>
+            group.items.map((delivery) => delivery.requestId),
+        ),
+        [['first', 'second'], ['later']],
+    );
+});

--- a/apps/delivery/lib/deliveryStopGrouping.ts
+++ b/apps/delivery/lib/deliveryStopGrouping.ts
@@ -1,0 +1,29 @@
+export function buildDeliveryStopKey(slotId: number, formattedAddress: string) {
+    const normalizedAddress = formattedAddress
+        .normalize('NFKC')
+        .toLocaleLowerCase('hr-HR')
+        .replace(/\s*,\s*/g, ',')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    return `${slotId}:${normalizedAddress}`;
+}
+
+export function groupByDeliveryStop<T extends { stopKey: string }>(
+    items: readonly T[],
+) {
+    const groups = new Map<string, T[]>();
+    for (const item of items) {
+        const group = groups.get(item.stopKey);
+        if (group) {
+            group.push(item);
+        } else {
+            groups.set(item.stopKey, [item]);
+        }
+    }
+
+    return Array.from(groups, ([stopKey, groupedItems]) => ({
+        stopKey,
+        items: groupedItems,
+    }));
+}

--- a/packages/storage/src/repositories/deliveryRunsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunsRepo.ts
@@ -318,34 +318,47 @@ export async function updateDeliveryRunEstimates({
     });
 }
 
-async function ensureOwnedActiveRunStop({
+async function ensureOwnedDeliveryRunStops({
     driverUserId,
     runId,
-    stopId,
+    stopIds,
     db = storage(),
 }: {
     driverUserId: string;
     runId: string;
-    stopId: number;
+    stopIds: number[];
     db?: DatabaseClient;
 }) {
-    const stop = await db.query.deliveryRunStops.findFirst({
+    const uniqueStopIds = Array.from(new Set(stopIds));
+    if (uniqueStopIds.length === 0) {
+        throw new Error('Active delivery stop not found');
+    }
+
+    const stops = await db.query.deliveryRunStops.findMany({
         where: and(
-            eq(deliveryRunStops.id, stopId),
             eq(deliveryRunStops.runId, runId),
+            inArray(deliveryRunStops.id, uniqueStopIds),
         ),
         with: { run: true },
+        orderBy: [asc(deliveryRunStops.sequence)],
     });
+    const run = stops[0]?.run;
 
     if (
-        !stop ||
-        stop.run.driverUserId !== driverUserId ||
-        stop.run.state !== DeliveryRunStates.ACTIVE
+        stops.length !== uniqueStopIds.length ||
+        !run ||
+        run.driverUserId !== driverUserId
     ) {
         throw new Error('Active delivery stop not found');
     }
 
-    if (stop.state !== DeliveryRunStopStates.DELIVERED) {
+    const hasUndeliveredStops = stops.some(
+        (stop) => stop.state !== DeliveryRunStopStates.DELIVERED,
+    );
+    if (hasUndeliveredStops) {
+        if (run.state !== DeliveryRunStates.ACTIVE) {
+            throw new Error('Active delivery stop not found');
+        }
         const currentStop = await db.query.deliveryRunStops.findFirst({
             columns: { id: true },
             where: and(
@@ -354,12 +367,47 @@ async function ensureOwnedActiveRunStop({
             ),
             orderBy: [asc(deliveryRunStops.sequence)],
         });
-        if (currentStop?.id !== stopId) {
+        if (currentStop && !uniqueStopIds.includes(currentStop.id)) {
             throw new Error('Delivery stops must be completed in route order');
         }
     }
 
-    return stop;
+    return stops;
+}
+
+export async function markDeliveryRunStopsArrived({
+    driverUserId,
+    runId,
+    stopIds,
+}: {
+    driverUserId: string;
+    runId: string;
+    stopIds: number[];
+}) {
+    return await storage().transaction(async (tx) => {
+        const stops = await ensureOwnedDeliveryRunStops({
+            driverUserId,
+            runId,
+            stopIds,
+            db: tx,
+        });
+        const now = new Date();
+
+        for (const stop of stops) {
+            if (stop.state === DeliveryRunStopStates.DELIVERED) {
+                continue;
+            }
+            await tx
+                .update(deliveryRunStops)
+                .set({
+                    state: DeliveryRunStopStates.ARRIVED,
+                    arrivedAt: stop.arrivedAt ?? now,
+                })
+                .where(eq(deliveryRunStops.id, stop.id));
+        }
+
+        return stops;
+    });
 }
 
 export async function markDeliveryRunStopArrived({
@@ -371,26 +419,12 @@ export async function markDeliveryRunStopArrived({
     runId: string;
     stopId: number;
 }) {
-    const stop = await ensureOwnedActiveRunStop({
+    const stops = await markDeliveryRunStopsArrived({
         driverUserId,
         runId,
-        stopId,
+        stopIds: [stopId],
     });
-
-    if (stop.state === DeliveryRunStopStates.DELIVERED) {
-        return stop;
-    }
-
-    const rows = await storage()
-        .update(deliveryRunStops)
-        .set({
-            state: DeliveryRunStopStates.ARRIVED,
-            arrivedAt: stop.arrivedAt ?? new Date(),
-        })
-        .where(eq(deliveryRunStops.id, stopId))
-        .returning();
-
-    return rows[0] ?? stop;
+    return stops[0];
 }
 
 export async function markDeliveryRunStopDelivered({
@@ -402,36 +436,40 @@ export async function markDeliveryRunStopDelivered({
     runId: string;
     stopId: number;
 }) {
-    return await storage().transaction(async (tx) =>
-        markDeliveryRunStopDeliveredInDatabase({
+    const requestIds = await storage().transaction(async (tx) =>
+        markDeliveryRunStopsDeliveredInDatabase({
             driverUserId,
             runId,
-            stopId,
+            stopIds: [stopId],
             db: tx,
         }),
     );
+    return requestIds[0];
 }
 
-async function markDeliveryRunStopDeliveredInDatabase({
+async function markDeliveryRunStopsDeliveredInDatabase({
     driverUserId,
     runId,
-    stopId,
+    stopIds,
     db,
 }: {
     driverUserId: string;
     runId: string;
-    stopId: number;
+    stopIds: number[];
     db: DatabaseClient;
 }) {
-    const stop = await ensureOwnedActiveRunStop({
+    const stops = await ensureOwnedDeliveryRunStops({
         driverUserId,
         runId,
-        stopId,
+        stopIds,
         db,
     });
+    const now = new Date();
 
-    if (stop.state !== DeliveryRunStopStates.DELIVERED) {
-        const now = new Date();
+    for (const stop of stops) {
+        if (stop.state === DeliveryRunStopStates.DELIVERED) {
+            continue;
+        }
         await db
             .update(deliveryRunStops)
             .set({
@@ -439,7 +477,7 @@ async function markDeliveryRunStopDeliveredInDatabase({
                 arrivedAt: stop.arrivedAt ?? now,
                 deliveredAt: now,
             })
-            .where(eq(deliveryRunStops.id, stopId));
+            .where(eq(deliveryRunStops.id, stop.id));
     }
 
     const remaining = await db.query.deliveryRunStops.findFirst({
@@ -463,10 +501,49 @@ async function markDeliveryRunStopDeliveredInDatabase({
                 currentLocationSpeed: null,
                 currentLocationRecordedAt: null,
             })
-            .where(eq(deliveryRuns.id, runId));
+            .where(
+                and(
+                    eq(deliveryRuns.id, runId),
+                    eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                ),
+            );
     }
 
-    return stop.deliveryRequestId;
+    return stops.map((stop) => stop.deliveryRequestId);
+}
+
+export async function fulfillDeliveryRunStops({
+    driverUserId,
+    runId,
+    stopIds,
+    deliveryNotes,
+}: {
+    driverUserId: string;
+    runId: string;
+    stopIds: number[];
+    deliveryNotes?: string;
+}) {
+    return await storage().transaction(async (tx) => {
+        const stops = await ensureOwnedDeliveryRunStops({
+            driverUserId,
+            runId,
+            stopIds,
+            db: tx,
+        });
+        for (const stop of stops) {
+            await fulfillDeliveryRequest(
+                stop.deliveryRequestId,
+                deliveryNotes,
+                tx,
+            );
+        }
+        return await markDeliveryRunStopsDeliveredInDatabase({
+            driverUserId,
+            runId,
+            stopIds,
+            db: tx,
+        });
+    });
 }
 
 export async function fulfillDeliveryRunStop({
@@ -480,19 +557,11 @@ export async function fulfillDeliveryRunStop({
     stopId: number;
     deliveryNotes?: string;
 }) {
-    return await storage().transaction(async (tx) => {
-        const stop = await ensureOwnedActiveRunStop({
-            driverUserId,
-            runId,
-            stopId,
-            db: tx,
-        });
-        await fulfillDeliveryRequest(stop.deliveryRequestId, deliveryNotes, tx);
-        return await markDeliveryRunStopDeliveredInDatabase({
-            driverUserId,
-            runId,
-            stopId,
-            db: tx,
-        });
+    const requestIds = await fulfillDeliveryRunStops({
+        driverUserId,
+        runId,
+        stopIds: [stopId],
+        deliveryNotes,
     });
+    return requestIds[0];
 }

--- a/packages/storage/src/repositories/deliveryRunsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunsRepo.ts
@@ -347,7 +347,8 @@ async function ensureOwnedDeliveryRunStops({
     if (
         stops.length !== uniqueStopIds.length ||
         !run ||
-        run.driverUserId !== driverUserId
+        run.driverUserId !== driverUserId ||
+        run.state !== DeliveryRunStates.ACTIVE
     ) {
         throw new Error('Active delivery stop not found');
     }
@@ -356,9 +357,6 @@ async function ensureOwnedDeliveryRunStops({
         (stop) => stop.state !== DeliveryRunStopStates.DELIVERED,
     );
     if (hasUndeliveredStops) {
-        if (run.state !== DeliveryRunStates.ACTIVE) {
-            throw new Error('Active delivery stop not found');
-        }
         const currentStop = await db.query.deliveryRunStops.findFirst({
             columns: { id: true },
             where: and(

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -6,9 +6,11 @@ import {
     createDeliveryRun,
     deliveryRequests,
     fulfillDeliveryRunStop,
+    fulfillDeliveryRunStops,
     getDeliveryRequest,
     getDeliveryRun,
     markDeliveryRunStopArrived,
+    markDeliveryRunStopsArrived,
     operations,
     pickupLocations,
     storage,
@@ -19,7 +21,7 @@ import {
 import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
-test('delivery run enforces stop order and limits tracking to the current delivery', async () => {
+test('delivery run fulfills a current bulk stop atomically and preserves route order', async () => {
     createTestDb();
     const accountId = await createTestAccount();
     const otherAccountId = await createTestAccount();
@@ -65,12 +67,17 @@ test('delivery run enforces stop order and limits tracking to the current delive
             {
                 entityId: 2,
                 entityTypeName: 'operation',
+                accountId,
+            },
+            {
+                entityId: 3,
+                entityTypeName: 'operation',
                 accountId: otherAccountId,
             },
         ])
         .returning({ id: operations.id });
-    assert.equal(operationRows.length, 2);
-    const requestIds = [randomUUID(), randomUUID()];
+    assert.equal(operationRows.length, 3);
+    const requestIds = [randomUUID(), randomUUID(), randomUUID()];
     await storage()
         .insert(deliveryRequests)
         .values(
@@ -88,20 +95,22 @@ test('delivery run enforces stop order and limits tracking to the current delive
         stops: requestIds.map((deliveryRequestId, index) => ({
             deliveryRequestId,
             sequence: index + 1,
-            latitude: 45.8 + index * 0.01,
-            longitude: 15.97 + index * 0.01,
-            formattedAddress: `Testna ${index + 1}, Zagreb, HR`,
+            latitude: index < 2 ? 45.8 : 45.81,
+            longitude: index < 2 ? 15.97 : 15.98,
+            formattedAddress: `Testna ${index < 2 ? 1 : 2}, Zagreb, HR`,
             estimatedArrivalAt: new Date(
-                Date.parse('2026-07-13T08:15:00.000Z') + index * 900_000,
+                Date.parse('2026-07-13T08:15:00.000Z') +
+                    (index < 2 ? 0 : 900_000),
             ),
             estimatedTravelSeconds: 600,
             estimatedDistanceMeters: 2_250,
         })),
     });
-    assert.equal(run.stops.length, 2);
-    const [firstStop, secondStop] = run.stops;
+    assert.equal(run.stops.length, 3);
+    const [firstStop, secondStop, thirdStop] = run.stops;
     assert.ok(firstStop);
     assert.ok(secondStop);
+    assert.ok(thirdStop);
 
     assert.equal(
         await accountCanTrackDeliveryRun({ accountId, runId: run.id }),
@@ -118,7 +127,7 @@ test('delivery run enforces stop order and limits tracking to the current delive
         markDeliveryRunStopArrived({
             driverUserId,
             runId: run.id,
-            stopId: secondStop.id,
+            stopId: thirdStop.id,
         }),
         /route order/,
     );
@@ -126,12 +135,12 @@ test('delivery run enforces stop order and limits tracking to the current delive
         fulfillDeliveryRunStop({
             driverUserId,
             runId: run.id,
-            stopId: secondStop.id,
+            stopId: thirdStop.id,
         }),
         /route order/,
     );
     assert.notEqual(
-        (await getDeliveryRequest(secondStop.deliveryRequestId))?.state,
+        (await getDeliveryRequest(thirdStop.deliveryRequestId))?.state,
         'fulfilled',
     );
 
@@ -142,11 +151,29 @@ test('delivery run enforces stop order and limits tracking to the current delive
         longitude: 15.971,
         recordedAt: new Date('2026-07-13T08:05:00.000Z'),
     });
-    await fulfillDeliveryRunStop({
+    await markDeliveryRunStopsArrived({
         driverUserId,
         runId: run.id,
-        stopId: firstStop.id,
+        stopIds: [firstStop.id, secondStop.id],
     });
+    const arrivedRun = await getDeliveryRun(run.id);
+    assert.deepEqual(
+        arrivedRun?.stops.slice(0, 2).map((stop) => stop.state),
+        ['arrived', 'arrived'],
+    );
+    await fulfillDeliveryRunStops({
+        driverUserId,
+        runId: run.id,
+        stopIds: [firstStop.id, secondStop.id],
+    });
+    assert.equal(
+        (await getDeliveryRequest(firstStop.deliveryRequestId))?.state,
+        'fulfilled',
+    );
+    assert.equal(
+        (await getDeliveryRequest(secondStop.deliveryRequestId))?.state,
+        'fulfilled',
+    );
     assert.equal(
         await accountCanTrackDeliveryRun({ accountId, runId: run.id }),
         false,
@@ -161,7 +188,7 @@ test('delivery run enforces stop order and limits tracking to the current delive
     await fulfillDeliveryRunStop({
         driverUserId,
         runId: run.id,
-        stopId: secondStop.id,
+        stopId: thirdStop.id,
     });
 
     const completedRun = await getDeliveryRun(run.id);

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -206,4 +206,12 @@ test('delivery run fulfills a current bulk stop atomically and preserves route o
         }),
         false,
     );
+    await assert.rejects(
+        fulfillDeliveryRunStops({
+            driverUserId,
+            runId: run.id,
+            stopIds: [firstStop.id, secondStop.id],
+        }),
+        /Active delivery stop not found/,
+    );
 });


### PR DESCRIPTION
## What changed

- count route capacity by physical stop instead of by delivery request
- group every eligible harvest with the same normalized address and time slot into one selection, waypoint, ETA, map marker, and driver stop card
- show all recipients, harvest details, notes, contacts, and trace links inside the bulk stop
- mark arrival and delivery for the whole stop atomically, while preserving each harvest's event history
- allow every account in the current bulk stop to see live driver tracking

## Why

The existing 26-stop route limit was applied to individual harvest records. That blocked valid routes where several harvests are delivered together at one address during one time slot, even though the route planner only needs one physical waypoint.

## Impact

Drivers can select and deliver any number of harvests within a grouped stop. The 26 limit now applies only to distinct address-and-time-slot stops. No database migration is required.

## Validation

- `pnpm lint --filter delivery --filter @gredice/storage`
- `pnpm --filter delivery test`
- `pnpm --filter delivery typecheck`
- `pnpm --filter delivery build`
- `pnpm test --filter @gredice/storage` (462 tests)
- `git diff --check`
