### PR TITLE
feat(farm): build phone-first Today workspace

### DIFF
--- a/apps/farm/app/FarmDashboardGreeting.tsx
+++ b/apps/farm/app/FarmDashboardGreeting.tsx
@@ -48,7 +48,7 @@ export function FarmDashboardGreeting({
     }, [displayName, initialDateIso, weather.data]);
 
     return (
-        <Typography level="h4" component="h1" semiBold>
+        <Typography className="sm:text-2xl" component="h1" level="h5" semiBold>
             {greeting}
         </Typography>
     );

--- a/apps/farm/app/FarmTodayLoadingState.spec.tsx
+++ b/apps/farm/app/FarmTodayLoadingState.spec.tsx
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import './globals.css';
+import { FarmTodayLoadingState } from './FarmTodayLoadingState';
+
+const phoneViewports = [
+    { width: 320, height: 568 },
+    { width: 390, height: 844 },
+    { width: 430, height: 932 },
+] as const;
+
+for (const viewport of phoneViewports) {
+    test(`keeps the compact Today loading shape within ${viewport.width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize(viewport);
+        const component = await mount(<FarmTodayLoadingState />);
+
+        const loadingRegion = page.getByRole('region', {
+            name: 'Učitavanje današnjih zadataka',
+        });
+        await expect(loadingRegion).toHaveAttribute('aria-busy', 'true');
+
+        await expect(
+            component.locator(
+                'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]',
+            ),
+        ).toHaveCount(0);
+
+        const summaryItems = component.locator(
+            '[data-today-loading-summary-item]',
+        );
+        await expect(summaryItems).toHaveCount(4);
+        expect(
+            await summaryItems.evaluateAll((items) => {
+                const firstTop = items[0]?.getBoundingClientRect().top;
+                return (
+                    typeof firstTop === 'number' &&
+                    items.every(
+                        (item) =>
+                            Math.abs(
+                                item.getBoundingClientRect().top - firstTop,
+                            ) < 1,
+                    )
+                );
+            }),
+        ).toBe(true);
+
+        const firstTaskBounds = await component
+            .locator('[data-today-loading-task]')
+            .boundingBox();
+        expect(firstTaskBounds).not.toBeNull();
+        if (!firstTaskBounds) {
+            throw new Error('Expected the first task loading card to render.');
+        }
+        expect(firstTaskBounds.y).toBeGreaterThanOrEqual(0);
+        expect(firstTaskBounds.y + firstTaskBounds.height).toBeLessThanOrEqual(
+            viewport.height,
+        );
+
+        expect(
+            await component.evaluate((element) => {
+                const bounds = element.getBoundingClientRect();
+                return (
+                    bounds.left >= 0 &&
+                    bounds.right <= window.innerWidth &&
+                    element.scrollWidth <= element.clientWidth
+                );
+            }),
+        ).toBe(true);
+        expect(
+            await page.evaluate(
+                () =>
+                    document.documentElement.scrollWidth <=
+                    document.documentElement.clientWidth,
+            ),
+        ).toBe(true);
+    });
+}

--- a/apps/farm/app/FarmTodayLoadingState.tsx
+++ b/apps/farm/app/FarmTodayLoadingState.tsx
@@ -1,0 +1,85 @@
+import { Skeleton } from '@gredice/ui/Skeleton';
+
+export function FarmTodayLoadingState() {
+    return (
+        <section
+            aria-busy="true"
+            aria-label="Učitavanje današnjih zadataka"
+            className="mx-auto w-full max-w-3xl px-3 py-4 sm:px-4"
+        >
+            <div aria-hidden="true" className="space-y-3">
+                <header className="flex min-h-11 items-start justify-between gap-2">
+                    <Skeleton className="h-7 w-36 max-w-[60%]" />
+                    <div className="flex shrink-0 gap-1">
+                        <Skeleton className="size-11" />
+                        <Skeleton className="size-11" />
+                    </div>
+                </header>
+
+                <div
+                    className="grid grid-cols-4 divide-x rounded-lg border bg-card px-1 py-2 shadow-xs"
+                    data-today-loading-summary
+                >
+                    <div
+                        className="min-w-0 space-y-1 text-center"
+                        data-today-loading-summary-item
+                    >
+                        <Skeleton className="mx-auto h-5 w-8 max-w-full" />
+                        <Skeleton className="mx-auto h-3 w-14 max-w-full" />
+                    </div>
+                    <div
+                        className="min-w-0 space-y-1 text-center"
+                        data-today-loading-summary-item
+                    >
+                        <Skeleton className="mx-auto h-5 w-8 max-w-full" />
+                        <Skeleton className="mx-auto h-3 w-16 max-w-full" />
+                    </div>
+                    <div
+                        className="min-w-0 space-y-1 text-center"
+                        data-today-loading-summary-item
+                    >
+                        <Skeleton className="mx-auto h-5 w-10 max-w-full" />
+                        <Skeleton className="mx-auto h-3 w-20 max-w-full" />
+                    </div>
+                    <div
+                        className="min-w-0 space-y-1 text-center"
+                        data-today-loading-summary-item
+                    >
+                        <Skeleton className="mx-auto h-5 w-10 max-w-full" />
+                        <Skeleton className="mx-auto h-3 w-14 max-w-full" />
+                    </div>
+                </div>
+
+                <section>
+                    <div
+                        className="space-y-3 rounded-lg border bg-card p-3 shadow-xs"
+                        data-today-loading-task
+                    >
+                        <div className="flex min-w-0 items-start gap-3">
+                            <div className="min-w-0 flex-1 space-y-2">
+                                <Skeleton className="h-3 w-24 max-w-full" />
+                                <Skeleton className="h-5 w-full" />
+                                <Skeleton className="h-5 w-4/5" />
+                            </div>
+                            <Skeleton className="size-6 shrink-0 rounded-full" />
+                        </div>
+                        <div className="flex min-w-0 flex-wrap gap-2">
+                            <Skeleton className="h-6 w-16 max-w-full rounded-full" />
+                            <Skeleton className="h-6 w-20 max-w-full rounded-full" />
+                            <Skeleton className="h-6 w-24 max-w-full rounded-full" />
+                        </div>
+                        <Skeleton className="h-11 w-full" />
+                    </div>
+                </section>
+
+                <section className="space-y-2">
+                    <Skeleton className="h-5 w-40 max-w-full" />
+                    <div className="space-y-2 rounded-lg border bg-card p-3 shadow-xs">
+                        <Skeleton className="h-4 w-3/4 max-w-full" />
+                        <Skeleton className="h-3 w-1/2 max-w-full" />
+                    </div>
+                </section>
+            </div>
+        </section>
+    );
+}

--- a/apps/farm/app/FarmTodayRefreshButton.tsx
+++ b/apps/farm/app/FarmTodayRefreshButton.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Reset } from '@gredice/ui/icons';
+import { useRouter } from 'next/navigation';
+
+export function FarmTodayRefreshButton() {
+    const router = useRouter();
+
+    return (
+        <Button
+            onClick={() => router.refresh()}
+            size="lg"
+            startDecorator={<Reset aria-hidden className="size-4" />}
+            variant="outlined"
+        >
+            Pokušaj ponovno
+        </Button>
+    );
+}

--- a/apps/farm/app/FarmTodayStatePanel.tsx
+++ b/apps/farm/app/FarmTodayStatePanel.tsx
@@ -1,0 +1,186 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent } from '@gredice/ui/Card';
+import { Success, Warning } from '@gredice/ui/icons';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { FarmTodayRefreshButton } from './FarmTodayRefreshButton';
+import type { FarmTodayWorkState } from './farmTodayModel';
+
+type FarmTodayAvailableStatePanelProps = {
+    completed: number;
+    dateKey: string;
+    pendingVerification: number;
+    workState: FarmTodayWorkState;
+};
+
+export function FarmTodayUnavailableState() {
+    return (
+        <Alert
+            className="items-start"
+            color="danger"
+            startDecorator={<Warning aria-hidden className="size-5" />}
+        >
+            <Stack spacing={3}>
+                <div>
+                    <Typography component="h2" level="h6" semiBold>
+                        Današnji zadaci se trenutno ne mogu učitati
+                    </Typography>
+                    <Typography level="body2">
+                        Osvježi prikaz ili otvori cijeli raspored dok ponovno
+                        uspostavljamo vezu.
+                    </Typography>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                    <FarmTodayRefreshButton />
+                    <Button href="/schedule" size="lg" variant="outlined">
+                        Otvori raspored
+                    </Button>
+                </div>
+            </Stack>
+        </Alert>
+    );
+}
+
+export function FarmTodayNoFarmState() {
+    return (
+        <Card>
+            <CardContent noHeader>
+                <Stack spacing={3}>
+                    <div>
+                        <Typography component="h2" level="h6" semiBold>
+                            Nemaš dodijeljenu farmu
+                        </Typography>
+                        <Typography level="body2">
+                            Kontaktiraj administratora kako bi te dodijelio
+                            farmi. Odabir farme nije potreban za svakodnevni
+                            rad.
+                        </Typography>
+                    </div>
+                    <Button
+                        className="w-fit"
+                        href="/settings"
+                        size="lg"
+                        variant="outlined"
+                    >
+                        Provjeri profil
+                    </Button>
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+}
+
+export function FarmTodayAvailableStatePanel({
+    completed,
+    dateKey,
+    pendingVerification,
+    workState,
+}: FarmTodayAvailableStatePanelProps) {
+    const scheduleHref = `/schedule?date=${dateKey}`;
+
+    if (workState === 'hasWork') {
+        return (
+            <Card>
+                <CardContent noHeader>
+                    <Stack spacing={3}>
+                        <div>
+                            <Typography component="h2" level="h6" semiBold>
+                                Trenutačno nema zadatka za dovršiti
+                            </Typography>
+                            <Typography level="body2">
+                                {pendingVerification > 0
+                                    ? `${pendingVerification} zadataka čeka potvrdu.`
+                                    : 'Provjeri cijeli raspored za dodatne detalje.'}
+                            </Typography>
+                        </div>
+                        <Button
+                            className="w-fit"
+                            href={scheduleHref}
+                            size="lg"
+                            variant="outlined"
+                        >
+                            Provjeri raspored
+                        </Button>
+                    </Stack>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    if (workState === 'incomplete') {
+        return (
+            <Alert
+                className="items-start"
+                color="warning"
+                startDecorator={<Warning aria-hidden className="size-5" />}
+            >
+                <Stack spacing={3}>
+                    <div>
+                        <Typography component="h2" level="h6" semiBold>
+                            Nisu dostupni svi današnji zadaci
+                        </Typography>
+                        <Typography level="body2">
+                            Ne prikazujemo da je posao gotov dok se svi podaci
+                            ne učitaju.
+                        </Typography>
+                    </div>
+                    <FarmTodayRefreshButton />
+                </Stack>
+            </Alert>
+        );
+    }
+
+    const content = {
+        allDone: {
+            description:
+                completed > 0
+                    ? `Potvrđeno je ${completed} današnjih zadataka.`
+                    : 'Za danas nema preostalih zadataka.',
+            icon: <Success aria-hidden className="size-5 text-green-600" />,
+            title: 'Današnji posao je gotov',
+        },
+        empty: {
+            description:
+                'Pogledaj raspored ako želiš provjeriti drugi datum ili planirati sljedeći posao.',
+            icon: null,
+            title: 'Danas nema planiranih zadataka',
+        },
+        noAssignedWork: {
+            description:
+                'Na farmi postoji planirani posao, ali zadaci su trenutačno dodijeljeni drugim članovima.',
+            icon: null,
+            title: 'Nema zadataka dodijeljenih tebi',
+        },
+    }[workState];
+
+    return (
+        <Card>
+            <CardContent noHeader>
+                <Stack spacing={3}>
+                    <div className="flex items-start gap-2">
+                        {content.icon}
+                        <div className="min-w-0">
+                            <Typography component="h2" level="h6" semiBold>
+                                {content.title}
+                            </Typography>
+                            <Typography level="body2">
+                                {content.description}
+                            </Typography>
+                        </div>
+                    </div>
+                    <Button
+                        className="w-fit"
+                        href={scheduleHref}
+                        size="lg"
+                        variant="outlined"
+                    >
+                        {workState === 'noAssignedWork'
+                            ? 'Otvori cijeli raspored'
+                            : 'Otvori raspored'}
+                    </Button>
+                </Stack>
+            </CardContent>
+        </Card>
+    );
+}

--- a/apps/farm/app/FarmTodaySummary.tsx
+++ b/apps/farm/app/FarmTodaySummary.tsx
@@ -1,0 +1,70 @@
+import type { FarmTodaySummary as FarmTodaySummaryData } from './farmTodayModel';
+import { formatMinutes } from './schedule/scheduleShared';
+
+type FarmTodaySummaryProps = {
+    summary: FarmTodaySummaryData;
+};
+
+function minimumCount(count: number, complete: boolean) {
+    return complete ? String(count) : `≥ ${count}`;
+}
+
+function remainingTime(summary: FarmTodaySummaryData) {
+    if (summary.remainingDuration.complete) {
+        return formatMinutes(summary.remainingDuration.minutes);
+    }
+
+    return summary.remainingDuration.minutes > 0
+        ? `≥ ${formatMinutes(summary.remainingDuration.minutes)}`
+        : '—';
+}
+
+export function FarmTodaySummary({ summary }: FarmTodaySummaryProps) {
+    const metrics = [
+        {
+            label: 'Preostalo',
+            value: minimumCount(summary.remaining, summary.countsComplete),
+        },
+        {
+            label: 'Kasni',
+            value: minimumCount(summary.overdue, summary.countsComplete),
+        },
+        {
+            label: 'Čeka',
+            value: minimumCount(
+                summary.pendingVerification,
+                summary.countsComplete,
+            ),
+        },
+        {
+            label: 'Vrijeme',
+            value: remainingTime(summary),
+        },
+    ];
+
+    return (
+        <section
+            aria-labelledby="farm-today-summary-title"
+            className="rounded-lg border bg-card px-1 py-2 shadow-xs"
+        >
+            <h2 className="sr-only" id="farm-today-summary-title">
+                Sažetak današnjih zadataka
+            </h2>
+            <div className="grid grid-cols-4 divide-x">
+                {metrics.map((metric) => (
+                    <div
+                        className="min-w-0 px-1 text-center sm:px-2"
+                        key={metric.label}
+                    >
+                        <div className="truncate text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground">
+                            {metric.label}
+                        </div>
+                        <div className="mt-0.5 truncate text-sm font-semibold tabular-nums sm:text-base">
+                            {metric.value}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/apps/farm/app/FarmTodayTaskLink.tsx
+++ b/apps/farm/app/FarmTodayTaskLink.tsx
@@ -1,0 +1,204 @@
+import { Chip } from '@gredice/ui/Chip';
+import {
+    Camera,
+    FileText,
+    ListTodo,
+    MapPin,
+    Navigate,
+    Warning,
+} from '@gredice/ui/icons';
+import { ListItem } from '@gredice/ui/List';
+import type { ReactNode } from 'react';
+import type { FarmTodayTask, FarmTodayTaskAssignment } from './farmTodayModel';
+import { ScheduleTaskDateChip } from './schedule/ScheduleTaskDateChip';
+import { ScheduleTaskDurationChip } from './schedule/ScheduleTaskDurationChip';
+import { ScheduleTaskStatusChip } from './schedule/ScheduleTaskStatusChip';
+import type { ScheduleOperationRequirementLevel } from './schedule/scheduleOperationRequirements';
+
+type FarmTodayTaskLinkProps = {
+    emphasis?: 'next' | 'standard';
+    task: FarmTodayTask;
+};
+
+function AssignmentChip({
+    assignment,
+}: {
+    assignment: FarmTodayTaskAssignment;
+}) {
+    return (
+        <Chip
+            color={assignment === 'mine' ? 'neutral' : 'warning'}
+            size="sm"
+            startDecorator={
+                assignment === 'shared' ? <Warning aria-hidden /> : undefined
+            }
+            variant="soft"
+        >
+            {assignment === 'mine' ? 'Dodijeljeno meni' : 'Nije dodijeljeno'}
+        </Chip>
+    );
+}
+
+function ActionableStateChip({ task }: { task: FarmTodayTask }) {
+    if (task.state !== 'actionable') {
+        return <ScheduleTaskStatusChip state={task.state} />;
+    }
+
+    if (task.overdue) {
+        return (
+            <Chip
+                color={
+                    task.ageIndicator?.level === 'critical'
+                        ? 'error'
+                        : 'warning'
+                }
+                size="sm"
+                startDecorator={<Warning aria-hidden />}
+                title={task.ageIndicator?.title ?? 'Zadatak kasni.'}
+                variant="soft"
+            >
+                {task.ageIndicator?.label ?? 'Kasni'}
+            </Chip>
+        );
+    }
+
+    return (
+        <Chip
+            color="success"
+            size="sm"
+            startDecorator={<ListTodo aria-hidden />}
+            variant="soft"
+        >
+            Za napraviti
+        </Chip>
+    );
+}
+
+function requirementLabel(
+    kind: 'images' | 'notes',
+    level: ScheduleOperationRequirementLevel,
+) {
+    const noun = kind === 'images' ? 'Fotografija' : 'Napomena';
+
+    if (level === 'required') {
+        return `${noun} obavezna`;
+    }
+    if (level === 'optional') {
+        return `${noun} po želji`;
+    }
+    return null;
+}
+
+function ProofRequirements({ task }: { task: FarmTodayTask }) {
+    const { images, notes } = task.proofRequirements;
+    const imageLabel = requirementLabel('images', images);
+    const notesLabel = requirementLabel('notes', notes);
+    const requirementsUnknown = images === 'unknown' || notes === 'unknown';
+    const visibleRequirements: ReactNode[] = [];
+
+    if (imageLabel) {
+        visibleRequirements.push(
+            <span
+                className="inline-flex min-w-0 items-center gap-1"
+                key="images"
+            >
+                <Camera aria-hidden className="size-3.5 shrink-0" />
+                {imageLabel}
+            </span>,
+        );
+    }
+    if (notesLabel) {
+        visibleRequirements.push(
+            <span
+                className="inline-flex min-w-0 items-center gap-1"
+                key="notes"
+            >
+                <FileText aria-hidden className="size-3.5 shrink-0" />
+                {notesLabel}
+            </span>,
+        );
+    }
+    if (requirementsUnknown) {
+        visibleRequirements.push(
+            <span
+                className="inline-flex min-w-0 items-center gap-1"
+                key="unknown"
+            >
+                <Warning aria-hidden className="size-3.5 shrink-0" />
+                Zahtjevi dokaza nisu dostupni
+            </span>,
+        );
+    }
+    if (visibleRequirements.length === 0) {
+        visibleRequirements.push(
+            <span className="inline-flex min-w-0 items-center gap-1" key="none">
+                <FileText aria-hidden className="size-3.5 shrink-0" />
+                Dokaz nije potreban
+            </span>,
+        );
+    }
+
+    return (
+        <div className="flex min-w-0 flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            {visibleRequirements}
+        </div>
+    );
+}
+
+export function FarmTodayTaskLink({
+    emphasis = 'standard',
+    task,
+}: FarmTodayTaskLinkProps) {
+    const destinationLabel =
+        task.kind === 'operation' ? 'Otvori upute' : 'Otvori gredicu';
+
+    return (
+        <ListItem
+            className="min-h-11 min-w-0 items-start px-3 py-2 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            href={task.href}
+            label={
+                <div
+                    className="min-w-0 space-y-1.5"
+                    data-farm-today-task={task.key}
+                    data-task-state={task.state}
+                >
+                    {emphasis === 'next' ? (
+                        <div className="text-[0.6875rem] font-semibold uppercase tracking-wide text-primary">
+                            Sljedeći zadatak
+                        </div>
+                    ) : null}
+                    <div className="min-w-0 text-sm font-semibold leading-snug [overflow-wrap:anywhere] sm:text-base">
+                        {task.label}
+                    </div>
+                    <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                        <span className="inline-flex min-w-0 items-start gap-1 [overflow-wrap:anywhere]">
+                            <MapPin
+                                aria-hidden
+                                className="mt-0.5 size-3.5 shrink-0"
+                            />
+                            {task.location.label}
+                        </span>
+                    </div>
+                    <div className="flex min-w-0 flex-wrap gap-1.5">
+                        <ActionableStateChip task={task} />
+                        <AssignmentChip assignment={task.assignment} />
+                        <ScheduleTaskDateChip
+                            scheduledDate={task.scheduledDate}
+                        />
+                        {task.durationMinutes === null ? null : (
+                            <ScheduleTaskDurationChip
+                                minutes={task.durationMinutes}
+                            />
+                        )}
+                    </div>
+                    <ProofRequirements task={task} />
+                    <span className="inline-flex min-h-6 items-center gap-1 text-xs font-semibold text-primary">
+                        {destinationLabel}
+                        <Navigate aria-hidden className="size-3.5" />
+                    </span>
+                </div>
+            }
+            variant="outlined"
+        />
+    );
+}

--- a/apps/farm/app/FarmTodayTools.tsx
+++ b/apps/farm/app/FarmTodayTools.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@gredice/ui/Button';
+import {
+    BookA,
+    Calendar,
+    Euro,
+    Fence,
+    Inbox,
+    MapPinHouse,
+    Sprout,
+} from '@gredice/ui/icons';
+
+const tools = [
+    { href: '/schedule', icon: Calendar, label: 'Cijeli raspored' },
+    { href: '/notifications', icon: Inbox, label: 'Obavijesti' },
+    { href: '/raised-beds', icon: Fence, label: 'Gredice' },
+    { href: '/greenhouse', icon: MapPinHouse, label: 'Staklenik' },
+    { href: '/operations', icon: BookA, label: 'Radnje' },
+    { href: '/plants', icon: Sprout, label: 'Biljke' },
+    { href: '/payouts', icon: Euro, label: 'Isplate' },
+];
+
+export function FarmTodayTools() {
+    return (
+        <section aria-labelledby="farm-today-tools-title" className="space-y-2">
+            <h2 className="text-sm font-semibold" id="farm-today-tools-title">
+                Ostali alati
+            </h2>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                {tools.map(({ href, icon: Icon, label }) => (
+                    <Button
+                        className="justify-start px-3 text-sm"
+                        fullWidth
+                        href={href}
+                        key={href}
+                        size="lg"
+                        startDecorator={<Icon aria-hidden className="size-4" />}
+                        variant="outlined"
+                    >
+                        {label}
+                    </Button>
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/apps/farm/app/FarmTodayView.spec.tsx
+++ b/apps/farm/app/FarmTodayView.spec.tsx
@@ -1,0 +1,486 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator } from '@playwright/test';
+import {
+    AppRouterContext,
+    type AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import './globals.css';
+import { FarmTodayView } from './FarmTodayView';
+import type {
+    FarmTodayData,
+    FarmTodayOperationTask,
+    FarmTodayPlantingTask,
+    FarmTodaySummary,
+} from './farmTodayModel';
+
+type AvailableFarmTodayData = Extract<FarmTodayData, { focusQueue: unknown }>;
+
+const phoneViewports = [
+    { width: 320, height: 568 },
+    { width: 390, height: 844 },
+    { width: 430, height: 932 },
+] as const;
+
+const nextNavigationRouter = {
+    back: () => undefined,
+    forward: () => undefined,
+    prefetch: () => undefined,
+    push: () => undefined,
+    refresh: () => undefined,
+    replace: () => undefined,
+} satisfies AppRouterInstance;
+
+function buildSummary(
+    overrides: Partial<FarmTodaySummary> = {},
+): FarmTodaySummary {
+    return {
+        assignedToMe: 0,
+        completed: 0,
+        countsComplete: true,
+        overdue: 0,
+        pendingVerification: 0,
+        remaining: 0,
+        remainingDuration: { complete: true, minutes: 0 },
+        unassigned: 0,
+        ...overrides,
+    };
+}
+
+function buildOperationTask(
+    overrides: Partial<FarmTodayOperationTask> = {},
+): FarmTodayOperationTask {
+    return {
+        ageIndicator: null,
+        assignment: 'mine',
+        durationMinutes: 20,
+        href: '/operations/701',
+        key: 'operation:701',
+        kind: 'operation',
+        label: 'Obreži rajčice',
+        location: {
+            kind: 'raisedBed',
+            label: 'Gredica A12 · pozicija 3',
+            positionIndex: 2,
+            raisedBedId: 12,
+        },
+        occurredAt: null,
+        operationId: 701,
+        overdue: false,
+        proofRequirements: { images: 'none', notes: 'none' },
+        scheduledDate: '2026-07-15T08:00:00.000Z',
+        state: 'actionable',
+        ...overrides,
+    };
+}
+
+function buildPlantingTask(
+    overrides: Partial<FarmTodayPlantingTask> = {},
+): FarmTodayPlantingTask {
+    return {
+        ageIndicator: null,
+        assignment: 'mine',
+        durationMinutes: 5,
+        fieldId: 801,
+        href: '/raised-beds/81',
+        key: 'planting:801',
+        kind: 'planting',
+        label: 'Sijanje: Salata',
+        location: {
+            kind: 'raisedBed',
+            label: 'Gredica B4 · pozicija 7',
+            positionIndex: 6,
+            raisedBedId: 81,
+        },
+        occurredAt: null,
+        overdue: false,
+        plantSortId: 901,
+        proofRequirements: { images: 'none', notes: 'none' },
+        raisedBedId: 81,
+        scheduledDate: '2026-07-15T09:00:00.000Z',
+        state: 'actionable',
+        ...overrides,
+    };
+}
+
+function buildAvailableData(
+    overrides: Partial<AvailableFarmTodayData> = {},
+): AvailableFarmTodayData {
+    return {
+        attentionItems: [],
+        dataIssues: [],
+        dateKey: '2026-07-15',
+        focusQueue: [],
+        status: 'ready',
+        summary: buildSummary(),
+        workState: 'empty',
+        ...overrides,
+    };
+}
+
+const nextTask = buildOperationTask({
+    ageIndicator: {
+        label: 'Kasni 4 dana',
+        level: 'critical',
+        title: 'Zadatak kasni 4 dana.',
+    },
+    label: 'Obreži bočne izboje na visokim rajčicama sorte Volovsko srce prije večernjeg zalijevanja',
+    location: {
+        kind: 'raisedBed',
+        label: 'Gredica Sjeverna proizvodna zona 123456 · pozicija 9',
+        positionIndex: 8,
+        raisedBedId: 12,
+    },
+    overdue: true,
+    proofRequirements: { images: 'required', notes: 'optional' },
+});
+
+const queuedTask = buildPlantingTask({
+    assignment: 'shared',
+    label: 'Sijanje u stakleniku: hrskava ljetna salata vrlo dugog naziva',
+    location: {
+        kind: 'greenhouse',
+        label: 'Staklenik · Gredica Južni tunel 81 · pozicija 7',
+        positionIndex: 6,
+        raisedBedId: 81,
+    },
+});
+
+const pendingTask = buildOperationTask({
+    assignment: 'shared',
+    href: '/operations/702',
+    key: 'operation:702',
+    label: 'Pregledaj fotografije navodnjavanja i potvrdi završetak radnje',
+    operationId: 702,
+    proofRequirements: { images: 'unknown', notes: 'unknown' },
+    state: 'pendingVerification',
+});
+
+const failedTask = buildOperationTask({
+    href: '/operations/703',
+    key: 'operation:703',
+    label: 'Provjeri neuspjelo prihranjivanje rajčice',
+    operationId: 703,
+    state: 'failed',
+});
+
+const mixedReadyData = buildAvailableData({
+    attentionItems: [
+        { reasons: ['overdue'], task: nextTask },
+        { reasons: ['unassigned'], task: queuedTask },
+        {
+            reasons: ['pendingVerification', 'unassigned'],
+            task: pendingTask,
+        },
+        { reasons: ['failed'], task: failedTask },
+    ],
+    focusQueue: [nextTask, queuedTask],
+    summary: buildSummary({
+        assignedToMe: 1,
+        overdue: 1,
+        pendingVerification: 1,
+        remaining: 2,
+        remainingDuration: { complete: true, minutes: 25 },
+        unassigned: 1,
+    }),
+    workState: 'hasWork',
+});
+
+function heading() {
+    return (
+        <h1 className="text-2xl font-semibold">
+            Dobro jutro, Marija Magdalenić!
+        </h1>
+    );
+}
+
+function todayView(data: FarmTodayData) {
+    return (
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <FarmTodayView
+                data={data}
+                heading={heading()}
+                headerActions={
+                    <>
+                        <button
+                            aria-label="Postavke"
+                            className="size-11"
+                            type="button"
+                        >
+                            P
+                        </button>
+                        <button
+                            aria-label="Odjavi se"
+                            className="size-11"
+                            type="button"
+                        >
+                            O
+                        </button>
+                    </>
+                }
+            />
+        </AppRouterContext.Provider>
+    );
+}
+
+async function expectNoHorizontalOverflow(component: Locator) {
+    expect(
+        await component.evaluate((element) => {
+            const bounds = element.getBoundingClientRect();
+            return (
+                bounds.left >= 0 &&
+                bounds.right <= window.innerWidth &&
+                element.scrollWidth <= element.clientWidth &&
+                document.documentElement.scrollWidth <=
+                    document.documentElement.clientWidth
+            );
+        }),
+    ).toBe(true);
+}
+
+async function expectTouchTargets(component: Locator) {
+    const targetSizes = await component
+        .locator(
+            'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]',
+        )
+        .evaluateAll((elements) =>
+            elements
+                .map((element) => ({
+                    bounds: element.getBoundingClientRect(),
+                    element,
+                }))
+                .filter(({ bounds }) => bounds.width > 0 && bounds.height > 0)
+                .map(({ bounds, element }) => ({
+                    description:
+                        `${element.tagName.toLowerCase()} ${element.getAttribute('href') ?? ''} ${element.getAttribute('aria-label') ?? ''} ${element.textContent?.trim() ?? ''}`.trim(),
+                    height: bounds.height,
+                    width: bounds.width,
+                })),
+        );
+
+    expect(targetSizes.length).toBeGreaterThan(0);
+    for (const target of targetSizes) {
+        expect(target.width, target.description).toBeGreaterThanOrEqual(44);
+        expect(target.height, target.description).toBeGreaterThanOrEqual(44);
+    }
+}
+
+for (const viewport of phoneViewports) {
+    test(`keeps mixed Today work usable at ${viewport.width}x${viewport.height}`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize(viewport);
+        const component = await mount(todayView(mixedReadyData));
+
+        const nextTaskLink = component.locator('a[href="/operations/701"]');
+        await expect(nextTaskLink).toHaveCount(1);
+        await expect(
+            component.locator('a[href="/raised-beds/81"]'),
+        ).toHaveCount(1);
+        expect(await nextTaskLink.evaluate((element) => element.tagName)).toBe(
+            'A',
+        );
+        await expect(nextTaskLink).toHaveAttribute('href', '/operations/701');
+        await expect(
+            nextTaskLink.locator('[data-farm-today-task="operation:701"]'),
+        ).toBeVisible();
+        await expect(component.getByRole('heading', { level: 1 })).toHaveCount(
+            1,
+        );
+        await expect(
+            component.getByRole('region', {
+                name: 'Sažetak današnjih zadataka',
+            }),
+        ).toBeVisible();
+        await expect(
+            component.getByRole('region', { name: 'Fokus' }),
+        ).toBeVisible();
+        await expect(
+            component.getByRole('region', { name: 'Treba pažnju' }),
+        ).toBeVisible();
+
+        const nextTaskBounds = await nextTaskLink.boundingBox();
+        expect(nextTaskBounds).not.toBeNull();
+        if (!nextTaskBounds) {
+            throw new Error('Expected the next-task card link to render.');
+        }
+        expect(nextTaskBounds.y).toBeGreaterThanOrEqual(0);
+        expect(nextTaskBounds.y + nextTaskBounds.height).toBeLessThanOrEqual(
+            viewport.height,
+        );
+
+        await expect(
+            nextTaskLink.locator(
+                'a, button, input, select, textarea, [role="button"], [role="checkbox"]',
+            ),
+        ).toHaveCount(0);
+        await expect(
+            component.getByText('Dovrši', { exact: false }),
+        ).toHaveCount(0);
+        await expect(component.getByRole('checkbox')).toHaveCount(0);
+
+        await expect(component.getByText('Kasni 4 dana')).toBeVisible();
+        await expect(component.getByText(nextTask.label)).toBeVisible();
+        await expect(
+            component.getByText(nextTask.location.label),
+        ).toBeVisible();
+        await expect(
+            nextTaskLink.getByText('20 min', { exact: true }),
+        ).toBeVisible();
+        await expect(
+            component.getByText('Dodijeljeno meni').first(),
+        ).toBeVisible();
+        await expect(component.getByText('Fotografija obavezna')).toBeVisible();
+        await expect(component.getByText('Napomena po želji')).toBeVisible();
+        await expect(component.getByText('Za napraviti')).toBeVisible();
+        await expect(
+            component.getByText('Nije dodijeljeno').first(),
+        ).toBeVisible();
+        await expect(
+            component.getByText('Dokaz nije potreban').first(),
+        ).toBeVisible();
+        await expect(component.getByText('Čeka potvrdu')).toBeVisible();
+        await expect(
+            component.getByText('Neuspjelo', { exact: true }),
+        ).toBeVisible();
+        await expect(
+            component.getByText('Zahtjevi dokaza nisu dostupni'),
+        ).toBeVisible();
+
+        await expectNoHorizontalOverflow(component);
+        await expectTouchTargets(component);
+    });
+}
+
+test('keeps a partial result actionable while explaining incomplete counts', async ({
+    mount,
+}) => {
+    const data = buildAvailableData({
+        dataIssues: ['pendingOperationsUnavailable'],
+        focusQueue: [nextTask],
+        status: 'partial',
+        summary: buildSummary({
+            assignedToMe: 1,
+            countsComplete: false,
+            overdue: 1,
+            remaining: 1,
+            remainingDuration: { complete: false, minutes: 20 },
+        }),
+        workState: 'hasWork',
+    });
+    const component = await mount(todayView(data));
+
+    await expect(
+        component.getByText('Prikazujemo dostupne podatke.'),
+    ).toBeVisible();
+    await expect(
+        component.getByText(
+            'Brojevi sa znakom ≥ najmanje su potvrđene vrijednosti.',
+        ),
+    ).toBeVisible();
+    await expect(component.locator('a[href="/operations/701"]')).toBeVisible();
+    await expect(
+        component.getByText('≥ 1', { exact: true }).first(),
+    ).toBeVisible();
+});
+
+const availableStateCases = [
+    {
+        description: 'Danas nema planiranih zadataka',
+        linkLabel: 'Otvori raspored',
+        name: 'empty',
+        summary: buildSummary(),
+        workState: 'empty',
+    },
+    {
+        description: 'Nema zadataka dodijeljenih tebi',
+        linkLabel: 'Otvori cijeli raspored',
+        name: 'noAssignedWork',
+        summary: buildSummary(),
+        workState: 'noAssignedWork',
+    },
+    {
+        description: 'Današnji posao je gotov',
+        linkLabel: 'Otvori raspored',
+        name: 'allDone',
+        summary: buildSummary({ completed: 3 }),
+        workState: 'allDone',
+    },
+] as const;
+
+for (const stateCase of availableStateCases) {
+    test(`renders a meaningful ${stateCase.name} Today state`, async ({
+        mount,
+    }) => {
+        const component = await mount(
+            todayView(
+                buildAvailableData({
+                    summary: stateCase.summary,
+                    workState: stateCase.workState,
+                }),
+            ),
+        );
+
+        await expect(
+            component.getByRole('heading', {
+                name: stateCase.description,
+            }),
+        ).toBeVisible();
+        const scheduleLink = component.getByRole('link', {
+            name: stateCase.linkLabel,
+        });
+        await expect(scheduleLink).toHaveAttribute(
+            'href',
+            '/schedule?date=2026-07-15',
+        );
+        await expectTouchTargets(component);
+    });
+}
+
+test('renders a meaningful unavailable Today state', async ({ mount }) => {
+    const data: FarmTodayData = {
+        dataIssues: ['farmsUnavailable'],
+        dateKey: '2026-07-15',
+        status: 'unavailable',
+    };
+    const component = await mount(todayView(data));
+
+    await expect(
+        component.getByRole('heading', {
+            name: 'Današnji zadaci se trenutno ne mogu učitati',
+        }),
+    ).toBeVisible();
+    await expect(
+        component.getByRole('button', { name: 'Pokušaj ponovno' }),
+    ).toBeVisible();
+    await expect(
+        component.getByRole('link', { name: 'Otvori raspored' }),
+    ).toHaveAttribute('href', '/schedule');
+    await expectTouchTargets(component);
+});
+
+test('renders a meaningful no-farm state without a farm selector', async ({
+    mount,
+}) => {
+    const data: FarmTodayData = {
+        dataIssues: [],
+        dateKey: '2026-07-15',
+        status: 'noFarm',
+    };
+    const component = await mount(todayView(data));
+
+    await expect(
+        component.getByRole('heading', { name: 'Nemaš dodijeljenu farmu' }),
+    ).toBeVisible();
+    await expect(
+        component.getByText('Odabir farme nije potreban za svakodnevni rad.', {
+            exact: false,
+        }),
+    ).toBeVisible();
+    await expect(
+        component.getByRole('link', { name: 'Provjeri profil' }),
+    ).toHaveAttribute('href', '/settings');
+    await expect(component.getByRole('combobox')).toHaveCount(0);
+    await expect(component.getByText('Moje farme')).toHaveCount(0);
+    await expectTouchTargets(component);
+});

--- a/apps/farm/app/FarmTodayView.spec.tsx
+++ b/apps/farm/app/FarmTodayView.spec.tsx
@@ -23,6 +23,7 @@ const phoneViewports = [
 
 const nextNavigationRouter = {
     back: () => undefined,
+    bfcacheId: 'farm-today-test',
     forward: () => undefined,
     prefetch: () => undefined,
     push: () => undefined,

--- a/apps/farm/app/FarmTodayView.tsx
+++ b/apps/farm/app/FarmTodayView.tsx
@@ -1,0 +1,164 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Warning } from '@gredice/ui/icons';
+import { List } from '@gredice/ui/List';
+import { Typography } from '@gredice/ui/Typography';
+import type { ReactNode } from 'react';
+import {
+    FarmTodayAvailableStatePanel,
+    FarmTodayNoFarmState,
+    FarmTodayUnavailableState,
+} from './FarmTodayStatePanel';
+import { FarmTodaySummary } from './FarmTodaySummary';
+import { FarmTodayTaskLink } from './FarmTodayTaskLink';
+import { FarmTodayTools } from './FarmTodayTools';
+import type { FarmTodayData } from './farmTodayModel';
+
+type FarmTodayViewProps = {
+    data: FarmTodayData;
+    headerActions?: ReactNode;
+    heading: ReactNode;
+};
+
+export function FarmTodayView({
+    data,
+    headerActions,
+    heading,
+}: FarmTodayViewProps) {
+    if (data.status === 'unavailable') {
+        return (
+            <main className="mx-auto w-full max-w-5xl space-y-3 px-3 py-3 sm:p-4">
+                <header className="flex min-h-11 min-w-0 items-start justify-between gap-2">
+                    <div className="min-w-0">{heading}</div>
+                    {headerActions ? (
+                        <div className="flex shrink-0 gap-1">
+                            {headerActions}
+                        </div>
+                    ) : null}
+                </header>
+                <FarmTodayUnavailableState />
+                <FarmTodayTools />
+            </main>
+        );
+    }
+
+    if (data.status === 'noFarm') {
+        return (
+            <main className="mx-auto w-full max-w-5xl space-y-3 px-3 py-3 sm:p-4">
+                <header className="flex min-h-11 min-w-0 items-start justify-between gap-2">
+                    <div className="min-w-0">{heading}</div>
+                    {headerActions ? (
+                        <div className="flex shrink-0 gap-1">
+                            {headerActions}
+                        </div>
+                    ) : null}
+                </header>
+                <FarmTodayNoFarmState />
+                <FarmTodayTools />
+            </main>
+        );
+    }
+
+    const focusKeys = new Set(data.focusQueue.map((task) => task.key));
+    const attentionItems = data.attentionItems.filter(
+        ({ task }) => !focusKeys.has(task.key),
+    );
+    const nextTask = data.focusQueue[0];
+    const remainingTasks = data.focusQueue.slice(1);
+    const partialNotice =
+        data.status === 'partial' ? (
+            <Alert
+                className="items-start"
+                color="warning"
+                startDecorator={<Warning aria-hidden className="size-4" />}
+            >
+                <div>
+                    <span className="font-medium">
+                        Prikazujemo dostupne podatke.
+                    </span>{' '}
+                    Brojevi sa znakom ≥ najmanje su potvrđene vrijednosti.
+                </div>
+            </Alert>
+        ) : null;
+
+    return (
+        <main className="mx-auto w-full max-w-5xl min-w-0 space-y-3 px-3 py-3 sm:p-4">
+            <header className="flex min-h-11 min-w-0 items-start justify-between gap-2">
+                <div className="min-w-0">{heading}</div>
+                {headerActions ? (
+                    <div className="flex shrink-0 gap-1">{headerActions}</div>
+                ) : null}
+            </header>
+
+            <FarmTodaySummary summary={data.summary} />
+
+            {nextTask ? (
+                <section aria-labelledby="farm-today-focus-title">
+                    <h2 className="sr-only" id="farm-today-focus-title">
+                        Fokus
+                    </h2>
+                    <List variant="outlined">
+                        <FarmTodayTaskLink emphasis="next" task={nextTask} />
+                    </List>
+                </section>
+            ) : null}
+
+            {nextTask ? partialNotice : null}
+
+            {remainingTasks.length > 0 ? (
+                <section
+                    aria-labelledby="farm-today-queue-title"
+                    className="space-y-2"
+                >
+                    <h2
+                        className="text-sm font-semibold"
+                        id="farm-today-queue-title"
+                    >
+                        Nakon toga
+                    </h2>
+                    <List variant="outlined">
+                        {remainingTasks.map((task) => (
+                            <FarmTodayTaskLink key={task.key} task={task} />
+                        ))}
+                    </List>
+                </section>
+            ) : null}
+
+            {!nextTask ? partialNotice : null}
+
+            {!nextTask ? (
+                <FarmTodayAvailableStatePanel
+                    completed={data.summary.completed}
+                    dateKey={data.dateKey}
+                    pendingVerification={data.summary.pendingVerification}
+                    workState={data.workState}
+                />
+            ) : null}
+
+            {attentionItems.length > 0 ? (
+                <section
+                    aria-labelledby="farm-today-attention-title"
+                    className="space-y-2"
+                >
+                    <div>
+                        <h2
+                            className="text-sm font-semibold"
+                            id="farm-today-attention-title"
+                        >
+                            Treba pažnju
+                        </h2>
+                        <Typography level="body3">
+                            Zadaci koji čekaju potvrdu ili zahtijevaju provjeru.
+                        </Typography>
+                    </div>
+                    <List variant="outlined">
+                        {attentionItems.map(({ task }) => (
+                            <FarmTodayTaskLink key={task.key} task={task} />
+                        ))}
+                    </List>
+                </section>
+            ) : null}
+
+            <FarmTodayTools />
+        </main>
+    );
+}

--- a/apps/farm/app/farmTodayData.ts
+++ b/apps/farm/app/farmTodayData.ts
@@ -1,0 +1,119 @@
+import 'server-only';
+
+import { getFarmsForUser, getTimeZoneDateKey } from '@gredice/storage';
+import { cache } from 'react';
+import {
+    composeFarmTodayData,
+    type FarmTodayData,
+    type FarmTodayOperationsSourceData,
+    type FarmTodaySource,
+} from './farmTodayModel';
+import {
+    getFarmScheduleOperationsData,
+    getFarmScheduleOperationsForDay,
+    getFarmSchedulePendingOperations,
+    getFarmSchedulePlantingsDayData,
+    getFarmSchedulePlantSorts,
+} from './schedule/scheduleData';
+import { FARM_SCHEDULE_TIME_ZONE } from './schedule/scheduleShared';
+
+function toSource<T>(result: PromiseSettledResult<T>): FarmTodaySource<T> {
+    return result.status === 'fulfilled'
+        ? { status: 'ready', data: result.value }
+        : { status: 'unavailable' };
+}
+
+function logRejectedSource(
+    source: string,
+    result: PromiseSettledResult<unknown>,
+) {
+    if (result.status === 'rejected') {
+        console.error(`[Farm Today] ${source} unavailable`, result.reason);
+    }
+}
+
+export const getFarmTodayData = cache(
+    async (userId: string): Promise<FarmTodayData> => {
+        const referenceDate = new Date();
+        const dateKey = getTimeZoneDateKey(
+            referenceDate,
+            FARM_SCHEDULE_TIME_ZONE,
+        );
+
+        const farmsResult = await Promise.allSettled([getFarmsForUser(userId)]);
+        logRejectedSource('farms', farmsResult[0]);
+        const farms = toSource(farmsResult[0]);
+
+        if (farms.status === 'unavailable') {
+            return {
+                dataIssues: ['farmsUnavailable'],
+                dateKey,
+                status: 'unavailable',
+            };
+        }
+
+        if (farms.data.length === 0) {
+            return {
+                dataIssues: [],
+                dateKey,
+                status: 'noFarm',
+            };
+        }
+
+        const [
+            plantingsResult,
+            scheduledOperationsResult,
+            pendingOperationsResult,
+            plantSortsResult,
+            operationDefinitionsResult,
+        ] = await Promise.allSettled([
+            getFarmSchedulePlantingsDayData(userId, dateKey, true),
+            getFarmScheduleOperationsForDay(userId, dateKey, true),
+            getFarmSchedulePendingOperations(userId),
+            getFarmSchedulePlantSorts(),
+            getFarmScheduleOperationsData(),
+        ]);
+        logRejectedSource('plantings', plantingsResult);
+        logRejectedSource('scheduled operations', scheduledOperationsResult);
+        logRejectedSource('pending operations', pendingOperationsResult);
+        logRejectedSource('plant sorts', plantSortsResult);
+        logRejectedSource('operation definitions', operationDefinitionsResult);
+
+        const operations: FarmTodaySource<FarmTodayOperationsSourceData> =
+            scheduledOperationsResult.status === 'rejected' &&
+            pendingOperationsResult.status === 'rejected'
+                ? { status: 'unavailable' }
+                : {
+                      status: 'ready',
+                      data: {
+                          pendingOperations:
+                              pendingOperationsResult.status === 'fulfilled'
+                                  ? pendingOperationsResult.value
+                                  : [],
+                          pendingOperationsComplete:
+                              pendingOperationsResult.status === 'fulfilled',
+                          raisedBeds:
+                              plantingsResult.status === 'fulfilled'
+                                  ? plantingsResult.value.raisedBeds
+                                  : [],
+                          scheduledOperations:
+                              scheduledOperationsResult.status === 'fulfilled'
+                                  ? scheduledOperationsResult.value
+                                  : [],
+                          scheduledOperationsComplete:
+                              scheduledOperationsResult.status === 'fulfilled',
+                      },
+                  };
+
+        return composeFarmTodayData({
+            dateKey,
+            farms: { status: 'ready', data: farms.data },
+            operationDefinitions: toSource(operationDefinitionsResult),
+            operations,
+            plantings: toSource(plantingsResult),
+            plantSorts: toSource(plantSortsResult),
+            referenceDate,
+            userId,
+        });
+    },
+);

--- a/apps/farm/app/farmTodayData.ts
+++ b/apps/farm/app/farmTodayData.ts
@@ -96,6 +96,8 @@ export const getFarmTodayData = cache(
                               plantingsResult.status === 'fulfilled'
                                   ? plantingsResult.value.raisedBeds
                                   : [],
+                          raisedBedsComplete:
+                              plantingsResult.status === 'fulfilled',
                           scheduledOperations:
                               scheduledOperationsResult.status === 'fulfilled'
                                   ? scheduledOperationsResult.value

--- a/apps/farm/app/farmTodayData.ts
+++ b/apps/farm/app/farmTodayData.ts
@@ -86,6 +86,7 @@ export const getFarmTodayData = cache(
                 : {
                       status: 'ready',
                       data: {
+                          authorizationScope: 'farmMembership',
                           pendingOperations:
                               pendingOperationsResult.status === 'fulfilled'
                                   ? pendingOperationsResult.value

--- a/apps/farm/app/farmTodayModel.spec.ts
+++ b/apps/farm/app/farmTodayModel.spec.ts
@@ -100,6 +100,7 @@ function emptyPlantings(): FarmTodayPlantingsSourceData {
 
 function emptyOperations(): FarmTodayOperationsSourceData {
     return {
+        authorizationScope: 'farmMembership',
         pendingOperations: [],
         pendingOperationsComplete: true,
         raisedBeds: [],
@@ -207,6 +208,7 @@ test('composes mixed operation and planting work without merging pending into co
         buildInput({
             operationDefinitions: ready(operationDefinitions),
             operations: ready({
+                authorizationScope: 'farmMembership',
                 pendingOperations: [operationPending],
                 pendingOperationsComplete: true,
                 raisedBeds: [raisedBed],
@@ -318,6 +320,7 @@ test('keeps shared work actionable but omits other-farmer and unrelated-farm det
                 buildDefinition({ id: 715, label: 'Krivi vlasnik gredice' }),
             ]),
             operations: ready({
+                authorizationScope: 'farmMembership',
                 pendingOperations: [],
                 pendingOperationsComplete: true,
                 raisedBeds: [buildRaisedBed()],
@@ -371,6 +374,7 @@ test('uses the primary operation assignee until completion authorization support
         buildInput({
             operationDefinitions: ready([buildDefinition()]),
             operations: ready({
+                authorizationScope: 'farmMembership',
                 pendingOperations: [],
                 pendingOperationsComplete: true,
                 raisedBeds: [buildRaisedBed()],
@@ -410,6 +414,7 @@ test('uses array-only operation assignments when the primary assignee is missing
         buildInput({
             operationDefinitions: ready([buildDefinition()]),
             operations: ready({
+                authorizationScope: 'farmMembership',
                 pendingOperations: [],
                 pendingOperationsComplete: true,
                 raisedBeds: [buildRaisedBed()],
@@ -547,11 +552,12 @@ test('returns explicit no-farm, empty, no-assigned-work, and all-done states', (
 });
 
 test('keeps available work in partial results and never turns total source failure into empty', () => {
-    const operation = buildOperation();
+    const operation = buildOperation({ farmId: null });
     const partial = composeFarmTodayData(
         buildInput({
             operationDefinitions: unavailable(),
             operations: ready({
+                authorizationScope: 'farmMembership',
                 pendingOperations: [],
                 pendingOperationsComplete: true,
                 raisedBeds: [],
@@ -614,6 +620,7 @@ test('keeps available work in partial results and never turns total source failu
         buildInput({
             operationDefinitions: ready([buildDefinition()]),
             operations: ready({
+                authorizationScope: 'farmMembership',
                 pendingOperations: [],
                 pendingOperationsComplete: false,
                 raisedBeds: [buildRaisedBed()],
@@ -640,6 +647,7 @@ test('keeps available work in partial results and never turns total source failu
         buildInput({
             operationDefinitions: ready([buildDefinition()]),
             operations: ready({
+                authorizationScope: 'farmMembership',
                 pendingOperations: [knownPending],
                 pendingOperationsComplete: true,
                 raisedBeds: [buildRaisedBed()],
@@ -698,6 +706,7 @@ test('retains tasks with safe fallbacks when individual directory entries are mi
         buildInput({
             operationDefinitions: ready([]),
             operations: ready({
+                authorizationScope: 'farmMembership',
                 pendingOperations: [],
                 pendingOperationsComplete: true,
                 raisedBeds: [buildRaisedBed()],

--- a/apps/farm/app/farmTodayModel.spec.ts
+++ b/apps/farm/app/farmTodayModel.spec.ts
@@ -103,6 +103,7 @@ function emptyOperations(): FarmTodayOperationsSourceData {
         pendingOperations: [],
         pendingOperationsComplete: true,
         raisedBeds: [],
+        raisedBedsComplete: true,
         scheduledOperations: [],
         scheduledOperationsComplete: true,
     };
@@ -209,6 +210,7 @@ test('composes mixed operation and planting work without merging pending into co
                 pendingOperations: [operationPending],
                 pendingOperationsComplete: true,
                 raisedBeds: [raisedBed],
+                raisedBedsComplete: true,
                 scheduledOperations: [
                     operationMine,
                     operationShared,
@@ -319,6 +321,7 @@ test('keeps shared work actionable but omits other-farmer and unrelated-farm det
                 pendingOperations: [],
                 pendingOperationsComplete: true,
                 raisedBeds: [buildRaisedBed()],
+                raisedBedsComplete: true,
                 scheduledOperations: [
                     sharedOperation,
                     otherOperation,
@@ -371,6 +374,7 @@ test('uses the primary operation assignee until completion authorization support
                 pendingOperations: [],
                 pendingOperationsComplete: true,
                 raisedBeds: [buildRaisedBed()],
+                raisedBedsComplete: true,
                 scheduledOperations: [
                     buildOperation({
                         assignedUserId: otherUserId,
@@ -409,6 +413,7 @@ test('uses array-only operation assignments when the primary assignee is missing
                 pendingOperations: [],
                 pendingOperationsComplete: true,
                 raisedBeds: [buildRaisedBed()],
+                raisedBedsComplete: true,
                 scheduledOperations: [mine, other],
                 scheduledOperationsComplete: true,
             }),
@@ -549,7 +554,8 @@ test('keeps available work in partial results and never turns total source failu
             operations: ready({
                 pendingOperations: [],
                 pendingOperationsComplete: true,
-                raisedBeds: [buildRaisedBed()],
+                raisedBeds: [],
+                raisedBedsComplete: false,
                 scheduledOperations: [operation],
                 scheduledOperationsComplete: true,
             }),
@@ -562,6 +568,12 @@ test('keeps available work in partial results and never turns total source failu
         expect(partial.workState).toBe('hasWork');
         expect(partial.summary.countsComplete).toBe(false);
         expect(partial.focusQueue).toHaveLength(1);
+        expect(partial.focusQueue[0]?.location).toEqual({
+            kind: 'raisedBed',
+            label: 'Gredica 10',
+            positionIndex: null,
+            raisedBedId: 10,
+        });
         expect(partial.focusQueue[0]?.durationMinutes).toBeNull();
         expect(partial.focusQueue[0]?.proofRequirements).toEqual({
             images: 'unknown',
@@ -605,6 +617,7 @@ test('keeps available work in partial results and never turns total source failu
                 pendingOperations: [],
                 pendingOperationsComplete: false,
                 raisedBeds: [buildRaisedBed()],
+                raisedBedsComplete: true,
                 scheduledOperations: [operation],
                 scheduledOperationsComplete: true,
             }),
@@ -630,6 +643,7 @@ test('keeps available work in partial results and never turns total source failu
                 pendingOperations: [knownPending],
                 pendingOperationsComplete: true,
                 raisedBeds: [buildRaisedBed()],
+                raisedBedsComplete: true,
                 scheduledOperations: [],
                 scheduledOperationsComplete: false,
             }),
@@ -687,6 +701,7 @@ test('retains tasks with safe fallbacks when individual directory entries are mi
                 pendingOperations: [],
                 pendingOperationsComplete: true,
                 raisedBeds: [buildRaisedBed()],
+                raisedBedsComplete: true,
                 scheduledOperations: [operation],
                 scheduledOperationsComplete: true,
             }),

--- a/apps/farm/app/farmTodayModel.spec.ts
+++ b/apps/farm/app/farmTodayModel.spec.ts
@@ -1,0 +1,713 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { expect, test } from '@playwright/test';
+import {
+    type ComposeFarmTodayDataInput,
+    composeFarmTodayData,
+    type FarmTodayOperationInput,
+    type FarmTodayOperationsSourceData,
+    type FarmTodayPlantingInput,
+    type FarmTodayPlantingsSourceData,
+    type FarmTodayRaisedBedInput,
+    type FarmTodaySource,
+} from './farmTodayModel';
+
+const userId = 'farmer-1';
+const otherUserId = 'farmer-2';
+const dateKey = '2026-07-15';
+const referenceDate = new Date('2026-07-15T10:00:00.000Z');
+const overdueDate = new Date('2026-07-12T10:00:00.000Z');
+const todayDate = new Date('2026-07-15T08:00:00.000Z');
+
+function ready<T>(data: T): FarmTodaySource<T> {
+    return { status: 'ready', data };
+}
+
+function unavailable<T>(): FarmTodaySource<T> {
+    return { status: 'unavailable' };
+}
+
+function buildField(
+    overrides: Partial<FarmTodayPlantingInput> = {},
+): FarmTodayPlantingInput {
+    return {
+        active: true,
+        assignedUserId: userId,
+        assignedUserIds: [userId],
+        id: 201,
+        plantScheduledDate: todayDate,
+        plantSortId: 601,
+        plantStatus: 'planned',
+        positionIndex: 0,
+        raisedBedId: 10,
+        sowingLocation: 'direct',
+        ...overrides,
+    };
+}
+
+function buildRaisedBed({
+    farmId = 1,
+    fields = [],
+    id = 10,
+}: {
+    farmId?: number;
+    fields?: FarmTodayPlantingInput[];
+    id?: number;
+} = {}): FarmTodayRaisedBedInput {
+    return {
+        farmId,
+        fields,
+        id,
+        physicalId: `A${id}`,
+    };
+}
+
+function buildOperation(
+    overrides: Partial<FarmTodayOperationInput> = {},
+): FarmTodayOperationInput {
+    return {
+        assignedUserId: userId,
+        assignedUserIds: [userId],
+        entityId: 701,
+        farmId: 1,
+        id: 101,
+        raisedBedFieldId: null,
+        raisedBedId: 10,
+        scheduledDate: todayDate,
+        status: 'planned',
+        ...overrides,
+    };
+}
+
+function buildDefinition({
+    duration = 20,
+    id = 701,
+    label = `Radnja ${id}`,
+}: {
+    duration?: number;
+    id?: number;
+    label?: string;
+} = {}): EntityStandardized {
+    return {
+        id,
+        attributes: { duration },
+        information: { label },
+    };
+}
+
+function emptyPlantings(): FarmTodayPlantingsSourceData {
+    return { raisedBeds: [], scheduledFields: [] };
+}
+
+function emptyOperations(): FarmTodayOperationsSourceData {
+    return {
+        pendingOperations: [],
+        pendingOperationsComplete: true,
+        raisedBeds: [],
+        scheduledOperations: [],
+        scheduledOperationsComplete: true,
+    };
+}
+
+function buildInput(
+    overrides: Partial<ComposeFarmTodayDataInput> = {},
+): ComposeFarmTodayDataInput {
+    return {
+        dateKey,
+        farms: ready([{ id: 1, name: 'Gredice farma' }]),
+        operationDefinitions: ready([]),
+        operations: ready(emptyOperations()),
+        plantings: ready(emptyPlantings()),
+        plantSorts: ready([]),
+        referenceDate,
+        userId,
+        ...overrides,
+    };
+}
+
+test('composes mixed operation and planting work without merging pending into completed', () => {
+    const operationMine = buildOperation({
+        id: 101,
+        entityId: 701,
+        scheduledDate: overdueDate,
+    });
+    const operationShared = buildOperation({
+        assignedUserId: null,
+        assignedUserIds: [],
+        entityId: 702,
+        id: 102,
+        scheduledDate: undefined,
+    });
+    const operationOther = buildOperation({
+        assignedUserId: otherUserId,
+        assignedUserIds: [otherUserId, userId],
+        entityId: 703,
+        id: 103,
+    });
+    const operationPending = buildOperation({
+        completedAt: new Date('2026-07-13T08:00:00.000Z'),
+        entityId: 704,
+        id: 104,
+        status: 'pendingVerification',
+    });
+    const operationCompleted = buildOperation({
+        completedAt: todayDate,
+        entityId: 705,
+        id: 105,
+        status: 'completed',
+    });
+    const plantingMine = buildField({
+        id: 201,
+        plantScheduledDate: overdueDate,
+    });
+    const plantingShared = buildField({
+        assignedUserId: null,
+        assignedUserIds: [],
+        id: 202,
+        plantScheduledDate: undefined,
+    });
+    const plantingOther = buildField({
+        assignedUserId: otherUserId,
+        assignedUserIds: [otherUserId],
+        id: 203,
+    });
+    const plantingPending = buildField({
+        id: 204,
+        plantSowDate: new Date('2026-07-13T08:00:00.000Z'),
+        plantStatus: 'pendingVerification',
+    });
+    const plantingCompleted = buildField({
+        id: 205,
+        plantSowDate: todayDate,
+        plantStatus: 'sowed',
+    });
+    const raisedBed = buildRaisedBed({
+        fields: [
+            plantingMine,
+            plantingShared,
+            plantingOther,
+            plantingPending,
+            plantingCompleted,
+        ],
+    });
+    const operationDefinitions = [
+        {
+            ...buildDefinition({ id: 701, duration: 20 }),
+            conditions: {
+                completionAttachImagesRequired: true,
+                completionAttachNotes: true,
+            },
+        },
+        buildDefinition({ id: 702, duration: 10 }),
+        buildDefinition({ id: 703 }),
+        buildDefinition({ id: 704 }),
+        buildDefinition({ id: 705 }),
+    ];
+    const result = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready(operationDefinitions),
+            operations: ready({
+                pendingOperations: [operationPending],
+                pendingOperationsComplete: true,
+                raisedBeds: [raisedBed],
+                scheduledOperations: [
+                    operationMine,
+                    operationShared,
+                    operationOther,
+                    operationCompleted,
+                ],
+                scheduledOperationsComplete: true,
+            }),
+            plantings: ready({
+                raisedBeds: [raisedBed],
+                scheduledFields: [
+                    plantingMine,
+                    plantingShared,
+                    plantingOther,
+                    plantingCompleted,
+                ],
+            }),
+            plantSorts: ready([{ id: 601, information: { name: 'Rajčica' } }]),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+
+    expect(result.workState).toBe('hasWork');
+    expect(result.summary).toEqual({
+        assignedToMe: 2,
+        completed: 2,
+        countsComplete: true,
+        overdue: 2,
+        pendingVerification: 2,
+        remaining: 4,
+        remainingDuration: { complete: true, minutes: 40 },
+        unassigned: 2,
+    });
+    expect(result.focusQueue.map((task) => task.key)).toEqual([
+        'operation:101',
+        'planting:201',
+        'operation:102',
+        'planting:202',
+    ]);
+    expect(
+        result.attentionItems
+            .filter((item) => item.reasons.includes('pendingVerification'))
+            .map((item) => item.task.key),
+    ).toEqual(['operation:104', 'planting:204']);
+    expect(result.focusQueue.map((task) => task.key)).not.toContain(
+        'operation:103',
+    );
+    expect(result.focusQueue.map((task) => task.key)).not.toContain(
+        'planting:203',
+    );
+
+    const operationTask = result.focusQueue.find(
+        (task) => task.key === 'operation:101',
+    );
+    expect(operationTask?.proofRequirements).toEqual({
+        images: 'required',
+        notes: 'optional',
+    });
+    expect(operationTask?.href).toBe('/operations/701');
+});
+
+test('keeps shared work actionable but omits other-farmer and unrelated-farm details', () => {
+    const sharedOperation = buildOperation({
+        assignedUserId: null,
+        assignedUserIds: [],
+        entityId: 711,
+        id: 111,
+    });
+    const otherOperation = buildOperation({
+        assignedUserId: otherUserId,
+        assignedUserIds: [otherUserId],
+        entityId: 712,
+        id: 112,
+    });
+    const malformedOperation = buildOperation({
+        entityId: 713,
+        farmId: 1,
+        id: 113,
+        raisedBedId: 999,
+    });
+    const unrelatedFarmOperation = buildOperation({
+        entityId: 714,
+        farmId: 2,
+        id: 114,
+        raisedBedId: null,
+    });
+    const mismatchedFarmOperation = buildOperation({
+        entityId: 715,
+        farmId: 2,
+        id: 115,
+        raisedBedId: 10,
+    });
+    const unrelatedField = buildField({ id: 299, raisedBedId: 99 });
+    const result = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([
+                buildDefinition({ id: 711, label: 'Zajednička radnja' }),
+                buildDefinition({ id: 712, label: 'Tuđa tajna radnja' }),
+                buildDefinition({ id: 713, label: 'Kriva lokacija' }),
+                buildDefinition({ id: 714, label: 'Radnja tuđe farme' }),
+                buildDefinition({ id: 715, label: 'Krivi vlasnik gredice' }),
+            ]),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [
+                    sharedOperation,
+                    otherOperation,
+                    malformedOperation,
+                    unrelatedFarmOperation,
+                    mismatchedFarmOperation,
+                ],
+                scheduledOperationsComplete: true,
+            }),
+            plantings: ready({
+                raisedBeds: [
+                    buildRaisedBed(),
+                    buildRaisedBed({
+                        farmId: 2,
+                        fields: [unrelatedField],
+                        id: 99,
+                    }),
+                ],
+                scheduledFields: [unrelatedField],
+            }),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+
+    expect(result.focusQueue.map((task) => task.key)).toEqual([
+        'operation:111',
+    ]);
+    expect(result.summary.assignedToMe).toBe(0);
+    expect(result.summary.unassigned).toBe(1);
+    expect(
+        result.attentionItems.find((item) => item.task.key === 'operation:111')
+            ?.reasons,
+    ).toContain('unassigned');
+    expect(JSON.stringify(result)).not.toContain('Tuđa tajna radnja');
+    expect(JSON.stringify(result)).not.toContain('Kriva lokacija');
+    expect(JSON.stringify(result)).not.toContain('Radnja tuđe farme');
+    expect(JSON.stringify(result)).not.toContain('Krivi vlasnik gredice');
+    expect(JSON.stringify(result)).not.toContain('planting:299');
+});
+
+test('uses the primary operation assignee until completion authorization supports multiple assignees', () => {
+    const result = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([buildDefinition()]),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [
+                    buildOperation({
+                        assignedUserId: otherUserId,
+                        assignedUserIds: [otherUserId, userId],
+                    }),
+                ],
+                scheduledOperationsComplete: true,
+            }),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+    expect(result.workState).toBe('noAssignedWork');
+    expect(result.focusQueue).toEqual([]);
+    expect(result.summary.remaining).toBe(0);
+});
+
+test('uses array-only operation assignments when the primary assignee is missing', () => {
+    const mine = buildOperation({
+        assignedUserId: null,
+        assignedUserIds: [otherUserId, userId],
+        id: 121,
+    });
+    const other = buildOperation({
+        assignedUserId: null,
+        assignedUserIds: [otherUserId],
+        id: 122,
+    });
+    const result = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([buildDefinition()]),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [mine, other],
+                scheduledOperationsComplete: true,
+            }),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+    expect(result.focusQueue.map((task) => task.key)).toEqual([
+        'operation:121',
+    ]);
+    expect(result.summary.assignedToMe).toBe(1);
+});
+
+test('treats planting multi-assignment containing the current user as mine', () => {
+    const field = buildField({
+        assignedUserId: otherUserId,
+        assignedUserIds: [otherUserId, userId],
+    });
+    const assignedElsewhere = buildField({
+        assignedUserId: userId,
+        assignedUserIds: [otherUserId],
+        id: 202,
+    });
+    const result = composeFarmTodayData(
+        buildInput({
+            plantings: ready({
+                raisedBeds: [
+                    buildRaisedBed({ fields: [field, assignedElsewhere] }),
+                ],
+                scheduledFields: [field, assignedElsewhere],
+            }),
+            plantSorts: ready([{ id: 601, information: { name: 'Rajčica' } }]),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+    expect(result.focusQueue.map((task) => task.key)).toEqual(['planting:201']);
+    expect(result.summary.assignedToMe).toBe(1);
+    expect(result.summary.unassigned).toBe(0);
+});
+
+test('uses Zagreb day boundaries for overdue state and deterministic focus order', () => {
+    const justBeforeZagrebMidnight = new Date('2026-07-14T21:59:59.000Z');
+    const atZagrebMidnight = new Date('2026-07-14T22:00:00.000Z');
+    const overdue = buildField({
+        id: 211,
+        plantScheduledDate: justBeforeZagrebMidnight,
+    });
+    const today = buildField({
+        id: 212,
+        plantScheduledDate: atZagrebMidnight,
+    });
+    const undated = buildField({
+        id: 213,
+        plantScheduledDate: undefined,
+    });
+    const raisedBed = buildRaisedBed({ fields: [overdue, today, undated] });
+    const result = composeFarmTodayData(
+        buildInput({
+            plantings: ready({
+                raisedBeds: [raisedBed],
+                scheduledFields: [today, undated, overdue],
+            }),
+            plantSorts: ready([{ id: 601, information: { name: 'Rajčica' } }]),
+        }),
+    );
+
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+        return;
+    }
+    expect(result.summary.overdue).toBe(1);
+    expect(result.focusQueue.map((task) => task.key)).toEqual([
+        'planting:211',
+        'planting:212',
+        'planting:213',
+    ]);
+});
+
+test('returns explicit no-farm, empty, no-assigned-work, and all-done states', () => {
+    expect(composeFarmTodayData(buildInput({ farms: ready([]) }))).toEqual({
+        dataIssues: [],
+        dateKey,
+        status: 'noFarm',
+    });
+
+    const empty = composeFarmTodayData(buildInput());
+    expect(empty.status).toBe('ready');
+    if (empty.status === 'ready') {
+        expect(empty.workState).toBe('empty');
+    }
+
+    const otherField = buildField({
+        assignedUserId: otherUserId,
+        assignedUserIds: [otherUserId],
+    });
+    const noAssignedWork = composeFarmTodayData(
+        buildInput({
+            plantings: ready({
+                raisedBeds: [buildRaisedBed({ fields: [otherField] })],
+                scheduledFields: [otherField],
+            }),
+        }),
+    );
+    expect(noAssignedWork.status).toBe('ready');
+    if (noAssignedWork.status === 'ready') {
+        expect(noAssignedWork.workState).toBe('noAssignedWork');
+    }
+
+    const completed = buildField({ plantStatus: 'sowed' });
+    const allDone = composeFarmTodayData(
+        buildInput({
+            plantings: ready({
+                raisedBeds: [buildRaisedBed({ fields: [completed] })],
+                scheduledFields: [completed],
+            }),
+            plantSorts: ready([{ id: 601, information: { name: 'Rajčica' } }]),
+        }),
+    );
+    expect(allDone.status).toBe('ready');
+    if (allDone.status === 'ready') {
+        expect(allDone.workState).toBe('allDone');
+        expect(allDone.summary.completed).toBe(1);
+    }
+});
+
+test('keeps available work in partial results and never turns total source failure into empty', () => {
+    const operation = buildOperation();
+    const partial = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: unavailable(),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [operation],
+                scheduledOperationsComplete: true,
+            }),
+            plantings: unavailable(),
+        }),
+    );
+
+    expect(partial.status).toBe('partial');
+    if (partial.status === 'partial') {
+        expect(partial.workState).toBe('hasWork');
+        expect(partial.summary.countsComplete).toBe(false);
+        expect(partial.focusQueue).toHaveLength(1);
+        expect(partial.focusQueue[0]?.durationMinutes).toBeNull();
+        expect(partial.focusQueue[0]?.proofRequirements).toEqual({
+            images: 'unknown',
+            notes: 'unknown',
+        });
+        expect(partial.summary.remainingDuration).toEqual({
+            complete: false,
+            minutes: 0,
+        });
+        expect(partial.dataIssues).toEqual([
+            'plantingsUnavailable',
+            'operationDefinitionsUnavailable',
+        ]);
+    }
+
+    const field = buildField();
+    const oppositePartial = composeFarmTodayData(
+        buildInput({
+            operations: unavailable(),
+            plantings: ready({
+                raisedBeds: [buildRaisedBed({ fields: [field] })],
+                scheduledFields: [field],
+            }),
+            plantSorts: ready([{ id: 601, information: { name: 'Rajčica' } }]),
+        }),
+    );
+    expect(oppositePartial.status).toBe('partial');
+    if (oppositePartial.status === 'partial') {
+        expect(oppositePartial.workState).toBe('hasWork');
+        expect(oppositePartial.summary.countsComplete).toBe(false);
+        expect(oppositePartial.focusQueue.map((task) => task.key)).toEqual([
+            'planting:201',
+        ]);
+        expect(oppositePartial.dataIssues).toEqual(['operationsUnavailable']);
+    }
+
+    const subreadPartial = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([buildDefinition()]),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: false,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [operation],
+                scheduledOperationsComplete: true,
+            }),
+        }),
+    );
+    expect(subreadPartial.status).toBe('partial');
+    if (subreadPartial.status === 'partial') {
+        expect(subreadPartial.workState).toBe('hasWork');
+        expect(subreadPartial.summary.countsComplete).toBe(false);
+        expect(subreadPartial.dataIssues).toEqual([
+            'pendingOperationsUnavailable',
+        ]);
+    }
+
+    const knownPending = buildOperation({
+        id: 131,
+        status: 'pendingVerification',
+    });
+    const reverseSubreadPartial = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([buildDefinition()]),
+            operations: ready({
+                pendingOperations: [knownPending],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [],
+                scheduledOperationsComplete: false,
+            }),
+        }),
+    );
+    expect(reverseSubreadPartial.status).toBe('partial');
+    if (reverseSubreadPartial.status === 'partial') {
+        expect(reverseSubreadPartial.workState).toBe('incomplete');
+        expect(reverseSubreadPartial.summary.pendingVerification).toBe(1);
+        expect(
+            reverseSubreadPartial.attentionItems.map((item) => item.task.key),
+        ).toContain('operation:131');
+        expect(reverseSubreadPartial.dataIssues).toEqual([
+            'scheduledOperationsUnavailable',
+        ]);
+    }
+
+    const incompleteEmpty = composeFarmTodayData(
+        buildInput({ operations: unavailable() }),
+    );
+    expect(incompleteEmpty.status).toBe('partial');
+    if (incompleteEmpty.status === 'partial') {
+        expect(incompleteEmpty.workState).toBe('incomplete');
+        expect(incompleteEmpty.summary.countsComplete).toBe(false);
+        expect(incompleteEmpty.summary.remainingDuration.complete).toBe(false);
+    }
+
+    expect(
+        composeFarmTodayData(
+            buildInput({
+                operations: unavailable(),
+                plantings: unavailable(),
+            }),
+        ),
+    ).toEqual({
+        dataIssues: ['plantingsUnavailable', 'operationsUnavailable'],
+        dateKey,
+        status: 'unavailable',
+    });
+
+    expect(composeFarmTodayData(buildInput({ farms: unavailable() }))).toEqual({
+        dataIssues: ['farmsUnavailable'],
+        dateKey,
+        status: 'unavailable',
+    });
+});
+
+test('retains tasks with safe fallbacks when individual directory entries are missing', () => {
+    const field = buildField();
+    const operation = buildOperation();
+    const result = composeFarmTodayData(
+        buildInput({
+            operationDefinitions: ready([]),
+            operations: ready({
+                pendingOperations: [],
+                pendingOperationsComplete: true,
+                raisedBeds: [buildRaisedBed()],
+                scheduledOperations: [operation],
+                scheduledOperationsComplete: true,
+            }),
+            plantings: ready({
+                raisedBeds: [buildRaisedBed({ fields: [field] })],
+                scheduledFields: [field],
+            }),
+            plantSorts: ready([]),
+        }),
+    );
+
+    expect(result.status).toBe('partial');
+    if (result.status !== 'partial') {
+        return;
+    }
+    expect(result.focusQueue.map((task) => task.label)).toEqual([
+        'Radnja #701',
+        'Sijanje: Nepoznata biljka',
+    ]);
+    expect(result.dataIssues).toEqual([
+        'plantSortMetadataMissing',
+        'operationDefinitionMissing',
+    ]);
+});

--- a/apps/farm/app/farmTodayModel.ts
+++ b/apps/farm/app/farmTodayModel.ts
@@ -74,6 +74,7 @@ export type FarmTodayPlantingsSourceData = {
 };
 
 export type FarmTodayOperationsSourceData = {
+    authorizationScope: 'farmMembership';
     pendingOperations: FarmTodayOperationInput[];
     pendingOperationsComplete: boolean;
     raisedBeds: FarmTodayRaisedBedInput[];
@@ -382,6 +383,7 @@ function isOperationAuthorized(
     operation: FarmTodayOperationInput,
     activeFarmIds: Set<number>,
     authorizedRaisedBedFarmIds: Map<number, number>,
+    authorizationScope: FarmTodayOperationsSourceData['authorizationScope'],
     raisedBedsComplete: boolean,
 ) {
     if (
@@ -406,10 +408,9 @@ function isOperationAuthorized(
             return false;
         }
 
-        return (
-            typeof operation.farmId === 'number' &&
-            activeFarmIds.has(operation.farmId)
-        );
+        return operation.farmId === null
+            ? authorizationScope === 'farmMembership'
+            : activeFarmIds.has(operation.farmId);
     }
 
     return (
@@ -480,6 +481,7 @@ function buildOperationCandidates({
                 operation,
                 activeFarmIds,
                 authorizedRaisedBedFarmIds,
+                source.authorizationScope,
                 source.raisedBedsComplete,
             )
         ) {

--- a/apps/farm/app/farmTodayModel.ts
+++ b/apps/farm/app/farmTodayModel.ts
@@ -77,6 +77,7 @@ export type FarmTodayOperationsSourceData = {
     pendingOperations: FarmTodayOperationInput[];
     pendingOperationsComplete: boolean;
     raisedBeds: FarmTodayRaisedBedInput[];
+    raisedBedsComplete: boolean;
     scheduledOperations: FarmTodayOperationInput[];
     scheduledOperationsComplete: boolean;
 };
@@ -381,6 +382,7 @@ function isOperationAuthorized(
     operation: FarmTodayOperationInput,
     activeFarmIds: Set<number>,
     authorizedRaisedBedFarmIds: Map<number, number>,
+    raisedBedsComplete: boolean,
 ) {
     if (
         typeof operation.farmId === 'number' &&
@@ -393,9 +395,20 @@ function isOperationAuthorized(
         const raisedBedFarmId = authorizedRaisedBedFarmIds.get(
             operation.raisedBedId,
         );
+        if (typeof raisedBedFarmId === 'number') {
+            return (
+                operation.farmId === null ||
+                operation.farmId === raisedBedFarmId
+            );
+        }
+
+        if (raisedBedsComplete) {
+            return false;
+        }
+
         return (
-            typeof raisedBedFarmId === 'number' &&
-            (operation.farmId === null || operation.farmId === raisedBedFarmId)
+            typeof operation.farmId === 'number' &&
+            activeFarmIds.has(operation.farmId)
         );
     }
 
@@ -467,6 +480,7 @@ function buildOperationCandidates({
                 operation,
                 activeFarmIds,
                 authorizedRaisedBedFarmIds,
+                source.raisedBedsComplete,
             )
         ) {
             continue;
@@ -502,6 +516,13 @@ function buildOperationCandidates({
                 positionIndex: raisedBedField?.positionIndex ?? null,
                 raisedBed,
             });
+        } else if (typeof operation.raisedBedId === 'number') {
+            location = {
+                kind: 'raisedBed',
+                label: `Gredica ${operation.raisedBedId}`,
+                positionIndex: null,
+                raisedBedId: operation.raisedBedId,
+            };
         } else {
             if (typeof operation.farmId !== 'number') {
                 continue;

--- a/apps/farm/app/farmTodayModel.ts
+++ b/apps/farm/app/farmTodayModel.ts
@@ -1,0 +1,781 @@
+import type { EntityStandardized, OperationStatus } from '@gredice/storage';
+import {
+    getScheduleOperationCompletionRequirements,
+    type ScheduleOperationCompletionRequirements,
+} from './schedule/scheduleOperationRequirements';
+import {
+    compareScheduleDates,
+    getOperationDurationMinutes,
+    getScheduleTaskAgeIndicator,
+    isScheduleDatePast,
+    PLANTING_TASK_DURATION_MINUTES,
+    type ScheduleTaskAgeIndicator,
+} from './schedule/scheduleShared';
+import {
+    getScheduleOperationTaskAssignment,
+    getSchedulePlantingTaskAssignment,
+    type ScheduleTaskAssignment,
+} from './schedule/scheduleTaskAssignment';
+import {
+    getOperationTaskState,
+    getPlantingTaskState,
+    getScheduleTaskSummary,
+    type ScheduleTaskState,
+} from './schedule/scheduleTaskState';
+
+type DateInput = Date | string | null | undefined;
+
+export type FarmTodaySource<T> =
+    | { status: 'ready'; data: T }
+    | { status: 'unavailable' };
+
+export type FarmTodayFarmInput = {
+    id: number;
+    name: string;
+};
+
+export type FarmTodayPlantingInput = {
+    active?: boolean;
+    assignedUserId?: string | null;
+    assignedUserIds?: string[];
+    id: number;
+    plantScheduledDate?: DateInput;
+    plantSortId?: number | null;
+    plantSowDate?: DateInput;
+    plantStatus?: string | null;
+    positionIndex: number;
+    raisedBedId: number;
+    sowingLocation?: 'direct' | 'greenhouse';
+};
+
+export type FarmTodayRaisedBedInput = {
+    farmId: number | null;
+    fields: FarmTodayPlantingInput[];
+    id: number;
+    physicalId?: string | null;
+};
+
+export type FarmTodayOperationInput = {
+    assignedUserId?: string | null;
+    assignedUserIds?: string[];
+    completedAt?: DateInput;
+    entityId: number;
+    farmId: number | null;
+    id: number;
+    raisedBedFieldId?: number | null;
+    raisedBedId: number | null;
+    scheduledDate?: DateInput;
+    status: OperationStatus;
+};
+
+export type FarmTodayPlantingsSourceData = {
+    raisedBeds: FarmTodayRaisedBedInput[];
+    scheduledFields: FarmTodayPlantingInput[];
+};
+
+export type FarmTodayOperationsSourceData = {
+    pendingOperations: FarmTodayOperationInput[];
+    pendingOperationsComplete: boolean;
+    raisedBeds: FarmTodayRaisedBedInput[];
+    scheduledOperations: FarmTodayOperationInput[];
+    scheduledOperationsComplete: boolean;
+};
+
+export type FarmTodayDataIssue =
+    | 'farmsUnavailable'
+    | 'plantingsUnavailable'
+    | 'operationsUnavailable'
+    | 'scheduledOperationsUnavailable'
+    | 'pendingOperationsUnavailable'
+    | 'plantSortsUnavailable'
+    | 'operationDefinitionsUnavailable'
+    | 'plantSortMetadataMissing'
+    | 'operationDefinitionMissing';
+
+export type FarmTodayTaskAssignment = Exclude<ScheduleTaskAssignment, 'other'>;
+
+export type FarmTodayTaskLocation =
+    | {
+          kind: 'farm';
+          farmId: number;
+          label: string;
+      }
+    | {
+          kind: 'raisedBed' | 'greenhouse';
+          label: string;
+          positionIndex: number | null;
+          raisedBedId: number;
+      };
+
+type FarmTodayTaskBase = {
+    ageIndicator: ScheduleTaskAgeIndicator | null;
+    assignment: FarmTodayTaskAssignment;
+    durationMinutes: number | null;
+    href: string;
+    key: string;
+    label: string;
+    location: FarmTodayTaskLocation;
+    occurredAt: string | null;
+    overdue: boolean;
+    scheduledDate: string | null;
+    state: ScheduleTaskState;
+};
+
+export type FarmTodayOperationTask = FarmTodayTaskBase & {
+    kind: 'operation';
+    operationId: number;
+    proofRequirements: ScheduleOperationCompletionRequirements;
+};
+
+export type FarmTodayPlantingTask = FarmTodayTaskBase & {
+    fieldId: number;
+    kind: 'planting';
+    plantSortId: number;
+    proofRequirements: {
+        images: 'none';
+        notes: 'none';
+    };
+    raisedBedId: number;
+};
+
+export type FarmTodayTask = FarmTodayOperationTask | FarmTodayPlantingTask;
+
+export type FarmTodayAttentionReason =
+    | 'canceled'
+    | 'failed'
+    | 'overdue'
+    | 'pendingVerification'
+    | 'unassigned';
+
+export type FarmTodayAttentionItem = {
+    reasons: FarmTodayAttentionReason[];
+    task: FarmTodayTask;
+};
+
+export type FarmTodaySummary = {
+    assignedToMe: number;
+    completed: number;
+    countsComplete: boolean;
+    overdue: number;
+    pendingVerification: number;
+    remaining: number;
+    remainingDuration: {
+        complete: boolean;
+        minutes: number;
+    };
+    unassigned: number;
+};
+
+export type FarmTodayWorkState =
+    | 'allDone'
+    | 'empty'
+    | 'hasWork'
+    | 'incomplete'
+    | 'noAssignedWork';
+
+type FarmTodayAvailableData = {
+    attentionItems: FarmTodayAttentionItem[];
+    dataIssues: FarmTodayDataIssue[];
+    dateKey: string;
+    focusQueue: FarmTodayTask[];
+    status: 'partial' | 'ready';
+    summary: FarmTodaySummary;
+    workState: FarmTodayWorkState;
+};
+
+export type FarmTodayData =
+    | FarmTodayAvailableData
+    | {
+          dataIssues: [];
+          dateKey: string;
+          status: 'noFarm';
+      }
+    | {
+          dataIssues: FarmTodayDataIssue[];
+          dateKey: string;
+          status: 'unavailable';
+      };
+
+export type ComposeFarmTodayDataInput = {
+    dateKey: string;
+    farms: FarmTodaySource<FarmTodayFarmInput[]>;
+    operationDefinitions: FarmTodaySource<EntityStandardized[]>;
+    operations: FarmTodaySource<FarmTodayOperationsSourceData>;
+    plantings: FarmTodaySource<FarmTodayPlantingsSourceData>;
+    plantSorts: FarmTodaySource<EntityStandardized[]>;
+    referenceDate: Date;
+    userId: string;
+};
+
+type CandidateBuildResult = {
+    authorizedCandidateCount: number;
+    tasks: FarmTodayTask[];
+};
+
+const dataIssueOrder: FarmTodayDataIssue[] = [
+    'farmsUnavailable',
+    'plantingsUnavailable',
+    'operationsUnavailable',
+    'scheduledOperationsUnavailable',
+    'pendingOperationsUnavailable',
+    'plantSortsUnavailable',
+    'operationDefinitionsUnavailable',
+    'plantSortMetadataMissing',
+    'operationDefinitionMissing',
+];
+
+function orderedIssues(issues: Set<FarmTodayDataIssue>) {
+    return dataIssueOrder.filter((issue) => issues.has(issue));
+}
+
+function toIsoString(value: DateInput) {
+    if (!value) {
+        return null;
+    }
+
+    const parsed = typeof value === 'string' ? new Date(value) : value;
+    return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+}
+
+function getRaisedBedLabel(raisedBed: FarmTodayRaisedBedInput) {
+    return raisedBed.physicalId
+        ? `Gr ${raisedBed.physicalId}`
+        : `Gredica ${raisedBed.id}`;
+}
+
+function getRaisedBedLocation({
+    greenhouse,
+    positionIndex,
+    raisedBed,
+}: {
+    greenhouse: boolean;
+    positionIndex: number | null;
+    raisedBed: FarmTodayRaisedBedInput;
+}): FarmTodayTaskLocation {
+    const positionLabel =
+        positionIndex === null ? '' : ` · pozicija ${positionIndex + 1}`;
+    const raisedBedLabel = `${getRaisedBedLabel(raisedBed)}${positionLabel}`;
+
+    return {
+        kind: greenhouse ? 'greenhouse' : 'raisedBed',
+        label: greenhouse ? `Staklenik · ${raisedBedLabel}` : raisedBedLabel,
+        positionIndex,
+        raisedBedId: raisedBed.id,
+    };
+}
+
+function buildTaskTiming(
+    state: ScheduleTaskState,
+    scheduledDate: DateInput,
+    referenceDate: Date,
+) {
+    const overdue =
+        state === 'actionable' &&
+        isScheduleDatePast(scheduledDate, referenceDate);
+
+    return {
+        ageIndicator:
+            state === 'actionable'
+                ? getScheduleTaskAgeIndicator(scheduledDate, referenceDate)
+                : null,
+        overdue,
+        scheduledDate: toIsoString(scheduledDate),
+    };
+}
+
+function dedupeById<T extends { id: number }>(items: T[]) {
+    return [...new Map(items.map((item) => [item.id, item])).values()];
+}
+
+function buildPlantingCandidates({
+    activeFarmIds,
+    issues,
+    plantSorts,
+    referenceDate,
+    source,
+    userId,
+}: {
+    activeFarmIds: Set<number>;
+    issues: Set<FarmTodayDataIssue>;
+    plantSorts: FarmTodaySource<EntityStandardized[]>;
+    referenceDate: Date;
+    source: FarmTodayPlantingsSourceData;
+    userId: string;
+}): CandidateBuildResult {
+    const authorizedRaisedBeds = source.raisedBeds.filter(
+        (raisedBed) =>
+            typeof raisedBed.farmId === 'number' &&
+            activeFarmIds.has(raisedBed.farmId),
+    );
+    const raisedBedById = new Map(
+        authorizedRaisedBeds.map((raisedBed) => [raisedBed.id, raisedBed]),
+    );
+    const pendingFields = authorizedRaisedBeds
+        .flatMap((raisedBed) => raisedBed.fields)
+        .filter(
+            (field) =>
+                field.active !== false &&
+                field.plantSortId &&
+                getPlantingTaskState(field.plantStatus) ===
+                    'pendingVerification',
+        );
+    const fields = dedupeById([...source.scheduledFields, ...pendingFields]);
+    const plantSortById =
+        plantSorts.status === 'ready'
+            ? new Map(
+                  plantSorts.data.map((plantSort) => [plantSort.id, plantSort]),
+              )
+            : new Map<number, EntityStandardized>();
+    const tasks: FarmTodayTask[] = [];
+    let authorizedCandidateCount = 0;
+
+    for (const field of fields) {
+        const raisedBed = raisedBedById.get(field.raisedBedId);
+        const state = getPlantingTaskState(field.plantStatus);
+        if (!raisedBed || !field.plantSortId || !state) {
+            continue;
+        }
+
+        authorizedCandidateCount += 1;
+        const assignment = getSchedulePlantingTaskAssignment(field, userId);
+        if (assignment === 'other') {
+            continue;
+        }
+
+        const plantSort = plantSortById.get(field.plantSortId);
+        if (plantSorts.status === 'ready' && !plantSort) {
+            issues.add('plantSortMetadataMissing');
+        }
+        const plantName = plantSort?.information?.name ?? 'Nepoznata biljka';
+        const greenhouse = field.sowingLocation === 'greenhouse';
+
+        tasks.push({
+            ...buildTaskTiming(state, field.plantScheduledDate, referenceDate),
+            assignment,
+            durationMinutes: PLANTING_TASK_DURATION_MINUTES,
+            fieldId: field.id,
+            href: `/raised-beds/${field.raisedBedId}`,
+            key: `planting:${field.id}`,
+            kind: 'planting',
+            label: `${greenhouse ? 'Sijanje u stakleniku' : 'Sijanje'}: ${plantName}`,
+            location: getRaisedBedLocation({
+                greenhouse,
+                positionIndex: field.positionIndex,
+                raisedBed,
+            }),
+            occurredAt: toIsoString(field.plantSowDate),
+            plantSortId: field.plantSortId,
+            proofRequirements: {
+                images: 'none',
+                notes: 'none',
+            },
+            raisedBedId: field.raisedBedId,
+            state,
+        });
+    }
+
+    return { authorizedCandidateCount, tasks };
+}
+
+function isOperationAuthorized(
+    operation: FarmTodayOperationInput,
+    activeFarmIds: Set<number>,
+    authorizedRaisedBedFarmIds: Map<number, number>,
+) {
+    if (
+        typeof operation.farmId === 'number' &&
+        !activeFarmIds.has(operation.farmId)
+    ) {
+        return false;
+    }
+
+    if (typeof operation.raisedBedId === 'number') {
+        const raisedBedFarmId = authorizedRaisedBedFarmIds.get(
+            operation.raisedBedId,
+        );
+        return (
+            typeof raisedBedFarmId === 'number' &&
+            (operation.farmId === null || operation.farmId === raisedBedFarmId)
+        );
+    }
+
+    return (
+        typeof operation.farmId === 'number' &&
+        activeFarmIds.has(operation.farmId)
+    );
+}
+
+function buildOperationCandidates({
+    activeFarmIds,
+    farms,
+    issues,
+    operationDefinitions,
+    referenceDate,
+    source,
+    userId,
+}: {
+    activeFarmIds: Set<number>;
+    farms: FarmTodayFarmInput[];
+    issues: Set<FarmTodayDataIssue>;
+    operationDefinitions: FarmTodaySource<EntityStandardized[]>;
+    referenceDate: Date;
+    source: FarmTodayOperationsSourceData;
+    userId: string;
+}): CandidateBuildResult {
+    const authorizedRaisedBeds = source.raisedBeds.filter(
+        (raisedBed) =>
+            typeof raisedBed.farmId === 'number' &&
+            activeFarmIds.has(raisedBed.farmId),
+    );
+    const raisedBedById = new Map(
+        authorizedRaisedBeds.map((raisedBed) => [raisedBed.id, raisedBed]),
+    );
+    const authorizedRaisedBedFarmEntries: [number, number][] = [];
+    for (const raisedBed of authorizedRaisedBeds) {
+        if (typeof raisedBed.farmId === 'number') {
+            authorizedRaisedBedFarmEntries.push([
+                raisedBed.id,
+                raisedBed.farmId,
+            ]);
+        }
+    }
+    const authorizedRaisedBedFarmIds = new Map(authorizedRaisedBedFarmEntries);
+    const pendingOperations = source.pendingOperations.filter(
+        (operation) =>
+            getOperationTaskState(operation.status) === 'pendingVerification',
+    );
+    const operations = dedupeById([
+        ...source.scheduledOperations,
+        ...pendingOperations,
+    ]);
+    const farmById = new Map(farms.map((farm) => [farm.id, farm]));
+    const operationDefinitionById =
+        operationDefinitions.status === 'ready'
+            ? new Map(
+                  operationDefinitions.data.map((definition) => [
+                      definition.id,
+                      definition,
+                  ]),
+              )
+            : new Map<number, EntityStandardized>();
+    const tasks: FarmTodayTask[] = [];
+    let authorizedCandidateCount = 0;
+
+    for (const operation of operations) {
+        if (
+            !isOperationAuthorized(
+                operation,
+                activeFarmIds,
+                authorizedRaisedBedFarmIds,
+            )
+        ) {
+            continue;
+        }
+
+        authorizedCandidateCount += 1;
+        const assignment = getScheduleOperationTaskAssignment(
+            operation,
+            userId,
+        );
+        if (assignment === 'other') {
+            continue;
+        }
+
+        const state = getOperationTaskState(operation.status);
+        const operationDefinition = operationDefinitionById.get(
+            operation.entityId,
+        );
+        if (operationDefinitions.status === 'ready' && !operationDefinition) {
+            issues.add('operationDefinitionMissing');
+        }
+        const raisedBed =
+            typeof operation.raisedBedId === 'number'
+                ? raisedBedById.get(operation.raisedBedId)
+                : undefined;
+        const raisedBedField = raisedBed?.fields.find(
+            (field) => field.id === operation.raisedBedFieldId,
+        );
+        let location: FarmTodayTaskLocation;
+        if (raisedBed) {
+            location = getRaisedBedLocation({
+                greenhouse: false,
+                positionIndex: raisedBedField?.positionIndex ?? null,
+                raisedBed,
+            });
+        } else {
+            if (typeof operation.farmId !== 'number') {
+                continue;
+            }
+
+            const farm = farmById.get(operation.farmId);
+            location = {
+                kind: 'farm',
+                farmId: operation.farmId,
+                label: farm?.name ?? `Farma ${operation.farmId}`,
+            };
+        }
+
+        tasks.push({
+            ...buildTaskTiming(state, operation.scheduledDate, referenceDate),
+            assignment,
+            durationMinutes: operationDefinition
+                ? getOperationDurationMinutes(operationDefinition)
+                : null,
+            href: `/operations/${operation.entityId}`,
+            key: `operation:${operation.id}`,
+            kind: 'operation',
+            label:
+                operationDefinition?.information?.label ??
+                operationDefinition?.information?.name ??
+                `Radnja #${operation.entityId}`,
+            location,
+            occurredAt: toIsoString(operation.completedAt),
+            operationId: operation.id,
+            proofRequirements: getScheduleOperationCompletionRequirements(
+                operationDefinition,
+                operationDefinitions.status === 'ready',
+            ),
+            state,
+        });
+    }
+
+    return { authorizedCandidateCount, tasks };
+}
+
+function compareFocusTasks(left: FarmTodayTask, right: FarmTodayTask) {
+    const assignmentComparison =
+        Number(left.assignment === 'shared') -
+        Number(right.assignment === 'shared');
+    if (assignmentComparison !== 0) {
+        return assignmentComparison;
+    }
+
+    const overdueComparison = Number(right.overdue) - Number(left.overdue);
+    if (overdueComparison !== 0) {
+        return overdueComparison;
+    }
+
+    const dateComparison = compareScheduleDates(
+        left.scheduledDate,
+        right.scheduledDate,
+    );
+    return dateComparison || left.key.localeCompare(right.key);
+}
+
+function getAttentionReasons(task: FarmTodayTask) {
+    const reasons: FarmTodayAttentionReason[] = [];
+
+    if (task.state === 'failed') {
+        reasons.push('failed');
+    } else if (task.state === 'canceled') {
+        reasons.push('canceled');
+    } else if (task.state === 'pendingVerification') {
+        reasons.push('pendingVerification');
+    }
+
+    if (task.overdue) {
+        reasons.push('overdue');
+    }
+
+    if (task.assignment === 'shared' && task.state !== 'completed') {
+        reasons.push('unassigned');
+    }
+
+    return reasons;
+}
+
+function attentionPriority(item: FarmTodayAttentionItem) {
+    if (item.reasons.includes('failed')) {
+        return 0;
+    }
+    if (item.reasons.includes('canceled')) {
+        return 1;
+    }
+    if (item.reasons.includes('pendingVerification')) {
+        return 2;
+    }
+    if (item.reasons.includes('overdue')) {
+        return 3;
+    }
+    return 4;
+}
+
+function compareAttentionItems(
+    left: FarmTodayAttentionItem,
+    right: FarmTodayAttentionItem,
+) {
+    const priorityComparison =
+        attentionPriority(left) - attentionPriority(right);
+    return priorityComparison || compareFocusTasks(left.task, right.task);
+}
+
+function getWorkState(
+    tasks: FarmTodayTask[],
+    authorizedCandidateCount: number,
+    summary: FarmTodaySummary,
+): FarmTodayWorkState {
+    if (!summary.countsComplete && summary.remaining === 0) {
+        return 'incomplete';
+    }
+
+    if (tasks.length === 0) {
+        return authorizedCandidateCount > 0 ? 'noAssignedWork' : 'empty';
+    }
+
+    if (summary.remaining === 0 && summary.pendingVerification === 0) {
+        return 'allDone';
+    }
+
+    return 'hasWork';
+}
+
+function buildSummary(
+    tasks: FarmTodayTask[],
+    countsComplete: boolean,
+): FarmTodaySummary {
+    const stateSummary = getScheduleTaskSummary(
+        tasks.map((task) => ({
+            state: task.state,
+            durationMinutes: task.durationMinutes ?? 0,
+        })),
+    );
+    const actionableTasks = tasks.filter((task) => task.state === 'actionable');
+
+    return {
+        assignedToMe: actionableTasks.filter(
+            (task) => task.assignment === 'mine',
+        ).length,
+        completed: stateSummary.completed.count,
+        countsComplete,
+        overdue: actionableTasks.filter((task) => task.overdue).length,
+        pendingVerification: stateSummary.pendingVerification.count,
+        remaining: stateSummary.actionable.count,
+        remainingDuration: {
+            complete:
+                countsComplete &&
+                actionableTasks.every((task) => task.durationMinutes !== null),
+            minutes: stateSummary.actionable.durationMinutes,
+        },
+        unassigned: actionableTasks.filter(
+            (task) => task.assignment === 'shared',
+        ).length,
+    };
+}
+
+export function composeFarmTodayData({
+    dateKey,
+    farms,
+    operationDefinitions,
+    operations,
+    plantings,
+    plantSorts,
+    referenceDate,
+    userId,
+}: ComposeFarmTodayDataInput): FarmTodayData {
+    if (farms.status === 'unavailable') {
+        return {
+            dataIssues: ['farmsUnavailable'],
+            dateKey,
+            status: 'unavailable',
+        };
+    }
+
+    if (farms.data.length === 0) {
+        return {
+            dataIssues: [],
+            dateKey,
+            status: 'noFarm',
+        };
+    }
+
+    const issues = new Set<FarmTodayDataIssue>();
+    if (plantings.status === 'unavailable') {
+        issues.add('plantingsUnavailable');
+    }
+    if (operations.status === 'unavailable') {
+        issues.add('operationsUnavailable');
+    } else if (
+        !operations.data.scheduledOperationsComplete &&
+        !operations.data.pendingOperationsComplete
+    ) {
+        issues.add('operationsUnavailable');
+    } else {
+        if (!operations.data.scheduledOperationsComplete) {
+            issues.add('scheduledOperationsUnavailable');
+        }
+        if (!operations.data.pendingOperationsComplete) {
+            issues.add('pendingOperationsUnavailable');
+        }
+    }
+    if (plantSorts.status === 'unavailable') {
+        issues.add('plantSortsUnavailable');
+    }
+    if (operationDefinitions.status === 'unavailable') {
+        issues.add('operationDefinitionsUnavailable');
+    }
+
+    const operationsHaveTaskData =
+        operations.status === 'ready' &&
+        (operations.data.scheduledOperationsComplete ||
+            operations.data.pendingOperationsComplete);
+    if (plantings.status === 'unavailable' && !operationsHaveTaskData) {
+        return {
+            dataIssues: orderedIssues(issues),
+            dateKey,
+            status: 'unavailable',
+        };
+    }
+
+    const activeFarmIds = new Set(farms.data.map((farm) => farm.id));
+    const plantingResult =
+        plantings.status === 'ready'
+            ? buildPlantingCandidates({
+                  activeFarmIds,
+                  issues,
+                  plantSorts,
+                  referenceDate,
+                  source: plantings.data,
+                  userId,
+              })
+            : { authorizedCandidateCount: 0, tasks: [] };
+    const operationResult =
+        operations.status === 'ready'
+            ? buildOperationCandidates({
+                  activeFarmIds,
+                  farms: farms.data,
+                  issues,
+                  operationDefinitions,
+                  referenceDate,
+                  source: operations.data,
+                  userId,
+              })
+            : { authorizedCandidateCount: 0, tasks: [] };
+    const tasks = [...plantingResult.tasks, ...operationResult.tasks];
+    const countsComplete =
+        plantings.status === 'ready' &&
+        operations.status === 'ready' &&
+        operations.data.scheduledOperationsComplete &&
+        operations.data.pendingOperationsComplete;
+    const summary = buildSummary(tasks, countsComplete);
+    const focusQueue = tasks
+        .filter((task) => task.state === 'actionable')
+        .sort(compareFocusTasks);
+    const attentionItems = tasks
+        .map((task) => ({ reasons: getAttentionReasons(task), task }))
+        .filter((item) => item.reasons.length > 0)
+        .sort(compareAttentionItems);
+    const dataIssues = orderedIssues(issues);
+    const authorizedCandidateCount =
+        plantingResult.authorizedCandidateCount +
+        operationResult.authorizedCandidateCount;
+
+    return {
+        attentionItems,
+        dataIssues,
+        dateKey,
+        focusQueue,
+        status: dataIssues.length > 0 ? 'partial' : 'ready',
+        summary,
+        workState: getWorkState(tasks, authorizedCandidateCount, summary),
+    };
+}

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -1,297 +1,83 @@
-import { getFarmsForUser, getUser } from '@gredice/storage';
-import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
-import { Button } from '@gredice/ui/Button';
-import {
-    Card,
-    CardContent,
-    CardHeader,
-    CardOverflow,
-    CardTitle,
-} from '@gredice/ui/Card';
-import { Chip } from '@gredice/ui/Chip';
-import {
-    BookA,
-    Calendar,
-    Euro,
-    Fence,
-    Inbox,
-    MapPinHouse,
-    Settings,
-    Shield,
-    Sprout,
-    User,
-} from '@gredice/ui/icons';
-import { Row } from '@gredice/ui/Row';
-import { Stack } from '@gredice/ui/Stack';
-import { Table } from '@gredice/ui/Table';
-import { Typography } from '@gredice/ui/Typography';
+import { getUser } from '@gredice/storage';
+import { IconButton } from '@gredice/ui/IconButton';
+import { Settings } from '@gredice/ui/icons';
 import { Suspense } from 'react';
 import LoginDialog from '../components/auth/LoginDialog';
 import { LogoutButton } from '../components/auth/LogoutButton';
 import { auth } from '../lib/auth/auth';
 import { FarmDashboardGreeting } from './FarmDashboardGreeting';
