### PR TITLE
feat(farm): compose Today work data

### DIFF
--- a/apps/farm/app/farmTodayData.ts
+++ b/apps/farm/app/farmTodayData.ts
@@ -1,0 +1,119 @@
+import 'server-only';
+
+import { getFarmsForUser, getTimeZoneDateKey } from '@gredice/storage';
+import { cache } from 'react';
+import {
+    composeFarmTodayData,
+    type FarmTodayData,
+    type FarmTodayOperationsSourceData,
+    type FarmTodaySource,
+} from './farmTodayModel';
+import {
+    getFarmScheduleOperationsData,
+    getFarmScheduleOperationsForDay,
+    getFarmSchedulePendingOperations,
+    getFarmSchedulePlantingsDayData,
+    getFarmSchedulePlantSorts,
+} from './schedule/scheduleData';
+import { FARM_SCHEDULE_TIME_ZONE } from './schedule/scheduleShared';
+
+function toSource<T>(result: PromiseSettledResult<T>): FarmTodaySource<T> {
+    return result.status === 'fulfilled'
+        ? { status: 'ready', data: result.value }
+        : { status: 'unavailable' };
+}
+
+function logRejectedSource(
+    source: string,
+    result: PromiseSettledResult<unknown>,
+) {
+    if (result.status === 'rejected') {
+        console.error(`[Farm Today] ${source} unavailable`, result.reason);
+    }
+}
+
+export const getFarmTodayData = cache(
+    async (userId: string): Promise<FarmTodayData> => {
+        const referenceDate = new Date();
+        const dateKey = getTimeZoneDateKey(
+            referenceDate,
+            FARM_SCHEDULE_TIME_ZONE,
+        );
+
+        const farmsResult = await Promise.allSettled([getFarmsForUser(userId)]);
+        logRejectedSource('farms', farmsResult[0]);
+        const farms = toSource(farmsResult[0]);
+
+        if (farms.status === 'unavailable') {
+            return {
+                dataIssues: ['farmsUnavailable'],
+                dateKey,
+                status: 'unavailable',
+            };
+        }
+
+        if (farms.data.length === 0) {
+            return {
+                dataIssues: [],
+                dateKey,
+                status: 'noFarm',
+            };
+        }
+
+        const [
+            plantingsResult,
+            scheduledOperationsResult,
+            pendingOperationsResult,
+            plantSortsResult,
+            operationDefinitionsResult,
+        ] = await Promise.allSettled([
+            getFarmSchedulePlantingsDayData(userId, dateKey, true),
+            getFarmScheduleOperationsForDay(userId, dateKey, true),
+            getFarmSchedulePendingOperations(userId),
+            getFarmSchedulePlantSorts(),
+            getFarmScheduleOperationsData(),
+        ]);
+        logRejectedSource('plantings', plantingsResult);
+        logRejectedSource('scheduled operations', scheduledOperationsResult);
+        logRejectedSource('pending operations', pendingOperationsResult);
+        logRejectedSource('plant sorts', plantSortsResult);
+        logRejectedSource('operation definitions', operationDefinitionsResult);
+
+        const operations: FarmTodaySource<FarmTodayOperationsSourceData> =
+            scheduledOperationsResult.status === 'rejected' &&
+            pendingOperationsResult.status === 'rejected'
+                ? { status: 'unavailable' }
+                : {
+                      status: 'ready',
+                      data: {
+                          pendingOperations:
+                              pendingOperationsResult.status === 'fulfilled'
+                                  ? pendingOperationsResult.value
+                                  : [],
+                          pendingOperationsComplete:
+                              pendingOperationsResult.status === 'fulfilled',
+                          raisedBeds:
+                              plantingsResult.status === 'fulfilled'
+                                  ? plantingsResult.value.raisedBeds
+                                  : [],
+                          scheduledOperations:
+                              scheduledOperationsResult.status === 'fulfilled'
+                                  ? scheduledOperationsResult.value
+                                  : [],
+                          scheduledOperationsComplete:
+                              scheduledOperationsResult.status === 'fulfilled',
+                      },
+                  };
+
+        return composeFarmTodayData({
+            dateKey,
+            farms: { status: 'ready', data: farms.data },
+            operationDefinitions: toSource(operationDefinitionsResult),
+            operations,
+            plantings: toSource(plantingsResult),
+            plantSorts: toSource(plantSortsResult),
+            referenceDate,
+            userId,
+        });
+    },
+);

--- a/apps/farm/app/farmTodayModel.spec.ts
+++ b/apps/farm/app/farmTodayModel.spec.ts
@@ -1,0 +1,713 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { expect, test } from '@playwright/test';
+import {
+    type ComposeFarmTodayDataInput,
+    composeFarmTodayData,
+    type FarmTodayOperationInput,
+    type FarmTodayOperationsSourceData,
+    type FarmTodayPlantingInput,
+    type FarmTodayPlantingsSourceData,
+    type FarmTodayRaisedBedInput,
+    type FarmTodaySource,
+} from './farmTodayModel';
+
+const userId = 'farmer-1';
+const otherUserId = 'farmer-2';
+const dateKey = '2026-07-15';
+const referenceDate = new Date('2026-07-15T10:00:00.000Z');
+const overdueDate = new Date('2026-07-12T10:00:00.000Z');
+const todayDate = new Date('2026-07-15T08:00:00.000Z');
+
+function ready<T>(data: T): FarmTodaySource<T> {
+    return { status: 'ready', data };
+}
+
+function unavailable<T>(): FarmTodaySource<T> {
+    return { status: 'unavailable' };
+}
+
+function buildField(
+    overrides: Partial<FarmTodayPlantingInput> = {},
+): FarmTodayPlantingInput {
+    return {
+        active: true,
+        assignedUserId: userId,
+        assignedUserIds: [userId],
+        id: 201,
+        plantScheduledDate: todayDate,
+        plantSortId: 601,
+        plantStatus: 'planned',
+        positionIndex: 0,
+        raisedBedId: 10,
+        sowingLocation: 'direct',
+        ...overrides,
+    };
+}
+
+function buildRaisedBed({
+    farmId = 1,
+    fields = [],
+    id = 10,
+}: {
+    farmId?: number;
+    fields?: FarmTodayPlantingInput[];
+    id?: number;
+} = {}): FarmTodayRaisedBedInput {
+    return {
+        farmId,
+        fields,
+        id,
+        physicalId: `A${id}`,
+    };
+}
+
+function buildOperation(
+    overrides: Partial<FarmTodayOperationInput> = {},
+): FarmTodayOperationInput {
+    return {
+        assignedUserId: userId,
+        assignedUserIds: [userId],
+        entityId: 701,
+        farmId: 1,
+        id: 101,
+        raisedBedFieldId: null,
+        raisedBedId: 10,
+        scheduledDate: todayDate,
+        status: 'planned',
+        ...overrides,
+    };
+}
+
+function buildDefinition({
+    duration = 20,
+    id = 701,
+    label = `Radnja ${id}`,
+}: {
+    duration?: number;
+    id?: number;
+    label?: string;
+} = {}): EntityStandardized {
+    return {
+        id,
+        attributes: { duration },
+        information: { label },
+    };
+}
+
+function emptyPlantings(): FarmTodayPlantingsSourceData {
+    return { raisedBeds: [], scheduledFields: [] };
+}
+
+function emptyOperations(): FarmTodayOperationsSourceData {
+    return {
+        pendingOperations: [],
+        pendingOperationsComplete: true,
+        raisedBeds: [],
+        scheduledOperations: [],
+        scheduledOperationsComplete: true,
+    };
+}
+
+function buildInput(
+    overrides: Partial<ComposeFarmTodayDataInput> = {},
+): ComposeFarmTodayDataInput {
+    return {
+        dateKey,
+        farms: ready([{ id: 1, name: 'Gredice farma' }]),
+        operationDefinitions: ready([]),
+        operations: ready(emptyOperations()),
+        plantings: ready(emptyPlantings()),
+        plantSorts: ready([]),
+        referenceDate,
+        userId,
+        ...overrides,
+    };
+}
+
+test('composes mixed operation and planting work without merging pending into completed', () => {
+    const operationMine = buildOperation({
+        id: 101,
+        entityId: 701,
+        scheduledDate: overdueDate,
+    });
+    const operationShared = buildOperation({
+        assignedUserId: null,
+        assignedUserIds: [],
+        entityId: 702,
+        id: 102,
+        scheduledDate: undefined,
+    });
+    const operationOther = buildOperation({
+        assignedUserId: otherUserId,
+        assignedUserIds: [otherUserId, userId],
+        entityId: 703,
+        id: 103,
+    });
+    const operationPending = buildOperation({
+        completedAt: new Date('2026-07-13T08:00:00.000Z'),
+        entityId: 704,
+        id: 104,
+        status: 'pendingVerification',
+    });
+    const operationCompleted = buildOperation({
+        completedAt: todayDate,
+        entityId: 705,
+        id: 105,
+        status: 'completed',
+    });
+    const plantingMine = buildField({
+        id: 201,
+        plantScheduledDate: overdueDate,
+    });
+    const plantingShared = buildField({
+        assignedUserId: null,
+        assignedUserIds: [],
+        id: 202,
+        plantScheduledDate: undefined,
+    });
+    const plantingOther = buildField({
+        assignedUserId: otherUserId,
+        assignedUserIds: [otherUserId],
+        id: 203,
+    });
+    const plantingPending = buildField({
+        id: 204,
+        plantSowDate: new Date('2026-07-13T08:00:00.000Z'),
+        plantStatus: 'pendingVerification',
+    });
+    const plantingCompleted = buildField({
+        id: 205,
+        plantSowDate: todayDate,
+        plantStatus: 'sowed',
+    });
+    const raisedBed = buildRaisedBed({
+        fields: [
+            plantingMine,
+            plantingShared,
+            plantingOther,
+            plantingPending,
+            plantingCompleted,
+        ],
+    });
+    const operationDefinitions = [
+        {
+            ...buildDefinition({ id: 701, duration: 20 }),
+            conditions: {
+                completionAttachImagesRequired: true,
+                completionAttachNotes: true,
+            },
+        },
+        buildDefinition({ id: 702, duration: 10 }),
+        buildDefinition({ id: 703 }),
+        buildDefinition({ id: 704 }),
+        buildDefinition({ id: 705 }),
+    ];
+    const result = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready(operationDefinitions),
+            operations: ready({
+                pendingOperations: [operationPending],
+                pendingOperationsComplete: true,
+                raisedBeds: [raisedBed],
+                scheduledOperations: [
+                    operationMine,
+                    operationShared,
+                    operationOther,
+                    operationCompleted,
+                ],
+                scheduledOperationsComplete: true,
+            }),
+            plantings: ready({
+                raisedBeds: [raisedBed],
+                scheduledFields: [
+                    plantingMine,
+                    plantingShared,
+                    plantingOther,
+                    plantingCompleted,
+                ],
+            }),
+            plantSorts: ready([{ id: 601, information: { name: 'Rajčica' } }]),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+
+    expect(result.workState).toBe('hasWork');
+    expect(result.summary).toEqual({
+        assignedToMe: 2,
+        completed: 2,
+        countsComplete: true,
+        overdue: 2,
+        pendingVerification: 2,
+        remaining: 4,
+        remainingDuration: { complete: true, minutes: 40 },
+        unassigned: 2,
+    });
+    expect(result.focusQueue.map((task) => task.key)).toEqual([
+        'operation:101',
+        'planting:201',
+        'operation:102',
+        'planting:202',
+    ]);
+    expect(
+        result.attentionItems
+            .filter((item) => item.reasons.includes('pendingVerification'))
+            .map((item) => item.task.key),
+    ).toEqual(['operation:104', 'planting:204']);
+    expect(result.focusQueue.map((task) => task.key)).not.toContain(
+        'operation:103',
+    );
+    expect(result.focusQueue.map((task) => task.key)).not.toContain(
+        'planting:203',
+    );
+
+    const operationTask = result.focusQueue.find(
+        (task) => task.key === 'operation:101',
+    );
+    expect(operationTask?.proofRequirements).toEqual({
+        images: 'required',
+        notes: 'optional',
+    });
+    expect(operationTask?.href).toBe('/operations/701');
+});
+
+test('keeps shared work actionable but omits other-farmer and unrelated-farm details', () => {
+    const sharedOperation = buildOperation({
+        assignedUserId: null,
+        assignedUserIds: [],
+        entityId: 711,
+        id: 111,
+    });
+    const otherOperation = buildOperation({
+        assignedUserId: otherUserId,
+        assignedUserIds: [otherUserId],
+        entityId: 712,
+        id: 112,
+    });
+    const malformedOperation = buildOperation({
+        entityId: 713,
+        farmId: 1,
+        id: 113,
+        raisedBedId: 999,
+    });
+    const unrelatedFarmOperation = buildOperation({
+        entityId: 714,
+        farmId: 2,
+        id: 114,
+        raisedBedId: null,
+    });
+    const mismatchedFarmOperation = buildOperation({
+        entityId: 715,
+        farmId: 2,
+        id: 115,
+        raisedBedId: 10,
+    });
+    const unrelatedField = buildField({ id: 299, raisedBedId: 99 });
+    const result = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([
+                buildDefinition({ id: 711, label: 'Zajednička radnja' }),
+                buildDefinition({ id: 712, label: 'Tuđa tajna radnja' }),
+                buildDefinition({ id: 713, label: 'Kriva lokacija' }),
+                buildDefinition({ id: 714, label: 'Radnja tuđe farme' }),
+                buildDefinition({ id: 715, label: 'Krivi vlasnik gredice' }),
+            ]),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [
+                    sharedOperation,
+                    otherOperation,
+                    malformedOperation,
+                    unrelatedFarmOperation,
+                    mismatchedFarmOperation,
+                ],
+                scheduledOperationsComplete: true,
+            }),
+            plantings: ready({
+                raisedBeds: [
+                    buildRaisedBed(),
+                    buildRaisedBed({
+                        farmId: 2,
+                        fields: [unrelatedField],
+                        id: 99,
+                    }),
+                ],
+                scheduledFields: [unrelatedField],
+            }),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+
+    expect(result.focusQueue.map((task) => task.key)).toEqual([
+        'operation:111',
+    ]);
+    expect(result.summary.assignedToMe).toBe(0);
+    expect(result.summary.unassigned).toBe(1);
+    expect(
+        result.attentionItems.find((item) => item.task.key === 'operation:111')
+            ?.reasons,
+    ).toContain('unassigned');
+    expect(JSON.stringify(result)).not.toContain('Tuđa tajna radnja');
+    expect(JSON.stringify(result)).not.toContain('Kriva lokacija');
+    expect(JSON.stringify(result)).not.toContain('Radnja tuđe farme');
+    expect(JSON.stringify(result)).not.toContain('Krivi vlasnik gredice');
+    expect(JSON.stringify(result)).not.toContain('planting:299');
+});
+
+test('uses the primary operation assignee until completion authorization supports multiple assignees', () => {
+    const result = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([buildDefinition()]),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [
+                    buildOperation({
+                        assignedUserId: otherUserId,
+                        assignedUserIds: [otherUserId, userId],
+                    }),
+                ],
+                scheduledOperationsComplete: true,
+            }),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+    expect(result.workState).toBe('noAssignedWork');
+    expect(result.focusQueue).toEqual([]);
+    expect(result.summary.remaining).toBe(0);
+});
+
+test('uses array-only operation assignments when the primary assignee is missing', () => {
+    const mine = buildOperation({
+        assignedUserId: null,
+        assignedUserIds: [otherUserId, userId],
+        id: 121,
+    });
+    const other = buildOperation({
+        assignedUserId: null,
+        assignedUserIds: [otherUserId],
+        id: 122,
+    });
+    const result = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([buildDefinition()]),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [mine, other],
+                scheduledOperationsComplete: true,
+            }),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+    expect(result.focusQueue.map((task) => task.key)).toEqual([
+        'operation:121',
+    ]);
+    expect(result.summary.assignedToMe).toBe(1);
+});
+
+test('treats planting multi-assignment containing the current user as mine', () => {
+    const field = buildField({
+        assignedUserId: otherUserId,
+        assignedUserIds: [otherUserId, userId],
+    });
+    const assignedElsewhere = buildField({
+        assignedUserId: userId,
+        assignedUserIds: [otherUserId],
+        id: 202,
+    });
+    const result = composeFarmTodayData(
+        buildInput({
+            plantings: ready({
+                raisedBeds: [
+                    buildRaisedBed({ fields: [field, assignedElsewhere] }),
+                ],
+                scheduledFields: [field, assignedElsewhere],
+            }),
+            plantSorts: ready([{ id: 601, information: { name: 'Rajčica' } }]),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+    expect(result.focusQueue.map((task) => task.key)).toEqual(['planting:201']);
+    expect(result.summary.assignedToMe).toBe(1);
+    expect(result.summary.unassigned).toBe(0);
+});
+
+test('uses Zagreb day boundaries for overdue state and deterministic focus order', () => {
+    const justBeforeZagrebMidnight = new Date('2026-07-14T21:59:59.000Z');
+    const atZagrebMidnight = new Date('2026-07-14T22:00:00.000Z');
+    const overdue = buildField({
+        id: 211,
+        plantScheduledDate: justBeforeZagrebMidnight,
+    });
+    const today = buildField({
+        id: 212,
+        plantScheduledDate: atZagrebMidnight,
+    });
+    const undated = buildField({
+        id: 213,
+        plantScheduledDate: undefined,
+    });
+    const raisedBed = buildRaisedBed({ fields: [overdue, today, undated] });
+    const result = composeFarmTodayData(
+        buildInput({
+            plantings: ready({
+                raisedBeds: [raisedBed],
+                scheduledFields: [today, undated, overdue],
+            }),
+            plantSorts: ready([{ id: 601, information: { name: 'Rajčica' } }]),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+    expect(result.summary.overdue).toBe(1);
+    expect(result.focusQueue.map((task) => task.key)).toEqual([
+        'planting:211',
+        'planting:212',
+        'planting:213',
+    ]);
+});
+
+test('returns explicit no-farm, empty, no-assigned-work, and all-done states', () => {
+    expect(composeFarmTodayData(buildInput({ farms: ready([]) }))).toEqual({
+        dataIssues: [],
+        dateKey,
+        status: 'noFarm',
+    });
+
+    const empty = composeFarmTodayData(buildInput());
+    expect(empty.status).toBe('ready');
+    if (empty.status === 'ready') {
+        expect(empty.workState).toBe('empty');
+    }
+
+    const otherField = buildField({
+        assignedUserId: otherUserId,
+        assignedUserIds: [otherUserId],
+    });
+    const noAssignedWork = composeFarmTodayData(
+        buildInput({
+            plantings: ready({
+                raisedBeds: [buildRaisedBed({ fields: [otherField] })],
+                scheduledFields: [otherField],
+            }),
+        }),
+    );
+    expect(noAssignedWork.status).toBe('ready');
+    if (noAssignedWork.status === 'ready') {
+        expect(noAssignedWork.workState).toBe('noAssignedWork');
+    }
+
+    const completed = buildField({ plantStatus: 'sowed' });
+    const allDone = composeFarmTodayData(
+        buildInput({
+            plantings: ready({
+                raisedBeds: [buildRaisedBed({ fields: [completed] })],
+                scheduledFields: [completed],
+            }),
+            plantSorts: ready([{ id: 601, information: { name: 'Rajčica' } }]),
+        }),
+    );
+    expect(allDone.status).toBe('ready');
+    if (allDone.status === 'ready') {
+        expect(allDone.workState).toBe('allDone');
+        expect(allDone.summary.completed).toBe(1);
+    }
+});
+
+test('keeps available work in partial results and never turns total source failure into empty', () => {
+    const operation = buildOperation();
+    const partial = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: unavailable(),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [operation],
+                scheduledOperationsComplete: true,
+            }),
+            plantings: unavailable(),
+        }),
+    );
+
+    expect(partial.status).toBe('partial');
+    if (partial.status === 'partial') {
+        expect(partial.workState).toBe('hasWork');
+        expect(partial.summary.countsComplete).toBe(false);
+        expect(partial.focusQueue).toHaveLength(1);
+        expect(partial.focusQueue[0]?.durationMinutes).toBeNull();
+        expect(partial.focusQueue[0]?.proofRequirements).toEqual({
+            images: 'unknown',
+            notes: 'unknown',
+        });
+        expect(partial.summary.remainingDuration).toEqual({
+            complete: false,
+            minutes: 0,
+        });
+        expect(partial.dataIssues).toEqual([
+            'plantingsUnavailable',
+            'operationDefinitionsUnavailable',
+        ]);
+    }
+
+    const field = buildField();
+    const oppositePartial = composeFarmTodayData(
+        buildInput({
+            operations: unavailable(),
+            plantings: ready({
+                raisedBeds: [buildRaisedBed({ fields: [field] })],
+                scheduledFields: [field],
+            }),
+            plantSorts: ready([{ id: 601, information: { name: 'Rajčica' } }]),
+        }),
+    );
+    expect(oppositePartial.status).toBe('partial');
+    if (oppositePartial.status === 'partial') {
+        expect(oppositePartial.workState).toBe('hasWork');
+        expect(oppositePartial.summary.countsComplete).toBe(false);
+        expect(oppositePartial.focusQueue.map((task) => task.key)).toEqual([
+            'planting:201',
+        ]);
+        expect(oppositePartial.dataIssues).toEqual(['operationsUnavailable']);
+    }
+
+    const subreadPartial = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([buildDefinition()]),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: false,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [operation],
+                scheduledOperationsComplete: true,
+            }),
+        }),
+    );
+    expect(subreadPartial.status).toBe('partial');
+    if (subreadPartial.status === 'partial') {
+        expect(subreadPartial.workState).toBe('hasWork');
+        expect(subreadPartial.summary.countsComplete).toBe(false);
+        expect(subreadPartial.dataIssues).toEqual([
+            'pendingOperationsUnavailable',
+        ]);
+    }
+
+    const knownPending = buildOperation({
+        id: 131,
+        status: 'pendingVerification',
+    });
+    const reverseSubreadPartial = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([buildDefinition()]),
+            operations: ready({
+                pendingOperations: [knownPending],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [],
+                scheduledOperationsComplete: false,
+            }),
+        }),
+    );
+    expect(reverseSubreadPartial.status).toBe('partial');
+    if (reverseSubreadPartial.status === 'partial') {
+        expect(reverseSubreadPartial.workState).toBe('incomplete');
+        expect(reverseSubreadPartial.summary.pendingVerification).toBe(1);
+        expect(
+            reverseSubreadPartial.attentionItems.map((item) => item.task.key),
+        ).toContain('operation:131');
+        expect(reverseSubreadPartial.dataIssues).toEqual([
+            'scheduledOperationsUnavailable',
+        ]);
+    }
+
+    const incompleteEmpty = composeFarmTodayData(
+        buildInput({ operations: unavailable() }),
+    );
+    expect(incompleteEmpty.status).toBe('partial');
+    if (incompleteEmpty.status === 'partial') {
+        expect(incompleteEmpty.workState).toBe('incomplete');
+        expect(incompleteEmpty.summary.countsComplete).toBe(false);
+        expect(incompleteEmpty.summary.remainingDuration.complete).toBe(false);
+    }
+
+    expect(
+        composeFarmTodayData(
+            buildInput({
+                operations: unavailable(),
+                plantings: unavailable(),
+            }),
+        ),
+    ).toEqual({
+        dataIssues: ['plantingsUnavailable', 'operationsUnavailable'],
+        dateKey,
+        status: 'unavailable',
+    });
+
+    expect(composeFarmTodayData(buildInput({ farms: unavailable() }))).toEqual({
+        dataIssues: ['farmsUnavailable'],
+        dateKey,
+        status: 'unavailable',
+    });
+});
+
+test('retains tasks with safe fallbacks when individual directory entries are missing', () => {
+    const field = buildField();
+    const operation = buildOperation();
+    const result = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([]),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [operation],
+                scheduledOperationsComplete: true,
+            }),
+            plantings: ready({
+                raisedBeds: [buildRaisedBed({ fields: [field] })],
+                scheduledFields: [field],
+            }),
+            plantSorts: ready([]),
+        }),
+    );
+
+    expect(result.status).toBe('partial');
+    if (result.status !== 'partial') {
+        return;
+    }
+    expect(result.focusQueue.map((task) => task.label)).toEqual([
+        'Radnja #701',
+        'Sijanje: Nepoznata biljka',
+    ]);
+    expect(result.dataIssues).toEqual([
+        'plantSortMetadataMissing',
+        'operationDefinitionMissing',
+    ]);
+});

