### PR TITLE
fix(game): align raised bed layer toggle borders

### DIFF
--- a/apps/garden/tests/raised-bed-field-hud.spec.tsx
+++ b/apps/garden/tests/raised-bed-field-hud.spec.tsx
@@ -829,6 +829,28 @@ test.describe('RaisedBedFieldItem HUD (desktop)', () => {
         expect(dragSensorErrors).toEqual([]);
     });
 
+    test('layer toggles stay borderless in light and dark modes', async ({
+        mount,
+        page,
+    }) => {
+        await mount(
+            <RaisedBedFieldDndDialogStory scenario={emptyScenario()} />,
+        );
+
+        const layerToggles = page.locator('[data-raised-bed-layer-control]');
+        await expect(layerToggles).toHaveCount(2);
+
+        for (const isDarkMode of [false, true]) {
+            await page.evaluate((dark) => {
+                document.documentElement.classList.toggle('dark', dark);
+            }, isDarkMode);
+
+            for (const layerToggle of await layerToggles.all()) {
+                await expect(layerToggle).toHaveCSS('border-top-width', '0px');
+            }
+        }
+    });
+
     test('abandoned raised bed shows inactivity message instead of sowing grid', async ({
         mount,
         page,

--- a/packages/game/src/hud/raisedBed/RaisedBedField.tsx
+++ b/packages/game/src/hud/raisedBed/RaisedBedField.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../hooks/useShoppingCart';
 import { useSwapShoppingCartPositions } from '../../hooks/useSwapShoppingCartPositions';
 import { isRaisedBedAbandoned } from '../../raisedBedConstants';
+import { ButtonGreen } from '../../shared-ui/ButtonGreen';
 import { getRaisedBedBlockIds } from '../../utils/raisedBedBlocks';
 import { isRaisedBedFieldOccupied } from '../../utils/raisedBedFields';
 import { getPositionIndexFromGrid } from '../../utils/raisedBedOrientation';
@@ -168,14 +169,14 @@ function RaisedBedFieldLayerToggle({
     storageName: 'history' | 'relationships';
 }) {
     return (
-        <button
+        <ButtonGreen
             aria-label={label}
             aria-pressed={isPressed}
             className={cx(
-                'inline-flex size-10 items-center justify-center rounded-md border-2 border-white shadow-md ring-1 ring-black/10 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-lime-700',
+                'size-10 p-0 shadow-md ring-1 ring-black/10 dark:ring-lime-100/10',
                 isPressed
-                    ? 'bg-gradient-to-br from-lime-100/90 to-lime-100/80 text-primary hover:text-primary/80 dark:from-emerald-950/95 dark:to-lime-950/90 dark:text-lime-50 dark:hover:from-emerald-900/95 dark:hover:to-lime-900/90'
-                    : 'bg-white/85 text-lime-950 hover:bg-white dark:bg-slate-950/90 dark:text-lime-100 dark:hover:bg-slate-900',
+                    ? undefined
+                    : 'bg-white/85 bg-none text-lime-950 hover:bg-white dark:bg-slate-950/90 dark:text-lime-100 dark:hover:bg-slate-900',
             )}
             data-raised-bed-layer-control={storageName}
             onClick={onClick}
@@ -183,7 +184,7 @@ function RaisedBedFieldLayerToggle({
             type="button"
         >
             {children}
-        </button>
+        </ButtonGreen>
     );
 }
 


### PR DESCRIPTION
## Summary

- replace the bespoke raised-bed layer toggle buttons with the shared green button primitive
- remove the hard-coded 2px white border and retain the app's subtle theme-aware ring
- preserve active and inactive toggle styling
- add a component regression test covering border rendering in light and dark modes

## Root cause

The two layer controls used a custom button implementation with `border-2 border-white`, so their outline stayed bright and visually heavier than the surrounding garden controls in both themes.

## Validation

- `corepack pnpm typecheck --filter @gredice/game`
- `corepack pnpm typecheck --filter www`
- `corepack pnpm test --filter @gredice/game` (396 tests)
- `corepack pnpm --filter garden test:prepare`
- `corepack pnpm exec playwright test tests/raised-bed-field-hud.spec.tsx --project=chromium --grep "layer toggles stay borderless"`
- `git diff --check`

## Note

`corepack pnpm typecheck --filter garden` remains blocked by an unrelated existing error in `tests/garden-tab.spec.tsx`: `Page` is not exported from `@playwright/experimental-ct-react`. The garden production build passes.