### PR TITLE
fix(delivery): make route address geocoding resilient

### DIFF
--- a/apps/delivery/app/api/driver/runs/route.ts
+++ b/apps/delivery/app/api/driver/runs/route.ts
@@ -1,5 +1,6 @@
 import { withAuth } from '../../../../lib/auth/auth';
 import {
+    deliveryRunStartErrorLogContext,
     deliveryRunStartErrorMessage,
     startDeliveryRun,
 } from '../../../../lib/deliveryDashboard';
@@ -25,15 +26,16 @@ export async function POST(request: Request) {
             });
             return Response.json({ id: run.id }, { status: 201 });
         } catch (error) {
+            const startErrorMessage = deliveryRunStartErrorMessage(error);
             console.error('Failed to start delivery run', {
-                error,
+                ...deliveryRunStartErrorLogContext(error),
                 requestCount: deliveryRequestIds.length,
                 userId,
             });
             return Response.json(
                 {
                     error:
-                        deliveryRunStartErrorMessage(error) ??
+                        startErrorMessage ??
                         'Rutu nije moguće pokrenuti. Provjeri adrese i pokušaj ponovno.',
                 },
                 { status: 409 },

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -31,6 +31,7 @@ import type {
 import {
     DeliveryRoutePlanningError,
     formatDeliveryDestinationAddress,
+    formatDeliveryGeocodingAddress,
     maximumDeliveryRouteStops,
     maximumDeliveryRouteWindowHours,
     planDeliveryRoute,
@@ -719,6 +720,9 @@ export async function startDeliveryRun({
                 formattedAddress: formatDeliveryDestinationAddress(
                     representative.address,
                 ),
+                geocodingAddress: formatDeliveryGeocodingAddress(
+                    representative.address,
+                ),
                 windowStartAt: representative.slot.startAt,
                 windowEndAt: representative.slot.endAt,
             };
@@ -994,4 +998,21 @@ export function deliveryRunStartErrorMessage(error: unknown) {
         error instanceof DeliveryRoutePlanningError
         ? error.message
         : null;
+}
+
+export function deliveryRunStartErrorLogContext(error: unknown) {
+    if (error instanceof DeliveryRoutePlanningError) {
+        return {
+            errorName: error.name,
+            errorCode: error.code,
+            deliveryRequestId: error.deliveryRequestId,
+        };
+    }
+    if (error instanceof DeliveryRunStartError) {
+        return {
+            errorName: error.name,
+            errorCode: 'invalid-selection',
+        };
+    }
+    return { error };
 }

--- a/apps/delivery/lib/deliveryRouting.node.spec.ts
+++ b/apps/delivery/lib/deliveryRouting.node.spec.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    buildGoogleGeocodingUrl,
     DeliveryRoutePlanningError,
     estimateDeliveryRoute,
     formatDeliveryDestinationAddress,
+    formatDeliveryGeocodingAddress,
     haversineDistanceMeters,
     nearestNeighborStopOrder,
     orderDeliveryStopsByTimeWindow,
@@ -21,6 +23,123 @@ test('formats a Croatian delivery address without empty lines', () => {
         }),
         'Ilica 1, 10000 Zagreb, HR',
     );
+});
+
+test('keeps address details for display but omits them from geocoding', () => {
+    const address = {
+        street1: 'Ilica 1',
+        street2: '2. kat',
+        postalCode: '10000',
+        city: 'Zagreb',
+        countryCode: 'HR',
+    };
+
+    assert.equal(
+        formatDeliveryDestinationAddress(address),
+        'Ilica 1, 2. kat, 10000 Zagreb, HR',
+    );
+    assert.equal(
+        formatDeliveryGeocodingAddress(address),
+        'Ilica 1, 10000 Zagreb, HR',
+    );
+});
+
+test('geocoding uses a Croatian region bias without a duplicate country filter', () => {
+    const url = buildGoogleGeocodingUrl(
+        'Ilica 1, 10000 Zagreb, HR',
+        'test-key',
+    );
+
+    assert.equal(url.searchParams.get('address'), 'Ilica 1, 10000 Zagreb, HR');
+    assert.equal(url.searchParams.get('language'), 'hr');
+    assert.equal(url.searchParams.get('region'), 'hr');
+    assert.equal(url.searchParams.get('components'), null);
+});
+
+test('route planning retries the display address when the simplified address is not found', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalApiKey = process.env.GREDICE_GOOGLE_MAPS_API_KEY;
+    const originalHqAddress = process.env.GREDICE_DELIVERY_HQ_ADDRESS;
+    const geocodingQueries: string[] = [];
+    process.env.GREDICE_GOOGLE_MAPS_API_KEY = 'test-key';
+    process.env.GREDICE_DELIVERY_HQ_ADDRESS =
+        'Ulica Julija Knifera 3, 10000 Zagreb, HR';
+    globalThis.fetch = async (input) => {
+        const url = new URL(
+            typeof input === 'string'
+                ? input
+                : input instanceof URL
+                  ? input.toString()
+                  : input.url,
+        );
+        if (url.hostname === 'maps.googleapis.com') {
+            const address = url.searchParams.get('address') ?? '';
+            geocodingQueries.push(address);
+            if (address === 'Ilica 1, 10000 Zagreb, HR') {
+                return Response.json({ status: 'ZERO_RESULTS', results: [] });
+            }
+            const location = address.startsWith('Ilica')
+                ? { lat: 45.813, lng: 15.977 }
+                : { lat: 45.776, lng: 15.963 };
+            return Response.json({
+                status: 'OK',
+                results: [{ geometry: { location } }],
+            });
+        }
+        if (url.hostname === 'routes.googleapis.com') {
+            return Response.json({
+                routes: [
+                    {
+                        distanceMeters: 1_000,
+                        duration: '600s',
+                        legs: [{ distanceMeters: 1_000, duration: '600s' }],
+                        polyline: { encodedPolyline: 'encoded' },
+                    },
+                ],
+            });
+        }
+        return new Response(null, { status: 404 });
+    };
+
+    try {
+        const plan = await planDeliveryRoute({
+            candidates: [
+                {
+                    deliveryRequestId: 'delivery-1',
+                    formattedAddress: 'Ilica 1, 2. kat, 10000 Zagreb, HR',
+                    geocodingAddress: 'Ilica 1, 10000 Zagreb, HR',
+                    windowStartAt: new Date('2026-07-14T08:00:00.000Z'),
+                    windowEndAt: new Date('2026-07-14T10:00:00.000Z'),
+                },
+            ],
+            departureTime: new Date('2026-07-14T07:30:00.000Z'),
+        });
+
+        assert.equal(
+            plan.stops[0]?.formattedAddress,
+            'Ilica 1, 2. kat, 10000 Zagreb, HR',
+        );
+        assert.deepEqual(
+            new Set(geocodingQueries),
+            new Set([
+                'Ulica Julija Knifera 3, 10000 Zagreb, HR',
+                'Ilica 1, 10000 Zagreb, HR',
+                'Ilica 1, 2. kat, 10000 Zagreb, HR',
+            ]),
+        );
+    } finally {
+        globalThis.fetch = originalFetch;
+        if (originalApiKey === undefined) {
+            delete process.env.GREDICE_GOOGLE_MAPS_API_KEY;
+        } else {
+            process.env.GREDICE_GOOGLE_MAPS_API_KEY = originalApiKey;
+        }
+        if (originalHqAddress === undefined) {
+            delete process.env.GREDICE_DELIVERY_HQ_ADDRESS;
+        } else {
+            process.env.GREDICE_DELIVERY_HQ_ADDRESS = originalHqAddress;
+        }
+    }
 });
 
 test('orders the closest remaining delivery stop first', () => {

--- a/apps/delivery/lib/deliveryRouting.ts
+++ b/apps/delivery/lib/deliveryRouting.ts
@@ -8,6 +8,7 @@ export type DeliveryCoordinates = {
 export type DeliveryRouteCandidate = {
     deliveryRequestId: string;
     formattedAddress: string;
+    geocodingAddress?: string;
     windowStartAt?: Date;
     windowEndAt?: Date;
 };
@@ -49,6 +50,14 @@ const defaultHqAddress = 'Ulica Julija Knifera 3, 10000 Zagreb, Hrvatska';
 
 export class DeliveryRoutePlanningError extends Error {
     override name = 'DeliveryRoutePlanningError';
+
+    constructor(
+        message: string,
+        readonly code = 'route-planning',
+        readonly deliveryRequestId?: string,
+    ) {
+        super(message);
+    }
 }
 
 function googleMapsApiKey() {
@@ -112,6 +121,36 @@ export function formatDeliveryDestinationAddress(address: {
         .map((value) => value?.trim())
         .filter((value): value is string => Boolean(value))
         .join(', ');
+}
+
+export function formatDeliveryGeocodingAddress(address: {
+    street1: string;
+    postalCode: string;
+    city: string;
+    countryCode: string;
+}) {
+    return [
+        address.street1,
+        `${address.postalCode} ${address.city}`,
+        address.countryCode,
+    ]
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .join(', ');
+}
+
+export function buildGoogleGeocodingUrl(
+    formattedAddress: string,
+    apiKey: string,
+) {
+    const url = new URL('https://maps.googleapis.com/maps/api/geocode/json');
+    url.searchParams.set('address', formattedAddress);
+    // The address already contains its country. A region bias improves local
+    // matching without redundantly applying a strict country component filter.
+    url.searchParams.set('language', 'hr');
+    url.searchParams.set('region', 'hr');
+    url.searchParams.set('key', apiKey);
+    return url;
 }
 
 export function haversineDistanceMeters(
@@ -330,35 +369,67 @@ function scheduledArrival({
     };
 }
 
-async function geocodeAddress(
-    formattedAddress: string,
-): Promise<DeliveryCoordinates> {
-    const url = new URL('https://maps.googleapis.com/maps/api/geocode/json');
-    url.searchParams.set('address', formattedAddress);
-    url.searchParams.set('components', 'country:HR');
-    url.searchParams.set('language', 'hr');
-    url.searchParams.set('region', 'hr');
-    url.searchParams.set('key', googleMapsApiKey());
+async function geocodeAddress({
+    formattedAddress,
+    geocodingAddress,
+    deliveryRequestId,
+}: {
+    formattedAddress: string;
+    geocodingAddress?: string;
+    deliveryRequestId?: string;
+}): Promise<DeliveryCoordinates> {
+    const queries = Array.from(
+        new Set(
+            [geocodingAddress, formattedAddress].filter(
+                (value): value is string => Boolean(value),
+            ),
+        ),
+    );
 
-    const response = await fetch(url, { cache: 'no-store' });
-    const body: unknown = await response.json().catch(() => null);
-    if (!response.ok || !isRecord(body) || body.status !== 'OK') {
-        throw new Error('Jednu od adresa nije moguće pronaći.');
+    for (const query of queries) {
+        const response = await fetch(
+            buildGoogleGeocodingUrl(query, googleMapsApiKey()),
+            { cache: 'no-store' },
+        );
+        const body: unknown = await response.json().catch(() => null);
+        if (response.ok && isRecord(body) && body.status === 'ZERO_RESULTS') {
+            continue;
+        }
+        if (!response.ok || !isRecord(body) || body.status !== 'OK') {
+            throw new Error(
+                'Google Maps trenutačno nije mogao provjeriti adrese dostave.',
+            );
+        }
+
+        const firstResult = Array.isArray(body.results)
+            ? body.results[0]
+            : null;
+        const geometry = isRecord(firstResult) ? firstResult.geometry : null;
+        const location = isRecord(geometry) ? geometry.location : null;
+        const latitude = isRecord(location)
+            ? numberField(location.lat)
+            : undefined;
+        const longitude = isRecord(location)
+            ? numberField(location.lng)
+            : undefined;
+
+        if (latitude === undefined || longitude === undefined) {
+            throw new Error(
+                'Google Maps nije vratio valjane koordinate dostave.',
+            );
+        }
+
+        return { latitude, longitude };
     }
 
-    const firstResult = Array.isArray(body.results) ? body.results[0] : null;
-    const geometry = isRecord(firstResult) ? firstResult.geometry : null;
-    const location = isRecord(geometry) ? geometry.location : null;
-    const latitude = isRecord(location) ? numberField(location.lat) : undefined;
-    const longitude = isRecord(location)
-        ? numberField(location.lng)
-        : undefined;
-
-    if (latitude === undefined || longitude === undefined) {
-        throw new Error('Jedna od adresa nema valjane koordinate.');
-    }
-
-    return { latitude, longitude };
+    const addressType = deliveryRequestId ? 'dostave' : 'sjedišta';
+    throw new DeliveryRoutePlanningError(
+        `Adresu ${addressType} "${formattedAddress}" nije moguće pronaći na karti. Provjeri zapis adrese i pokušaj ponovno.`,
+        deliveryRequestId
+            ? 'delivery-address-not-found'
+            : 'hq-address-not-found',
+        deliveryRequestId,
+    );
 }
 
 function locationWaypoint(coordinates: DeliveryCoordinates) {
@@ -604,11 +675,15 @@ export async function planDeliveryRoute({
     const hqAddress =
         process.env.GREDICE_DELIVERY_HQ_ADDRESS?.trim() || defaultHqAddress;
     const [origin, geocodedStops] = await Promise.all([
-        geocodeAddress(hqAddress),
+        geocodeAddress({ formattedAddress: hqAddress }),
         Promise.all(
             candidates.map(async (candidate) => ({
                 ...candidate,
-                ...(await geocodeAddress(candidate.formattedAddress)),
+                ...(await geocodeAddress({
+                    formattedAddress: candidate.formattedAddress,
+                    geocodingAddress: candidate.geocodingAddress,
+                    deliveryRequestId: candidate.deliveryRequestId,
+                })),
             })),
         ),
     ]);


### PR DESCRIPTION
## Summary

- geocode the physical street address without optional apartment, floor, or address-detail text
- remove the duplicate strict country component while retaining Croatian language and region bias
- retry with the complete display address when the simplified address has no result
- return the exact invalid address to the driver while keeping personal address data out of server logs

## Root cause

Production requests to `POST /api/driver/runs` failed with `Jednu od adresa nije moguće pronaći.` The geocoding request supplied `HR` in the formatted address and again as a strict `country:HR` component filter. It also included optional `street2` details that are useful for delivery but can prevent Google from matching the physical location.

## Impact

Drivers can start connected routes when a delivery address contains apartment, floor, or similar details. If an address is genuinely not recognized, the app now identifies that address so it can be corrected instead of showing a generic route error.

## Validation

- `pnpm lint --filter delivery`
- `pnpm --filter delivery test` (22 tests)
- `pnpm --filter delivery typecheck`
- `pnpm --filter delivery build`
- `git diff --check`
