### PR TITLE
fix(delivery): secure and characterize workflow boundaries

### DIFF
--- a/apps/api/app/api/[...route]/deliveryRoutes.ts
+++ b/apps/api/app/api/[...route]/deliveryRoutes.ts
@@ -1,6 +1,4 @@
-import { notifyDeliveryRequestEvent } from '@gredice/notifications';
 import {
-    cancelDeliveryRequest,
     createDeliveryAddress,
     createDeliveryRequest,
     deleteDeliveryAddress,
@@ -20,10 +18,8 @@ import {
 import { Hono } from 'hono';
 import { describeRoute, validator as zValidator } from 'hono-openapi';
 import { z } from 'zod';
-import {
-    createDeliveryRequestCalendarEvent,
-    deleteDeliveryRequestCalendarEvent,
-} from '../../../lib/delivery/calendarSync';
+import { createDeliveryRequestCalendarEvent } from '../../../lib/delivery/calendarSync';
+import { cancelDeliveryRequestForCurrentAccount } from '../../../lib/delivery/cancelDeliveryRequestForAccount';
 import { authSecurity, publicSecurity } from '../../../lib/docs/security';
 import {
     type AuthVariables,
@@ -113,7 +109,10 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const validationErrors = validateDeliveryAddress(data);
             if (validationErrors.length > 0) {
                 return context.json(
-                    { error: 'Validation failed', details: validationErrors },
+                    {
+                        error: 'Validation failed',
+                        details: validationErrors,
+                    },
                     400,
                 );
             }
@@ -157,7 +156,10 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const validationErrors = validateDeliveryAddress(data);
             if (validationErrors.length > 0) {
                 return context.json(
-                    { error: 'Validation failed', details: validationErrors },
+                    {
+                        error: 'Validation failed',
+                        details: validationErrors,
+                    },
                     400,
                 );
             }
@@ -293,13 +295,20 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 return context.json({ id: requestId }, 201);
             } catch (error) {
                 console.error('Failed to create delivery request:', error);
+                const errorMessage =
+                    error instanceof Error ? error.message : 'Unknown error';
+
+                if (errorMessage.endsWith('or access denied')) {
+                    return context.json(
+                        { error: 'Delivery resource not found' },
+                        404,
+                    );
+                }
+
                 return context.json(
                     {
                         error: 'Failed to create delivery request',
-                        details:
-                            error instanceof Error
-                                ? error.message
-                                : 'Unknown error',
+                        details: errorMessage,
                     },
                     500,
                 );
@@ -325,26 +334,12 @@ const app = new Hono<{ Variables: AuthVariables }>()
             try {
                 // TODO: Move to service
                 // TODO: Add email notification for delivery cancellation
-                await cancelDeliveryRequest(
-                    id,
-                    'user',
+                await cancelDeliveryRequestForCurrentAccount({
+                    requestId: id,
+                    accountId,
                     cancelReason,
                     note,
-                    accountId,
-                );
-                await notifyDeliveryRequestEvent(id, 'cancelled', {
-                    reason: cancelReason,
-                    note,
                 });
-                (await getPostHogClient()).capture({
-                    distinctId: accountId,
-                    event: 'delivery_request_cancelled',
-                    properties: {
-                        request_id: id,
-                        cancel_reason: cancelReason,
-                    },
-                });
-                void deleteDeliveryRequestCalendarEvent(id);
                 return context.json({ success: true });
             } catch (error) {
                 console.error('Failed to cancel delivery request:', error);
@@ -354,8 +349,18 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 // Handle specific error cases
                 if (errorMessage.includes('cutoff time has passed')) {
                     return context.json(
-                        { error: 'CUTOFF_EXPIRED', message: errorMessage },
+                        {
+                            error: 'CUTOFF_EXPIRED',
+                            message: errorMessage,
+                        },
                         400,
+                    );
+                }
+
+                if (errorMessage === 'Delivery request not found') {
+                    return context.json(
+                        { error: 'Delivery request not found' },
+                        404,
                     );
                 }
 

--- a/apps/api/lib/delivery/cancelDeliveryRequestForAccount.node.spec.ts
+++ b/apps/api/lib/delivery/cancelDeliveryRequestForAccount.node.spec.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    type CancelDeliveryRequestForAccountDeps,
+    cancelDeliveryRequestForCurrentAccount,
+} from './cancelDeliveryRequestForAccount';
+
+const input = {
+    requestId: '39ba692d-4cd6-4937-9851-4527b56353c3',
+    accountId: 'account-1',
+    cancelReason: 'Promjena plana',
+};
+
+function deps(
+    overrides: Partial<CancelDeliveryRequestForAccountDeps> = {},
+): CancelDeliveryRequestForAccountDeps {
+    return {
+        cancelDeliveryRequestForAccount: async () => undefined,
+        notifyDeliveryCancelled: async () => undefined,
+        captureDeliveryCancelled: async () => undefined,
+        deleteDeliveryRequestCalendarEvent: async () => undefined,
+        ...overrides,
+    };
+}
+
+test('account-bound cancellation runs no side effects when ownership is denied', async () => {
+    let notificationCount = 0;
+    let analyticsCount = 0;
+    let calendarCount = 0;
+
+    await assert.rejects(
+        cancelDeliveryRequestForCurrentAccount(
+            input,
+            deps({
+                cancelDeliveryRequestForAccount: async () => {
+                    throw new Error('Delivery request not found');
+                },
+                notifyDeliveryCancelled: async () => {
+                    notificationCount += 1;
+                },
+                captureDeliveryCancelled: async () => {
+                    analyticsCount += 1;
+                },
+                deleteDeliveryRequestCalendarEvent: async () => {
+                    calendarCount += 1;
+                },
+            }),
+        ),
+        /Delivery request not found/,
+    );
+
+    assert.equal(notificationCount, 0);
+    assert.equal(analyticsCount, 0);
+    assert.equal(calendarCount, 0);
+});
+
+test('account-bound cancellation forwards ownership and runs side effects after success', async () => {
+    const calls: Array<{
+        requestId: string;
+        accountId: string;
+        cancelReason: string;
+    }> = [];
+    let notificationCount = 0;
+    let analyticsCount = 0;
+    let calendarCount = 0;
+
+    await cancelDeliveryRequestForCurrentAccount(
+        input,
+        deps({
+            cancelDeliveryRequestForAccount: async (data) => {
+                calls.push({
+                    requestId: data.requestId,
+                    accountId: data.accountId,
+                    cancelReason: data.cancelReason,
+                });
+            },
+            notifyDeliveryCancelled: async () => {
+                notificationCount += 1;
+            },
+            captureDeliveryCancelled: async () => {
+                analyticsCount += 1;
+            },
+            deleteDeliveryRequestCalendarEvent: async () => {
+                calendarCount += 1;
+            },
+        }),
+    );
+
+    assert.deepEqual(calls, [input]);
+    assert.equal(notificationCount, 1);
+    assert.equal(analyticsCount, 1);
+    assert.equal(calendarCount, 1);
+});

--- a/apps/api/lib/delivery/cancelDeliveryRequestForAccount.ts
+++ b/apps/api/lib/delivery/cancelDeliveryRequestForAccount.ts
@@ -1,0 +1,61 @@
+import { notifyDeliveryRequestEvent } from '@gredice/notifications';
+import { cancelDeliveryRequestForAccount } from '@gredice/storage';
+import { getPostHogClient } from '../posthog-server';
+import { deleteDeliveryRequestCalendarEvent } from './calendarSync';
+
+export type CancelDeliveryRequestForAccountDeps = {
+    cancelDeliveryRequestForAccount: typeof cancelDeliveryRequestForAccount;
+    notifyDeliveryCancelled: (
+        requestId: string,
+        data: { reason: string; note?: string },
+    ) => Promise<void>;
+    captureDeliveryCancelled: (data: {
+        accountId: string;
+        requestId: string;
+        cancelReason: string;
+    }) => Promise<void>;
+    deleteDeliveryRequestCalendarEvent: (requestId: string) => Promise<void>;
+};
+
+const defaultDeps: CancelDeliveryRequestForAccountDeps = {
+    cancelDeliveryRequestForAccount,
+    notifyDeliveryCancelled: (requestId, data) =>
+        notifyDeliveryRequestEvent(requestId, 'cancelled', data),
+    captureDeliveryCancelled: async ({
+        accountId,
+        requestId,
+        cancelReason,
+    }) => {
+        (await getPostHogClient()).capture({
+            distinctId: accountId,
+            event: 'delivery_request_cancelled',
+            properties: {
+                request_id: requestId,
+                cancel_reason: cancelReason,
+            },
+        });
+    },
+    deleteDeliveryRequestCalendarEvent,
+};
+
+export async function cancelDeliveryRequestForCurrentAccount(
+    input: {
+        requestId: string;
+        accountId: string;
+        cancelReason: string;
+        note?: string;
+    },
+    deps: CancelDeliveryRequestForAccountDeps = defaultDeps,
+) {
+    await deps.cancelDeliveryRequestForAccount(input);
+    await deps.notifyDeliveryCancelled(input.requestId, {
+        reason: input.cancelReason,
+        note: input.note,
+    });
+    await deps.captureDeliveryCancelled({
+        accountId: input.accountId,
+        requestId: input.requestId,
+        cancelReason: input.cancelReason,
+    });
+    void deps.deleteDeliveryRequestCalendarEvent(input.requestId);
+}

--- a/apps/delivery/lib/deliveryDashboard.node.spec.ts
+++ b/apps/delivery/lib/deliveryDashboard.node.spec.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { accountCanTrackCurrentDeliveryGroup } from './deliveryDashboard';
+
+const pending = 'pending';
+const delivered = 'delivered';
+
+function group(
+    items: Array<{
+        state: string;
+        accountId?: string;
+    }>,
+) {
+    return {
+        items: items.map((item) => ({
+            stop: { state: item.state },
+            request: item.accountId ? { accountId: item.accountId } : undefined,
+        })),
+    };
+}
+
+test('customer map allows every account in the current bulk delivery group', () => {
+    const groups = [
+        group([
+            { state: pending, accountId: 'account-1' },
+            { state: pending, accountId: 'account-2' },
+        ]),
+        group([{ state: pending, accountId: 'account-3' }]),
+    ];
+
+    assert.equal(
+        accountCanTrackCurrentDeliveryGroup({
+            accountId: 'account-1',
+            runState: 'active',
+            groups,
+        }),
+        true,
+    );
+    assert.equal(
+        accountCanTrackCurrentDeliveryGroup({
+            accountId: 'account-2',
+            runState: 'active',
+            groups,
+        }),
+        true,
+    );
+});
+
+test('customer map denies later stops and delivered earlier stops', () => {
+    const groups = [
+        group([{ state: delivered, accountId: 'account-1' }]),
+        group([{ state: pending, accountId: 'account-2' }]),
+        group([{ state: pending, accountId: 'account-3' }]),
+    ];
+
+    assert.equal(
+        accountCanTrackCurrentDeliveryGroup({
+            accountId: 'account-1',
+            runState: 'active',
+            groups,
+        }),
+        false,
+    );
+    assert.equal(
+        accountCanTrackCurrentDeliveryGroup({
+            accountId: 'account-2',
+            runState: 'active',
+            groups,
+        }),
+        true,
+    );
+    assert.equal(
+        accountCanTrackCurrentDeliveryGroup({
+            accountId: 'account-3',
+            runState: 'active',
+            groups,
+        }),
+        false,
+    );
+});
+
+test('customer map denies tracking when the delivery run is not active', () => {
+    assert.equal(
+        accountCanTrackCurrentDeliveryGroup({
+            accountId: 'account-1',
+            runState: 'completed',
+            groups: [group([{ state: pending, accountId: 'account-1' }])],
+        }),
+        false,
+    );
+});

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -886,6 +886,30 @@ export async function accountCanTrackDeliveryRun({
         return false;
     }
     const groups = await resolveDeliveryRunStopGroups(run);
+    return accountCanTrackCurrentDeliveryGroup({
+        accountId,
+        runState: run.state,
+        groups,
+    });
+}
+
+export function accountCanTrackCurrentDeliveryGroup({
+    accountId,
+    runState,
+    groups,
+}: {
+    accountId: string;
+    runState: string;
+    groups: ReadonlyArray<{
+        items: ReadonlyArray<{
+            stop: { state: string };
+            request?: { accountId?: string | null };
+        }>;
+    }>;
+}) {
+    if (runState !== DeliveryRunStates.ACTIVE) {
+        return false;
+    }
     const currentGroup = groups.find((group) =>
         group.items.some(
             ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,

--- a/apps/delivery/lib/deliveryRouting.node.spec.ts
+++ b/apps/delivery/lib/deliveryRouting.node.spec.ts
@@ -142,6 +142,89 @@ test('route planning retries the display address when the simplified address is 
     }
 });
 
+test('falls back to a local route estimate when Google Routes is unavailable', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalWarn = console.warn;
+    const originalApiKey = process.env.GREDICE_GOOGLE_MAPS_SERVER_API_KEY;
+    const originalHqAddress = process.env.GREDICE_DELIVERY_HQ_ADDRESS;
+    let routesRequestCount = 0;
+    let fallbackWarningCount = 0;
+    process.env.GREDICE_GOOGLE_MAPS_SERVER_API_KEY = 'test-key';
+    process.env.GREDICE_DELIVERY_HQ_ADDRESS =
+        'Ulica Julija Knifera 3, 10000 Zagreb, HR';
+    globalThis.fetch = async (input) => {
+        const url = new URL(
+            typeof input === 'string'
+                ? input
+                : input instanceof URL
+                  ? input.toString()
+                  : input.url,
+        );
+        if (url.hostname === 'maps.googleapis.com') {
+            const address = url.searchParams.get('address') ?? '';
+            const location = address.startsWith('Ilica')
+                ? { lat: 45.813, lng: 15.977 }
+                : { lat: 45.776, lng: 15.963 };
+            return Response.json({
+                status: 'OK',
+                results: [{ geometry: { location } }],
+            });
+        }
+        if (url.hostname === 'routes.googleapis.com') {
+            routesRequestCount += 1;
+            return Response.json(
+                { error: { status: 'UNAVAILABLE' } },
+                { status: 503 },
+            );
+        }
+        return new Response(null, { status: 404 });
+    };
+    console.warn = (message) => {
+        if (
+            message === 'Google route optimization failed; using local fallback'
+        ) {
+            fallbackWarningCount += 1;
+        }
+    };
+
+    try {
+        const plan = await planDeliveryRoute({
+            candidates: [
+                {
+                    deliveryRequestId: 'delivery-1',
+                    formattedAddress: 'Ilica 1, 10000 Zagreb, HR',
+                    windowStartAt: new Date('2026-07-14T08:00:00.000Z'),
+                    windowEndAt: new Date('2026-07-14T10:00:00.000Z'),
+                },
+            ],
+            departureTime: new Date('2026-07-14T07:30:00.000Z'),
+        });
+
+        assert.equal(routesRequestCount, 1);
+        assert.equal(fallbackWarningCount, 1);
+        assert.equal(plan.encodedPolyline, undefined);
+        assert.ok(plan.totalDistanceMeters > 0);
+        assert.equal(plan.stops[0]?.deliveryRequestId, 'delivery-1');
+        assert.equal(
+            plan.stops[0]?.estimatedArrivalAt.toISOString(),
+            '2026-07-14T08:00:00.000Z',
+        );
+    } finally {
+        globalThis.fetch = originalFetch;
+        console.warn = originalWarn;
+        if (originalApiKey === undefined) {
+            delete process.env.GREDICE_GOOGLE_MAPS_SERVER_API_KEY;
+        } else {
+            process.env.GREDICE_GOOGLE_MAPS_SERVER_API_KEY = originalApiKey;
+        }
+        if (originalHqAddress === undefined) {
+            delete process.env.GREDICE_DELIVERY_HQ_ADDRESS;
+        } else {
+            process.env.GREDICE_DELIVERY_HQ_ADDRESS = originalHqAddress;
+        }
+    }
+});
+
 test('reports a server key restriction without exposing Google error details', async () => {
     const originalFetch = globalThis.fetch;
     const originalApiKey = process.env.GREDICE_GOOGLE_MAPS_SERVER_API_KEY;

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -356,7 +356,7 @@ async function reconstructDeliveryRequestRows<
         createdAt: Date;
         updatedAt: Date;
     },
->(requests: TRequest[]) {
+>(requests: TRequest[], accountIdsByOperationId: ReadonlyMap<number, string>) {
     if (requests.length === 0) {
         return [];
     }
@@ -432,18 +432,44 @@ async function reconstructDeliveryRequestRows<
         locations.map((location) => [location.id, location]),
     );
 
-    return reconstructedRows.map((row) => ({
-        ...row,
-        slot: row.projection.slotId
-            ? slotsById.get(row.projection.slotId)
-            : undefined,
-        address: row.projection.addressId
+    return reconstructedRows.map((row) => {
+        const accountId = accountIdsByOperationId.get(row.request.operationId);
+        const address = row.projection.addressId
             ? addressesById.get(row.projection.addressId)
-            : undefined,
-        location: row.projection.locationId
-            ? locationsById.get(row.projection.locationId)
-            : undefined,
-    }));
+            : undefined;
+
+        return {
+            ...row,
+            accountId,
+            slot: row.projection.slotId
+                ? slotsById.get(row.projection.slotId)
+                : undefined,
+            address:
+                accountId && address?.accountId === accountId
+                    ? address
+                    : undefined,
+            location: row.projection.locationId
+                ? locationsById.get(row.projection.locationId)
+                : undefined,
+        };
+    });
+}
+
+function getOperationAccountIds(
+    requests: Array<{
+        operationId: number;
+        operation?: {
+            accountId: string | null;
+        } | null;
+    }>,
+) {
+    const accountIds = new Map<number, string>();
+    for (const request of requests) {
+        if (request.operation?.accountId) {
+            accountIds.set(request.operationId, request.operation.accountId);
+        }
+    }
+    return accountIds;
 }
 
 function filterDeliveryRequestRows<
@@ -507,18 +533,21 @@ async function reconstructDeliveryRequestFromEvents(
         cancelReason,
         requestNotes,
         deliveryNotes,
-        accountId,
         surveySent,
     } = reconstructDeliveryRequestState(request.createdAt, events);
 
-    // Fetch slot, address, location, and operation in parallel
-    const [slot, address, location, operation] = await Promise.all([
+    const operation = await getOperationById(request.operationId);
+    if (!operation.accountId) {
+        throw new Error('Delivery request owner not found');
+    }
+    const accountId = operation.accountId;
+
+    // The operation owner is authoritative for request ownership. Event data
+    // is historical input and must not grant access to another account.
+    const [slot, address, location] = await Promise.all([
         slotId ? getTimeSlot(slotId) : undefined,
-        addressId && accountId
-            ? getDeliveryAddress(addressId, accountId)
-            : undefined,
+        addressId ? getDeliveryAddress(addressId, accountId) : undefined,
         locationId ? getPickupLocation(locationId) : undefined,
-        getOperationById(request.operationId),
     ]);
 
     const [operationEntity, raisedBed, fields, traceLinks] = await Promise.all([
@@ -676,8 +705,18 @@ async function getDeliveryRequestsSummaryUncached(
     const requests = await storage().query.deliveryRequests.findMany({
         where: whereConditions.length > 0 ? and(...whereConditions) : undefined,
         orderBy: [desc(deliveryRequests.createdAt)],
+        with: {
+            operation: {
+                columns: {
+                    accountId: true,
+                },
+            },
+        },
     });
-    const reconstructedRows = await reconstructDeliveryRequestRows(requests);
+    const reconstructedRows = await reconstructDeliveryRequestRows(
+        requests,
+        getOperationAccountIds(requests),
+    );
     const filteredRows = filterDeliveryRequestRows(reconstructedRows, {
         state,
         slotId,
@@ -686,7 +725,7 @@ async function getDeliveryRequestsSummaryUncached(
     });
 
     return filteredRows.map(
-        ({ request, projection, slot, address, location }) => ({
+        ({ request, projection, accountId, slot, address, location }) => ({
             id: request.id,
             operationId: request.operationId,
             state: projection.state,
@@ -700,7 +739,7 @@ async function getDeliveryRequestsSummaryUncached(
             surveySent: projection.surveySent,
             createdAt: request.createdAt,
             updatedAt: request.updatedAt,
-            accountId: projection.accountId,
+            accountId,
         }),
     );
 }
@@ -734,7 +773,10 @@ export async function getDeliveryRequestsWithEvents(
             },
         },
     });
-    const reconstructedRows = await reconstructDeliveryRequestRows(requests);
+    const reconstructedRows = await reconstructDeliveryRequestRows(
+        requests,
+        getOperationAccountIds(requests),
+    );
     const filteredRows = filterDeliveryRequestRows(reconstructedRows, {
         state,
         slotId,
@@ -865,7 +907,7 @@ export async function getDeliveryRequestsWithEvents(
     );
 
     return filteredRows.map(
-        ({ request, projection, slot, address, location }) => {
+        ({ request, projection, accountId, slot, address, location }) => {
             const rawOperation = request.operation;
             const operation =
                 operationsById.get(request.operationId) ??
@@ -924,7 +966,7 @@ export async function getDeliveryRequestsWithEvents(
                     : null,
                 createdAt: request.createdAt,
                 updatedAt: request.updatedAt,
-                accountId: projection.accountId,
+                accountId,
             };
         },
     );
@@ -1042,6 +1084,31 @@ export async function createDeliveryRequest(data: {
 
     if (data.mode === 'pickup' && !data.locationId) {
         throw new Error('Location ID is required for pickup mode');
+    }
+
+    const operation = await storage().query.operations.findFirst({
+        columns: {
+            id: true,
+        },
+        where: and(
+            eq(operations.id, data.operationId),
+            eq(operations.accountId, data.accountId),
+            eq(operations.isDeleted, false),
+        ),
+    });
+
+    if (!operation) {
+        throw new Error('Operation not found or access denied');
+    }
+
+    if (data.mode === 'delivery' && data.addressId) {
+        const address = await getDeliveryAddress(
+            data.addressId,
+            data.accountId,
+        );
+        if (!address) {
+            throw new Error('Delivery address not found or access denied');
+        }
     }
 
     // Check if operation already has a delivery request
@@ -1170,6 +1237,32 @@ export async function cancelDeliveryRequest(
             note,
             cancelledBy: actorId,
         }),
+    );
+}
+
+export async function cancelDeliveryRequestForAccount({
+    requestId,
+    accountId,
+    cancelReason,
+    note,
+}: {
+    requestId: string;
+    accountId: string;
+    cancelReason: string;
+    note?: string;
+}): Promise<void> {
+    const request = await getDeliveryRequest(requestId);
+
+    if (!request || request.accountId !== accountId) {
+        throw new Error('Delivery request not found');
+    }
+
+    await cancelDeliveryRequest(
+        requestId,
+        'user',
+        cancelReason,
+        note,
+        accountId,
     );
 }
 

--- a/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
@@ -4,8 +4,10 @@ import test from 'node:test';
 import {
     acceptOperation,
     cancelDeliveryRequest,
+    cancelDeliveryRequestForAccount,
     changeDeliveryRequestSlot,
     createAttributeDefinition,
+    createDeliveryAddress,
     createDeliveryRequest,
     createEntity,
     createEvent,
@@ -15,12 +17,15 @@ import {
     createPickupLocation,
     createTimeSlot,
     DeliveryRequestStates,
+    deliveryRequests,
     events,
+    getDeliveryRequest,
     getDeliveryRequestsWithEvents,
     getPendingDeliveryReadyEmailRequestIds,
     getTimeSlot,
     knownEvents,
     knownEventTypes,
+    operations,
     raisedBedFields,
     raisedBeds,
     storage,
@@ -304,6 +309,155 @@ test('createDeliveryRequest rejects pickup slots after their close deadline', as
     assert.equal(slot?.status, TimeSlotStatuses.CLOSED);
 });
 
+test('createDeliveryRequest enforces operation and address ownership', async () => {
+    createTestDb();
+
+    const ownerAccountId = await createTestAccount();
+    const foreignAccountId = await createTestAccount();
+    const locationId = await createPickupLocation({
+        name: `Ownership location ${randomUUID()}`,
+        street1: 'Testna 1',
+        city: 'Zagreb',
+        postalCode: '10000',
+        countryCode: 'HR',
+    });
+    const slotStartAt = new Date('2099-02-01T08:00:00.000Z');
+    const pickupSlotId = await createTimeSlot({
+        locationId,
+        type: 'pickup',
+        startAt: slotStartAt,
+        endAt: new Date(slotStartAt.getTime() + 2 * 60 * 60 * 1000),
+        status: TimeSlotStatuses.SCHEDULED,
+    });
+    const deliverySlotId = await createTimeSlot({
+        locationId,
+        type: 'delivery',
+        startAt: slotStartAt,
+        endAt: new Date(slotStartAt.getTime() + 2 * 60 * 60 * 1000),
+        status: TimeSlotStatuses.SCHEDULED,
+    });
+    const [operation] = await storage()
+        .insert(operations)
+        .values({
+            entityId: 1,
+            entityTypeName: 'operation',
+            accountId: ownerAccountId,
+        })
+        .returning({ id: operations.id });
+    assert.ok(operation);
+    const foreignAddressId = await createDeliveryAddress({
+        accountId: foreignAccountId,
+        label: 'Tuđa adresa',
+        contactName: 'Drugi korisnik',
+        phone: '+385 91 000 0000',
+        street1: 'Tuđa 12',
+        city: 'Zagreb',
+        postalCode: '10000',
+        countryCode: 'HR',
+    });
+
+    await assert.rejects(
+        createDeliveryRequest({
+            operationId: operation.id,
+            slotId: pickupSlotId,
+            mode: 'pickup',
+            locationId,
+            accountId: foreignAccountId,
+        }),
+        /Operation not found or access denied/,
+    );
+    await assert.rejects(
+        createDeliveryRequest({
+            operationId: operation.id,
+            slotId: deliverySlotId,
+            mode: 'delivery',
+            addressId: foreignAddressId,
+            accountId: ownerAccountId,
+        }),
+        /Delivery address not found or access denied/,
+    );
+
+    const insertedRequests = await storage().query.deliveryRequests.findMany({
+        where: eq(deliveryRequests.operationId, operation.id),
+    });
+    assert.deepEqual(insertedRequests, []);
+});
+
+test('legacy request reconstruction uses the operation owner and hides foreign addresses', async () => {
+    createTestDb();
+
+    const ownerAccountId = await createTestAccount();
+    const foreignAccountId = await createTestAccount();
+    const locationId = await createPickupLocation({
+        name: `Legacy ownership location ${randomUUID()}`,
+        street1: 'Testna 1',
+        city: 'Zagreb',
+        postalCode: '10000',
+        countryCode: 'HR',
+    });
+    const slotStartAt = new Date('2099-02-02T08:00:00.000Z');
+    const slotId = await createTimeSlot({
+        locationId,
+        type: 'delivery',
+        startAt: slotStartAt,
+        endAt: new Date(slotStartAt.getTime() + 2 * 60 * 60 * 1000),
+        status: TimeSlotStatuses.SCHEDULED,
+    });
+    const [operation] = await storage()
+        .insert(operations)
+        .values({
+            entityId: 1,
+            entityTypeName: 'operation',
+            accountId: ownerAccountId,
+        })
+        .returning({ id: operations.id });
+    assert.ok(operation);
+    const foreignAddressId = await createDeliveryAddress({
+        accountId: foreignAccountId,
+        label: 'Privatna adresa',
+        contactName: 'Drugi korisnik',
+        phone: '+385 91 111 1111',
+        street1: 'Privatna 9',
+        city: 'Zagreb',
+        postalCode: '10000',
+        countryCode: 'HR',
+    });
+    const requestId = randomUUID();
+    await storage().insert(deliveryRequests).values({
+        id: requestId,
+        operationId: operation.id,
+    });
+    await createEvent(
+        knownEvents.delivery.requestCreatedV1(requestId, {
+            operationId: operation.id,
+            slotId,
+            mode: 'delivery',
+            addressId: foreignAddressId,
+            accountId: foreignAccountId,
+        }),
+    );
+
+    const request = await getDeliveryRequest(requestId);
+    const ownerRequests = await getDeliveryRequestsWithEvents(ownerAccountId);
+    const foreignRequests =
+        await getDeliveryRequestsWithEvents(foreignAccountId);
+
+    assert.equal(request?.accountId, ownerAccountId);
+    assert.equal(request?.address, undefined);
+    assert.equal(
+        ownerRequests.find((item) => item.id === requestId)?.accountId,
+        ownerAccountId,
+    );
+    assert.equal(
+        ownerRequests.find((item) => item.id === requestId)?.address,
+        undefined,
+    );
+    assert.equal(
+        foreignRequests.some((item) => item.id === requestId),
+        false,
+    );
+});
+
 test('changeDeliveryRequestSlot rejects pickup slots after their close deadline', async () => {
     const fixture = await createDeliveryRequestWithTraceFixture();
     const slotStartAt = new Date('2099-01-03T08:00:00.000Z');
@@ -457,4 +611,33 @@ test('uncancelDeliveryRequest restores cancelled requests to confirmed', async (
 
     assert.equal(restoredRequest?.state, DeliveryRequestStates.CONFIRMED);
     assert.equal(restoredRequest?.cancelReason, undefined);
+});
+
+test('account cancellation cannot mutate another account request', async () => {
+    const fixture = await createDeliveryRequestWithTraceFixture();
+    const foreignAccountId = await createTestAccount();
+    const originalRequest = await getDeliveryRequest(fixture.requestId);
+    assert.ok(originalRequest);
+
+    await assert.rejects(
+        cancelDeliveryRequestForAccount({
+            requestId: fixture.requestId,
+            accountId: foreignAccountId,
+            cancelReason: 'Nije moj zahtjev',
+        }),
+        /Delivery request not found/,
+    );
+
+    const unchangedRequest = await getDeliveryRequest(fixture.requestId);
+    assert.equal(unchangedRequest?.state, originalRequest.state);
+
+    await cancelDeliveryRequestForAccount({
+        requestId: fixture.requestId,
+        accountId: fixture.accountId,
+        cancelReason: 'Promjena plana',
+    });
+
+    const cancelledRequest = await getDeliveryRequest(fixture.requestId);
+    assert.equal(cancelledRequest?.state, DeliveryRequestStates.CANCELLED);
+    assert.equal(cancelledRequest?.cancelReason, 'Promjena plana');
 });

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -3,37 +3,63 @@ import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
     accountCanTrackDeliveryRun,
+    cancelDeliveryRequest,
+    changeDeliveryRequestSlot,
+    createDeliveryAddress,
     createDeliveryRun,
+    createEvent,
     deliveryRequests,
     fulfillDeliveryRunStop,
     fulfillDeliveryRunStops,
     getDeliveryRequest,
     getDeliveryRun,
+    knownEvents,
     markDeliveryRunStopArrived,
     markDeliveryRunStopsArrived,
     operations,
     pickupLocations,
     storage,
     timeSlots,
+    updateDeliveryAddress,
     updateDeliveryRunLocation,
     users,
 } from '@gredice/storage';
 import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
-test('delivery run fulfills a current bulk stop atomically and preserves route order', async () => {
+type DeliveryRunFixture = Awaited<ReturnType<typeof createDeliveryRunFixture>>;
+
+async function createDeliveryRunFixture({
+    accountIndexes = [0],
+    driverCount = 1,
+}: {
+    accountIndexes?: number[];
+    driverCount?: number;
+} = {}) {
     createTestDb();
-    const accountId = await createTestAccount();
-    const otherAccountId = await createTestAccount();
-    const driverUserId = randomUUID();
+    assert.ok(accountIndexes.length > 0);
+    assert.ok(driverCount > 0);
+
+    const accountCount = Math.max(...accountIndexes) + 1;
+    const accountIds: string[] = [];
+    for (let index = 0; index < accountCount; index += 1) {
+        accountIds.push(await createTestAccount());
+    }
+
+    const driverUserIds = Array.from({ length: driverCount }, () =>
+        randomUUID(),
+    );
     await storage()
         .insert(users)
-        .values({
-            id: driverUserId,
-            userName: `driver-${driverUserId}@example.test`,
-            displayName: 'Test Driver',
-            role: 'driver',
-        });
+        .values(
+            driverUserIds.map((driverUserId, index) => ({
+                id: driverUserId,
+                userName: `driver-${driverUserId}@example.test`,
+                displayName: `Test Driver ${index + 1}`,
+                role: 'driver',
+            })),
+        );
+
     const [location] = await storage()
         .insert(pickupLocations)
         .values({
@@ -45,6 +71,7 @@ test('delivery run fulfills a current bulk stop atomically and preserves route o
         })
         .returning();
     assert.ok(location);
+
     const [slot] = await storage()
         .insert(timeSlots)
         .values({
@@ -58,26 +85,21 @@ test('delivery run fulfills a current bulk stop atomically and preserves route o
 
     const operationRows = await storage()
         .insert(operations)
-        .values([
-            {
-                entityId: 1,
-                entityTypeName: 'operation',
-                accountId,
-            },
-            {
-                entityId: 2,
-                entityTypeName: 'operation',
-                accountId,
-            },
-            {
-                entityId: 3,
-                entityTypeName: 'operation',
-                accountId: otherAccountId,
-            },
-        ])
+        .values(
+            accountIndexes.map((accountIndex, index) => {
+                const accountId = accountIds[accountIndex];
+                assert.ok(accountId);
+                return {
+                    entityId: index + 1,
+                    entityTypeName: 'operation',
+                    accountId,
+                };
+            }),
+        )
         .returning({ id: operations.id });
-    assert.equal(operationRows.length, 3);
-    const requestIds = [randomUUID(), randomUUID(), randomUUID()];
+    assert.equal(operationRows.length, accountIndexes.length);
+
+    const requestIds = operationRows.map(() => randomUUID());
     await storage()
         .insert(deliveryRequests)
         .values(
@@ -87,24 +109,97 @@ test('delivery run fulfills a current bulk stop atomically and preserves route o
             })),
         );
 
-    const run = await createDeliveryRun({
-        driverUserId,
+    return {
+        accountIds,
+        driverUserIds,
+        locationId: location.id,
+        operationIds: operationRows.map((operation) => operation.id),
+        requestIds,
         timeSlotId: slot.id,
-        totalDistanceMeters: 4_500,
-        totalDurationSeconds: 1_200,
-        stops: requestIds.map((deliveryRequestId, index) => ({
+    };
+}
+
+async function createRequestEvents(fixture: DeliveryRunFixture) {
+    for (const [index, requestId] of fixture.requestIds.entries()) {
+        const operationId = fixture.operationIds[index];
+        const accountId = fixture.accountIds[0];
+        assert.ok(operationId);
+        assert.ok(accountId);
+        await createEvent(
+            knownEvents.delivery.requestCreatedV1(requestId, {
+                operationId,
+                slotId: fixture.timeSlotId,
+                mode: 'pickup',
+                locationId: fixture.locationId,
+                accountId,
+            }),
+        );
+    }
+}
+
+function createRunStops(requestIds: string[]) {
+    return requestIds.map((deliveryRequestId, index) => {
+        const destinationIndex = Math.floor(index / 2);
+        return {
             deliveryRequestId,
             sequence: index + 1,
-            latitude: index < 2 ? 45.8 : 45.81,
-            longitude: index < 2 ? 15.97 : 15.98,
-            formattedAddress: `Testna ${index < 2 ? 1 : 2}, Zagreb, HR`,
+            latitude: 45.8 + destinationIndex / 100,
+            longitude: 15.97 + destinationIndex / 100,
+            formattedAddress: `Testna ${destinationIndex + 1}, Zagreb, HR`,
             estimatedArrivalAt: new Date(
                 Date.parse('2026-07-13T08:15:00.000Z') +
-                    (index < 2 ? 0 : 900_000),
+                    destinationIndex * 900_000,
             ),
             estimatedTravelSeconds: 600,
             estimatedDistanceMeters: 2_250,
-        })),
+        };
+    });
+}
+
+function createRun({
+    fixture,
+    driverUserId,
+    requestIds,
+    stops,
+    totalDistanceMeters = 4_500,
+    totalDurationSeconds = 1_200,
+}: {
+    fixture: DeliveryRunFixture;
+    driverUserId: string;
+    requestIds: string[];
+    stops?: ReturnType<typeof createRunStops>;
+    totalDistanceMeters?: number;
+    totalDurationSeconds?: number;
+}) {
+    return createDeliveryRun({
+        driverUserId,
+        timeSlotId: fixture.timeSlotId,
+        totalDistanceMeters,
+        totalDurationSeconds,
+        stops: stops ?? createRunStops(requestIds),
+    });
+}
+
+test('delivery run fulfills a current bulk stop atomically and preserves route order', async () => {
+    const fixture = await createDeliveryRunFixture({
+        accountIndexes: [0, 0, 1, 0],
+    });
+    const [accountId, otherAccountId] = fixture.accountIds;
+    const [driverUserId] = fixture.driverUserIds;
+    const [firstRequestId, secondRequestId, thirdRequestId, nextRequestId] =
+        fixture.requestIds;
+    assert.ok(accountId);
+    assert.ok(otherAccountId);
+    assert.ok(driverUserId);
+    assert.ok(firstRequestId);
+    assert.ok(secondRequestId);
+    assert.ok(thirdRequestId);
+    assert.ok(nextRequestId);
+
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [firstRequestId, secondRequestId, thirdRequestId],
     });
     assert.equal(run.stops.length, 3);
     const [firstStop, secondStop, thirdStop] = run.stops;
@@ -149,6 +244,9 @@ test('delivery run fulfills a current bulk stop atomically and preserves route o
         driverUserId,
         latitude: 45.801,
         longitude: 15.971,
+        accuracy: 7,
+        heading: 180,
+        speed: 8.5,
         recordedAt: new Date('2026-07-13T08:05:00.000Z'),
     });
     await markDeliveryRunStopsArrived({
@@ -193,8 +291,13 @@ test('delivery run fulfills a current bulk stop atomically and preserves route o
 
     const completedRun = await getDeliveryRun(run.id);
     assert.equal(completedRun?.state, 'completed');
-    assert.equal(completedRun?.currentLatitude, null);
-    assert.equal(completedRun?.currentLongitude, null);
+    assert.ok(completedRun?.completedAt);
+    assert.equal(completedRun.currentLatitude, null);
+    assert.equal(completedRun.currentLongitude, null);
+    assert.equal(completedRun.currentLocationAccuracy, null);
+    assert.equal(completedRun.currentLocationHeading, null);
+    assert.equal(completedRun.currentLocationSpeed, null);
+    assert.equal(completedRun.currentLocationRecordedAt, null);
     assert.equal(
         await accountCanTrackDeliveryRun({ accountId, runId: run.id }),
         false,
@@ -214,4 +317,309 @@ test('delivery run fulfills a current bulk stop atomically and preserves route o
         }),
         /Active delivery stop not found/,
     );
+
+    const nextRun = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [nextRequestId],
+    });
+    assert.notEqual(nextRun.id, run.id);
+    assert.equal(nextRun.state, 'active');
+});
+
+test('same-driver route creation replays the active run and ignores a new selection', async () => {
+    const fixture = await createDeliveryRunFixture({ accountIndexes: [0, 0] });
+    const [driverUserId] = fixture.driverUserIds;
+    const [firstRequestId, secondRequestId] = fixture.requestIds;
+    assert.ok(driverUserId);
+    assert.ok(firstRequestId);
+    assert.ok(secondRequestId);
+
+    const originalRun = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [firstRequestId],
+        totalDistanceMeters: 1_000,
+        totalDurationSeconds: 300,
+    });
+    const replayedRun = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [secondRequestId],
+        totalDistanceMeters: 9_000,
+        totalDurationSeconds: 3_000,
+    });
+
+    assert.equal(replayedRun.id, originalRun.id);
+    assert.equal(replayedRun.totalDistanceMeters, 1_000);
+    assert.equal(replayedRun.totalDurationSeconds, 300);
+    assert.deepEqual(
+        replayedRun.stops.map((stop) => stop.deliveryRequestId),
+        [firstRequestId],
+    );
+});
+
+test('concurrent cross-driver assignment permits one run and rolls back the loser', async () => {
+    const fixture = await createDeliveryRunFixture({
+        accountIndexes: [0, 0],
+        driverCount: 2,
+    });
+    const [firstDriverUserId, secondDriverUserId] = fixture.driverUserIds;
+    const [contestedRequestId, recoveryRequestId] = fixture.requestIds;
+    assert.ok(firstDriverUserId);
+    assert.ok(secondDriverUserId);
+    assert.ok(contestedRequestId);
+    assert.ok(recoveryRequestId);
+
+    const attempts = await Promise.allSettled([
+        createRun({
+            fixture,
+            driverUserId: firstDriverUserId,
+            requestIds: [contestedRequestId],
+        }),
+        createRun({
+            fixture,
+            driverUserId: secondDriverUserId,
+            requestIds: [contestedRequestId],
+        }),
+    ]);
+    assert.equal(
+        attempts.filter((result) => result.status === 'fulfilled').length,
+        1,
+    );
+    assert.equal(
+        attempts.filter((result) => result.status === 'rejected').length,
+        1,
+    );
+
+    const winningIndex = attempts.findIndex(
+        (result) => result.status === 'fulfilled',
+    );
+    assert.notEqual(winningIndex, -1);
+    const losingDriverUserId =
+        winningIndex === 0 ? secondDriverUserId : firstDriverUserId;
+    const recoveryRun = await createRun({
+        fixture,
+        driverUserId: losingDriverUserId,
+        requestIds: [recoveryRequestId],
+    });
+    assert.deepEqual(
+        recoveryRun.stops.map((stop) => stop.deliveryRequestId),
+        [recoveryRequestId],
+    );
+});
+
+test('an older GPS sample is rejected without overwriting the latest telemetry', async () => {
+    const fixture = await createDeliveryRunFixture();
+    const [driverUserId] = fixture.driverUserIds;
+    const [requestId] = fixture.requestIds;
+    assert.ok(driverUserId);
+    assert.ok(requestId);
+
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [requestId],
+    });
+    const latestRecordedAt = new Date('2026-07-13T08:10:00.000Z');
+    await updateDeliveryRunLocation({
+        runId: run.id,
+        driverUserId,
+        latitude: 45.812,
+        longitude: 15.982,
+        accuracy: 5,
+        heading: 135,
+        speed: 9.25,
+        recordedAt: latestRecordedAt,
+    });
+
+    await assert.rejects(
+        updateDeliveryRunLocation({
+            runId: run.id,
+            driverUserId,
+            latitude: 45.7,
+            longitude: 15.8,
+            accuracy: 99,
+            heading: 5,
+            speed: 1,
+            recordedAt: new Date('2026-07-13T08:09:59.000Z'),
+        }),
+        /Active delivery run not found/,
+    );
+
+    const persistedRun = await getDeliveryRun(run.id);
+    assert.equal(persistedRun?.currentLatitude, 45.812);
+    assert.equal(persistedRun?.currentLongitude, 15.982);
+    assert.equal(persistedRun?.currentLocationAccuracy, 5);
+    assert.equal(persistedRun?.currentLocationHeading, 135);
+    assert.equal(persistedRun?.currentLocationSpeed, 9.25);
+    assert.equal(
+        persistedRun?.currentLocationRecordedAt?.toISOString(),
+        latestRecordedAt.toISOString(),
+    );
+});
+
+test('cancelled bulk member rolls back fulfillment of the current route group', async () => {
+    const fixture = await createDeliveryRunFixture({
+        accountIndexes: [0, 0, 0],
+    });
+    await createRequestEvents(fixture);
+    const [driverUserId] = fixture.driverUserIds;
+    const [firstRequestId, secondRequestId] = fixture.requestIds;
+    assert.ok(driverUserId);
+    assert.ok(firstRequestId);
+    assert.ok(secondRequestId);
+
+    await cancelDeliveryRequest(
+        secondRequestId,
+        'admin',
+        'Otkazano prije dostave',
+    );
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: fixture.requestIds,
+    });
+    const [firstStop, secondStop, thirdStop] = run.stops;
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+    assert.ok(thirdStop);
+
+    await assert.rejects(
+        fulfillDeliveryRunStops({
+            driverUserId,
+            runId: run.id,
+            stopIds: [firstStop.id, secondStop.id],
+        }),
+        /Cannot fulfill a cancelled delivery request/,
+    );
+
+    const unchangedRun = await getDeliveryRun(run.id);
+    assert.deepEqual(
+        unchangedRun?.stops.map((stop) => stop.state),
+        ['pending', 'pending', 'pending'],
+    );
+    assert.notEqual(
+        (await getDeliveryRequest(firstRequestId))?.state,
+        'fulfilled',
+    );
+    await assert.rejects(
+        fulfillDeliveryRunStop({
+            driverUserId,
+            runId: run.id,
+            stopId: thirdStop.id,
+        }),
+        /Delivery stops must be completed in route order/,
+    );
+});
+
+test('[legacy] active run keeps snapshots while the source address and slot mutate', async () => {
+    const fixture = await createDeliveryRunFixture();
+    const [accountId] = fixture.accountIds;
+    const [driverUserId] = fixture.driverUserIds;
+    const [operationId] = fixture.operationIds;
+    const [requestId] = fixture.requestIds;
+    assert.ok(accountId);
+    assert.ok(driverUserId);
+    assert.ok(operationId);
+    assert.ok(requestId);
+
+    const addressId = await createDeliveryAddress({
+        accountId,
+        label: 'Početna adresa',
+        contactName: 'Primatelj',
+        phone: '+385 91 222 2222',
+        street1: 'Stara 1',
+        city: 'Zagreb',
+        postalCode: '10000',
+        countryCode: 'HR',
+    });
+    await createEvent(
+        knownEvents.delivery.requestCreatedV1(requestId, {
+            operationId,
+            slotId: fixture.timeSlotId,
+            mode: 'delivery',
+            addressId,
+            accountId,
+        }),
+    );
+    const [newSlot] = await storage()
+        .insert(timeSlots)
+        .values({
+            locationId: fixture.locationId,
+            type: 'delivery',
+            startAt: new Date('2099-07-13T11:00:00.000Z'),
+            endAt: new Date('2099-07-13T13:00:00.000Z'),
+        })
+        .returning({ id: timeSlots.id });
+    assert.ok(newSlot);
+    const [plannedStop] = createRunStops([requestId]);
+    assert.ok(plannedStop);
+    const snapshotAddress = 'Stara 1, 10000 Zagreb, HR';
+    assert.equal(
+        (await getDeliveryRequest(requestId))?.address?.street1,
+        'Stara 1',
+    );
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [requestId],
+        stops: [{ ...plannedStop, formattedAddress: snapshotAddress }],
+    });
+    assert.equal(run.stops[0]?.formattedAddress, snapshotAddress);
+
+    await updateDeliveryAddress(
+        { id: addressId, street1: 'Nova 2' },
+        accountId,
+    );
+    await changeDeliveryRequestSlot(requestId, newSlot.id);
+
+    const changedRequest = await getDeliveryRequest(requestId);
+    const unchangedRun = await getDeliveryRun(run.id);
+    assert.equal(changedRequest?.address?.street1, 'Nova 2');
+    assert.equal(changedRequest?.slot?.id, newSlot.id);
+    assert.equal(unchangedRun?.timeSlotId, fixture.timeSlotId);
+    assert.equal(unchangedRun?.stops[0]?.formattedAddress, snapshotAddress);
+});
+
+test('[legacy] bulk fulfillment accepts a non-contiguous set containing the current stop', async () => {
+    const fixture = await createDeliveryRunFixture({
+        accountIndexes: [0, 0, 0],
+    });
+    const [driverUserId] = fixture.driverUserIds;
+    assert.ok(driverUserId);
+
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: fixture.requestIds,
+    });
+    const [firstStop, secondStop, thirdStop] = run.stops;
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+    assert.ok(thirdStop);
+
+    await fulfillDeliveryRunStops({
+        driverUserId,
+        runId: run.id,
+        stopIds: [firstStop.id, thirdStop.id],
+    });
+
+    const skippedRun = await getDeliveryRun(run.id);
+    assert.equal(skippedRun?.state, 'active');
+    assert.deepEqual(
+        skippedRun?.stops.map((stop) => stop.state),
+        ['delivered', 'pending', 'delivered'],
+    );
+    assert.notEqual(
+        (await getDeliveryRequest(secondStop.deliveryRequestId))?.state,
+        'fulfilled',
+    );
+
+    await fulfillDeliveryRunStop({
+        driverUserId,
+        runId: run.id,
+        stopId: secondStop.id,
+    });
+    assert.equal((await getDeliveryRun(run.id))?.state, 'completed');
 });


### PR DESCRIPTION
## Summary

- characterize delivery-run assignment races, replay, route ordering, bulk rollback, mutable address/slot snapshots, stale GPS samples, customer-map privacy, completion cleanup, and Google routing fallback
- enforce delivery request operation and address ownership, derive request ownership from the operation, and prevent legacy foreign-address exposure
- add an account-bound customer cancellation path that returns 404 on denied resources and runs notification, analytics, and calendar side effects only after authorization succeeds
- mark intentional non-contiguous bulk fulfillment and active-run snapshot divergence as legacy behavior for later epic tasks

## Validation

- `corepack pnpm --filter @gredice/storage test:node` (471 passed)
- `corepack pnpm --filter @gredice/storage test:node deliveryRequestsRepo.node.spec.ts` (8 passed)
- `corepack pnpm --filter @gredice/storage test:node deliveryRunsRepo.node.spec.ts` (7 passed)
- `corepack pnpm --filter api test:node` (205 passed)
- `corepack pnpm --filter delivery test` (27 passed)
- `corepack pnpm typecheck --filter delivery`
- targeted Biome checks for all changed API, delivery, and storage files

`api` and `@gredice/storage` do not expose package typecheck scripts. Direct `tsc --noEmit` remains blocked by unrelated existing billing, web-push, script, and test typing errors; it reported no errors in the changed files.

Closes #4145