--- a/apps/farm/app/farmTodayModel.ts
+++ b/apps/farm/app/farmTodayModel.ts
@@ -1,0 +1,781 @@
+import type { EntityStandardized, OperationStatus } from '@gredice/storage';
+import {
+    getScheduleOperationCompletionRequirements,
+    type ScheduleOperationCompletionRequirements,
+} from './schedule/scheduleOperationRequirements';
+import {
+    compareScheduleDates,
+    getOperationDurationMinutes,
+    getScheduleTaskAgeIndicator,
+    isScheduleDatePast,
+    PLANTING_TASK_DURATION_MINUTES,
+    type ScheduleTaskAgeIndicator,
+} from './schedule/scheduleShared';
+import {
+    getScheduleOperationTaskAssignment,
+    getSchedulePlantingTaskAssignment,
+    type ScheduleTaskAssignment,
+} from './schedule/scheduleTaskAssignment';
+import {
+    getOperationTaskState,
+    getPlantingTaskState,
+    getScheduleTaskSummary,
+    type ScheduleTaskState,
+} from './schedule/scheduleTaskState';
+
+type DateInput = Date | string | null | undefined;
+
+export type FarmTodaySource<T> =
+    | { status: 'ready'; data: T }
+    | { status: 'unavailable' };
+
+export type FarmTodayFarmInput = {
+    id: number;
+    name: string;
+};
+
+export type FarmTodayPlantingInput = {
+    active?: boolean;
+    assignedUserId?: string | null;
+    assignedUserIds?: string[];
+    id: number;
+    plantScheduledDate?: DateInput;
+    plantSortId?: number | null;
+    plantSowDate?: DateInput;
+    plantStatus?: string | null;
+    positionIndex: number;
+    raisedBedId: number;
+    sowingLocation?: 'direct' | 'greenhouse';
+};
+
+export type FarmTodayRaisedBedInput = {
+    farmId: number | null;
+    fields: FarmTodayPlantingInput[];
+    id: number;
+    physicalId?: string | null;
+};
+
+export type FarmTodayOperationInput = {
+    assignedUserId?: string | null;
+    assignedUserIds?: string[];
+    completedAt?: DateInput;
+    entityId: number;
+    farmId: number | null;
+    id: number;
+    raisedBedFieldId?: number | null;
+    raisedBedId: number | null;
+    scheduledDate?: DateInput;
+    status: OperationStatus;
+};
+
+export type FarmTodayPlantingsSourceData = {
+    raisedBeds: FarmTodayRaisedBedInput[];
+    scheduledFields: FarmTodayPlantingInput[];
+};
+
+export type FarmTodayOperationsSourceData = {
+    pendingOperations: FarmTodayOperationInput[];
+    pendingOperationsComplete: boolean;
+    raisedBeds: FarmTodayRaisedBedInput[];
+    scheduledOperations: FarmTodayOperationInput[];
+    scheduledOperationsComplete: boolean;
+};
+
+export type FarmTodayDataIssue =
+    | 'farmsUnavailable'
+    | 'plantingsUnavailable'
+    | 'operationsUnavailable'
+    | 'scheduledOperationsUnavailable'
+    | 'pendingOperationsUnavailable'
+    | 'plantSortsUnavailable'
+    | 'operationDefinitionsUnavailable'
+    | 'plantSortMetadataMissing'
+    | 'operationDefinitionMissing';
+
+export type FarmTodayTaskAssignment = Exclude<ScheduleTaskAssignment, 'other'>;
+
+export type FarmTodayTaskLocation =
+    | {
+          kind: 'farm';
+          farmId: number;
+          label: string;
+      }
+    | {
+          kind: 'raisedBed' | 'greenhouse';
+          label: string;
+          positionIndex: number | null;
+          raisedBedId: number;
+      };
+
+type FarmTodayTaskBase = {
+    ageIndicator: ScheduleTaskAgeIndicator | null;
+    assignment: FarmTodayTaskAssignment;
+    durationMinutes: number | null;
+    href: string;
+    key: string;
+    label: string;
+    location: FarmTodayTaskLocation;
+    occurredAt: string | null;
+    overdue: boolean;
+    scheduledDate: string | null;
+    state: ScheduleTaskState;
+};
+
+export type FarmTodayOperationTask = FarmTodayTaskBase & {
+    kind: 'operation';
+    operationId: number;
+    proofRequirements: ScheduleOperationCompletionRequirements;
+};
+
+export type FarmTodayPlantingTask = FarmTodayTaskBase & {
+    fieldId: number;
+    kind: 'planting';
+    plantSortId: number;
+    proofRequirements: {
+        images: 'none';
+        notes: 'none';
+    };
+    raisedBedId: number;
+};
+
+export type FarmTodayTask = FarmTodayOperationTask | FarmTodayPlantingTask;
+
+export type FarmTodayAttentionReason =
+    | 'canceled'
+    | 'failed'
+    | 'overdue'
+    | 'pendingVerification'
+    | 'unassigned';
+
+export type FarmTodayAttentionItem = {
+    reasons: FarmTodayAttentionReason[];
+    task: FarmTodayTask;
+};
+
+export type FarmTodaySummary = {
+    assignedToMe: number;
+    completed: number;
+    countsComplete: boolean;
+    overdue: number;
+    pendingVerification: number;
+    remaining: number;
+    remainingDuration: {
+        complete: boolean;
+        minutes: number;
+    };
+    unassigned: number;
+};
+
+export type FarmTodayWorkState =
+    | 'allDone'
+    | 'empty'
+    | 'hasWork'
+    | 'incomplete'
+    | 'noAssignedWork';
+
+type FarmTodayAvailableData = {
+    attentionItems: FarmTodayAttentionItem[];
+    dataIssues: FarmTodayDataIssue[];
+    dateKey: string;
+    focusQueue: FarmTodayTask[];
+    status: 'partial' | 'ready';
+    summary: FarmTodaySummary;
+    workState: FarmTodayWorkState;
+};
+
+export type FarmTodayData =
+    | FarmTodayAvailableData
+    | {
+          dataIssues: [];
+          dateKey: string;
+          status: 'noFarm';
+      }
+    | {
+          dataIssues: FarmTodayDataIssue[];
+          dateKey: string;
+          status: 'unavailable';
+      };
+
+export type ComposeFarmTodayDataInput = {
+    dateKey: string;
+    farms: FarmTodaySource<FarmTodayFarmInput[]>;
+    operationDefinitions: FarmTodaySource<EntityStandardized[]>;
+    operations: FarmTodaySource<FarmTodayOperationsSourceData>;
+    plantings: FarmTodaySource<FarmTodayPlantingsSourceData>;
+    plantSorts: FarmTodaySource<EntityStandardized[]>;
+    referenceDate: Date;
+    userId: string;
+};
+
+type CandidateBuildResult = {
+    authorizedCandidateCount: number;
+    tasks: FarmTodayTask[];
+};
+
+const dataIssueOrder: FarmTodayDataIssue[] = [
+    'farmsUnavailable',
+    'plantingsUnavailable',
+    'operationsUnavailable',
+    'scheduledOperationsUnavailable',
+    'pendingOperationsUnavailable',
+    'plantSortsUnavailable',
+    'operationDefinitionsUnavailable',
+    'plantSortMetadataMissing',
+    'operationDefinitionMissing',
+];
+
+function orderedIssues(issues: Set<FarmTodayDataIssue>) {
+    return dataIssueOrder.filter((issue) => issues.has(issue));
+}
+
+function toIsoString(value: DateInput) {
+    if (!value) {
+        return null;
+    }
+
+    const parsed = typeof value === 'string' ? new Date(value) : value;
+    return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+}
+
+function getRaisedBedLabel(raisedBed: FarmTodayRaisedBedInput) {
+    return raisedBed.physicalId
+        ? `Gr ${raisedBed.physicalId}`
+        : `Gredica ${raisedBed.id}`;
+}
+
+function getRaisedBedLocation({
+    greenhouse,
+    positionIndex,
+    raisedBed,
+}: {
+    greenhouse: boolean;
+    positionIndex: number | null;
+    raisedBed: FarmTodayRaisedBedInput;
+}): FarmTodayTaskLocation {
+    const positionLabel =
+        positionIndex === null ? '' : ` · pozicija ${positionIndex + 1}`;
+    const raisedBedLabel = `${getRaisedBedLabel(raisedBed)}${positionLabel}`;
+
+    return {
+        kind: greenhouse ? 'greenhouse' : 'raisedBed',
+        label: greenhouse ? `Staklenik · ${raisedBedLabel}` : raisedBedLabel,
+        positionIndex,
+        raisedBedId: raisedBed.id,
+    };
+}
+
+function buildTaskTiming(
+    state: ScheduleTaskState,
+    scheduledDate: DateInput,
+    referenceDate: Date,
+) {
+    const overdue =
+        state === 'actionable' &&
+        isScheduleDatePast(scheduledDate, referenceDate);
+
+    return {
+        ageIndicator:
+            state === 'actionable'
+                ? getScheduleTaskAgeIndicator(scheduledDate, referenceDate)
+                : null,
+        overdue,
+        scheduledDate: toIsoString(scheduledDate),
+    };
+}
+
+function dedupeById<T extends { id: number }>(items: T[]) {
+    return [...new Map(items.map((item) => [item.id, item])).values()];
+}
+
+function buildPlantingCandidates({
+    activeFarmIds,
+    issues,
+    plantSorts,
+    referenceDate,
+    source,
+    userId,
+}: {
+    activeFarmIds: Set<number>;
+    issues: Set<FarmTodayDataIssue>;
+    plantSorts: FarmTodaySource<EntityStandardized[]>;
+    referenceDate: Date;
+    source: FarmTodayPlantingsSourceData;
+    userId: string;
+}): CandidateBuildResult {
+    const authorizedRaisedBeds = source.raisedBeds.filter(
+        (raisedBed) =>
+            typeof raisedBed.farmId === 'number' &&
+            activeFarmIds.has(raisedBed.farmId),
+    );
+    const raisedBedById = new Map(
+        authorizedRaisedBeds.map((raisedBed) => [raisedBed.id, raisedBed]),
+    );
+    const pendingFields = authorizedRaisedBeds
+        .flatMap((raisedBed) => raisedBed.fields)
+        .filter(
+            (field) =>
+                field.active !== false &&
+                field.plantSortId &&
+                getPlantingTaskState(field.plantStatus) ===
+                    'pendingVerification',
+        );
+    const fields = dedupeById([...source.scheduledFields, ...pendingFields]);
+    const plantSortById =
+        plantSorts.status === 'ready'
+            ? new Map(
+                  plantSorts.data.map((plantSort) => [plantSort.id, plantSort]),
+              )
+            : new Map<number, EntityStandardized>();
+    const tasks: FarmTodayTask[] = [];
+    let authorizedCandidateCount = 0;
+
+    for (const field of fields) {
+        const raisedBed = raisedBedById.get(field.raisedBedId);
+        const state = getPlantingTaskState(field.plantStatus);
+        if (!raisedBed || !field.plantSortId || !state) {
+            continue;
+        }
+
+        authorizedCandidateCount += 1;
+        const assignment = getSchedulePlantingTaskAssignment(field, userId);
+        if (assignment === 'other') {
+            continue;
+        }
+
+        const plantSort = plantSortById.get(field.plantSortId);
+        if (plantSorts.status === 'ready' && !plantSort) {
+            issues.add('plantSortMetadataMissing');
+        }
+        const plantName = plantSort?.information?.name ?? 'Nepoznata biljka';
+        const greenhouse = field.sowingLocation === 'greenhouse';
+
+        tasks.push({
+            ...buildTaskTiming(state, field.plantScheduledDate, referenceDate),
+            assignment,
+            durationMinutes: PLANTING_TASK_DURATION_MINUTES,
+            fieldId: field.id,
+            href: `/raised-beds/${field.raisedBedId}`,
+            key: `planting:${field.id}`,
+            kind: 'planting',
+            label: `${greenhouse ? 'Sijanje u stakleniku' : 'Sijanje'}: ${plantName}`,
+            location: getRaisedBedLocation({
+                greenhouse,
+                positionIndex: field.positionIndex,
+                raisedBed,
+            }),
+            occurredAt: toIsoString(field.plantSowDate),
+            plantSortId: field.plantSortId,
+            proofRequirements: {
+                images: 'none',
+                notes: 'none',
+            },
+            raisedBedId: field.raisedBedId,
+            state,
+        });
+    }
+
+    return { authorizedCandidateCount, tasks };
+}
+
+function isOperationAuthorized(
+    operation: FarmTodayOperationInput,
+    activeFarmIds: Set<number>,
+    authorizedRaisedBedFarmIds: Map<number, number>,
+) {
+    if (
+        typeof operation.farmId === 'number' &&
+        !activeFarmIds.has(operation.farmId)
+    ) {
+        return false;
+    }
+
+    if (typeof operation.raisedBedId === 'number') {
+        const raisedBedFarmId = authorizedRaisedBedFarmIds.get(
+            operation.raisedBedId,
+        );
+        return (
+            typeof raisedBedFarmId === 'number' &&
+            (operation.farmId === null || operation.farmId === raisedBedFarmId)
+        );
+    }
+
+    return (
+        typeof operation.farmId === 'number' &&
+        activeFarmIds.has(operation.farmId)
+    );
+}
+
+function buildOperationCandidates({
+    activeFarmIds,
+    farms,
+    issues,
+    operationDefinitions,
+    referenceDate,
+    source,
+    userId,
+}: {
+    activeFarmIds: Set<number>;
+    farms: FarmTodayFarmInput[];
+    issues: Set<FarmTodayDataIssue>;
+    operationDefinitions: FarmTodaySource<EntityStandardized[]>;
+    referenceDate: Date;
+    source: FarmTodayOperationsSourceData;
+    userId: string;
+}): CandidateBuildResult {
+    const authorizedRaisedBeds = source.raisedBeds.filter(
+        (raisedBed) =>
+            typeof raisedBed.farmId === 'number' &&
+            activeFarmIds.has(raisedBed.farmId),
+    );
+    const raisedBedById = new Map(
+        authorizedRaisedBeds.map((raisedBed) => [raisedBed.id, raisedBed]),
+    );
+    const authorizedRaisedBedFarmEntries: [number, number][] = [];
+    for (const raisedBed of authorizedRaisedBeds) {
+        if (typeof raisedBed.farmId === 'number') {
+            authorizedRaisedBedFarmEntries.push([
+                raisedBed.id,
+                raisedBed.farmId,
+            ]);
+        }
+    }
+    const authorizedRaisedBedFarmIds = new Map(authorizedRaisedBedFarmEntries);
+    const pendingOperations = source.pendingOperations.filter(
+        (operation) =>
+            getOperationTaskState(operation.status) === 'pendingVerification',
+    );
+    const operations = dedupeById([
+        ...source.scheduledOperations,
+        ...pendingOperations,
+    ]);
+    const farmById = new Map(farms.map((farm) => [farm.id, farm]));
+    const operationDefinitionById =
+        operationDefinitions.status === 'ready'
+            ? new Map(
+                  operationDefinitions.data.map((definition) => [
+                      definition.id,
+                      definition,
+                  ]),
+              )
+            : new Map<number, EntityStandardized>();
+    const tasks: FarmTodayTask[] = [];
+    let authorizedCandidateCount = 0;
+
+    for (const operation of operations) {
+        if (
+            !isOperationAuthorized(
+                operation,
+                activeFarmIds,
+                authorizedRaisedBedFarmIds,
+            )
+        ) {
+            continue;
+        }
+
+        authorizedCandidateCount += 1;
+        const assignment = getScheduleOperationTaskAssignment(
+            operation,
+            userId,
+        );
+        if (assignment === 'other') {
+            continue;
+        }
+
+        const state = getOperationTaskState(operation.status);
+        const operationDefinition = operationDefinitionById.get(
+            operation.entityId,
+        );
+        if (operationDefinitions.status === 'ready' && !operationDefinition) {
+            issues.add('operationDefinitionMissing');
+        }
+        const raisedBed =
+            typeof operation.raisedBedId === 'number'
+                ? raisedBedById.get(operation.raisedBedId)
+                : undefined;
+        const raisedBedField = raisedBed?.fields.find(
+            (field) => field.id === operation.raisedBedFieldId,
+        );
+        let location: FarmTodayTaskLocation;
+        if (raisedBed) {
+            location = getRaisedBedLocation({
+                greenhouse: false,
+                positionIndex: raisedBedField?.positionIndex ?? null,
+                raisedBed,
+            });
+        } else {
+            if (typeof operation.farmId !== 'number') {
+                continue;
+            }
+
+            const farm = farmById.get(operation.farmId);
+            location = {
+                kind: 'farm',
+                farmId: operation.farmId,
+                label: farm?.name ?? `Farma ${operation.farmId}`,
+            };
+        }
+
+        tasks.push({
+            ...buildTaskTiming(state, operation.scheduledDate, referenceDate),
+            assignment,
+            durationMinutes: operationDefinition
+                ? getOperationDurationMinutes(operationDefinition)
+                : null,
+            href: `/operations/${operation.entityId}`,
+            key: `operation:${operation.id}`,
+            kind: 'operation',
+            label:
+                operationDefinition?.information?.label ??
+                operationDefinition?.information?.name ??
+                `Radnja #${operation.entityId}`,
+            location,
+            occurredAt: toIsoString(operation.completedAt),
+            operationId: operation.id,
+            proofRequirements: getScheduleOperationCompletionRequirements(
+                operationDefinition,
+                operationDefinitions.status === 'ready',
+            ),
+            state,
+        });
+    }
+
+    return { authorizedCandidateCount, tasks };
+}
+
+function compareFocusTasks(left: FarmTodayTask, right: FarmTodayTask) {
+    const assignmentComparison =
+        Number(left.assignment === 'shared') -
+        Number(right.assignment === 'shared');
+    if (assignmentComparison !== 0) {
+        return assignmentComparison;
+    }
+
+    const overdueComparison = Number(right.overdue) - Number(left.overdue);
+    if (overdueComparison !== 0) {
+        return overdueComparison;
+    }
+
+    const dateComparison = compareScheduleDates(
+        left.scheduledDate,
+        right.scheduledDate,
+    );
+    return dateComparison || left.key.localeCompare(right.key);
+}
+
+function getAttentionReasons(task: FarmTodayTask) {
+    const reasons: FarmTodayAttentionReason[] = [];
+
+    if (task.state === 'failed') {
+        reasons.push('failed');
+    } else if (task.state === 'canceled') {
+        reasons.push('canceled');
+    } else if (task.state === 'pendingVerification') {
+        reasons.push('pendingVerification');
+    }
+
+    if (task.overdue) {
+        reasons.push('overdue');
+    }
+
+    if (task.assignment === 'shared' && task.state !== 'completed') {
+        reasons.push('unassigned');
+    }
+
+    return reasons;
+}
+
+function attentionPriority(item: FarmTodayAttentionItem) {
+    if (item.reasons.includes('failed')) {
+        return 0;
+    }
+    if (item.reasons.includes('canceled')) {
+        return 1;
+    }
+    if (item.reasons.includes('pendingVerification')) {
+        return 2;
+    }
+    if (item.reasons.includes('overdue')) {
+        return 3;
+    }
+    return 4;
+}
+
+function compareAttentionItems(
+    left: FarmTodayAttentionItem,
+    right: FarmTodayAttentionItem,
+) {
+    const priorityComparison =
+        attentionPriority(left) - attentionPriority(right);
+    return priorityComparison || compareFocusTasks(left.task, right.task);
+}
+
+function getWorkState(
+    tasks: FarmTodayTask[],
+    authorizedCandidateCount: number,
+    summary: FarmTodaySummary,
+): FarmTodayWorkState {
+    if (!summary.countsComplete && summary.remaining === 0) {
+        return 'incomplete';
+    }
+
+    if (tasks.length === 0) {
+        return authorizedCandidateCount > 0 ? 'noAssignedWork' : 'empty';
+    }
+
+    if (summary.remaining === 0 && summary.pendingVerification === 0) {
+        return 'allDone';
+    }
+
+    return 'hasWork';
+}
+
+function buildSummary(
+    tasks: FarmTodayTask[],
+    countsComplete: boolean,
+): FarmTodaySummary {
+    const stateSummary = getScheduleTaskSummary(
+        tasks.map((task) => ({
+            state: task.state,
+            durationMinutes: task.durationMinutes ?? 0,
+        })),
+    );
+    const actionableTasks = tasks.filter((task) => task.state === 'actionable');
+
+    return {
+        assignedToMe: actionableTasks.filter(
+            (task) => task.assignment === 'mine',
+        ).length,
+        completed: stateSummary.completed.count,
+        countsComplete,
+        overdue: actionableTasks.filter((task) => task.overdue).length,
+        pendingVerification: stateSummary.pendingVerification.count,
+        remaining: stateSummary.actionable.count,
+        remainingDuration: {
+            complete:
+                countsComplete &&
+                actionableTasks.every((task) => task.durationMinutes !== null),
+            minutes: stateSummary.actionable.durationMinutes,
+        },
+        unassigned: actionableTasks.filter(
+            (task) => task.assignment === 'shared',
+        ).length,
+    };
+}
+
+export function composeFarmTodayData({
+    dateKey,
+    farms,
+    operationDefinitions,
+    operations,
+    plantings,
+    plantSorts,
+    referenceDate,
+    userId,
+}: ComposeFarmTodayDataInput): FarmTodayData {
+    if (farms.status === 'unavailable') {
+        return {
+            dataIssues: ['farmsUnavailable'],
+            dateKey,
+            status: 'unavailable',
+        };
+    }
+
+    if (farms.data.length === 0) {
+        return {
+            dataIssues: [],
+            dateKey,
+            status: 'noFarm',
+        };
+    }
+
+    const issues = new Set<FarmTodayDataIssue>();
+    if (plantings.status === 'unavailable') {
+        issues.add('plantingsUnavailable');
+    }
+    if (operations.status === 'unavailable') {
+        issues.add('operationsUnavailable');
+    } else if (
+        !operations.data.scheduledOperationsComplete &&
+        !operations.data.pendingOperationsComplete
+    ) {
+        issues.add('operationsUnavailable');
+    } else {
+        if (!operations.data.scheduledOperationsComplete) {
+            issues.add('scheduledOperationsUnavailable');
+        }
+        if (!operations.data.pendingOperationsComplete) {
+            issues.add('pendingOperationsUnavailable');
+        }
+    }
+    if (plantSorts.status === 'unavailable') {
+        issues.add('plantSortsUnavailable');
+    }
+    if (operationDefinitions.status === 'unavailable') {
+        issues.add('operationDefinitionsUnavailable');
+    }
+
+    const operationsHaveTaskData =
+        operations.status === 'ready' &&
+        (operations.data.scheduledOperationsComplete ||
+            operations.data.pendingOperationsComplete);
+    if (plantings.status === 'unavailable' && !operationsHaveTaskData) {
+        return {
+            dataIssues: orderedIssues(issues),
+            dateKey,
+            status: 'unavailable',
+        };
+    }
+
+    const activeFarmIds = new Set(farms.data.map((farm) => farm.id));
+    const plantingResult =
+        plantings.status === 'ready'
+            ? buildPlantingCandidates({
+                  activeFarmIds,
+                  issues,
+                  plantSorts,
+                  referenceDate,
+                  source: plantings.data,
+                  userId,
+              })
+            : { authorizedCandidateCount: 0, tasks: [] };
+    const operationResult =
+        operations.status === 'ready'
+            ? buildOperationCandidates({
+                  activeFarmIds,
+                  farms: farms.data,
+                  issues,
+                  operationDefinitions,
+                  referenceDate,
+                  source: operations.data,
+                  userId,
+              })
+            : { authorizedCandidateCount: 0, tasks: [] };
+    const tasks = [...plantingResult.tasks, ...operationResult.tasks];
+    const countsComplete =
+        plantings.status === 'ready' &&
+        operations.status === 'ready' &&
+        operations.data.scheduledOperationsComplete &&
+        operations.data.pendingOperationsComplete;
+    const summary = buildSummary(tasks, countsComplete);
+    const focusQueue = tasks
+        .filter((task) => task.state === 'actionable')
+        .sort(compareFocusTasks);
+    const attentionItems = tasks
+        .map((task) => ({ reasons: getAttentionReasons(task), task }))
+        .filter((item) => item.reasons.length > 0)
+        .sort(compareAttentionItems);
+    const dataIssues = orderedIssues(issues);
+    const authorizedCandidateCount =
+        plantingResult.authorizedCandidateCount +
+        operationResult.authorizedCandidateCount;
+
+    return {
+        attentionItems,
+        dataIssues,
+        dateKey,
+        focusQueue,
+        status: dataIssues.length > 0 ? 'partial' : 'ready',
+        summary,
+        workState: getWorkState(tasks, authorizedCandidateCount, summary),
+    };
+}

