### PR TITLE
fix(delivery): preflight route selections

### DIFF
--- a/apps/delivery/app/api/driver/runs/preflight/route.ts
+++ b/apps/delivery/app/api/driver/runs/preflight/route.ts
@@ -1,0 +1,71 @@
+import { withAuth } from '../../../../../lib/auth/auth';
+import {
+    deliveryRunStartErrorLogContext,
+    deliveryRunStartErrorMessage,
+} from '../../../../../lib/deliveryDashboard';
+import {
+    DeliveryRunPreparationError,
+    prepareDeliveryRun,
+} from '../../../../../lib/deliveryRunPlanning';
+import { parseDeliveryRunRequestBody } from '../../../../../lib/deliveryRunRequest';
+
+export async function POST(request: Request) {
+    return await withAuth(['driver', 'admin'], async ({ userId }) => {
+        const body: unknown = await request.json().catch(() => null);
+        const deliveryRequestIds = parseDeliveryRunRequestBody(body);
+        if (!deliveryRequestIds) {
+            return Response.json(
+                { error: 'Odaberi barem jednu valjanu dostavu.' },
+                { status: 400 },
+            );
+        }
+
+        try {
+            const preparation = await prepareDeliveryRun({
+                driverUserId: userId,
+                deliveryRequestIds,
+            });
+            return Response.json({
+                valid: true,
+                summary: preparation.summary,
+            });
+        } catch (error) {
+            const message = deliveryRunStartErrorMessage(error);
+            const context = deliveryRunStartErrorLogContext(error);
+            if (message) {
+                console.warn('Delivery run preflight rejected', {
+                    ...context,
+                    requestCount: deliveryRequestIds.length,
+                    userId,
+                });
+                return Response.json(
+                    {
+                        valid: false,
+                        error: message,
+                        code:
+                            error instanceof DeliveryRunPreparationError
+                                ? error.code
+                                : undefined,
+                        conflict:
+                            error instanceof DeliveryRunPreparationError
+                                ? error.conflict
+                                : undefined,
+                    },
+                    { status: 409 },
+                );
+            }
+
+            console.error('Delivery run preflight failed', {
+                ...context,
+                requestCount: deliveryRequestIds.length,
+                userId,
+            });
+            return Response.json(
+                {
+                    error: 'Rutu trenutačno nije moguće provjeriti. Pokušaj ponovno.',
+                },
+                { status: 503 },
+            );
+        }
+    });
+}

--- a/apps/delivery/app/api/driver/runs/route.ts
+++ b/apps/delivery/app/api/driver/runs/route.ts
@@ -4,6 +4,7 @@ import {
     deliveryRunStartErrorMessage,
     startDeliveryRun,
 } from '../../../../lib/deliveryDashboard';
+import { DeliveryRunPreparationError } from '../../../../lib/deliveryRunPlanning';
 import { parseDeliveryRunRequestBody } from '../../../../lib/deliveryRunRequest';
 
 export async function POST(request: Request) {
@@ -37,6 +38,14 @@ export async function POST(request: Request) {
                     error:
                         startErrorMessage ??
                         'Rutu nije moguće pokrenuti. Provjeri adrese i pokušaj ponovno.',
+                    code:
+                        error instanceof DeliveryRunPreparationError
+                            ? error.code
+                            : undefined,
+                    conflict:
+                        error instanceof DeliveryRunPreparationError
+                            ? error.conflict
+                            : undefined,
                 },
                 { status: 409 },
             );

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -73,6 +73,7 @@ async function postAction(path: string, body?: object) {
                 : 'Radnju nije moguće dovršiti.';
         throw new Error(message);
     }
