### PR TITLE
fix(farm): scope dashboard farms to signed-in user

### DIFF
--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -1,4 +1,4 @@
-import { getFarms, getUser } from '@gredice/storage';
+import { getFarmsForUser, getUser } from '@gredice/storage';
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
 import { Button } from '@gredice/ui/Button';
 import {
@@ -71,7 +71,10 @@ function formatCoordinate(value?: number | null) {
 
 async function FarmerDashboard() {
     const { userId } = await auth(['farmer', 'admin']);
-    const [dbUser, farms] = await Promise.all([getUser(userId), getFarms()]);
+    const [dbUser, farms] = await Promise.all([
+        getUser(userId),
+        getFarmsForUser(userId),
+    ]);
 
     if (!dbUser) {
         return (
@@ -229,7 +232,7 @@ async function FarmerDashboard() {
                         <Stack spacing={2}>
                             <CardTitle>Moje farme</CardTitle>
                             <Typography className="text-sm text-muted-foreground">
-                                Pregled aktivnih farmi u Gredice sustavu.
+                                Pregled farmi koje su ti dodijeljene.
                             </Typography>
                         </Stack>
                     </CardHeader>
@@ -265,9 +268,8 @@ async function FarmerDashboard() {
                             </Table>
                         ) : (
                             <div className="p-6 text-sm text-muted-foreground">
-                                Još nema dodanih farmi. Kontaktiraj
-                                administratora kako bi dodali tvoju prvu
-                                lokaciju.
+                                Nema dodijeljenih farmi. Kontaktiraj
+                                administratora kako bi ti dodijelio farmu.
                             </div>
                         )}
                     </CardOverflow>

--- a/packages/storage/tests/farmsRepo.node.spec.ts
+++ b/packages/storage/tests/farmsRepo.node.spec.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    assignUserToFarm,
+    createFarm,
+    farms,
+    getFarmsForUser,
+    storage,
+    users,
+} from '@gredice/storage';
+import { eq } from 'drizzle-orm';
+import { createTestDb } from './testDb';
+
+async function createFarmer() {
+    const userId = randomUUID();
+    await storage()
+        .insert(users)
+        .values({
+            id: userId,
+            userName: `farm-dashboard-${userId}@example.com`,
+            displayName: 'Farm Dashboard User',
+            role: 'farmer',
+        });
+
+    return userId;
+}
+
+async function createTestFarm(name: string) {
+    return createFarm({
+        name,
+        latitude: 0,
+        longitude: 0,
+    });
+}
+
+test('getFarmsForUser returns only assigned active farms', async () => {
+    createTestDb();
+
+    const userId = await createFarmer();
+    const otherUserId = await createFarmer();
+    const assignedFarmId = await createTestFarm('Assigned farm');
+    const otherUsersFarmId = await createTestFarm("Other user's farm");
+    const deletedFarmId = await createTestFarm('Deleted assigned farm');
+
+    await Promise.all([
+        assignUserToFarm(assignedFarmId, userId),
+        assignUserToFarm(otherUsersFarmId, otherUserId),
+        assignUserToFarm(deletedFarmId, userId),
+    ]);
+    await storage()
+        .update(farms)
+        .set({ isDeleted: true })
+        .where(eq(farms.id, deletedFarmId));
+
+    const visibleFarms = await getFarmsForUser(userId);
+
+    assert.deepEqual(
+        visibleFarms.map((farm) => farm.id),
+        [assignedFarmId],
+    );
+});


### PR DESCRIPTION
## Summary

- load dashboard farms through the signed-in user assignment relation
- keep soft-deleted and other farmers' farms out of the Farm dashboard
- clarify the assigned-farm and no-assignment copy without adding a farm selector
- add repository regression coverage for active, cross-farmer, and deleted assignments

## Root cause

The Farm dashboard used the global `getFarms()` repository query even though the page is request-authenticated. That exposed every farm record to both farmer and Farm-app admin roles instead of enforcing the existing user-to-farm assignment boundary.

## Impact

Farmers and Farm-app admins now see only active farms assigned to their account. Global farm management in the admin app is unchanged, and the single-farm farmer experience remains the default.

## Validation

- `corepack pnpm lint --filter=farm --filter=@gredice/storage`
- `corepack pnpm --filter @gredice/storage test:node farmsRepo.node.spec.ts`
- `corepack pnpm --filter farm build`
- `git diff --check`

Fixes #4149