--- a/apps/farm/app/schedule/CompleteOperationModal.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.tsx
@@ -318,6 +318,7 @@ export function CompleteOperationModal({
             onOpenChange={handleOpenChange}
             trigger={
                 <Checkbox
+                    aria-label={`Dovrši: ${label}`}
                     className="size-5"
                     checked={isOpen}
                     onCheckedChange={(checked: boolean) =>

--- a/apps/farm/app/schedule/CompletePlantingModal.tsx
+++ b/apps/farm/app/schedule/CompletePlantingModal.tsx
@@ -42,6 +42,7 @@ export function CompletePlantingModal({
             onOpenChange={setOpen}
             trigger={
                 <Checkbox
+                    aria-label={`Dovrši: ${label}`}
                     className="size-5"
                     checked={open}
                     onCheckedChange={(checked: boolean) => setOpen(checked)}

--- a/apps/farm/app/schedule/FarmScheduleLoadingState.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.spec.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../globals.css';
+import { FarmScheduleLoadingState } from './FarmScheduleLoadingState';
+
+for (const width of [320, 1280]) {
+    test(`keeps the schedule summary skeleton within ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 800 });
+        await mount(<FarmScheduleLoadingState />);
+
+        expect(
+            await page.evaluate(
+                () =>
+                    document.documentElement.scrollWidth <=
+                    document.documentElement.clientWidth,
+            ),
+        ).toBe(true);
+    });
+}

--- a/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
@@ -10,13 +10,15 @@ export function FarmScheduleLoadingState() {
             aria-busy="true"
         >
             <div className="space-y-2">
-                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-1 sm:gap-2">
+                <div className="grid min-w-0 grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-start gap-1 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-2">
                     <Skeleton className="h-8 w-10 rounded-md sm:h-10 sm:w-12" />
                     <div className="grid justify-items-center gap-1">
                         <Skeleton className="h-4 w-16" />
                         <Skeleton className="h-4 w-24" />
                     </div>
-                    <ScheduleDaySummarySkeleton />
+                    <div className="col-span-3 min-w-0 justify-self-stretch sm:col-span-1 sm:justify-self-end">
+                        <ScheduleDaySummarySkeleton />
+                    </div>
                 </div>
                 <div className="flex justify-end">
                     <Skeleton className="h-8 w-24 rounded-md" />

--- a/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
+++ b/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
@@ -128,7 +128,7 @@ export function FarmScheduleNavigationFrame({
             aria-busy={showPendingContent}
         >
             <div className="space-y-2">
-                <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-1 sm:gap-2">
+                <div className="grid min-w-0 grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-start gap-1 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-2">
                     <div className="justify-self-start">
                         <HomeButton className="h-8 sm:h-10" />
                     </div>
@@ -176,7 +176,7 @@ export function FarmScheduleNavigationFrame({
                             </Link>
                         </Row>
                     </div>
-                    <div className="min-w-0 justify-self-end">
+                    <div className="col-span-3 min-w-0 justify-self-stretch sm:col-span-1 sm:justify-self-end">
                         {showPendingContent ? (
                             <ScheduleDaySummarySkeleton />
                         ) : (

--- a/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
@@ -14,6 +14,11 @@ import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
 import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
 import type { FarmScheduleDayData } from './scheduleData';
 import {
+    getScheduleOperationCompletionRequirements,
+    isScheduleOperationRequirementVisible,
+} from './scheduleOperationRequirements';
+import { getScheduleOperationTaskAssignment } from './scheduleTaskAssignment';
+import {
     getOperationTaskState,
     getScheduleTaskPresentation,
 } from './scheduleTaskState';
@@ -24,6 +29,7 @@ export type FarmOperationCardData = Pick<
     FarmOperation,
     | 'assignedUser'
     | 'assignedUserId'
+    | 'assignedUserIds'
     | 'completionNotes'
     | 'id'
     | 'imageUrls'
@@ -49,23 +55,19 @@ export function FarmScheduleOperationTaskCard({
 }: FarmScheduleOperationTaskCardProps) {
     const taskState = getOperationTaskState(operation.status);
     const taskPresentation = getScheduleTaskPresentation(taskState);
+    const assignment = getScheduleOperationTaskAssignment(operation, userId);
     const canComplete =
-        taskPresentation.showCompletionControl &&
-        (!operation.assignedUserId || operation.assignedUserId === userId);
-    const attachImages = Boolean(
-        operationData?.conditions?.completionAttachImages ||
-            operationData?.conditions?.completionAttachImagesRequired,
+        taskPresentation.showCompletionControl && assignment !== 'other';
+    const requirements =
+        getScheduleOperationCompletionRequirements(operationData);
+    const attachImages = isScheduleOperationRequirementVisible(
+        requirements.images,
     );
-    const attachImagesRequired = Boolean(
-        operationData?.conditions?.completionAttachImagesRequired,
+    const attachImagesRequired = requirements.images === 'required';
+    const attachNotes = isScheduleOperationRequirementVisible(
+        requirements.notes,
     );
-    const attachNotes = Boolean(
-        operationData?.conditions?.completionAttachNotes ||
-            operationData?.conditions?.completionAttachNotesRequired,
-    );
-    const attachNotesRequired = Boolean(
-        operationData?.conditions?.completionAttachNotesRequired,
-    );
+    const attachNotesRequired = requirements.notes === 'required';
     const showRequirementIcons =
         taskPresentation.showRequirementIndicators &&
         (attachImages || attachNotes);

--- a/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
@@ -1,0 +1,162 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { Row } from '@gredice/ui/Row';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { UserAvatar } from '@gredice/ui/UserAvatar';
+import { cx } from '@gredice/ui/utils';
+import type { ReactNode } from 'react';
+import { OperationCompletionAttachments } from './OperationCompletionAttachments';
+import { OperationRequirementIcons } from './OperationRequirementIcons';
+import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
+import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
+import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
+import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
+import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
+import type { FarmScheduleDayData } from './scheduleData';
+import {
+    getOperationTaskState,
+    getScheduleTaskPresentation,
+} from './scheduleTaskState';
+
+type FarmOperation = FarmScheduleDayData['scheduledOperations'][number];
+
+export type FarmOperationCardData = Pick<
+    FarmOperation,
+    | 'assignedUser'
+    | 'assignedUserId'
+    | 'completionNotes'
+    | 'id'
+    | 'imageUrls'
+    | 'scheduledDate'
+    | 'status'
+> & {
+    durationMinutes: number;
+    label: string;
+};
+
+type FarmScheduleOperationTaskCardProps = {
+    completionAction?: ReactNode;
+    operation: FarmOperationCardData;
+    operationData: EntityStandardized | undefined;
+    userId: string;
+};
+
+export function FarmScheduleOperationTaskCard({
+    completionAction,
+    operation,
+    operationData,
+    userId,
+}: FarmScheduleOperationTaskCardProps) {
+    const taskState = getOperationTaskState(operation.status);
+    const taskPresentation = getScheduleTaskPresentation(taskState);
+    const canComplete =
+        taskPresentation.showCompletionControl &&
+        (!operation.assignedUserId || operation.assignedUserId === userId);
+    const attachImages = Boolean(
+        operationData?.conditions?.completionAttachImages ||
+            operationData?.conditions?.completionAttachImagesRequired,
+    );
+    const attachImagesRequired = Boolean(
+        operationData?.conditions?.completionAttachImagesRequired,
+    );
+    const attachNotes = Boolean(
+        operationData?.conditions?.completionAttachNotes ||
+            operationData?.conditions?.completionAttachNotesRequired,
+    );
+    const attachNotesRequired = Boolean(
+        operationData?.conditions?.completionAttachNotesRequired,
+    );
+    const showRequirementIcons =
+        taskPresentation.showRequirementIndicators &&
+        (attachImages || attachNotes);
+
+    return (
+        <div
+            data-task-state={taskState}
+            className={cx(
+                'rounded-lg border px-3 py-2 transition-opacity',
+                taskPresentation.isCompleted
+                    ? 'bg-white/70 opacity-70'
+                    : 'bg-white',
+            )}
+        >
+            <Row
+                spacing={2}
+                className="min-w-0 items-start justify-between gap-3"
+            >
+                <Row spacing={2} className="min-w-0 grow items-start">
+                    <ScheduleTaskStateControl
+                        action={canComplete ? completionAction : undefined}
+                        label={operation.label}
+                        state={taskState}
+                        unavailableTitle="Radnja je dodijeljena drugom korisniku."
+                    />
+                    <Stack spacing={1} className="min-w-0 grow">
+                        <Typography
+                            className={
+                                taskPresentation.isCompleted
+                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
+                                    : '[overflow-wrap:anywhere]'
+                            }
+                        >
+                            {operation.label}
+                        </Typography>
+                        <Row
+                            spacing={2}
+                            className="items-center flex-wrap gap-y-1"
+                        >
+                            <ScheduleTaskStatusChip state={taskState} />
+                            <ScheduleTaskDurationChip
+                                minutes={operation.durationMinutes}
+                            />
+                            <ScheduleTaskDateChip
+                                scheduledDate={operation.scheduledDate}
+                            />
+                            {taskPresentation.showAgeIndicator && (
+                                <ScheduleTaskAgeIndicatorChip
+                                    scheduledDate={operation.scheduledDate}
+                                />
+                            )}
+                        </Row>
+                    </Stack>
+                </Row>
+                {(showRequirementIcons ||
+                    taskPresentation.showCompletionAttachments ||
+                    operation.assignedUser) && (
+                    <Row spacing={1} className="shrink-0 items-center">
+                        {showRequirementIcons && (
+                            <OperationRequirementIcons
+                                attachImages={attachImages}
+                                attachImagesRequired={attachImagesRequired}
+                                attachNotes={attachNotes}
+                                attachNotesRequired={attachNotesRequired}
+                            />
+                        )}
+                        {taskPresentation.showCompletionAttachments && (
+                            <OperationCompletionAttachments
+                                operationId={operation.id}
+                                notes={operation.completionNotes}
+                                imageUrls={operation.imageUrls}
+                            />
+                        )}
+                        {operation.assignedUser && (
+                            <div
+                                className="shrink-0"
+                                title={`Dodijeljeno: ${operation.assignedUser.displayName ?? operation.assignedUser.userName}`}
+                            >
+                                <UserAvatar
+                                    avatarUrl={operation.assignedUser.avatarUrl}
+                                    displayName={
+                                        operation.assignedUser.displayName ??
+                                        operation.assignedUser.userName
+                                    }
+                                    className="size-7 rounded-full"
+                                />
+                            </div>
+                        )}
+                    </Row>
+                )}
+            </Row>
+        </div>
+    );
+}

--- a/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
@@ -1,20 +1,13 @@
 import type { EntityStandardized } from '@gredice/storage';
-import { Checkbox } from '@gredice/ui/Checkbox';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { UserAvatar } from '@gredice/ui/UserAvatar';
-import { cx } from '@gredice/ui/utils';
 import { Suspense } from 'react';
 import { CompleteOperationModal } from './CompleteOperationModal';
-import { OperationCompletionAttachments } from './OperationCompletionAttachments';
-import { OperationRequirementIcons } from './OperationRequirementIcons';
+import { FarmScheduleOperationTaskCard } from './FarmScheduleOperationTaskCard';
 import { RaisedBedScheduleGroupHeader } from './RaisedBedScheduleGroupHeader';
 import { RaisedBedScheduleGroupHeaderWithPhotos } from './RaisedBedScheduleGroupHeaderWithPhotos';
 import { ScheduleSectionSummaryBadges } from './ScheduleSectionSummaryBadges';
-import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
-import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
-import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
 import type {
     FarmScheduleDayData,
     FarmScheduleRaisedBedPhotoPreview,
@@ -25,16 +18,11 @@ import {
     getFieldPhysicalPositionIndex,
     getOperationDurationMinutes,
     groupRaisedBedsForSchedule,
-    isOperationCompleted,
     shouldDisplayScheduleOperation,
 } from './scheduleShared';
 
 type FarmRaisedBed = FarmScheduleDayData['raisedBeds'][number];
 type FarmOperation = FarmScheduleDayData['scheduledOperations'][number];
-type FarmOperationCardData = FarmOperation & {
-    durationMinutes: number;
-    label: string;
-};
 
 interface FarmScheduleOperationsSectionProps {
     raisedBeds: FarmScheduleDayData['raisedBeds'];
@@ -154,127 +142,6 @@ export function FarmScheduleOperationsSection({
             }),
         );
 
-    function renderOperationCard(operation: FarmOperationCardData) {
-        const completed = isOperationCompleted(operation.status);
-        const operationData = operationDataById.get(operation.entityId);
-        const canComplete =
-            !completed &&
-            (!operation.assignedUserId || operation.assignedUserId === userId);
-        const attachImages = Boolean(
-            operationData?.conditions?.completionAttachImages ||
-                operationData?.conditions?.completionAttachImagesRequired,
-        );
-        const attachImagesRequired = Boolean(
-            operationData?.conditions?.completionAttachImagesRequired,
-        );
-        const attachNotes = Boolean(
-            operationData?.conditions?.completionAttachNotes ||
-                operationData?.conditions?.completionAttachNotesRequired,
-        );
-        const attachNotesRequired = Boolean(
-            operationData?.conditions?.completionAttachNotesRequired,
-        );
-        const showRequirementIcons =
-            !completed && (attachImages || attachNotes);
-
-        return (
-            <div
-                key={operation.id}
-                className={cx(
-                    'rounded-lg border px-3 py-2 transition-opacity',
-                    completed ? 'bg-white/70 opacity-70' : 'bg-white',
-                )}
-            >
-                <Row
-                    spacing={2}
-                    className="min-w-0 items-start justify-between gap-3"
-                >
-                    <Row spacing={2} className="min-w-0 grow items-start">
-                        {completed ? (
-                            <Checkbox className="size-5" checked disabled />
-                        ) : canComplete ? (
-                            <CompleteOperationModal
-                                operationId={operation.id}
-                                label={operation.label}
-                                conditions={operationData?.conditions}
-                            />
-                        ) : (
-                            <div title="Radnja je dodijeljena drugom korisniku.">
-                                <Checkbox className="size-5" disabled />
-                            </div>
-                        )}
-                        <Stack spacing={1} className="min-w-0 grow">
-                            <Typography
-                                className={
-                                    completed
-                                        ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
-                                        : '[overflow-wrap:anywhere]'
-                                }
-                            >
-                                {operation.label}
-                            </Typography>
-                            <Row
-                                spacing={2}
-                                className="items-center flex-wrap gap-y-1"
-                            >
-                                <ScheduleTaskDurationChip
-                                    minutes={operation.durationMinutes}
-                                />
-                                <ScheduleTaskDateChip
-                                    scheduledDate={operation.scheduledDate}
-                                />
-                                {!completed && (
-                                    <ScheduleTaskAgeIndicatorChip
-                                        scheduledDate={operation.scheduledDate}
-                                    />
-                                )}
-                            </Row>
-                        </Stack>
-                    </Row>
-                    {(showRequirementIcons ||
-                        completed ||
-                        operation.assignedUser) && (
-                        <Row spacing={1} className="shrink-0 items-center">
-                            {showRequirementIcons && (
-                                <OperationRequirementIcons
-                                    attachImages={attachImages}
-                                    attachImagesRequired={attachImagesRequired}
-                                    attachNotes={attachNotes}
-                                    attachNotesRequired={attachNotesRequired}
-                                />
-                            )}
-                            {completed && (
-                                <OperationCompletionAttachments
-                                    operationId={operation.id}
-                                    notes={operation.completionNotes}
-                                    imageUrls={operation.imageUrls}
-                                />
-                            )}
-                            {operation.assignedUser && (
-                                <div
-                                    className="shrink-0"
-                                    title={`Dodijeljeno: ${operation.assignedUser.displayName ?? operation.assignedUser.userName}`}
-                                >
-                                    <UserAvatar
-                                        avatarUrl={
-                                            operation.assignedUser.avatarUrl
-                                        }
-                                        displayName={
-                                            operation.assignedUser
-                                                .displayName ??
-                                            operation.assignedUser.userName
-                                        }
-                                        className="size-7 rounded-full"
-                                    />
-                                </div>
-                            )}
-                        </Row>
-                    )}
-                </Row>
-            </div>
-        );
-    }
-
     const farmTotalDuration = farmOperations.reduce(
         (sum, operation) => sum + operation.durationMinutes,
         0,
@@ -339,9 +206,27 @@ export function FarmScheduleOperationsSection({
                     />
                 </Row>
                 <Stack spacing={2}>
-                    {wateringOperations.map((operation) =>
-                        renderOperationCard(operation),
-                    )}
+                    {wateringOperations.map((operation) => (
+                        <FarmScheduleOperationTaskCard
+                            key={operation.id}
+                            completionAction={
+                                <CompleteOperationModal
+                                    operationId={operation.id}
+                                    label={operation.label}
+                                    conditions={
+                                        operationDataById.get(
+                                            operation.entityId,
+                                        )?.conditions
+                                    }
+                                />
+                            }
+                            operation={operation}
+                            operationData={operationDataById.get(
+                                operation.entityId,
+                            )}
+                            userId={userId}
+                        />
+                    ))}
                 </Stack>
             </Stack>
         );
@@ -432,190 +317,27 @@ export function FarmScheduleOperationsSection({
                                 </Row>
                             </div>
                             <Stack spacing={2}>
-                                {dayOperations.map((operation) => {
-                                    const completed = isOperationCompleted(
-                                        operation.status,
-                                    );
-                                    const operationData = operationDataById.get(
-                                        operation.entityId,
-                                    );
-                                    const canComplete =
-                                        !completed &&
-                                        (!operation.assignedUserId ||
-                                            operation.assignedUserId ===
-                                                userId);
-                                    const attachImages = Boolean(
-                                        operationData?.conditions
-                                            ?.completionAttachImages ||
-                                            operationData?.conditions
-                                                ?.completionAttachImagesRequired,
-                                    );
-                                    const attachImagesRequired = Boolean(
-                                        operationData?.conditions
-                                            ?.completionAttachImagesRequired,
-                                    );
-                                    const attachNotes = Boolean(
-                                        operationData?.conditions
-                                            ?.completionAttachNotes ||
-                                            operationData?.conditions
-                                                ?.completionAttachNotesRequired,
-                                    );
-                                    const attachNotesRequired = Boolean(
-                                        operationData?.conditions
-                                            ?.completionAttachNotesRequired,
-                                    );
-                                    const showRequirementIcons =
-                                        !completed &&
-                                        (attachImages || attachNotes);
-
-                                    return (
-                                        <div
-                                            key={operation.id}
-                                            className={cx(
-                                                'rounded-lg border px-3 py-2 transition-opacity',
-                                                completed
-                                                    ? 'bg-white/70 opacity-70'
-                                                    : 'bg-white',
-                                            )}
-                                        >
-                                            <Row
-                                                spacing={2}
-                                                className="min-w-0 items-start justify-between gap-3"
-                                            >
-                                                <Row
-                                                    spacing={2}
-                                                    className="min-w-0 grow items-start"
-                                                >
-                                                    {completed ? (
-                                                        <Checkbox
-                                                            className="size-5"
-                                                            checked
-                                                            disabled
-                                                        />
-                                                    ) : canComplete ? (
-                                                        <CompleteOperationModal
-                                                            operationId={
-                                                                operation.id
-                                                            }
-                                                            label={
-                                                                operation.label
-                                                            }
-                                                            conditions={
-                                                                operationDataById.get(
-                                                                    operation.entityId,
-                                                                )?.conditions
-                                                            }
-                                                        />
-                                                    ) : (
-                                                        <div title="Radnja je dodijeljena drugom korisniku.">
-                                                            <Checkbox
-                                                                className="size-5"
-                                                                disabled
-                                                            />
-                                                        </div>
-                                                    )}
-                                                    <Stack
-                                                        spacing={1}
-                                                        className="min-w-0 grow"
-                                                    >
-                                                        <Typography
-                                                            className={
-                                                                completed
-                                                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
-                                                                    : '[overflow-wrap:anywhere]'
-                                                            }
-                                                        >
-                                                            {operation.label}
-                                                        </Typography>
-                                                        <Row
-                                                            spacing={2}
-                                                            className="items-center flex-wrap gap-y-1"
-                                                        >
-                                                            <ScheduleTaskDurationChip
-                                                                minutes={
-                                                                    operation.durationMinutes
-                                                                }
-                                                            />
-                                                            <ScheduleTaskDateChip
-                                                                scheduledDate={
-                                                                    operation.scheduledDate
-                                                                }
-                                                            />
-                                                            {!completed && (
-                                                                <ScheduleTaskAgeIndicatorChip
-                                                                    scheduledDate={
-                                                                        operation.scheduledDate
-                                                                    }
-                                                                />
-                                                            )}
-                                                        </Row>
-                                                    </Stack>
-                                                </Row>
-                                                {(showRequirementIcons ||
-                                                    completed ||
-                                                    operation.assignedUser) && (
-                                                    <Row
-                                                        spacing={1}
-                                                        className="shrink-0 items-center"
-                                                    >
-                                                        {showRequirementIcons && (
-                                                            <OperationRequirementIcons
-                                                                attachImages={
-                                                                    attachImages
-                                                                }
-                                                                attachImagesRequired={
-                                                                    attachImagesRequired
-                                                                }
-                                                                attachNotes={
-                                                                    attachNotes
-                                                                }
-                                                                attachNotesRequired={
-                                                                    attachNotesRequired
-                                                                }
-                                                            />
-                                                        )}
-                                                        {completed && (
-                                                            <OperationCompletionAttachments
-                                                                operationId={
-                                                                    operation.id
-                                                                }
-                                                                notes={
-                                                                    operation.completionNotes
-                                                                }
-                                                                imageUrls={
-                                                                    operation.imageUrls
-                                                                }
-                                                            />
-                                                        )}
-                                                        {operation.assignedUser && (
-                                                            <div
-                                                                className="shrink-0"
-                                                                title={`Dodijeljeno: ${operation.assignedUser.displayName ?? operation.assignedUser.userName}`}
-                                                            >
-                                                                <UserAvatar
-                                                                    avatarUrl={
-                                                                        operation
-                                                                            .assignedUser
-                                                                            .avatarUrl
-                                                                    }
-                                                                    displayName={
-                                                                        operation
-                                                                            .assignedUser
-                                                                            .displayName ??
-                                                                        operation
-                                                                            .assignedUser
-                                                                            .userName
-                                                                    }
-                                                                    className="size-7 rounded-full"
-                                                                />
-                                                            </div>
-                                                        )}
-                                                    </Row>
-                                                )}
-                                            </Row>
-                                        </div>
-                                    );
-                                })}
+                                {dayOperations.map((operation) => (
+                                    <FarmScheduleOperationTaskCard
+                                        key={operation.id}
+                                        completionAction={
+                                            <CompleteOperationModal
+                                                operationId={operation.id}
+                                                label={operation.label}
+                                                conditions={
+                                                    operationDataById.get(
+                                                        operation.entityId,
+                                                    )?.conditions
+                                                }
+                                            />
+                                        }
+                                        operation={operation}
+                                        operationData={operationDataById.get(
+                                            operation.entityId,
+                                        )}
+                                        userId={userId}
+                                    />
+                                ))}
                             </Stack>
                         </Stack>
                     );
@@ -632,9 +354,27 @@ export function FarmScheduleOperationsSection({
                         />
                     </Row>
                     <Stack spacing={2}>
-                        {farmOperations.map((operation) =>
-                            renderOperationCard(operation),
-                        )}
+                        {farmOperations.map((operation) => (
+                            <FarmScheduleOperationTaskCard
+                                key={operation.id}
+                                completionAction={
+                                    <CompleteOperationModal
+                                        operationId={operation.id}
+                                        label={operation.label}
+                                        conditions={
+                                            operationDataById.get(
+                                                operation.entityId,
+                                            )?.conditions
+                                        }
+                                    />
+                                }
+                                operation={operation}
+                                operationData={operationDataById.get(
+                                    operation.entityId,
+                                )}
+                                userId={userId}
+                            />
+                        ))}
                     </Stack>
                 </Stack>
             )}

--- a/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
@@ -1,0 +1,148 @@
+import type {
+    EntityStandardized,
+    RaisedBedFieldAssignableFarmUser,
+} from '@gredice/storage';
+import { Chip } from '@gredice/ui/Chip';
+import { Row } from '@gredice/ui/Row';
+import { Skeleton } from '@gredice/ui/Skeleton';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { cx } from '@gredice/ui/utils';
+import { type ReactNode, Suspense } from 'react';
+import { PlantingAssignedUserAvatar } from './PlantingAssignedUserAvatar';
+import { SchedulePlantVisual } from './SchedulePlantVisual';
+import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
+import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
+import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
+import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
+import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
+import type { FarmScheduleDayData } from './scheduleData';
+import { PLANTING_TASK_DURATION_MINUTES } from './scheduleShared';
+import {
+    getPlantingTaskState,
+    getScheduleTaskPresentation,
+} from './scheduleTaskState';
+
+type FarmSchedulePlantingField = Pick<
+    FarmScheduleDayData['scheduledFields'][number],
+    | 'assignedUserId'
+    | 'id'
+    | 'plantScheduledDate'
+    | 'plantStatus'
+    | 'positionIndex'
+    | 'raisedBedId'
+    | 'sowingLocation'
+>;
+
+interface FarmSchedulePlantingTaskCardProps {
+    field: FarmSchedulePlantingField;
+    label: string;
+    plantSort: EntityStandardized | undefined;
+    userId: string;
+    completionAction?: ReactNode;
+    assignedUserByFieldIdPromise: Promise<
+        Map<number, RaisedBedFieldAssignableFarmUser>
+    >;
+}
+
+export function FarmSchedulePlantingTaskCard({
+    field,
+    label,
+    plantSort,
+    userId,
+    completionAction,
+    assignedUserByFieldIdPromise,
+}: FarmSchedulePlantingTaskCardProps) {
+    const taskState = getPlantingTaskState(field.plantStatus);
+    if (!taskState) {
+        return null;
+    }
+
+    const taskPresentation = getScheduleTaskPresentation(taskState);
+    const lockedByAssignment =
+        taskPresentation.showCompletionControl &&
+        !!field.assignedUserId &&
+        field.assignedUserId !== userId;
+    const canComplete =
+        taskPresentation.showCompletionControl && !lockedByAssignment;
+    const greenhouseSowing = field.sowingLocation === 'greenhouse';
+
+    return (
+        <div
+            data-task-state={taskState}
+            className={cx(
+                'rounded-lg border px-3 py-2 transition-opacity',
+                taskPresentation.isCompleted
+                    ? 'bg-white/70 opacity-70'
+                    : 'bg-white',
+                lockedByAssignment &&
+                    !taskPresentation.isCompleted &&
+                    'opacity-70',
+            )}
+        >
+            <Row
+                spacing={2}
+                className="min-w-0 items-start justify-between gap-3"
+            >
+                <Row spacing={2} className="min-w-0 grow items-start">
+                    <ScheduleTaskStateControl
+                        action={canComplete ? completionAction : undefined}
+                        label={label}
+                        state={taskState}
+                        unavailableTitle="Sijanje je dodijeljeno drugom korisniku."
+                    />
+                    <SchedulePlantVisual plantSort={plantSort} label={label} />
+                    <Stack spacing={1} className="min-w-0 grow">
+                        <Typography
+                            className={
+                                taskPresentation.isCompleted
+                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
+                                    : '[overflow-wrap:anywhere]'
+                            }
+                        >
+                            {label}
+                        </Typography>
+                        <Row
+                            spacing={2}
+                            className="items-center flex-wrap gap-y-1"
+                        >
+                            <ScheduleTaskStatusChip state={taskState} />
+                            <ScheduleTaskDurationChip
+                                minutes={PLANTING_TASK_DURATION_MINUTES}
+                            />
+                            {greenhouseSowing && (
+                                <Chip size="sm" color="success" variant="soft">
+                                    Staklenik
+                                </Chip>
+                            )}
+                            <ScheduleTaskDateChip
+                                scheduledDate={field.plantScheduledDate}
+                            />
+                            {taskPresentation.showAgeIndicator && (
+                                <ScheduleTaskAgeIndicatorChip
+                                    scheduledDate={field.plantScheduledDate}
+                                />
+                            )}
+                        </Row>
+                    </Stack>
+                </Row>
+                {field.assignedUserId && (
+                    <Suspense
+                        fallback={
+                            <Skeleton className="size-7 shrink-0 rounded-full" />
+                        }
+                    >
+                        <PlantingAssignedUserAvatar
+                            assignedUserByFieldIdPromise={
+                                assignedUserByFieldIdPromise
+                            }
+                            fieldId={field.id}
+                        />
+                    </Suspense>
+                )}
+            </Row>
+        </div>
+    );
+}
+
+export default FarmSchedulePlantingTaskCard;

--- a/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
@@ -18,6 +18,7 @@ import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
 import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
 import type { FarmScheduleDayData } from './scheduleData';
 import { PLANTING_TASK_DURATION_MINUTES } from './scheduleShared';
+import { getSchedulePlantingTaskAssignment } from './scheduleTaskAssignment';
 import {
     getPlantingTaskState,
     getScheduleTaskPresentation,
@@ -26,6 +27,7 @@ import {
 type FarmSchedulePlantingField = Pick<
     FarmScheduleDayData['scheduledFields'][number],
     | 'assignedUserId'
+    | 'assignedUserIds'
     | 'id'
     | 'plantScheduledDate'
     | 'plantStatus'
@@ -61,8 +63,7 @@ export function FarmSchedulePlantingTaskCard({
     const taskPresentation = getScheduleTaskPresentation(taskState);
     const lockedByAssignment =
         taskPresentation.showCompletionControl &&
-        !!field.assignedUserId &&
-        field.assignedUserId !== userId;
+        getSchedulePlantingTaskAssignment(field, userId) === 'other';
     const canComplete =
         taskPresentation.showCompletionControl && !lockedByAssignment;
     const greenhouseSowing = field.sowingLocation === 'greenhouse';

--- a/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingsSection.tsx
@@ -3,23 +3,14 @@ import type {
     EntityStandardized,
     RaisedBedFieldAssignableFarmUser,
 } from '@gredice/storage';
-import { Checkbox } from '@gredice/ui/Checkbox';
-import { Chip } from '@gredice/ui/Chip';
 import { Row } from '@gredice/ui/Row';
-import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
-import { cx } from '@gredice/ui/utils';
 import { Suspense } from 'react';
 import { CompletePlantingModal } from './CompletePlantingModal';
-import { PlantingAssignedUserAvatar } from './PlantingAssignedUserAvatar';
+import { FarmSchedulePlantingTaskCard } from './FarmSchedulePlantingTaskCard';
 import { RaisedBedScheduleGroupHeader } from './RaisedBedScheduleGroupHeader';
 import { RaisedBedScheduleGroupHeaderWithPhotos } from './RaisedBedScheduleGroupHeaderWithPhotos';
-import { SchedulePlantVisual } from './SchedulePlantVisual';
 import { ScheduleSectionSummaryBadges } from './ScheduleSectionSummaryBadges';
-import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
-import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
-import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
 import type {
     FarmScheduleDayData,
     FarmScheduleRaisedBedPhotoPreview,
@@ -28,8 +19,6 @@ import {
     compareScheduleDates,
     getFieldPhysicalPositionIndex,
     groupRaisedBedsForSchedule,
-    isFieldApproved,
-    isFieldCompleted,
     PLANTING_TASK_DURATION_MINUTES,
 } from './scheduleShared';
 
@@ -183,147 +172,32 @@ export function FarmSchedulePlantingsSection({
                             </div>
                             <Stack spacing={2}>
                                 {dayFields.map((field) => {
-                                    const completed = isFieldCompleted(
-                                        field.plantStatus,
-                                    );
-                                    const approved = isFieldApproved(
-                                        field.plantStatus,
-                                    );
-                                    const lockedByAssignment =
-                                        !completed &&
-                                        !!field.assignedUserId &&
-                                        field.assignedUserId !== userId;
-                                    const canComplete =
-                                        !completed && !lockedByAssignment;
-                                    const greenhouseSowing =
-                                        field.sowingLocation === 'greenhouse';
                                     const plantSort = field.plantSortId
                                         ? plantSortById.get(field.plantSortId)
                                         : undefined;
-                                    const statusText =
-                                        !completed && !approved
-                                            ? 'Nije potvrđeno'
-                                            : null;
 
                                     return (
-                                        <div
+                                        <FarmSchedulePlantingTaskCard
                                             key={field.id}
-                                            className={cx(
-                                                'rounded-lg border px-3 py-2 transition-opacity',
-                                                completed
-                                                    ? 'bg-white/70 opacity-70'
-                                                    : 'bg-white',
-                                                lockedByAssignment &&
-                                                    !completed &&
-                                                    'opacity-70',
-                                            )}
-                                        >
-                                            <Row
-                                                spacing={2}
-                                                className="min-w-0 items-start justify-between gap-3"
-                                            >
-                                                <Row
-                                                    spacing={2}
-                                                    className="min-w-0 grow items-start"
-                                                >
-                                                    {completed ? (
-                                                        <Checkbox
-                                                            className="size-5"
-                                                            checked
-                                                            disabled
-                                                        />
-                                                    ) : canComplete ? (
-                                                        <CompletePlantingModal
-                                                            label={field.label}
-                                                            raisedBedId={
-                                                                field.raisedBedId
-                                                            }
-                                                            positionIndex={
-                                                                field.positionIndex
-                                                            }
-                                                        />
-                                                    ) : (
-                                                        <div title="Sijanje je dodijeljeno drugom korisniku.">
-                                                            <Checkbox
-                                                                className="size-5"
-                                                                disabled
-                                                            />
-                                                        </div>
-                                                    )}
-                                                    <SchedulePlantVisual
-                                                        plantSort={plantSort}
-                                                        label={field.label}
-                                                    />
-                                                    <Stack
-                                                        spacing={1}
-                                                        className="min-w-0 grow"
-                                                    >
-                                                        <Typography
-                                                            className={
-                                                                completed
-                                                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
-                                                                    : '[overflow-wrap:anywhere]'
-                                                            }
-                                                        >
-                                                            {field.label}
-                                                        </Typography>
-                                                        <Row
-                                                            spacing={2}
-                                                            className="items-center flex-wrap gap-y-1"
-                                                        >
-                                                            {statusText && (
-                                                                <Typography
-                                                                    level="body2"
-                                                                    className="text-muted-foreground"
-                                                                >
-                                                                    {statusText}
-                                                                </Typography>
-                                                            )}
-                                                            <ScheduleTaskDurationChip
-                                                                minutes={
-                                                                    PLANTING_TASK_DURATION_MINUTES
-                                                                }
-                                                            />
-                                                            {greenhouseSowing && (
-                                                                <Chip
-                                                                    size="sm"
-                                                                    color="success"
-                                                                    variant="soft"
-                                                                >
-                                                                    Staklenik
-                                                                </Chip>
-                                                            )}
-                                                            <ScheduleTaskDateChip
-                                                                scheduledDate={
-                                                                    field.plantScheduledDate
-                                                                }
-                                                            />
-                                                            {!completed && (
-                                                                <ScheduleTaskAgeIndicatorChip
-                                                                    scheduledDate={
-                                                                        field.plantScheduledDate
-                                                                    }
-                                                                />
-                                                            )}
-                                                        </Row>
-                                                    </Stack>
-                                                </Row>
-                                                {field.assignedUserId && (
-                                                    <Suspense
-                                                        fallback={
-                                                            <Skeleton className="size-7 shrink-0 rounded-full" />
-                                                        }
-                                                    >
-                                                        <PlantingAssignedUserAvatar
-                                                            assignedUserByFieldIdPromise={
-                                                                assignedUserByFieldIdPromise
-                                                            }
-                                                            fieldId={field.id}
-                                                        />
-                                                    </Suspense>
-                                                )}
-                                            </Row>
-                                        </div>
+                                            completionAction={
+                                                <CompletePlantingModal
+                                                    label={field.label}
+                                                    raisedBedId={
+                                                        field.raisedBedId
+                                                    }
+                                                    positionIndex={
+                                                        field.positionIndex
+                                                    }
+                                                />
+                                            }
+                                            field={field}
+                                            label={field.label}
+                                            plantSort={plantSort}
+                                            userId={userId}
+                                            assignedUserByFieldIdPromise={
+                                                assignedUserByFieldIdPromise
+                                            }
+                                        />
                                     );
                                 })}
                             </Stack>

--- a/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
@@ -25,6 +25,7 @@ function buildOperation(
     return {
         assignedUser: null,
         assignedUserId: null,
+        assignedUserIds: [],
         completionNotes: undefined,
         durationMinutes: 15,
         id,
@@ -56,6 +57,50 @@ async function assertCardsStayWithinViewport(component: Locator) {
         ),
     ).toBe(true);
 }
+
+test('locks array-only work assigned to another farmer on a phone', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    const component = await mount(
+        <div className="space-y-2">
+            <FarmScheduleOperationTaskCard
+                completionAction={<button type="button">Dovrši radnju</button>}
+                operation={{
+                    ...buildOperation(10, 'planned', 'Zalij salatu'),
+                    assignedUserIds: ['farmer-2'],
+                }}
+                operationData={undefined}
+                userId="farmer-1"
+            />
+            <FarmSchedulePlantingTaskCard
+                completionAction={<button type="button">Dovrši sijanje</button>}
+                field={{
+                    assignedUserId: null,
+                    assignedUserIds: ['farmer-2'],
+                    id: 10,
+                    plantScheduledDate: scheduledDate,
+                    plantStatus: 'planned',
+                    positionIndex: 0,
+                    raisedBedId: 10,
+                    sowingLocation: 'direct',
+                }}
+                label="Posij salatu"
+                plantSort={undefined}
+                userId="farmer-1"
+                assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
+            />
+        </div>,
+    );
+
+    await expect(component.getByRole('button')).toHaveCount(0);
+    await expect(component.getByRole('checkbox')).toHaveCount(2);
+    for (const checkbox of await component.getByRole('checkbox').all()) {
+        await expect(checkbox).toBeDisabled();
+    }
+    await assertCardsStayWithinViewport(component);
+});
 
 for (const width of [320, 390, 1280]) {
     test(`renders operation pending and verified states within ${width}px`, async ({
@@ -147,6 +192,7 @@ for (const width of [320, 390, 1280]) {
                     }
                     field={{
                         assignedUserId: null,
+                        assignedUserIds: [],
                         id: 1,
                         plantScheduledDate: scheduledDate,
                         plantStatus: 'pendingVerification',
@@ -165,6 +211,7 @@ for (const width of [320, 390, 1280]) {
                     }
                     field={{
                         assignedUserId: null,
+                        assignedUserIds: [],
                         id: 2,
                         plantScheduledDate: scheduledDate,
                         plantStatus: 'sowed',
@@ -183,6 +230,7 @@ for (const width of [320, 390, 1280]) {
                     }
                     field={{
                         assignedUserId: null,
+                        assignedUserIds: [],
                         id: 3,
                         plantScheduledDate: scheduledDate,
                         plantStatus: 'planned',

--- a/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
@@ -1,0 +1,234 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator } from '@playwright/test';
+import '../globals.css';
+import {
+    type FarmOperationCardData,
+    FarmScheduleOperationTaskCard,
+} from './FarmScheduleOperationTaskCard';
+import { FarmSchedulePlantingTaskCard } from './FarmSchedulePlantingTaskCard';
+
+const scheduledDate = new Date('2026-07-15T08:00:00.000Z');
+const assignedUserByFieldIdPromise = Promise.resolve(new Map());
+
+const operationLabels = {
+    pending:
+        'Vrlo duga radnja pripreme zemlje koja mora ostati čitljiva na uskom telefonu',
+    completed:
+        'Potvrđena radnja prihrane povrća s dovoljno dugim opisom za mali zaslon',
+};
+
+function buildOperation(
+    id: number,
+    status: FarmOperationCardData['status'],
+    label: string,
+): FarmOperationCardData {
+    return {
+        assignedUser: null,
+        assignedUserId: null,
+        completionNotes: undefined,
+        durationMinutes: 15,
+        id,
+        imageUrls: undefined,
+        label,
+        scheduledDate,
+        status,
+    };
+}
+
+const plantingLabels = {
+    pending:
+        'Sijanje vrlo dugog naziva sorte rajčice koje mora ostati čitljivo na telefonu',
+    completed:
+        'Potvrđeno sijanje povrća s namjerno dugim opisom za uski mobilni zaslon',
+};
+
+async function assertCardsStayWithinViewport(component: Locator) {
+    expect(
+        await component.locator('[data-task-state]').evaluateAll((cards) =>
+            cards.every((card) => {
+                const bounds = card.getBoundingClientRect();
+                return (
+                    bounds.left >= 0 &&
+                    bounds.right <= window.innerWidth &&
+                    card.scrollWidth <= card.clientWidth
+                );
+            }),
+        ),
+    ).toBe(true);
+}
+
+for (const width of [320, 390, 1280]) {
+    test(`renders operation pending and verified states within ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 720 });
+        const component = await mount(
+            <div className="space-y-2">
+                <FarmScheduleOperationTaskCard
+                    completionAction={
+                        <button type="button">Dovrši radnju</button>
+                    }
+                    operation={buildOperation(
+                        1,
+                        'pendingVerification',
+                        operationLabels.pending,
+                    )}
+                    operationData={undefined}
+                    userId="farmer-1"
+                />
+                <FarmScheduleOperationTaskCard
+                    completionAction={
+                        <button type="button">Dovrši radnju</button>
+                    }
+                    operation={buildOperation(
+                        2,
+                        'completed',
+                        operationLabels.completed,
+                    )}
+                    operationData={undefined}
+                    userId="farmer-1"
+                />
+                <FarmScheduleOperationTaskCard
+                    completionAction={
+                        <button type="button">Dovrši radnju</button>
+                    }
+                    operation={buildOperation(3, 'planned', 'Zalij salatu')}
+                    operationData={undefined}
+                    userId="farmer-1"
+                />
+            </div>,
+        );
+
+        const pendingCard = component.locator(
+            '[data-task-state="pendingVerification"]',
+        );
+        await expect(
+            pendingCard.getByText('Čeka potvrdu', { exact: true }),
+        ).toBeVisible();
+        await expect(pendingCard.getByRole('checkbox')).toHaveCount(0);
+        await expect(pendingCard.getByRole('button')).toHaveCount(0);
+        await expect(
+            pendingCard.getByText(operationLabels.pending),
+        ).toBeVisible();
+
+        const completedCard = component.locator(
+            '[data-task-state="completed"]',
+        );
+        await expect(
+            completedCard.getByText('Potvrđeno', { exact: true }),
+        ).toBeVisible();
+        const verifiedControl = completedCard.getByRole('checkbox', {
+            name: `Potvrđeno: ${operationLabels.completed}`,
+        });
+        await expect(verifiedControl).toBeChecked();
+        await expect(verifiedControl).toBeDisabled();
+
+        const actionableCard = component.locator(
+            '[data-task-state="actionable"]',
+        );
+        await expect(
+            actionableCard.getByRole('button', { name: 'Dovrši radnju' }),
+        ).toBeVisible();
+
+        await assertCardsStayWithinViewport(component);
+    });
+
+    test(`renders planting pending and verified states within ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 720 });
+        const component = await mount(
+            <div className="space-y-2">
+                <FarmSchedulePlantingTaskCard
+                    completionAction={
+                        <button type="button">Dovrši sijanje</button>
+                    }
+                    field={{
+                        assignedUserId: null,
+                        id: 1,
+                        plantScheduledDate: scheduledDate,
+                        plantStatus: 'pendingVerification',
+                        positionIndex: 0,
+                        raisedBedId: 10,
+                        sowingLocation: 'direct',
+                    }}
+                    label={plantingLabels.pending}
+                    plantSort={undefined}
+                    userId="farmer-1"
+                    assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
+                />
+                <FarmSchedulePlantingTaskCard
+                    completionAction={
+                        <button type="button">Dovrši sijanje</button>
+                    }
+                    field={{
+                        assignedUserId: null,
+                        id: 2,
+                        plantScheduledDate: scheduledDate,
+                        plantStatus: 'sowed',
+                        positionIndex: 1,
+                        raisedBedId: 10,
+                        sowingLocation: 'direct',
+                    }}
+                    label={plantingLabels.completed}
+                    plantSort={undefined}
+                    userId="farmer-1"
+                    assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
+                />
+                <FarmSchedulePlantingTaskCard
+                    completionAction={
+                        <button type="button">Dovrši sijanje</button>
+                    }
+                    field={{
+                        assignedUserId: null,
+                        id: 3,
+                        plantScheduledDate: scheduledDate,
+                        plantStatus: 'planned',
+                        positionIndex: 2,
+                        raisedBedId: 10,
+                        sowingLocation: 'direct',
+                    }}
+                    label="Posij salatu"
+                    plantSort={undefined}
+                    userId="farmer-1"
+                    assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
+                />
+            </div>,
+        );
+
+        const pendingCard = component.locator(
+            '[data-task-state="pendingVerification"]',
+        );
+        await expect(
+            pendingCard.getByText('Čeka potvrdu', { exact: true }),
+        ).toBeVisible();
+        await expect(pendingCard.getByRole('checkbox')).toHaveCount(0);
+        await expect(pendingCard.getByRole('button')).toHaveCount(0);
+        await expect(
+            pendingCard.getByText(plantingLabels.pending),
+        ).toBeVisible();
+
+        const completedCard = component.locator(
+            '[data-task-state="completed"]',
+        );
+        await expect(
+            completedCard.getByText('Potvrđeno', { exact: true }),
+        ).toBeVisible();
+        const verifiedControl = completedCard.getByRole('checkbox', {
+            name: `Potvrđeno: ${plantingLabels.completed}`,
+        });
+        await expect(verifiedControl).toBeChecked();
+        await expect(verifiedControl).toBeDisabled();
+
+        const actionableCard = component.locator(
+            '[data-task-state="actionable"]',
+        );
+        await expect(
+            actionableCard.getByRole('button', { name: 'Dovrši sijanje' }),
+        ).toBeVisible();
+
+        await assertCardsStayWithinViewport(component);
+    });
+}

--- a/apps/farm/app/schedule/ScheduleDaySummary.spec.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummary.spec.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../globals.css';
+import { ScheduleDaySummaryView } from './ScheduleDaySummary';
+import { getScheduleTaskSummary } from './scheduleTaskState';
+
+const summary = getScheduleTaskSummary([
+    { state: 'actionable', durationMinutes: 75 },
+    { state: 'pendingVerification', durationMinutes: 5 },
+    { state: 'completed', durationMinutes: 5 },
+    { state: 'failed', durationMinutes: 5 },
+    { state: 'canceled', durationMinutes: 5 },
+]);
+
+for (const width of [320, 390]) {
+    test(`keeps every daily status within ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 640 });
+        const component = await mount(
+            <ScheduleDaySummaryView summary={summary} />,
+        );
+
+        const group = component;
+        await expect(group).toHaveAttribute(
+            'aria-label',
+            'Sažetak dnevnih zadataka',
+        );
+        await expect(
+            component.getByText('Preostalo', { exact: true }),
+        ).toBeVisible();
+        await expect(component.getByText('Čeka potvrdu')).toBeVisible();
+        await expect(component.getByText('Potvrđeno')).toBeVisible();
+        await expect(component.getByText('Preostalo vrijeme')).toBeVisible();
+        await expect(component.getByText('Neuspjelo')).toBeVisible();
+        await expect(component.getByText('Otkazano')).toBeVisible();
+
+        expect(
+            await group.evaluate((element) => {
+                const groupBounds = element.getBoundingClientRect();
+                const itemBounds = Array.from(element.children).map((child) =>
+                    child.getBoundingClientRect(),
+                );
+
+                return (
+                    groupBounds.left >= 0 &&
+                    groupBounds.right <= window.innerWidth &&
+                    itemBounds.every(
+                        (bounds) =>
+                            bounds.left >= groupBounds.left &&
+                            bounds.right <= groupBounds.right,
+                    )
+                );
+            }),
+        ).toBe(true);
+    });
+}

--- a/apps/farm/app/schedule/ScheduleDaySummary.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummary.tsx
@@ -1,11 +1,17 @@
 import type { EntityStandardized } from '@gredice/storage';
-import { Row } from '@gredice/ui/Row';
 import { Typography } from '@gredice/ui/Typography';
 import type { FarmScheduleDayData } from './scheduleData';
 import {
     getOperationDurationMinutes,
     PLANTING_TASK_DURATION_MINUTES,
 } from './scheduleShared';
+import {
+    getOperationTaskState,
+    getPlantingTaskState,
+    getScheduleTaskSummary,
+    type ScheduleTaskSummary,
+    type ScheduleTaskSummaryItem,
+} from './scheduleTaskState';
 
 function formatMinutes(minutes: number) {
     const rounded = Math.ceil(Math.max(0, minutes));
@@ -28,8 +34,6 @@ export function ScheduleDaySummary({
 }: ScheduleDaySummaryProps) {
     const { scheduledFields, scheduledOperations } = dayData;
 
-    const taskCount = scheduledOperations.length + scheduledFields.length;
-
     const operationDataById = new Map<number, EntityStandardized>();
     if (operationsData) {
         for (const op of operationsData) {
@@ -37,25 +41,62 @@ export function ScheduleDaySummary({
         }
     }
 
-    const totalMinutes =
-        scheduledOperations.reduce(
-            (sum, op) =>
-                sum +
-                getOperationDurationMinutes(operationDataById.get(op.entityId)),
-            0,
-        ) +
-        scheduledFields.length * PLANTING_TASK_DURATION_MINUTES;
+    const plantingItems = scheduledFields.flatMap((field) => {
+        const state = getPlantingTaskState(field.plantStatus);
 
+        return state
+            ? [
+                  {
+                      state,
+                      durationMinutes: PLANTING_TASK_DURATION_MINUTES,
+                  },
+              ]
+            : [];
+    });
+    const operationItems = scheduledOperations.map((operation) => ({
+        state: getOperationTaskState(operation.status),
+        durationMinutes: getOperationDurationMinutes(
+            operationDataById.get(operation.entityId),
+        ),
+    }));
+    const summaryItems: ScheduleTaskSummaryItem[] = [
+        ...plantingItems,
+        ...operationItems,
+    ];
+    const summary = getScheduleTaskSummary(summaryItems);
+
+    return <ScheduleDaySummaryView summary={summary} />;
+}
+
+export function ScheduleDaySummaryView({
+    summary,
+}: {
+    summary: ScheduleTaskSummary;
+}) {
     return (
-        <Row className="gap-1 sm:gap-2">
-            <SummaryItem label="Zadataka" value={taskCount} />
-            {totalMinutes > 0 && (
+        <section
+            aria-label="Sažetak dnevnih zadataka"
+            className="grid w-full grid-cols-[repeat(auto-fit,minmax(4.5rem,1fr))] items-start gap-2 sm:flex sm:w-auto sm:justify-end"
+        >
+            <SummaryItem label="Preostalo" value={summary.actionable.count} />
+            <SummaryItem
+                label="Čeka potvrdu"
+                value={summary.pendingVerification.count}
+            />
+            <SummaryItem label="Potvrđeno" value={summary.completed.count} />
+            {summary.actionable.durationMinutes > 0 && (
                 <SummaryItem
-                    label="Vrijeme"
-                    value={formatMinutes(totalMinutes)}
+                    label="Preostalo vrijeme"
+                    value={formatMinutes(summary.actionable.durationMinutes)}
                 />
             )}
-        </Row>
+            {summary.failed.count > 0 && (
+                <SummaryItem label="Neuspjelo" value={summary.failed.count} />
+            )}
+            {summary.canceled.count > 0 && (
+                <SummaryItem label="Otkazano" value={summary.canceled.count} />
+            )}
+        </section>
     );
 }
 
@@ -67,7 +108,7 @@ function SummaryItem({
     value: string | number;
 }) {
     return (
-        <div className="text-center leading-tight">
+        <div className="min-w-0 text-center leading-tight">
             <Typography level="body2" semiBold className="text-xs sm:text-sm">
                 {value}
             </Typography>

--- a/apps/farm/app/schedule/ScheduleDaySummarySkeleton.tsx
+++ b/apps/farm/app/schedule/ScheduleDaySummarySkeleton.tsx
@@ -1,9 +1,8 @@
-import { Row } from '@gredice/ui/Row';
 import { Skeleton } from '@gredice/ui/Skeleton';
 
 function SummaryItemSkeleton() {
     return (
-        <div className="space-y-1 text-center">
+        <div className="min-w-0 space-y-1 text-center">
             <Skeleton className="mx-auto h-3 w-6 sm:h-4 sm:w-8" />
             <Skeleton className="mx-auto h-3 w-10 sm:h-4 sm:w-14" />
         </div>
@@ -12,9 +11,11 @@ function SummaryItemSkeleton() {
 
 export function ScheduleDaySummarySkeleton() {
     return (
-        <Row className="gap-1 sm:gap-2">
+        <div className="grid w-full grid-cols-[repeat(auto-fit,minmax(4.5rem,1fr))] items-start gap-2 sm:flex sm:w-auto sm:justify-end">
             <SummaryItemSkeleton />
             <SummaryItemSkeleton />
-        </Row>
+            <SummaryItemSkeleton />
+            <SummaryItemSkeleton />
+        </div>
     );
 }

--- a/apps/farm/app/schedule/ScheduleTaskStateControl.spec.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskStateControl.spec.tsx
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
+
+for (const width of [320, 1280]) {
+    test(`keeps submitted work non-actionable at ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 640 });
+        const component = await mount(
+            <ScheduleTaskStateControl
+                action={<button type="button">Dovrši</button>}
+                label="Zalij gredicu broj 12"
+                state="pendingVerification"
+                unavailableTitle="Radnja nije dostupna."
+            />,
+        );
+
+        await expect(component.getByRole('button')).toHaveCount(0);
+        await expect(component.getByRole('checkbox')).toHaveCount(0);
+    });
+}
+
+test('renders only verified work as checked completion', async ({ mount }) => {
+    const component = await mount(
+        <ScheduleTaskStateControl
+            label="Posij mrkvu"
+            state="completed"
+            unavailableTitle="Sijanje nije dostupno."
+        />,
+    );
+
+    const checkbox = component.getByRole('checkbox', {
+        name: 'Potvrđeno: Posij mrkvu',
+    });
+    await expect(checkbox).toBeChecked();
+    await expect(checkbox).toBeDisabled();
+});
+
+test('keeps actionable controls available and names locked work', async ({
+    mount,
+    page,
+}) => {
+    const actionable = await mount(
+        <ScheduleTaskStateControl
+            action={<button type="button">Dovrši</button>}
+            label="Zalij salatu"
+            state="actionable"
+            unavailableTitle="Radnja nije dostupna."
+        />,
+    );
+    await expect(page.getByRole('button', { name: 'Dovrši' })).toBeVisible();
+    await actionable.unmount();
+
+    await mount(
+        <ScheduleTaskStateControl
+            label="Zalij salatu"
+            state="actionable"
+            unavailableTitle="Radnja je dodijeljena drugom korisniku."
+        />,
+    );
+    await expect(
+        page.getByRole('checkbox', {
+            name: 'Nije dostupno: Zalij salatu. Radnja je dodijeljena drugom korisniku.',
+        }),
+    ).toBeDisabled();
+});

--- a/apps/farm/app/schedule/ScheduleTaskStateControl.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskStateControl.tsx
@@ -1,0 +1,46 @@
+import { Checkbox } from '@gredice/ui/Checkbox';
+import type { ReactNode } from 'react';
+import type { ScheduleTaskState } from './scheduleTaskState';
+
+interface ScheduleTaskStateControlProps {
+    action?: ReactNode;
+    label: string;
+    state: ScheduleTaskState;
+    unavailableTitle: string;
+}
+
+export function ScheduleTaskStateControl({
+    action,
+    label,
+    state,
+    unavailableTitle,
+}: ScheduleTaskStateControlProps) {
+    if (state === 'completed') {
+        return (
+            <Checkbox
+                aria-label={`Potvrđeno: ${label}`}
+                className="size-5"
+                checked
+                disabled
+            />
+        );
+    }
+
+    if (state !== 'actionable') {
+        return null;
+    }
+
+    if (action) {
+        return action;
+    }
+
+    return (
+        <div title={unavailableTitle}>
+            <Checkbox
+                aria-label={`Nije dostupno: ${label}. ${unavailableTitle}`}
+                className="size-5"
+                disabled
+            />
+        </div>
+    );
+}

--- a/apps/farm/app/schedule/ScheduleTaskStatusChip.spec.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskStatusChip.spec.tsx
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import '../globals.css';
+import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
+import type { ScheduleTaskState } from './scheduleTaskState';
+
+const visibleStates: Exclude<ScheduleTaskState, 'actionable'>[] = [
+    'pendingVerification',
+    'completed',
+    'failed',
+    'canceled',
+];
+
+test('renders every terminal and review state with visible text', async ({
+    mount,
+}) => {
+    const component = await mount(
+        <div className="flex max-w-full flex-wrap gap-2">
+            {visibleStates.map((state) => (
+                <ScheduleTaskStatusChip key={state} state={state} />
+            ))}
+        </div>,
+    );
+
+    await expect(component.getByText('Čeka potvrdu')).toBeVisible();
+    await expect(component.getByText('Potvrđeno')).toBeVisible();
+    await expect(component.getByText('Neuspjelo')).toBeVisible();
+    await expect(component.getByText('Otkazano')).toBeVisible();
+});
+
+test('keeps the pending label visible at a phone viewport', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 640 });
+    const component = await mount(
+        <div className="flex w-full max-w-full flex-wrap gap-2">
+            {visibleStates.map((state) => (
+                <ScheduleTaskStatusChip key={state} state={state} />
+            ))}
+        </div>,
+    );
+
+    const pending = component.getByText('Čeka potvrdu');
+    await expect(pending).toBeVisible();
+    await expect(
+        component.locator('[data-task-state="pendingVerification"]'),
+    ).toHaveCount(1);
+    expect(
+        await page.evaluate(
+            () =>
+                document.documentElement.scrollWidth <=
+                document.documentElement.clientWidth,
+        ),
+    ).toBe(true);
+});

--- a/apps/farm/app/schedule/ScheduleTaskStatusChip.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskStatusChip.tsx
@@ -1,0 +1,69 @@
+import { Chip, type ColorPaletteProp } from '@gredice/ui/Chip';
+import {
+    Disabled,
+    Error as ErrorIcon,
+    Hourglass,
+    Verified,
+} from '@gredice/ui/icons';
+import type { ComponentType } from 'react';
+import type { ScheduleTaskState } from './scheduleTaskState';
+
+type VisibleScheduleTaskState = Exclude<ScheduleTaskState, 'actionable'>;
+
+const statusConfig: Record<
+    VisibleScheduleTaskState,
+    {
+        color: ColorPaletteProp;
+        icon: ComponentType<{
+            'aria-hidden'?: boolean;
+            className?: string;
+        }>;
+        label: string;
+    }
+> = {
+    pendingVerification: {
+        color: 'warning',
+        icon: Hourglass,
+        label: 'Čeka potvrdu',
+    },
+    completed: {
+        color: 'success',
+        icon: Verified,
+        label: 'Potvrđeno',
+    },
+    failed: {
+        color: 'error',
+        icon: ErrorIcon,
+        label: 'Neuspjelo',
+    },
+    canceled: {
+        color: 'neutral',
+        icon: Disabled,
+        label: 'Otkazano',
+    },
+};
+
+interface ScheduleTaskStatusChipProps {
+    state: ScheduleTaskState;
+}
+
+export function ScheduleTaskStatusChip({ state }: ScheduleTaskStatusChipProps) {
+    if (state === 'actionable') {
+        return null;
+    }
+
+    const config = statusConfig[state];
+    const StatusIcon = config.icon;
+
+    return (
+        <Chip
+            color={config.color}
+            data-task-state={state}
+            size="sm"
+            startDecorator={<StatusIcon aria-hidden />}
+            variant="soft"
+        >
+            {config.label}
+        </Chip>
+    );
+}

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -13,6 +13,10 @@ import {
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import { auth } from '../../lib/auth/auth';
+import {
+    getScheduleOperationTaskAssignment,
+    getSchedulePlantingTaskAssignment,
+} from './scheduleTaskAssignment';
 
 const MAX_COMPLETION_NOTES_LENGTH = 2000;
 
@@ -41,7 +45,7 @@ async function assertFarmerCanCompleteOperation(
         throw new Error('Nemaš dozvolu za označavanje ove radnje.');
     }
 
-    if (operation.assignedUserId && operation.assignedUserId !== userId) {
+    if (getScheduleOperationTaskAssignment(operation, userId) === 'other') {
         throw new Error('Ova radnja je dodijeljena drugom korisniku.');
     }
 
@@ -63,13 +67,7 @@ async function assertFarmerCanCompletePlanting(
         throw new Error('Nemaš dozvolu za označavanje ovog sijanja.');
     }
 
-    const assignedUserIds = field.assignedUserIds ?? [];
-    const isAssignedToAnotherUser =
-        assignedUserIds.length > 0
-            ? !assignedUserIds.includes(userId)
-            : !!field.assignedUserId && field.assignedUserId !== userId;
-
-    if (isAssignedToAnotherUser) {
+    if (getSchedulePlantingTaskAssignment(field, userId) === 'other') {
         throw new Error('Ovo sijanje je dodijeljeno drugom korisniku.');
     }
 

--- a/apps/farm/app/schedule/scheduleData.ts
+++ b/apps/farm/app/schedule/scheduleData.ts
@@ -7,6 +7,7 @@ import {
     getEntitiesFormatted,
     getFarmUserAcceptedOperations,
     getFarmUserAcceptedOperationsByScheduleRange,
+    getFarmUserPendingVerificationOperations,
     getFarmUserRaisedBeds,
     getRaisedBedPhotoPreviews,
     getTimeZoneDateKey,
@@ -170,6 +171,10 @@ export const getFarmScheduleOperations = cache(async (userId: string) => {
         scheduleCacheTtls.operations,
     );
 });
+
+export const getFarmSchedulePendingOperations = cache(async (userId: string) =>
+    getFarmUserPendingVerificationOperations(userId),
+);
 
 export const getFarmScheduleOperationsForDay = cache(
     async (userId: string, dateKey: string, isToday: boolean) => {

--- a/apps/farm/app/schedule/scheduleData.ts
+++ b/apps/farm/app/schedule/scheduleData.ts
@@ -15,21 +15,15 @@ import {
     scheduleCacheTtls,
 } from '@gredice/storage';
 import { cache } from 'react';
+import {
+    getCarryoverOperationsForToday,
+    getScheduledFieldsForDay,
+    getSelectedDateOperationsForDay,
+} from './scheduleDayFilters';
 import { FARM_SCHEDULE_TIME_ZONE } from './scheduleShared';
 
 const operationsBackDays = 90;
 const raisedBedPhotoPreviewImageLimit = 3;
-const SCHEDULE_FIELD_STATUSES = new Set([
-    'planned',
-    'pendingVerification',
-    'sowed',
-]);
-const SCHEDULE_OPERATION_STATUSES = new Set([
-    'new',
-    'planned',
-    'pendingVerification',
-    'completed',
-]);
 
 function startOfDaysAgo(days: number) {
     const todayKey = getTimeZoneDateKey(new Date(), FARM_SCHEDULE_TIME_ZONE);
@@ -41,130 +35,6 @@ function startOfDaysAgo(days: number) {
 
 function dedupeById<T extends { id: number }>(items: T[]) {
     return Array.from(new Map(items.map((item) => [item.id, item])).values());
-}
-
-function isOperationCompleted(status?: string) {
-    return status === 'completed' || status === 'pendingVerification';
-}
-
-function isFieldCompleted(status?: string) {
-    return status === 'sowed' || status === 'pendingVerification';
-}
-
-function getScheduledFieldsForDay(
-    isToday: boolean,
-    dateKey: string,
-    raisedBeds: FarmScheduleRaisedBed[],
-) {
-    return raisedBeds
-        .filter((raisedBed) => Boolean(raisedBed.physicalId))
-        .flatMap((raisedBed) => raisedBed.fields)
-        .filter((field) => {
-            if (!field.plantSortId) {
-                return false;
-            }
-
-            if (!SCHEDULE_FIELD_STATUSES.has(field.plantStatus ?? 'new')) {
-                return false;
-            }
-
-            if (isFieldCompleted(field.plantStatus) && field.plantSowDate) {
-                const sowDate = new Date(field.plantSowDate);
-                return (
-                    getTimeZoneDateKey(sowDate, FARM_SCHEDULE_TIME_ZONE) ===
-                    dateKey
-                );
-            }
-
-            if (!field.plantScheduledDate) {
-                return isToday;
-            }
-
-            const scheduledDate = new Date(field.plantScheduledDate);
-            const scheduledDateKey = getTimeZoneDateKey(
-                scheduledDate,
-                FARM_SCHEDULE_TIME_ZONE,
-            );
-
-            return (
-                scheduledDateKey === dateKey ||
-                (isToday && scheduledDateKey < dateKey)
-            );
-        });
-}
-
-function getSelectedDateOperationsForDay(
-    dateKey: string,
-    operations: FarmScheduleOperation[],
-) {
-    return operations.filter((operation) => {
-        if (!SCHEDULE_OPERATION_STATUSES.has(operation.status)) {
-            return false;
-        }
-
-        if (
-            operation.raisedBedId === null &&
-            typeof operation.farmId !== 'number'
-        ) {
-            return false;
-        }
-
-        if (isOperationCompleted(operation.status) && operation.completedAt) {
-            const completedDate = new Date(operation.completedAt);
-            return (
-                getTimeZoneDateKey(completedDate, FARM_SCHEDULE_TIME_ZONE) ===
-                dateKey
-            );
-        }
-
-        const scheduledDate = operation.scheduledDate
-            ? new Date(operation.scheduledDate)
-            : undefined;
-
-        return (
-            scheduledDate !== undefined &&
-            getTimeZoneDateKey(scheduledDate, FARM_SCHEDULE_TIME_ZONE) ===
-                dateKey
-        );
-    });
-}
-
-function getCarryoverOperationsForToday(
-    isToday: boolean,
-    dateKey: string,
-    operations: FarmScheduleOperation[],
-) {
-    if (!isToday) {
-        return [];
-    }
-
-    return operations.filter((operation) => {
-        if (!SCHEDULE_OPERATION_STATUSES.has(operation.status)) {
-            return false;
-        }
-
-        if (isOperationCompleted(operation.status)) {
-            return false;
-        }
-
-        if (
-            operation.raisedBedId === null &&
-            typeof operation.farmId !== 'number'
-        ) {
-            return false;
-        }
-
-        if (!operation.scheduledDate) {
-            return true;
-        }
-
-        return (
-            getTimeZoneDateKey(
-                new Date(operation.scheduledDate),
-                FARM_SCHEDULE_TIME_ZONE,
-            ) < dateKey
-        );
-    });
 }
 
 function sortOperationsNewestFirst(operations: FarmScheduleOperation[]) {

--- a/apps/farm/app/schedule/scheduleDayFilters.spec.ts
+++ b/apps/farm/app/schedule/scheduleDayFilters.spec.ts
@@ -1,0 +1,201 @@
+import type { OperationStatus } from '@gredice/storage';
+import { expect, test } from '@playwright/test';
+import {
+    getCarryoverOperationsForToday,
+    getScheduledFieldsForDay,
+    getSelectedDateOperationsForDay,
+} from './scheduleDayFilters';
+
+const yesterdayKey = '2026-05-13';
+const todayKey = '2026-05-14';
+const yesterdayNoon = new Date('2026-05-13T10:00:00.000Z');
+
+type TestField = {
+    id: number;
+    plantScheduledDate?: Date;
+    plantSortId: number;
+    plantSowDate?: Date;
+    plantStatus: string;
+};
+
+type TestOperation = {
+    completedAt?: Date;
+    farmId: number | null;
+    id: number;
+    raisedBedId: number | null;
+    scheduledDate?: Date;
+    status: OperationStatus;
+};
+
+function buildField(overrides: Partial<TestField> = {}): TestField {
+    return {
+        id: 1,
+        plantScheduledDate: yesterdayNoon,
+        plantSortId: 100,
+        plantStatus: 'planned',
+        ...overrides,
+    };
+}
+
+function buildRaisedBed(field: TestField) {
+    return {
+        fields: [field],
+        physicalId: 'A1',
+    };
+}
+
+function buildOperation(overrides: Partial<TestOperation> = {}): TestOperation {
+    return {
+        farmId: null,
+        id: 1,
+        raisedBedId: 10,
+        scheduledDate: yesterdayNoon,
+        status: 'planned',
+        ...overrides,
+    };
+}
+
+test('pending planting stays on its submission day without actionable carryover', () => {
+    const field = buildField({
+        plantSowDate: yesterdayNoon,
+        plantStatus: 'pendingVerification',
+    });
+    const raisedBeds = [buildRaisedBed(field)];
+
+    expect(
+        getScheduledFieldsForDay(false, yesterdayKey, raisedBeds).map(
+            (item) => item.id,
+        ),
+    ).toEqual([field.id]);
+    expect(getScheduledFieldsForDay(true, todayKey, raisedBeds)).toEqual([]);
+    expect(getScheduledFieldsForDay(false, todayKey, raisedBeds)).toEqual([]);
+});
+
+test('verified planting appears only on its actual sow date', () => {
+    const verifiedField = buildField({
+        plantScheduledDate: new Date('2026-05-10T10:00:00.000Z'),
+        plantSowDate: yesterdayNoon,
+        plantStatus: 'sowed',
+    });
+    const missingSowDate = buildField({
+        id: 2,
+        plantStatus: 'sowed',
+    });
+    const raisedBeds = [
+        buildRaisedBed(verifiedField),
+        buildRaisedBed(missingSowDate),
+    ];
+
+    expect(
+        getScheduledFieldsForDay(false, yesterdayKey, raisedBeds).map(
+            (item) => item.id,
+        ),
+    ).toEqual([verifiedField.id, missingSowDate.id]);
+    expect(
+        getScheduledFieldsForDay(true, todayKey, raisedBeds).map(
+            (item) => item.id,
+        ),
+    ).toEqual([missingSowDate.id]);
+});
+
+test('pending operation stays on its submission day without actionable carryover', () => {
+    const operation = buildOperation({
+        completedAt: yesterdayNoon,
+        status: 'pendingVerification',
+    });
+
+    expect(
+        getSelectedDateOperationsForDay(yesterdayKey, [operation]).map(
+            (item) => item.id,
+        ),
+    ).toEqual([operation.id]);
+    expect(getCarryoverOperationsForToday(true, todayKey, [operation])).toEqual(
+        [],
+    );
+    expect(
+        getCarryoverOperationsForToday(false, todayKey, [operation]),
+    ).toEqual([]);
+});
+
+test('pending work without a submission timestamp falls back to its schedule date', () => {
+    const field = buildField({ plantStatus: 'pendingVerification' });
+    const operation = buildOperation({ status: 'pendingVerification' });
+
+    expect(
+        getScheduledFieldsForDay(false, yesterdayKey, [
+            buildRaisedBed(field),
+        ]).map((item) => item.id),
+    ).toEqual([field.id]);
+    expect(
+        getSelectedDateOperationsForDay(yesterdayKey, [operation]).map(
+            (item) => item.id,
+        ),
+    ).toEqual([operation.id]);
+});
+
+test('verified operation appears only on its actual completion date', () => {
+    const operation = buildOperation({
+        completedAt: yesterdayNoon,
+        scheduledDate: new Date('2026-05-10T10:00:00.000Z'),
+        status: 'completed',
+    });
+
+    expect(
+        getSelectedDateOperationsForDay(yesterdayKey, [operation]).map(
+            (item) => item.id,
+        ),
+    ).toEqual([operation.id]);
+    expect(getSelectedDateOperationsForDay('2026-05-10', [operation])).toEqual(
+        [],
+    );
+    expect(getCarryoverOperationsForToday(true, todayKey, [operation])).toEqual(
+        [],
+    );
+});
+
+test('only actionable overdue or unscheduled operations carry into Today', () => {
+    const overdue = buildOperation({ id: 1 });
+    const unscheduled = buildOperation({ id: 2, scheduledDate: undefined });
+    const future = buildOperation({
+        id: 3,
+        scheduledDate: new Date('2026-05-15T10:00:00.000Z'),
+    });
+    const failed = buildOperation({ id: 4, status: 'failed' });
+    const canceled = buildOperation({ id: 5, status: 'canceled' });
+
+    expect(
+        getCarryoverOperationsForToday(true, todayKey, [
+            overdue,
+            unscheduled,
+            future,
+            failed,
+            canceled,
+        ]).map((item) => item.id),
+    ).toEqual([overdue.id, unscheduled.id]);
+
+    expect(
+        getSelectedDateOperationsForDay(yesterdayKey, [failed, canceled]),
+    ).toEqual([]);
+});
+
+test('Zagreb midnight stays on its local schedule day', () => {
+    const july11 = '2026-07-11';
+    const july12 = '2026-07-12';
+    const july12InZagreb = new Date('2026-07-11T22:00:56.865Z');
+    const operation = buildOperation({ scheduledDate: july12InZagreb });
+    const field = buildField({ plantScheduledDate: july12InZagreb });
+    const raisedBeds = [buildRaisedBed(field)];
+
+    expect(getSelectedDateOperationsForDay(july11, [operation])).toEqual([]);
+    expect(
+        getSelectedDateOperationsForDay(july12, [operation]).map(
+            (item) => item.id,
+        ),
+    ).toEqual([operation.id]);
+    expect(getScheduledFieldsForDay(true, july11, raisedBeds)).toEqual([]);
+    expect(
+        getScheduledFieldsForDay(false, july12, raisedBeds).map(
+            (item) => item.id,
+        ),
+    ).toEqual([field.id]);
+});

--- a/apps/farm/app/schedule/scheduleDayFilters.ts
+++ b/apps/farm/app/schedule/scheduleDayFilters.ts
@@ -1,0 +1,166 @@
+import type { OperationStatus } from '@gredice/storage';
+import { getFarmScheduleDateKey } from './scheduleShared';
+import {
+    getOperationTaskState,
+    getPlantingTaskState,
+    isActionableTaskState,
+    isCompletedTaskState,
+    isPendingTaskState,
+} from './scheduleTaskState';
+
+type ScheduleDate = Date | string | null | undefined;
+
+type ScheduleField = {
+    plantScheduledDate?: ScheduleDate;
+    plantSortId?: number | null;
+    plantSowDate?: ScheduleDate;
+    plantStatus?: string | null;
+};
+
+type ScheduleRaisedBed<TField extends ScheduleField> = {
+    fields: TField[];
+    physicalId?: string | null;
+};
+
+type ScheduleOperation = {
+    completedAt?: ScheduleDate;
+    farmId?: number | null;
+    raisedBedId?: number | null;
+    scheduledDate?: ScheduleDate;
+    status?: OperationStatus | null;
+};
+
+function getDateKey(date: ScheduleDate) {
+    if (!date) {
+        return undefined;
+    }
+
+    const parsedDate = typeof date === 'string' ? new Date(date) : date;
+
+    return Number.isFinite(parsedDate.getTime())
+        ? getFarmScheduleDateKey(parsedDate)
+        : undefined;
+}
+
+function hasScheduleLocation(operation: ScheduleOperation) {
+    return (
+        typeof operation.raisedBedId === 'number' ||
+        typeof operation.farmId === 'number'
+    );
+}
+
+/**
+ * Selects planting tasks for a calendar day. Submitted and verified sowing is
+ * historical and follows its actual sow date without becoming carryover work.
+ */
+export function getScheduledFieldsForDay<TField extends ScheduleField>(
+    isToday: boolean,
+    dateKey: string,
+    raisedBeds: ScheduleRaisedBed<TField>[],
+) {
+    return raisedBeds
+        .filter((raisedBed) => Boolean(raisedBed.physicalId))
+        .flatMap((raisedBed) => raisedBed.fields)
+        .filter((field) => {
+            if (!field.plantSortId) {
+                return false;
+            }
+
+            const taskState = getPlantingTaskState(field.plantStatus);
+
+            if (!taskState) {
+                return false;
+            }
+
+            const sowDateKey = getDateKey(field.plantSowDate);
+
+            if (
+                (isPendingTaskState(taskState) ||
+                    isCompletedTaskState(taskState)) &&
+                sowDateKey
+            ) {
+                return sowDateKey === dateKey;
+            }
+
+            const scheduledDateKey = getDateKey(field.plantScheduledDate);
+
+            if (!scheduledDateKey) {
+                return isToday;
+            }
+
+            return (
+                scheduledDateKey === dateKey ||
+                (isToday && scheduledDateKey < dateKey)
+            );
+        });
+}
+
+/**
+ * Selects operations for the requested calendar date. Submitted and verified
+ * work follows the actual completion date; actionable work follows its planned
+ * date. Carryover into Today is handled separately so the range queries remain
+ * bounded to the requested date.
+ */
+export function getSelectedDateOperationsForDay<
+    TOperation extends ScheduleOperation,
+>(dateKey: string, operations: TOperation[]) {
+    return operations.filter((operation) => {
+        if (!operation.status) {
+            return false;
+        }
+
+        if (!hasScheduleLocation(operation)) {
+            return false;
+        }
+
+        const taskState = getOperationTaskState(operation.status);
+
+        if (
+            !isActionableTaskState(taskState) &&
+            !isPendingTaskState(taskState) &&
+            !isCompletedTaskState(taskState)
+        ) {
+            return false;
+        }
+
+        if (isPendingTaskState(taskState) || isCompletedTaskState(taskState)) {
+            const completedDateKey = getDateKey(operation.completedAt);
+            if (completedDateKey) {
+                return completedDateKey === dateKey;
+            }
+        }
+
+        return getDateKey(operation.scheduledDate) === dateKey;
+    });
+}
+
+/**
+ * Carries unfinished actionable work into Today. Pending verification,
+ * verified, failed, and canceled work never becomes an overdue task.
+ */
+export function getCarryoverOperationsForToday<
+    TOperation extends ScheduleOperation,
+>(isToday: boolean, dateKey: string, operations: TOperation[]) {
+    if (!isToday) {
+        return [];
+    }
+
+    return operations.filter((operation) => {
+        if (!operation.status) {
+            return false;
+        }
+
+        if (!hasScheduleLocation(operation)) {
+            return false;
+        }
+
+        const taskState = getOperationTaskState(operation.status);
+
+        if (!isActionableTaskState(taskState)) {
+            return false;
+        }
+
+        const scheduledDateKey = getDateKey(operation.scheduledDate);
+        return !scheduledDateKey || scheduledDateKey < dateKey;
+    });
+}

--- a/apps/farm/app/schedule/scheduleOperationRequirements.ts
+++ b/apps/farm/app/schedule/scheduleOperationRequirements.ts
@@ -1,0 +1,60 @@
+import type { EntityStandardized } from '@gredice/storage';
+
+export type ScheduleOperationRequirementLevel =
+    | 'none'
+    | 'optional'
+    | 'required'
+    | 'unknown';
+
+export type ScheduleOperationCompletionRequirements = {
+    images: ScheduleOperationRequirementLevel;
+    notes: ScheduleOperationRequirementLevel;
+};
+
+function getRequirementLevel({
+    enabled,
+    metadataAvailable,
+    operationData,
+    required,
+}: {
+    enabled: boolean | undefined;
+    metadataAvailable: boolean;
+    operationData: EntityStandardized | undefined;
+    required: boolean | undefined;
+}): ScheduleOperationRequirementLevel {
+    if (!metadataAvailable || !operationData) {
+        return 'unknown';
+    }
+
+    if (required) {
+        return 'required';
+    }
+
+    return enabled ? 'optional' : 'none';
+}
+
+export function getScheduleOperationCompletionRequirements(
+    operationData: EntityStandardized | undefined,
+    metadataAvailable = true,
+): ScheduleOperationCompletionRequirements {
+    return {
+        images: getRequirementLevel({
+            enabled: operationData?.conditions?.completionAttachImages,
+            metadataAvailable,
+            operationData,
+            required: operationData?.conditions?.completionAttachImagesRequired,
+        }),
+        notes: getRequirementLevel({
+            enabled: operationData?.conditions?.completionAttachNotes,
+            metadataAvailable,
+            operationData,
+            required: operationData?.conditions?.completionAttachNotesRequired,
+        }),
+    };
+}
+
+export function isScheduleOperationRequirementVisible(
+    level: ScheduleOperationRequirementLevel,
+) {
+    return level === 'optional' || level === 'required';
+}

--- a/apps/farm/app/schedule/scheduleShared.ts
+++ b/apps/farm/app/schedule/scheduleShared.ts
@@ -308,15 +308,3 @@ export function getScheduleTaskAgeIndicator(
 
     return null;
 }
-
-export function isOperationCompleted(status?: string) {
-    return status === 'completed' || status === 'pendingVerification';
-}
-
-export function isFieldApproved(status?: string) {
-    return status === 'planned';
-}
-
-export function isFieldCompleted(status?: string) {
-    return status === 'sowed' || status === 'pendingVerification';
-}

--- a/apps/farm/app/schedule/scheduleTaskAssignment.spec.ts
+++ b/apps/farm/app/schedule/scheduleTaskAssignment.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+import {
+    getScheduleOperationTaskAssignment,
+    getSchedulePlantingTaskAssignment,
+} from './scheduleTaskAssignment';
+
+const userId = 'farmer-1';
+const otherUserId = 'farmer-2';
+
+test('keeps the operation primary assignee authoritative and supports array-only events', () => {
+    expect(
+        getScheduleOperationTaskAssignment(
+            {
+                assignedUserId: otherUserId,
+                assignedUserIds: [otherUserId, userId],
+            },
+            userId,
+        ),
+    ).toBe('other');
+    expect(
+        getScheduleOperationTaskAssignment(
+            { assignedUserId: null, assignedUserIds: [userId] },
+            userId,
+        ),
+    ).toBe('mine');
+    expect(
+        getScheduleOperationTaskAssignment(
+            { assignedUserId: null, assignedUserIds: [otherUserId] },
+            userId,
+        ),
+    ).toBe('other');
+    expect(
+        getScheduleOperationTaskAssignment(
+            { assignedUserId: null, assignedUserIds: [] },
+            userId,
+        ),
+    ).toBe('shared');
+});
+
+test('uses planting assignment arrays before the legacy primary assignee', () => {
+    expect(
+        getSchedulePlantingTaskAssignment(
+            {
+                assignedUserId: otherUserId,
+                assignedUserIds: [otherUserId, userId],
+            },
+            userId,
+        ),
+    ).toBe('mine');
+    expect(
+        getSchedulePlantingTaskAssignment(
+            { assignedUserId: userId, assignedUserIds: [otherUserId] },
+            userId,
+        ),
+    ).toBe('other');
+    expect(
+        getSchedulePlantingTaskAssignment(
+            { assignedUserId: null, assignedUserIds: [] },
+            userId,
+        ),
+    ).toBe('shared');
+});

--- a/apps/farm/app/schedule/scheduleTaskAssignment.ts
+++ b/apps/farm/app/schedule/scheduleTaskAssignment.ts
@@ -1,0 +1,58 @@
+export type ScheduleTaskAssignment = 'mine' | 'other' | 'shared';
+
+type ScheduleTaskAssignmentInput = {
+    assignedUserId?: string | null;
+    assignedUserIds?: readonly string[] | null;
+};
+
+function normalizeAssignedUserIds(
+    assignedUserIds: readonly string[] | null | undefined,
+) {
+    return Array.from(
+        new Set(
+            (assignedUserIds ?? []).filter(
+                (value) => typeof value === 'string' && value.length > 0,
+            ),
+        ),
+    );
+}
+
+function classifyAssignedUserIds(
+    assignedUserIds: string[],
+    userId: string,
+): ScheduleTaskAssignment {
+    if (assignedUserIds.length === 0) {
+        return 'shared';
+    }
+
+    return assignedUserIds.includes(userId) ? 'mine' : 'other';
+}
+
+export function getScheduleOperationTaskAssignment(
+    task: ScheduleTaskAssignmentInput,
+    userId: string,
+): ScheduleTaskAssignment {
+    if (task.assignedUserId) {
+        return task.assignedUserId === userId ? 'mine' : 'other';
+    }
+
+    return classifyAssignedUserIds(
+        normalizeAssignedUserIds(task.assignedUserIds),
+        userId,
+    );
+}
+
+export function getSchedulePlantingTaskAssignment(
+    task: ScheduleTaskAssignmentInput,
+    userId: string,
+): ScheduleTaskAssignment {
+    const assignedUserIds = normalizeAssignedUserIds(task.assignedUserIds);
+    if (assignedUserIds.length > 0) {
+        return classifyAssignedUserIds(assignedUserIds, userId);
+    }
+
+    return classifyAssignedUserIds(
+        task.assignedUserId ? [task.assignedUserId] : [],
+        userId,
+    );
+}

--- a/apps/farm/app/schedule/scheduleTaskState.spec.ts
+++ b/apps/farm/app/schedule/scheduleTaskState.spec.ts
@@ -1,0 +1,123 @@
+import type { OperationStatus } from '@gredice/storage';
+import { expect, test } from '@playwright/test';
+import {
+    getOperationTaskState,
+    getPlantingTaskState,
+    getScheduleTaskPresentation,
+    getScheduleTaskSummary,
+    isActionableTaskState,
+    isCompletedTaskState,
+    isPendingTaskState,
+    type SchedulePlantingStatus,
+    type ScheduleTaskState,
+    type ScheduleTaskSummaryItem,
+} from './scheduleTaskState';
+
+const operationStateCases = [
+    { status: 'new', expectedState: 'actionable' },
+    { status: 'planned', expectedState: 'actionable' },
+    {
+        status: 'pendingVerification',
+        expectedState: 'pendingVerification',
+    },
+    { status: 'completed', expectedState: 'completed' },
+    { status: 'failed', expectedState: 'failed' },
+    { status: 'canceled', expectedState: 'canceled' },
+] satisfies Array<{
+    status: OperationStatus;
+    expectedState: ScheduleTaskState;
+}>;
+
+const plantingStateCases = [
+    { status: 'planned', expectedState: 'actionable' },
+    {
+        status: 'pendingVerification',
+        expectedState: 'pendingVerification',
+    },
+    { status: 'sowed', expectedState: 'completed' },
+] satisfies Array<{
+    status: SchedulePlantingStatus;
+    expectedState: ScheduleTaskState;
+}>;
+
+test('maps every operation status to a distinct schedule task state', () => {
+    for (const { status, expectedState } of operationStateCases) {
+        expect(getOperationTaskState(status)).toBe(expectedState);
+    }
+});
+
+test('maps every scheduled planting status to its task state', () => {
+    for (const { status, expectedState } of plantingStateCases) {
+        expect(getPlantingTaskState(status)).toBe(expectedState);
+    }
+});
+
+test('keeps submitted work pending instead of treating it as completed', () => {
+    const operationState = getOperationTaskState('pendingVerification');
+    const plantingState = getPlantingTaskState('pendingVerification');
+
+    expect(isPendingTaskState(operationState)).toBe(true);
+    expect(isPendingTaskState(plantingState)).toBe(true);
+    expect(isCompletedTaskState(operationState)).toBe(false);
+    expect(isCompletedTaskState(plantingState)).toBe(false);
+    expect(isActionableTaskState(operationState)).toBe(false);
+    expect(isActionableTaskState(plantingState)).toBe(false);
+
+    expect(getScheduleTaskPresentation(operationState)).toEqual({
+        isActionable: false,
+        isCompleted: false,
+        isPendingVerification: true,
+        showAgeIndicator: false,
+        showCompletionAttachments: true,
+        showCompletionControl: false,
+        showRequirementIndicators: false,
+    });
+    expect(getScheduleTaskPresentation('completed')).toEqual({
+        isActionable: false,
+        isCompleted: true,
+        isPendingVerification: false,
+        showAgeIndicator: false,
+        showCompletionAttachments: true,
+        showCompletionControl: false,
+        showRequirementIndicators: false,
+    });
+});
+
+test('summarizes task counts and duration with consistent state totals', () => {
+    const items = [
+        { state: 'actionable', durationMinutes: 15 },
+        { state: 'actionable', durationMinutes: 5 },
+        { state: 'pendingVerification', durationMinutes: 10 },
+        { state: 'completed', durationMinutes: 7 },
+        { state: 'failed', durationMinutes: 3 },
+        { state: 'canceled', durationMinutes: -2 },
+    ] satisfies ScheduleTaskSummaryItem[];
+
+    const summary = getScheduleTaskSummary(items);
+    const stateMetrics = [
+        summary.actionable,
+        summary.pendingVerification,
+        summary.completed,
+        summary.failed,
+        summary.canceled,
+    ];
+
+    expect(summary.actionable).toEqual({ count: 2, durationMinutes: 20 });
+    expect(summary.pendingVerification).toEqual({
+        count: 1,
+        durationMinutes: 10,
+    });
+    expect(summary.completed).toEqual({ count: 1, durationMinutes: 7 });
+    expect(summary.failed).toEqual({ count: 1, durationMinutes: 3 });
+    expect(summary.canceled).toEqual({ count: 1, durationMinutes: 0 });
+    expect(summary.total).toEqual({ count: 6, durationMinutes: 40 });
+    expect(
+        stateMetrics.reduce((total, metrics) => total + metrics.count, 0),
+    ).toBe(summary.total.count);
+    expect(
+        stateMetrics.reduce(
+            (total, metrics) => total + metrics.durationMinutes,
+            0,
+        ),
+    ).toBe(summary.total.durationMinutes);
+});

--- a/apps/farm/app/schedule/scheduleTaskState.ts
+++ b/apps/farm/app/schedule/scheduleTaskState.ts
@@ -1,0 +1,151 @@
+import type { OperationStatus } from '@gredice/storage';
+
+export type ScheduleTaskState =
+    | 'actionable'
+    | 'pendingVerification'
+    | 'completed'
+    | 'failed'
+    | 'canceled';
+
+export type SchedulePlantingStatus =
+    | 'planned'
+    | 'pendingVerification'
+    | 'sowed';
+
+type SchedulePlantingTaskState = Extract<
+    ScheduleTaskState,
+    'actionable' | 'pendingVerification' | 'completed'
+>;
+
+export type ScheduleTaskSummaryItem = {
+    state: ScheduleTaskState;
+    durationMinutes: number;
+};
+
+export type ScheduleTaskMetrics = {
+    count: number;
+    durationMinutes: number;
+};
+
+export type ScheduleTaskSummary = {
+    total: ScheduleTaskMetrics;
+    actionable: ScheduleTaskMetrics;
+    pendingVerification: ScheduleTaskMetrics;
+    completed: ScheduleTaskMetrics;
+    failed: ScheduleTaskMetrics;
+    canceled: ScheduleTaskMetrics;
+};
+
+export type ScheduleTaskPresentation = {
+    isActionable: boolean;
+    isCompleted: boolean;
+    isPendingVerification: boolean;
+    showAgeIndicator: boolean;
+    showCompletionAttachments: boolean;
+    showCompletionControl: boolean;
+    showRequirementIndicators: boolean;
+};
+
+const operationTaskStateByStatus = {
+    new: 'actionable',
+    planned: 'actionable',
+    pendingVerification: 'pendingVerification',
+    completed: 'completed',
+    failed: 'failed',
+    canceled: 'canceled',
+} satisfies Record<OperationStatus, ScheduleTaskState>;
+
+export function getOperationTaskState(status: OperationStatus) {
+    return operationTaskStateByStatus[status];
+}
+
+export function getPlantingTaskState(
+    status: SchedulePlantingStatus,
+): SchedulePlantingTaskState;
+export function getPlantingTaskState(
+    status: string | null | undefined,
+): SchedulePlantingTaskState | null;
+export function getPlantingTaskState(status: string | null | undefined) {
+    switch (status) {
+        case 'planned':
+            return 'actionable';
+        case 'pendingVerification':
+            return 'pendingVerification';
+        case 'sowed':
+            return 'completed';
+        default:
+            return null;
+    }
+}
+
+export function isActionableTaskState(
+    state: ScheduleTaskState | null | undefined,
+): state is 'actionable' {
+    return state === 'actionable';
+}
+
+export function isPendingTaskState(
+    state: ScheduleTaskState | null | undefined,
+): state is 'pendingVerification' {
+    return state === 'pendingVerification';
+}
+
+export function isCompletedTaskState(
+    state: ScheduleTaskState | null | undefined,
+): state is 'completed' {
+    return state === 'completed';
+}
+
+export function getScheduleTaskPresentation(
+    state: ScheduleTaskState,
+): ScheduleTaskPresentation {
+    const isActionable = isActionableTaskState(state);
+    const isCompleted = isCompletedTaskState(state);
+    const isPendingVerification = isPendingTaskState(state);
+
+    return {
+        isActionable,
+        isCompleted,
+        isPendingVerification,
+        showAgeIndicator: isActionable,
+        showCompletionAttachments: isPendingVerification || isCompleted,
+        showCompletionControl: isActionable,
+        showRequirementIndicators: isActionable,
+    };
+}
+
+function createEmptyMetrics(): ScheduleTaskMetrics {
+    return {
+        count: 0,
+        durationMinutes: 0,
+    };
+}
+
+function normalizeDurationMinutes(durationMinutes: number) {
+    return Number.isFinite(durationMinutes) ? Math.max(0, durationMinutes) : 0;
+}
+
+export function getScheduleTaskSummary(
+    items: ScheduleTaskSummaryItem[],
+): ScheduleTaskSummary {
+    const summary: ScheduleTaskSummary = {
+        total: createEmptyMetrics(),
+        actionable: createEmptyMetrics(),
+        pendingVerification: createEmptyMetrics(),
+        completed: createEmptyMetrics(),
+        failed: createEmptyMetrics(),
+        canceled: createEmptyMetrics(),
+    };
+
+    for (const item of items) {
+        const durationMinutes = normalizeDurationMinutes(item.durationMinutes);
+        const stateMetrics = summary[item.state];
+
+        summary.total.count += 1;
+        summary.total.durationMinutes += durationMinutes;
+        stateMetrics.count += 1;
+        stateMetrics.durationMinutes += durationMinutes;
+    }
+
+    return summary;
+}

--- a/packages/storage/src/cache/scheduleCache.ts
+++ b/packages/storage/src/cache/scheduleCache.ts
@@ -21,6 +21,8 @@ type DeliveryRequestsSummaryCacheInput = {
 };
 
 const CACHE_VERSION = 'v2';
+// Raised-bed payloads added farmId in v3; keep old cached shapes out of Farm Today.
+const FARM_USER_RAISED_BED_PAYLOAD_VERSION = 'v3';
 
 export const scheduleCacheTtls = {
     day: 45,
@@ -80,7 +82,7 @@ export const scheduleCacheKeys = {
     adminDay: (date: Date | string, isToday: boolean) =>
         `schedule:admin:day:${localDateKey(date)}:today:${isToday ? '1' : '0'}:${CACHE_VERSION}`,
     farmUserRaisedBeds: (userId: string) =>
-        `schedule:farm:user:${safePart(userId)}:raisedBeds:${CACHE_VERSION}`,
+        `schedule:farm:user:${safePart(userId)}:raisedBeds:${FARM_USER_RAISED_BED_PAYLOAD_VERSION}`,
     farmUserOperations: (userId: string, input?: DateRangeCacheInput) =>
         `schedule:farm:user:${safePart(userId)}:operations:${rangePart(input)}:${CACHE_VERSION}`,
     farmUserActiveOperations: (userId: string, from: Date) =>
@@ -90,7 +92,7 @@ export const scheduleCacheKeys = {
     farmRaisedBedPhotoPreviews: (raisedBedIds: number[]) =>
         `schedule:farm:raisedBedPhotoPreviews:${raisedBedIds.map(safePart).join(',')}:${CACHE_VERSION}`,
     farmUserDay: (userId: string, date: Date | string, isToday: boolean) =>
-        `schedule:farm:user:${safePart(userId)}:day:${localDateKey(date)}:today:${isToday ? '1' : '0'}:${CACHE_VERSION}`,
+        `schedule:farm:user:${safePart(userId)}:day:${localDateKey(date)}:today:${isToday ? '1' : '0'}:${FARM_USER_RAISED_BED_PAYLOAD_VERSION}`,
     deliveryRequestsSummary: (input: DeliveryRequestsSummaryCacheInput) =>
         [
             'delivery:requests:summary',

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -836,6 +836,41 @@ export async function getFarmUserAcceptedOperations(
     );
 }
 
+export async function getFarmUserPendingVerificationOperations(userId: string) {
+    const filter = { status: 'pendingVerification' } satisfies OperationsFilter;
+
+    return cacheScheduleRead(
+        scheduleCacheKeys.farmUserOperations(userId, filter),
+        async () => {
+            const rows = await storage()
+                .select({ operation: operations })
+                .from(operations)
+                .leftJoin(raisedBeds, eq(operations.raisedBedId, raisedBeds.id))
+                .leftJoin(
+                    gardens,
+                    eq(gardens.id, operationGardenIdExpression()),
+                )
+                .innerJoin(
+                    farmUsers,
+                    eq(farmUsers.farmId, operationFarmIdExpression()),
+                )
+                .where(
+                    and(
+                        eq(farmUsers.userId, userId),
+                        eq(operations.isAccepted, true),
+                        eq(operations.isDeleted, false),
+                        operationLocationIntegrityWhere(),
+                        getOperationStatusWhere(filter.status),
+                    ),
+                )
+                .orderBy(desc(operations.timestamp));
+
+            return fillOperationAggregates(rows.map((row) => row.operation));
+        },
+        scheduleCacheTtls.operations,
+    );
+}
+
 async function getFarmUserAcceptedOperationsUncached(
     userId: string,
     filter?: OperationsFilter,

--- a/packages/storage/src/repositories/raisedBedsRepo.ts
+++ b/packages/storage/src/repositories/raisedBedsRepo.ts
@@ -20,6 +20,7 @@ import { generateRaisedBedName } from '../helpers/generateRaisedBedName';
 import { RAISED_BED_PHOTO_OPERATION_ID } from '../helpers/raisedBedPhotoOperations';
 import {
     events,
+    farms,
     farmUsers,
     gardens,
     type InsertRaisedBed,
@@ -817,15 +818,17 @@ export async function getFarmUserRaisedBeds(userId: string) {
 
 async function getFarmUserRaisedBedsUncached(userId: string) {
     const farmRaisedBeds = await storage()
-        .select({ raisedBed: raisedBeds })
+        .select({ farmId: gardens.farmId, raisedBed: raisedBeds })
         .from(raisedBeds)
         .innerJoin(gardens, eq(raisedBeds.gardenId, gardens.id))
+        .innerJoin(farms, eq(gardens.farmId, farms.id))
         .innerJoin(farmUsers, eq(gardens.farmId, farmUsers.farmId))
         .where(
             and(
                 eq(farmUsers.userId, userId),
                 eq(raisedBeds.isDeleted, false),
                 eq(gardens.isDeleted, false),
+                eq(farms.isDeleted, false),
                 // Sandbox ("play") gardens never appear in farm scheduling.
                 eq(gardens.isSandbox, false),
             ),
@@ -836,8 +839,9 @@ async function getFarmUserRaisedBedsUncached(userId: string) {
         farmRaisedBeds.map((row) => row.raisedBed.id),
     );
 
-    return farmRaisedBeds.map(({ raisedBed }) => ({
+    return farmRaisedBeds.map(({ farmId, raisedBed }) => ({
         ...raisedBed,
+        farmId,
         fields: fieldsByRaisedBedId.get(raisedBed.id) ?? [],
     }));
 }

--- a/packages/storage/tests/operationsRepo.pending.node.spec.ts
+++ b/packages/storage/tests/operationsRepo.pending.node.spec.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    acceptOperation,
+    assignUserToFarm,
+    createEvent,
+    createFarm,
+    createOperation,
+    events,
+    getFarmUserPendingVerificationOperations,
+    knownEvents,
+    knownEventTypes,
+    storage,
+    users,
+} from '@gredice/storage';
+import { and, eq } from 'drizzle-orm';
+import { createTestDb } from './testDb';
+
+async function createTestUser() {
+    const userId = randomUUID();
+    await storage()
+        .insert(users)
+        .values({
+            id: userId,
+            userName: `${userId}@example.com`,
+            role: 'farmer',
+        });
+    return userId;
+}
+
+async function createAcceptedFarmOperation(farmId: number, timestamp: Date) {
+    const operationId = await createOperation({
+        entityId: 1,
+        entityTypeName: 'operation',
+        farmId,
+        timestamp,
+    });
+    await acceptOperation(operationId);
+    return operationId;
+}
+
+test('pending operation read keeps old outstanding work and excludes terminal or unrelated work', async () => {
+    createTestDb();
+    const userId = await createTestUser();
+    const otherUserId = await createTestUser();
+    const farmId = await createFarm({
+        name: `Pending operation farm ${randomUUID()}`,
+        latitude: 45.8,
+        longitude: 15.9,
+    });
+    const otherFarmId = await createFarm({
+        name: `Other pending operation farm ${randomUUID()}`,
+        latitude: 45.9,
+        longitude: 16,
+    });
+    await Promise.all([
+        assignUserToFarm(farmId, userId),
+        assignUserToFarm(otherFarmId, otherUserId),
+    ]);
+
+    const oldPendingOperationId = await createAcceptedFarmOperation(
+        farmId,
+        new Date('2000-01-01T08:00:00.000Z'),
+    );
+    const verifiedOperationId = await createAcceptedFarmOperation(
+        farmId,
+        new Date('2000-01-02T08:00:00.000Z'),
+    );
+    const untouchedOperationId = await createAcceptedFarmOperation(
+        farmId,
+        new Date('2000-01-03T08:00:00.000Z'),
+    );
+    const otherFarmPendingOperationId = await createAcceptedFarmOperation(
+        otherFarmId,
+        new Date('2000-01-04T08:00:00.000Z'),
+    );
+
+    for (const operationId of [
+        oldPendingOperationId,
+        verifiedOperationId,
+        otherFarmPendingOperationId,
+    ]) {
+        await createEvent(
+            knownEvents.operations.completedV1(operationId.toString(), {
+                completedBy: randomUUID(),
+            }),
+        );
+    }
+    await storage()
+        .update(events)
+        .set({ createdAt: new Date('2000-01-05T08:00:00.000Z') })
+        .where(
+            and(
+                eq(events.aggregateId, oldPendingOperationId.toString()),
+                eq(events.type, knownEventTypes.operations.complete),
+            ),
+        );
+    await createEvent(
+        knownEvents.operations.verifiedV1(verifiedOperationId.toString(), {
+            verifiedBy: randomUUID(),
+        }),
+    );
+
+    const pendingOperations =
+        await getFarmUserPendingVerificationOperations(userId);
+    const pendingOperationIds = pendingOperations.map(
+        (operation) => operation.id,
+    );
+
+    assert.deepStrictEqual(pendingOperationIds, [oldPendingOperationId]);
+    assert.ok(!pendingOperationIds.includes(verifiedOperationId));
+    assert.ok(!pendingOperationIds.includes(untouchedOperationId));
+    assert.ok(!pendingOperationIds.includes(otherFarmPendingOperationId));
+});

--- a/packages/storage/tests/raisedBedsRepo.farmUser.node.spec.ts
+++ b/packages/storage/tests/raisedBedsRepo.farmUser.node.spec.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    assignUserToFarm,
+    createAccount,
+    createFarm,
+    createGarden,
+    getFarmUserRaisedBeds,
+    storage,
+    users,
+} from '@gredice/storage';
+import { eq } from 'drizzle-orm';
+import { farms } from '../src/schema';
+import { createTestBlock, createTestRaisedBed } from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+async function createTestUser() {
+    const userId = randomUUID();
+    await storage()
+        .insert(users)
+        .values({
+            id: userId,
+            userName: `${userId}@example.com`,
+            role: 'user',
+        });
+    return userId;
+}
+
+async function createFarmRaisedBed({
+    farmId,
+    isSandbox = false,
+    name,
+}: {
+    farmId: number;
+    isSandbox?: boolean;
+    name: string;
+}) {
+    const accountId = await createAccount();
+    const gardenId = await createGarden({
+        accountId,
+        farmId,
+        isSandbox,
+        name,
+    });
+    const blockId = await createTestBlock(gardenId, `${name} block`);
+    return createTestRaisedBed(gardenId, accountId, blockId);
+}
+
+test('getFarmUserRaisedBeds returns only beds from active assigned non-sandbox farms with their farm id', async () => {
+    createTestDb();
+    const userId = await createTestUser();
+    const otherUserId = await createTestUser();
+    const activeFarmId = await createFarm({
+        name: `Active assigned farm ${randomUUID()}`,
+        latitude: 45.8,
+        longitude: 15.9,
+    });
+    const otherFarmId = await createFarm({
+        name: `Other user's farm ${randomUUID()}`,
+        latitude: 45.9,
+        longitude: 16,
+    });
+    const deletedFarmId = await createFarm({
+        name: `Deleted assigned farm ${randomUUID()}`,
+        latitude: 46,
+        longitude: 16.1,
+    });
+
+    await Promise.all([
+        assignUserToFarm(activeFarmId, userId),
+        assignUserToFarm(deletedFarmId, userId),
+        assignUserToFarm(otherFarmId, otherUserId),
+    ]);
+
+    const activeRaisedBedId = await createFarmRaisedBed({
+        farmId: activeFarmId,
+        name: `Active assigned garden ${randomUUID()}`,
+    });
+    const otherUsersRaisedBedId = await createFarmRaisedBed({
+        farmId: otherFarmId,
+        name: `Other user's garden ${randomUUID()}`,
+    });
+    const deletedFarmRaisedBedId = await createFarmRaisedBed({
+        farmId: deletedFarmId,
+        name: `Deleted assigned farm garden ${randomUUID()}`,
+    });
+    const sandboxRaisedBedId = await createFarmRaisedBed({
+        farmId: activeFarmId,
+        isSandbox: true,
+        name: `Sandbox garden ${randomUUID()}`,
+    });
+
+    await storage()
+        .update(farms)
+        .set({ isDeleted: true })
+        .where(eq(farms.id, deletedFarmId));
+
+    const raisedBeds = await getFarmUserRaisedBeds(userId);
+
+    assert.deepStrictEqual(
+        raisedBeds.map((raisedBed) => ({
+            farmId: raisedBed.farmId,
+            id: raisedBed.id,
+        })),
+        [{ farmId: activeFarmId, id: activeRaisedBedId }],
+    );
+    assert.ok(
+        !raisedBeds.some((raisedBed) =>
+            [
+                otherUsersRaisedBedId,
+                deletedFarmRaisedBedId,
+                sandboxRaisedBedId,
+            ].includes(raisedBed.id),
+        ),
+    );
+});


### PR DESCRIPTION
## Summary\n\n- add a server-owned Today projection for operations and plantings with focus, attention, duration, overdue, pending-verification, and verified-completion summaries\n- reuse Schedule state, Zagreb-day, duration, proof-requirement, and assignment rules instead of creating parallel interpretations\n- keep shared unassigned work visible while omitting work assigned exclusively to another farmer from personal details and counts\n- fail closed on unrelated or malformed farm and raised-bed locations and expose explicit no-farm, empty, no-assignment, partial, incomplete, and unavailable states\n- preserve all outstanding pending operations with a database-filtered query, version cached raised-bed payloads, and log partial-source failures server-side\n- align Schedule cards and completion actions with the same array-aware assignment rules, including a 320px locked-work regression test\n\n## Scope\n\nThis is the data-contract task only. The phone-first Today workspace is implemented in #4156, and the shell and navigation work remains in #4157. No ordinary farmer farm selector is added.\n\nThis PR is stacked on #4169 and targets feat/farm-task-verification-states; it should be retargeted to main after #4169 merges.\n\n## Validation\n\n- corepack pnpm --filter farm test — 70 passed\n- corepack pnpm --filter farm build — passed\n- corepack pnpm --filter farm exec tsc --noEmit -p tsconfig.json — passed\n- corepack pnpm --filter @gredice/storage test:node operationsRepo.pending.node.spec.ts raisedBedsRepo.farmUser.node.spec.ts — 2 passed\n- targeted Biome checks and git diff --check — passed\n\nFixes #4155