+    return data;
 }
 
 export function DeliveryDashboard() {
@@ -100,6 +101,25 @@ export function DeliveryDashboard() {
                 error instanceof Error
                     ? error.message
                     : 'Radnju nije moguće dovršiti.',
+            );
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    const startRun = async (deliveryRequestIds: string[]) => {
+        setPendingAction('start-route');
+        setActionError(null);
+        try {
+            const body = { deliveryRequestIds };
+            await postAction('/api/driver/runs/preflight', body);
+            await postAction('/api/driver/runs', body);
+            await query.refetch();
+        } catch (error) {
+            setActionError(
+                error instanceof Error
+                    ? error.message
+                    : 'Rutu nije moguće pokrenuti.',
             );
         } finally {
             setPendingAction(null);
@@ -161,10 +181,9 @@ export function DeliveryDashboard() {
                     dashboard={dashboard}
                     trackingState={trackingState}
                     pendingAction={pendingAction}
+                    onSelectionChange={() => setActionError(null)}
                     onStartRun={(deliveryRequestIds) =>
-                        void perform('start-route', '/api/driver/runs', {
-                            deliveryRequestIds,
-                        })
+                        void startRun(deliveryRequestIds)
                     }
                     onArrive={(runId, stopId) =>
                         void perform(

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -23,6 +23,11 @@ import {
     formatDistance,
     formatTravelDuration,
 } from '../lib/deliveryFormatting';
+import {
+    applyDeliveryRouteSelection,
+    deliveryRouteSelectionCandidatesFromBatches,
+    inspectDeliveryRouteSelection,
+} from '../lib/deliveryRouteSelection';
 import { groupByDeliveryStop } from '../lib/deliveryStopGrouping';
 import { selectDeliveryStopFromHarvestTrace } from '../lib/harvestTraceScan';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
@@ -52,6 +57,7 @@ export function DriverDashboard({
     dashboard,
     trackingState,
     pendingAction,
+    onSelectionChange,
     onStartRun,
     onArrive,
     onDeliver,
@@ -59,6 +65,7 @@ export function DriverDashboard({
     dashboard: DriverDeliveryDashboard;
     trackingState: DriverTrackingState;
     pendingAction: string | null;
+    onSelectionChange: () => void;
     onStartRun: (deliveryRequestIds: string[]) => void;
     onArrive: (runId: string, stopId: number) => void;
     onDeliver: (runId: string, stopId: number, notes?: string) => void;
@@ -68,6 +75,10 @@ export function DriverDashboard({
     const [selectedRequestIds, setSelectedRequestIdsState] = useState<string[]>(
         [],
     );
+    const [rejectedSelectionAttempt, setRejectedSelectionAttempt] = useState<{
+        currentRequestIds: string[];
+        nextRequestIds: string[];
+    } | null>(null);
     const selectedRequestIdsRef = useRef<string[]>([]);
     const availableOrders = dashboard.batches.flatMap((batch) => batch.orders);
     const selectableOrders = availableOrders.filter(
@@ -81,6 +92,9 @@ export function DriverDashboard({
         availableOrders.map((order) => [order.requestId, order]),
     );
     const availableStopGroups = groupByDeliveryStop(selectableOrders);
+    const selectionCandidates = deliveryRouteSelectionCandidatesFromBatches(
+        dashboard.batches,
+    );
     const effectiveSelectedRequestIds = selectedRequestIds.filter((requestId) =>
         availableRequestIdSet.has(requestId),
     );
@@ -91,11 +105,45 @@ export function DriverDashboard({
             return order ? [order.stopKey] : [];
         }),
     );
+    const selectionInspection = inspectDeliveryRouteSelection({
+        candidates: selectionCandidates,
+        requestIds: effectiveSelectedRequestIds,
+        maximumRouteStops: dashboard.maximumRouteStops,
+        maximumRouteWindowHours: dashboard.maximumRouteWindowHours,
+    });
     const selectionLimitReached =
-        selectedStopKeys.size >= dashboard.maximumRouteStops;
-    const selectedSlotCount = dashboard.batches.filter((batch) =>
-        batch.orders.some((order) => selectedRequestIdSet.has(order.requestId)),
-    ).length;
+        selectionInspection.summary.stopCount >= dashboard.maximumRouteStops;
+    const selectedSlotCount = selectionInspection.summary.slots.length;
+    const selectedPickupLocationCount =
+        selectionInspection.summary.pickupLocations.length;
+    const selectedWindowSpanHours = Math.ceil(
+        selectionInspection.summary.windowSpanMinutes / 60,
+    );
+    const reconciledRejectedSelection = rejectedSelectionAttempt
+        ? applyDeliveryRouteSelection({
+              candidates: selectionCandidates,
+              currentRequestIds: rejectedSelectionAttempt.currentRequestIds,
+              nextRequestIds: rejectedSelectionAttempt.nextRequestIds,
+              maximumRouteStops: dashboard.maximumRouteStops,
+              maximumRouteWindowHours: dashboard.maximumRouteWindowHours,
+          })
+        : null;
+    const activeSelectionConflict =
+        reconciledRejectedSelection?.status === 'rejected'
+            ? reconciledRejectedSelection.conflict
+            : selectionInspection.conflict;
+    const separateRouteLocation =
+        activeSelectionConflict?.pickupLocations.find((location) =>
+            location.requestIds.some((requestId) =>
+                activeSelectionConflict.separateRouteRequestIds.includes(
+                    requestId,
+                ),
+            ),
+        ) ?? null;
+    const separateRouteLocationLabel =
+        separateRouteLocation?.name ??
+        separateRouteLocation?.address ??
+        'odabranu lokaciju';
     const availableTraceCount = new Set(
         selectableOrders.flatMap((order) =>
             order.harvest.tracePath ? [order.harvest.tracePath] : [],
@@ -107,11 +155,34 @@ export function DriverDashboard({
         setSelectedRequestIdsState(requestIds);
     };
 
+    const applySelectedRequestIds = (requestIds: string[]) => {
+        onSelectionChange();
+        const currentRequestIds = selectedRequestIdsRef.current;
+        const result = applyDeliveryRouteSelection({
+            candidates: selectionCandidates,
+            currentRequestIds,
+            nextRequestIds: requestIds,
+            maximumRouteStops: dashboard.maximumRouteStops,
+            maximumRouteWindowHours: dashboard.maximumRouteWindowHours,
+        });
+        if (result.status === 'rejected') {
+            setRejectedSelectionAttempt({
+                currentRequestIds,
+                nextRequestIds: requestIds,
+            });
+            return result;
+        }
+
+        setRejectedSelectionAttempt(null);
+        replaceSelectedRequestIds(result.requestIds);
+        return result;
+    };
+
     const updateSelectedRequestIds = (
         update: (current: string[]) => string[],
     ) => {
         const nextRequestIds = update(selectedRequestIdsRef.current);
-        replaceSelectedRequestIds(nextRequestIds);
+        return applySelectedRequestIds(nextRequestIds);
     };
 
     const toggleOrder = (requestId: string, checked: boolean) => {
@@ -189,7 +260,7 @@ export function DriverDashboard({
     };
 
     const selectAllAvailable = () => {
-        replaceSelectedRequestIds(
+        applySelectedRequestIds(
             availableStopGroups
                 .slice(0, dashboard.maximumRouteStops)
                 .flatMap((group) =>
@@ -207,7 +278,21 @@ export function DriverDashboard({
         });
 
         if (result.status === 'selected') {
-            replaceSelectedRequestIds(result.nextSelectedRequestIds);
+            const selectionResult = applySelectedRequestIds(
+                result.nextSelectedRequestIds,
+            );
+            if (selectionResult.status === 'rejected') {
+                return {
+                    ...result,
+                    status: 'route-conflict' as const,
+                    message: selectionResult.conflict.message,
+                    code: selectionResult.conflict.code,
+                    conflictingRequestIds:
+                        selectionResult.conflict.conflictingRequestIds,
+                    separateRouteRequestIds:
+                        selectionResult.conflict.separateRouteRequestIds,
+                };
+            }
         }
 
         return result;
@@ -415,6 +500,27 @@ export function DriverDashboard({
                                                         ? 'termin'
                                                         : 'termina'}
                                                 </Chip>
+                                                <Chip color="neutral" size="sm">
+                                                    {
+                                                        selectedPickupLocationCount
+                                                    }{' '}
+                                                    {selectedPickupLocationCount ===
+                                                    1
+                                                        ? 'lokacija preuzimanja'
+                                                        : 'lokacije preuzimanja'}
+                                                </Chip>
+                                                {effectiveSelectedRequestIds.length >
+                                                0 ? (
+                                                    <Chip
+                                                        color="neutral"
+                                                        size="sm"
+                                                    >
+                                                        {
+                                                            selectedWindowSpanHours
+                                                        }{' '}
+                                                        h raspon termina
+                                                    </Chip>
+                                                ) : null}
                                             </div>
                                             <Typography
                                                 level="body3"
@@ -431,7 +537,10 @@ export function DriverDashboard({
                                                     dashboard.maximumRouteWindowHours
                                                 }{' '}
                                                 sata i poštuju se pri izračunu
-                                                dolazaka. Urodi koji se još
+                                                dolazaka. Dok povezane lokacije
+                                                preuzimanja nisu dio plana,
+                                                jedna ruta kreće s jedne
+                                                lokacije. Urodi koji se još
                                                 pripremaju ostaju vidljivi, ali
                                                 ih nije moguće odabrati.
                                             </Typography>
@@ -451,6 +560,20 @@ export function DriverDashboard({
                                                     effectiveSelectedRequestIds.length
                                                 }
                                                 onScan={scanHarvestTrace}
+                                                onReplacePickupSelection={(
+                                                    requestIds,
+                                                ) => {
+                                                    const result =
+                                                        applySelectedRequestIds(
+                                                            requestIds,
+                                                        );
+                                                    return (
+                                                        result.status ===
+                                                            'accepted' &&
+                                                        result.requestIds
+                                                            .length > 0
+                                                    );
+                                                }}
                                             />
                                             <Button
                                                 variant="outlined"
@@ -471,9 +594,7 @@ export function DriverDashboard({
                                                         0
                                                 }
                                                 onClick={() =>
-                                                    replaceSelectedRequestIds(
-                                                        [],
-                                                    )
+                                                    applySelectedRequestIds([])
                                                 }
                                                 startDecorator={
                                                     <Reset className="size-4" />
@@ -489,7 +610,10 @@ export function DriverDashboard({
                                                 disabled={
                                                     Boolean(pendingAction) ||
                                                     effectiveSelectedRequestIds.length ===
-                                                        0
+                                                        0 ||
+                                                    Boolean(
+                                                        selectionInspection.conflict,
+                                                    )
                                                 }
                                                 onClick={() =>
                                                     onStartRun(
@@ -513,6 +637,54 @@ export function DriverDashboard({
                                         </div>
                                     </CardContent>
                                 </Card>
+
+                                {activeSelectionConflict ? (
+                                    <Alert
+                                        color="warning"
+                                        startDecorator={
+                                            <Warning className="size-5" />
+                                        }
+                                    >
+                                        <div className="space-y-3">
+                                            <span className="block">
+                                                {
+                                                    activeSelectionConflict.message
+                                                }
+                                            </span>
+                                            <div className="flex flex-wrap gap-2">
+                                                {activeSelectionConflict
+                                                    .separateRouteRequestIds
+                                                    .length > 0 ? (
+                                                    <Button
+                                                        size="sm"
+                                                        variant="outlined"
+                                                        onClick={() =>
+                                                            applySelectedRequestIds(
+                                                                activeSelectionConflict.separateRouteRequestIds,
+                                                            )
+                                                        }
+                                                    >
+                                                        {activeSelectionConflict.code ===
+                                                        'mixed-pickup-locations'
+                                                            ? `Zadrži samo ${separateRouteLocationLabel}`
+                                                            : 'Zadrži kompatibilan odabir'}
+                                                    </Button>
+                                                ) : null}
+                                                <Button
+                                                    size="sm"
+                                                    variant="plain"
+                                                    onClick={() =>
+                                                        applySelectedRequestIds(
+                                                            [],
+                                                        )
+                                                    }
+                                                >
+                                                    Poništi odabir
+                                                </Button>
+                                            </div>
+                                        </div>
+                                    </Alert>
+                                ) : null}
 
                                 {selectionLimitReached &&
                                 availableStopGroups.length >

--- a/apps/delivery/components/HarvestTraceScanner.tsx
+++ b/apps/delivery/components/HarvestTraceScanner.tsx
@@ -39,6 +39,11 @@ type ScanHistoryItem = {
     message: string;
 };
 
+type PickupRouteConflict = Extract<
+    HarvestTraceSelectionResult,
+    { status: 'route-conflict' }
+>;
+
 function scanHistoryItem(
     id: number,
     result: HarvestTraceSelectionResult | HarvestTraceVerificationResult,
@@ -62,6 +67,12 @@ function scanHistoryItem(
                 color: 'warning',
                 message:
                     'Dosegnut je najveći broj fizičkih stanica za jednu rutu.',
+            };
+        case 'route-conflict':
+            return {
+                id,
+                color: 'warning',
+                message: result.message,
             };
         case 'ambiguous':
             return {
@@ -140,6 +151,7 @@ export function HarvestTraceScanner({
     disabled,
     completedTraceCount,
     onScan,
+    onReplacePickupSelection,
 }: {
     variant: 'pickup' | 'verification';
     availableTraceCount: number;
@@ -148,6 +160,7 @@ export function HarvestTraceScanner({
     onScan: (
         value: string,
     ) => HarvestTraceSelectionResult | HarvestTraceVerificationResult;
+    onReplacePickupSelection?: (requestIds: string[]) => boolean;
 }) {
     const [open, setOpen] = useState(false);
     const [cameraState, setCameraState] = useState<CameraState>(
@@ -156,10 +169,13 @@ export function HarvestTraceScanner({
     const [cameraError, setCameraError] = useState<string | null>(null);
     const [manualValue, setManualValue] = useState('');
     const [history, setHistory] = useState<ScanHistoryItem[]>([]);
+    const [pickupRouteConflict, setPickupRouteConflict] =
+        useState<PickupRouteConflict | null>(null);
     const [uniqueScanCount, setUniqueScanCount] = useState(0);
     const videoRef = useRef<HTMLVideoElement>(null);
     const readerRef = useRef<BrowserQRCodeReader | null>(null);
     const seenValuesRef = useRef(new Set<string>());
+    const pickupRouteConflictScanValueRef = useRef<string | null>(null);
     const historyIdRef = useRef(0);
     const onScanRef = useRef(onScan);
 
@@ -194,6 +210,28 @@ export function HarvestTraceScanner({
             setUniqueScanCount(seenValuesRef.current.size);
             historyIdRef.current += 1;
             const result = onScanRef.current(normalizedValue);
+            if (result.status === 'route-conflict') {
+                const displacedConflictScanValue =
+                    pickupRouteConflictScanValueRef.current;
+                if (
+                    displacedConflictScanValue &&
+                    displacedConflictScanValue !== normalizedValue
+                ) {
+                    seenValuesRef.current.delete(displacedConflictScanValue);
+                    setUniqueScanCount(seenValuesRef.current.size);
+                }
+                pickupRouteConflictScanValueRef.current = normalizedValue;
+                setPickupRouteConflict(result);
+            } else if (result.status === 'selected') {
+                const resolvedConflictScanValue =
+                    pickupRouteConflictScanValueRef.current;
+                if (resolvedConflictScanValue) {
+                    seenValuesRef.current.delete(resolvedConflictScanValue);
+                    setUniqueScanCount(seenValuesRef.current.size);
+                }
+                pickupRouteConflictScanValueRef.current = null;
+                setPickupRouteConflict(null);
+            }
             setHistory((current) => [
                 scanHistoryItem(historyIdRef.current, result),
                 ...current.slice(0, 3),
@@ -306,8 +344,10 @@ export function HarvestTraceScanner({
 
     function openScanner() {
         seenValuesRef.current.clear();
+        pickupRouteConflictScanValueRef.current = null;
         historyIdRef.current = 0;
         setHistory([]);
+        setPickupRouteConflict(null);
         setUniqueScanCount(0);
         setManualValue('');
         setCameraError(null);
@@ -319,6 +359,26 @@ export function HarvestTraceScanner({
         event.preventDefault();
         processScan(manualValue, 'manual');
         setManualValue('');
+    }
+
+    function replacePickupSelection(requestIds: string[]) {
+        if (onReplacePickupSelection?.(requestIds)) {
+            pickupRouteConflictScanValueRef.current = null;
+            setPickupRouteConflict(null);
+            return;
+        }
+        const failedScanValue = pickupRouteConflictScanValueRef.current;
+        if (failedScanValue) {
+            seenValuesRef.current.delete(failedScanValue);
+            setUniqueScanCount(seenValuesRef.current.size);
+        }
+        pickupRouteConflictScanValueRef.current = null;
+        setPickupRouteConflict(null);
+        pushHistory({
+            color: 'warning',
+            message:
+                'Dostave su se u međuvremenu promijenile. Osvježi odabir i skeniraj dostupni QR ponovno.',
+        });
     }
 
     const verificationMode = variant === 'verification';
@@ -424,6 +484,52 @@ export function HarvestTraceScanner({
                             startDecorator={<Warning className="size-5" />}
                         >
                             {cameraError}
+                        </Alert>
+                    ) : null}
+
+                    {pickupRouteConflict && onReplacePickupSelection ? (
+                        <Alert
+                            color="warning"
+                            startDecorator={<Warning className="size-5" />}
+                        >
+                            <div className="space-y-3">
+                                <span className="block">
+                                    {pickupRouteConflict.message}
+                                </span>
+                                <div className="flex flex-wrap gap-2">
+                                    {pickupRouteConflict.conflictingRequestIds
+                                        .length > 0 ? (
+                                        <Button
+                                            size="sm"
+                                            variant="outlined"
+                                            onClick={() =>
+                                                replacePickupSelection(
+                                                    pickupRouteConflict.conflictingRequestIds,
+                                                )
+                                            }
+                                        >
+                                            {pickupRouteConflict.code ===
+                                            'mixed-pickup-locations'
+                                                ? 'Prebaci na skeniranu lokaciju'
+                                                : 'Prebaci na skenirani termin'}
+                                        </Button>
+                                    ) : null}
+                                    {pickupRouteConflict.separateRouteRequestIds
+                                        .length > 0 ? (
+                                        <Button
+                                            size="sm"
+                                            variant="plain"
+                                            onClick={() =>
+                                                replacePickupSelection(
+                                                    pickupRouteConflict.separateRouteRequestIds,
+                                                )
+                                            }
+                                        >
+                                            Zadrži trenutačni odabir
+                                        </Button>
+                                    ) : null}
+                                </div>
+                            </div>
                         </Alert>
                     ) : null}
 

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -31,12 +31,15 @@ import type {
 import {
     DeliveryRoutePlanningError,
     formatDeliveryDestinationAddress,
-    formatDeliveryGeocodingAddress,
     maximumDeliveryRouteStops,
     maximumDeliveryRouteWindowHours,
-    planDeliveryRoute,
     recalculateDeliveryRoute,
 } from './deliveryRouting';
+import {
+    DeliveryRunPreparationError,
+    prepareDeliveryRun,
+    revalidatePreparedDeliveryRun,
+} from './deliveryRunPlanning';
 import {
     buildDeliveryStopKey,
     groupByDeliveryStop,
@@ -63,10 +66,6 @@ const batchStates: ReadonlySet<string> = new Set([
     DeliveryRequestStates.READY,
 ]);
 const etaRefreshIntervalMs = 2 * 60 * 1000;
-
-export class DeliveryRunStartError extends Error {
-    override name = 'DeliveryRunStartError';
-}
 
 function iso(value?: Date | null) {
     return value?.toISOString() ?? null;
@@ -439,6 +438,7 @@ async function driverDashboard({
         {
             startAt: Date;
             endAt: Date;
+            pickupLocationId: number;
             pickupLocationName: string | null;
             pickupAddress: string | null;
             orders: DeliveryRouteOrderSummary[];
@@ -471,6 +471,7 @@ async function driverDashboard({
             batchesBySlot.set(request.slot.id, {
                 startAt: request.slot.startAt,
                 endAt: request.slot.endAt,
+                pickupLocationId: request.slot.locationId,
                 pickupLocationName: pickupLocation?.name ?? null,
                 pickupAddress: pickupLocation
                     ? formatDeliveryDestinationAddress(pickupLocation)
@@ -492,6 +493,7 @@ async function driverDashboard({
             slotId,
             startAt: batch.startAt.toISOString(),
             endAt: batch.endAt.toISOString(),
+            pickupLocationId: batch.pickupLocationId,
             pickupLocationName: batch.pickupLocationName,
             pickupAddress: batch.pickupAddress,
             deliveryCount: batch.orders.length,
@@ -646,135 +648,12 @@ export async function startDeliveryRun({
         await ensureRunRequestsReady(existingRun);
         return existingRun;
     }
-    if (deliveryRequestIds.length === 0) {
-        throw new DeliveryRunStartError('Odaberi barem jednu dostavu.');
-    }
-
-    const requests = await getDeliveryRequestsWithEvents();
-    const requestsById = new Map(
-        requests.map((request) => [request.id, request]),
-    );
-    const selectedStopKeys = new Set<string>();
-    const now = new Date();
-    for (const requestId of deliveryRequestIds) {
-        const request = requestsById.get(requestId);
-        if (
-            request?.mode !== 'delivery' ||
-            !request.address ||
-            !request.slot ||
-            request.state !== DeliveryRequestStates.READY ||
-            request.slot.endAt < now
-        ) {
-            throw new DeliveryRunStartError(
-                'Jedna ili više odabranih dostava još nije spremna za preuzimanje. Osvježi popis i pokušaj ponovno.',
-            );
-        }
-        selectedStopKeys.add(deliveryRequestStopKey(request));
-    }
-    if (selectedStopKeys.size > maximumDeliveryRouteStops) {
-        throw new DeliveryRunStartError(
-            `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} fizičkih stanica. Dostave na istoj adresi u istom terminu računaju se kao jedna stanica.`,
-        );
-    }
-
-    const candidates = requests.filter(
-        (request) =>
-            request.mode === 'delivery' &&
-            request.address &&
-            request.slot &&
-            request.state === DeliveryRequestStates.READY &&
-            request.slot.endAt >= now &&
-            selectedStopKeys.has(deliveryRequestStopKey(request)),
-    );
-
-    const existingStops = await getDeliveryRunStopsForRequestIds(
-        candidates.map((request) => request.id),
-    );
-    if (existingStops.length > 0) {
-        throw new DeliveryRunStartError(
-            'Jedna ili više odabranih dostava već je dodijeljena drugoj ruti. Osvježi popis i odaberi ponovno.',
-        );
-    }
-
-    const candidateGroups = groupByDeliveryStop(
-        candidates.map((request) => ({
-            request,
-            stopKey: deliveryRequestStopKey(request),
-        })),
-    );
-    const candidateGroupsByRepresentativeId = new Map<
-        string,
-        (typeof candidateGroups)[number]
-    >();
-    const plan = await planDeliveryRoute({
-        candidates: candidateGroups.map((group) => {
-            const representative = group.items[0]?.request;
-            if (!representative?.address || !representative.slot) {
-                throw new DeliveryRunStartError(
-                    'Odabrana dostava nema valjanu adresu ili termin.',
-                );
-            }
-            candidateGroupsByRepresentativeId.set(representative.id, group);
-            return {
-                deliveryRequestId: representative.id,
-                formattedAddress: formatDeliveryDestinationAddress(
-                    representative.address,
-                ),
-                geocodingAddress: formatDeliveryGeocodingAddress(
-                    representative.address,
-                ),
-                windowStartAt: representative.slot.startAt,
-                windowEndAt: representative.slot.endAt,
-            };
-        }),
-    });
-    const primarySlot = candidates
-        .map((request) => request.slot)
-        .filter((slot): slot is NonNullable<typeof slot> => Boolean(slot))
-        .sort(
-            (first, second) =>
-                first.startAt.getTime() - second.startAt.getTime(),
-        )[0];
-    if (!primarySlot) {
-        throw new DeliveryRunStartError(
-            'Odabrane dostave nemaju valjani termin.',
-        );
-    }
-    let storedSequence = 0;
-    const storedStops = plan.stops.flatMap((plannedStop) => {
-        const group = candidateGroupsByRepresentativeId.get(
-            plannedStop.deliveryRequestId,
-        );
-        if (!group) {
-            throw new DeliveryRunStartError(
-                'Planirana dostavna stanica nije pronađena.',
-            );
-        }
-
-        return group.items.map(({ request }) => {
-            storedSequence += 1;
-            return {
-                deliveryRequestId: request.id,
-                sequence: storedSequence,
-                latitude: plannedStop.latitude,
-                longitude: plannedStop.longitude,
-                formattedAddress: plannedStop.formattedAddress,
-                estimatedArrivalAt: plannedStop.estimatedArrivalAt,
-                estimatedTravelSeconds: plannedStop.estimatedTravelSeconds,
-                estimatedDistanceMeters: plannedStop.estimatedDistanceMeters,
-            };
-        });
-    });
-    const run = await createDeliveryRun({
+    const preparation = await prepareDeliveryRun({
         driverUserId,
-        timeSlotId: primarySlot.id,
-        encodedPolyline: plan.encodedPolyline,
-        totalDistanceMeters: plan.totalDistanceMeters,
-        totalDurationSeconds: plan.totalDurationSeconds,
-        stops: storedStops,
+        deliveryRequestIds,
     });
-
-    return run;
+    await revalidatePreparedDeliveryRun(preparation);
+    return await createDeliveryRun(preparation.createRunInput);
 }
 
 export async function arriveAtDeliveryStop({
@@ -1018,7 +897,7 @@ export async function recordDriverLocation({
 }
 
 export function deliveryRunStartErrorMessage(error: unknown) {
-    return error instanceof DeliveryRunStartError ||
+    return error instanceof DeliveryRunPreparationError ||
         error instanceof DeliveryRoutePlanningError
         ? error.message
         : null;
@@ -1032,10 +911,11 @@ export function deliveryRunStartErrorLogContext(error: unknown) {
             deliveryRequestId: error.deliveryRequestId,
         };
     }
-    if (error instanceof DeliveryRunStartError) {
+    if (error instanceof DeliveryRunPreparationError) {
         return {
             errorName: error.name,
-            errorCode: 'invalid-selection',
+            errorCode: error.code,
+            deliveryRequestId: error.conflict.deliveryRequestId,
         };
     }
     return { error };

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -67,6 +67,7 @@ export type DeliveryBatchSummary = {
     slotId: number;
     startAt: string;
     endAt: string;
+    pickupLocationId: number;
     pickupLocationName: string | null;
     pickupAddress: string | null;
     deliveryCount: number;

--- a/apps/delivery/lib/deliveryRouteSelection.node.spec.ts
+++ b/apps/delivery/lib/deliveryRouteSelection.node.spec.ts
@@ -1,0 +1,469 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    applyDeliveryRouteSelection,
+    type DeliveryRouteSelectionCandidate,
+    inspectDeliveryRouteSelection,
+} from './deliveryRouteSelection';
+
+const earlyStart = '2026-07-15T08:00:00.000Z';
+const earlyEnd = '2026-07-15T10:00:00.000Z';
+
+function candidate({
+    requestId,
+    stopKey = `stop:${requestId}`,
+    readyForPickup = true,
+    pickupLocationId = 1,
+    pickupLocationName = 'Glavno sjedište',
+    pickupAddress = 'Ulica Julija Knifera 3, Zagreb',
+    slotId = 10,
+    slotStartAt = earlyStart,
+    slotEndAt = earlyEnd,
+    deliveryAddress = `Adresa ${requestId}`,
+}: {
+    requestId: string;
+    stopKey?: string;
+    readyForPickup?: boolean;
+    pickupLocationId?: number;
+    pickupLocationName?: string | null;
+    pickupAddress?: string | null;
+    slotId?: number;
+    slotStartAt?: string;
+    slotEndAt?: string;
+    deliveryAddress?: string;
+}): DeliveryRouteSelectionCandidate {
+    return {
+        requestId,
+        stopKey,
+        readyForPickup,
+        pickupLocationId,
+        pickupLocationName,
+        pickupAddress,
+        slotId,
+        slotStartAt,
+        slotEndAt,
+        deliveryAddress,
+    };
+}
+
+function apply({
+    candidates,
+    currentRequestIds = [],
+    nextRequestIds,
+    maximumRouteStops = 26,
+    maximumRouteWindowHours = 24,
+}: {
+    candidates: DeliveryRouteSelectionCandidate[];
+    currentRequestIds?: string[];
+    nextRequestIds: string[];
+    maximumRouteStops?: number;
+    maximumRouteWindowHours?: number;
+}) {
+    return applyDeliveryRouteSelection({
+        candidates,
+        currentRequestIds,
+        nextRequestIds,
+        maximumRouteStops,
+        maximumRouteWindowHours,
+    });
+}
+
+test('manual bulk selection keeps every ready harvest at one physical stop', () => {
+    const candidates = [
+        candidate({ requestId: 'bulk-one', stopKey: 'bulk-stop' }),
+        candidate({ requestId: 'bulk-two', stopKey: 'bulk-stop' }),
+        candidate({
+            requestId: 'bulk-not-ready',
+            stopKey: 'bulk-stop',
+            readyForPickup: false,
+        }),
+    ];
+
+    const result = apply({
+        candidates,
+        nextRequestIds: ['bulk-one', 'bulk-two', 'bulk-not-ready'],
+    });
+
+    assert.equal(result.status, 'accepted');
+    assert.deepEqual(result.requestIds, ['bulk-one', 'bulk-two']);
+    assert.equal(result.summary.deliveryCount, 2);
+    assert.equal(result.summary.stopCount, 1);
+    assert.deepEqual(result.summary.pickupLocations[0]?.requestIds, [
+        'bulk-one',
+        'bulk-two',
+    ]);
+});
+
+test('same-location selections across compatible slots are accepted and summarized', () => {
+    const candidates = [
+        candidate({ requestId: 'morning', slotId: 10 }),
+        candidate({
+            requestId: 'afternoon',
+            slotId: 11,
+            slotStartAt: '2026-07-15T12:00:00.000Z',
+            slotEndAt: '2026-07-15T14:00:00.000Z',
+        }),
+    ];
+
+    const result = apply({
+        candidates,
+        currentRequestIds: ['morning'],
+        nextRequestIds: ['morning', 'afternoon'],
+    });
+
+    assert.equal(result.status, 'accepted');
+    assert.deepEqual(result.requestIds, ['morning', 'afternoon']);
+    assert.equal(result.summary.pickupLocations.length, 1);
+    assert.deepEqual(
+        result.summary.slots.map((slot) => slot.id),
+        [10, 11],
+    );
+    assert.equal(result.summary.windowStartAt, earlyStart);
+    assert.equal(result.summary.windowEndAt, '2026-07-15T14:00:00.000Z');
+    assert.equal(result.summary.windowSpanMinutes, 360);
+});
+
+test('mixed pickup locations reject the attempted manual change and preserve current IDs', () => {
+    const candidates = [
+        candidate({ requestId: 'selected' }),
+        candidate({
+            requestId: 'other-location',
+            pickupLocationId: 2,
+            pickupLocationName: 'Istočno skladište',
+            pickupAddress: 'Druga 2, Zagreb',
+            slotId: 20,
+        }),
+    ];
+
+    const result = apply({
+        candidates,
+        currentRequestIds: ['selected'],
+        nextRequestIds: ['selected', 'other-location'],
+    });
+
+    assert.equal(result.status, 'rejected');
+    assert.deepEqual(result.requestIds, ['selected']);
+    assert.deepEqual(result.summary.requestIds, ['selected']);
+    assert.equal(result.conflict.code, 'mixed-pickup-locations');
+    assert.deepEqual(result.conflict.conflictingRequestIds, ['other-location']);
+    assert.deepEqual(
+        result.conflict.pickupLocations.map((location) => ({
+            id: location.id,
+            name: location.name,
+            address: location.address,
+        })),
+        [
+            {
+                id: 1,
+                name: 'Glavno sjedište',
+                address: 'Ulica Julija Knifera 3, Zagreb',
+            },
+            {
+                id: 2,
+                name: 'Istočno skladište',
+                address: 'Druga 2, Zagreb',
+            },
+        ],
+    );
+    assert.deepEqual(result.conflict.separateRouteRequestIds, ['selected']);
+    assert.match(result.conflict.message, /Istočno skladište/);
+});
+
+test('batch selection rejects mixed-location additions atomically', () => {
+    const candidates = [
+        candidate({ requestId: 'current', stopKey: 'current-stop' }),
+        candidate({
+            requestId: 'batch-one',
+            stopKey: 'batch-stop-one',
+            pickupLocationId: 2,
+            pickupLocationName: 'Zapadno skladište',
+            slotId: 20,
+        }),
+        candidate({
+            requestId: 'batch-two',
+            stopKey: 'batch-stop-two',
+            pickupLocationId: 2,
+            pickupLocationName: 'Zapadno skladište',
+            slotId: 20,
+        }),
+    ];
+
+    const result = apply({
+        candidates,
+        currentRequestIds: ['current'],
+        nextRequestIds: ['current', 'batch-one', 'batch-two'],
+    });
+
+    assert.equal(result.status, 'rejected');
+    assert.deepEqual(result.requestIds, ['current']);
+    assert.deepEqual(result.conflict.conflictingRequestIds, [
+        'batch-one',
+        'batch-two',
+    ]);
+    assert.deepEqual(result.conflict.separateRouteRequestIds, ['current']);
+});
+
+test('select-all conflict returns the same deterministic compatible suggestion', () => {
+    const candidates = [
+        candidate({ requestId: 'hq-one', stopKey: 'hq-bulk' }),
+        candidate({ requestId: 'hq-two', stopKey: 'hq-bulk' }),
+        candidate({
+            requestId: 'remote-one',
+            pickupLocationId: 2,
+            pickupLocationName: 'Druga lokacija',
+            slotId: 20,
+        }),
+        candidate({
+            requestId: 'remote-two',
+            pickupLocationId: 2,
+            pickupLocationName: 'Druga lokacija',
+            slotId: 20,
+        }),
+    ];
+    const requestIds = candidates.map(({ requestId }) => requestId);
+
+    const first = inspectDeliveryRouteSelection({
+        candidates,
+        requestIds,
+        maximumRouteStops: 26,
+        maximumRouteWindowHours: 24,
+    });
+    const second = inspectDeliveryRouteSelection({
+        candidates,
+        requestIds,
+        maximumRouteStops: 26,
+        maximumRouteWindowHours: 24,
+    });
+
+    assert.equal(first.conflict?.code, 'mixed-pickup-locations');
+    assert.deepEqual(first.conflict?.separateRouteRequestIds, [
+        'hq-one',
+        'hq-two',
+    ]);
+    assert.deepEqual(
+        second.conflict?.separateRouteRequestIds,
+        first.conflict?.separateRouteRequestIds,
+    );
+});
+
+test('a selection spanning more than 24 hours is rejected with its conflicting slot', () => {
+    const candidates = [
+        candidate({ requestId: 'first-slot', slotId: 10 }),
+        candidate({
+            requestId: 'late-slot-one',
+            stopKey: 'late-bulk',
+            slotId: 11,
+            slotStartAt: '2026-07-16T10:00:01.000Z',
+            slotEndAt: '2026-07-16T12:00:01.000Z',
+        }),
+        candidate({
+            requestId: 'late-slot-two',
+            stopKey: 'late-bulk',
+            slotId: 11,
+            slotStartAt: '2026-07-16T10:00:01.000Z',
+            slotEndAt: '2026-07-16T12:00:01.000Z',
+        }),
+    ];
+
+    const result = apply({
+        candidates,
+        currentRequestIds: ['first-slot'],
+        nextRequestIds: ['first-slot', 'late-slot-one', 'late-slot-two'],
+    });
+
+    assert.equal(result.status, 'rejected');
+    assert.deepEqual(result.requestIds, ['first-slot']);
+    assert.equal(result.conflict.code, 'route-window-span-exceeded');
+    assert.deepEqual(result.conflict.conflictingRequestIds, [
+        'late-slot-one',
+        'late-slot-two',
+    ]);
+    assert.deepEqual(result.conflict.separateRouteRequestIds, ['first-slot']);
+    assert.equal(result.conflict.deliveryAddress, 'Adresa late-slot-one');
+});
+
+test('an earlier attempted slot is identified instead of blaming the current later slot', () => {
+    const candidates = [
+        candidate({
+            requestId: 'current-late',
+            slotId: 20,
+            slotStartAt: '2026-07-16T10:00:01.000Z',
+            slotEndAt: '2026-07-16T12:00:01.000Z',
+        }),
+        candidate({
+            requestId: 'attempted-early',
+            slotId: 10,
+            slotStartAt: earlyStart,
+            slotEndAt: earlyEnd,
+        }),
+    ];
+
+    const result = apply({
+        candidates,
+        currentRequestIds: ['current-late'],
+        nextRequestIds: ['current-late', 'attempted-early'],
+    });
+
+    assert.equal(result.status, 'rejected');
+    assert.deepEqual(result.requestIds, ['current-late']);
+    assert.deepEqual(result.conflict.conflictingRequestIds, [
+        'attempted-early',
+    ]);
+    assert.equal(result.conflict.deliveryAddress, 'Adresa attempted-early');
+    assert.match(result.conflict.message, /Dodani termin/);
+    assert.deepEqual(result.conflict.separateRouteRequestIds, ['current-late']);
+});
+
+test('physical-stop limits count a bulk address once and reject only the excess group', () => {
+    const candidates = [
+        candidate({ requestId: 'bulk-one', stopKey: 'bulk-stop' }),
+        candidate({ requestId: 'bulk-two', stopKey: 'bulk-stop' }),
+        candidate({ requestId: 'second-stop', stopKey: 'second-stop' }),
+        candidate({ requestId: 'third-one', stopKey: 'third-stop' }),
+        candidate({ requestId: 'third-two', stopKey: 'third-stop' }),
+    ];
+
+    const accepted = apply({
+        candidates,
+        nextRequestIds: ['bulk-one', 'bulk-two', 'second-stop'],
+        maximumRouteStops: 2,
+    });
+    assert.equal(accepted.status, 'accepted');
+    assert.equal(accepted.summary.deliveryCount, 3);
+    assert.equal(accepted.summary.stopCount, 2);
+
+    const rejected = apply({
+        candidates,
+        currentRequestIds: accepted.requestIds,
+        nextRequestIds: [
+            'bulk-one',
+            'bulk-two',
+            'second-stop',
+            'third-one',
+            'third-two',
+        ],
+        maximumRouteStops: 2,
+    });
+    assert.equal(rejected.status, 'rejected');
+    assert.deepEqual(rejected.requestIds, [
+        'bulk-one',
+        'bulk-two',
+        'second-stop',
+    ]);
+    assert.equal(rejected.conflict.code, 'route-stop-limit-exceeded');
+    assert.deepEqual(rejected.conflict.conflictingRequestIds, [
+        'third-one',
+        'third-two',
+    ]);
+    assert.deepEqual(rejected.conflict.separateRouteRequestIds, [
+        'bulk-one',
+        'bulk-two',
+        'second-stop',
+    ]);
+});
+
+test('stale, duplicate, and no-longer-ready request IDs are pruned', () => {
+    const candidates = [
+        candidate({ requestId: 'ready' }),
+        candidate({ requestId: 'not-ready', readyForPickup: false }),
+    ];
+
+    const result = apply({
+        candidates,
+        currentRequestIds: ['stale-current'],
+        nextRequestIds: ['stale-next', 'ready', 'ready', 'not-ready'],
+    });
+
+    assert.equal(result.status, 'accepted');
+    assert.deepEqual(result.requestIds, ['ready']);
+    assert.deepEqual(result.summary.requestIds, ['ready']);
+});
+
+test('reset accepts an empty replacement and clears all summary counts', () => {
+    const candidates = [candidate({ requestId: 'selected' })];
+
+    const result = apply({
+        candidates,
+        currentRequestIds: ['selected'],
+        nextRequestIds: [],
+    });
+
+    assert.equal(result.status, 'accepted');
+    assert.deepEqual(result.requestIds, []);
+    assert.equal(result.summary.deliveryCount, 0);
+    assert.equal(result.summary.stopCount, 0);
+    assert.deepEqual(result.summary.pickupLocations, []);
+    assert.deepEqual(result.summary.slots, []);
+    assert.equal(result.summary.windowStartAt, null);
+    assert.equal(result.summary.windowEndAt, null);
+    assert.equal(result.summary.windowSpanMinutes, 0);
+});
+
+test('QR-proposed IDs use the same atomic mixed-location guard', () => {
+    const candidates = [
+        candidate({ requestId: 'scanned-first', stopKey: 'first-bulk' }),
+        candidate({ requestId: 'first-sibling', stopKey: 'first-bulk' }),
+        candidate({
+            requestId: 'scanned-remote',
+            stopKey: 'remote-bulk',
+            pickupLocationId: 2,
+            pickupLocationName: 'QR lokacija',
+            slotId: 20,
+        }),
+        candidate({
+            requestId: 'remote-sibling',
+            stopKey: 'remote-bulk',
+            pickupLocationId: 2,
+            pickupLocationName: 'QR lokacija',
+            slotId: 20,
+        }),
+    ];
+
+    const firstScan = apply({
+        candidates,
+        nextRequestIds: ['scanned-first', 'first-sibling'],
+    });
+    assert.equal(firstScan.status, 'accepted');
+
+    const secondScan = apply({
+        candidates,
+        currentRequestIds: firstScan.requestIds,
+        nextRequestIds: [
+            ...firstScan.requestIds,
+            'scanned-remote',
+            'remote-sibling',
+        ],
+    });
+
+    assert.equal(secondScan.status, 'rejected');
+    assert.deepEqual(secondScan.requestIds, ['scanned-first', 'first-sibling']);
+    assert.equal(secondScan.conflict.code, 'mixed-pickup-locations');
+    assert.deepEqual(secondScan.conflict.conflictingRequestIds, [
+        'scanned-remote',
+        'remote-sibling',
+    ]);
+});
+
+test('invalid delivery windows report the exact request and address', () => {
+    const candidates = [
+        candidate({
+            requestId: 'invalid-window',
+            slotStartAt: 'not-a-date',
+            slotEndAt: earlyEnd,
+            deliveryAddress: 'Neispravna 1',
+        }),
+    ];
+
+    const result = apply({
+        candidates,
+        currentRequestIds: [],
+        nextRequestIds: ['invalid-window'],
+    });
+
+    assert.equal(result.status, 'rejected');
+    assert.deepEqual(result.requestIds, []);
+    assert.equal(result.conflict.code, 'delivery-window-invalid');
+    assert.deepEqual(result.conflict.conflictingRequestIds, ['invalid-window']);
+    assert.equal(result.conflict.deliveryAddress, 'Neispravna 1');
+    assert.deepEqual(result.conflict.separateRouteRequestIds, []);
+});

--- a/apps/delivery/lib/deliveryRouteSelection.ts
+++ b/apps/delivery/lib/deliveryRouteSelection.ts
@@ -1,0 +1,467 @@
+import type { DeliveryBatchSummary } from './deliveryDashboardTypes';
+
+export type DeliveryRouteSelectionCandidate = {
+    requestId: string;
+    stopKey: string;
+    readyForPickup: boolean;
+    pickupLocationId: number;
+    pickupLocationName: string | null;
+    pickupAddress: string | null;
+    slotId: number;
+    slotStartAt: string;
+    slotEndAt: string;
+    deliveryAddress: string;
+};
+
+export type DeliveryRouteSelectionPickupLocation = {
+    id: number;
+    name: string | null;
+    address: string | null;
+    requestIds: string[];
+};
+
+export type DeliveryRouteSelectionSlot = {
+    id: number;
+    startAt: string;
+    endAt: string;
+    requestIds: string[];
+};
+
+export type DeliveryRouteSelectionConflict = {
+    code:
+        | 'delivery-window-invalid'
+        | 'mixed-pickup-locations'
+        | 'route-stop-limit-exceeded'
+        | 'route-window-span-exceeded';
+    message: string;
+    conflictingRequestIds: string[];
+    pickupLocations: DeliveryRouteSelectionPickupLocation[];
+    slots: DeliveryRouteSelectionSlot[];
+    deliveryAddress: string | null;
+    separateRouteRequestIds: string[];
+};
+
+export type DeliveryRouteSelectionSummary = {
+    requestIds: string[];
+    deliveryCount: number;
+    stopCount: number;
+    pickupLocations: DeliveryRouteSelectionPickupLocation[];
+    slots: DeliveryRouteSelectionSlot[];
+    windowStartAt: string | null;
+    windowEndAt: string | null;
+    windowSpanMinutes: number;
+};
+
+export type DeliveryRouteSelectionInspection = {
+    summary: DeliveryRouteSelectionSummary;
+    conflict: DeliveryRouteSelectionConflict | null;
+};
+
+export type DeliveryRouteSelectionChange =
+    | {
+          status: 'accepted';
+          requestIds: string[];
+          summary: DeliveryRouteSelectionSummary;
+      }
+    | {
+          status: 'rejected';
+          requestIds: string[];
+          summary: DeliveryRouteSelectionSummary;
+          conflict: DeliveryRouteSelectionConflict;
+      };
+
+function pickupLocationLabel(location: DeliveryRouteSelectionPickupLocation) {
+    return (
+        location.name?.trim() ||
+        location.address?.trim() ||
+        `Lokacija preuzimanja ${location.id}`
+    );
+}
+
+function formatSlotDateTime(value: number) {
+    return new Intl.DateTimeFormat('hr-HR', {
+        dateStyle: 'short',
+        timeStyle: 'short',
+        timeZone: 'Europe/Zagreb',
+    }).format(value);
+}
+
+function uniqueCandidates(
+    candidates: readonly DeliveryRouteSelectionCandidate[],
+    requestIds: readonly string[],
+) {
+    const candidateByRequestId = new Map(
+        candidates.map((candidate) => [candidate.requestId, candidate]),
+    );
+    const uniqueRequestIds = Array.from(new Set(requestIds));
+    return uniqueRequestIds.flatMap((requestId) => {
+        const candidate = candidateByRequestId.get(requestId);
+        return candidate?.readyForPickup ? [candidate] : [];
+    });
+}
+
+function pickupLocations(
+    candidates: readonly DeliveryRouteSelectionCandidate[],
+) {
+    const grouped = new Map<number, DeliveryRouteSelectionPickupLocation>();
+    for (const candidate of candidates) {
+        const existing = grouped.get(candidate.pickupLocationId);
+        if (existing) {
+            existing.requestIds.push(candidate.requestId);
+        } else {
+            grouped.set(candidate.pickupLocationId, {
+                id: candidate.pickupLocationId,
+                name: candidate.pickupLocationName,
+                address: candidate.pickupAddress,
+                requestIds: [candidate.requestId],
+            });
+        }
+    }
+    return Array.from(grouped.values());
+}
+
+function slots(candidates: readonly DeliveryRouteSelectionCandidate[]) {
+    const grouped = new Map<number, DeliveryRouteSelectionSlot>();
+    for (const candidate of candidates) {
+        const existing = grouped.get(candidate.slotId);
+        if (existing) {
+            existing.requestIds.push(candidate.requestId);
+        } else {
+            grouped.set(candidate.slotId, {
+                id: candidate.slotId,
+                startAt: candidate.slotStartAt,
+                endAt: candidate.slotEndAt,
+                requestIds: [candidate.requestId],
+            });
+        }
+    }
+    return Array.from(grouped.values()).sort(
+        (first, second) =>
+            new Date(first.startAt).getTime() -
+            new Date(second.startAt).getTime(),
+    );
+}
+
+function buildSummary(
+    candidates: readonly DeliveryRouteSelectionCandidate[],
+): DeliveryRouteSelectionSummary {
+    const timestamps = candidates.flatMap((candidate) => {
+        const startAt = new Date(candidate.slotStartAt).getTime();
+        const endAt = new Date(candidate.slotEndAt).getTime();
+        return Number.isFinite(startAt) && Number.isFinite(endAt)
+            ? [{ startAt, endAt }]
+            : [];
+    });
+    const windowStart =
+        timestamps.length > 0
+            ? Math.min(...timestamps.map(({ startAt }) => startAt))
+            : null;
+    const windowEnd =
+        timestamps.length > 0
+            ? Math.max(...timestamps.map(({ endAt }) => endAt))
+            : null;
+
+    return {
+        requestIds: candidates.map((candidate) => candidate.requestId),
+        deliveryCount: candidates.length,
+        stopCount: new Set(candidates.map((candidate) => candidate.stopKey))
+            .size,
+        pickupLocations: pickupLocations(candidates),
+        slots: slots(candidates),
+        windowStartAt:
+            windowStart === null ? null : new Date(windowStart).toISOString(),
+        windowEndAt:
+            windowEnd === null ? null : new Date(windowEnd).toISOString(),
+        windowSpanMinutes:
+            windowStart === null || windowEnd === null
+                ? 0
+                : Math.round((windowEnd - windowStart) / 60_000),
+    };
+}
+
+function findConflict({
+    candidates,
+    maximumRouteStops,
+    maximumRouteWindowHours,
+}: {
+    candidates: readonly DeliveryRouteSelectionCandidate[];
+    maximumRouteStops: number;
+    maximumRouteWindowHours: number;
+}): Omit<DeliveryRouteSelectionConflict, 'separateRouteRequestIds'> | null {
+    const selectedPickupLocations = pickupLocations(candidates);
+    const selectedSlots = slots(candidates);
+    const invalidWindowCandidate = candidates.find((candidate) => {
+        const startAt = new Date(candidate.slotStartAt).getTime();
+        const endAt = new Date(candidate.slotEndAt).getTime();
+        return (
+            !Number.isFinite(startAt) ||
+            !Number.isFinite(endAt) ||
+            startAt >= endAt
+        );
+    });
+    if (invalidWindowCandidate) {
+        return {
+            code: 'delivery-window-invalid',
+            message: `Termin dostave za adresu ${invalidWindowCandidate.deliveryAddress} nije valjan. Osvježi popis i pokušaj ponovno.`,
+            conflictingRequestIds: [invalidWindowCandidate.requestId],
+            pickupLocations: selectedPickupLocations,
+            slots: selectedSlots,
+            deliveryAddress: invalidWindowCandidate.deliveryAddress,
+        };
+    }
+
+    if (selectedPickupLocations.length > 1) {
+        const [firstLocation, secondLocation] = selectedPickupLocations;
+        if (firstLocation && secondLocation) {
+            return {
+                code: 'mixed-pickup-locations',
+                message: `Odabrani urodi čekaju na više lokacija preuzimanja: ${pickupLocationLabel(firstLocation)} i ${pickupLocationLabel(secondLocation)}. Pokreni zasebnu rutu za svaku lokaciju.`,
+                conflictingRequestIds: secondLocation.requestIds,
+                pickupLocations: selectedPickupLocations,
+                slots: selectedSlots,
+                deliveryAddress: null,
+            };
+        }
+    }
+
+    const stopGroups = new Map<string, DeliveryRouteSelectionCandidate[]>();
+    for (const candidate of candidates) {
+        const group = stopGroups.get(candidate.stopKey);
+        if (group) group.push(candidate);
+        else stopGroups.set(candidate.stopKey, [candidate]);
+    }
+    if (stopGroups.size > maximumRouteStops) {
+        const conflictingGroup = Array.from(stopGroups.values())[
+            maximumRouteStops
+        ];
+        const conflictingCandidate = conflictingGroup?.[0];
+        return {
+            code: 'route-stop-limit-exceeded',
+            message: `Jedna ruta može sadržavati najviše ${maximumRouteStops} fizičkih stanica. Adresu ${conflictingCandidate?.deliveryAddress ?? 'sljedeće dostave'} ostavi za zasebnu rutu.`,
+            conflictingRequestIds:
+                conflictingGroup?.map((candidate) => candidate.requestId) ?? [],
+            pickupLocations: selectedPickupLocations,
+            slots: selectedSlots,
+            deliveryAddress: conflictingCandidate?.deliveryAddress ?? null,
+        };
+    }
+
+    const timestamps = candidates.map((candidate) => ({
+        candidate,
+        startAt: new Date(candidate.slotStartAt).getTime(),
+        endAt: new Date(candidate.slotEndAt).getTime(),
+    }));
+    if (timestamps.length > 0) {
+        const earliest = timestamps.reduce((first, current) =>
+            current.startAt < first.startAt ? current : first,
+        );
+        const latest = timestamps.reduce((first, current) =>
+            current.endAt > first.endAt ? current : first,
+        );
+        if (
+            latest.endAt - earliest.startAt >
+            maximumRouteWindowHours * 60 * 60 * 1_000
+        ) {
+            const conflictingSlot = selectedSlots.find(
+                (slot) => slot.id === latest.candidate.slotId,
+            );
+            return {
+                code: 'route-window-span-exceeded',
+                message: `Odabrani termini traju od ${formatSlotDateTime(earliest.startAt)} do ${formatSlotDateTime(latest.endAt)}, dulje od dopuštenih ${maximumRouteWindowHours} sata. Termin od ${formatSlotDateTime(latest.startAt)} ostavi za zasebnu rutu.`,
+                conflictingRequestIds: conflictingSlot?.requestIds ?? [
+                    latest.candidate.requestId,
+                ],
+                pickupLocations: selectedPickupLocations,
+                slots: selectedSlots,
+                deliveryAddress: latest.candidate.deliveryAddress,
+            };
+        }
+    }
+
+    return null;
+}
+
+function compatibleRequestIds({
+    candidates,
+    maximumRouteStops,
+    maximumRouteWindowHours,
+}: {
+    candidates: readonly DeliveryRouteSelectionCandidate[];
+    maximumRouteStops: number;
+    maximumRouteWindowHours: number;
+}) {
+    const groups = new Map<string, DeliveryRouteSelectionCandidate[]>();
+    for (const candidate of candidates) {
+        const group = groups.get(candidate.stopKey);
+        if (group) group.push(candidate);
+        else groups.set(candidate.stopKey, [candidate]);
+    }
+
+    const accepted: DeliveryRouteSelectionCandidate[] = [];
+    for (const group of groups.values()) {
+        const proposed = [...accepted, ...group];
+        if (
+            !findConflict({
+                candidates: proposed,
+                maximumRouteStops,
+                maximumRouteWindowHours,
+            })
+        ) {
+            accepted.push(...group);
+        }
+    }
+    return accepted.map((candidate) => candidate.requestId);
+}
+
+export function inspectDeliveryRouteSelection({
+    candidates,
+    requestIds,
+    maximumRouteStops,
+    maximumRouteWindowHours,
+}: {
+    candidates: readonly DeliveryRouteSelectionCandidate[];
+    requestIds: readonly string[];
+    maximumRouteStops: number;
+    maximumRouteWindowHours: number;
+}): DeliveryRouteSelectionInspection {
+    const selectedCandidates = uniqueCandidates(candidates, requestIds);
+    const summary = buildSummary(selectedCandidates);
+    const conflict = findConflict({
+        candidates: selectedCandidates,
+        maximumRouteStops,
+        maximumRouteWindowHours,
+    });
+    return {
+        summary,
+        conflict: conflict
+            ? {
+                  ...conflict,
+                  separateRouteRequestIds: compatibleRequestIds({
+                      candidates: selectedCandidates,
+                      maximumRouteStops,
+                      maximumRouteWindowHours,
+                  }),
+              }
+            : null,
+    };
+}
+
+export function applyDeliveryRouteSelection({
+    candidates,
+    currentRequestIds,
+    nextRequestIds,
+    maximumRouteStops,
+    maximumRouteWindowHours,
+}: {
+    candidates: readonly DeliveryRouteSelectionCandidate[];
+    currentRequestIds: readonly string[];
+    nextRequestIds: readonly string[];
+    maximumRouteStops: number;
+    maximumRouteWindowHours: number;
+}): DeliveryRouteSelectionChange {
+    const current = inspectDeliveryRouteSelection({
+        candidates,
+        requestIds: currentRequestIds,
+        maximumRouteStops,
+        maximumRouteWindowHours,
+    });
+    const next = inspectDeliveryRouteSelection({
+        candidates,
+        requestIds: nextRequestIds,
+        maximumRouteStops,
+        maximumRouteWindowHours,
+    });
+    if (!next.conflict) {
+        return {
+            status: 'accepted',
+            requestIds: next.summary.requestIds,
+            summary: next.summary,
+        };
+    }
+
+    let conflict = next.conflict;
+    if (
+        conflict.code === 'route-window-span-exceeded' &&
+        current.summary.requestIds.length > 0 &&
+        current.summary.windowStartAt &&
+        current.summary.windowEndAt
+    ) {
+        const currentRequestIdSet = new Set(current.summary.requestIds);
+        const candidateByRequestId = new Map(
+            candidates.map((candidate) => [candidate.requestId, candidate]),
+        );
+        const currentWindowStart = new Date(
+            current.summary.windowStartAt,
+        ).getTime();
+        const currentWindowEnd = new Date(
+            current.summary.windowEndAt,
+        ).getTime();
+        const attemptedCandidates = next.summary.requestIds.flatMap(
+            (requestId) => {
+                const candidate = candidateByRequestId.get(requestId);
+                return !currentRequestIdSet.has(requestId) && candidate
+                    ? [candidate]
+                    : [];
+            },
+        );
+        const attemptedCandidate = attemptedCandidates.sort((first, second) => {
+            const firstStart = new Date(first.slotStartAt).getTime();
+            const firstEnd = new Date(first.slotEndAt).getTime();
+            const secondStart = new Date(second.slotStartAt).getTime();
+            const secondEnd = new Date(second.slotEndAt).getTime();
+            const firstExtension = Math.max(
+                currentWindowStart - firstStart,
+                firstEnd - currentWindowEnd,
+                0,
+            );
+            const secondExtension = Math.max(
+                currentWindowStart - secondStart,
+                secondEnd - currentWindowEnd,
+                0,
+            );
+            return secondExtension - firstExtension;
+        })[0];
+        if (attemptedCandidate) {
+            const attemptedSlotRequestIds = attemptedCandidates
+                .filter(
+                    (candidate) =>
+                        candidate.slotId === attemptedCandidate.slotId,
+                )
+                .map((candidate) => candidate.requestId);
+            conflict = {
+                ...conflict,
+                message: `Dodani termin ${formatSlotDateTime(new Date(attemptedCandidate.slotStartAt).getTime())} – ${formatSlotDateTime(new Date(attemptedCandidate.slotEndAt).getTime())} proširuje odabrani raspon na više od ${maximumRouteWindowHours} sata. Ostavi taj termin za zasebnu rutu.`,
+                conflictingRequestIds: attemptedSlotRequestIds,
+                deliveryAddress: attemptedCandidate.deliveryAddress,
+            };
+        }
+    }
+
+    return {
+        status: 'rejected',
+        requestIds: current.summary.requestIds,
+        summary: current.summary,
+        conflict,
+    };
+}
+
+export function deliveryRouteSelectionCandidatesFromBatches(
+    batches: readonly DeliveryBatchSummary[],
+) {
+    return batches.flatMap((batch) =>
+        batch.orders.map(
+            (order): DeliveryRouteSelectionCandidate => ({
+                requestId: order.requestId,
+                stopKey: order.stopKey,
+                readyForPickup: order.readyForPickup,
+                pickupLocationId: batch.pickupLocationId,
+                pickupLocationName: batch.pickupLocationName,
+                pickupAddress: batch.pickupAddress,
+                slotId: batch.slotId,
+                slotStartAt: batch.startAt,
+                slotEndAt: batch.endAt,
+                deliveryAddress: order.address,
+            }),
+        ),
+    );
+}

--- a/apps/delivery/lib/deliveryRouting.node.spec.ts
+++ b/apps/delivery/lib/deliveryRouting.node.spec.ts
@@ -7,6 +7,7 @@ import {
     formatDeliveryDestinationAddress,
     formatDeliveryGeocodingAddress,
     haversineDistanceMeters,
+    maximumDeliveryRouteStops,
     nearestNeighborStopOrder,
     orderDeliveryStopsByTimeWindow,
     planDeliveryRoute,
@@ -436,28 +437,100 @@ test('waits for a future delivery window and rejects an expired one', () => {
                 departureTime: new Date('2026-07-13T10:01:00.000Z'),
                 optimize: false,
             }),
-        DeliveryRoutePlanningError,
+        (error: unknown) => {
+            assert.ok(error instanceof DeliveryRoutePlanningError);
+            assert.equal(error.code, 'arrival-window-infeasible');
+            assert.equal(error.deliveryRequestId, 'scheduled');
+            assert.match(error.message, /Scheduled/);
+            return true;
+        },
     );
 });
 
-test('rejects selected time windows that span more than one route day', async () => {
+test('reports the first delivery beyond the physical stop limit', async () => {
+    const candidates = Array.from(
+        { length: maximumDeliveryRouteStops + 1 },
+        (_value, index) => ({
+            deliveryRequestId: `delivery-${index}`,
+            formattedAddress: `Adresa ${index + 1}`,
+            windowStartAt: new Date('2026-07-13T08:00:00.000Z'),
+            windowEndAt: new Date('2026-07-13T10:00:00.000Z'),
+        }),
+    );
+
+    await assert.rejects(
+        planDeliveryRoute({ candidates }),
+        (error: unknown) => {
+            assert.ok(error instanceof DeliveryRoutePlanningError);
+            assert.equal(error.code, 'route-stop-limit-exceeded');
+            assert.equal(
+                error.deliveryRequestId,
+                `delivery-${maximumDeliveryRouteStops}`,
+            );
+            assert.match(
+                error.message,
+                new RegExp(`Adresa ${maximumDeliveryRouteStops + 1}`),
+            );
+            return true;
+        },
+    );
+});
+
+test('reports the delivery with an invalid window', async () => {
     await assert.rejects(
         planDeliveryRoute({
             candidates: [
                 {
-                    deliveryRequestId: 'first',
-                    formattedAddress: 'First',
-                    windowStartAt: new Date('2026-07-13T08:00:00.000Z'),
-                    windowEndAt: new Date('2026-07-13T10:00:00.000Z'),
-                },
-                {
-                    deliveryRequestId: 'second',
-                    formattedAddress: 'Second',
-                    windowStartAt: new Date('2026-07-14T10:00:01.000Z'),
-                    windowEndAt: new Date('2026-07-14T12:00:01.000Z'),
+                    deliveryRequestId: 'invalid-window',
+                    formattedAddress: 'Ilica 99, Zagreb',
+                    windowStartAt: new Date('2026-07-13T10:00:00.000Z'),
+                    windowEndAt: new Date('2026-07-13T09:00:00.000Z'),
                 },
             ],
         }),
-        DeliveryRoutePlanningError,
+        (error: unknown) => {
+            assert.ok(error instanceof DeliveryRoutePlanningError);
+            assert.equal(error.code, 'delivery-window-invalid');
+            assert.equal(error.deliveryRequestId, 'invalid-window');
+            assert.match(error.message, /Ilica 99/);
+            return true;
+        },
     );
+});
+
+test('reports a deterministic delivery when selected windows span more than one route day', async () => {
+    const first = {
+        deliveryRequestId: 'first',
+        formattedAddress: 'First',
+        windowStartAt: new Date('2026-07-13T08:00:00.000Z'),
+        windowEndAt: new Date('2026-07-13T10:00:00.000Z'),
+    };
+    const lateA = {
+        deliveryRequestId: 'late-a',
+        formattedAddress: 'Late A',
+        windowStartAt: new Date('2026-07-14T10:00:01.000Z'),
+        windowEndAt: new Date('2026-07-14T12:00:01.000Z'),
+    };
+    const lateZ = {
+        deliveryRequestId: 'late-z',
+        formattedAddress: 'Late Z',
+        windowStartAt: new Date('2026-07-14T10:00:01.000Z'),
+        windowEndAt: new Date('2026-07-14T12:00:01.000Z'),
+    };
+
+    for (const candidates of [
+        [lateZ, first, lateA],
+        [lateA, first, lateZ],
+    ]) {
+        await assert.rejects(
+            planDeliveryRoute({ candidates }),
+            (error: unknown) => {
+                assert.ok(error instanceof DeliveryRoutePlanningError);
+                assert.equal(error.code, 'route-window-span-exceeded');
+                assert.equal(error.deliveryRequestId, 'late-a');
+                assert.match(error.message, /Late A/);
+                return true;
+            },
+        );
+    }
 });

--- a/apps/delivery/lib/deliveryRouting.ts
+++ b/apps/delivery/lib/deliveryRouting.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import { formatDeliveryDateTime } from './deliveryFormatting';
 
 export type DeliveryCoordinates = {
     latitude: number;
@@ -58,6 +59,46 @@ export class DeliveryRoutePlanningError extends Error {
     ) {
         super(message);
     }
+}
+
+function routeStopLimitError(candidates: DeliveryRouteCandidate[]) {
+    const offendingCandidate = candidates[maximumDeliveryRouteStops];
+    const offendingAddress = offendingCandidate
+        ? ` Prva dostava izvan ograničenja je "${offendingCandidate.formattedAddress}".`
+        : '';
+
+    return new DeliveryRoutePlanningError(
+        `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} fizičkih stanica.${offendingAddress} Izdvoji je u zasebnu rutu.`,
+        'route-stop-limit-exceeded',
+        offendingCandidate?.deliveryRequestId,
+    );
+}
+
+function compareWindowSpanCandidates(
+    first: DeliveryRouteCandidate,
+    second: DeliveryRouteCandidate,
+) {
+    const endDifference =
+        (second.windowEndAt?.getTime() ?? Number.NEGATIVE_INFINITY) -
+        (first.windowEndAt?.getTime() ?? Number.NEGATIVE_INFINITY);
+    if (endDifference !== 0) return endDifference;
+
+    const startDifference =
+        (second.windowStartAt?.getTime() ?? Number.NEGATIVE_INFINITY) -
+        (first.windowStartAt?.getTime() ?? Number.NEGATIVE_INFINITY);
+    if (startDifference !== 0) return startDifference;
+
+    return first.deliveryRequestId.localeCompare(second.deliveryRequestId);
+}
+
+function windowSpanOffendingCandidate(candidates: DeliveryRouteCandidate[]) {
+    return [...candidates].sort(compareWindowSpanCandidates)[0];
+}
+
+function deliveryWindowDescription(candidate: DeliveryRouteCandidate) {
+    if (!candidate.windowStartAt || !candidate.windowEndAt) return null;
+
+    return `${formatDeliveryDateTime(candidate.windowStartAt.toISOString())} – ${formatDeliveryDateTime(candidate.windowEndAt.toISOString())}`;
 }
 
 function googleMapsServerApiKey() {
@@ -366,7 +407,9 @@ function scheduledArrival({
         arrivalTime > windowEndTime
     ) {
         throw new DeliveryRoutePlanningError(
-            'Odabrane dostave nije moguće obaviti unutar svih termina. Ukloni dio dostava ili izradi zasebnu rutu.',
+            `Dostavu za adresu "${stop.formattedAddress}" nije moguće stići unutar termina koji završava ${formatDeliveryDateTime(stop.windowEndAt?.toISOString() ?? null)}. Izdvoji je u zasebnu rutu ili promijeni redoslijed.`,
+            'arrival-window-infeasible',
+            stop.deliveryRequestId,
         );
     }
 
@@ -485,9 +528,7 @@ async function computeGoogleRoute({
     enforceTimeWindows: boolean;
 }): Promise<DeliveryRoutePlan> {
     if (stops.length > maximumDeliveryRouteStops) {
-        throw new Error(
-            `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} fizičkih stanica.`,
-        );
+        throw routeStopLimitError(stops);
     }
 
     const destinationIndex = optimize
@@ -650,9 +691,7 @@ export async function planDeliveryRoute({
         throw new Error('Nema dostava za planiranje rute.');
     }
     if (candidates.length > maximumDeliveryRouteStops) {
-        throw new Error(
-            `Jedna ruta može sadržavati najviše ${maximumDeliveryRouteStops} fizičkih stanica.`,
-        );
+        throw routeStopLimitError(candidates);
     }
     for (const candidate of candidates) {
         if (
@@ -663,7 +702,9 @@ export async function planDeliveryRoute({
             candidate.windowStartAt >= candidate.windowEndAt
         ) {
             throw new DeliveryRoutePlanningError(
-                'Jedna ili više odabranih dostava nema valjani termin.',
+                `Dostava za adresu "${candidate.formattedAddress}" nema valjani termin. Provjeri termin ili je izdvoji u zasebnu rutu.`,
+                'delivery-window-invalid',
+                candidate.deliveryRequestId,
             );
         }
     }
@@ -679,8 +720,19 @@ export async function planDeliveryRoute({
         latestWindowEnd - earliestWindowStart >
         maximumDeliveryRouteWindowHours * 60 * 60 * 1_000
     ) {
+        const offendingCandidate = windowSpanOffendingCandidate(candidates);
+        const offendingWindow = offendingCandidate
+            ? deliveryWindowDescription(offendingCandidate)
+            : null;
+        const offendingDelivery = offendingCandidate
+            ? ` Termin za adresu "${offendingCandidate.formattedAddress}"${
+                  offendingWindow ? ` (${offendingWindow})` : ''
+              } izlazi iz dopuštenog raspona.`
+            : '';
         throw new DeliveryRoutePlanningError(
-            `Jedna ruta može povezati termine unutar najviše ${maximumDeliveryRouteWindowHours} sata. Za udaljenije termine izradi zasebne rute.`,
+            `Jedna ruta može povezati termine unutar najviše ${maximumDeliveryRouteWindowHours} sata.${offendingDelivery} Izdvoji taj termin u zasebnu rutu.`,
+            'route-window-span-exceeded',
+            offendingCandidate?.deliveryRequestId,
         );
     }
 

--- a/apps/delivery/lib/deliveryRunPlanning.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunPlanning.node.spec.ts
@@ -1,0 +1,507 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    DeliveryRoutePlanningError,
+    maximumDeliveryRouteStops,
+} from './deliveryRouting';
+import {
+    type DeliveryRunPlanningDependencies,
+    type DeliveryRunPlanningRequest,
+    DeliveryRunPreparationError,
+    prepareDeliveryRun,
+    revalidatePreparedDeliveryRun,
+} from './deliveryRunPlanning';
+
+const now = new Date('2026-07-15T07:00:00.000Z');
+
+type CallCounters = {
+    activeRunReads: number;
+    requestReads: number;
+    assignmentReads: number;
+    plannerCalls: number;
+    mutationCalls: number;
+};
+
+function request({
+    id,
+    state = 'ready',
+    slotId = 1,
+    locationId = 10,
+    locationName = 'HQ Zagreb',
+    slotStartAt = '2026-07-15T08:00:00.000Z',
+    slotEndAt = '2026-07-15T10:00:00.000Z',
+    addressId = 100,
+    street1 = 'Ilica 1',
+    withAddress = true,
+    withSlot = true,
+}: {
+    id: string;
+    state?: string;
+    slotId?: number;
+    locationId?: number;
+    locationName?: string;
+    slotStartAt?: string;
+    slotEndAt?: string;
+    addressId?: number;
+    street1?: string;
+    withAddress?: boolean;
+    withSlot?: boolean;
+}): DeliveryRunPlanningRequest {
+    return {
+        id,
+        mode: 'delivery',
+        state,
+        address: withAddress
+            ? {
+                  id: addressId,
+                  street1,
+                  postalCode: '10000',
+                  city: 'Zagreb',
+                  countryCode: 'HR',
+              }
+            : undefined,
+        slot: withSlot
+            ? {
+                  id: slotId,
+                  locationId,
+                  startAt: new Date(slotStartAt),
+                  endAt: new Date(slotEndAt),
+                  location: {
+                      id: locationId,
+                      name: locationName,
+                      street1: `Lokacija ${locationId}`,
+                      postalCode: '10000',
+                      city: 'Zagreb',
+                      countryCode: 'HR',
+                  },
+              }
+            : undefined,
+    };
+}
+
+function planningDependencies({
+    requests,
+    activeRunId,
+    assignedRequestId,
+    planRoute,
+}: {
+    requests: DeliveryRunPlanningRequest[];
+    activeRunId?: string;
+    assignedRequestId?: string;
+    planRoute?: DeliveryRunPlanningDependencies['planRoute'];
+}) {
+    const counters: CallCounters = {
+        activeRunReads: 0,
+        requestReads: 0,
+        assignmentReads: 0,
+        plannerCalls: 0,
+        mutationCalls: 0,
+    };
+    const dependencies: DeliveryRunPlanningDependencies = {
+        getActiveRunForDriver: async () => {
+            counters.activeRunReads += 1;
+            return activeRunId ? { id: activeRunId } : undefined;
+        },
+        getRequests: async () => {
+            counters.requestReads += 1;
+            return requests;
+        },
+        getAssignedStops: async () => {
+            counters.assignmentReads += 1;
+            return assignedRequestId
+                ? [{ stop: { deliveryRequestId: assignedRequestId } }]
+                : [];
+        },
+        planRoute: async (input) => {
+            counters.plannerCalls += 1;
+            if (planRoute) return await planRoute(input);
+
+            return {
+                encodedPolyline: 'prepared-polyline',
+                totalDistanceMeters: input.candidates.length * 1_000,
+                totalDurationSeconds: input.candidates.length * 600,
+                stops: input.candidates.map((candidate, index) => ({
+                    ...candidate,
+                    latitude: 45.81 + index / 100,
+                    longitude: 15.97 + index / 100,
+                    sequence: index + 1,
+                    estimatedArrivalAt: new Date(
+                        now.getTime() + (index + 1) * 600_000,
+                    ),
+                    estimatedTravelSeconds: 600,
+                    estimatedDistanceMeters: 1_000,
+                })),
+            };
+        },
+        now: () => now,
+    };
+
+    return { dependencies, counters };
+}
+
+async function preparationError(
+    promise: Promise<unknown>,
+): Promise<DeliveryRunPreparationError> {
+    try {
+        await promise;
+    } catch (error) {
+        assert.ok(error instanceof DeliveryRunPreparationError);
+        return error;
+    }
+    assert.fail('Expected delivery run preparation to fail');
+}
+
+test('prepares a valid single-location run and expands every ready delivery at a bulk stop', async () => {
+    const requests = [
+        request({ id: 'bulk-one', addressId: 100 }),
+        request({ id: 'bulk-two', addressId: 100 }),
+        request({
+            id: 'later-stop',
+            slotId: 2,
+            slotStartAt: '2026-07-15T10:00:00.000Z',
+            slotEndAt: '2026-07-15T12:00:00.000Z',
+            addressId: 200,
+            street1: 'Vukovarska 2',
+        }),
+    ];
+    const { dependencies, counters } = planningDependencies({ requests });
+
+    const prepared = await prepareDeliveryRun(
+        {
+            driverUserId: 'driver-one',
+            deliveryRequestIds: ['bulk-one', 'later-stop'],
+        },
+        dependencies,
+    );
+
+    assert.equal(prepared.summary.deliveryCount, 3);
+    assert.equal(prepared.summary.stopCount, 2);
+    assert.equal(prepared.summary.slotCount, 2);
+    assert.deepEqual(
+        prepared.summary.pickupLocations.map((location) => location.id),
+        [10],
+    );
+    assert.equal(prepared.createRunInput.timeSlotId, 1);
+    assert.equal(prepared.createRunInput.totalDistanceMeters, 2_000);
+    assert.deepEqual(
+        prepared.createRunInput.stops.map((stop) => stop.deliveryRequestId),
+        ['bulk-one', 'bulk-two', 'later-stop'],
+    );
+    assert.deepEqual(
+        prepared.createRunInput.stops.map((stop) => stop.sequence),
+        [1, 2, 3],
+    );
+    assert.deepEqual(
+        prepared.requestSnapshots.map((snapshot) => snapshot.requestId),
+        ['bulk-one', 'bulk-two', 'later-stop'],
+    );
+    assert.deepEqual(counters, {
+        activeRunReads: 1,
+        requestReads: 1,
+        assignmentReads: 1,
+        plannerCalls: 1,
+        mutationCalls: 0,
+    });
+});
+
+test('revalidates an unchanged preparation immediately before persistence', async () => {
+    const requests = [request({ id: 'selected' })];
+    const { dependencies, counters } = planningDependencies({ requests });
+    const prepared = await prepareDeliveryRun(
+        {
+            driverUserId: 'driver-one',
+            deliveryRequestIds: ['selected'],
+        },
+        dependencies,
+    );
+
+    await revalidatePreparedDeliveryRun(prepared, dependencies);
+
+    assert.deepEqual(counters, {
+        activeRunReads: 2,
+        requestReads: 2,
+        assignmentReads: 2,
+        plannerCalls: 1,
+        mutationCalls: 0,
+    });
+});
+
+test('revalidation rejects a request that changed while its route was planned', async () => {
+    const selected = request({ id: 'selected' });
+    const requests = [selected];
+    const { dependencies, counters } = planningDependencies({ requests });
+    const prepared = await prepareDeliveryRun(
+        {
+            driverUserId: 'driver-one',
+            deliveryRequestIds: ['selected'],
+        },
+        dependencies,
+    );
+    selected.state = 'cancelled';
+
+    const error = await preparationError(
+        revalidatePreparedDeliveryRun(prepared, dependencies),
+    );
+
+    assert.equal(error.code, 'delivery-selection-changed');
+    assert.equal(error.conflict.deliveryRequestId, 'selected');
+    assert.equal(counters.plannerCalls, 1);
+    assert.equal(counters.mutationCalls, 0);
+});
+
+test('revalidation rejects a newly ready member of a prepared bulk stop', async () => {
+    const requests = [request({ id: 'bulk-one' })];
+    const { dependencies, counters } = planningDependencies({ requests });
+    const prepared = await prepareDeliveryRun(
+        {
+            driverUserId: 'driver-one',
+            deliveryRequestIds: ['bulk-one'],
+        },
+        dependencies,
+    );
+    requests.push(request({ id: 'bulk-two' }));
+
+    const error = await preparationError(
+        revalidatePreparedDeliveryRun(prepared, dependencies),
+    );
+
+    assert.equal(error.code, 'delivery-bulk-selection-changed');
+    assert.equal(error.conflict.deliveryRequestId, 'bulk-two');
+    assert.equal(counters.plannerCalls, 1);
+    assert.equal(counters.mutationCalls, 0);
+});
+
+test('rejects an active driver before reading or planning a new selection', async () => {
+    const { dependencies, counters } = planningDependencies({
+        requests: [request({ id: 'selected' })],
+        activeRunId: 'active-run',
+    });
+
+    const error = await preparationError(
+        prepareDeliveryRun(
+            {
+                driverUserId: 'driver-one',
+                deliveryRequestIds: ['selected'],
+            },
+            dependencies,
+        ),
+    );
+
+    assert.equal(error.code, 'active-run-exists');
+    assert.equal(error.conflict.activeRunId, 'active-run');
+    assert.deepEqual(counters, {
+        activeRunReads: 1,
+        requestReads: 0,
+        assignmentReads: 0,
+        plannerCalls: 0,
+        mutationCalls: 0,
+    });
+});
+
+test('rejects unavailable selections before assignment checks or route planning', async (context) => {
+    const cases = [
+        {
+            name: 'not ready',
+            selected: request({ id: 'selected', state: 'preparing' }),
+        },
+        {
+            name: 'missing address',
+            selected: request({ id: 'selected', withAddress: false }),
+        },
+        {
+            name: 'missing slot',
+            selected: request({ id: 'selected', withSlot: false }),
+        },
+        {
+            name: 'expired slot',
+            selected: request({
+                id: 'selected',
+                slotStartAt: '2026-07-15T04:00:00.000Z',
+                slotEndAt: '2026-07-15T06:00:00.000Z',
+            }),
+        },
+    ];
+
+    for (const testCase of cases) {
+        await context.test(testCase.name, async () => {
+            const { dependencies, counters } = planningDependencies({
+                requests: [testCase.selected],
+            });
+            const error = await preparationError(
+                prepareDeliveryRun(
+                    {
+                        driverUserId: 'driver-one',
+                        deliveryRequestIds: ['selected'],
+                    },
+                    dependencies,
+                ),
+            );
+
+            assert.equal(error.code, 'delivery-not-ready');
+            assert.equal(error.conflict.deliveryRequestId, 'selected');
+            assert.equal(counters.assignmentReads, 0);
+            assert.equal(counters.plannerCalls, 0);
+            assert.equal(counters.mutationCalls, 0);
+        });
+    }
+});
+
+test('rejects mixed pickup locations through the shared policy before the planner', async () => {
+    const requests = [
+        request({ id: 'hq', locationId: 10, locationName: 'HQ Zagreb' }),
+        request({
+            id: 'east',
+            slotId: 2,
+            locationId: 20,
+            locationName: 'Istočno skladište',
+            addressId: 200,
+            street1: 'Vukovarska 2',
+        }),
+    ];
+    const { dependencies, counters } = planningDependencies({ requests });
+
+    const error = await preparationError(
+        prepareDeliveryRun(
+            {
+                driverUserId: 'driver-one',
+                deliveryRequestIds: ['hq', 'east'],
+            },
+            dependencies,
+        ),
+    );
+
+    assert.equal(error.code, 'mixed-pickup-locations');
+    assert.equal(error.conflict.deliveryRequestId, 'east');
+    assert.deepEqual(error.conflict.selection?.conflictingRequestIds, ['east']);
+    assert.deepEqual(
+        error.conflict.selection?.pickupLocations.map(
+            (location) => location.id,
+        ),
+        [10, 20],
+    );
+    assert.equal(counters.assignmentReads, 0);
+    assert.equal(counters.plannerCalls, 0);
+    assert.equal(counters.mutationCalls, 0);
+});
+
+test('rejects selections whose combined window exceeds the shared route span', async () => {
+    const requests = [
+        request({ id: 'today' }),
+        request({
+            id: 'tomorrow',
+            slotId: 2,
+            slotStartAt: '2026-07-16T09:00:01.000Z',
+            slotEndAt: '2026-07-16T11:00:01.000Z',
+            addressId: 200,
+            street1: 'Vukovarska 2',
+        }),
+    ];
+    const { dependencies, counters } = planningDependencies({ requests });
+
+    const error = await preparationError(
+        prepareDeliveryRun(
+            {
+                driverUserId: 'driver-one',
+                deliveryRequestIds: ['today', 'tomorrow'],
+            },
+            dependencies,
+        ),
+    );
+
+    assert.equal(error.code, 'route-window-span-exceeded');
+    assert.equal(error.conflict.deliveryRequestId, 'tomorrow');
+    assert.equal(counters.assignmentReads, 0);
+    assert.equal(counters.plannerCalls, 0);
+    assert.equal(counters.mutationCalls, 0);
+});
+
+test('rejects a selection beyond the shared physical-stop limit before the planner', async () => {
+    const requests = Array.from(
+        { length: maximumDeliveryRouteStops + 1 },
+        (_value, index) =>
+            request({
+                id: `request-${index}`,
+                addressId: 100 + index,
+                street1: `Adresa ${index}`,
+            }),
+    );
+    const { dependencies, counters } = planningDependencies({ requests });
+
+    const error = await preparationError(
+        prepareDeliveryRun(
+            {
+                driverUserId: 'driver-one',
+                deliveryRequestIds: requests.map((item) => item.id),
+            },
+            dependencies,
+        ),
+    );
+
+    assert.equal(error.code, 'route-stop-limit-exceeded');
+    assert.equal(
+        error.conflict.deliveryRequestId,
+        `request-${maximumDeliveryRouteStops}`,
+    );
+    assert.equal(
+        error.conflict.selection?.separateRouteRequestIds.length,
+        maximumDeliveryRouteStops,
+    );
+    assert.equal(counters.assignmentReads, 0);
+    assert.equal(counters.plannerCalls, 0);
+    assert.equal(counters.mutationCalls, 0);
+});
+
+test('rejects an assigned bulk member before route planning', async () => {
+    const requests = [request({ id: 'bulk-one' }), request({ id: 'bulk-two' })];
+    const { dependencies, counters } = planningDependencies({
+        requests,
+        assignedRequestId: 'bulk-two',
+    });
+
+    const error = await preparationError(
+        prepareDeliveryRun(
+            {
+                driverUserId: 'driver-one',
+                deliveryRequestIds: ['bulk-one'],
+            },
+            dependencies,
+        ),
+    );
+
+    assert.equal(error.code, 'delivery-already-assigned');
+    assert.equal(error.conflict.deliveryRequestId, 'bulk-two');
+    assert.equal(counters.plannerCalls, 0);
+    assert.equal(counters.mutationCalls, 0);
+});
+
+test('enriches a route-planning conflict with its selected address, slot, and pickup location', async () => {
+    const selected = request({ id: 'unmapped-address' });
+    const { dependencies, counters } = planningDependencies({
+        requests: [selected],
+        planRoute: async () => {
+            throw new DeliveryRoutePlanningError(
+                'Adresu dostave nije moguće pronaći.',
+                'delivery-address-not-found',
+                'unmapped-address',
+            );
+        },
+    });
+
+    const error = await preparationError(
+        prepareDeliveryRun(
+            {
+                driverUserId: 'driver-one',
+                deliveryRequestIds: ['unmapped-address'],
+            },
+            dependencies,
+        ),
+    );
+
+    assert.equal(error.code, 'delivery-address-not-found');
+    assert.equal(error.conflict.deliveryRequestId, 'unmapped-address');
+    assert.equal(error.conflict.deliveryAddress, 'Ilica 1, 10000 Zagreb, HR');
+    assert.equal(error.conflict.slot?.id, 1);
+    assert.equal(error.conflict.pickupLocation?.id, 10);
+    assert.equal(counters.plannerCalls, 1);
+    assert.equal(counters.mutationCalls, 0);
+});

--- a/apps/delivery/lib/deliveryRunPlanning.ts
+++ b/apps/delivery/lib/deliveryRunPlanning.ts
@@ -1,0 +1,587 @@
+import {
+    DeliveryRequestStates,
+    getActiveDeliveryRunForDriver,
+    getDeliveryRequestsWithEvents,
+    getDeliveryRunStopsForRequestIds,
+} from '@gredice/storage';
+import 'server-only';
+import type {
+    DeliveryRouteSelectionCandidate,
+    DeliveryRouteSelectionConflict,
+    DeliveryRouteSelectionSummary,
+} from './deliveryRouteSelection';
+import { inspectDeliveryRouteSelection } from './deliveryRouteSelection';
+import {
+    DeliveryRoutePlanningError,
+    formatDeliveryDestinationAddress,
+    formatDeliveryGeocodingAddress,
+    maximumDeliveryRouteStops,
+    maximumDeliveryRouteWindowHours,
+    planDeliveryRoute,
+} from './deliveryRouting';
+import {
+    buildDeliveryStopKey,
+    groupByDeliveryStop,
+} from './deliveryStopGrouping';
+
+type DeliveryRunPlanningAddress = {
+    id: number;
+    street1: string;
+    street2?: string | null;
+    postalCode: string;
+    city: string;
+    countryCode: string;
+};
+
+type DeliveryRunPlanningPickupLocation = {
+    id: number;
+    name: string;
+    street1: string;
+    street2?: string | null;
+    postalCode: string;
+    city: string;
+    countryCode: string;
+};
+
+export type DeliveryRunPlanningRequest = {
+    id: string;
+    mode?: string;
+    state: string;
+    address?: DeliveryRunPlanningAddress;
+    slot?: {
+        id: number;
+        locationId: number;
+        startAt: Date;
+        endAt: Date;
+        location?: DeliveryRunPlanningPickupLocation | null;
+    };
+};
+
+type AssignedDeliveryRunStop = {
+    stop: {
+        deliveryRequestId: string;
+    };
+};
+
+export type DeliveryRunPlanningDependencies = {
+    getActiveRunForDriver: (
+        driverUserId: string,
+    ) => Promise<{ id: string } | undefined>;
+    getRequests: () => Promise<readonly DeliveryRunPlanningRequest[]>;
+    getAssignedStops: (
+        requestIds: string[],
+    ) => Promise<readonly AssignedDeliveryRunStop[]>;
+    planRoute: typeof planDeliveryRoute;
+    now: () => Date;
+};
+
+const defaultDependencies: DeliveryRunPlanningDependencies = {
+    getActiveRunForDriver: getActiveDeliveryRunForDriver,
+    getRequests: getDeliveryRequestsWithEvents,
+    getAssignedStops: getDeliveryRunStopsForRequestIds,
+    planRoute: planDeliveryRoute,
+    now: () => new Date(),
+};
+
+export type DeliveryRunPreparationConflict = {
+    code: string;
+    deliveryRequestId?: string;
+    activeRunId?: string;
+    stopKey?: string;
+    deliveryAddress?: string;
+    slot?: {
+        id: number;
+        startAt: string;
+        endAt: string;
+    };
+    pickupLocation?: {
+        id: number;
+        name: string | null;
+        address: string | null;
+    };
+    selection?: DeliveryRouteSelectionConflict;
+};
+
+export class DeliveryRunPreparationError extends Error {
+    override name = 'DeliveryRunPreparationError';
+
+    constructor(
+        message: string,
+        readonly conflict: DeliveryRunPreparationConflict,
+    ) {
+        super(message);
+    }
+
+    get code() {
+        return this.conflict.code;
+    }
+}
+
+export type DeliveryRunRequestSnapshot = {
+    requestId: string;
+    state: string;
+    stopKey: string;
+    addressId: number;
+    slotId: number;
+    pickupLocationId: number;
+    slotStartAt: string;
+    slotEndAt: string;
+};
+
+export type PreparedDeliveryRunStop = {
+    deliveryRequestId: string;
+    sequence: number;
+    latitude: number;
+    longitude: number;
+    formattedAddress: string;
+    estimatedArrivalAt: Date;
+    estimatedTravelSeconds: number;
+    estimatedDistanceMeters: number;
+};
+
+export type DeliveryRunPreflightSummary = DeliveryRouteSelectionSummary & {
+    slotCount: number;
+    totalDistanceMeters: number;
+    totalDurationSeconds: number;
+};
+
+export type PreparedDeliveryRun = {
+    createRunInput: {
+        driverUserId: string;
+        timeSlotId: number;
+        encodedPolyline?: string;
+        totalDistanceMeters: number;
+        totalDurationSeconds: number;
+        stops: PreparedDeliveryRunStop[];
+    };
+    summary: DeliveryRunPreflightSummary;
+    requestSnapshots: DeliveryRunRequestSnapshot[];
+};
+
+function sameRequestIds(first: readonly string[], second: readonly string[]) {
+    if (first.length !== second.length) return false;
+    const secondIds = new Set(second);
+    return first.every((requestId) => secondIds.has(requestId));
+}
+
+function stopKey(request: DeliveryRunPlanningRequest) {
+    if (!request.slot || !request.address) {
+        return `request:${request.id}`;
+    }
+    return buildDeliveryStopKey(
+        request.slot.id,
+        formatDeliveryDestinationAddress(request.address),
+    );
+}
+
+function pickupAddress(
+    location: DeliveryRunPlanningPickupLocation | null | undefined,
+) {
+    return location ? formatDeliveryDestinationAddress(location) : null;
+}
+
+function selectionCandidate(
+    request: DeliveryRunPlanningRequest,
+): DeliveryRouteSelectionCandidate | null {
+    if (!request.slot || !request.address) return null;
+
+    return {
+        requestId: request.id,
+        stopKey: stopKey(request),
+        readyForPickup: request.state === DeliveryRequestStates.READY,
+        pickupLocationId: request.slot.locationId,
+        pickupLocationName: request.slot.location?.name ?? null,
+        pickupAddress: pickupAddress(request.slot.location),
+        slotId: request.slot.id,
+        slotStartAt: request.slot.startAt.toISOString(),
+        slotEndAt: request.slot.endAt.toISOString(),
+        deliveryAddress: formatDeliveryDestinationAddress(request.address),
+    };
+}
+
+function requestConflict(
+    code: string,
+    request: DeliveryRunPlanningRequest | undefined,
+): DeliveryRunPreparationConflict {
+    const candidate = request ? selectionCandidate(request) : null;
+    return {
+        code,
+        deliveryRequestId: request?.id,
+        stopKey: candidate?.stopKey,
+        deliveryAddress: candidate?.deliveryAddress,
+        slot: request?.slot
+            ? {
+                  id: request.slot.id,
+                  startAt: request.slot.startAt.toISOString(),
+                  endAt: request.slot.endAt.toISOString(),
+              }
+            : undefined,
+        pickupLocation: request?.slot
+            ? {
+                  id: request.slot.locationId,
+                  name: request.slot.location?.name ?? null,
+                  address: pickupAddress(request.slot.location),
+              }
+            : undefined,
+    };
+}
+
+function selectionPreparationError(
+    conflict: DeliveryRouteSelectionConflict,
+    requestsById: ReadonlyMap<string, DeliveryRunPlanningRequest>,
+) {
+    const conflictingRequestId = conflict.conflictingRequestIds[0];
+    const request = conflictingRequestId
+        ? requestsById.get(conflictingRequestId)
+        : undefined;
+    return new DeliveryRunPreparationError(conflict.message, {
+        ...requestConflict(conflict.code, request),
+        selection: conflict,
+    });
+}
+
+function routePreparationError(
+    error: DeliveryRoutePlanningError,
+    requestsById: ReadonlyMap<string, DeliveryRunPlanningRequest>,
+) {
+    const request = error.deliveryRequestId
+        ? requestsById.get(error.deliveryRequestId)
+        : undefined;
+    return new DeliveryRunPreparationError(
+        error.message,
+        requestConflict(error.code, request),
+    );
+}
+
+function assertSelectedRequest(
+    requestId: string,
+    request: DeliveryRunPlanningRequest | undefined,
+    now: Date,
+) {
+    if (
+        request?.mode !== 'delivery' ||
+        !request.address ||
+        !request.slot ||
+        request.state !== DeliveryRequestStates.READY ||
+        request.slot.endAt < now
+    ) {
+        throw new DeliveryRunPreparationError(
+            'Jedna ili više odabranih dostava još nije spremna za preuzimanje. Osvježi popis i pokušaj ponovno.',
+            requestConflict(
+                'delivery-not-ready',
+                request ?? { id: requestId, state: '' },
+            ),
+        );
+    }
+}
+
+export async function prepareDeliveryRun(
+    {
+        driverUserId,
+        deliveryRequestIds,
+    }: {
+        driverUserId: string;
+        deliveryRequestIds: string[];
+    },
+    dependencies: DeliveryRunPlanningDependencies = defaultDependencies,
+): Promise<PreparedDeliveryRun> {
+    const existingRun = await dependencies.getActiveRunForDriver(driverUserId);
+    if (existingRun) {
+        throw new DeliveryRunPreparationError(
+            'Već imaš aktivnu rutu. Osvježi prikaz i nastavi postojeću rutu.',
+            {
+                code: 'active-run-exists',
+                activeRunId: existingRun.id,
+            },
+        );
+    }
+
+    const uniqueRequestIds = Array.from(new Set(deliveryRequestIds));
+    if (
+        uniqueRequestIds.length === 0 ||
+        uniqueRequestIds.length !== deliveryRequestIds.length
+    ) {
+        throw new DeliveryRunPreparationError(
+            'Odaberi barem jednu valjanu dostavu.',
+            { code: 'invalid-selection' },
+        );
+    }
+
+    const requests = await dependencies.getRequests();
+    const requestsById = new Map(
+        requests.map((request) => [request.id, request]),
+    );
+    const now = dependencies.now();
+    const selectedStopKeys = new Set<string>();
+    for (const requestId of uniqueRequestIds) {
+        const request = requestsById.get(requestId);
+        assertSelectedRequest(requestId, request, now);
+        if (request) selectedStopKeys.add(stopKey(request));
+    }
+
+    const candidates = requests.filter(
+        (request) =>
+            request.mode === 'delivery' &&
+            request.address &&
+            request.slot &&
+            request.state === DeliveryRequestStates.READY &&
+            request.slot.endAt >= now &&
+            selectedStopKeys.has(stopKey(request)),
+    );
+    const normalizedCandidates = candidates.flatMap((request) => {
+        const candidate = selectionCandidate(request);
+        return candidate ? [candidate] : [];
+    });
+    const inspection = inspectDeliveryRouteSelection({
+        candidates: normalizedCandidates,
+        requestIds: normalizedCandidates.map(
+            (candidate) => candidate.requestId,
+        ),
+        maximumRouteStops: maximumDeliveryRouteStops,
+        maximumRouteWindowHours: maximumDeliveryRouteWindowHours,
+    });
+    if (inspection.conflict) {
+        throw selectionPreparationError(inspection.conflict, requestsById);
+    }
+
+    const existingStops = await dependencies.getAssignedStops(
+        normalizedCandidates.map((candidate) => candidate.requestId),
+    );
+    if (existingStops.length > 0) {
+        const assignedRequestId = existingStops[0]?.stop.deliveryRequestId;
+        throw new DeliveryRunPreparationError(
+            'Jedna ili više odabranih dostava već je dodijeljena drugoj ruti. Osvježi popis i odaberi ponovno.',
+            requestConflict(
+                'delivery-already-assigned',
+                assignedRequestId
+                    ? requestsById.get(assignedRequestId)
+                    : undefined,
+            ),
+        );
+    }
+
+    const candidateGroups = groupByDeliveryStop(
+        candidates.map((request) => ({ request, stopKey: stopKey(request) })),
+    );
+    const groupsByRepresentativeId = new Map<
+        string,
+        (typeof candidateGroups)[number]
+    >();
+    let plan: Awaited<ReturnType<typeof planDeliveryRoute>>;
+    try {
+        plan = await dependencies.planRoute({
+            candidates: candidateGroups.map((group) => {
+                const representative = group.items[0]?.request;
+                if (!representative?.address || !representative.slot) {
+                    throw new DeliveryRunPreparationError(
+                        'Odabrana dostava nema valjanu adresu ili termin.',
+                        requestConflict(
+                            'delivery-address-or-slot-invalid',
+                            representative,
+                        ),
+                    );
+                }
+                groupsByRepresentativeId.set(representative.id, group);
+                return {
+                    deliveryRequestId: representative.id,
+                    formattedAddress: formatDeliveryDestinationAddress(
+                        representative.address,
+                    ),
+                    geocodingAddress: formatDeliveryGeocodingAddress(
+                        representative.address,
+                    ),
+                    windowStartAt: representative.slot.startAt,
+                    windowEndAt: representative.slot.endAt,
+                };
+            }),
+            departureTime: now,
+        });
+    } catch (error) {
+        if (error instanceof DeliveryRoutePlanningError) {
+            throw routePreparationError(error, requestsById);
+        }
+        throw error;
+    }
+
+    const primarySlot = candidates
+        .flatMap((request) => (request.slot ? [request.slot] : []))
+        .sort(
+            (first, second) =>
+                first.startAt.getTime() - second.startAt.getTime(),
+        )[0];
+    if (!primarySlot) {
+        throw new DeliveryRunPreparationError(
+            'Odabrane dostave nemaju valjani termin.',
+            { code: 'delivery-slot-invalid' },
+        );
+    }
+
+    let storedSequence = 0;
+    const storedStops = plan.stops.flatMap((plannedStop) => {
+        const group = groupsByRepresentativeId.get(
+            plannedStop.deliveryRequestId,
+        );
+        if (!group) {
+            throw new DeliveryRunPreparationError(
+                'Planirana dostavna stanica nije pronađena.',
+                {
+                    code: 'planned-stop-not-found',
+                    deliveryRequestId: plannedStop.deliveryRequestId,
+                },
+            );
+        }
+
+        return group.items.map(({ request }) => {
+            storedSequence += 1;
+            return {
+                deliveryRequestId: request.id,
+                sequence: storedSequence,
+                latitude: plannedStop.latitude,
+                longitude: plannedStop.longitude,
+                formattedAddress: plannedStop.formattedAddress,
+                estimatedArrivalAt: plannedStop.estimatedArrivalAt,
+                estimatedTravelSeconds: plannedStop.estimatedTravelSeconds,
+                estimatedDistanceMeters: plannedStop.estimatedDistanceMeters,
+            };
+        });
+    });
+    const snapshots = candidates.flatMap((request) => {
+        const candidate = selectionCandidate(request);
+        return request.slot && request.address && candidate
+            ? [
+                  {
+                      requestId: request.id,
+                      state: request.state,
+                      stopKey: candidate.stopKey,
+                      addressId: request.address.id,
+                      slotId: request.slot.id,
+                      pickupLocationId: request.slot.locationId,
+                      slotStartAt: request.slot.startAt.toISOString(),
+                      slotEndAt: request.slot.endAt.toISOString(),
+                  },
+              ]
+            : [];
+    });
+
+    return {
+        createRunInput: {
+            driverUserId,
+            timeSlotId: primarySlot.id,
+            encodedPolyline: plan.encodedPolyline,
+            totalDistanceMeters: plan.totalDistanceMeters,
+            totalDurationSeconds: plan.totalDurationSeconds,
+            stops: storedStops,
+        },
+        summary: {
+            ...inspection.summary,
+            slotCount: inspection.summary.slots.length,
+            totalDistanceMeters: plan.totalDistanceMeters,
+            totalDurationSeconds: plan.totalDurationSeconds,
+        },
+        requestSnapshots: snapshots,
+    };
+}
+
+export async function revalidatePreparedDeliveryRun(
+    preparation: PreparedDeliveryRun,
+    dependencies: DeliveryRunPlanningDependencies = defaultDependencies,
+) {
+    const existingRun = await dependencies.getActiveRunForDriver(
+        preparation.createRunInput.driverUserId,
+    );
+    if (existingRun) {
+        throw new DeliveryRunPreparationError(
+            'Već imaš aktivnu rutu. Osvježi prikaz i nastavi postojeću rutu.',
+            {
+                code: 'active-run-exists',
+                activeRunId: existingRun.id,
+            },
+        );
+    }
+
+    const requests = await dependencies.getRequests();
+    const requestsById = new Map(
+        requests.map((request) => [request.id, request]),
+    );
+    const now = dependencies.now();
+    const selectedStopKeys = new Set(
+        preparation.requestSnapshots.map((snapshot) => snapshot.stopKey),
+    );
+
+    for (const snapshot of preparation.requestSnapshots) {
+        const request = requestsById.get(snapshot.requestId);
+        const candidate = request ? selectionCandidate(request) : null;
+        if (
+            request?.mode !== 'delivery' ||
+            request.state !== snapshot.state ||
+            request.state !== DeliveryRequestStates.READY ||
+            !request.address ||
+            request.address.id !== snapshot.addressId ||
+            !request.slot ||
+            request.slot.endAt < now ||
+            request.slot.id !== snapshot.slotId ||
+            request.slot.locationId !== snapshot.pickupLocationId ||
+            request.slot.startAt.toISOString() !== snapshot.slotStartAt ||
+            request.slot.endAt.toISOString() !== snapshot.slotEndAt ||
+            candidate?.stopKey !== snapshot.stopKey
+        ) {
+            throw new DeliveryRunPreparationError(
+                'Odabrane dostave promijenile su se tijekom provjere rute. Osvježi popis i pokušaj ponovno.',
+                requestConflict(
+                    'delivery-selection-changed',
+                    request ?? { id: snapshot.requestId, state: '' },
+                ),
+            );
+        }
+    }
+
+    const currentBulkRequestIds = requests.flatMap((request) => {
+        if (
+            request.mode !== 'delivery' ||
+            request.state !== DeliveryRequestStates.READY ||
+            !request.address ||
+            !request.slot ||
+            request.slot.endAt < now ||
+            !selectedStopKeys.has(stopKey(request))
+        ) {
+            return [];
+        }
+        return [request.id];
+    });
+    const snapshotRequestIds = preparation.requestSnapshots.map(
+        (snapshot) => snapshot.requestId,
+    );
+    if (!sameRequestIds(currentBulkRequestIds, snapshotRequestIds)) {
+        const changedRequestId =
+            currentBulkRequestIds.find(
+                (requestId) => !snapshotRequestIds.includes(requestId),
+            ) ??
+            snapshotRequestIds.find(
+                (requestId) => !currentBulkRequestIds.includes(requestId),
+            );
+        throw new DeliveryRunPreparationError(
+            'Skupna stanica promijenila se tijekom provjere rute. Osvježi popis kako nijedan spreman urod ne bi ostao iza.',
+            requestConflict(
+                'delivery-bulk-selection-changed',
+                changedRequestId
+                    ? requestsById.get(changedRequestId)
+                    : undefined,
+            ),
+        );
+    }
+
+    const assignedStops =
+        await dependencies.getAssignedStops(snapshotRequestIds);
+    if (assignedStops.length > 0) {
+        const assignedRequestId = assignedStops[0]?.stop.deliveryRequestId;
+        throw new DeliveryRunPreparationError(
+            'Jedna ili više odabranih dostava već je dodijeljena drugoj ruti. Osvježi popis i odaberi ponovno.',
+            requestConflict(
+                'delivery-already-assigned',
+                assignedRequestId
+                    ? requestsById.get(assignedRequestId)
+                    : undefined,
+            ),
+        );
+    }
+}

--- a/apps/delivery/lib/harvestTraceScan.node.spec.ts
+++ b/apps/delivery/lib/harvestTraceScan.node.spec.ts
@@ -5,6 +5,10 @@ import type {
     DeliveryStopDeliverySummary,
 } from './deliveryDashboardTypes';
 import {
+    applyDeliveryRouteSelection,
+    type DeliveryRouteSelectionCandidate,
+} from './deliveryRouteSelection';
+import {
     normalizeHarvestTraceScanValue,
     selectDeliveryStopFromHarvestTrace,
     verifyDeliveryStopHarvestTrace,
@@ -211,6 +215,77 @@ test('accumulates delivery stops across consecutive live scans', () => {
         'two',
         'three',
     ]);
+});
+
+test('keeps the current QR selection when a live scan belongs to another pickup location', () => {
+    const orders = [
+        order({ requestId: 'one', stopKey: 'slot:1', token: firstToken }),
+        order({ requestId: 'two', stopKey: 'slot:2', token: secondToken }),
+    ];
+    const candidates: DeliveryRouteSelectionCandidate[] = [
+        {
+            requestId: 'one',
+            stopKey: 'slot:1',
+            readyForPickup: true,
+            pickupLocationId: 1,
+            pickupLocationName: 'Sjedište',
+            pickupAddress: 'Prva 1, Zagreb',
+            slotId: 1,
+            slotStartAt: '2026-07-15T08:00:00.000Z',
+            slotEndAt: '2026-07-15T10:00:00.000Z',
+            deliveryAddress: 'Kupac 1, Zagreb',
+        },
+        {
+            requestId: 'two',
+            stopKey: 'slot:2',
+            readyForPickup: true,
+            pickupLocationId: 2,
+            pickupLocationName: 'Drugo skladište',
+            pickupAddress: 'Druga 2, Zagreb',
+            slotId: 2,
+            slotStartAt: '2026-07-15T08:00:00.000Z',
+            slotEndAt: '2026-07-15T10:00:00.000Z',
+            deliveryAddress: 'Kupac 2, Zagreb',
+        },
+    ];
+    const firstScan = selectDeliveryStopFromHarvestTrace({
+        orders,
+        selectedRequestIds: [],
+        maximumRouteStops: 26,
+        scanValue: firstToken,
+    });
+    assert.equal(firstScan.status, 'selected');
+    if (firstScan.status !== 'selected') return;
+    const firstSelection = applyDeliveryRouteSelection({
+        candidates,
+        currentRequestIds: [],
+        nextRequestIds: firstScan.nextSelectedRequestIds,
+        maximumRouteStops: 26,
+        maximumRouteWindowHours: 24,
+    });
+    assert.equal(firstSelection.status, 'accepted');
+    if (firstSelection.status !== 'accepted') return;
+
+    const secondScan = selectDeliveryStopFromHarvestTrace({
+        orders,
+        selectedRequestIds: firstSelection.requestIds,
+        maximumRouteStops: 26,
+        scanValue: secondToken,
+    });
+    assert.equal(secondScan.status, 'selected');
+    if (secondScan.status !== 'selected') return;
+    const secondSelection = applyDeliveryRouteSelection({
+        candidates,
+        currentRequestIds: firstSelection.requestIds,
+        nextRequestIds: secondScan.nextSelectedRequestIds,
+        maximumRouteStops: 26,
+        maximumRouteWindowHours: 24,
+    });
+
+    assert.equal(secondSelection.status, 'rejected');
+    if (secondSelection.status !== 'rejected') return;
+    assert.equal(secondSelection.conflict.code, 'mixed-pickup-locations');
+    assert.deepEqual(secondSelection.requestIds, ['one']);
 });
 
 test('reports duplicate, unavailable, ambiguous, and route-limit scans', () => {

--- a/apps/delivery/lib/harvestTraceScan.ts
+++ b/apps/delivery/lib/harvestTraceScan.ts
@@ -2,6 +2,7 @@ import type {
     DeliveryRouteOrderSummary,
     DeliveryStopDeliverySummary,
 } from './deliveryDashboardTypes';
+import type { DeliveryRouteSelectionConflict } from './deliveryRouteSelection';
 
 const harvestTraceTokenPattern = /^[A-Za-z0-9_-]{16,96}$/;
 const harvestTraceBaseUrl = 'https://www.gredice.com';
@@ -68,6 +69,13 @@ export type HarvestTraceSelectionResult =
       }
     | ({ status: 'already-selected' } & HarvestTraceSelectionContext)
     | ({ status: 'limit-reached' } & HarvestTraceSelectionContext)
+    | ({
+          status: 'route-conflict';
+          message: string;
+          code: DeliveryRouteSelectionConflict['code'];
+          conflictingRequestIds: string[];
+          separateRouteRequestIds: string[];
+      } & HarvestTraceSelectionContext)
     | ({
           status: 'selected';
           nextSelectedRequestIds: string[];


### PR DESCRIPTION
## Summary

- apply one shared route-selection policy to manual, bulk, select-all, and live QR pickup flows
- show pickup-location, slot, physical-stop, and route-window conflicts with in-context recovery actions
- add a read-only server preflight and revalidate request state, bulk membership, slot, address, pickup location, and assignment immediately before run persistence
- return actionable, structured route-planning errors without logging private delivery addresses

## Validation

- `corepack pnpm --filter delivery test` — 57 passed
- `corepack pnpm typecheck --filter delivery`
- `corepack pnpm --filter delivery exec biome check .`
- `corepack pnpm build --filter delivery`
- `git diff --check`
- independent architecture and driver-flow reviews — no findings

## Follow-up boundary

Durable atomic request-version reservation and reuse of the private prepared Maps plan are tracked in #4122, which owns pickup-node/run persistence. This PR performs an immediate authoritative re-read before the existing transactional run creation.

Closes #4121
