### PR TITLE
feat(delivery): add QR pickup and handoff verification

### DIFF
--- a/apps/delivery/components/DeliveryBatchCard.tsx
+++ b/apps/delivery/components/DeliveryBatchCard.tsx
@@ -30,10 +30,12 @@ export function DeliveryBatchCard({
     onToggleOrder: (requestId: string, checked: boolean) => void;
 }) {
     const stopGroups = groupByDeliveryStop(batch.orders);
-    const selectedCount = batch.orders.filter((order) =>
+    const readyOrders = batch.orders.filter((order) => order.readyForPickup);
+    const selectedCount = readyOrders.filter((order) =>
         selectedRequestIds.has(order.requestId),
     ).length;
-    const allSelected = selectedCount === batch.orders.length;
+    const allSelected =
+        readyOrders.length > 0 && selectedCount === readyOrders.length;
     const batchSelectionState = allSelected
         ? true
         : selectedCount > 0
@@ -60,7 +62,8 @@ export function DeliveryBatchCard({
                                 <Truck className="size-4" />
                                 {batch.deliveryCount}{' '}
                                 {batch.deliveryCount === 1 ? 'urod' : 'uroda'} ·{' '}
-                                {batch.stopCount}{' '}
+                                {readyOrders.length}/{batch.deliveryCount}{' '}
+                                spremno · {batch.stopCount}{' '}
                                 {batch.stopCount === 1
                                     ? 'stanica'
                                     : batch.stopCount < 5
@@ -86,15 +89,19 @@ export function DeliveryBatchCard({
                     <Checkbox
                         checked={batchSelectionState}
                         disabled={
-                            disabled || (selectionLimitReached && !allSelected)
+                            disabled ||
+                            readyOrders.length === 0 ||
+                            (selectionLimitReached && !allSelected)
                         }
                         onCheckedChange={(value) =>
                             onToggleBatch(value === true)
                         }
                         label={
                             allSelected
-                                ? 'Poništi termin'
-                                : 'Odaberi cijeli termin'
+                                ? 'Poništi spremne'
+                                : readyOrders.length === 0
+                                  ? 'Nema spremnih uroda'
+                                  : 'Odaberi sve spremne'
                         }
                     />
                 </div>
@@ -102,9 +109,15 @@ export function DeliveryBatchCard({
                     {stopGroups.flatMap((group) => {
                         const firstOrder = group.items[0];
                         if (!firstOrder) return [];
-                        const checked = group.items.every((order) =>
-                            selectedRequestIds.has(order.requestId),
+                        const readyGroupOrders = group.items.filter(
+                            (order) => order.readyForPickup,
                         );
+                        const firstReadyOrder = readyGroupOrders[0];
+                        const checked =
+                            readyGroupOrders.length > 0 &&
+                            readyGroupOrders.every((order) =>
+                                selectedRequestIds.has(order.requestId),
+                            );
                         return [
                             <DeliverySelectionItem
                                 key={group.stopKey}
@@ -112,12 +125,18 @@ export function DeliveryBatchCard({
                                 checked={checked}
                                 disabled={
                                     disabled ||
+                                    readyGroupOrders.length === 0 ||
                                     (selectionLimitReached &&
                                         !selectedStopKeys.has(group.stopKey))
                                 }
-                                onCheckedChange={(value) =>
-                                    onToggleOrder(firstOrder.requestId, value)
-                                }
+                                onCheckedChange={(value) => {
+                                    if (firstReadyOrder) {
+                                        onToggleOrder(
+                                            firstReadyOrder.requestId,
+                                            value,
+                                        );
+                                    }
+                                }}
                             />,
                         ];
                     })}

--- a/apps/delivery/components/DeliveryHarvestVerification.tsx
+++ b/apps/delivery/components/DeliveryHarvestVerification.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Chip } from '@gredice/ui/Chip';
+import { Check, Info } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import { useId, useRef, useState } from 'react';
+import type { DeliveryStopDeliverySummary } from '../lib/deliveryDashboardTypes';
+import {
+    normalizeHarvestTraceScanValue,
+    verifyDeliveryStopHarvestTrace,
+} from '../lib/harvestTraceScan';
+import { HarvestTraceScanner } from './HarvestTraceScanner';
+
+export function DeliveryHarvestVerification({
+    deliveries,
+    disabled,
+}: {
+    deliveries: DeliveryStopDeliverySummary[];
+    disabled: boolean;
+}) {
+    const headingId = useId();
+    const [verifiedTracePaths, setVerifiedTracePaths] = useState<string[]>([]);
+    const verifiedTracePathsRef = useRef<string[]>([]);
+    const tracePathByRequestId = new Map(
+        deliveries.flatMap((delivery) => {
+            const tracePath = delivery.harvest.tracePath
+                ? normalizeHarvestTraceScanValue(delivery.harvest.tracePath)
+                : null;
+            return tracePath ? [[delivery.requestId, tracePath]] : [];
+        }),
+    );
+    const expectedTracePaths = new Set(tracePathByRequestId.values());
+    const verifiedTracePathSet = new Set(
+        verifiedTracePaths.filter((tracePath) =>
+            expectedTracePaths.has(tracePath),
+        ),
+    );
+    const expectedTraceCount = expectedTracePaths.size;
+    const verifiedTraceCount = verifiedTracePathSet.size;
+    const allExpectedTracesVerified =
+        expectedTraceCount > 0 && verifiedTraceCount === expectedTraceCount;
+
+    const verifyTrace = (value: string) => {
+        const result = verifyDeliveryStopHarvestTrace({
+            deliveries,
+            verifiedTracePaths: verifiedTracePathsRef.current,
+            scanValue: value,
+        });
+
+        if (result.status === 'verified') {
+            verifiedTracePathsRef.current = result.nextVerifiedTracePaths;
+            setVerifiedTracePaths(result.nextVerifiedTracePaths);
+        }
+
+        return result;
+    };
+
+    return (
+        <section className="space-y-3" aria-labelledby={headingId}>
+            <div>
+                <Typography id={headingId} level="body2" semiBold>
+                    QR provjera predaje
+                </Typography>
+                <Typography
+                    level="body3"
+                    className="mt-0.5 text-muted-foreground"
+                >
+                    Provjeri urode dok ih predaješ korisniku kako ništa ne bi
+                    ostalo u vozilu.
+                </Typography>
+            </div>
+
+            <Alert
+                color={allExpectedTracesVerified ? 'success' : 'info'}
+                startDecorator={
+                    allExpectedTracesVerified ? (
+                        <Check className="size-5" />
+                    ) : (
+                        <Info className="size-5" />
+                    )
+                }
+            >
+                {expectedTraceCount === 0
+                    ? 'Za ovu stanicu nema dostupnih QR kodova. Nastavi ručnom provjerom.'
+                    : allExpectedTracesVerified
+                      ? 'Svi urodi s dostupnim QR kodom provjereni su za ovu stanicu.'
+                      : `Provjereno ${verifiedTraceCount} od ${expectedTraceCount}. Skeniraj preostale etikete ako su dostupne.`}
+            </Alert>
+
+            {expectedTraceCount > 0 ? (
+                <HarvestTraceScanner
+                    variant="verification"
+                    availableTraceCount={expectedTraceCount}
+                    completedTraceCount={verifiedTraceCount}
+                    disabled={disabled}
+                    onScan={verifyTrace}
+                />
+            ) : null}
+
+            <ul className="space-y-2" aria-label="Urodi na ovoj stanici">
+                {deliveries.map((delivery) => {
+                    const tracePath = tracePathByRequestId.get(
+                        delivery.requestId,
+                    );
+                    const verified = Boolean(
+                        tracePath && verifiedTracePathSet.has(tracePath),
+                    );
+
+                    return (
+                        <li
+                            key={delivery.requestId}
+                            className="flex items-center justify-between gap-3 rounded-md bg-muted/70 px-3 py-2"
+                        >
+                            <div className="min-w-0">
+                                <Typography
+                                    level="body3"
+                                    semiBold
+                                    className="truncate"
+                                >
+                                    {delivery.harvest.plantName}
+                                </Typography>
+                                <Typography
+                                    level="body3"
+                                    className="truncate text-muted-foreground"
+                                >
+                                    {delivery.contactName}
+                                </Typography>
+                            </div>
+                            <Chip
+                                color={verified ? 'success' : 'neutral'}
+                                size="sm"
+                            >
+                                {verified
+                                    ? 'Provjereno'
+                                    : tracePath
+                                      ? 'Nije skenirano'
+                                      : 'Bez QR koda'}
+                            </Chip>
+                        </li>
+                    );
+                })}
+            </ul>
+
+            <Typography level="body3" className="text-muted-foreground">
+                Ova provjera nije obavezna. Dostavu možeš potvrditi i ako
+                etiketa nedostaje ili skeniranje nije moguće.
+            </Typography>
+        </section>
+    );
+}

--- a/apps/delivery/components/DeliverySelectionItem.tsx
+++ b/apps/delivery/components/DeliverySelectionItem.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Checkbox } from '@gredice/ui/Checkbox';
+import { Chip } from '@gredice/ui/Chip';
 import { Leaf, MapPin } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import type { DeliveryRouteOrderSummary } from '../lib/deliveryDashboardTypes';
@@ -18,19 +19,23 @@ export function DeliverySelectionItem({
 }) {
     const firstOrder = orders[0];
     if (!firstOrder) return null;
+    const readyOrders = orders.filter((order) => order.readyForPickup);
+    const hasReadyOrders = readyOrders.length > 0;
 
     return (
         <div
             className={
                 checked
                     ? 'bg-primary/5 px-4 py-3'
-                    : 'px-4 py-3 transition-colors hover:bg-muted/50'
+                    : hasReadyOrders
+                      ? 'px-4 py-3 transition-colors hover:bg-muted/50'
+                      : 'bg-muted/30 px-4 py-3'
             }
         >
             <Checkbox
                 id={`delivery-stop-${firstOrder.requestId}`}
                 checked={checked}
-                disabled={disabled}
+                disabled={disabled || !hasReadyOrders}
                 onCheckedChange={(value) => onCheckedChange(value === true)}
                 className="mt-1 size-5"
                 label={
@@ -44,15 +49,18 @@ export function DeliverySelectionItem({
                             level="body3"
                             className="block text-muted-foreground"
                         >
-                            {orders.length}{' '}
-                            {orders.length === 1 ? 'urod' : 'uroda'} na ovoj
-                            stanici
+                            {readyOrders.length} / {orders.length} spremno za
+                            preuzimanje na ovoj stanici
                         </Typography>
                         <span className="block space-y-2 pt-1">
                             {orders.map((order) => (
                                 <span
                                     key={order.requestId}
-                                    className="block rounded-md border bg-background/70 p-2"
+                                    className={
+                                        order.readyForPickup
+                                            ? 'block rounded-md border bg-background/70 p-2'
+                                            : 'block rounded-md border border-dashed bg-muted/30 p-2'
+                                    }
                                 >
                                     <span className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
                                         <Typography
@@ -70,6 +78,17 @@ export function DeliverySelectionItem({
                                             {order.harvest.plantName}
                                         </Typography>
                                     </span>
+                                    <Chip
+                                        color={
+                                            order.readyForPickup
+                                                ? 'success'
+                                                : 'warning'
+                                        }
+                                        size="sm"
+                                        className="mt-2"
+                                    >
+                                        {order.pickupStatusLabel}
+                                    </Chip>
                                     {order.requestNotes ? (
                                         <span className="mt-1 flex items-start gap-2 text-sm font-normal text-amber-800 dark:text-amber-200">
                                             <Leaf className="mt-0.5 size-4 shrink-0" />

--- a/apps/delivery/components/DeliveryStopCard.tsx
+++ b/apps/delivery/components/DeliveryStopCard.tsx
@@ -25,6 +25,7 @@ import {
     formatDistance,
     formatTravelDuration,
 } from '../lib/deliveryFormatting';
+import { DeliveryHarvestVerification } from './DeliveryHarvestVerification';
 
 function statusColor(
     status: string,
@@ -312,6 +313,20 @@ export function DeliveryStopCard({
 
                 {driverMode && stop.isCurrent && !delivered ? (
                     <div className="space-y-3 border-t pt-4">
+                        {stop.stopState === 'arrived' ? (
+                            <DeliveryHarvestVerification
+                                deliveries={stop.deliveries}
+                                disabled={Boolean(pendingAction)}
+                            />
+                        ) : (
+                            <Typography
+                                level="body3"
+                                className="rounded-md bg-muted/70 p-3 text-muted-foreground"
+                            >
+                                Nakon potvrde dolaska možeš opcionalno skenirati
+                                QR etikete i provjeriti urode za ovu stanicu.
+                            </Typography>
+                        )}
                         <label
                             className="block text-sm font-medium"
                             htmlFor={`notes-${stop.id}`}

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -15,7 +15,7 @@ import {
     Warning,
 } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { DriverTrackingState } from '../hooks/useDriverTracking';
 import type { DriverDeliveryDashboard } from '../lib/deliveryDashboardTypes';
 import {
@@ -24,10 +24,12 @@ import {
     formatTravelDuration,
 } from '../lib/deliveryFormatting';
 import { groupByDeliveryStop } from '../lib/deliveryStopGrouping';
+import { selectDeliveryStopFromHarvestTrace } from '../lib/harvestTraceScan';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
 import { DeliveryBatchCard } from './DeliveryBatchCard';
 import { DeliveryMap } from './DeliveryMap';
 import { DeliveryStopCard } from './DeliveryStopCard';
+import { HarvestTraceScanner } from './HarvestTraceScanner';
 
 function trackingMessage(state: DriverTrackingState) {
     switch (state) {
@@ -63,14 +65,22 @@ export function DriverDashboard({
 }) {
     const run = dashboard.activeRun;
     const locationMessage = trackingMessage(trackingState);
-    const [selectedRequestIds, setSelectedRequestIds] = useState<string[]>([]);
+    const [selectedRequestIds, setSelectedRequestIdsState] = useState<string[]>(
+        [],
+    );
+    const selectedRequestIdsRef = useRef<string[]>([]);
     const availableOrders = dashboard.batches.flatMap((batch) => batch.orders);
-    const availableRequestIds = availableOrders.map((order) => order.requestId);
+    const selectableOrders = availableOrders.filter(
+        (order) => order.readyForPickup,
+    );
+    const availableRequestIds = selectableOrders.map(
+        (order) => order.requestId,
+    );
     const availableRequestIdSet = new Set(availableRequestIds);
     const ordersByRequestId = new Map(
         availableOrders.map((order) => [order.requestId, order]),
     );
-    const availableStopGroups = groupByDeliveryStop(availableOrders);
+    const availableStopGroups = groupByDeliveryStop(selectableOrders);
     const effectiveSelectedRequestIds = selectedRequestIds.filter((requestId) =>
         availableRequestIdSet.has(requestId),
     );
@@ -86,15 +96,32 @@ export function DriverDashboard({
     const selectedSlotCount = dashboard.batches.filter((batch) =>
         batch.orders.some((order) => selectedRequestIdSet.has(order.requestId)),
     ).length;
+    const availableTraceCount = new Set(
+        selectableOrders.flatMap((order) =>
+            order.harvest.tracePath ? [order.harvest.tracePath] : [],
+        ),
+    ).size;
+
+    const replaceSelectedRequestIds = (requestIds: string[]) => {
+        selectedRequestIdsRef.current = requestIds;
+        setSelectedRequestIdsState(requestIds);
+    };
+
+    const updateSelectedRequestIds = (
+        update: (current: string[]) => string[],
+    ) => {
+        const nextRequestIds = update(selectedRequestIdsRef.current);
+        replaceSelectedRequestIds(nextRequestIds);
+    };
 
     const toggleOrder = (requestId: string, checked: boolean) => {
         const order = ordersByRequestId.get(requestId);
-        if (!order) return;
-        const groupedRequestIds = availableOrders.flatMap((candidate) =>
+        if (!order?.readyForPickup) return;
+        const groupedRequestIds = selectableOrders.flatMap((candidate) =>
             candidate.stopKey === order.stopKey ? [candidate.requestId] : [],
         );
         const groupedRequestIdSet = new Set(groupedRequestIds);
-        setSelectedRequestIds((current) => {
+        updateSelectedRequestIds((current) => {
             const availableCurrent = current.filter((id) =>
                 availableRequestIdSet.has(id),
             );
@@ -125,8 +152,13 @@ export function DriverDashboard({
         batch: DriverDeliveryDashboard['batches'][number],
         checked: boolean,
     ) => {
-        const batchIds = new Set(batch.orders.map((order) => order.requestId));
-        setSelectedRequestIds((current) => {
+        const readyBatchOrders = batch.orders.filter(
+            (order) => order.readyForPickup,
+        );
+        const batchIds = new Set(
+            readyBatchOrders.map((order) => order.requestId),
+        );
+        updateSelectedRequestIds((current) => {
             const availableCurrent = current.filter((id) =>
                 availableRequestIdSet.has(id),
             );
@@ -141,7 +173,7 @@ export function DriverDashboard({
                     return order ? [order.stopKey] : [];
                 }),
             );
-            for (const group of groupByDeliveryStop(batch.orders)) {
+            for (const group of groupByDeliveryStop(readyBatchOrders)) {
                 if (!nextStopKeys.has(group.stopKey)) {
                     if (nextStopKeys.size >= dashboard.maximumRouteStops) {
                         continue;
@@ -157,13 +189,28 @@ export function DriverDashboard({
     };
 
     const selectAllAvailable = () => {
-        setSelectedRequestIds(
+        replaceSelectedRequestIds(
             availableStopGroups
                 .slice(0, dashboard.maximumRouteStops)
                 .flatMap((group) =>
                     group.items.map((order) => order.requestId),
                 ),
         );
+    };
+
+    const scanHarvestTrace = (value: string) => {
+        const result = selectDeliveryStopFromHarvestTrace({
+            orders: availableOrders,
+            selectedRequestIds: selectedRequestIdsRef.current,
+            maximumRouteStops: dashboard.maximumRouteStops,
+            scanValue: value,
+        });
+
+        if (result.status === 'selected') {
+            replaceSelectedRequestIds(result.nextSelectedRequestIds);
+        }
+
+        return result;
     };
 
     return (
@@ -180,7 +227,7 @@ export function DriverDashboard({
                     <Typography className="mt-1 text-muted-foreground">
                         {run
                             ? 'Slijedi redoslijed stanica, potvrdi dolazak i nastavi nakon svake dostave.'
-                            : 'Odaberi narudžbe iz jednog ili više termina. Preuzimanjem se urodi označavaju spremnima i računa povezana ruta kroz sve lokacije.'}
+                            : 'Odaberi urode koje je lokacija preuzimanja označila spremnima. Zatim se računa povezana ruta kroz sve lokacije.'}
                     </Typography>
                 </div>
 
@@ -384,18 +431,37 @@ export function DriverDashboard({
                                                     dashboard.maximumRouteWindowHours
                                                 }{' '}
                                                 sata i poštuju se pri izračunu
-                                                dolazaka.
+                                                dolazaka. Urodi koji se još
+                                                pripremaju ostaju vidljivi, ali
+                                                ih nije moguće odabrati.
                                             </Typography>
                                         </div>
                                         <div className="flex flex-wrap gap-2">
+                                            <HarvestTraceScanner
+                                                variant="pickup"
+                                                availableTraceCount={
+                                                    availableTraceCount
+                                                }
+                                                disabled={
+                                                    Boolean(pendingAction) ||
+                                                    selectableOrders.length ===
+                                                        0
+                                                }
+                                                completedTraceCount={
+                                                    effectiveSelectedRequestIds.length
+                                                }
+                                                onScan={scanHarvestTrace}
+                                            />
                                             <Button
                                                 variant="outlined"
-                                                disabled={Boolean(
-                                                    pendingAction,
-                                                )}
+                                                disabled={
+                                                    Boolean(pendingAction) ||
+                                                    selectableOrders.length ===
+                                                        0
+                                                }
                                                 onClick={selectAllAvailable}
                                             >
-                                                Odaberi sve
+                                                Odaberi sve spremne
                                             </Button>
                                             <Button
                                                 variant="plain"
@@ -405,7 +471,9 @@ export function DriverDashboard({
                                                         0
                                                 }
                                                 onClick={() =>
-                                                    setSelectedRequestIds([])
+                                                    replaceSelectedRequestIds(
+                                                        [],
+                                                    )
                                                 }
                                                 startDecorator={
                                                     <Reset className="size-4" />
@@ -493,7 +561,7 @@ export function DriverDashboard({
                                     </Typography>
                                     <Typography className="max-w-md text-muted-foreground">
                                         Novi termini pojavit će se ovdje kada su
-                                        dostave potvrđene ili u pripremi.
+                                        dostave potvrđene.
                                     </Typography>
                                 </CardContent>
                             </Card>

--- a/apps/delivery/components/HarvestTraceScanner.tsx
+++ b/apps/delivery/components/HarvestTraceScanner.tsx
@@ -1,0 +1,492 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Chip } from '@gredice/ui/Chip';
+import { Input } from '@gredice/ui/Input';
+import {
+    Camera,
+    Check,
+    Info,
+    LoaderSpinner,
+    Tally3,
+    Warning,
+} from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { Typography } from '@gredice/ui/Typography';
+import type { BrowserQRCodeReader } from '@zxing/library';
+import {
+    type FormEvent,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
+import type {
+    HarvestTraceSelectionResult,
+    HarvestTraceVerificationResult,
+} from '../lib/harvestTraceScan';
+
+type CameraState =
+    | 'requesting-permission'
+    | 'scanning'
+    | 'unsupported'
+    | 'error';
+
+type ScanHistoryItem = {
+    id: number;
+    color: 'success' | 'info' | 'warning' | 'danger';
+    message: string;
+};
+
+function scanHistoryItem(
+    id: number,
+    result: HarvestTraceSelectionResult | HarvestTraceVerificationResult,
+): ScanHistoryItem {
+    switch (result.status) {
+        case 'selected':
+            return {
+                id,
+                color: 'success',
+                message: `${result.plantName} · ${result.contactName}. Odabrano ${result.deliveryCount} ${result.deliveryCount === 1 ? 'urod' : 'uroda'} na ovoj skupnoj stanici.`,
+            };
+        case 'already-selected':
+            return {
+                id,
+                color: 'info',
+                message: `${result.plantName} · ${result.contactName} već je u odabranoj skupnoj stanici.`,
+            };
+        case 'limit-reached':
+            return {
+                id,
+                color: 'warning',
+                message:
+                    'Dosegnut je najveći broj fizičkih stanica za jednu rutu.',
+            };
+        case 'ambiguous':
+            return {
+                id,
+                color: 'warning',
+                message:
+                    'QR kod je povezan s više dostupnih termina. Odaberi dostavu ručno.',
+            };
+        case 'not-found':
+            return {
+                id,
+                color: 'warning',
+                message:
+                    'Ovaj QR kod nije povezan ni s jednom trenutačno dostupnom dostavom.',
+            };
+        case 'not-ready':
+            return {
+                id,
+                color: 'warning',
+                message: `Dostava za ${result.plantName} · ${result.contactName} još nije spremna za preuzimanje na lokaciji.`,
+            };
+        case 'invalid':
+            return {
+                id,
+                color: 'danger',
+                message: 'Kod nije valjana Gredice poveznica traga uroda.',
+            };
+        case 'verified':
+            return {
+                id,
+                color: 'success',
+                message: `${result.plantName} · ${result.contactName} potvrđen je za ovu dostavu.`,
+            };
+        case 'already-verified':
+            return {
+                id,
+                color: 'info',
+                message: `${result.plantName} · ${result.contactName} već je provjeren na ovoj stanici.`,
+            };
+        case 'not-at-stop':
+            return {
+                id,
+                color: 'warning',
+                message:
+                    'Ovaj QR kod nije na popisu uroda za trenutačnu stanicu.',
+            };
+        case 'verification-invalid':
+            return {
+                id,
+                color: 'danger',
+                message: 'Kod nije valjana Gredice poveznica traga uroda.',
+            };
+    }
+}
+
+function cameraAccessError(error: unknown) {
+    if (error instanceof DOMException) {
+        switch (error.name) {
+            case 'NotAllowedError':
+            case 'SecurityError':
+                return 'Dopusti pristup kameri u pregledniku. Kamera radi samo na sigurnoj HTTPS vezi.';
+            case 'NotFoundError':
+            case 'OverconstrainedError':
+                return 'Na ovom uređaju nije pronađena dostupna kamera.';
+            case 'NotReadableError':
+                return 'Kameru trenutačno koristi druga aplikacija. Zatvori je i pokušaj ponovno.';
+        }
+    }
+
+    return 'Kameru trenutačno nije moguće pokrenuti. Kod možeš unijeti ručno.';
+}
+
+export function HarvestTraceScanner({
+    variant,
+    availableTraceCount,
+    disabled,
+    completedTraceCount,
+    onScan,
+}: {
+    variant: 'pickup' | 'verification';
+    availableTraceCount: number;
+    disabled: boolean;
+    completedTraceCount: number;
+    onScan: (
+        value: string,
+    ) => HarvestTraceSelectionResult | HarvestTraceVerificationResult;
+}) {
+    const [open, setOpen] = useState(false);
+    const [cameraState, setCameraState] = useState<CameraState>(
+        'requesting-permission',
+    );
+    const [cameraError, setCameraError] = useState<string | null>(null);
+    const [manualValue, setManualValue] = useState('');
+    const [history, setHistory] = useState<ScanHistoryItem[]>([]);
+    const [uniqueScanCount, setUniqueScanCount] = useState(0);
+    const videoRef = useRef<HTMLVideoElement>(null);
+    const readerRef = useRef<BrowserQRCodeReader | null>(null);
+    const seenValuesRef = useRef(new Set<string>());
+    const historyIdRef = useRef(0);
+    const onScanRef = useRef(onScan);
+
+    useEffect(() => {
+        onScanRef.current = onScan;
+    }, [onScan]);
+
+    const pushHistory = useCallback((item: Omit<ScanHistoryItem, 'id'>) => {
+        historyIdRef.current += 1;
+        setHistory((current) => [
+            { id: historyIdRef.current, ...item },
+            ...current.slice(0, 3),
+        ]);
+    }, []);
+
+    const processScan = useCallback(
+        (value: string, source: 'camera' | 'manual') => {
+            const normalizedValue = value.trim();
+            if (!normalizedValue) return;
+
+            if (seenValuesRef.current.has(normalizedValue)) {
+                if (source === 'manual') {
+                    pushHistory({
+                        color: 'info',
+                        message: 'Ovaj je kod već očitan u trenutnoj sesiji.',
+                    });
+                }
+                return;
+            }
+
+            seenValuesRef.current.add(normalizedValue);
+            setUniqueScanCount(seenValuesRef.current.size);
+            historyIdRef.current += 1;
+            const result = onScanRef.current(normalizedValue);
+            setHistory((current) => [
+                scanHistoryItem(historyIdRef.current, result),
+                ...current.slice(0, 3),
+            ]);
+
+            if (result.status === 'selected' || result.status === 'verified') {
+                navigator.vibrate?.(80);
+            }
+        },
+        [pushHistory],
+    );
+
+    useEffect(() => {
+        if (!open) return;
+
+        if (!navigator.mediaDevices?.getUserMedia) {
+            setCameraState('unsupported');
+            setCameraError(
+                'Ovaj preglednik ne podržava kameru. Kod možeš unijeti ručno.',
+            );
+            return;
+        }
+
+        let active = true;
+
+        async function startScanner() {
+            setCameraState('requesting-permission');
+            setCameraError(null);
+
+            try {
+                const {
+                    BrowserQRCodeReader,
+                    ChecksumException,
+                    FormatException,
+                    NotFoundException,
+                } = await import('@zxing/library');
+                if (!active) return;
+
+                const video = videoRef.current;
+                if (!video) {
+                    throw new Error('Camera preview is not available.');
+                }
+
+                const reader = new BrowserQRCodeReader(250);
+                let decodingFailed = false;
+                readerRef.current = reader;
+                await reader.decodeFromConstraints(
+                    {
+                        audio: false,
+                        video: {
+                            facingMode: { ideal: 'environment' },
+                            width: { ideal: 1280 },
+                            height: { ideal: 720 },
+                        },
+                    },
+                    video,
+                    (result, error) => {
+                        if (!active) return;
+                        if (result) {
+                            processScan(result.getText(), 'camera');
+                            return;
+                        }
+                        if (
+                            error &&
+                            !(error instanceof NotFoundException) &&
+                            !(error instanceof ChecksumException) &&
+                            !(error instanceof FormatException)
+                        ) {
+                            decodingFailed = true;
+                            reader.reset();
+                            readerRef.current = null;
+                            setCameraState('error');
+                            setCameraError(
+                                'QR kod nije moguće očitati. Pokušaj ponovno ili ga unesi ručno.',
+                            );
+                        }
+                    },
+                );
+
+                if (active && !decodingFailed) {
+                    setCameraState('scanning');
+                } else if (!active) {
+                    reader.reset();
+                }
+            } catch (error) {
+                if (!active) return;
+                readerRef.current?.reset();
+                readerRef.current = null;
+                setCameraState('error');
+                setCameraError(cameraAccessError(error));
+            }
+        }
+
+        void startScanner();
+
+        return () => {
+            active = false;
+            readerRef.current?.reset();
+            readerRef.current = null;
+
+            const video = videoRef.current;
+            if (video?.srcObject instanceof MediaStream) {
+                for (const track of video.srcObject.getTracks()) {
+                    track.stop();
+                }
+                video.srcObject = null;
+            }
+        };
+    }, [open, processScan]);
+
+    function openScanner() {
+        seenValuesRef.current.clear();
+        historyIdRef.current = 0;
+        setHistory([]);
+        setUniqueScanCount(0);
+        setManualValue('');
+        setCameraError(null);
+        setCameraState('requesting-permission');
+        setOpen(true);
+    }
+
+    function submitManualValue(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        processScan(manualValue, 'manual');
+        setManualValue('');
+    }
+
+    const verificationMode = variant === 'verification';
+
+    return (
+        <>
+            <Button
+                variant="outlined"
+                disabled={disabled || availableTraceCount === 0}
+                onClick={openScanner}
+                startDecorator={<Camera className="size-4" />}
+            >
+                {verificationMode ? 'Provjeri QR kodove' : 'Skeniraj QR kodove'}
+            </Button>
+            <Modal
+                open={open}
+                onOpenChange={setOpen}
+                title={
+                    verificationMode
+                        ? 'Provjera uroda za dostavu'
+                        : 'Skeniranje tragova uroda'
+                }
+                description={
+                    verificationMode
+                        ? 'Skeniranje je pomoćna provjera i nikada ne blokira potvrdu dostave.'
+                        : 'Kamera ostaje aktivna kako bi se više QR kodova moglo očitati bez zatvaranja skenera.'
+                }
+                className="md:max-w-xl"
+            >
+                <div className="space-y-4">
+                    <div className="pr-8">
+                        <Typography level="h3" semiBold>
+                            {verificationMode
+                                ? 'Provjeri urode na stanici'
+                                : 'Skeniraj tragove uroda'}
+                        </Typography>
+                        <Typography
+                            level="body3"
+                            className="mt-1 text-muted-foreground"
+                        >
+                            {verificationMode
+                                ? 'Kamera ostaje uključena. Skeniraj etikete uroda koje predaješ korisniku.'
+                                : 'Kamera ostaje uključena. Svaki novi QR automatski odabire cijelu skupnu stanicu dostave.'}
+                        </Typography>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                        <Chip color="info" size="sm">
+                            <Tally3 className="mr-1 size-4" />
+                            {uniqueScanCount} očitano
+                        </Chip>
+                        <Chip color="success" size="sm">
+                            <Check className="mr-1 size-4" />
+                            {completedTraceCount}{' '}
+                            {verificationMode ? 'provjereno' : 'odabrano'}
+                        </Chip>
+                        <Chip color="neutral" size="sm">
+                            {availableTraceCount}{' '}
+                            {verificationMode
+                                ? 'očekivanih QR kodova'
+                                : 'dostupnih QR kodova'}
+                        </Chip>
+                    </div>
+
+                    <div className="relative aspect-[4/3] overflow-hidden rounded-xl bg-black">
+                        <video
+                            ref={videoRef}
+                            className="h-full w-full object-cover"
+                            playsInline
+                            muted
+                            aria-label="Prikaz kamere za skeniranje QR kodova"
+                        />
+                        {cameraState === 'scanning' ? (
+                            <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/10">
+                                <div className="size-52 rounded-2xl border-2 border-dashed border-white shadow-[0_0_0_999px_rgba(0,0,0,0.28)]" />
+                            </div>
+                        ) : (
+                            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-black/75 px-6 text-center text-white">
+                                {cameraState === 'requesting-permission' ? (
+                                    <LoaderSpinner className="size-7 animate-spin" />
+                                ) : (
+                                    <Camera className="size-8" />
+                                )}
+                                <Typography component="span" level="body2">
+                                    {cameraState === 'requesting-permission'
+                                        ? 'Pokretanje kamere…'
+                                        : 'Kamera nije dostupna'}
+                                </Typography>
+                            </div>
+                        )}
+                        {cameraState === 'scanning' ? (
+                            <div className="absolute inset-x-3 bottom-3 flex justify-center">
+                                <Chip color="neutral" size="sm">
+                                    Kamera je aktivna · usmjeri sljedeći QR
+                                </Chip>
+                            </div>
+                        ) : null}
+                    </div>
+
+                    {cameraError ? (
+                        <Alert
+                            color="warning"
+                            startDecorator={<Warning className="size-5" />}
+                        >
+                            {cameraError}
+                        </Alert>
+                    ) : null}
+
+                    <div
+                        className="space-y-2"
+                        role="log"
+                        aria-label="Posljednja očitanja"
+                        aria-live="polite"
+                        aria-relevant="additions"
+                    >
+                        {history.map((item) => (
+                            <Alert
+                                key={item.id}
+                                color={item.color}
+                                startDecorator={
+                                    item.color === 'success' ? (
+                                        <Check className="size-5" />
+                                    ) : item.color === 'info' ? (
+                                        <Info className="size-5" />
+                                    ) : (
+                                        <Warning className="size-5" />
+                                    )
+                                }
+                            >
+                                {item.message}
+                            </Alert>
+                        ))}
+                    </div>
+
+                    <form
+                        className="flex flex-col gap-2 sm:flex-row sm:items-end"
+                        onSubmit={submitManualValue}
+                    >
+                        <Input
+                            label="Ručni unos"
+                            helperText="Zalijepi cijelu poveznicu ili token s etikete."
+                            placeholder="https://www.gredice.com/trag/…"
+                            value={manualValue}
+                            onChange={(event) =>
+                                setManualValue(event.target.value)
+                            }
+                            autoCapitalize="none"
+                            autoComplete="off"
+                            spellCheck={false}
+                            fullWidth
+                        />
+                        <Button
+                            type="submit"
+                            variant="outlined"
+                            disabled={!manualValue.trim()}
+                            className="sm:mb-5"
+                        >
+                            Dodaj kod
+                        </Button>
+                    </form>
+
+                    <Button className="w-full" onClick={() => setOpen(false)}>
+                        {verificationMode
+                            ? 'Završi provjeru'
+                            : 'Završi skeniranje'}
+                    </Button>
+                </div>
+            </Modal>
+        </>
+    );
+}

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -229,6 +229,16 @@ function statusLabel({
     }
 }
 
+function pickupStatusLabel(requestState: string) {
+    if (requestState === DeliveryRequestStates.READY) {
+        return 'Spremno za preuzimanje';
+    }
+    if (requestState === DeliveryRequestStates.PREPARING) {
+        return 'U pripremi na lokaciji preuzimanja';
+    }
+    return 'Još nije spremno za preuzimanje';
+}
+
 type DeliveryRunSnapshot = Pick<
     DeliveryRun,
     | 'id'
@@ -444,6 +454,8 @@ async function driverDashboard({
         const order = {
             requestId: request.id,
             stopKey: deliveryRequestStopKey(request),
+            readyForPickup: request.state === DeliveryRequestStates.READY,
+            pickupStatusLabel: pickupStatusLabel(request.state),
             contactName: request.address.contactName,
             address: formatDeliveryDestinationAddress(request.address),
             addressLabel: request.address.label,
@@ -649,11 +661,11 @@ export async function startDeliveryRun({
             request?.mode !== 'delivery' ||
             !request.address ||
             !request.slot ||
-            !batchStates.has(request.state) ||
+            request.state !== DeliveryRequestStates.READY ||
             request.slot.endAt < now
         ) {
             throw new DeliveryRunStartError(
-                'Jedna ili više odabranih dostava više nije dostupna za preuzimanje. Osvježi popis i pokušaj ponovno.',
+                'Jedna ili više odabranih dostava još nije spremna za preuzimanje. Osvježi popis i pokušaj ponovno.',
             );
         }
         selectedStopKeys.add(deliveryRequestStopKey(request));
@@ -669,7 +681,7 @@ export async function startDeliveryRun({
             request.mode === 'delivery' &&
             request.address &&
             request.slot &&
-            batchStates.has(request.state) &&
+            request.state === DeliveryRequestStates.READY &&
             request.slot.endAt >= now &&
             selectedStopKeys.has(deliveryRequestStopKey(request)),
     );
@@ -757,8 +769,6 @@ export async function startDeliveryRun({
         totalDurationSeconds: plan.totalDurationSeconds,
         stops: storedStops,
     });
-
-    await ensureRunRequestsReady(run);
 
     return run;
 }

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -77,6 +77,8 @@ export type DeliveryBatchSummary = {
 export type DeliveryRouteOrderSummary = {
     requestId: string;
     stopKey: string;
+    readyForPickup: boolean;
+    pickupStatusLabel: string;
     contactName: string;
     address: string;
     addressLabel: string | null;

--- a/apps/delivery/lib/harvestTraceScan.node.spec.ts
+++ b/apps/delivery/lib/harvestTraceScan.node.spec.ts
@@ -1,0 +1,323 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type {
+    DeliveryRouteOrderSummary,
+    DeliveryStopDeliverySummary,
+} from './deliveryDashboardTypes';
+import {
+    normalizeHarvestTraceScanValue,
+    selectDeliveryStopFromHarvestTrace,
+    verifyDeliveryStopHarvestTrace,
+} from './harvestTraceScan';
+
+const firstToken = 'first-valid-trace-token-2026';
+const secondToken = 'second-valid-trace-token-2026';
+
+function order({
+    requestId,
+    stopKey,
+    token,
+    readyForPickup = true,
+}: {
+    requestId: string;
+    stopKey: string;
+    token: string | null;
+    readyForPickup?: boolean;
+}): DeliveryRouteOrderSummary {
+    return {
+        requestId,
+        stopKey,
+        readyForPickup,
+        pickupStatusLabel: readyForPickup
+            ? 'Spremno za preuzimanje'
+            : 'Još nije spremno za preuzimanje',
+        contactName: `Kontakt ${requestId}`,
+        address: 'Testna 1, Zagreb, HR',
+        addressLabel: null,
+        requestNotes: null,
+        harvest: {
+            plantName: `Biljka ${requestId}`,
+            operationName: null,
+            raisedBedName: null,
+            fieldName: null,
+            tracePath: token ? `/trag/${token}` : null,
+        },
+    };
+}
+
+function delivery({
+    requestId,
+    token,
+}: {
+    requestId: string;
+    token: string | null;
+}): DeliveryStopDeliverySummary {
+    return {
+        requestId,
+        requestState: 'in_delivery',
+        contactName: `Kontakt ${requestId}`,
+        phone: null,
+        addressLabel: null,
+        requestNotes: null,
+        deliveryNotes: null,
+        harvest: {
+            plantName: `Biljka ${requestId}`,
+            operationName: null,
+            raisedBedName: null,
+            fieldName: null,
+            tracePath: token ? `/trag/${token}` : null,
+        },
+        accountContacts: [],
+    };
+}
+
+test('normalizes official harvest trace QR values', () => {
+    assert.equal(
+        normalizeHarvestTraceScanValue(
+            `https://www.gredice.com/trag/${firstToken}?source=label#trace`,
+        ),
+        `/trag/${firstToken}`,
+    );
+    assert.equal(
+        normalizeHarvestTraceScanValue(`/trag/${firstToken}`),
+        `/trag/${firstToken}`,
+    );
+    assert.equal(
+        normalizeHarvestTraceScanValue(`trag/${firstToken}`),
+        `/trag/${firstToken}`,
+    );
+    assert.equal(
+        normalizeHarvestTraceScanValue(firstToken),
+        `/trag/${firstToken}`,
+    );
+});
+
+test('rejects non-Gredice URLs and malformed trace values', () => {
+    assert.equal(
+        normalizeHarvestTraceScanValue(
+            `https://example.com/trag/${firstToken}`,
+        ),
+        null,
+    );
+    assert.equal(
+        normalizeHarvestTraceScanValue('https://www.gredice.com/drugo/token'),
+        null,
+    );
+    assert.equal(normalizeHarvestTraceScanValue('kratko'), null);
+});
+
+test('selects every delivery in the scanned physical stop', () => {
+    const orders = [
+        order({ requestId: 'one', stopKey: 'slot:1', token: firstToken }),
+        order({ requestId: 'two', stopKey: 'slot:1', token: secondToken }),
+        order({ requestId: 'three', stopKey: 'slot:2', token: null }),
+    ];
+
+    const result = selectDeliveryStopFromHarvestTrace({
+        orders,
+        selectedRequestIds: [],
+        maximumRouteStops: 26,
+        scanValue: `https://www.gredice.com/trag/${firstToken}`,
+    });
+
+    assert.equal(result.status, 'selected');
+    if (result.status !== 'selected') return;
+    assert.deepEqual(result.nextSelectedRequestIds, ['one', 'two']);
+    assert.equal(result.newlySelectedCount, 2);
+    assert.equal(result.deliveryCount, 2);
+});
+
+test('allows scanning another harvest at an already selected stop at the route limit', () => {
+    const orders = [
+        order({ requestId: 'one', stopKey: 'slot:1', token: firstToken }),
+        order({ requestId: 'two', stopKey: 'slot:1', token: secondToken }),
+    ];
+
+    const result = selectDeliveryStopFromHarvestTrace({
+        orders,
+        selectedRequestIds: ['one'],
+        maximumRouteStops: 1,
+        scanValue: secondToken,
+    });
+
+    assert.equal(result.status, 'selected');
+    if (result.status !== 'selected') return;
+    assert.deepEqual(result.nextSelectedRequestIds, ['one', 'two']);
+    assert.equal(result.newlySelectedCount, 1);
+});
+
+test('does not select harvests that are not ready for HQ pickup', () => {
+    const orders = [
+        order({ requestId: 'ready', stopKey: 'slot:1', token: firstToken }),
+        order({
+            requestId: 'not-ready',
+            stopKey: 'slot:1',
+            token: secondToken,
+            readyForPickup: false,
+        }),
+        order({ requestId: 'ready-two', stopKey: 'slot:1', token: null }),
+    ];
+
+    const readyResult = selectDeliveryStopFromHarvestTrace({
+        orders,
+        selectedRequestIds: [],
+        maximumRouteStops: 1,
+        scanValue: firstToken,
+    });
+    assert.equal(readyResult.status, 'selected');
+    if (readyResult.status !== 'selected') return;
+    assert.deepEqual(readyResult.nextSelectedRequestIds, [
+        'ready',
+        'ready-two',
+    ]);
+
+    assert.equal(
+        selectDeliveryStopFromHarvestTrace({
+            orders,
+            selectedRequestIds: readyResult.nextSelectedRequestIds,
+            maximumRouteStops: 1,
+            scanValue: secondToken,
+        }).status,
+        'not-ready',
+    );
+});
+
+test('accumulates delivery stops across consecutive live scans', () => {
+    const orders = [
+        order({ requestId: 'one', stopKey: 'slot:1', token: firstToken }),
+        order({ requestId: 'two', stopKey: 'slot:1', token: null }),
+        order({ requestId: 'three', stopKey: 'slot:2', token: secondToken }),
+    ];
+
+    const firstResult = selectDeliveryStopFromHarvestTrace({
+        orders,
+        selectedRequestIds: [],
+        maximumRouteStops: 2,
+        scanValue: firstToken,
+    });
+    assert.equal(firstResult.status, 'selected');
+    if (firstResult.status !== 'selected') return;
+
+    const secondResult = selectDeliveryStopFromHarvestTrace({
+        orders,
+        selectedRequestIds: firstResult.nextSelectedRequestIds,
+        maximumRouteStops: 2,
+        scanValue: secondToken,
+    });
+    assert.equal(secondResult.status, 'selected');
+    if (secondResult.status !== 'selected') return;
+    assert.deepEqual(secondResult.nextSelectedRequestIds, [
+        'one',
+        'two',
+        'three',
+    ]);
+});
+
+test('reports duplicate, unavailable, ambiguous, and route-limit scans', () => {
+    const orders = [
+        order({ requestId: 'one', stopKey: 'slot:1', token: firstToken }),
+        order({ requestId: 'two', stopKey: 'slot:2', token: secondToken }),
+    ];
+
+    assert.equal(
+        selectDeliveryStopFromHarvestTrace({
+            orders,
+            selectedRequestIds: ['one'],
+            maximumRouteStops: 2,
+            scanValue: firstToken,
+        }).status,
+        'already-selected',
+    );
+    assert.equal(
+        selectDeliveryStopFromHarvestTrace({
+            orders,
+            selectedRequestIds: [],
+            maximumRouteStops: 2,
+            scanValue: 'unavailable-valid-trace-token',
+        }).status,
+        'not-found',
+    );
+    assert.equal(
+        selectDeliveryStopFromHarvestTrace({
+            orders,
+            selectedRequestIds: ['one'],
+            maximumRouteStops: 1,
+            scanValue: secondToken,
+        }).status,
+        'limit-reached',
+    );
+
+    const ambiguousOrders = [
+        order({ requestId: 'one', stopKey: 'slot:1', token: firstToken }),
+        order({ requestId: 'two', stopKey: 'slot:2', token: firstToken }),
+    ];
+    assert.equal(
+        selectDeliveryStopFromHarvestTrace({
+            orders: ambiguousOrders,
+            selectedRequestIds: [],
+            maximumRouteStops: 2,
+            scanValue: firstToken,
+        }).status,
+        'ambiguous',
+    );
+});
+
+test('accumulates optional delivery verification scans for the current stop', () => {
+    const deliveries = [
+        delivery({ requestId: 'one', token: firstToken }),
+        delivery({ requestId: 'two', token: secondToken }),
+        delivery({ requestId: 'without-code', token: null }),
+    ];
+
+    const firstResult = verifyDeliveryStopHarvestTrace({
+        deliveries,
+        verifiedTracePaths: [],
+        scanValue: firstToken,
+    });
+    assert.equal(firstResult.status, 'verified');
+    if (firstResult.status !== 'verified') return;
+    assert.deepEqual(firstResult.nextVerifiedTracePaths, [
+        `/trag/${firstToken}`,
+    ]);
+
+    const secondResult = verifyDeliveryStopHarvestTrace({
+        deliveries,
+        verifiedTracePaths: firstResult.nextVerifiedTracePaths,
+        scanValue: `https://www.gredice.com/trag/${secondToken}`,
+    });
+    assert.equal(secondResult.status, 'verified');
+    if (secondResult.status !== 'verified') return;
+    assert.deepEqual(secondResult.nextVerifiedTracePaths, [
+        `/trag/${firstToken}`,
+        `/trag/${secondToken}`,
+    ]);
+});
+
+test('reports repeated, invalid, and wrong-stop verification scans without blocking delivery', () => {
+    const deliveries = [delivery({ requestId: 'one', token: firstToken })];
+
+    assert.equal(
+        verifyDeliveryStopHarvestTrace({
+            deliveries,
+            verifiedTracePaths: [`/trag/${firstToken}`],
+            scanValue: firstToken,
+        }).status,
+        'already-verified',
+    );
+    assert.equal(
+        verifyDeliveryStopHarvestTrace({
+            deliveries,
+            verifiedTracePaths: [],
+            scanValue: secondToken,
+        }).status,
+        'not-at-stop',
+    );
+    assert.equal(
+        verifyDeliveryStopHarvestTrace({
+            deliveries,
+            verifiedTracePaths: [],
+            scanValue: 'nije-qr-kod',
+        }).status,
+        'verification-invalid',
+    );
+});

--- a/apps/delivery/lib/harvestTraceScan.ts
+++ b/apps/delivery/lib/harvestTraceScan.ts
@@ -1,0 +1,249 @@
+import type {
+    DeliveryRouteOrderSummary,
+    DeliveryStopDeliverySummary,
+} from './deliveryDashboardTypes';
+
+const harvestTraceTokenPattern = /^[A-Za-z0-9_-]{16,96}$/;
+const harvestTraceBaseUrl = 'https://www.gredice.com';
+
+function isGrediceHostname(hostname: string) {
+    return hostname === 'gredice.com' || hostname.endsWith('.gredice.com');
+}
+
+export function normalizeHarvestTraceScanValue(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    if (harvestTraceTokenPattern.test(trimmed)) {
+        return `/trag/${trimmed}`;
+    }
+
+    let url: URL;
+    try {
+        url = new URL(trimmed, harvestTraceBaseUrl);
+    } catch {
+        return null;
+    }
+
+    const isAbsoluteUrl =
+        /^[A-Za-z][A-Za-z\d+.-]*:/.test(trimmed) || trimmed.startsWith('//');
+    if (
+        isAbsoluteUrl &&
+        (url.protocol !== 'https:' ||
+            !isGrediceHostname(url.hostname) ||
+            Boolean(url.username) ||
+            Boolean(url.password))
+    ) {
+        return null;
+    }
+
+    const segments = url.pathname.split('/').filter(Boolean);
+    if (
+        segments.length !== 2 ||
+        segments[0] !== 'trag' ||
+        !harvestTraceTokenPattern.test(segments[1] ?? '')
+    ) {
+        return null;
+    }
+
+    return `/trag/${segments[1]}`;
+}
+
+type HarvestTraceSelectionContext = {
+    tracePath: string;
+    plantName: string;
+    contactName: string;
+    deliveryCount: number;
+};
+
+export type HarvestTraceSelectionResult =
+    | { status: 'invalid' }
+    | { status: 'not-found'; tracePath: string }
+    | { status: 'ambiguous'; tracePath: string }
+    | {
+          status: 'not-ready';
+          tracePath: string;
+          plantName: string;
+          contactName: string;
+      }
+    | ({ status: 'already-selected' } & HarvestTraceSelectionContext)
+    | ({ status: 'limit-reached' } & HarvestTraceSelectionContext)
+    | ({
+          status: 'selected';
+          nextSelectedRequestIds: string[];
+          newlySelectedCount: number;
+      } & HarvestTraceSelectionContext);
+
+type HarvestTraceVerificationContext = {
+    tracePath: string;
+    plantName: string;
+    contactName: string;
+};
+
+export type HarvestTraceVerificationResult =
+    | { status: 'verification-invalid' }
+    | { status: 'not-at-stop'; tracePath: string }
+    | ({ status: 'already-verified' } & HarvestTraceVerificationContext)
+    | ({
+          status: 'verified';
+          nextVerifiedTracePaths: string[];
+      } & HarvestTraceVerificationContext);
+
+export function selectDeliveryStopFromHarvestTrace({
+    orders,
+    selectedRequestIds,
+    maximumRouteStops,
+    scanValue,
+}: {
+    orders: DeliveryRouteOrderSummary[];
+    selectedRequestIds: string[];
+    maximumRouteStops: number;
+    scanValue: string;
+}): HarvestTraceSelectionResult {
+    const tracePath = normalizeHarvestTraceScanValue(scanValue);
+    if (!tracePath) return { status: 'invalid' };
+
+    const matchingOrders = orders.filter(
+        (order) =>
+            order.harvest.tracePath &&
+            normalizeHarvestTraceScanValue(order.harvest.tracePath) ===
+                tracePath,
+    );
+    if (matchingOrders.length === 0) {
+        return { status: 'not-found', tracePath };
+    }
+
+    const readyMatchingOrders = matchingOrders.filter(
+        (order) => order.readyForPickup,
+    );
+    if (readyMatchingOrders.length === 0) {
+        const matchingOrder = matchingOrders[0];
+        if (!matchingOrder) {
+            return { status: 'not-found', tracePath };
+        }
+        return {
+            status: 'not-ready',
+            tracePath,
+            plantName: matchingOrder.harvest.plantName,
+            contactName: matchingOrder.contactName,
+        };
+    }
+
+    const matchingStopKeys = new Set(
+        readyMatchingOrders.map((order) => order.stopKey),
+    );
+    if (matchingStopKeys.size !== 1) {
+        return { status: 'ambiguous', tracePath };
+    }
+
+    const matchedOrder = readyMatchingOrders[0];
+    if (!matchedOrder) {
+        return { status: 'not-found', tracePath };
+    }
+
+    const stopOrders = orders.filter(
+        (order) =>
+            order.stopKey === matchedOrder.stopKey && order.readyForPickup,
+    );
+    const availableRequestIds = new Set(
+        orders.flatMap((order) =>
+            order.readyForPickup ? [order.requestId] : [],
+        ),
+    );
+    const availableSelectedRequestIds = Array.from(
+        new Set(
+            selectedRequestIds.filter((requestId) =>
+                availableRequestIds.has(requestId),
+            ),
+        ),
+    );
+    const selectedRequestIdSet = new Set(availableSelectedRequestIds);
+    const context = {
+        tracePath,
+        plantName: matchedOrder.harvest.plantName,
+        contactName: matchedOrder.contactName,
+        deliveryCount: stopOrders.length,
+    };
+
+    if (
+        stopOrders.every((order) => selectedRequestIdSet.has(order.requestId))
+    ) {
+        return { status: 'already-selected', ...context };
+    }
+
+    const ordersByRequestId = new Map(
+        orders.map((order) => [order.requestId, order]),
+    );
+    const selectedStopKeys = new Set(
+        availableSelectedRequestIds.flatMap((requestId) => {
+            const order = ordersByRequestId.get(requestId);
+            return order ? [order.stopKey] : [];
+        }),
+    );
+    if (
+        !selectedStopKeys.has(matchedOrder.stopKey) &&
+        selectedStopKeys.size >= maximumRouteStops
+    ) {
+        return { status: 'limit-reached', ...context };
+    }
+
+    const newlySelectedCount = stopOrders.filter(
+        (order) => !selectedRequestIdSet.has(order.requestId),
+    ).length;
+    for (const order of stopOrders) {
+        selectedRequestIdSet.add(order.requestId);
+    }
+
+    return {
+        status: 'selected',
+        ...context,
+        nextSelectedRequestIds: Array.from(selectedRequestIdSet),
+        newlySelectedCount,
+    };
+}
+
+export function verifyDeliveryStopHarvestTrace({
+    deliveries,
+    verifiedTracePaths,
+    scanValue,
+}: {
+    deliveries: DeliveryStopDeliverySummary[];
+    verifiedTracePaths: string[];
+    scanValue: string;
+}): HarvestTraceVerificationResult {
+    const tracePath = normalizeHarvestTraceScanValue(scanValue);
+    if (!tracePath) return { status: 'verification-invalid' };
+
+    const matchingDelivery = deliveries.find(
+        (delivery) =>
+            delivery.harvest.tracePath &&
+            normalizeHarvestTraceScanValue(delivery.harvest.tracePath) ===
+                tracePath,
+    );
+    if (!matchingDelivery) {
+        return { status: 'not-at-stop', tracePath };
+    }
+
+    const normalizedVerifiedTracePaths = new Set(
+        verifiedTracePaths.flatMap((value) => {
+            const normalized = normalizeHarvestTraceScanValue(value);
+            return normalized ? [normalized] : [];
+        }),
+    );
+    const context = {
+        tracePath,
+        plantName: matchingDelivery.harvest.plantName,
+        contactName: matchingDelivery.contactName,
+    };
+
+    if (normalizedVerifiedTracePaths.has(tracePath)) {
+        return { status: 'already-verified', ...context };
+    }
+
+    normalizedVerifiedTracePaths.add(tracePath);
+    return {
+        status: 'verified',
+        ...context,
+        nextVerifiedTracePaths: Array.from(normalizedVerifiedTracePaths),
+    };
+}

--- a/apps/delivery/package.json
+++ b/apps/delivery/package.json
@@ -33,6 +33,7 @@
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "@vercel/analytics": "2.0.1",
+        "@zxing/library": "0.23.0",
         "babel-plugin-react-compiler": "19.1.0-rc.3",
         "postcss": "8.5.16",
         "tailwindcss": "4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,9 @@ importers:
       '@vercel/analytics':
         specifier: 2.0.1
         version: 2.0.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react@19.2.7)(vue@3.5.39(typescript@6.0.3))
+      '@zxing/library':
+        specifier: 0.23.0
+        version: 0.23.0
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.3
         version: 19.1.0-rc.3


### PR DESCRIPTION
## Summary

- add continuous plant trace QR scanning for fast HQ pickup selection
- select only ready harvests, preserving bulk same-address and time-slot grouping
- add optional per-stop QR handoff verification after driver arrival
- keep non-ready deliveries visible with clear status while preventing UI and API selection

## Impact

Drivers can scan multiple labels in one session at pickup and verify handoff at the destination. Missing labels never block delivery completion. New routes include only harvests already marked ready by the pickup location.

## Validation

- `pnpm lint --filter delivery`
- `pnpm --filter delivery test` (19 tests)
- `pnpm --filter delivery typecheck`
- `pnpm --filter delivery build`
- `git diff --check`
