### PR TITLE
fix(news): respect Novosti base path in card links

### DIFF
--- a/apps/news/components/NewsCard.tsx
+++ b/apps/news/components/NewsCard.tsx
@@ -1,4 +1,5 @@
 import type { Route } from 'next';
+import Link from 'next/link';
 import { formatNewsDate } from '../lib/news';
 
 export type NewsCardKind = 'blog' | 'changelog';
@@ -41,7 +42,7 @@ export function NewsCard({
 
     return (
         <article className="w-full">
-            <a
+            <Link
                 className={`news-card-view-transition grid overflow-hidden rounded-md border bg-card shadow-xs transition-colors hover:bg-muted/20 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ${
                     entry.metaImageUrl
                         ? 'md:grid-cols-[minmax(0,1fr)_10rem]'
@@ -97,7 +98,7 @@ export function NewsCard({
                         />
                     </div>
                 ) : null}
-            </a>
+            </Link>
         </article>
     );
 }


### PR DESCRIPTION
## Summary

- render Novosti cards with Next.js links so the configured `/novosti` base path is preserved
- fix 404s for “Što je novo” entries and the same latent issue for blog cards

## Root cause

`NewsCard` used a raw anchor with app-relative paths such as `/sto-je-novo/<slug>`. Raw anchors do not apply the News app's Next.js `basePath`, so navigation escaped `/novosti` and reached a non-existent route on `www.gredice.com`.

## Validation

- `corepack pnpm --filter news exec biome check components/NewsCard.tsx`
- `corepack pnpm --filter news typecheck`
- `corepack pnpm --filter news build`
- rendered timeline links now use `/novosti/sto-je-novo/<slug>`
- patched local detail route returns HTTP 200
- production comparison: canonical `/novosti/sto-je-novo/<slug>` returns 200 while the previously generated `/sto-je-novo/<slug>` returns 404