+import { FarmTodayLoadingState } from './FarmTodayLoadingState';
+import { FarmTodayView } from './FarmTodayView';
+import { getFarmTodayData } from './farmTodayData';
 
-function formatDate(date?: Date | string | null) {
-    if (!date) {
-        return '—';
+export const dynamic = 'force-dynamic';
+
+async function getFarmAuth() {
+    try {
+        return await auth(['farmer', 'admin']);
+    } catch {
+        return null;
     }
-
-    const parsed = typeof date === 'string' ? new Date(date) : date;
-    if (Number.isNaN(parsed.getTime())) {
-        return '—';
-    }
-
-    return parsed.toLocaleDateString('hr-HR', {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-    });
 }
 
-const roleConfig: Record<
-    string,
-    {
-        label: string;
-        icon: typeof Fence;
-        color: 'neutral' | 'success' | 'warning';
-    }
-> = {
-    user: { label: 'Korisnik', icon: User, color: 'neutral' },
-    farmer: { label: 'Poljoprivrednik', icon: Fence, color: 'success' },
-    admin: { label: 'Administrator', icon: Shield, color: 'warning' },
-};
-
-function formatCoordinate(value?: number | null) {
-    if (typeof value !== 'number' || Number.isNaN(value)) {
-        return '—';
-    }
-
-    return `${value.toFixed(4)}°`;
-}
-
-async function FarmerDashboard() {
-    const { userId } = await auth(['farmer', 'admin']);
-    const [dbUser, farms] = await Promise.all([
-        getUser(userId),
-        getFarmsForUser(userId),
+async function FarmTodayDashboard({
+    fallbackDisplayName,
+    userId,
+}: {
+    fallbackDisplayName: string;
+    userId: string;
+}) {
+    const [data, dbUser] = await Promise.all([
+        getFarmTodayData(userId),
+        getUser(userId).catch((cause) => {
+            console.error('[Farm Today] user profile unavailable', cause);
+            return null;
+        }),
     ]);
-
-    if (!dbUser) {
-        return (
-            <div className="max-w-5xl mx-auto w-full px-4 py-10">
-                <Typography level="h3" semiBold>
-                    Korisnik nije pronađen.
-                </Typography>
-            </div>
-        );
-    }
-
-    const displayName = dbUser.displayName ?? dbUser.userName;
-    const joinDate = formatDate(dbUser.createdAt);
-    const role = roleConfig[dbUser.role];
-    const RoleIcon = role?.icon ?? User;
+    const displayName =
+        dbUser?.displayName ?? dbUser?.userName ?? fallbackDisplayName;
 
     return (
-        <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
-            <Card>
-                <CardContent noHeader>
-                    <Stack spacing={4}>
-                        <Row
-                            justifyContent="space-between"
-                            className="flex-wrap items-start gap-3"
-                        >
-                            <Stack className="min-w-0">
-                                <FarmDashboardGreeting
-                                    displayName={displayName}
-                                    initialDateIso={new Date().toISOString()}
-                                />
-                                <Typography
-                                    level="body2"
-                                    className="text-muted-foreground"
-                                >
-                                    Upravljaj farmom, planiraj nadolazeće
-                                    aktivnosti i prati napredak u realnom
-                                    vremenu.
-                                </Typography>
-                            </Stack>
-                            <Row spacing={1} className="shrink-0">
-                                <Button
-                                    aria-label="Postavke"
-                                    className="aspect-square px-0"
-                                    href="/settings"
-                                    title="Postavke"
-                                    variant="plain"
-                                >
-                                    <Settings className="size-4 shrink-0" />
-                                </Button>
-                                <LogoutButton />
-                            </Row>
-                        </Row>
-                        <Row spacing={2} className="flex-wrap gap-y-2">
-                            <Chip
-                                color={role?.color ?? 'neutral'}
-                                startDecorator={<RoleIcon className="size-4" />}
-                            >
-                                {role?.label ?? dbUser.role}
-                            </Chip>
-                            <Chip color="neutral">Član od {joinDate}</Chip>
-                        </Row>
-                    </Stack>
-                </CardContent>
-            </Card>
-            <div className="grid gap-4 sm:grid-cols-2">
-                <Card className="h-full">
-                    <CardHeader>
-                        <Stack spacing={2}>
-                            <CardTitle>Brze radnje</CardTitle>
-                            <Typography className="text-sm text-muted-foreground">
-                                Alati za svakodnevno upravljanje farmom stižu
-                                uskoro.
-                            </Typography>
-                        </Stack>
-                    </CardHeader>
-                    <CardOverflow>
-                        <div className="grid grid-cols-2 gap-3 p-4">
-                            <Button
-                                variant="solid"
-                                size="lg"
-                                fullWidth
-                                className="h-24 flex-col text-center text-base"
-                                startDecorator={<Calendar className="size-6" />}
-                                href="/schedule"
-                            >
-                                Dnevni zadaci
-                            </Button>
-                            <Button
-                                variant="soft"
-                                size="lg"
-                                fullWidth
-                                className="h-24 flex-col text-center text-base"
-                                startDecorator={<Inbox className="size-6" />}
-                                href="/notifications"
-                            >
-                                Obavijesti
-                            </Button>
-                            <Button
-                                variant="soft"
-                                size="lg"
-                                fullWidth
-                                className="h-24 flex-col text-center text-base"
-                                startDecorator={<Fence className="size-6" />}
-                                href="/raised-beds"
-                            >
-                                Gredice
-                            </Button>
-                            <Button
-                                variant="soft"
-                                size="lg"
-                                fullWidth
-                                className="h-24 flex-col text-center text-base"
-                                startDecorator={
-                                    <MapPinHouse className="size-6" />
-                                }
-                                href="/greenhouse"
-                            >
-                                Staklenik
-                            </Button>
-                            <Button
-                                variant="soft"
-                                size="lg"
-                                fullWidth
-                                className="h-24 flex-col text-center text-base"
-                                startDecorator={<BookA className="size-6" />}
-                                href="/operations"
-                            >
-                                Radnje
-                            </Button>
-                            <Button
-                                variant="soft"
-                                size="lg"
-                                fullWidth
-                                className="h-24 flex-col text-center text-base"
-                                startDecorator={<Sprout className="size-6" />}
-                                href="/plants"
-                            >
-                                Biljke
-                            </Button>
-                            <Button
-                                variant="soft"
-                                size="lg"
-                                fullWidth
-                                className="h-24 flex-col text-center text-base"
-                                startDecorator={<Euro className="size-6" />}
-                                href="/payouts"
-                            >
-                                Isplate
-                            </Button>
-                        </div>
-                    </CardOverflow>
-                </Card>
-                <Card className="h-full">
-                    <CardHeader>
-                        <Stack spacing={2}>
-                            <CardTitle>Moje farme</CardTitle>
-                            <Typography className="text-sm text-muted-foreground">
-                                Pregled farmi koje su ti dodijeljene.
-                            </Typography>
-                        </Stack>
-                    </CardHeader>
-                    <CardOverflow>
-                        {farms.length ? (
-                            <Table>
-                                <Table.Header>
-                                    <Table.Row>
-                                        <Table.Head>Naziv</Table.Head>
-                                        <Table.Head>Lokacija</Table.Head>
-                                        <Table.Head>Aktivna od</Table.Head>
-                                    </Table.Row>
-                                </Table.Header>
-                                <Table.Body>
-                                    {farms.map((farm) => (
-                                        <Table.Row key={farm.id}>
-                                            <Table.Cell>{farm.name}</Table.Cell>
-                                            <Table.Cell>
-                                                {formatCoordinate(
-                                                    farm.latitude,
-                                                )}
-                                                ,{' '}
-                                                {formatCoordinate(
-                                                    farm.longitude,
-                                                )}
-                                            </Table.Cell>
-                                            <Table.Cell>
-                                                {formatDate(farm.createdAt)}
-                                            </Table.Cell>
-                                        </Table.Row>
-                                    ))}
-                                </Table.Body>
-                            </Table>
-                        ) : (
-                            <div className="p-6 text-sm text-muted-foreground">
-                                Nema dodijeljenih farmi. Kontaktiraj
-                                administratora kako bi ti dodijelio farmu.
-                            </div>
-                        )}
-                    </CardOverflow>
-                </Card>
-            </div>
-        </div>
+        <FarmTodayView
+            data={data}
+            heading={
+                <FarmDashboardGreeting
+                    displayName={displayName}
+                    initialDateIso={new Date().toISOString()}
+                />
+            }
+            headerActions={
+                <>
+                    <IconButton
+                        href="/settings"
+                        size="lg"
+                        title="Postavke"
+                        variant="plain"
+                    >
+                        <Settings aria-hidden className="size-4 shrink-0" />
+                    </IconButton>
+                    <LogoutButton size="lg" />
+                </>
+            }
+        />
     );
 }
 
-export default function Home() {
-    const authFarmer = auth.bind(null, ['farmer', 'admin']);
+export default async function Home() {
+    const authContext = await getFarmAuth();
 
     return (
         <div className="min-h-[100dvh] w-full bg-background">
-            <AuthProtectedSection auth={authFarmer}>
-                <Suspense>
-                    <FarmerDashboard />
+            {authContext ? (
+                <Suspense fallback={<FarmTodayLoadingState />}>
+                    <FarmTodayDashboard
+                        fallbackDisplayName={authContext.user.userName}
+                        userId={authContext.userId}
+                    />
                 </Suspense>
-            </AuthProtectedSection>
-            <SignedOut auth={authFarmer}>
+            ) : (
                 <LoginDialog />
-            </SignedOut>
+            )}
         </div>
     );
 }

--- a/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
@@ -14,6 +14,11 @@ import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
 import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
 import type { FarmScheduleDayData } from './scheduleData';
 import {
+    getScheduleOperationCompletionRequirements,
+    isScheduleOperationRequirementVisible,
+} from './scheduleOperationRequirements';
+import { getScheduleOperationTaskAssignment } from './scheduleTaskAssignment';
+import {
     getOperationTaskState,
     getScheduleTaskPresentation,
 } from './scheduleTaskState';
@@ -24,6 +29,7 @@ export type FarmOperationCardData = Pick<
     FarmOperation,
     | 'assignedUser'
     | 'assignedUserId'
+    | 'assignedUserIds'
     | 'completionNotes'
     | 'id'
     | 'imageUrls'
@@ -49,23 +55,19 @@ export function FarmScheduleOperationTaskCard({
 }: FarmScheduleOperationTaskCardProps) {
     const taskState = getOperationTaskState(operation.status);
     const taskPresentation = getScheduleTaskPresentation(taskState);
+    const assignment = getScheduleOperationTaskAssignment(operation, userId);
     const canComplete =
-        taskPresentation.showCompletionControl &&
-        (!operation.assignedUserId || operation.assignedUserId === userId);
-    const attachImages = Boolean(
-        operationData?.conditions?.completionAttachImages ||
-            operationData?.conditions?.completionAttachImagesRequired,
+        taskPresentation.showCompletionControl && assignment !== 'other';
+    const requirements =
+        getScheduleOperationCompletionRequirements(operationData);
+    const attachImages = isScheduleOperationRequirementVisible(
+        requirements.images,
     );
-    const attachImagesRequired = Boolean(
-        operationData?.conditions?.completionAttachImagesRequired,
+    const attachImagesRequired = requirements.images === 'required';
+    const attachNotes = isScheduleOperationRequirementVisible(
+        requirements.notes,
     );
-    const attachNotes = Boolean(
-        operationData?.conditions?.completionAttachNotes ||
-            operationData?.conditions?.completionAttachNotesRequired,
-    );
-    const attachNotesRequired = Boolean(
-        operationData?.conditions?.completionAttachNotesRequired,
-    );
+    const attachNotesRequired = requirements.notes === 'required';
     const showRequirementIcons =
         taskPresentation.showRequirementIndicators &&
         (attachImages || attachNotes);

--- a/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
@@ -18,6 +18,7 @@ import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
 import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
 import type { FarmScheduleDayData } from './scheduleData';
 import { PLANTING_TASK_DURATION_MINUTES } from './scheduleShared';
+import { getSchedulePlantingTaskAssignment } from './scheduleTaskAssignment';
 import {
     getPlantingTaskState,
     getScheduleTaskPresentation,
@@ -26,6 +27,7 @@ import {
 type FarmSchedulePlantingField = Pick<
     FarmScheduleDayData['scheduledFields'][number],
     | 'assignedUserId'
+    | 'assignedUserIds'
     | 'id'
     | 'plantScheduledDate'
     | 'plantStatus'
@@ -61,8 +63,7 @@ export function FarmSchedulePlantingTaskCard({
     const taskPresentation = getScheduleTaskPresentation(taskState);
     const lockedByAssignment =
         taskPresentation.showCompletionControl &&
-        !!field.assignedUserId &&
-        field.assignedUserId !== userId;
+        getSchedulePlantingTaskAssignment(field, userId) === 'other';
     const canComplete =
         taskPresentation.showCompletionControl && !lockedByAssignment;
     const greenhouseSowing = field.sowingLocation === 'greenhouse';

--- a/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
@@ -25,6 +25,7 @@ function buildOperation(
     return {
         assignedUser: null,
         assignedUserId: null,
+        assignedUserIds: [],
         completionNotes: undefined,
         durationMinutes: 15,
         id,
@@ -56,6 +57,50 @@ async function assertCardsStayWithinViewport(component: Locator) {
         ),
     ).toBe(true);
 }
+
+test('locks array-only work assigned to another farmer on a phone', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    const component = await mount(
+        <div className="space-y-2">
+            <FarmScheduleOperationTaskCard
+                completionAction={<button type="button">Dovrši radnju</button>}
+                operation={{
+                    ...buildOperation(10, 'planned', 'Zalij salatu'),
+                    assignedUserIds: ['farmer-2'],
+                }}
+                operationData={undefined}
+                userId="farmer-1"
+            />
+            <FarmSchedulePlantingTaskCard
+                completionAction={<button type="button">Dovrši sijanje</button>}
+                field={{
+                    assignedUserId: null,
+                    assignedUserIds: ['farmer-2'],
+                    id: 10,
+                    plantScheduledDate: scheduledDate,
+                    plantStatus: 'planned',
+                    positionIndex: 0,
+                    raisedBedId: 10,
+                    sowingLocation: 'direct',
+                }}
+                label="Posij salatu"
+                plantSort={undefined}
+                userId="farmer-1"
+                assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
+            />
+        </div>,
+    );
+
+    await expect(component.getByRole('button')).toHaveCount(0);
+    await expect(component.getByRole('checkbox')).toHaveCount(2);
+    for (const checkbox of await component.getByRole('checkbox').all()) {
+        await expect(checkbox).toBeDisabled();
+    }
+    await assertCardsStayWithinViewport(component);
+});
 
 for (const width of [320, 390, 1280]) {
     test(`renders operation pending and verified states within ${width}px`, async ({
@@ -147,6 +192,7 @@ for (const width of [320, 390, 1280]) {
                     }
                     field={{
                         assignedUserId: null,
+                        assignedUserIds: [],
                         id: 1,
                         plantScheduledDate: scheduledDate,
                         plantStatus: 'pendingVerification',
@@ -165,6 +211,7 @@ for (const width of [320, 390, 1280]) {
                     }
                     field={{
                         assignedUserId: null,
+                        assignedUserIds: [],
                         id: 2,
                         plantScheduledDate: scheduledDate,
                         plantStatus: 'sowed',
@@ -183,6 +230,7 @@ for (const width of [320, 390, 1280]) {
                     }
                     field={{
                         assignedUserId: null,
+                        assignedUserIds: [],
                         id: 3,
                         plantScheduledDate: scheduledDate,
                         plantStatus: 'planned',

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -13,6 +13,10 @@ import {
 } from '@gredice/storage';
 import { revalidatePath } from 'next/cache';
 import { auth } from '../../lib/auth/auth';
+import {
+    getScheduleOperationTaskAssignment,
+    getSchedulePlantingTaskAssignment,
+} from './scheduleTaskAssignment';
 
 const MAX_COMPLETION_NOTES_LENGTH = 2000;
 
@@ -41,7 +45,7 @@ async function assertFarmerCanCompleteOperation(
         throw new Error('Nemaš dozvolu za označavanje ove radnje.');
     }
 
-    if (operation.assignedUserId && operation.assignedUserId !== userId) {
+    if (getScheduleOperationTaskAssignment(operation, userId) === 'other') {
         throw new Error('Ova radnja je dodijeljena drugom korisniku.');
     }
 
@@ -63,13 +67,7 @@ async function assertFarmerCanCompletePlanting(
         throw new Error('Nemaš dozvolu za označavanje ovog sijanja.');
     }
 
-    const assignedUserIds = field.assignedUserIds ?? [];
-    const isAssignedToAnotherUser =
-        assignedUserIds.length > 0
-            ? !assignedUserIds.includes(userId)
-            : !!field.assignedUserId && field.assignedUserId !== userId;
-
-    if (isAssignedToAnotherUser) {
+    if (getSchedulePlantingTaskAssignment(field, userId) === 'other') {
         throw new Error('Ovo sijanje je dodijeljeno drugom korisniku.');
     }
 

--- a/apps/farm/app/schedule/scheduleData.ts
+++ b/apps/farm/app/schedule/scheduleData.ts
@@ -7,6 +7,7 @@ import {
     getEntitiesFormatted,
     getFarmUserAcceptedOperations,
     getFarmUserAcceptedOperationsByScheduleRange,
+    getFarmUserPendingVerificationOperations,
     getFarmUserRaisedBeds,
     getRaisedBedPhotoPreviews,
     getTimeZoneDateKey,
@@ -170,6 +171,10 @@ export const getFarmScheduleOperations = cache(async (userId: string) => {
         scheduleCacheTtls.operations,
     );
 });
+
+export const getFarmSchedulePendingOperations = cache(async (userId: string) =>
+    getFarmUserPendingVerificationOperations(userId),
+);
 
 export const getFarmScheduleOperationsForDay = cache(
     async (userId: string, dateKey: string, isToday: boolean) => {

--- a/apps/farm/app/schedule/scheduleOperationRequirements.ts
+++ b/apps/farm/app/schedule/scheduleOperationRequirements.ts
@@ -1,0 +1,60 @@
+import type { EntityStandardized } from '@gredice/storage';
+
+export type ScheduleOperationRequirementLevel =
+    | 'none'
+    | 'optional'
+    | 'required'
+    | 'unknown';
+
+export type ScheduleOperationCompletionRequirements = {
+    images: ScheduleOperationRequirementLevel;
+    notes: ScheduleOperationRequirementLevel;
+};
+
+function getRequirementLevel({
+    enabled,
+    metadataAvailable,
+    operationData,
+    required,
+}: {
+    enabled: boolean | undefined;
+    metadataAvailable: boolean;
+    operationData: EntityStandardized | undefined;
+    required: boolean | undefined;
+}): ScheduleOperationRequirementLevel {
+    if (!metadataAvailable || !operationData) {
+        return 'unknown';
+    }
+
+    if (required) {
+        return 'required';
+    }
+
+    return enabled ? 'optional' : 'none';
+}
+
+export function getScheduleOperationCompletionRequirements(
+    operationData: EntityStandardized | undefined,
+    metadataAvailable = true,
+): ScheduleOperationCompletionRequirements {
+    return {
+        images: getRequirementLevel({
+            enabled: operationData?.conditions?.completionAttachImages,
+            metadataAvailable,
+            operationData,
+            required: operationData?.conditions?.completionAttachImagesRequired,
+        }),
+        notes: getRequirementLevel({
+            enabled: operationData?.conditions?.completionAttachNotes,
+            metadataAvailable,
+            operationData,
+            required: operationData?.conditions?.completionAttachNotesRequired,
+        }),
+    };
+}
+
+export function isScheduleOperationRequirementVisible(
+    level: ScheduleOperationRequirementLevel,
+) {
+    return level === 'optional' || level === 'required';
+}

--- a/apps/farm/app/schedule/scheduleTaskAssignment.spec.ts
+++ b/apps/farm/app/schedule/scheduleTaskAssignment.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+import {
+    getScheduleOperationTaskAssignment,
+    getSchedulePlantingTaskAssignment,
+} from './scheduleTaskAssignment';
+
+const userId = 'farmer-1';
+const otherUserId = 'farmer-2';
+
+test('keeps the operation primary assignee authoritative and supports array-only events', () => {
+    expect(
+        getScheduleOperationTaskAssignment(
+            {
+                assignedUserId: otherUserId,
+                assignedUserIds: [otherUserId, userId],
+            },
+            userId,
+        ),
+    ).toBe('other');
+    expect(
+        getScheduleOperationTaskAssignment(
+            { assignedUserId: null, assignedUserIds: [userId] },
+            userId,
+        ),
+    ).toBe('mine');
+    expect(
+        getScheduleOperationTaskAssignment(
+            { assignedUserId: null, assignedUserIds: [otherUserId] },
+            userId,
+        ),
+    ).toBe('other');
+    expect(
+        getScheduleOperationTaskAssignment(
+            { assignedUserId: null, assignedUserIds: [] },
+            userId,
+        ),
+    ).toBe('shared');
+});
+
+test('uses planting assignment arrays before the legacy primary assignee', () => {
+    expect(
+        getSchedulePlantingTaskAssignment(
+            {
+                assignedUserId: otherUserId,
+                assignedUserIds: [otherUserId, userId],
+            },
+            userId,
+        ),
+    ).toBe('mine');
+    expect(
+        getSchedulePlantingTaskAssignment(
+            { assignedUserId: userId, assignedUserIds: [otherUserId] },
+            userId,
+        ),
+    ).toBe('other');
+    expect(
+        getSchedulePlantingTaskAssignment(
+            { assignedUserId: null, assignedUserIds: [] },
+            userId,
+        ),
+    ).toBe('shared');
+});

--- a/apps/farm/app/schedule/scheduleTaskAssignment.ts
+++ b/apps/farm/app/schedule/scheduleTaskAssignment.ts
@@ -1,0 +1,58 @@
+export type ScheduleTaskAssignment = 'mine' | 'other' | 'shared';
+
+type ScheduleTaskAssignmentInput = {
+    assignedUserId?: string | null;
+    assignedUserIds?: readonly string[] | null;
+};
+
+function normalizeAssignedUserIds(
+    assignedUserIds: readonly string[] | null | undefined,
+) {
+    return Array.from(
+        new Set(
+            (assignedUserIds ?? []).filter(
+                (value) => typeof value === 'string' && value.length > 0,
+            ),
+        ),
+    );
+}
+
+function classifyAssignedUserIds(
+    assignedUserIds: string[],
+    userId: string,
+): ScheduleTaskAssignment {
+    if (assignedUserIds.length === 0) {
+        return 'shared';
+    }
+
+    return assignedUserIds.includes(userId) ? 'mine' : 'other';
+}
+
+export function getScheduleOperationTaskAssignment(
+    task: ScheduleTaskAssignmentInput,
+    userId: string,
+): ScheduleTaskAssignment {
+    if (task.assignedUserId) {
+        return task.assignedUserId === userId ? 'mine' : 'other';
+    }
+
+    return classifyAssignedUserIds(
+        normalizeAssignedUserIds(task.assignedUserIds),
+        userId,
+    );
+}
+
+export function getSchedulePlantingTaskAssignment(
+    task: ScheduleTaskAssignmentInput,
+    userId: string,
+): ScheduleTaskAssignment {
+    const assignedUserIds = normalizeAssignedUserIds(task.assignedUserIds);
+    if (assignedUserIds.length > 0) {
+        return classifyAssignedUserIds(assignedUserIds, userId);
+    }
+
+    return classifyAssignedUserIds(
+        task.assignedUserId ? [task.assignedUserId] : [],
+        userId,
+    );
+}

--- a/apps/farm/components/auth/LogoutButton.tsx
+++ b/apps/farm/components/auth/LogoutButton.tsx
@@ -7,7 +7,11 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { queryClient } from '../providers/ClientAppProvider';
 
-export function LogoutButton() {
+export function LogoutButton({
+    size = 'md',
+}: {
+    size?: 'xs' | 'sm' | 'md' | 'lg';
+}) {
     const router = useRouter();
     const [loading, setLoading] = useState(false);
 
@@ -35,6 +39,7 @@ export function LogoutButton() {
         <IconButton
             title="Odjavi se"
             variant="plain"
+            size={size}
             loading={loading}
             onClick={handleLogout}
             className="whitespace-nowrap"

--- a/apps/farm/playwright/index.tsx
+++ b/apps/farm/playwright/index.tsx
@@ -1,1 +1,1 @@
-// import '../app/globals.css';
+import '../app/globals.css';

--- a/packages/storage/src/cache/scheduleCache.ts
+++ b/packages/storage/src/cache/scheduleCache.ts
@@ -21,6 +21,8 @@ type DeliveryRequestsSummaryCacheInput = {
 };
 
 const CACHE_VERSION = 'v2';
+// Raised-bed payloads added farmId in v3; keep old cached shapes out of Farm Today.
+const FARM_USER_RAISED_BED_PAYLOAD_VERSION = 'v3';
 
 export const scheduleCacheTtls = {
     day: 45,
@@ -80,7 +82,7 @@ export const scheduleCacheKeys = {
     adminDay: (date: Date | string, isToday: boolean) =>
         `schedule:admin:day:${localDateKey(date)}:today:${isToday ? '1' : '0'}:${CACHE_VERSION}`,
     farmUserRaisedBeds: (userId: string) =>
-        `schedule:farm:user:${safePart(userId)}:raisedBeds:${CACHE_VERSION}`,
+        `schedule:farm:user:${safePart(userId)}:raisedBeds:${FARM_USER_RAISED_BED_PAYLOAD_VERSION}`,
     farmUserOperations: (userId: string, input?: DateRangeCacheInput) =>
         `schedule:farm:user:${safePart(userId)}:operations:${rangePart(input)}:${CACHE_VERSION}`,
     farmUserActiveOperations: (userId: string, from: Date) =>
@@ -90,7 +92,7 @@ export const scheduleCacheKeys = {
     farmRaisedBedPhotoPreviews: (raisedBedIds: number[]) =>
         `schedule:farm:raisedBedPhotoPreviews:${raisedBedIds.map(safePart).join(',')}:${CACHE_VERSION}`,
     farmUserDay: (userId: string, date: Date | string, isToday: boolean) =>
-        `schedule:farm:user:${safePart(userId)}:day:${localDateKey(date)}:today:${isToday ? '1' : '0'}:${CACHE_VERSION}`,
+        `schedule:farm:user:${safePart(userId)}:day:${localDateKey(date)}:today:${isToday ? '1' : '0'}:${FARM_USER_RAISED_BED_PAYLOAD_VERSION}`,
     deliveryRequestsSummary: (input: DeliveryRequestsSummaryCacheInput) =>
         [
             'delivery:requests:summary',

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -4,6 +4,7 @@ import {
     count,
     desc,
     eq,
+    exists,
     gte,
     inArray,
     isNotNull,
@@ -20,6 +21,7 @@ import {
 } from '../cache/scheduleCache';
 import {
     events,
+    farms,
     farmUsers,
     gardens,
     type InsertOperation,
@@ -77,10 +79,36 @@ function operationFarmIdExpression() {
 
 function operationLocationIntegrityWhere() {
     return and(
-        or(isNull(operations.raisedBedId), eq(raisedBeds.isDeleted, false)),
+        or(
+            isNull(operations.raisedBedId),
+            and(
+                eq(raisedBeds.isDeleted, false),
+                or(
+                    isNull(operations.gardenId),
+                    eq(operations.gardenId, raisedBeds.gardenId),
+                ),
+            ),
+        ),
         or(
             and(isNull(operations.gardenId), isNull(operations.raisedBedId)),
-            eq(gardens.isDeleted, false),
+            and(
+                eq(gardens.isDeleted, false),
+                or(
+                    isNull(operations.farmId),
+                    eq(operations.farmId, gardens.farmId),
+                ),
+            ),
+        ),
+        exists(
+            storage()
+                .select({ id: farms.id })
+                .from(farms)
+                .where(
+                    and(
+                        eq(farms.id, operationFarmIdExpression()),
+                        eq(farms.isDeleted, false),
+                    ),
+                ),
         ),
     );
 }

--- a/packages/storage/src/repositories/operationsRepo.ts
+++ b/packages/storage/src/repositories/operationsRepo.ts
@@ -836,6 +836,41 @@ export async function getFarmUserAcceptedOperations(
     );
 }
 
+export async function getFarmUserPendingVerificationOperations(userId: string) {
+    const filter = { status: 'pendingVerification' } satisfies OperationsFilter;
+
+    return cacheScheduleRead(
+        scheduleCacheKeys.farmUserOperations(userId, filter),
+        async () => {
+            const rows = await storage()
+                .select({ operation: operations })
+                .from(operations)
+                .leftJoin(raisedBeds, eq(operations.raisedBedId, raisedBeds.id))
+                .leftJoin(
+                    gardens,
+                    eq(gardens.id, operationGardenIdExpression()),
+                )
+                .innerJoin(
+                    farmUsers,
+                    eq(farmUsers.farmId, operationFarmIdExpression()),
+                )
+                .where(
+                    and(
+                        eq(farmUsers.userId, userId),
+                        eq(operations.isAccepted, true),
+                        eq(operations.isDeleted, false),
+                        operationLocationIntegrityWhere(),
+                        getOperationStatusWhere(filter.status),
+                    ),
+                )
+                .orderBy(desc(operations.timestamp));
+
+            return fillOperationAggregates(rows.map((row) => row.operation));
+        },
+        scheduleCacheTtls.operations,
+    );
+}
+
 async function getFarmUserAcceptedOperationsUncached(
     userId: string,
     filter?: OperationsFilter,

--- a/packages/storage/src/repositories/raisedBedsRepo.ts
+++ b/packages/storage/src/repositories/raisedBedsRepo.ts
@@ -20,6 +20,7 @@ import { generateRaisedBedName } from '../helpers/generateRaisedBedName';
 import { RAISED_BED_PHOTO_OPERATION_ID } from '../helpers/raisedBedPhotoOperations';
 import {
     events,
+    farms,
     farmUsers,
     gardens,
     type InsertRaisedBed,
@@ -817,15 +818,17 @@ export async function getFarmUserRaisedBeds(userId: string) {
 
 async function getFarmUserRaisedBedsUncached(userId: string) {
     const farmRaisedBeds = await storage()
-        .select({ raisedBed: raisedBeds })
+        .select({ farmId: gardens.farmId, raisedBed: raisedBeds })
         .from(raisedBeds)
         .innerJoin(gardens, eq(raisedBeds.gardenId, gardens.id))
+        .innerJoin(farms, eq(gardens.farmId, farms.id))
         .innerJoin(farmUsers, eq(gardens.farmId, farmUsers.farmId))
         .where(
             and(
                 eq(farmUsers.userId, userId),
                 eq(raisedBeds.isDeleted, false),
                 eq(gardens.isDeleted, false),
+                eq(farms.isDeleted, false),
                 // Sandbox ("play") gardens never appear in farm scheduling.
                 eq(gardens.isSandbox, false),
             ),
@@ -836,8 +839,9 @@ async function getFarmUserRaisedBedsUncached(userId: string) {
         farmRaisedBeds.map((row) => row.raisedBed.id),
     );
 
-    return farmRaisedBeds.map(({ raisedBed }) => ({
+    return farmRaisedBeds.map(({ farmId, raisedBed }) => ({
         ...raisedBed,
+        farmId,
         fields: fieldsByRaisedBedId.get(raisedBed.id) ?? [],
     }));
 }

--- a/packages/storage/tests/helpers/testHelpers.ts
+++ b/packages/storage/tests/helpers/testHelpers.ts
@@ -22,14 +22,16 @@ export async function createTestGarden(opts: {
 
 export async function ensureFarmId() {
     const farms = await getFarms();
-    if (farms.length === 0) {
-        return await createFarm({
-            name: 'Default Farm',
-            longitude: 0,
-            latitude: 0,
-        });
+    const activeFarm = farms.find((farm) => !farm.isDeleted);
+    if (activeFarm) {
+        return activeFarm.id;
     }
-    return farms[0].id;
+
+    return await createFarm({
+        name: 'Default Farm',
+        longitude: 0,
+        latitude: 0,
+    });
 }
 
 /**

--- a/packages/storage/tests/operationsRepo.node.spec.ts
+++ b/packages/storage/tests/operationsRepo.node.spec.ts
@@ -138,6 +138,97 @@ test('farm-targeted operations are visible and assignable for farm users', async
     );
 });
 
+test('farm-user reads reject operations with inconsistent raised-bed locations', async () => {
+    createTestDb();
+
+    const userId = randomUUID();
+    await storage()
+        .insert(users)
+        .values({
+            id: userId,
+            userName: `location-integrity-${userId}@example.com`,
+            displayName: 'Location Integrity User',
+            role: 'farmer',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+    const firstFarmId = await createFarm({
+        name: 'First Operation Farm',
+        longitude: 0,
+        latitude: 0,
+    });
+    const secondFarmId = await createFarm({
+        name: 'Second Operation Farm',
+        longitude: 0,
+        latitude: 0,
+    });
+    await assignUserToFarm(firstFarmId, userId);
+
+    const firstAccountId = await createAccount();
+    const secondAccountId = await createAccount();
+    const firstGardenId = await createTestGarden({
+        accountId: firstAccountId,
+        farmId: firstFarmId,
+    });
+    const secondGardenId = await createTestGarden({
+        accountId: secondAccountId,
+        farmId: secondFarmId,
+    });
+    const firstBlockId = await createTestBlock(
+        firstGardenId,
+        'first-operation-location',
+    );
+    const secondBlockId = await createTestBlock(
+        secondGardenId,
+        'second-operation-location',
+    );
+    const firstRaisedBedId = await createTestRaisedBed(
+        firstGardenId,
+        firstAccountId,
+        firstBlockId,
+    );
+    const secondRaisedBedId = await createTestRaisedBed(
+        secondGardenId,
+        secondAccountId,
+        secondBlockId,
+    );
+
+    const validOperationId = await createOperation({
+        accountId: firstAccountId,
+        entityId: 1,
+        entityTypeName: 'operation',
+        gardenId: firstGardenId,
+        raisedBedId: firstRaisedBedId,
+    });
+    const mismatchedOperationId = await createOperation({
+        accountId: firstAccountId,
+        entityId: 1,
+        entityTypeName: 'operation',
+        gardenId: firstGardenId,
+        raisedBedId: secondRaisedBedId,
+    });
+    await acceptOperation(validOperationId);
+    await acceptOperation(mismatchedOperationId);
+
+    const acceptedOperations = await getFarmUserAcceptedOperations(userId, {
+        from: new Date('2000-01-01T00:00:00.000Z'),
+    });
+
+    assert.ok(
+        acceptedOperations.some(
+            (operation) => operation.id === validOperationId,
+        ),
+        'Expected the valid raised-bed operation to remain visible',
+    );
+    assert.ok(
+        acceptedOperations.every(
+            (operation) => operation.id !== mismatchedOperationId,
+        ),
+        'Expected the cross-farm raised-bed mismatch to stay hidden',
+    );
+});
+
 test('getOperationsPage uses completion dates for completed operation ordering', async () => {
     createTestDb();
     const { accountId, gardenId, raisedBedId } =

--- a/packages/storage/tests/operationsRepo.pending.node.spec.ts
+++ b/packages/storage/tests/operationsRepo.pending.node.spec.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    acceptOperation,
+    assignUserToFarm,
+    createEvent,
+    createFarm,
+    createOperation,
+    events,
+    getFarmUserPendingVerificationOperations,
+    knownEvents,
+    knownEventTypes,
+    storage,
+    users,
+} from '@gredice/storage';
+import { and, eq } from 'drizzle-orm';
+import { createTestDb } from './testDb';
+
+async function createTestUser() {
+    const userId = randomUUID();
+    await storage()
+        .insert(users)
+        .values({
+            id: userId,
+            userName: `${userId}@example.com`,
+            role: 'farmer',
+        });
+    return userId;
+}
+
+async function createAcceptedFarmOperation(farmId: number, timestamp: Date) {
+    const operationId = await createOperation({
+        entityId: 1,
+        entityTypeName: 'operation',
+        farmId,
+        timestamp,
+    });
+    await acceptOperation(operationId);
+    return operationId;
+}
+
+test('pending operation read keeps old outstanding work and excludes terminal or unrelated work', async () => {
+    createTestDb();
+    const userId = await createTestUser();
+    const otherUserId = await createTestUser();
+    const farmId = await createFarm({
+        name: `Pending operation farm ${randomUUID()}`,
+        latitude: 45.8,
+        longitude: 15.9,
+    });
+    const otherFarmId = await createFarm({
+        name: `Other pending operation farm ${randomUUID()}`,
+        latitude: 45.9,
+        longitude: 16,
+    });
+    await Promise.all([
+        assignUserToFarm(farmId, userId),
+        assignUserToFarm(otherFarmId, otherUserId),
+    ]);
+
+    const oldPendingOperationId = await createAcceptedFarmOperation(
+        farmId,
+        new Date('2000-01-01T08:00:00.000Z'),
+    );
+    const verifiedOperationId = await createAcceptedFarmOperation(
+        farmId,
+        new Date('2000-01-02T08:00:00.000Z'),
+    );
+    const untouchedOperationId = await createAcceptedFarmOperation(
+        farmId,
+        new Date('2000-01-03T08:00:00.000Z'),
+    );
+    const otherFarmPendingOperationId = await createAcceptedFarmOperation(
+        otherFarmId,
+        new Date('2000-01-04T08:00:00.000Z'),
+    );
+
+    for (const operationId of [
+        oldPendingOperationId,
+        verifiedOperationId,
+        otherFarmPendingOperationId,
+    ]) {
+        await createEvent(
+            knownEvents.operations.completedV1(operationId.toString(), {
+                completedBy: randomUUID(),
+            }),
+        );
+    }
+    await storage()
+        .update(events)
+        .set({ createdAt: new Date('2000-01-05T08:00:00.000Z') })
+        .where(
+            and(
+                eq(events.aggregateId, oldPendingOperationId.toString()),
+                eq(events.type, knownEventTypes.operations.complete),
+            ),
+        );
+    await createEvent(
+        knownEvents.operations.verifiedV1(verifiedOperationId.toString(), {
+            verifiedBy: randomUUID(),
+        }),
+    );
+
+    const pendingOperations =
+        await getFarmUserPendingVerificationOperations(userId);
+    const pendingOperationIds = pendingOperations.map(
+        (operation) => operation.id,
+    );
+
+    assert.deepStrictEqual(pendingOperationIds, [oldPendingOperationId]);
+    assert.ok(!pendingOperationIds.includes(verifiedOperationId));
+    assert.ok(!pendingOperationIds.includes(untouchedOperationId));
+    assert.ok(!pendingOperationIds.includes(otherFarmPendingOperationId));
+});

--- a/packages/storage/tests/raisedBedsRepo.farmUser.node.spec.ts
+++ b/packages/storage/tests/raisedBedsRepo.farmUser.node.spec.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import test from 'node:test';
+import {
+    assignUserToFarm,
+    createAccount,
+    createFarm,
+    createGarden,
+    getFarmUserRaisedBeds,
+    storage,
+    users,
+} from '@gredice/storage';
+import { eq } from 'drizzle-orm';
+import { farms } from '../src/schema';
+import { createTestBlock, createTestRaisedBed } from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+async function createTestUser() {
+    const userId = randomUUID();
+    await storage()
+        .insert(users)
+        .values({
+            id: userId,
+            userName: `${userId}@example.com`,
+            role: 'user',
+        });
+    return userId;
+}
+
+async function createFarmRaisedBed({
+    farmId,
+    isSandbox = false,
+    name,
+}: {
+    farmId: number;
+    isSandbox?: boolean;
+    name: string;
+}) {
+    const accountId = await createAccount();
+    const gardenId = await createGarden({
+        accountId,
+        farmId,
+        isSandbox,
+        name,
+    });
+    const blockId = await createTestBlock(gardenId, `${name} block`);
+    return createTestRaisedBed(gardenId, accountId, blockId);
+}
+
+test('getFarmUserRaisedBeds returns only beds from active assigned non-sandbox farms with their farm id', async () => {
+    createTestDb();
+    const userId = await createTestUser();
+    const otherUserId = await createTestUser();
+    const activeFarmId = await createFarm({
+        name: `Active assigned farm ${randomUUID()}`,
+        latitude: 45.8,
+        longitude: 15.9,
+    });
+    const otherFarmId = await createFarm({
+        name: `Other user's farm ${randomUUID()}`,
+        latitude: 45.9,
+        longitude: 16,
+    });
+    const deletedFarmId = await createFarm({
+        name: `Deleted assigned farm ${randomUUID()}`,
+        latitude: 46,
+        longitude: 16.1,
+    });
+
+    await Promise.all([
+        assignUserToFarm(activeFarmId, userId),
+        assignUserToFarm(deletedFarmId, userId),
+        assignUserToFarm(otherFarmId, otherUserId),
+    ]);
+
+    const activeRaisedBedId = await createFarmRaisedBed({
+        farmId: activeFarmId,
+        name: `Active assigned garden ${randomUUID()}`,
+    });
+    const otherUsersRaisedBedId = await createFarmRaisedBed({
+        farmId: otherFarmId,
+        name: `Other user's garden ${randomUUID()}`,
+    });
+    const deletedFarmRaisedBedId = await createFarmRaisedBed({
+        farmId: deletedFarmId,
+        name: `Deleted assigned farm garden ${randomUUID()}`,
+    });
+    const sandboxRaisedBedId = await createFarmRaisedBed({
+        farmId: activeFarmId,
+        isSandbox: true,
+        name: `Sandbox garden ${randomUUID()}`,
+    });
+
+    await storage()
+        .update(farms)
+        .set({ isDeleted: true })
+        .where(eq(farms.id, deletedFarmId));
+
+    const raisedBeds = await getFarmUserRaisedBeds(userId);
+
+    assert.deepStrictEqual(
+        raisedBeds.map((raisedBed) => ({
+            farmId: raisedBed.farmId,
+            id: raisedBed.id,
+        })),
+        [{ farmId: activeFarmId, id: activeRaisedBedId }],
+    );
+    assert.ok(
+        !raisedBeds.some((raisedBed) =>
+            [
+                otherUsersRaisedBedId,
+                deletedFarmRaisedBedId,
+                sandboxRaisedBedId,
+            ].includes(raisedBed.id),
+        ),
+    );
+});

--- a/packages/storage/tests/testHelpers.node.spec.ts
+++ b/packages/storage/tests/testHelpers.node.spec.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createFarm, farms, getFarms, storage } from '@gredice/storage';
+import { eq, inArray } from 'drizzle-orm';
+import { ensureFarmId } from './helpers/testHelpers';
+import { createTestDb } from './testDb';
+
+test('ensureFarmId creates and reuses an active farm when only deleted farms exist', async (t) => {
+    createTestDb();
+
+    const originalFarms = await getFarms();
+    const originalFarmIds = new Set(originalFarms.map((farm) => farm.id));
+    t.after(async () => {
+        const createdFarmIds = (await getFarms())
+            .filter((farm) => !originalFarmIds.has(farm.id))
+            .map((farm) => farm.id);
+        if (createdFarmIds.length > 0) {
+            await storage()
+                .delete(farms)
+                .where(inArray(farms.id, createdFarmIds));
+        }
+
+        for (const farm of originalFarms) {
+            await storage()
+                .update(farms)
+                .set({ isDeleted: farm.isDeleted })
+                .where(eq(farms.id, farm.id));
+        }
+    });
+
+    const deletedFarmId = await createFarm({
+        name: 'Deleted helper farm',
+        latitude: 0,
+        longitude: 0,
+    });
+    const allFarmIds = (await getFarms()).map((farm) => farm.id);
+    await storage()
+        .update(farms)
+        .set({ isDeleted: true })
+        .where(inArray(farms.id, allFarmIds));
+
+    const activeFarmId = await ensureFarmId();
+    const activeFarm = (await getFarms()).find(
+        (farm) => farm.id === activeFarmId,
+    );
+
+    assert.ok(activeFarm);
+    assert.equal(activeFarm.isDeleted, false);
+    assert.notEqual(activeFarm.id, deletedFarmId);
+    assert.equal(await ensureFarmId(), activeFarmId);
+});


### PR DESCRIPTION
## Summary

- replace the launcher-first Farm home with a compact Today briefing backed by the authenticated farmer data contract
- put the complete next-task card in the first phone viewport, with explicit location, timing, assignment, state, and proof requirements
- use one semantic whole-card link with honest destinations and no completion control on the dashboard
- provide ready, partial, unavailable, no-farm, empty, no-assigned-work, and all-done states with useful recovery actions
- keep the single-farm default: remove the global farms table and add no farmer-facing farm selector
- load real Farm styles in component tests so mobile geometry and 44px touch-target assertions measure production CSS

## Validation

- pnpm --filter farm exec biome check on all changed Farm files
- pnpm --filter farm exec tsc --noEmit
- pnpm --filter farm test:prepare
- pnpm --filter farm test:run: 82 passed
- focused Today component coverage at 320x568, 390x844, and 430x932: 12 passed
- independent final auth/mobile review: no P1/P2 findings

## Stack

- Depends on #4171 and currently targets feat/farm-today-data.
- Retarget to main after the data-contract PR merges.
- Mobile app-shell analytics remain in #4157; completion actions remain in #4152; locally queued/sync states remain in #4166 because the current Today contract has no local queue state.

Fixes #4156
