### PR TITLE
fix(farm): distinguish submitted and verified work

### DIFF
--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -1,4 +1,4 @@
-import { getFarms, getUser } from '@gredice/storage';
+import { getFarmsForUser, getUser } from '@gredice/storage';
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
 import { Button } from '@gredice/ui/Button';
 import {
@@ -71,7 +71,10 @@ function formatCoordinate(value?: number | null) {
 
 async function FarmerDashboard() {
     const { userId } = await auth(['farmer', 'admin']);
-    const [dbUser, farms] = await Promise.all([getUser(userId), getFarms()]);
+    const [dbUser, farms] = await Promise.all([
+        getUser(userId),
+        getFarmsForUser(userId),
+    ]);
 
     if (!dbUser) {
         return (
@@ -229,7 +232,7 @@ async function FarmerDashboard() {
                         <Stack spacing={2}>
                             <CardTitle>Moje farme</CardTitle>
                             <Typography className="text-sm text-muted-foreground">
-                                Pregled aktivnih farmi u Gredice sustavu.
+                                Pregled farmi koje su ti dodijeljene.
                             </Typography>
                         </Stack>
                     </CardHeader>
@@ -265,9 +268,8 @@ async function FarmerDashboard() {
                             </Table>
                         ) : (
                             <div className="p-6 text-sm text-muted-foreground">
-                                Još nema dodanih farmi. Kontaktiraj
-                                administratora kako bi dodali tvoju prvu
-                                lokaciju.
+                                Nema dodijeljenih farmi. Kontaktiraj
+                                administratora kako bi ti dodijelio farmu.
                             </div>
                         )}
                     </CardOverflow>

--- a/apps/farm/app/schedule/CompleteOperationModal.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.tsx
@@ -318,6 +318,7 @@ export function CompleteOperationModal({
             onOpenChange={handleOpenChange}
             trigger={
                 <Checkbox
+                    aria-label={`Dovrši: ${label}`}
                     className="size-5"
                     checked={isOpen}
                     onCheckedChange={(checked: boolean) =>

--- a/apps/farm/app/schedule/CompletePlantingModal.tsx
+++ b/apps/farm/app/schedule/CompletePlantingModal.tsx
@@ -42,6 +42,7 @@ export function CompletePlantingModal({
             onOpenChange={setOpen}
             trigger={
                 <Checkbox
+                    aria-label={`Dovrši: ${label}`}
                     className="size-5"
                     checked={open}
                     onCheckedChange={(checked: boolean) => setOpen(checked)}

--- a/apps/farm/app/schedule/FarmScheduleLoadingState.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.spec.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../globals.css';
+import { FarmScheduleLoadingState } from './FarmScheduleLoadingState';
+
+for (const width of [320, 1280]) {
+    test(`keeps the schedule summary skeleton within ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 800 });
+        await mount(<FarmScheduleLoadingState />);
+
+        expect(
+            await page.evaluate(
+                () =>
+                    document.documentElement.scrollWidth <=
+                    document.documentElement.clientWidth,
+            ),
+        ).toBe(true);
+    });
+}

--- a/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
@@ -10,13 +10,15 @@ export function FarmScheduleLoadingState() {
             aria-busy="true"
         >
             <div className="space-y-2">
-                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-1 sm:gap-2">
+                <div className="grid min-w-0 grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-start gap-1 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-2">
                     <Skeleton className="h-8 w-10 rounded-md sm:h-10 sm:w-12" />
                     <div className="grid justify-items-center gap-1">
                         <Skeleton className="h-4 w-16" />
                         <Skeleton className="h-4 w-24" />
                     </div>
-                    <ScheduleDaySummarySkeleton />
+                    <div className="col-span-3 min-w-0 justify-self-stretch sm:col-span-1 sm:justify-self-end">
+                        <ScheduleDaySummarySkeleton />
+                    </div>
                 </div>
                 <div className="flex justify-end">
                     <Skeleton className="h-8 w-24 rounded-md" />

--- a/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
+++ b/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
@@ -128,7 +128,7 @@ export function FarmScheduleNavigationFrame({
             aria-busy={showPendingContent}
         >
             <div className="space-y-2">
-                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-1 sm:gap-2">
+                <div className="grid min-w-0 grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-start gap-1 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-2">
                     <div className="justify-self-start">
                         <HomeButton className="h-8 sm:h-10" />
                     </div>
@@ -176,7 +176,7 @@ export function FarmScheduleNavigationFrame({
                             </Link>
                         </Row>
                     </div>
-                    <div className="min-w-0 justify-self-end">
+                    <div className="col-span-3 min-w-0 justify-self-stretch sm:col-span-1 sm:justify-self-end">
                         {showPendingContent ? (
                             <ScheduleDaySummarySkeleton />
                         ) : (

--- a/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
@@ -1,0 +1,162 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
+import { cx } from '@gredice/ui/utils';
+import type { ReactNode } from 'react';
+import { OperationCompletionAttachments } from './OperationCompletionAttachments';
+import { OperationRequirementIcons } from './OperationRequirementIcons';
+import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
+import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
+import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
+import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
+import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
+import type { FarmScheduleDayData } from './scheduleData';
+import {
+    getOperationTaskState,
+    getScheduleTaskPresentation,
+} from './scheduleTaskState';
+
+type FarmOperation = FarmScheduleDayData['scheduledOperations'][number];
+
+export type FarmOperationCardData = Pick<
+    FarmOperation,
+    | 'assignedUser'
+    | 'assignedUserId'
+    | 'completionNotes'
+    | 'id'
+    | 'imageUrls'
+    | 'scheduledDate'
+    | 'status'
+> & {
+    durationMinutes: number;
+    label: string;
+};
+
+type FarmScheduleOperationTaskCardProps = {
+    completionAction?: ReactNode;
+    operation: FarmOperationCardData;
+    operationData: EntityStandardized | undefined;
+    userId: string;
+};
+
+export function FarmScheduleOperationTaskCard({
+    completionAction,
+    operation,
+    operationData,
+    userId,
+}: FarmScheduleOperationTaskCardProps) {
+    const taskState = getOperationTaskState(operation.status);
+    const taskPresentation = getScheduleTaskPresentation(taskState);
+    const canComplete =
+        taskPresentation.showCompletionControl &&
+        (!operation.assignedUserId || operation.assignedUserId === userId);
+    const attachImages = Boolean(
+        operationData?.conditions?.completionAttachImages ||
+            operationData?.conditions?.completionAttachImagesRequired,
+    );
+    const attachImagesRequired = Boolean(
+        operationData?.conditions?.completionAttachImagesRequired,
+    );
+    const attachNotes = Boolean(
+        operationData?.conditions?.completionAttachNotes ||
+            operationData?.conditions?.completionAttachNotesRequired,
+    );
+    const attachNotesRequired = Boolean(
+        operationData?.conditions?.completionAttachNotesRequired,
+    );
+    const showRequirementIcons =
+        taskPresentation.showRequirementIndicators &&
+        (attachImages || attachNotes);
+
+    return (
+        <div
+            data-task-state={taskState}
+            className={cx(
+                'rounded-lg border px-3 py-2 transition-opacity',
+                taskPresentation.isCompleted
+                    ? 'bg-white/70 opacity-70'
+                    : 'bg-white',
+            )}
+        >
+            <Row
+                spacing={2}
+                className="min-w-0 items-start justify-between gap-3"
+            >
+                <Row spacing={2} className="min-w-0 grow items-start">
+                    <ScheduleTaskStateControl
+                        action={canComplete ? completionAction : undefined}
+                        label={operation.label}
+                        state={taskState}
+                        unavailableTitle="Radnja je dodijeljena drugom korisniku."
+                    />
+                    <Stack spacing={1} className="min-w-0 grow">
+                        <Typography
+                            className={
+                                taskPresentation.isCompleted
+                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
+                                    : '[overflow-wrap:anywhere]'
+                            }
+                        >
+                            {operation.label}
+                        </Typography>
+                        <Row
+                            spacing={2}
+                            className="items-center flex-wrap gap-y-1"
+                        >
+                            <ScheduleTaskStatusChip state={taskState} />
+                            <ScheduleTaskDurationChip
+                                minutes={operation.durationMinutes}
+                            />
+                            <ScheduleTaskDateChip
+                                scheduledDate={operation.scheduledDate}
+                            />
+                            {taskPresentation.showAgeIndicator && (
+                                <ScheduleTaskAgeIndicatorChip
+                                    scheduledDate={operation.scheduledDate}
+                                />
+                            )}
+                        </Row>
+                    </Stack>
+                </Row>
+                {(showRequirementIcons ||
+                    taskPresentation.showCompletionAttachments ||
+                    operation.assignedUser) && (
+                    <Row spacing={1} className="shrink-0 items-center">
+                        {showRequirementIcons && (
+                            <OperationRequirementIcons
+                                attachImages={attachImages}
+                                attachImagesRequired={attachImagesRequired}
+                                attachNotes={attachNotes}
+                                attachNotesRequired={attachNotesRequired}
+                            />
+                        )}
+                        {taskPresentation.showCompletionAttachments && (
+                            <OperationCompletionAttachments
+                                operationId={operation.id}
+                                notes={operation.completionNotes}
+                                imageUrls={operation.imageUrls}
+                            />
+                        )}
+                        {operation.assignedUser && (
+                            <div
+                                className="shrink-0"
+                                title={`Dodijeljeno: ${operation.assignedUser.displayName ?? operation.assignedUser.userName}`}
+                            >
+                                <UserAvatar
+                                    avatarUrl={operation.assignedUser.avatarUrl}
+                                    displayName={
+                                        operation.assignedUser.displayName ??
+                                        operation.assignedUser.userName
+                                    }
+                                    className="size-7 rounded-full"
+                                />
+                            </div>
+                        )}
+                    </Row>
+                )}
+            </Row>
+        </div>
+    );
+}

--- a/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
@@ -1,20 +1,13 @@
 import type { EntityStandardized } from '@gredice/storage';
-import { Checkbox } from '@gredice/ui/Checkbox';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { UserAvatar } from '@gredice/ui/UserAvatar';
-import { cx } from '@gredice/ui/utils';
 import { Suspense } from 'react';
 import { CompleteOperationModal } from './CompleteOperationModal';
-import { OperationCompletionAttachments } from './OperationCompletionAttachments';
-import { OperationRequirementIcons } from './OperationRequirementIcons';
+import { FarmScheduleOperationTaskCard } from './FarmScheduleOperationTaskCard';
 import { RaisedBedScheduleGroupHeader } from './RaisedBedScheduleGroupHeader';
 import { RaisedBedScheduleGroupHeaderWithPhotos } from './RaisedBedScheduleGroupHeaderWithPhotos';
 import { ScheduleSectionSummaryBadges } from './ScheduleSectionSummaryBadges';
-import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
-import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
-import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
 import type {
     FarmScheduleDayData,
     FarmScheduleRaisedBedPhotoPreview,
@@ -25,16 +18,11 @@ import {
     getFieldPhysicalPositionIndex,
     getOperationDurationMinutes,
     groupRaisedBedsForSchedule,
-    isOperationCompleted,
     shouldDisplayScheduleOperation,
 } from './scheduleShared';
 
 type FarmRaisedBed = FarmScheduleDayData['raisedBeds'][number];
 type FarmOperation = FarmScheduleDayData['scheduledOperations'][number];
-type FarmOperationCardData = FarmOperation & {
-    durationMinutes: number;
-    label: string;
-};
 
 interface FarmScheduleOperationsSectionProps {
     raisedBeds: FarmScheduleDayData['raisedBeds'];
@@ -154,127 +142,6 @@ export function FarmScheduleOperationsSection({
             }),
         );
 
-    function renderOperationCard(operation: FarmOperationCardData) {
-        const completed = isOperationCompleted(operation.status);
-        const operationData = operationDataById.get(operation.entityId);
-        const canComplete =
-            !completed &&
-            (!operation.assignedUserId || operation.assignedUserId === userId);
-        const attachImages = Boolean(
-            operationData?.conditions?.completionAttachImages ||
-                operationData?.conditions?.completionAttachImagesRequired,
-        );
-        const attachImagesRequired = Boolean(
-            operationData?.conditions?.completionAttachImagesRequired,
-        );
-        const attachNotes = Boolean(
-            operationData?.conditions?.completionAttachNotes ||
-                operationData?.conditions?.completionAttachNotesRequired,
-        );
-        const attachNotesRequired = Boolean(
-            operationData?.conditions?.completionAttachNotesRequired,
-        );
-        const showRequirementIcons =
-            !completed && (attachImages || attachNotes);
-
-        return (
-            <div
-                key={operation.id}
-                className={cx(
-                    'rounded-lg border px-3 py-2 transition-opacity',
-                    completed ? 'bg-white/70 opacity-70' : 'bg-white',
-                )}
-            >
-                <Row
-                    spacing={2}
-                    className="min-w-0 items-start justify-between gap-3"
-                >
-                    <Row spacing={2} className="min-w-0 grow items-start">
-                        {completed ? (
-                            <Checkbox className="size-5" checked disabled />
-                        ) : canComplete ? (
-                            <CompleteOperationModal
-                                operationId={operation.id}
-                                label={operation.label}
-                                conditions={operationData?.conditions}
-                            />
-                        ) : (
-                            <div title="Radnja je dodijeljena drugom korisniku.">
-                                <Checkbox className="size-5" disabled />
-                            </div>
-                        )}
-                        <Stack spacing={1} className="min-w-0 grow">
-                            <Typography
-                                className={
-                                    completed
-                                        ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
-                                        : '[overflow-wrap:anywhere]'
-                                }
-                            >
-                                {operation.label}
-                            </Typography>
-                            <Row
-                                spacing={2}
-                                className="items-center flex-wrap gap-y-1"
-                            >
-                                <ScheduleTaskDurationChip
-                                    minutes={operation.durationMinutes}
-                                />
-                                <ScheduleTaskDateChip
-                                    scheduledDate={operation.scheduledDate}
-                                />
-                                {!completed && (
-                                    <ScheduleTaskAgeIndicatorChip
-                                        scheduledDate={operation.scheduledDate}
-                                    />
-                                )}
-                            </Row>
-                        </Stack>
-                    </Row>
-                    {(showRequirementIcons ||
-                        completed ||
-                        operation.assignedUser) && (
-                        <Row spacing={1} className="shrink-0 items-center">
-                            {showRequirementIcons && (
-                                <OperationRequirementIcons
-                                    attachImages={attachImages}
-                                    attachImagesRequired={attachImagesRequired}
-                                    attachNotes={attachNotes}
-                                    attachNotesRequired={attachNotesRequired}
-                                />
-                            )}
-                            {completed && (
-                                <OperationCompletionAttachments
-                                    operationId={operation.id}
-                                    notes={operation.completionNotes}
-                                    imageUrls={operation.imageUrls}
-                                />
-                            )}
-                            {operation.assignedUser && (
-                                <div
-                                    className="shrink-0"
-                                    title={`Dodijeljeno: ${operation.assignedUser.displayName ?? operation.assignedUser.userName}`}
-                                >
-                                    <UserAvatar
-                                        avatarUrl={
-                                            operation.assignedUser.avatarUrl
-                                        }
-                                        displayName={
-                                            operation.assignedUser
-                                                .displayName ??
-                                            operation.assignedUser.userName
-                                        }
-                                        className="size-7 rounded-full"
-                                    />
-                                </div>
-                            )}
-                        </Row>
-                    )}
-                </Row>
-            </div>
-        );
-    }
-
     const farmTotalDuration = farmOperations.reduce(
         (sum, operation) => sum + operation.durationMinutes,
         0,
@@ -339,9 +206,27 @@ export function FarmScheduleOperationsSection({
                     />
                 </Row>
                 <Stack spacing={2}>
-                    {wateringOperations.map((operation) =>
-                        renderOperationCard(operation),
-                    )}
+                    {wateringOperations.map((operation) => (
+                        <FarmScheduleOperationTaskCard
+                            key={operation.id}
+                            completionAction={
+                                <CompleteOperationModal
+                                    operationId={operation.id}
+                                    label={operation.label}
+                                    conditions={
+                                        operationDataById.get(
+                                            operation.entityId,
+                                        )?.conditions
+                                    }
+                                />
+                            }
+                            operation={operation}
+                            operationData={operationDataById.get(
+                                operation.entityId,
+                            )}
+                            userId={userId}
+                        />
+                    ))}
                 </Stack>
             </Stack>
         );
@@ -432,190 +317,27 @@ export function FarmScheduleOperationsSection({
                                 </Row>
                             </div>
                             <Stack spacing={2}>
-                                {dayOperations.map((operation) => {
-                                    const completed = isOperationCompleted(
-                                        operation.status,
-                                    );
-                                    const operationData = operationDataById.get(
-                                        operation.entityId,
-                                    );
-                                    const canComplete =
-                                        !completed &&
-                                        (!operation.assignedUserId ||
-                                            operation.assignedUserId ===
-                                                userId);
-                                    const attachImages = Boolean(
-                                        operationData?.conditions
-                                            ?.completionAttachImages ||
-                                            operationData?.conditions
-                                                ?.completionAttachImagesRequired,
-                                    );
-                                    const attachImagesRequired = Boolean(
-                                        operationData?.conditions
-                                            ?.completionAttachImagesRequired,
-                                    );
-                                    const attachNotes = Boolean(
-                                        operationData?.conditions
-                                            ?.completionAttachNotes ||
-                                            operationData?.conditions
-                                                ?.completionAttachNotesRequired,
-                                    );
-                                    const attachNotesRequired = Boolean(
-                                        operationData?.conditions
-                                            ?.completionAttachNotesRequired,
-                                    );
-                                    const showRequirementIcons =
-                                        !completed &&
-                                        (attachImages || attachNotes);
-
-                                    return (
-                                        <div
-                                            key={operation.id}
-                                            className={cx(
-                                                'rounded-lg border px-3 py-2 transition-opacity',
-                                                completed
-                                                    ? 'bg-white/70 opacity-70'
-                                                    : 'bg-white',
-                                            )}
-                                        >
-                                            <Row
-                                                spacing={2}
-                                                className="min-w-0 items-start justify-between gap-3"
-                                            >
-                                                <Row
-                                                    spacing={2}
-                                                    className="min-w-0 grow items-start"
-                                                >
-                                                    {completed ? (
-                                                        <Checkbox
-                                                            className="size-5"
-                                                            checked
-                                                            disabled
-                                                        />
-                                                    ) : canComplete ? (
-                                                        <CompleteOperationModal
-                                                            operationId={
-                                                                operation.id
-                                                            }
-                                                            label={
-                                                                operation.label
-                                                            }
-                                                            conditions={
-                                                                operationDataById.get(
-                                                                    operation.entityId,
-                                                                )?.conditions
-                                                            }
-                                                        />
-                                                    ) : (
-                                                        <div title="Radnja je dodijeljena drugom korisniku.">
-                                                            <Checkbox
-                                                                className="size-5"
-                                                                disabled
-                                                            />
-                                                        </div>
-                                                    )}
-                                                    <Stack
-                                                        spacing={1}
-                                                        className="min-w-0 grow"
-                                                    >
-                                                        <Typography
-                                                            className={
-                                                                completed
-                                                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
-                                                                    : '[overflow-wrap:anywhere]'
-                                                            }
-                                                        >
-                                                            {operation.label}
-                                                        </Typography>
-                                                        <Row
-                                                            spacing={2}
-                                                            className="items-center flex-wrap gap-y-1"
-                                                        >
-                                                            <ScheduleTaskDurationChip
-                                                                minutes={
-                                                                    operation.durationMinutes
-                                                                }
-                                                            />
-                                                            <ScheduleTaskDateChip
-                                                                scheduledDate={
-                                                                    operation.scheduledDate
-                                                                }
-                                                            />
-                                                            {!completed && (
-                                                                <ScheduleTaskAgeIndicatorChip
-                                                                    scheduledDate={
-                                                                        operation.scheduledDate
-                                                                    }
-                                                                />
-                                                            )}
-                                                        </Row>
-                                                    </Stack>
-                                                </Row>
-                                                {(showRequirementIcons ||
-                                                    completed ||
-                                                    operation.assignedUser) && (
-                                                    <Row
-                                                        spacing={1}
-                                                        className="shrink-0 items-center"
-                                                    >
-                                                        {showRequirementIcons && (
-                                                            <OperationRequirementIcons
-                                                                attachImages={
-                                                                    attachImages
-                                                                }
-                                                                attachImagesRequired={
-                                                                    attachImagesRequired
-                                                                }
-                                                                attachNotes={
-                                                                    attachNotes
-                                                                }
-                                                                attachNotesRequired={
-                                                                    attachNotesRequired
-                                                                }
-                                                            />
-                                                        )}
-                                                        {completed && (
-                                                            <OperationCompletionAttachments
-                                                                operationId={
-                                                                    operation.id
-                                                                }
-                                                                notes={
-                                                                    operation.completionNotes
-                                                                }
-                                                                imageUrls={
-                                                                    operation.imageUrls
-                                                                }
-                                                            />
-                                                        )}
-                                                        {operation.assignedUser && (
-                                                            <div
-                                                                className="shrink-0"
-                                                                title={`Dodijeljeno: ${operation.assignedUser.displayName ?? operation.assignedUser.userName}`}
-                                                            >
-                                                                <UserAvatar
-                                                                    avatarUrl={
-                                                                        operation
-                                                                            .assignedUser
-                                                                            .avatarUrl
-                                                                    }
-                                                                    displayName={
-                                                                        operation
-                                                                            .assignedUser
-                                                                            .displayName ??
-                                                                        operation
-                                                                            .assignedUser
-                                                                            .userName
-                                                                    }
-                                                                    className="size-7 rounded-full"
-                                                                />
-                                                            </div>
-                                                        )}
-                                                    </Row>
-                                                )}
-                                            </Row>
-                                        </div>
-                                    );
-                                })}
+                                {dayOperations.map((operation) => (
+                                    <FarmScheduleOperationTaskCard
+                                        key={operation.id}
+                                        completionAction={
+                                            <CompleteOperationModal
+                                                operationId={operation.id}
+                                                label={operation.label}
+                                                conditions={
+                                                    operationDataById.get(
+                                                        operation.entityId,
+                                                    )?.conditions
+                                                }
+                                            />
+                                        }
+                                        operation={operation}
+                                        operationData={operationDataById.get(
+                                            operation.entityId,
+                                        )}
+                                        userId={userId}
+                                    />
+                                ))}
                             </Stack>
                         </Stack>
                     );
@@ -632,9 +354,27 @@ export function FarmScheduleOperationsSection({
                         />
                     </Row>
                     <Stack spacing={2}>
-                        {farmOperations.map((operation) =>
-                            renderOperationCard(operation),
-                        )}
+                        {farmOperations.map((operation) => (
+                            <FarmScheduleOperationTaskCard
+                                key={operation.id}
+                                completionAction={
+                                    <CompleteOperationModal
+                                        operationId={operation.id}
+                                        label={operation.label}
+                                        conditions={
+                                            operationDataById.get(
+                                                operation.entityId,
+                                            )?.conditions
+                                        }
+                                    />
+                                }
+                                operation={operation}
+                                operationData={operationDataById.get(
+                                    operation.entityId,
+                                )}
+                                userId={userId}
+                            />
+                        ))}
                     </Stack>
                 </Stack>
             )}

--- a/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
@@ -1,0 +1,148 @@
+import type {
+    EntityStandardized,
+    RaisedBedFieldAssignableFarmUser,
+} from '@gredice/storage';
+import { Chip } from '@gredice/ui/Chip';
+import { Row } from '@gredice/ui/Row';
+import { Skeleton } from '@gredice/ui/Skeleton';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import { type ReactNode, Suspense } from 'react';
+import { PlantingAssignedUserAvatar } from './PlantingAssignedUserAvatar';
+import { SchedulePlantVisual } from './SchedulePlantVisual';
+import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
+import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
+import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
+import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
+import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
+import type { FarmScheduleDayData } from './scheduleData';
+import { PLANTING_TASK_DURATION_MINUTES } from './scheduleShared';
+import {
+    getPlantingTaskState,
+    getScheduleTaskPresentation,
+} from './scheduleTaskState';
+
+type FarmSchedulePlantingField = Pick<
+    FarmScheduleDayData['scheduledFields'][number],
+    | 'assignedUserId'
+    | 'id'
+    | 'plantScheduledDate'
+    | 'plantStatus'
+    | 'positionIndex'
+    | 'raisedBedId'
+    | 'sowingLocation'
+>;
+
+interface FarmSchedulePlantingTaskCardProps {
+    field: FarmSchedulePlantingField;
+    label: string;
+    plantSort: EntityStandardized | undefined;
+    userId: string;
+    completionAction?: ReactNode;
+    assignedUserByFieldIdPromise: Promise<
+        Map<number, RaisedBedFieldAssignableFarmUser>
+    >;
+}
+
+export function FarmSchedulePlantingTaskCard({
+    field,
+    label,
+    plantSort,
+    userId,
+    completionAction,
+    assignedUserByFieldIdPromise,
+}: FarmSchedulePlantingTaskCardProps) {
+    const taskState = getPlantingTaskState(field.plantStatus);
+    if (!taskState) {
+        return null;
+    }
+
+    const taskPresentation = getScheduleTaskPresentation(taskState);
+    const lockedByAssignment =
+        taskPresentation.showCompletionControl &&
+        !!field.assignedUserId &&
+        field.assignedUserId !== userId;
+    const canComplete =
+        taskPresentation.showCompletionControl && !lockedByAssignment;
+    const greenhouseSowing = field.sowingLocation === 'greenhouse';
+
+    return (
+        <div
+            data-task-state={taskState}
+            className={cx(
+                'rounded-lg border px-3 py-2 transition-opacity',
+                taskPresentation.isCompleted
+                    ? 'bg-white/70 opacity-70'
+                    : 'bg-white',
+                lockedByAssignment &&
+                    !taskPresentation.isCompleted &&
+                    'opacity-70',
+            )}
+        >
+            <Row
+                spacing={2}
+                className="min-w-0 items-start justify-between gap-3"
+            >
+                <Row spacing={2} className="min-w-0 grow items-start">
+                    <ScheduleTaskStateControl
+                        action={canComplete ? completionAction : undefined}
+                        label={label}
+                        state={taskState}
+                        unavailableTitle="Sijanje je dodijeljeno drugom korisniku."
+                    />
+                    <SchedulePlantVisual plantSort={plantSort} label={label} />
+                    <Stack spacing={1} className="min-w-0 grow">
+                        <Typography
+                            className={
+                                taskPresentation.isCompleted
+                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
+                                    : '[overflow-wrap:anywhere]'
+                            }
+                        >
+                            {label}
+                        </Typography>
+                        <Row
+                            spacing={2}
+                            className="items-center flex-wrap gap-y-1"
+                        >
+                            <ScheduleTaskStatusChip state={taskState} />
+                            <ScheduleTaskDurationChip
+                                minutes={PLANTING_TASK_DURATION_MINUTES}
+                            />
+                            {greenhouseSowing && (
+                                <Chip size="sm" color="success" variant="soft">
+                                    Staklenik
+                                </Chip>
+                            )}
+                            <ScheduleTaskDateChip
+                                scheduledDate={field.plantScheduledDate}
+                            />
+                            {taskPresentation.showAgeIndicator && (
+                                <ScheduleTaskAgeIndicatorChip
+                                    scheduledDate={field.plantScheduledDate}
+                                />
+                            )}
+                        </Row>
+                    </Stack>
+                </Row>
+                {field.assignedUserId && (
+                    <Suspense
+                        fallback={
+                            <Skeleton className="size-7 shrink-0 rounded-full" />
+                        }
+                    >
+                        <PlantingAssignedUserAvatar
+                            assignedUserByFieldIdPromise={
+                                assignedUserByFieldIdPromise
+                            }
+                            fieldId={field.id}
+                        />
+                    </Suspense>
+                )}
+            </Row>
+        </div>
+    );
+}
+
+export default FarmSchedulePlantingTaskCard;

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -3,23 +3,14 @@ import type {
     EntityStandardized,
     RaisedBedFieldAssignableFarmUser,
 } from '@gredice/storage';
-import { Checkbox } from '@gredice/ui/Checkbox';
-import { Chip } from '@gredice/ui/Chip';
 import { Row } from '@gredice/ui/Row';
-import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
-import { cx } from '@gredice/ui/utils';
 import { Suspense } from 'react';
 import { CompletePlantingModal } from './CompletePlantingModal';
-import { PlantingAssignedUserAvatar } from './PlantingAssignedUserAvatar';
+import { FarmSchedulePlantingTaskCard } from './FarmSchedulePlantingTaskCard';
 import { RaisedBedScheduleGroupHeader } from './RaisedBedScheduleGroupHeader';
 import { RaisedBedScheduleGroupHeaderWithPhotos } from './RaisedBedScheduleGroupHeaderWithPhotos';
-import { SchedulePlantVisual } from './SchedulePlantVisual';
 import { ScheduleSectionSummaryBadges } from './ScheduleSectionSummaryBadges';
-import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
-import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
-import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
 import type {
     FarmScheduleDayData,
     FarmScheduleRaisedBedPhotoPreview,
@@ -28,8 +19,6 @@ import {
     compareScheduleDates,
     getFieldPhysicalPositionIndex,
     groupRaisedBedsForSchedule,
-    isFieldApproved,
-    isFieldCompleted,
     PLANTING_TASK_DURATION_MINUTES,
 } from './scheduleShared';
 
@@ -183,147 +172,32 @@ export function FarmSchedulePlantingsSection({
                             </div>
                             <Stack spacing={2}>
                                 {dayFields.map((field) => {
-                                    const completed = isFieldCompleted(
-                                        field.plantStatus,
-                                    );
-                                    const approved = isFieldApproved(
-                                        field.plantStatus,
-                                    );
-                                    const lockedByAssignment =
-                                        !completed &&
-                                        !!field.assignedUserId &&
-                                        field.assignedUserId !== userId;
-                                    const canComplete =
-                                        !completed && !lockedByAssignment;
-                                    const greenhouseSowing =
-                                        field.sowingLocation === 'greenhouse';
                                     const plantSort = field.plantSortId
                                         ? plantSortById.get(field.plantSortId)
                                         : undefined;
-                                    const statusText =
-                                        !completed && !approved
-                                            ? 'Nije potvrđeno'
-                                            : null;
 
                                     return (
-                                        <div
+                                        <FarmSchedulePlantingTaskCard
                                             key={field.id}
-                                            className={cx(
-                                                'rounded-lg border px-3 py-2 transition-opacity',
-                                                completed
-                                                    ? 'bg-white/70 opacity-70'
-                                                    : 'bg-white',
-                                                lockedByAssignment &&
-                                                    !completed &&
-                                                    'opacity-70',
-                                            )}
-                                        >
-                                            <Row
-                                                spacing={2}
-                                                className="min-w-0 items-start justify-between gap-3"
-                                            >
-                                                <Row
-                                                    spacing={2}
-                                                    className="min-w-0 grow items-start"
-                                                >
-                                                    {completed ? (
-                                                        <Checkbox
-                                                            className="size-5"
-                                                            checked
-                                                            disabled
-                                                        />
-                                                    ) : canComplete ? (
-                                                        <CompletePlantingModal
-                                                            label={field.label}
-                                                            raisedBedId={
-                                                                field.raisedBedId
-                                                            }
-                                                            positionIndex={
-                                                                field.positionIndex
-                                                            }
-                                                        />
-                                                    ) : (
-                                                        <div title="Sijanje je dodijeljeno drugom korisniku.">
-                                                            <Checkbox
-                                                                className="size-5"
-                                                                disabled
-                                                            />
-                                                        </div>
-                                                    )}
-                                                    <SchedulePlantVisual
-                                                        plantSort={plantSort}
-                                                        label={field.label}
-                                                    />
-                                                    <Stack
-                                                        spacing={1}
-                                                        className="min-w-0 grow"
-                                                    >
-                                                        <Typography
-                                                            className={
-                                                                completed
-                                                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
-                                                                    : '[overflow-wrap:anywhere]'
-                                                            }
-                                                        >
-                                                            {field.label}
-                                                        </Typography>
-                                                        <Row
-                                                            spacing={2}
-                                                            className="items-center flex-wrap gap-y-1"
-                                                        >
-                                                            {statusText && (
-                                                                <Typography
-                                                                    level="body2"
-                                                                    className="text-muted-foreground"
-                                                                >
-                                                                    {statusText}
-                                                                </Typography>
-                                                            )}
-                                                            <ScheduleTaskDurationChip
-                                                                minutes={
-                                                                    PLANTING_TASK_DURATION_MINUTES
-                                                                }
-                                                            />
-                                                            {greenhouseSowing && (
-                                                                <Chip
-                                                                    size="sm"
-                                                                    color="success"
-                                                                    variant="soft"
-                                                                >
-                                                                    Staklenik
-                                                                </Chip>
-                                                            )}
-                                                            <ScheduleTaskDateChip
-                                                                scheduledDate={
-                                                                    field.plantScheduledDate
-                                                                }
-                                                            />
-                                                            {!completed && (
-                                                                <ScheduleTaskAgeIndicatorChip
-                                                                    scheduledDate={
-                                                                        field.plantScheduledDate
-                                                                    }
-                                                                />
-                                                            )}
-                                                        </Row>
-                                                    </Stack>
-                                                </Row>
-                                                {field.assignedUserId && (
-                                                    <Suspense
-                                                        fallback={
-                                                            <Skeleton className="size-7 shrink-0 rounded-full" />
-                                                        }
-                                                    >
-                                                        <PlantingAssignedUserAvatar
-                                                            assignedUserByFieldIdPromise={
-                                                                assignedUserByFieldIdPromise
-                                                            }
-                                                            fieldId={field.id}
-                                                        />
-                                                    </Suspense>
-                                                )}
-                                            </Row>
-                                        </div>
+                                            completionAction={
+                                                <CompletePlantingModal
+                                                    label={field.label}
+                                                    raisedBedId={
+                                                        field.raisedBedId
+                                                    }
+                                                    positionIndex={
+                                                        field.positionIndex
+                                                    }
+                                                />
+                                            }
+                                            field={field}
+                                            label={field.label}
+                                            plantSort={plantSort}
+                                            userId={userId}
+                                            assignedUserByFieldIdPromise={
+                                                assignedUserByFieldIdPromise
+                                            }
+                                        />
                                     );
                                 })}
                             </Stack>

--- a/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
@@ -1,0 +1,234 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator } from '@playwright/test';
+import '../globals.css';
+import {
+    type FarmOperationCardData,
+    FarmScheduleOperationTaskCard,
+} from './FarmScheduleOperationTaskCard';
+import { FarmSchedulePlantingTaskCard } from './FarmSchedulePlantingTaskCard';
+
+const scheduledDate = new Date('2026-07-15T08:00:00.000Z');
+const assignedUserByFieldIdPromise = Promise.resolve(new Map());
+
+const operationLabels = {
+    pending:
+        'Vrlo duga radnja pripreme zemlje koja mora ostati čitljiva na uskom telefonu',
+    completed:
+        'Potvrđena radnja prihrane povrća s dovoljno dugim opisom za mali zaslon',
+};
+
+function buildOperation(
+    id: number,
+    status: FarmOperationCardData['status'],
+    label: string,
+): FarmOperationCardData {
+    return {
+        assignedUser: null,
+        assignedUserId: null,
+        completionNotes: undefined,
+        durationMinutes: 15,
+        id,
+        imageUrls: undefined,
+        label,
+        scheduledDate,
+        status,
+    };
+}
+
+const plantingLabels = {
+    pending:
+        'Sijanje vrlo dugog naziva sorte rajčice koje mora ostati čitljivo na telefonu',
+    completed:
+        'Potvrđeno sijanje povrća s namjerno dugim opisom za uski mobilni zaslon',
+};
+
+async function assertCardsStayWithinViewport(component: Locator) {
+    expect(
+        await component.locator('[data-task-state]').evaluateAll((cards) =>
+            cards.every((card) => {
+                const bounds = card.getBoundingClientRect();
+                return (
+                    bounds.left >= 0 &&
+                    bounds.right <= window.innerWidth &&
+                    card.scrollWidth <= card.clientWidth
+                );
+            }),
+        ),
+    ).toBe(true);
+}
+
+for (const width of [320, 390, 1280]) {
+    test(`renders operation pending and verified states within ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 720 });
+        const component = await mount(
+            <div className="space-y-2">
+                <FarmScheduleOperationTaskCard
+                    completionAction={
+                        <button type="button">Dovrši radnju</button>
+                    }
+                    operation={buildOperation(
+                        1,
+                        'pendingVerification',
+                        operationLabels.pending,
+                    )}
+                    operationData={undefined}
+                    userId="farmer-1"
+                />
+                <FarmScheduleOperationTaskCard
+                    completionAction={
+                        <button type="button">Dovrši radnju</button>
+                    }
+                    operation={buildOperation(
+                        2,
+                        'completed',
+                        operationLabels.completed,
+                    )}
+                    operationData={undefined}
+                    userId="farmer-1"
+                />
+                <FarmScheduleOperationTaskCard
+                    completionAction={
+                        <button type="button">Dovrši radnju</button>
+                    }
+                    operation={buildOperation(3, 'planned', 'Zalij salatu')}
+                    operationData={undefined}
+                    userId="farmer-1"
+                />
+            </div>,
+        );
+
+        const pendingCard = component.locator(
+            '[data-task-state="pendingVerification"]',
+        );
+        await expect(
+            pendingCard.getByText('Čeka potvrdu', { exact: true }),
+        ).toBeVisible();
+        await expect(pendingCard.getByRole('checkbox')).toHaveCount(0);
+        await expect(pendingCard.getByRole('button')).toHaveCount(0);
+        await expect(
+            pendingCard.getByText(operationLabels.pending),
+        ).toBeVisible();
+
+        const completedCard = component.locator(
+            '[data-task-state="completed"]',
+        );
+        await expect(
+            completedCard.getByText('Potvrđeno', { exact: true }),
+        ).toBeVisible();
+        const verifiedControl = completedCard.getByRole('checkbox', {
+            name: `Potvrđeno: ${operationLabels.completed}`,
+        });
+        await expect(verifiedControl).toBeChecked();
+        await expect(verifiedControl).toBeDisabled();
+
+        const actionableCard = component.locator(
+            '[data-task-state="actionable"]',
+        );
+        await expect(
+            actionableCard.getByRole('button', { name: 'Dovrši radnju' }),
+        ).toBeVisible();
+
+        await assertCardsStayWithinViewport(component);
+    });
+
+    test(`renders planting pending and verified states within ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 720 });
+        const component = await mount(
+            <div className="space-y-2">
+                <FarmSchedulePlantingTaskCard
+                    completionAction={
+                        <button type="button">Dovrši sijanje</button>
+                    }
+                    field={{
+                        assignedUserId: null,
+                        id: 1,
+                        plantScheduledDate: scheduledDate,
+                        plantStatus: 'pendingVerification',
+                        positionIndex: 0,
+                        raisedBedId: 10,
+                        sowingLocation: 'direct',
+                    }}
+                    label={plantingLabels.pending}
+                    plantSort={undefined}
+                    userId="farmer-1"
+                    assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
+                />
+                <FarmSchedulePlantingTaskCard
+                    completionAction={
+                        <button type="button">Dovrši sijanje</button>
+                    }
+                    field={{
+                        assignedUserId: null,
+                        id: 2,
+                        plantScheduledDate: scheduledDate,
+                        plantStatus: 'sowed',
+                        positionIndex: 1,
+                        raisedBedId: 10,
+                        sowingLocation: 'direct',
+                    }}
+                    label={plantingLabels.completed}
+                    plantSort={undefined}
+                    userId="farmer-1"
+                    assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
+                />
+                <FarmSchedulePlantingTaskCard
+                    completionAction={
+                        <button type="button">Dovrši sijanje</button>
+                    }
+                    field={{
+                        assignedUserId: null,
+                        id: 3,
+                        plantScheduledDate: scheduledDate,
+                        plantStatus: 'planned',
+                        positionIndex: 2,
+                        raisedBedId: 10,
+                        sowingLocation: 'direct',
+                    }}
+                    label="Posij salatu"
+                    plantSort={undefined}
+                    userId="farmer-1"
+                    assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
+                />
+            </div>,
+        );
+
+        const pendingCard = component.locator(
+            '[data-task-state="pendingVerification"]',
+        );
+        await expect(
+            pendingCard.getByText('Čeka potvrdu', { exact: true }),
+        ).toBeVisible();
+        await expect(pendingCard.getByRole('checkbox')).toHaveCount(0);
+        await expect(pendingCard.getByRole('button')).toHaveCount(0);
+        await expect(
+            pendingCard.getByText(plantingLabels.pending),
+        ).toBeVisible();
+
+        const completedCard = component.locator(
+            '[data-task-state="completed"]',
+        );
+        await expect(
+            completedCard.getByText('Potvrđeno', { exact: true }),
+        ).toBeVisible();
+        const verifiedControl = completedCard.getByRole('checkbox', {
+            name: `Potvrđeno: ${plantingLabels.completed}`,
+        });
+        await expect(verifiedControl).toBeChecked();
+        await expect(verifiedControl).toBeDisabled();
+
+        const actionableCard = component.locator(
+            '[data-task-state="actionable"]',
+        );
+        await expect(
+            actionableCard.getByRole('button', { name: 'Dovrši sijanje' }),
+        ).toBeVisible();
+
+        await assertCardsStayWithinViewport(component);
+    });
+}

--- a/apps/farm/app/schedule/ScheduleDaySummary.spec.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummary.spec.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../globals.css';
+import { ScheduleDaySummaryView } from './ScheduleDaySummary';
+import { getScheduleTaskSummary } from './scheduleTaskState';
+
+const summary = getScheduleTaskSummary([
+    { state: 'actionable', durationMinutes: 75 },
+    { state: 'pendingVerification', durationMinutes: 5 },
+    { state: 'completed', durationMinutes: 5 },
+    { state: 'failed', durationMinutes: 5 },
+    { state: 'canceled', durationMinutes: 5 },
+]);
+
+for (const width of [320, 390]) {
+    test(`keeps every daily status within ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 640 });
+        const component = await mount(
+            <ScheduleDaySummaryView summary={summary} />,
+        );
+
+        const group = component;
+        await expect(group).toHaveAttribute(
+            'aria-label',
+            'Sažetak dnevnih zadataka',
+        );
+        await expect(
+            component.getByText('Preostalo', { exact: true }),
+        ).toBeVisible();
+        await expect(component.getByText('Čeka potvrdu')).toBeVisible();
+        await expect(component.getByText('Potvrđeno')).toBeVisible();
+        await expect(component.getByText('Preostalo vrijeme')).toBeVisible();
+        await expect(component.getByText('Neuspjelo')).toBeVisible();
+        await expect(component.getByText('Otkazano')).toBeVisible();
+
+        expect(
+            await group.evaluate((element) => {
+                const groupBounds = element.getBoundingClientRect();
+                const itemBounds = Array.from(element.children).map((child) =>
+                    child.getBoundingClientRect(),
+                );
+
+                return (
+                    groupBounds.left >= 0 &&
+                    groupBounds.right <= window.innerWidth &&
+                    itemBounds.every(
+                        (bounds) =>
+                            bounds.left >= groupBounds.left &&
+                            bounds.right <= groupBounds.right,
+                    )
+                );
+            }),
+        ).toBe(true);
+    });
+}

--- a/apps/farm/app/schedule/ScheduleDaySummary.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummary.tsx
@@ -1,11 +1,17 @@
 import type { EntityStandardized } from '@gredice/storage';
-import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
 import type { FarmScheduleDayData } from './scheduleData';
 import {
     getOperationDurationMinutes,
     PLANTING_TASK_DURATION_MINUTES,
 } from './scheduleShared';
+import {
+    getOperationTaskState,
+    getPlantingTaskState,
+    getScheduleTaskSummary,
+    type ScheduleTaskSummary,
+    type ScheduleTaskSummaryItem,
+} from './scheduleTaskState';
 
 function formatMinutes(minutes: number) {
     const rounded = Math.ceil(Math.max(0, minutes));
@@ -28,8 +34,6 @@ export function ScheduleDaySummary({
 }: ScheduleDaySummaryProps) {
     const { scheduledFields, scheduledOperations } = dayData;
 
-    const taskCount = scheduledOperations.length + scheduledFields.length;
-
     const operationDataById = new Map<number, EntityStandardized>();
     if (operationsData) {
         for (const op of operationsData) {
@@ -37,25 +41,62 @@ export function ScheduleDaySummary({
         }
     }
 
-    const totalMinutes =
-        scheduledOperations.reduce(
-            (sum, op) =>
-                sum +
-                getOperationDurationMinutes(operationDataById.get(op.entityId)),
-            0,
-        ) +
-        scheduledFields.length * PLANTING_TASK_DURATION_MINUTES;
+    const plantingItems = scheduledFields.flatMap((field) => {
+        const state = getPlantingTaskState(field.plantStatus);
 
+        return state
+            ? [
+                  {
+                      state,
+                      durationMinutes: PLANTING_TASK_DURATION_MINUTES,
+                  },
+              ]
+            : [];
+    });
+    const operationItems = scheduledOperations.map((operation) => ({
+        state: getOperationTaskState(operation.status),
+        durationMinutes: getOperationDurationMinutes(
+            operationDataById.get(operation.entityId),
+        ),
+    }));
+    const summaryItems: ScheduleTaskSummaryItem[] = [
+        ...plantingItems,
+        ...operationItems,
+    ];
+    const summary = getScheduleTaskSummary(summaryItems);
+
+    return <ScheduleDaySummaryView summary={summary} />;
+}
+
+export function ScheduleDaySummaryView({
+    summary,
+}: {
+    summary: ScheduleTaskSummary;
+}) {
     return (
-        <Row className="gap-1 sm:gap-2">
-            <SummaryItem label="Zadataka" value={taskCount} />
-            {totalMinutes > 0 && (
+        <section
+            aria-label="Sažetak dnevnih zadataka"
+            className="grid w-full grid-cols-[repeat(auto-fit,minmax(4.5rem,1fr))] items-start gap-2 sm:flex sm:w-auto sm:justify-end"
+        >
+            <SummaryItem label="Preostalo" value={summary.actionable.count} />
+            <SummaryItem
+                label="Čeka potvrdu"
+                value={summary.pendingVerification.count}
+            />
+            <SummaryItem label="Potvrđeno" value={summary.completed.count} />
+            {summary.actionable.durationMinutes > 0 && (
                 <SummaryItem
-                    label="Vrijeme"
-                    value={formatMinutes(totalMinutes)}
+                    label="Preostalo vrijeme"
+                    value={formatMinutes(summary.actionable.durationMinutes)}
                 />
             )}
-        </Row>
+            {summary.failed.count > 0 && (
+                <SummaryItem label="Neuspjelo" value={summary.failed.count} />
+            )}
+            {summary.canceled.count > 0 && (
+                <SummaryItem label="Otkazano" value={summary.canceled.count} />
+            )}
+        </section>
     );
 }
 
@@ -67,7 +108,7 @@ function SummaryItem({
     value: string | number;
 }) {
     return (
-        <div className="text-center leading-tight">
+        <div className="min-w-0 text-center leading-tight">
             <Typography level="body2" semiBold className="text-xs sm:text-sm">
                 {value}
             </Typography>

--- a/apps/farm/app/schedule/ScheduleDaySummarySkeleton.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummarySkeleton.tsx
@@ -1,9 +1,8 @@
-import { Row } from '@gredice/ui/Row';
 import { Skeleton } from '@gredice/ui/Skeleton';
 
 function SummaryItemSkeleton() {
     return (
-        <div className="space-y-1 text-center">
+        <div className="min-w-0 space-y-1 text-center">
             <Skeleton className="mx-auto h-3 w-6 sm:h-4 sm:w-8" />
             <Skeleton className="mx-auto h-3 w-10 sm:h-4 sm:w-14" />
         </div>
@@ -12,9 +11,11 @@ function SummaryItemSkeleton() {
 
 export function ScheduleDaySummarySkeleton() {
     return (
-        <Row className="gap-1 sm:gap-2">
+        <div className="grid w-full grid-cols-[repeat(auto-fit,minmax(4.5rem,1fr))] items-start gap-2 sm:flex sm:w-auto sm:justify-end">
             <SummaryItemSkeleton />
             <SummaryItemSkeleton />
-        </Row>
+            <SummaryItemSkeleton />
+            <SummaryItemSkeleton />
+        </div>
     );
 }

--- a/apps/farm/app/schedule/ScheduleTaskStateControl.spec.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskStateControl.spec.tsx
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
+
+for (const width of [320, 1280]) {
+    test(`keeps submitted work non-actionable at ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 640 });
+        const component = await mount(
+            <ScheduleTaskStateControl
+                action={<button type="button">Dovrši</button>}
+                label="Zalij gredicu broj 12"
+                state="pendingVerification"
+                unavailableTitle="Radnja nije dostupna."
+            />,
+        );
+
+        await expect(component.getByRole('button')).toHaveCount(0);
+        await expect(component.getByRole('checkbox')).toHaveCount(0);
+    });
+}
+
+test('renders only verified work as checked completion', async ({ mount }) => {
+    const component = await mount(
+        <ScheduleTaskStateControl
+            label="Posij mrkvu"
+            state="completed"
+            unavailableTitle="Sijanje nije dostupno."
+        />,
+    );
+
+    const checkbox = component.getByRole('checkbox', {
+        name: 'Potvrđeno: Posij mrkvu',
+    });
+    await expect(checkbox).toBeChecked();
+    await expect(checkbox).toBeDisabled();
+});
+
+test('keeps actionable controls available and names locked work', async ({
+    mount,
+    page,
+}) => {
+    const actionable = await mount(
+        <ScheduleTaskStateControl
+            action={<button type="button">Dovrši</button>}
+            label="Zalij salatu"
+            state="actionable"
+            unavailableTitle="Radnja nije dostupna."
+        />,
+    );
+    await expect(page.getByRole('button', { name: 'Dovrši' })).toBeVisible();
+    await actionable.unmount();
+
+    await mount(
+        <ScheduleTaskStateControl
+            label="Zalij salatu"
+            state="actionable"
+            unavailableTitle="Radnja je dodijeljena drugom korisniku."
+        />,
+    );
+    await expect(
+        page.getByRole('checkbox', {
+            name: 'Nije dostupno: Zalij salatu. Radnja je dodijeljena drugom korisniku.',
+        }),
+    ).toBeDisabled();
+});

--- a/apps/farm/app/schedule/ScheduleTaskStateControl.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskStateControl.tsx
@@ -1,0 +1,46 @@
+import { Checkbox } from '@gredice/ui/Checkbox';
+import type { ReactNode } from 'react';
+import type { ScheduleTaskState } from './scheduleTaskState';
+
+interface ScheduleTaskStateControlProps {
+    action?: ReactNode;
+    label: string;
+    state: ScheduleTaskState;
+    unavailableTitle: string;
+}
+
+export function ScheduleTaskStateControl({
+    action,
+    label,
+    state,
+    unavailableTitle,
+}: ScheduleTaskStateControlProps) {
+    if (state === 'completed') {
+        return (
+            <Checkbox
+                aria-label={`Potvrđeno: ${label}`}
+                className="size-5"
+                checked
+                disabled
+            />
+        );
+    }
+
+    if (state !== 'actionable') {
+        return null;
+    }
+
+    if (action) {
+        return action;
+    }
+
+    return (
+        <div title={unavailableTitle}>
+            <Checkbox
+                aria-label={`Nije dostupno: ${label}. ${unavailableTitle}`}
+                className="size-5"
+                disabled
+            />
+        </div>
+    );
+}

--- a/apps/farm/app/schedule/ScheduleTaskStatusChip.spec.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskStatusChip.spec.tsx
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../globals.css';
+import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
+import type { ScheduleTaskState } from './scheduleTaskState';
+
+const visibleStates: Exclude<ScheduleTaskState, 'actionable'>[] = [
+    'pendingVerification',
+    'completed',
+    'failed',
+    'canceled',
+];
+
+test('renders every terminal and review state with visible text', async ({
+    mount,
+}) => {
+    const component = await mount(
+        <div className="flex max-w-full flex-wrap gap-2">
+            {visibleStates.map((state) => (
+                <ScheduleTaskStatusChip key={state} state={state} />
+            ))}
+        </div>,
+    );
+
+    await expect(component.getByText('Čeka potvrdu')).toBeVisible();
+    await expect(component.getByText('Potvrđeno')).toBeVisible();
+    await expect(component.getByText('Neuspjelo')).toBeVisible();
+    await expect(component.getByText('Otkazano')).toBeVisible();
+});
+
+test('keeps the pending label visible at a phone viewport', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 640 });
+    const component = await mount(
+        <div className="flex w-full max-w-full flex-wrap gap-2">
+            {visibleStates.map((state) => (
+                <ScheduleTaskStatusChip key={state} state={state} />
+            ))}
+        </div>,
+    );
+
+    const pending = component.getByText('Čeka potvrdu');
+    await expect(pending).toBeVisible();
+    await expect(
+        component.locator('[data-task-state="pendingVerification"]'),
+    ).toHaveCount(1);
+    expect(
+        await page.evaluate(
+            () =>
+                document.documentElement.scrollWidth <=
+                document.documentElement.clientWidth,
+        ),
+    ).toBe(true);
+});

--- a/apps/farm/app/schedule/ScheduleTaskStatusChip.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskStatusChip.tsx
@@ -1,0 +1,69 @@
+import { Chip, type ColorPaletteProp } from '@gredice/ui/Chip';
+import {
+    Disabled,
+    Error as ErrorIcon,
+    Hourglass,
+    Verified,
+} from '@gredice/ui/icons';
+import type { ComponentType } from 'react';
+import type { ScheduleTaskState } from './scheduleTaskState';
+
+type VisibleScheduleTaskState = Exclude<ScheduleTaskState, 'actionable'>;
+
+const statusConfig: Record<
+    VisibleScheduleTaskState,
+    {
+        color: ColorPaletteProp;
+        icon: ComponentType<{
+            'aria-hidden'?: boolean;
+            className?: string;
+        }>;
+        label: string;
+    }
+> = {
+    pendingVerification: {
+        color: 'warning',
+        icon: Hourglass,
+        label: 'Čeka potvrdu',
+    },
+    completed: {
+        color: 'success',
+        icon: Verified,
+        label: 'Potvrđeno',
+    },
+    failed: {
+        color: 'error',
+        icon: ErrorIcon,
+        label: 'Neuspjelo',
+    },
+    canceled: {
+        color: 'neutral',
+        icon: Disabled,
+        label: 'Otkazano',
+    },
+};
+
+interface ScheduleTaskStatusChipProps {
+    state: ScheduleTaskState;
+}
+
+export function ScheduleTaskStatusChip({ state }: ScheduleTaskStatusChipProps) {
+    if (state === 'actionable') {
+        return null;
+    }
+
+    const config = statusConfig[state];
+    const StatusIcon = config.icon;
+
+    return (
+        <Chip
+            color={config.color}
+            data-task-state={state}
+            size="sm"
+            startDecorator={<StatusIcon aria-hidden />}
+            variant="soft"
+        >
+            {config.label}
+        </Chip>
+    );
+}

--- a/apps/farm/app/schedule/scheduleData.ts
+++ b/apps/farm/app/schedule/scheduleData.ts
@@ -15,21 +15,15 @@ import {
     scheduleCacheTtls,
 } from '@gredice/storage';
 import { cache } from 'react';
+import {
+    getCarryoverOperationsForToday,
+    getScheduledFieldsForDay,
+    getSelectedDateOperationsForDay,
+} from './scheduleDayFilters';
 import { FARM_SCHEDULE_TIME_ZONE } from './scheduleShared';
 
 const operationsBackDays = 90;
 const raisedBedPhotoPreviewImageLimit = 3;
-const SCHEDULE_FIELD_STATUSES = new Set([
-    'planned',
-    'pendingVerification',
-    'sowed',
-]);
-const SCHEDULE_OPERATION_STATUSES = new Set([
-    'new',
-    'planned',
-    'pendingVerification',
-    'completed',
-]);
 
 function startOfDaysAgo(days: number) {
     const todayKey = getTimeZoneDateKey(new Date(), FARM_SCHEDULE_TIME_ZONE);
@@ -41,130 +35,6 @@ function startOfDaysAgo(days: number) {
 
 function dedupeById<T extends { id: number }>(items: T[]) {
     return Array.from(new Map(items.map((item) => [item.id, item])).values());
-}
-
-function isOperationCompleted(status?: string) {
-    return status === 'completed' || status === 'pendingVerification';
-}
-
-function isFieldCompleted(status?: string) {
-    return status === 'sowed' || status === 'pendingVerification';
-}
-
-function getScheduledFieldsForDay(
-    isToday: boolean,
-    dateKey: string,
-    raisedBeds: FarmScheduleRaisedBed[],
-) {
-    return raisedBeds
-        .filter((raisedBed) => Boolean(raisedBed.physicalId))
-        .flatMap((raisedBed) => raisedBed.fields)
-        .filter((field) => {
-            if (!field.plantSortId) {
-                return false;
-            }
-
-            if (!SCHEDULE_FIELD_STATUSES.has(field.plantStatus ?? 'new')) {
-                return false;
-            }
-
-            if (isFieldCompleted(field.plantStatus) && field.plantSowDate) {
-                const sowDate = new Date(field.plantSowDate);
-                return (
-                    getTimeZoneDateKey(sowDate, FARM_SCHEDULE_TIME_ZONE) ===
-                    dateKey
-                );
-            }
-
-            if (!field.plantScheduledDate) {
-                return isToday;
-            }
-
-            const scheduledDate = new Date(field.plantScheduledDate);
-            const scheduledDateKey = getTimeZoneDateKey(
-                scheduledDate,
-                FARM_SCHEDULE_TIME_ZONE,
-            );
-
-            return (
-                scheduledDateKey === dateKey ||
-                (isToday && scheduledDateKey < dateKey)
-            );
-        });
-}
-
-function getSelectedDateOperationsForDay(
-    dateKey: string,
-    operations: FarmScheduleOperation[],
-) {
-    return operations.filter((operation) => {
-        if (!SCHEDULE_OPERATION_STATUSES.has(operation.status)) {
-            return false;
-        }
-
-        if (
-            operation.raisedBedId === null &&
-            typeof operation.farmId !== 'number'
-        ) {
-            return false;
-        }
-
-        if (isOperationCompleted(operation.status) && operation.completedAt) {
-            const completedDate = new Date(operation.completedAt);
-            return (
-                getTimeZoneDateKey(completedDate, FARM_SCHEDULE_TIME_ZONE) ===
-                dateKey
-            );
-        }
-
-        const scheduledDate = operation.scheduledDate
-            ? new Date(operation.scheduledDate)
-            : undefined;
-
-        return (
-            scheduledDate !== undefined &&
-            getTimeZoneDateKey(scheduledDate, FARM_SCHEDULE_TIME_ZONE) ===
-                dateKey
-        );
-    });
-}
-
-function getCarryoverOperationsForToday(
-    isToday: boolean,
-    dateKey: string,
-    operations: FarmScheduleOperation[],
-) {
-    if (!isToday) {
-        return [];
-    }
-
-    return operations.filter((operation) => {
-        if (!SCHEDULE_OPERATION_STATUSES.has(operation.status)) {
-            return false;
-        }
-
-        if (isOperationCompleted(operation.status)) {
-            return false;
-        }
-
-        if (
-            operation.raisedBedId === null &&
-            typeof operation.farmId !== 'number'
-        ) {
-            return false;
-        }
-
-        if (!operation.scheduledDate) {
-            return true;
-        }
-
-        return (
-            getTimeZoneDateKey(
-                new Date(operation.scheduledDate),
-                FARM_SCHEDULE_TIME_ZONE,
-            ) < dateKey
-        );
-    });
 }
 
 function sortOperationsNewestFirst(operations: FarmScheduleOperation[]) {

--- a/apps/farm/app/schedule/scheduleDayFilters.spec.ts
+++ b/apps/farm/app/schedule/scheduleDayFilters.spec.ts
@@ -1,0 +1,201 @@
+import type { OperationStatus } from '@gredice/storage';
+import { expect, test } from '@playwright/test';
+import {
+    getCarryoverOperationsForToday,
+    getScheduledFieldsForDay,
+    getSelectedDateOperationsForDay,
+} from './scheduleDayFilters';
+
+const yesterdayKey = '2026-05-13';
+const todayKey = '2026-05-14';
+const yesterdayNoon = new Date('2026-05-13T10:00:00.000Z');
+
+type TestField = {
+    id: number;
+    plantScheduledDate?: Date;
+    plantSortId: number;
+    plantSowDate?: Date;
+    plantStatus: string;
+};
+
+type TestOperation = {
+    completedAt?: Date;
+    farmId: number | null;
+    id: number;
+    raisedBedId: number | null;
+    scheduledDate?: Date;
+    status: OperationStatus;
+};
+
+function buildField(overrides: Partial<TestField> = {}): TestField {
+    return {
+        id: 1,
+        plantScheduledDate: yesterdayNoon,
+        plantSortId: 100,
+        plantStatus: 'planned',
+        ...overrides,
+    };
+}
+
+function buildRaisedBed(field: TestField) {
+    return {
+        fields: [field],
+        physicalId: 'A1',
+    };
+}
+
+function buildOperation(overrides: Partial<TestOperation> = {}): TestOperation {
+    return {
+        farmId: null,
+        id: 1,
+        raisedBedId: 10,
+        scheduledDate: yesterdayNoon,
+        status: 'planned',
+        ...overrides,
+    };
+}
+
+test('pending planting stays on its submission day without actionable carryover', () => {
+    const field = buildField({
+        plantSowDate: yesterdayNoon,
+        plantStatus: 'pendingVerification',
+    });
+    const raisedBeds = [buildRaisedBed(field)];
+
+    expect(
+        getScheduledFieldsForDay(false, yesterdayKey, raisedBeds).map(
+            (item) => item.id,
+        ),
+    ).toEqual([field.id]);
+    expect(getScheduledFieldsForDay(true, todayKey, raisedBeds)).toEqual([]);
+    expect(getScheduledFieldsForDay(false, todayKey, raisedBeds)).toEqual([]);
+});
+
+test('verified planting appears only on its actual sow date', () => {
+    const verifiedField = buildField({
+        plantScheduledDate: new Date('2026-05-10T10:00:00.000Z'),
+        plantSowDate: yesterdayNoon,
+        plantStatus: 'sowed',
+    });
+    const missingSowDate = buildField({
+        id: 2,
+        plantStatus: 'sowed',
+    });
+    const raisedBeds = [
+        buildRaisedBed(verifiedField),
+        buildRaisedBed(missingSowDate),
+    ];
+
+    expect(
+        getScheduledFieldsForDay(false, yesterdayKey, raisedBeds).map(
+            (item) => item.id,
+        ),
+    ).toEqual([verifiedField.id, missingSowDate.id]);
+    expect(
+        getScheduledFieldsForDay(true, todayKey, raisedBeds).map(
+            (item) => item.id,
+        ),
+    ).toEqual([missingSowDate.id]);
+});
+
+test('pending operation stays on its submission day without actionable carryover', () => {
+    const operation = buildOperation({
+        completedAt: yesterdayNoon,
+        status: 'pendingVerification',
+    });
+
+    expect(
+        getSelectedDateOperationsForDay(yesterdayKey, [operation]).map(
+            (item) => item.id,
+        ),
+    ).toEqual([operation.id]);
+    expect(getCarryoverOperationsForToday(true, todayKey, [operation])).toEqual(
+        [],
+    );
+    expect(
+        getCarryoverOperationsForToday(false, todayKey, [operation]),
+    ).toEqual([]);
+});
+
+test('pending work without a submission timestamp falls back to its schedule date', () => {
+    const field = buildField({ plantStatus: 'pendingVerification' });
+    const operation = buildOperation({ status: 'pendingVerification' });
+
+    expect(
+        getScheduledFieldsForDay(false, yesterdayKey, [
+            buildRaisedBed(field),
+        ]).map((item) => item.id),
+    ).toEqual([field.id]);
+    expect(
+        getSelectedDateOperationsForDay(yesterdayKey, [operation]).map(
+            (item) => item.id,
+        ),
+    ).toEqual([operation.id]);
+});
+
+test('verified operation appears only on its actual completion date', () => {
+    const operation = buildOperation({
+        completedAt: yesterdayNoon,
+        scheduledDate: new Date('2026-05-10T10:00:00.000Z'),
+        status: 'completed',
+    });
+
+    expect(
+        getSelectedDateOperationsForDay(yesterdayKey, [operation]).map(
+            (item) => item.id,
+        ),
+    ).toEqual([operation.id]);
+    expect(getSelectedDateOperationsForDay('2026-05-10', [operation])).toEqual(
+        [],
+    );
+    expect(getCarryoverOperationsForToday(true, todayKey, [operation])).toEqual(
+        [],
+    );
+});
+
+test('only actionable overdue or unscheduled operations carry into Today', () => {
+    const overdue = buildOperation({ id: 1 });
+    const unscheduled = buildOperation({ id: 2, scheduledDate: undefined });
+    const future = buildOperation({
+        id: 3,
+        scheduledDate: new Date('2026-05-15T10:00:00.000Z'),
+    });
+    const failed = buildOperation({ id: 4, status: 'failed' });
+    const canceled = buildOperation({ id: 5, status: 'canceled' });
+
+    expect(
+        getCarryoverOperationsForToday(true, todayKey, [
+            overdue,
+            unscheduled,
+            future,
+            failed,
+            canceled,
+        ]).map((item) => item.id),
+    ).toEqual([overdue.id, unscheduled.id]);
+
+    expect(
+        getSelectedDateOperationsForDay(yesterdayKey, [failed, canceled]),
+    ).toEqual([]);
+});
+
+test('Zagreb midnight stays on its local schedule day', () => {
+    const july11 = '2026-07-11';
+    const july12 = '2026-07-12';
+    const july12InZagreb = new Date('2026-07-11T22:00:56.865Z');
+    const operation = buildOperation({ scheduledDate: july12InZagreb });
+    const field = buildField({ plantScheduledDate: july12InZagreb });
+    const raisedBeds = [buildRaisedBed(field)];
+
+    expect(getSelectedDateOperationsForDay(july11, [operation])).toEqual([]);
+    expect(
+        getSelectedDateOperationsForDay(july12, [operation]).map(
+            (item) => item.id,
+        ),
+    ).toEqual([operation.id]);
+    expect(getScheduledFieldsForDay(true, july11, raisedBeds)).toEqual([]);
+    expect(
+        getScheduledFieldsForDay(false, july12, raisedBeds).map(
+            (item) => item.id,
+        ),
+    ).toEqual([field.id]);
+});

--- a/apps/farm/app/schedule/scheduleDayFilters.ts
+++ b/apps/farm/app/schedule/scheduleDayFilters.ts
@@ -1,0 +1,166 @@
+import type { OperationStatus } from '@gredice/storage';
+import { getFarmScheduleDateKey } from './scheduleShared';
+import {
+    getOperationTaskState,
+    getPlantingTaskState,
+    isActionableTaskState,
+    isCompletedTaskState,
+    isPendingTaskState,
+} from './scheduleTaskState';
+
+type ScheduleDate = Date | string | null | undefined;
+
+type ScheduleField = {
+    plantScheduledDate?: ScheduleDate;
+    plantSortId?: number | null;
+    plantSowDate?: ScheduleDate;
+    plantStatus?: string | null;
+};
+
+type ScheduleRaisedBed<TField extends ScheduleField> = {
+    fields: TField[];
+    physicalId?: string | null;
+};
+
+type ScheduleOperation = {
+    completedAt?: ScheduleDate;
+    farmId?: number | null;
+    raisedBedId?: number | null;
+    scheduledDate?: ScheduleDate;
+    status?: OperationStatus | null;
+};
+
+function getDateKey(date: ScheduleDate) {
+    if (!date) {
+        return undefined;
+    }
+
+    const parsedDate = typeof date === 'string' ? new Date(date) : date;
+
+    return Number.isFinite(parsedDate.getTime())
+        ? getFarmScheduleDateKey(parsedDate)
+        : undefined;
+}
+
+function hasScheduleLocation(operation: ScheduleOperation) {
+    return (
+        typeof operation.raisedBedId === 'number' ||
+        typeof operation.farmId === 'number'
+    );
+}
+
+/**
+ * Selects planting tasks for a calendar day. Submitted and verified sowing is
+ * historical and follows its actual sow date without becoming carryover work.
+ */
+export function getScheduledFieldsForDay<TField extends ScheduleField>(
+    isToday: boolean,
+    dateKey: string,
+    raisedBeds: ScheduleRaisedBed<TField>[],
+) {
+    return raisedBeds
+        .filter((raisedBed) => Boolean(raisedBed.physicalId))
+        .flatMap((raisedBed) => raisedBed.fields)
+        .filter((field) => {
+            if (!field.plantSortId) {
+                return false;
+            }
+
+            const taskState = getPlantingTaskState(field.plantStatus);
+
+            if (!taskState) {
+                return false;
+            }
+
+            const sowDateKey = getDateKey(field.plantSowDate);
+
+            if (
+                (isPendingTaskState(taskState) ||
+                    isCompletedTaskState(taskState)) &&
+                sowDateKey
+            ) {
+                return sowDateKey === dateKey;
+            }
+
+            const scheduledDateKey = getDateKey(field.plantScheduledDate);
+
+            if (!scheduledDateKey) {
+                return isToday;
+            }
+
+            return (
+                scheduledDateKey === dateKey ||
+                (isToday && scheduledDateKey < dateKey)
+            );
+        });
+}
+
+/**
+ * Selects operations for the requested calendar date. Submitted and verified
+ * work follows the actual completion date; actionable work follows its planned
+ * date. Carryover into Today is handled separately so the range queries remain
+ * bounded to the requested date.
+ */
+export function getSelectedDateOperationsForDay<
+    TOperation extends ScheduleOperation,
+>(dateKey: string, operations: TOperation[]) {
+    return operations.filter((operation) => {
+        if (!operation.status) {
+            return false;
+        }
+
+        if (!hasScheduleLocation(operation)) {
+            return false;
+        }
+
+        const taskState = getOperationTaskState(operation.status);
+
+        if (
+            !isActionableTaskState(taskState) &&
+            !isPendingTaskState(taskState) &&
+            !isCompletedTaskState(taskState)
+        ) {
+            return false;
+        }
+
+        if (isPendingTaskState(taskState) || isCompletedTaskState(taskState)) {
+            const completedDateKey = getDateKey(operation.completedAt);
+            if (completedDateKey) {
+                return completedDateKey === dateKey;
+            }
+        }
+
+        return getDateKey(operation.scheduledDate) === dateKey;
+    });
+}
+
+/**
+ * Carries unfinished actionable work into Today. Pending verification,
+ * verified, failed, and canceled work never becomes an overdue task.
+ */
+export function getCarryoverOperationsForToday<
+    TOperation extends ScheduleOperation,
+>(isToday: boolean, dateKey: string, operations: TOperation[]) {
+    if (!isToday) {
+        return [];
+    }
+
+    return operations.filter((operation) => {
+        if (!operation.status) {
+            return false;
+        }
+
+        if (!hasScheduleLocation(operation)) {
+            return false;
+        }
+
+        const taskState = getOperationTaskState(operation.status);
+
+        if (!isActionableTaskState(taskState)) {
+            return false;
+        }
+
+        const scheduledDateKey = getDateKey(operation.scheduledDate);
+        return !scheduledDateKey || scheduledDateKey < dateKey;
+    });
+}

--- a/apps/farm/app/schedule/scheduleShared.ts
+++ b/apps/farm/app/schedule/scheduleShared.ts
@@ -308,15 +308,3 @@ export function getScheduleTaskAgeIndicator(
 
     return null;
 }
-
-export function isOperationCompleted(status?: string) {
-    return status === 'completed' || status === 'pendingVerification';
-}
-
-export function isFieldApproved(status?: string) {
-    return status === 'planned';
-}
-
-export function isFieldCompleted(status?: string) {
-    return status === 'sowed' || status === 'pendingVerification';
-}

--- a/apps/farm/app/schedule/scheduleTaskState.spec.ts
+++ b/apps/farm/app/schedule/scheduleTaskState.spec.ts
@@ -1,0 +1,123 @@
+import type { OperationStatus } from '@gredice/storage';
+import { expect, test } from '@playwright/test';
+import {
+    getOperationTaskState,
+    getPlantingTaskState,
+    getScheduleTaskPresentation,
+    getScheduleTaskSummary,
+    isActionableTaskState,
+    isCompletedTaskState,
+    isPendingTaskState,
+    type SchedulePlantingStatus,
+    type ScheduleTaskState,
+    type ScheduleTaskSummaryItem,
+} from './scheduleTaskState';
+
+const operationStateCases = [
+    { status: 'new', expectedState: 'actionable' },
+    { status: 'planned', expectedState: 'actionable' },
+    {
+        status: 'pendingVerification',
+        expectedState: 'pendingVerification',
+    },
+    { status: 'completed', expectedState: 'completed' },
+    { status: 'failed', expectedState: 'failed' },
+    { status: 'canceled', expectedState: 'canceled' },
+] satisfies Array<{
+    status: OperationStatus;
+    expectedState: ScheduleTaskState;
+}>;
+
+const plantingStateCases = [
+    { status: 'planned', expectedState: 'actionable' },
+    {
+        status: 'pendingVerification',
+        expectedState: 'pendingVerification',
+    },
+    { status: 'sowed', expectedState: 'completed' },
+] satisfies Array<{
+    status: SchedulePlantingStatus;
+    expectedState: ScheduleTaskState;
+}>;
+
+test('maps every operation status to a distinct schedule task state', () => {
+    for (const { status, expectedState } of operationStateCases) {
+        expect(getOperationTaskState(status)).toBe(expectedState);
+    }
+});
+
+test('maps every scheduled planting status to its task state', () => {
+    for (const { status, expectedState } of plantingStateCases) {
+        expect(getPlantingTaskState(status)).toBe(expectedState);
+    }
+});
+
+test('keeps submitted work pending instead of treating it as completed', () => {
+    const operationState = getOperationTaskState('pendingVerification');
+    const plantingState = getPlantingTaskState('pendingVerification');
+
+    expect(isPendingTaskState(operationState)).toBe(true);
+    expect(isPendingTaskState(plantingState)).toBe(true);
+    expect(isCompletedTaskState(operationState)).toBe(false);
+    expect(isCompletedTaskState(plantingState)).toBe(false);
+    expect(isActionableTaskState(operationState)).toBe(false);
+    expect(isActionableTaskState(plantingState)).toBe(false);
+
+    expect(getScheduleTaskPresentation(operationState)).toEqual({
+        isActionable: false,
+        isCompleted: false,
+        isPendingVerification: true,
+        showAgeIndicator: false,
+        showCompletionAttachments: true,
+        showCompletionControl: false,
+        showRequirementIndicators: false,
+    });
+    expect(getScheduleTaskPresentation('completed')).toEqual({
+        isActionable: false,
+        isCompleted: true,
+        isPendingVerification: false,
+        showAgeIndicator: false,
+        showCompletionAttachments: true,
+        showCompletionControl: false,
+        showRequirementIndicators: false,
+    });
+});
+
+test('summarizes task counts and duration with consistent state totals', () => {
+    const items = [
+        { state: 'actionable', durationMinutes: 15 },
+        { state: 'actionable', durationMinutes: 5 },
+        { state: 'pendingVerification', durationMinutes: 10 },
+        { state: 'completed', durationMinutes: 7 },
+        { state: 'failed', durationMinutes: 3 },
+        { state: 'canceled', durationMinutes: -2 },
+    ] satisfies ScheduleTaskSummaryItem[];
+
+    const summary = getScheduleTaskSummary(items);
+    const stateMetrics = [
+        summary.actionable,
+        summary.pendingVerification,
+        summary.completed,
+        summary.failed,
+        summary.canceled,
+    ];
+
+    expect(summary.actionable).toEqual({ count: 2, durationMinutes: 20 });
+    expect(summary.pendingVerification).toEqual({
+        count: 1,
+        durationMinutes: 10,
+    });
+    expect(summary.completed).toEqual({ count: 1, durationMinutes: 7 });
+    expect(summary.failed).toEqual({ count: 1, durationMinutes: 3 });
+    expect(summary.canceled).toEqual({ count: 1, durationMinutes: 0 });
+    expect(summary.total).toEqual({ count: 6, durationMinutes: 40 });
+    expect(
+        stateMetrics.reduce((total, metrics) => total + metrics.count, 0),
+    ).toBe(summary.total.count);
+    expect(
+        stateMetrics.reduce(
+            (total, metrics) => total + metrics.durationMinutes,
+            0,
+        ),
+    ).toBe(summary.total.durationMinutes);
+});

--- a/apps/farm/app/schedule/scheduleTaskState.ts
+++ b/apps/farm/app/schedule/scheduleTaskState.ts
@@ -1,0 +1,151 @@
+import type { OperationStatus } from '@gredice/storage';
+
+export type ScheduleTaskState =
+    | 'actionable'
+    | 'pendingVerification'
+    | 'completed'
+    | 'failed'
+    | 'canceled';
+
+export type SchedulePlantingStatus =
+    | 'planned'
+    | 'pendingVerification'
+    | 'sowed';
+
+type SchedulePlantingTaskState = Extract<
+    ScheduleTaskState,
+    'actionable' | 'pendingVerification' | 'completed'
+>;
+
+export type ScheduleTaskSummaryItem = {
+    state: ScheduleTaskState;
+    durationMinutes: number;
+};
+
+export type ScheduleTaskMetrics = {
+    count: number;
+    durationMinutes: number;
+};
+
+export type ScheduleTaskSummary = {
+    total: ScheduleTaskMetrics;
+    actionable: ScheduleTaskMetrics;
+    pendingVerification: ScheduleTaskMetrics;
+    completed: ScheduleTaskMetrics;
+    failed: ScheduleTaskMetrics;
+    canceled: ScheduleTaskMetrics;
+};
+
+export type ScheduleTaskPresentation = {
+    isActionable: boolean;
+    isCompleted: boolean;
+    isPendingVerification: boolean;
+    showAgeIndicator: boolean;
+    showCompletionAttachments: boolean;
+    showCompletionControl: boolean;
+    showRequirementIndicators: boolean;
+};
+
+const operationTaskStateByStatus = {
+    new: 'actionable',
+    planned: 'actionable',
+    pendingVerification: 'pendingVerification',
+    completed: 'completed',
+    failed: 'failed',
+    canceled: 'canceled',
+} satisfies Record<OperationStatus, ScheduleTaskState>;
+
+export function getOperationTaskState(status: OperationStatus) {
+    return operationTaskStateByStatus[status];
+}
+
+export function getPlantingTaskState(
+    status: SchedulePlantingStatus,
+): SchedulePlantingTaskState;
+export function getPlantingTaskState(
+    status: string | null | undefined,
+): SchedulePlantingTaskState | null;
+export function getPlantingTaskState(status: string | null | undefined) {
+    switch (status) {
+        case 'planned':
+            return 'actionable';
+        case 'pendingVerification':
+            return 'pendingVerification';
+        case 'sowed':
+            return 'completed';
+        default:
+            return null;
+    }
+}
+
+export function isActionableTaskState(
+    state: ScheduleTaskState | null | undefined,
+): state is 'actionable' {
+    return state === 'actionable';
+}
+
+export function isPendingTaskState(
+    state: ScheduleTaskState | null | undefined,
+): state is 'pendingVerification' {
+    return state === 'pendingVerification';
+}
+
+export function isCompletedTaskState(
+    state: ScheduleTaskState | null | undefined,
+): state is 'completed' {
+    return state === 'completed';
+}
+
+export function getScheduleTaskPresentation(
+    state: ScheduleTaskState,
+): ScheduleTaskPresentation {
+    const isActionable = isActionableTaskState(state);
+    const isCompleted = isCompletedTaskState(state);
+    const isPendingVerification = isPendingTaskState(state);
+
+    return {
+        isActionable,
+        isCompleted,
+        isPendingVerification,
+        showAgeIndicator: isActionable,
+        showCompletionAttachments: isPendingVerification || isCompleted,
+        showCompletionControl: isActionable,
+        showRequirementIndicators: isActionable,
+    };
+}
+
+function createEmptyMetrics(): ScheduleTaskMetrics {
+    return {
+        count: 0,
+        durationMinutes: 0,
+    };
+}
+
+function normalizeDurationMinutes(durationMinutes: number) {
+    return Number.isFinite(durationMinutes) ? Math.max(0, durationMinutes) : 0;
+}
+
+export function getScheduleTaskSummary(
+    items: ScheduleTaskSummaryItem[],
+): ScheduleTaskSummary {
+    const summary: ScheduleTaskSummary = {
+        total: createEmptyMetrics(),
+        actionable: createEmptyMetrics(),
+        pendingVerification: createEmptyMetrics(),
+        completed: createEmptyMetrics(),
+        failed: createEmptyMetrics(),
+        canceled: createEmptyMetrics(),
+    };
+
+    for (const item of items) {
+        const durationMinutes = normalizeDurationMinutes(item.durationMinutes);
+        const stateMetrics = summary[item.state];
+
+        summary.total.count += 1;
+        summary.total.durationMinutes += durationMinutes;
+        stateMetrics.count += 1;
+        stateMetrics.durationMinutes += durationMinutes;
+    }
+
+    return summary;
+}

--- a/packages/storage/tests/farmsRepo.node.spec.ts
+++ b/packages/storage/tests/farmsRepo.node.spec.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    assignUserToFarm,
+    createFarm,
+    farms,
+    getFarmsForUser,
+    storage,
+    users,
+} from '@gredice/storage';
+import { eq } from 'drizzle-orm';
+import { createTestDb } from './testDb';
+
+async function createFarmer() {
+    const userId = randomUUID();
+    await storage()
+        .insert(users)
+        .values({
+            id: userId,
+            userName: `farm-dashboard-${userId}@example.com`,
+            displayName: 'Farm Dashboard User',
+            role: 'farmer',
+        });
+
+    return userId;
+}
+
+async function createTestFarm(name: string) {
+    return createFarm({
+        name,
+        latitude: 0,
+        longitude: 0,
+    });
+}
+
+test('getFarmsForUser returns only assigned active farms', async () => {
+    createTestDb();
+
+    const userId = await createFarmer();
+    const otherUserId = await createFarmer();
+    const assignedFarmId = await createTestFarm('Assigned farm');
+    const otherUsersFarmId = await createTestFarm("Other user's farm");
+    const deletedFarmId = await createTestFarm('Deleted assigned farm');
+
+    await Promise.all([
+        assignUserToFarm(assignedFarmId, userId),
+        assignUserToFarm(otherUsersFarmId, otherUserId),
+        assignUserToFarm(deletedFarmId, userId),
+    ]);
+    await storage()
+        .update(farms)
+        .set({ isDeleted: true })
+        .where(eq(farms.id, deletedFarmId));
+
+    const visibleFarms = await getFarmsForUser(userId);
+
+    assert.deepEqual(
+        visibleFarms.map((farm) => farm.id),
+        [assignedFarmId],
+    );
+});


### PR DESCRIPTION
## Summary

- introduce one schedule task-state contract that keeps actionable, pending verification, verified completion, failed, and canceled presentation distinct
- render **Čeka potvrdu** as a text-and-icon state without a second completion action, while verified work remains checked and clearly completed
- split pending, verified, and remaining counts in the day summary and label actionable duration as **Preostalo vrijeme**
- preserve the existing Zagreb date selection and carryover behavior while extracting it into focused, tested helpers
- keep the summary, loading state, and real planting/operation cards within 320px and 390px phone viewports

## Scope boundaries

- server-side authorization and verification behavior are unchanged
- durable farmer-visible rejected/blocked history is deferred to #4160, where the domain reason and event timestamp will be added
- explicit 44px task completion actions remain #4158
- 44px mobile app-shell/navigation targets remain #4157

## Validation

- `corepack pnpm --filter farm lint`
- `corepack pnpm --filter farm exec tsc --noEmit`
- `corepack pnpm --filter farm test:prepare`
- `corepack pnpm --filter farm test:run` — 58 passed
- focused task-state and responsive suite — 27 passed
- `git diff --check`


## Stack

- Depends on #4167 and targets feat/farm-scope-dashboard-farms so authorization scoping lands first.
- Retarget to main after #4167 merges.

Fixes #4150