### PR TITLE
feat(farm): replace task checkboxes with mobile actions

### DIFF
--- a/apps/farm/app/FarmTodayStatePanel.tsx
+++ b/apps/farm/app/FarmTodayStatePanel.tsx
@@ -33,7 +33,14 @@ export function FarmTodayUnavailableState() {
                 </div>
                 <div className="flex flex-wrap gap-2">
                     <FarmTodayRefreshButton />
-                    <Button href="/schedule" size="lg" variant="outlined">
+                    <Button
+                        data-farm-analytics="navigation"
+                        data-farm-navigation-destination="schedule"
+                        data-farm-navigation-source="today_tools"
+                        href="/schedule"
+                        size="lg"
+                        variant="outlined"
+                    >
                         Otvori raspored
                     </Button>
                 </div>
@@ -59,6 +66,9 @@ export function FarmTodayNoFarmState() {
                     </div>
                     <Button
                         className="w-fit"
+                        data-farm-analytics="navigation"
+                        data-farm-navigation-destination="settings"
+                        data-farm-navigation-source="today_tools"
                         href="/settings"
                         size="lg"
                         variant="outlined"
@@ -96,6 +106,9 @@ export function FarmTodayAvailableStatePanel({
                         </div>
                         <Button
                             className="w-fit"
+                            data-farm-analytics="navigation"
+                            data-farm-navigation-destination="schedule"
+                            data-farm-navigation-source="today_tools"
                             href={scheduleHref}
                             size="lg"
                             variant="outlined"
@@ -171,6 +184,9 @@ export function FarmTodayAvailableStatePanel({
                     </div>
                     <Button
                         className="w-fit"
+                        data-farm-analytics="navigation"
+                        data-farm-navigation-destination="schedule"
+                        data-farm-navigation-source="today_tools"
                         href={scheduleHref}
                         size="lg"
                         variant="outlined"

--- a/apps/farm/app/FarmTodayTaskLink.tsx
+++ b/apps/farm/app/FarmTodayTaskLink.tsx
@@ -7,8 +7,9 @@ import {
     Navigate,
     Warning,
 } from '@gredice/ui/icons';
-import { ListItem } from '@gredice/ui/List';
+import NextLink from 'next/link';
 import type { ReactNode } from 'react';
+import type { FarmTodayTaskSource } from '../components/analytics/farmAnalytics';
 import type { FarmTodayTask, FarmTodayTaskAssignment } from './farmTodayModel';
 import { ScheduleTaskDateChip } from './schedule/ScheduleTaskDateChip';
 import { ScheduleTaskDurationChip } from './schedule/ScheduleTaskDurationChip';
@@ -17,6 +18,7 @@ import type { ScheduleOperationRequirementLevel } from './schedule/scheduleOpera
 
 type FarmTodayTaskLinkProps = {
     emphasis?: 'next' | 'standard';
+    source: FarmTodayTaskSource;
     task: FarmTodayTask;
 };
 
@@ -147,16 +149,24 @@ function ProofRequirements({ task }: { task: FarmTodayTask }) {
 
 export function FarmTodayTaskLink({
     emphasis = 'standard',
+    source,
     task,
 }: FarmTodayTaskLinkProps) {
     const destinationLabel =
         task.kind === 'operation' ? 'Otvori upute' : 'Otvori gredicu';
 
     return (
-        <ListItem
-            className="min-h-11 min-w-0 items-start px-3 py-2 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            href={task.href}
-            label={
+        <NextLink
+            className="flex h-auto min-h-11 w-full min-w-0 items-start justify-start gap-2 rounded-none bg-transparent px-3 py-2 text-left text-sm text-foreground transition-colors first:rounded-t-[calc(var(--radius)-1px)] last:rounded-b-[calc(var(--radius)-1px)] hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            data-farm-analytics="today_task"
+            data-farm-task-assignment={task.assignment}
+            data-farm-task-kind={task.kind}
+            data-farm-task-overdue={task.overdue ? 'true' : 'false'}
+            data-farm-task-source={source}
+            data-farm-task-state={task.state}
+            href={{ pathname: task.href }}
+        >
+            <div className="min-w-0 grow">
                 <div
                     className="min-w-0 space-y-1.5"
                     data-farm-today-task={task.key}
@@ -197,8 +207,7 @@ export function FarmTodayTaskLink({
                         <Navigate aria-hidden className="size-3.5" />
                     </span>
                 </div>
-            }
-            variant="outlined"
-        />
+            </div>
+        </NextLink>
     );
 }

--- a/apps/farm/app/FarmTodayTools.tsx
+++ b/apps/farm/app/FarmTodayTools.tsx
@@ -8,16 +8,57 @@ import {
     MapPinHouse,
     Sprout,
 } from '@gredice/ui/icons';
+import type { FarmNavigationDestination } from '../components/analytics/farmAnalytics';
 
 const tools = [
-    { href: '/schedule', icon: Calendar, label: 'Cijeli raspored' },
-    { href: '/notifications', icon: Inbox, label: 'Obavijesti' },
-    { href: '/raised-beds', icon: Fence, label: 'Gredice' },
-    { href: '/greenhouse', icon: MapPinHouse, label: 'Staklenik' },
-    { href: '/operations', icon: BookA, label: 'Radnje' },
-    { href: '/plants', icon: Sprout, label: 'Biljke' },
-    { href: '/payouts', icon: Euro, label: 'Isplate' },
-];
+    {
+        destination: 'schedule',
+        href: '/schedule',
+        icon: Calendar,
+        label: 'Cijeli raspored',
+    },
+    {
+        destination: 'notifications',
+        href: '/notifications',
+        icon: Inbox,
+        label: 'Obavijesti',
+    },
+    {
+        destination: 'raised_beds',
+        href: '/raised-beds',
+        icon: Fence,
+        label: 'Gredice',
+    },
+    {
+        destination: 'greenhouse',
+        href: '/greenhouse',
+        icon: MapPinHouse,
+        label: 'Staklenik',
+    },
+    {
+        destination: 'operations',
+        href: '/operations',
+        icon: BookA,
+        label: 'Radnje',
+    },
+    {
+        destination: 'plants',
+        href: '/plants',
+        icon: Sprout,
+        label: 'Biljke',
+    },
+    {
+        destination: 'payouts',
+        href: '/payouts',
+        icon: Euro,
+        label: 'Isplate',
+    },
+] satisfies {
+    destination: FarmNavigationDestination;
+    href: string;
+    icon: typeof Calendar;
+    label: string;
+}[];
 
 export function FarmTodayTools() {
     return (
@@ -26,9 +67,12 @@ export function FarmTodayTools() {
                 Ostali alati
             </h2>
             <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                {tools.map(({ href, icon: Icon, label }) => (
+                {tools.map(({ destination, href, icon: Icon, label }) => (
                     <Button
                         className="justify-start px-3 text-sm"
+                        data-farm-analytics="navigation"
+                        data-farm-navigation-destination={destination}
+                        data-farm-navigation-source="today_tools"
                         fullWidth
                         href={href}
                         key={href}

--- a/apps/farm/app/FarmTodayView.spec.tsx
+++ b/apps/farm/app/FarmTodayView.spec.tsx
@@ -17,6 +17,7 @@ type AvailableFarmTodayData = Extract<FarmTodayData, { focusQueue: unknown }>;
 
 const phoneViewports = [
     { width: 320, height: 568 },
+    { width: 375, height: 667 },
     { width: 390, height: 844 },
     { width: 430, height: 932 },
 ] as const;

--- a/apps/farm/app/FarmTodayView.tsx
+++ b/apps/farm/app/FarmTodayView.tsx
@@ -3,6 +3,7 @@ import { Warning } from '@gredice/ui/icons';
 import { List } from '@gredice/ui/List';
 import { Typography } from '@gredice/ui/Typography';
 import type { ReactNode } from 'react';
+import { FarmTodayViewTracker } from '../components/analytics/FarmTodayViewTracker';
 import {
     FarmTodayAvailableStatePanel,
     FarmTodayNoFarmState,
@@ -24,9 +25,24 @@ export function FarmTodayView({
     headerActions,
     heading,
 }: FarmTodayViewProps) {
+    const viewTracker =
+        data.status === 'ready' || data.status === 'partial' ? (
+            <FarmTodayViewTracker
+                dataStatus={data.status}
+                hasNextTask={data.focusQueue.length > 0}
+                workState={data.workState}
+            />
+        ) : (
+            <FarmTodayViewTracker
+                dataStatus={data.status}
+                hasNextTask={false}
+            />
+        );
+
     if (data.status === 'unavailable') {
         return (
             <main className="mx-auto w-full max-w-5xl space-y-3 px-3 py-3 sm:p-4">
+                {viewTracker}
                 <header className="flex min-h-11 min-w-0 items-start justify-between gap-2">
                     <div className="min-w-0">{heading}</div>
                     {headerActions ? (
@@ -44,6 +60,7 @@ export function FarmTodayView({
     if (data.status === 'noFarm') {
         return (
             <main className="mx-auto w-full max-w-5xl space-y-3 px-3 py-3 sm:p-4">
+                {viewTracker}
                 <header className="flex min-h-11 min-w-0 items-start justify-between gap-2">
                     <div className="min-w-0">{heading}</div>
                     {headerActions ? (
@@ -82,6 +99,7 @@ export function FarmTodayView({
 
     return (
         <main className="mx-auto w-full max-w-5xl min-w-0 space-y-3 px-3 py-3 sm:p-4">
+            {viewTracker}
             <header className="flex min-h-11 min-w-0 items-start justify-between gap-2">
                 <div className="min-w-0">{heading}</div>
                 {headerActions ? (
@@ -97,7 +115,11 @@ export function FarmTodayView({
                         Fokus
                     </h2>
                     <List variant="outlined">
-                        <FarmTodayTaskLink emphasis="next" task={nextTask} />
+                        <FarmTodayTaskLink
+                            emphasis="next"
+                            source="next"
+                            task={nextTask}
+                        />
                     </List>
                 </section>
             ) : null}
@@ -117,7 +139,11 @@ export function FarmTodayView({
                     </h2>
                     <List variant="outlined">
                         {remainingTasks.map((task) => (
-                            <FarmTodayTaskLink key={task.key} task={task} />
+                            <FarmTodayTaskLink
+                                key={task.key}
+                                source="queue"
+                                task={task}
+                            />
                         ))}
                     </List>
                 </section>
@@ -152,7 +178,11 @@ export function FarmTodayView({
                     </div>
                     <List variant="outlined">
                         {attentionItems.map(({ task }) => (
-                            <FarmTodayTaskLink key={task.key} task={task} />
+                            <FarmTodayTaskLink
+                                key={task.key}
+                                source="attention"
+                                task={task}
+                            />
                         ))}
                     </List>
                 </section>

--- a/apps/farm/app/globals.css
+++ b/apps/farm/app/globals.css
@@ -46,6 +46,12 @@
 
         --bg-selection: #8b5e34;
         --text-selection: #fff;
+
+        --farm-mobile-navigation-height: 3.5rem;
+        --farm-safe-area-bottom: env(safe-area-inset-bottom, 0px);
+        --farm-safe-area-left: env(safe-area-inset-left, 0px);
+        --farm-safe-area-right: env(safe-area-inset-right, 0px);
+        --farm-safe-area-top: env(safe-area-inset-top, 0px);
     }
 
     .dark {

--- a/apps/farm/app/greenhouse/page.tsx
+++ b/apps/farm/app/greenhouse/page.tsx
@@ -24,7 +24,6 @@ import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import Link from 'next/link';
 import LoginDialog from '../../components/auth/LoginDialog';
-import { HomeButton } from '../../components/HomeButton';
 import { auth } from '../../lib/auth/auth';
 import { KnownPages } from '../../src/KnownPages';
 
@@ -251,10 +250,6 @@ async function GreenhousePageContent() {
 
     return (
         <div className="mx-auto w-full max-w-5xl space-y-4 p-4">
-            <div className="flex min-w-0 items-center">
-                <HomeButton />
-            </div>
-
             <Card>
                 <CardContent noHeader>
                     <Row
@@ -262,7 +257,7 @@ async function GreenhousePageContent() {
                         className="flex-wrap items-start gap-3"
                     >
                         <Stack spacing={1} className="min-w-0">
-                            <Typography level="h3" semiBold>
+                            <Typography component="h1" level="h5" semiBold>
                                 Staklenik
                             </Typography>
                             <Typography

--- a/apps/farm/app/layout.tsx
+++ b/apps/farm/app/layout.tsx
@@ -1,11 +1,14 @@
 import { ImpersonationBanner } from '@gredice/ui/ImpersonationBanner';
-import { PostHogPageView, PostHogProvider } from '@posthog/next';
-import { Analytics } from '@vercel/analytics/react';
 import { VercelToolbar } from '@vercel/toolbar/next';
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import Head from 'next/head';
 import type { ReactNode } from 'react';
+import { FarmAnalyticsProvider } from '../components/analytics/FarmAnalyticsProvider';
+import { FarmPageViewTracker } from '../components/analytics/FarmPageViewTracker';
+import { FarmPostHogProvider } from '../components/analytics/FarmPostHogProvider';
+import { FarmWebAnalytics } from '../components/analytics/FarmWebAnalytics';
+import { FarmAppShell } from '../components/navigation/FarmAppShell';
 import { AuthAppProvider } from '../components/providers/AuthAppProvider';
 import { ClientAppProvider } from '../components/providers/ClientAppProvider';
 
@@ -18,6 +21,7 @@ export function generateMetadata(): Metadata {
 
 export const viewport: Viewport = {
     initialScale: 1,
+    viewportFit: 'cover',
     width: 'device-width',
 };
 
@@ -41,10 +45,12 @@ export default function RootLayout({
             <ClientAppProvider>
                 <AuthAppProvider>
                     <ImpersonationBanner />
-                    {children}
+                    <FarmAnalyticsProvider>
+                        <FarmAppShell>{children}</FarmAppShell>
+                    </FarmAnalyticsProvider>
                 </AuthAppProvider>
             </ClientAppProvider>
-            <Analytics />
+            <FarmWebAnalytics />
             {shouldInjectToolbar && <VercelToolbar />}
         </>
     );
@@ -61,19 +67,14 @@ export default function RootLayout({
             </Head>
             <body className="antialiased min-h-screen flex w-full min-w-0 overflow-x-hidden bg-background">
                 {postHogApiKey ? (
-                    <PostHogProvider
+                    <FarmPostHogProvider
                         apiKey={postHogApiKey}
-                        clientOptions={{
-                            api_host: postHogApiHost,
-                            capture_exceptions: true,
-                            debug: process.env.NODE_ENV === 'development',
-                            defaults: '2026-01-30',
-                            ui_host: postHogUiHost ?? null,
-                        }}
+                        apiHost={postHogApiHost}
+                        uiHost={postHogUiHost}
                     >
-                        <PostHogPageView />
+                        <FarmPageViewTracker />
                         {content}
-                    </PostHogProvider>
+                    </FarmPostHogProvider>
                 ) : (
                     content
                 )}

--- a/apps/farm/app/more/page.tsx
+++ b/apps/farm/app/more/page.tsx
@@ -1,0 +1,106 @@
+import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
+import {
+    Calendar,
+    FileText,
+    Navigate,
+    Settings,
+    Sprout,
+    Wallet,
+} from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import Link from 'next/link';
+import LoginDialog from '../../components/auth/LoginDialog';
+import { auth } from '../../lib/auth/auth';
+import { KnownPages } from '../../src/KnownPages';
+
+export const dynamic = 'force-dynamic';
+
+const moreDestinations = [
+    {
+        destination: 'schedule',
+        href: KnownPages.Schedule,
+        icon: Calendar,
+        label: 'Raspored',
+    },
+    {
+        destination: 'operations',
+        href: KnownPages.Operations,
+        icon: FileText,
+        label: 'Priručnik radnji',
+    },
+    {
+        destination: 'plants',
+        href: KnownPages.Plants,
+        icon: Sprout,
+        label: 'Biljke',
+    },
+    {
+        destination: 'payouts',
+        href: KnownPages.Payouts,
+        icon: Wallet,
+        label: 'Isplate',
+    },
+    {
+        destination: 'settings',
+        href: KnownPages.Settings,
+        icon: Settings,
+        label: 'Postavke',
+    },
+] as const;
+
+export default function FarmMorePage() {
+    const authFarmer = auth.bind(null, ['farmer', 'admin']);
+
+    return (
+        <div className="min-h-[100dvh] w-full bg-background">
+            <AuthProtectedSection auth={authFarmer}>
+                <main
+                    aria-labelledby="farm-more-heading"
+                    className="mx-auto w-full max-w-5xl space-y-4 p-4"
+                >
+                    <Typography
+                        id="farm-more-heading"
+                        component="h1"
+                        level="h5"
+                        semiBold
+                    >
+                        Više
+                    </Typography>
+                    <nav aria-label="Dodatne mogućnosti">
+                        <div className="grid gap-2 sm:grid-cols-2">
+                            {moreDestinations.map(
+                                ({ destination, href, icon: Icon, label }) => (
+                                    <Link
+                                        key={destination}
+                                        href={href}
+                                        data-farm-analytics="navigation"
+                                        data-farm-navigation-destination={
+                                            destination
+                                        }
+                                        data-farm-navigation-source="more_page"
+                                        className="flex min-h-11 min-w-0 items-center gap-3 rounded-lg border bg-card px-3 py-2.5 text-card-foreground transition-colors hover:bg-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                                    >
+                                        <Icon
+                                            aria-hidden="true"
+                                            className="size-5 shrink-0 text-primary"
+                                        />
+                                        <span className="min-w-0 flex-1 font-medium [overflow-wrap:anywhere]">
+                                            {label}
+                                        </span>
+                                        <Navigate
+                                            aria-hidden="true"
+                                            className="size-4 shrink-0 text-muted-foreground"
+                                        />
+                                    </Link>
+                                ),
+                            )}
+                        </div>
+                    </nav>
+                </main>
+            </AuthProtectedSection>
+            <SignedOut auth={authFarmer}>
+                <LoginDialog />
+            </SignedOut>
+        </div>
+    );
+}

--- a/apps/farm/app/notifications/page.tsx
+++ b/apps/farm/app/notifications/page.tsx
@@ -1,8 +1,6 @@
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
-import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
-import { HomeButton } from '../../components/HomeButton';
 import { auth } from '../../lib/auth/auth';
 import { FarmNotificationsPanel } from './FarmNotificationsPanel';
 
@@ -11,14 +9,9 @@ export const dynamic = 'force-dynamic';
 function FarmNotificationsContent() {
     return (
         <div className="mx-auto w-full max-w-5xl space-y-4 p-4">
-            <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center gap-2">
-                <HomeButton />
-                <Stack spacing={0} className="min-w-0">
-                    <Typography level="h3" semiBold>
-                        Obavijesti
-                    </Typography>
-                </Stack>
-            </div>
+            <Typography component="h1" level="h5" semiBold>
+                Obavijesti
+            </Typography>
             <FarmNotificationsPanel />
         </div>
     );

--- a/apps/farm/app/operations/page.tsx
+++ b/apps/farm/app/operations/page.tsx
@@ -1,7 +1,6 @@
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
 import { Typography } from '@gredice/ui/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
-import { HomeButton } from '../../components/HomeButton';
 import { auth } from '../../lib/auth/auth';
 import { getFarmScheduleOperationsData } from '../schedule/scheduleData';
 import { OperationsHandbook } from './OperationsHandbook';
@@ -14,9 +13,9 @@ async function OperationsHandbookContent() {
 
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
-            <div className="flex min-w-0 items-center">
-                <HomeButton />
-            </div>
+            <Typography component="h1" level="h5" semiBold>
+                Priručnik radnji
+            </Typography>
             {operationsData.length > 0 ? (
                 <OperationsHandbook operationsData={operationsData} />
             ) : (

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -49,6 +49,9 @@ async function FarmTodayDashboard({
             headerActions={
                 <>
                     <IconButton
+                        data-farm-analytics="navigation"
+                        data-farm-navigation-destination="settings"
+                        data-farm-navigation-source="today_tools"
                         href="/settings"
                         size="lg"
                         title="Postavke"

--- a/apps/farm/app/payouts/page.tsx
+++ b/apps/farm/app/payouts/page.tsx
@@ -19,7 +19,6 @@ import { Stack } from '@gredice/ui/Stack';
 import { Table } from '@gredice/ui/Table';
 import { Typography } from '@gredice/ui/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
-import { HomeButton } from '../../components/HomeButton';
 import { auth } from '../../lib/auth/auth';
 import { FarmPayoutFarmSelect } from './FarmPayoutFarmSelect';
 import { PayoutRequestForm } from './PayoutRequestForm';
@@ -137,9 +136,9 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
     if (!selectedFarm) {
         return (
             <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
-                <div className="flex min-w-0 items-center">
-                    <HomeButton />
-                </div>
+                <Typography component="h1" level="h5" semiBold>
+                    Isplate
+                </Typography>
                 <Card>
                     <CardContent>
                         <Typography
@@ -186,9 +185,9 @@ async function PayoutsContent({ selectedFarmId }: { selectedFarmId?: number }) {
 
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
-            <div className="flex min-w-0 items-center">
-                <HomeButton />
-            </div>
+            <Typography component="h1" level="h5" semiBold>
+                Isplate
+            </Typography>
 
             {farms.length > 1 && (
                 <Card>

--- a/apps/farm/app/plants/page.tsx
+++ b/apps/farm/app/plants/page.tsx
@@ -1,7 +1,6 @@
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
 import { Typography } from '@gredice/ui/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
-import { HomeButton } from '../../components/HomeButton';
 import { auth } from '../../lib/auth/auth';
 import { getFarmSchedulePlantSorts } from '../schedule/scheduleData';
 import { PlantsHandbook } from './PlantsHandbook';
@@ -14,9 +13,9 @@ async function PlantsHandbookContent() {
 
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
-            <div className="flex min-w-0 items-center">
-                <HomeButton />
-            </div>
+            <Typography component="h1" level="h5" semiBold>
+                Biljke
+            </Typography>
             {plantSortsData.length > 0 ? (
                 <PlantsHandbook plantSortsData={plantSortsData} />
             ) : (

--- a/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
+++ b/apps/farm/app/raised-beds/[raisedBedId]/page.tsx
@@ -123,8 +123,11 @@ async function RaisedBedDetailPageContent({
 
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
-            <div className="flex min-w-0 items-center">
+            <div className="flex min-w-0 items-center gap-2">
                 <HomeButton href="/raised-beds" title="Povratak na gredice" />
+                <Typography component="h1" level="h5" semiBold>
+                    Gredica {raisedBed.physicalId ?? raisedBed.id}
+                </Typography>
             </div>
 
             <Card>

--- a/apps/farm/app/raised-beds/page.tsx
+++ b/apps/farm/app/raised-beds/page.tsx
@@ -16,7 +16,6 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
-import { HomeButton } from '../../components/HomeButton';
 import { auth } from '../../lib/auth/auth';
 
 export const dynamic = 'force-dynamic';
@@ -135,9 +134,9 @@ async function RaisedBedsPageContent() {
 
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
-            <div className="flex min-w-0 items-center">
-                <HomeButton />
-            </div>
+            <Typography component="h1" level="h5" semiBold>
+                Gredice
+            </Typography>
 
             {activeRaisedBeds.length === 0 ? (
                 <Card>

--- a/apps/farm/app/schedule/CompleteOperationModal.spec.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.spec.tsx
@@ -1,0 +1,196 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
+import { CompleteOperationModal } from './CompleteOperationModal';
+import { CompletePlantingModal } from './CompletePlantingModal';
+
+async function holdCompletionActions(page: Page) {
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState = {
+            hold: true,
+            operationCalls: 0,
+            plantingCalls: 0,
+        };
+    });
+}
+
+async function releaseCompletionAction(page: Page) {
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState?.release?.();
+    });
+}
+
+async function settleResponsiveModal(page: Page) {
+    await page.evaluate(
+        () =>
+            new Promise<void>((resolve) => {
+                requestAnimationFrame(() =>
+                    requestAnimationFrame(() => resolve()),
+                );
+            }),
+    );
+}
+
+test('opens both real mobile dialogs from their explicit completion triggers', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    await mount(
+        <div className="space-y-2">
+            <CompleteOperationModal label="Zalij rajčice" operationId={42} />
+            <CompletePlantingModal
+                label="Posij salatu"
+                positionIndex={0}
+                raisedBedId={12}
+            />
+        </div>,
+    );
+    await settleResponsiveModal(page);
+
+    await page
+        .getByRole('button', { name: 'Dovrši radnju: Zalij rajčice' })
+        .click();
+    const operationDialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await expect(operationDialog).toBeVisible();
+    await operationDialog.getByRole('button', { name: 'Odustani' }).click();
+    await expect(operationDialog).toBeHidden();
+
+    await page
+        .getByRole('button', { name: 'Dovrši sijanje: Posij salatu' })
+        .click();
+    await expect(
+        page.getByRole('dialog', { name: 'Potvrda sijanja' }),
+    ).toBeVisible();
+});
+
+for (const width of [320, 375, 390, 430]) {
+    test(`keeps required-photo completion controls touchable at ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 720 });
+        await mount(
+            <CompleteOperationModal
+                conditions={{ completionAttachImagesRequired: true }}
+                defaultOpen
+                label="Vrlo duga radnja prihrane rajčice"
+                operationId={42}
+            />,
+        );
+        await settleResponsiveModal(page);
+
+        const dialog = page.getByRole('dialog', {
+            name: 'Potvrda završetka radnje',
+        });
+        await expect(dialog).toBeVisible();
+        const actionableButtons = dialog.getByRole('button').filter({
+            hasText: /Uslikaj fotografiju|Dodaj slike|Odustani|Potvrdi/,
+        });
+        await expect(actionableButtons).toHaveCount(4);
+
+        const undersizedOrClipped = await actionableButtons.evaluateAll(
+            (targets) =>
+                targets.flatMap((target) => {
+                    const bounds = target.getBoundingClientRect();
+                    if (
+                        bounds.width >= 44 &&
+                        bounds.height >= 44 &&
+                        bounds.left >= 0 &&
+                        bounds.right <= window.innerWidth
+                    ) {
+                        return [];
+                    }
+
+                    return [
+                        {
+                            height: bounds.height,
+                            label: target.textContent?.trim(),
+                            width: bounds.width,
+                        },
+                    ];
+                }),
+        );
+        expect(undersizedOrClipped).toEqual([]);
+    });
+}
+
+test('keeps operation completion open for server confirmation and ignores rapid repeat input', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    await holdCompletionActions(page);
+    await mount(
+        <CompleteOperationModal
+            defaultOpen
+            label="Zalij rajčice"
+            operationId={42}
+        />,
+    );
+    await settleResponsiveModal(page);
+    const dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    const confirmButton = dialog.getByRole('button', { name: 'Potvrdi' });
+    await confirmButton.evaluate((button) => {
+        button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await expect
+        .poll(() =>
+            page.evaluate(() => {
+                return (
+                    window.__farmScheduleActionTestState?.operationCalls ?? -1
+                );
+            }),
+        )
+        .toBe(1);
+    await expect(confirmButton).toBeDisabled();
+    await expect(confirmButton).toHaveAttribute('aria-busy', 'true');
+    await expect(dialog).toBeVisible();
+
+    await releaseCompletionAction(page);
+    await expect(dialog).toBeHidden();
+});
+
+test('keeps planting completion open for server confirmation and ignores rapid repeat input', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    await holdCompletionActions(page);
+    await mount(
+        <CompletePlantingModal
+            defaultOpen
+            label="Posij salatu"
+            positionIndex={0}
+            raisedBedId={12}
+        />,
+    );
+    await settleResponsiveModal(page);
+    const dialog = page.getByRole('dialog', { name: 'Potvrda sijanja' });
+    const confirmButton = dialog.getByRole('button', { name: 'Potvrdi' });
+    await confirmButton.evaluate((button) => {
+        button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await expect
+        .poll(() =>
+            page.evaluate(() => {
+                return (
+                    window.__farmScheduleActionTestState?.plantingCalls ?? -1
+                );
+            }),
+        )
+        .toBe(1);
+    await expect(confirmButton).toBeDisabled();
+    await expect(confirmButton).toHaveAttribute('aria-busy', 'true');
+    await expect(dialog).toBeVisible();
+
+    await releaseCompletionAction(page);
+    await expect(dialog).toBeHidden();
+});

--- a/apps/farm/app/schedule/CompleteOperationModal.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.tsx
@@ -2,7 +2,6 @@
 
 import type { EntityStandardized } from '@gredice/storage';
 import { Button } from '@gredice/ui/Button';
-import { Checkbox } from '@gredice/ui/Checkbox';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
@@ -13,6 +12,7 @@ import {
     completeFarmOperation,
     completeFarmOperationWithImageUrls,
 } from './actions';
+import { ScheduleTaskCompletionButton } from './ScheduleTaskCompletionButton';
 
 type UploadItemStatus = 'pending' | 'uploading' | 'uploaded' | 'failed';
 
@@ -89,20 +89,23 @@ interface CompleteOperationModalProps {
     operationId: number;
     label: string;
     conditions?: EntityStandardized['conditions'];
+    defaultOpen?: boolean;
 }
 
 export function CompleteOperationModal({
     operationId,
     label,
     conditions,
+    defaultOpen = false,
 }: CompleteOperationModalProps) {
-    const [isOpen, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(defaultOpen);
     const [uploadItems, setUploadItems] = useState<UploadItem[]>([]);
     const [notes, setNotes] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const cameraInputRef = useRef<HTMLInputElement>(null);
+    const submissionInFlightRef = useRef(false);
 
     const attachImages = Boolean(
         conditions?.completionAttachImages ||
@@ -126,6 +129,10 @@ export function CompleteOperationModal({
     );
 
     const handleOpenChange = (open: boolean) => {
+        if (!open && submissionInFlightRef.current) {
+            return;
+        }
+
         setIsOpen(open);
         setErrorMessage(null);
         if (!open) {
@@ -249,6 +256,10 @@ export function CompleteOperationModal({
     };
 
     const handleConfirm = async () => {
+        if (submissionInFlightRef.current) {
+            return;
+        }
+
         try {
             setErrorMessage(null);
             if (notesRequiredMissing) {
@@ -256,6 +267,7 @@ export function CompleteOperationModal({
                 return;
             }
 
+            submissionInFlightRef.current = true;
             setIsSubmitting(true);
             const completionNotes = attachNotes ? trimmedNotes : undefined;
             if (attachImages && uploadItems.length > 0) {
@@ -291,11 +303,13 @@ export function CompleteOperationModal({
                     completionNotes,
                 );
             }
+            submissionInFlightRef.current = false;
             handleOpenChange(false);
         } catch (error) {
             console.error('Error completing operation:', error);
             setErrorMessage('Spremanje nije uspjelo. Pokušajte ponovno.');
         } finally {
+            submissionInFlightRef.current = false;
             setIsSubmitting(false);
         }
     };
@@ -314,16 +328,13 @@ export function CompleteOperationModal({
     return (
         <Modal
             title="Potvrda završetka radnje"
+            dismissible={!isSubmitting}
             open={isOpen}
             onOpenChange={handleOpenChange}
             trigger={
-                <Checkbox
-                    aria-label={`Dovrši: ${label}`}
-                    className="size-5"
-                    checked={isOpen}
-                    onCheckedChange={(checked: boolean) =>
-                        handleOpenChange(checked)
-                    }
+                <ScheduleTaskCompletionButton
+                    actionLabel="Dovrši radnju"
+                    label={label}
                 />
             }
         >
@@ -360,6 +371,7 @@ export function CompleteOperationModal({
                             type="button"
                             onClick={() => cameraInputRef.current?.click()}
                             disabled={isSubmitting}
+                            size="lg"
                         >
                             Uslikaj fotografiju
                         </Button>
@@ -368,6 +380,7 @@ export function CompleteOperationModal({
                             type="button"
                             onClick={() => fileInputRef.current?.click()}
                             disabled={isSubmitting}
+                            size="lg"
                         >
                             {uploadItems.length > 0
                                 ? 'Dodaj još slika'
@@ -432,6 +445,7 @@ export function CompleteOperationModal({
                                                         <Button
                                                             variant="outlined"
                                                             type="button"
+                                                            size="lg"
                                                             onClick={() =>
                                                                 resetUploadItem(
                                                                     uploadItem.id,
@@ -496,11 +510,13 @@ export function CompleteOperationModal({
                         variant="outlined"
                         onClick={() => handleOpenChange(false)}
                         disabled={isSubmitting}
+                        size="lg"
                     >
                         Odustani
                     </Button>
                     <Button
                         variant="solid"
+                        aria-busy={isSubmitting}
                         onClick={handleConfirm}
                         disabled={
                             isSubmitting ||
@@ -509,6 +525,7 @@ export function CompleteOperationModal({
                             notesRequiredMissing
                         }
                         loading={isSubmitting}
+                        size="lg"
                     >
                         {hasFailedUploads ? 'Pokušaj ponovno' : 'Potvrdi'}
                     </Button>

--- a/apps/farm/app/schedule/CompletePlantingModal.tsx
+++ b/apps/farm/app/schedule/CompletePlantingModal.tsx
@@ -1,36 +1,54 @@
 'use client';
 
 import { Button } from '@gredice/ui/Button';
-import { Checkbox } from '@gredice/ui/Checkbox';
 import { Modal } from '@gredice/ui/Modal';
 import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { completeFarmPlanting } from './actions';
+import { ScheduleTaskCompletionButton } from './ScheduleTaskCompletionButton';
 
 interface CompletePlantingModalProps {
     label: string;
     raisedBedId: number;
     positionIndex: number;
+    defaultOpen?: boolean;
 }
 
 export function CompletePlantingModal({
     label,
     raisedBedId,
     positionIndex,
+    defaultOpen = false,
 }: CompletePlantingModalProps) {
-    const [open, setOpen] = useState(false);
+    const [open, setOpen] = useState(defaultOpen);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const submissionInFlightRef = useRef(false);
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        if (!nextOpen && submissionInFlightRef.current) {
+            return;
+        }
+
+        setOpen(nextOpen);
+    };
 
     const handleConfirm = async () => {
+        if (submissionInFlightRef.current) {
+            return;
+        }
+
+        submissionInFlightRef.current = true;
         try {
             setIsSubmitting(true);
             await completeFarmPlanting(raisedBedId, positionIndex);
+            submissionInFlightRef.current = false;
             setOpen(false);
         } catch (error) {
             console.error('Error completing planting:', error);
         } finally {
+            submissionInFlightRef.current = false;
             setIsSubmitting(false);
         }
     };
@@ -38,14 +56,13 @@ export function CompletePlantingModal({
     return (
         <Modal
             title="Potvrda sijanja"
+            dismissible={!isSubmitting}
             open={open}
-            onOpenChange={setOpen}
+            onOpenChange={handleOpenChange}
             trigger={
-                <Checkbox
-                    aria-label={`Dovrši: ${label}`}
-                    className="size-5"
-                    checked={open}
-                    onCheckedChange={(checked: boolean) => setOpen(checked)}
+                <ScheduleTaskCompletionButton
+                    actionLabel="Dovrši sijanje"
+                    label={label}
                 />
             }
         >
@@ -61,16 +78,19 @@ export function CompletePlantingModal({
                 >
                     <Button
                         variant="outlined"
-                        onClick={() => setOpen(false)}
+                        onClick={() => handleOpenChange(false)}
                         disabled={isSubmitting}
+                        size="lg"
                     >
                         Odustani
                     </Button>
                     <Button
                         variant="solid"
+                        aria-busy={isSubmitting}
                         onClick={handleConfirm}
                         loading={isSubmitting}
                         disabled={isSubmitting}
+                        size="lg"
                     >
                         Potvrdi
                     </Button>

--- a/apps/farm/app/schedule/FarmScheduleLoadingState.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.spec.tsx
@@ -8,7 +8,11 @@ for (const width of [320, 1280]) {
         page,
     }) => {
         await page.setViewportSize({ width, height: 800 });
-        await mount(<FarmScheduleLoadingState />);
+        const component = await mount(<FarmScheduleLoadingState />);
+
+        await expect(
+            component.getByRole('heading', { level: 1, name: 'Raspored' }),
+        ).toBeVisible();
 
         expect(
             await page.evaluate(

--- a/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
+++ b/apps/farm/app/schedule/FarmScheduleLoadingState.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from '@gredice/ui/Skeleton';
 import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
 import { FarmScheduleSectionSkeleton } from './FarmScheduleSectionSkeleton';
 import { ScheduleDaySummarySkeleton } from './ScheduleDaySummarySkeleton';
 
@@ -10,13 +11,21 @@ export function FarmScheduleLoadingState() {
             aria-busy="true"
         >
             <div className="space-y-2">
-                <div className="grid min-w-0 grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-start gap-1 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-2">
-                    <Skeleton className="h-8 w-10 rounded-md sm:h-10 sm:w-12" />
-                    <div className="grid justify-items-center gap-1">
-                        <Skeleton className="h-4 w-16" />
-                        <Skeleton className="h-4 w-24" />
+                <Typography component="h1" level="h5" semiBold>
+                    Raspored
+                </Typography>
+                <div className="grid min-w-0 items-start gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+                    <div className="min-w-0 justify-self-center sm:justify-self-start">
+                        <div className="grid min-w-0 grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-center gap-1 sm:gap-2">
+                            <Skeleton className="h-8 w-10 rounded-md sm:h-10" />
+                            <div className="grid justify-items-center gap-1">
+                                <Skeleton className="h-4 w-16" />
+                                <Skeleton className="h-4 w-24" />
+                            </div>
+                            <Skeleton className="h-8 w-10 rounded-md sm:h-10" />
+                        </div>
                     </div>
-                    <div className="col-span-3 min-w-0 justify-self-stretch sm:col-span-1 sm:justify-self-end">
+                    <div className="min-w-0 justify-self-stretch sm:justify-self-end">
                         <ScheduleDaySummarySkeleton />
                     </div>
                 </div>

--- a/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
+++ b/apps/farm/app/schedule/FarmScheduleNavigationFrame.tsx
@@ -10,7 +10,6 @@ import type { Route } from 'next';
 import { useRouter } from 'next/navigation';
 import type { MouseEvent, ReactNode } from 'react';
 import { useEffect, useState, useTransition } from 'react';
-import { HomeButton } from '../../components/HomeButton';
 import { FarmScheduleSectionSkeleton } from './FarmScheduleSectionSkeleton';
 import { ScheduleDaySummarySkeleton } from './ScheduleDaySummarySkeleton';
 import { getFarmScheduleDateKey } from './scheduleShared';
@@ -128,11 +127,11 @@ export function FarmScheduleNavigationFrame({
             aria-busy={showPendingContent}
         >
             <div className="space-y-2">
-                <div className="grid min-w-0 grid-cols-[2.5rem_minmax(0,1fr)_2.5rem] items-start gap-1 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-2">
-                    <div className="justify-self-start">
-                        <HomeButton className="h-8 sm:h-10" />
-                    </div>
-                    <div className="min-w-0 justify-self-center">
+                <Typography component="h1" level="h5" semiBold>
+                    Raspored
+                </Typography>
+                <div className="grid min-w-0 items-start gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+                    <div className="min-w-0 justify-self-center sm:justify-self-start">
                         <Row className="shrink-0 gap-1 sm:gap-2">
                             <Link
                                 href={prevHref}
@@ -176,7 +175,7 @@ export function FarmScheduleNavigationFrame({
                             </Link>
                         </Row>
                     </div>
-                    <div className="col-span-3 min-w-0 justify-self-stretch sm:col-span-1 sm:justify-self-end">
+                    <div className="min-w-0 justify-self-stretch sm:justify-self-end">
                         {showPendingContent ? (
                             <ScheduleDaySummarySkeleton />
                         ) : (

--- a/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationTaskCard.tsx
@@ -9,6 +9,7 @@ import { OperationCompletionAttachments } from './OperationCompletionAttachments
 import { OperationRequirementIcons } from './OperationRequirementIcons';
 import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
 import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
+import { ScheduleTaskDetailsLink } from './ScheduleTaskDetailsLink';
 import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
 import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
 import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
@@ -31,6 +32,7 @@ export type FarmOperationCardData = Pick<
     | 'assignedUserId'
     | 'assignedUserIds'
     | 'completionNotes'
+    | 'entityId'
     | 'id'
     | 'imageUrls'
     | 'scheduledDate'
@@ -71,94 +73,108 @@ export function FarmScheduleOperationTaskCard({
     const showRequirementIcons =
         taskPresentation.showRequirementIndicators &&
         (attachImages || attachNotes);
+    const hasCompletionAttachments =
+        taskPresentation.showCompletionAttachments &&
+        (Boolean(operation.completionNotes?.trim()) ||
+            Boolean(operation.imageUrls?.some((url) => url.trim().length > 0)));
+    const detailsContent = (
+        <Row spacing={2} className="min-w-0 items-start justify-between gap-3">
+            <Stack spacing={1} className="min-w-0 grow">
+                <Typography
+                    className={
+                        taskPresentation.isCompleted
+                            ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
+                            : '[overflow-wrap:anywhere]'
+                    }
+                >
+                    {operation.label}
+                </Typography>
+                <Row spacing={2} className="items-center flex-wrap gap-y-1">
+                    <ScheduleTaskStatusChip state={taskState} />
+                    <ScheduleTaskDurationChip
+                        minutes={operation.durationMinutes}
+                    />
+                    <ScheduleTaskDateChip
+                        scheduledDate={operation.scheduledDate}
+                    />
+                    {taskPresentation.showAgeIndicator && (
+                        <ScheduleTaskAgeIndicatorChip
+                            scheduledDate={operation.scheduledDate}
+                        />
+                    )}
+                </Row>
+            </Stack>
+            {(showRequirementIcons || operation.assignedUser) && (
+                <Row spacing={1} className="shrink-0 items-center">
+                    {showRequirementIcons && (
+                        <OperationRequirementIcons
+                            attachImages={attachImages}
+                            attachImagesRequired={attachImagesRequired}
+                            attachNotes={attachNotes}
+                            attachNotesRequired={attachNotesRequired}
+                        />
+                    )}
+                    {operation.assignedUser && (
+                        <div
+                            className="shrink-0"
+                            title={`Dodijeljeno: ${operation.assignedUser.displayName ?? operation.assignedUser.userName}`}
+                        >
+                            <UserAvatar
+                                avatarUrl={operation.assignedUser.avatarUrl}
+                                displayName={
+                                    operation.assignedUser.displayName ??
+                                    operation.assignedUser.userName
+                                }
+                                className="size-7 rounded-full"
+                            />
+                        </div>
+                    )}
+                </Row>
+            )}
+        </Row>
+    );
 
     return (
         <div
             data-task-state={taskState}
             className={cx(
-                'rounded-lg border px-3 py-2 transition-opacity',
-                taskPresentation.isCompleted
-                    ? 'bg-white/70 opacity-70'
-                    : 'bg-white',
+                'rounded-lg border px-3 py-2',
+                taskPresentation.isCompleted ? 'bg-muted/30' : 'bg-white',
             )}
         >
-            <Row
-                spacing={2}
-                className="min-w-0 items-start justify-between gap-3"
-            >
-                <Row spacing={2} className="min-w-0 grow items-start">
-                    <ScheduleTaskStateControl
-                        action={canComplete ? completionAction : undefined}
-                        label={operation.label}
-                        state={taskState}
-                        unavailableTitle="Radnja je dodijeljena drugom korisniku."
-                    />
-                    <Stack spacing={1} className="min-w-0 grow">
-                        <Typography
-                            className={
-                                taskPresentation.isCompleted
-                                    ? 'line-through text-muted-foreground [overflow-wrap:anywhere]'
-                                    : '[overflow-wrap:anywhere]'
-                            }
-                        >
-                            {operation.label}
-                        </Typography>
-                        <Row
-                            spacing={2}
-                            className="items-center flex-wrap gap-y-1"
-                        >
-                            <ScheduleTaskStatusChip state={taskState} />
-                            <ScheduleTaskDurationChip
-                                minutes={operation.durationMinutes}
-                            />
-                            <ScheduleTaskDateChip
-                                scheduledDate={operation.scheduledDate}
-                            />
-                            {taskPresentation.showAgeIndicator && (
-                                <ScheduleTaskAgeIndicatorChip
-                                    scheduledDate={operation.scheduledDate}
-                                />
-                            )}
-                        </Row>
-                    </Stack>
-                </Row>
-                {(showRequirementIcons ||
-                    taskPresentation.showCompletionAttachments ||
-                    operation.assignedUser) && (
-                    <Row spacing={1} className="shrink-0 items-center">
-                        {showRequirementIcons && (
-                            <OperationRequirementIcons
-                                attachImages={attachImages}
-                                attachImagesRequired={attachImagesRequired}
-                                attachNotes={attachNotes}
-                                attachNotesRequired={attachNotesRequired}
-                            />
-                        )}
-                        {taskPresentation.showCompletionAttachments && (
-                            <OperationCompletionAttachments
-                                operationId={operation.id}
-                                notes={operation.completionNotes}
-                                imageUrls={operation.imageUrls}
-                            />
-                        )}
-                        {operation.assignedUser && (
-                            <div
-                                className="shrink-0"
-                                title={`Dodijeljeno: ${operation.assignedUser.displayName ?? operation.assignedUser.userName}`}
-                            >
-                                <UserAvatar
-                                    avatarUrl={operation.assignedUser.avatarUrl}
-                                    displayName={
-                                        operation.assignedUser.displayName ??
-                                        operation.assignedUser.userName
-                                    }
-                                    className="size-7 rounded-full"
-                                />
-                            </div>
-                        )}
-                    </Row>
-                )}
-            </Row>
+            {operationData ? (
+                <ScheduleTaskDetailsLink
+                    actionLabel="Otvori upute"
+                    href={`/operations/${operation.entityId}`}
+                >
+                    {detailsContent}
+                </ScheduleTaskDetailsLink>
+            ) : (
+                <div className="min-w-0 px-1 py-1">
+                    {detailsContent}
+                    <Typography
+                        className="mt-1.5 text-muted-foreground"
+                        level="body2"
+                    >
+                        Upute trenutno nisu dostupne.
+                    </Typography>
+                </div>
+            )}
+            {hasCompletionAttachments && (
+                <OperationCompletionAttachments
+                    className="mt-2 border-t pt-2"
+                    operationId={operation.id}
+                    notes={operation.completionNotes}
+                    imageUrls={operation.imageUrls}
+                />
+            )}
+            <ScheduleTaskStateControl
+                action={canComplete ? completionAction : undefined}
+                actionLabel="Dovrši radnju"
+                label={operation.label}
+                state={taskState}
+                unavailableTitle="Radnja je dodijeljena drugom korisniku."
+            />
         </div>
     );
 }

--- a/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
+++ b/apps/farm/app/schedule/FarmSchedulePlantingTaskCard.tsx
@@ -13,6 +13,7 @@ import { PlantingAssignedUserAvatar } from './PlantingAssignedUserAvatar';
 import { SchedulePlantVisual } from './SchedulePlantVisual';
 import { ScheduleTaskAgeIndicatorChip } from './ScheduleTaskAgeIndicatorChip';
 import { ScheduleTaskDateChip } from './ScheduleTaskDateChip';
+import { ScheduleTaskDetailsLink } from './ScheduleTaskDetailsLink';
 import { ScheduleTaskDurationChip } from './ScheduleTaskDurationChip';
 import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
 import { ScheduleTaskStatusChip } from './ScheduleTaskStatusChip';
@@ -72,26 +73,21 @@ export function FarmSchedulePlantingTaskCard({
         <div
             data-task-state={taskState}
             className={cx(
-                'rounded-lg border px-3 py-2 transition-opacity',
-                taskPresentation.isCompleted
-                    ? 'bg-white/70 opacity-70'
-                    : 'bg-white',
+                'rounded-lg border px-3 py-2',
+                taskPresentation.isCompleted ? 'bg-muted/30' : 'bg-white',
                 lockedByAssignment &&
                     !taskPresentation.isCompleted &&
-                    'opacity-70',
+                    'bg-muted/20',
             )}
         >
-            <Row
-                spacing={2}
-                className="min-w-0 items-start justify-between gap-3"
+            <ScheduleTaskDetailsLink
+                actionLabel="Otvori gredicu"
+                href={`/raised-beds/${field.raisedBedId}`}
             >
-                <Row spacing={2} className="min-w-0 grow items-start">
-                    <ScheduleTaskStateControl
-                        action={canComplete ? completionAction : undefined}
-                        label={label}
-                        state={taskState}
-                        unavailableTitle="Sijanje je dodijeljeno drugom korisniku."
-                    />
+                <Row
+                    spacing={2}
+                    className="min-w-0 items-start justify-between gap-3"
+                >
                     <SchedulePlantVisual plantSort={plantSort} label={label} />
                     <Stack spacing={1} className="min-w-0 grow">
                         <Typography
@@ -126,22 +122,29 @@ export function FarmSchedulePlantingTaskCard({
                             )}
                         </Row>
                     </Stack>
-                </Row>
-                {field.assignedUserId && (
-                    <Suspense
-                        fallback={
-                            <Skeleton className="size-7 shrink-0 rounded-full" />
-                        }
-                    >
-                        <PlantingAssignedUserAvatar
-                            assignedUserByFieldIdPromise={
-                                assignedUserByFieldIdPromise
+                    {field.assignedUserId && (
+                        <Suspense
+                            fallback={
+                                <Skeleton className="size-7 shrink-0 rounded-full" />
                             }
-                            fieldId={field.id}
-                        />
-                    </Suspense>
-                )}
-            </Row>
+                        >
+                            <PlantingAssignedUserAvatar
+                                assignedUserByFieldIdPromise={
+                                    assignedUserByFieldIdPromise
+                                }
+                                fieldId={field.id}
+                            />
+                        </Suspense>
+                    )}
+                </Row>
+            </ScheduleTaskDetailsLink>
+            <ScheduleTaskStateControl
+                action={canComplete ? completionAction : undefined}
+                actionLabel="Dovrši sijanje"
+                label={label}
+                state={taskState}
+                unavailableTitle="Sijanje je dodijeljeno drugom korisniku."
+            />
         </div>
     );
 }

--- a/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
@@ -1,3 +1,5 @@
+import type { EntityStandardized } from '@gredice/storage';
+import { Button } from '@gredice/ui/Button';
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Locator } from '@playwright/test';
 import '../globals.css';
@@ -28,12 +30,36 @@ function buildOperation(
         assignedUserIds: [],
         completionNotes: undefined,
         durationMinutes: 15,
+        entityId: id + 1000,
         id,
         imageUrls: undefined,
         label,
         scheduledDate,
         status,
     };
+}
+
+function buildOperationDefinition(id: number): EntityStandardized {
+    return {
+        id,
+        attributes: { duration: 15 },
+        information: { label: `Radnja ${id}` },
+    };
+}
+
+function completionAction(label: string, loading = false) {
+    return (
+        <Button
+            aria-busy={loading}
+            className="h-auto min-h-11 whitespace-normal py-2 [overflow-wrap:anywhere]"
+            fullWidth
+            loading={loading}
+            size="lg"
+            type="button"
+        >
+            {label}
+        </Button>
+    );
 }
 
 const plantingLabels = {
@@ -58,6 +84,32 @@ async function assertCardsStayWithinViewport(component: Locator) {
     ).toBe(true);
 }
 
+async function assertPrimaryTargetsAreTouchable(component: Locator) {
+    const undersizedTargets = await component
+        .locator('a[href], button')
+        .evaluateAll((targets) =>
+            targets.flatMap((target) => {
+                const bounds = target.getBoundingClientRect();
+                if (bounds.width >= 44 && bounds.height >= 44) {
+                    return [];
+                }
+
+                return [
+                    {
+                        height: bounds.height,
+                        label:
+                            target.getAttribute('aria-label') ??
+                            target.textContent?.trim() ??
+                            target.tagName,
+                        width: bounds.width,
+                    },
+                ];
+            }),
+        );
+
+    expect(undersizedTargets).toEqual([]);
+}
+
 test('locks array-only work assigned to another farmer on a phone', async ({
     mount,
     page,
@@ -66,16 +118,16 @@ test('locks array-only work assigned to another farmer on a phone', async ({
     const component = await mount(
         <div className="space-y-2">
             <FarmScheduleOperationTaskCard
-                completionAction={<button type="button">Dovrši radnju</button>}
+                completionAction={completionAction('Dovrši radnju')}
                 operation={{
                     ...buildOperation(10, 'planned', 'Zalij salatu'),
                     assignedUserIds: ['farmer-2'],
                 }}
-                operationData={undefined}
+                operationData={buildOperationDefinition(1010)}
                 userId="farmer-1"
             />
             <FarmSchedulePlantingTaskCard
-                completionAction={<button type="button">Dovrši sijanje</button>}
+                completionAction={completionAction('Dovrši sijanje')}
                 field={{
                     assignedUserId: null,
                     assignedUserIds: ['farmer-2'],
@@ -94,15 +146,113 @@ test('locks array-only work assigned to another farmer on a phone', async ({
         </div>,
     );
 
-    await expect(component.getByRole('button')).toHaveCount(0);
-    await expect(component.getByRole('checkbox')).toHaveCount(2);
-    for (const checkbox of await component.getByRole('checkbox').all()) {
-        await expect(checkbox).toBeDisabled();
+    await expect(component.getByRole('link')).toHaveCount(2);
+    await expect(component.getByRole('checkbox')).toHaveCount(0);
+    const lockedButtons = component.getByRole('button');
+    await expect(lockedButtons).toHaveCount(2);
+    for (const button of await lockedButtons.all()) {
+        await expect(button).toBeDisabled();
     }
+    await expect(
+        component.getByText('Radnja je dodijeljena drugom korisniku.'),
+    ).toBeVisible();
+    await expect(
+        component.getByText('Sijanje je dodijeljeno drugom korisniku.'),
+    ).toBeVisible();
     await assertCardsStayWithinViewport(component);
+    await assertPrimaryTargetsAreTouchable(component);
 });
 
-for (const width of [320, 390, 1280]) {
+test('keeps details before completion in keyboard order without nesting actions', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    const component = await mount(
+        <FarmScheduleOperationTaskCard
+            completionAction={completionAction('Dovrši radnju')}
+            operation={buildOperation(
+                20,
+                'planned',
+                'Vrlo duga radnja koju farmer otvara prije završetka',
+            )}
+            operationData={buildOperationDefinition(1020)}
+            userId="farmer-1"
+        />,
+    );
+
+    const detailsLink = component.getByRole('link', {
+        name: /Otvori upute/,
+    });
+    const completionButton = component.getByRole('button', {
+        name: 'Dovrši radnju',
+    });
+    await expect(detailsLink.getByRole('button')).toHaveCount(0);
+    await detailsLink.focus();
+    await page.keyboard.press('Tab');
+    await expect(completionButton).toBeFocused();
+    await assertCardsStayWithinViewport(component);
+    await assertPrimaryTargetsAreTouchable(component);
+});
+
+test('does not link unavailable operation guidance to a guaranteed 404', async ({
+    mount,
+}) => {
+    const component = await mount(
+        <FarmScheduleOperationTaskCard
+            completionAction={completionAction('Dovrši radnju')}
+            operation={buildOperation(
+                22,
+                'planned',
+                'Radnja sa zastarjelim uputama',
+            )}
+            operationData={undefined}
+            userId="farmer-1"
+        />,
+    );
+
+    await expect(component.getByRole('link')).toHaveCount(0);
+    await expect(
+        component.getByText('Upute trenutno nisu dostupne.'),
+    ).toBeVisible();
+    await expect(
+        component.getByRole('button', { name: 'Dovrši radnju' }),
+    ).toBeVisible();
+});
+
+test('keeps loading completion explicit, disabled, and phone-sized', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    const component = await mount(
+        <FarmSchedulePlantingTaskCard
+            completionAction={completionAction('Dovrši sijanje', true)}
+            field={{
+                assignedUserId: null,
+                assignedUserIds: [],
+                id: 21,
+                plantScheduledDate: scheduledDate,
+                plantStatus: 'planned',
+                positionIndex: 0,
+                raisedBedId: 10,
+                sowingLocation: 'direct',
+            }}
+            label="Sijanje vrlo duge sorte povrća"
+            plantSort={undefined}
+            userId="farmer-1"
+            assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
+        />,
+    );
+
+    const completionButton = component.getByRole('button');
+    await expect(completionButton).toBeDisabled();
+    await expect(completionButton).toHaveAttribute('aria-busy', 'true');
+    await assertCardsStayWithinViewport(component);
+    await assertPrimaryTargetsAreTouchable(component);
+});
+
+for (const width of [320, 375, 390, 430, 1280]) {
     test(`renders operation pending and verified states within ${width}px`, async ({
         mount,
         page,
@@ -111,35 +261,36 @@ for (const width of [320, 390, 1280]) {
         const component = await mount(
             <div className="space-y-2">
                 <FarmScheduleOperationTaskCard
-                    completionAction={
-                        <button type="button">Dovrši radnju</button>
-                    }
+                    completionAction={completionAction('Dovrši radnju')}
                     operation={buildOperation(
                         1,
                         'pendingVerification',
                         operationLabels.pending,
                     )}
-                    operationData={undefined}
+                    operationData={buildOperationDefinition(1001)}
                     userId="farmer-1"
                 />
                 <FarmScheduleOperationTaskCard
-                    completionAction={
-                        <button type="button">Dovrši radnju</button>
-                    }
-                    operation={buildOperation(
-                        2,
-                        'completed',
-                        operationLabels.completed,
-                    )}
-                    operationData={undefined}
+                    completionAction={completionAction('Dovrši radnju')}
+                    operation={{
+                        ...buildOperation(
+                            2,
+                            'completed',
+                            operationLabels.completed,
+                        ),
+                        completionNotes:
+                            'Fotografije i napomena potvrđuju završetak.',
+                        imageUrls: [
+                            'https://images.unsplash.com/photo-1416879595882-3373a0480b5b',
+                        ],
+                    }}
+                    operationData={buildOperationDefinition(1002)}
                     userId="farmer-1"
                 />
                 <FarmScheduleOperationTaskCard
-                    completionAction={
-                        <button type="button">Dovrši radnju</button>
-                    }
+                    completionAction={completionAction('Dovrši radnju')}
                     operation={buildOperation(3, 'planned', 'Zalij salatu')}
-                    operationData={undefined}
+                    operationData={buildOperationDefinition(1003)}
                     userId="farmer-1"
                 />
             </div>,
@@ -154,6 +305,9 @@ for (const width of [320, 390, 1280]) {
         await expect(pendingCard.getByRole('checkbox')).toHaveCount(0);
         await expect(pendingCard.getByRole('button')).toHaveCount(0);
         await expect(
+            pendingCard.getByRole('link', { name: /Otvori upute/ }),
+        ).toHaveAttribute('href', '/operations/1001');
+        await expect(
             pendingCard.getByText(operationLabels.pending),
         ).toBeVisible();
 
@@ -163,11 +317,20 @@ for (const width of [320, 390, 1280]) {
         await expect(
             completedCard.getByText('Potvrđeno', { exact: true }),
         ).toBeVisible();
-        const verifiedControl = completedCard.getByRole('checkbox', {
-            name: `Potvrđeno: ${operationLabels.completed}`,
-        });
-        await expect(verifiedControl).toBeChecked();
-        await expect(verifiedControl).toBeDisabled();
+        await expect(completedCard.getByRole('checkbox')).toHaveCount(0);
+        await expect(
+            completedCard.getByRole('button', {
+                name: 'Prikaži napomenu završetka',
+            }),
+        ).toBeVisible();
+        await expect(
+            completedCard.getByRole('button', {
+                name: /Otvori galeriju u punoj veličini/,
+            }),
+        ).toBeVisible();
+        await expect(
+            completedCard.getByRole('link', { name: /Otvori upute/ }),
+        ).toHaveAttribute('href', '/operations/1002');
 
         const actionableCard = component.locator(
             '[data-task-state="actionable"]',
@@ -175,8 +338,17 @@ for (const width of [320, 390, 1280]) {
         await expect(
             actionableCard.getByRole('button', { name: 'Dovrši radnju' }),
         ).toBeVisible();
+        await expect(
+            actionableCard.getByRole('link', { name: /Otvori upute/ }),
+        ).toHaveAttribute('href', '/operations/1003');
+        await expect(
+            actionableCard
+                .getByRole('link', { name: /Otvori upute/ })
+                .getByRole('button'),
+        ).toHaveCount(0);
 
         await assertCardsStayWithinViewport(component);
+        await assertPrimaryTargetsAreTouchable(component);
     });
 
     test(`renders planting pending and verified states within ${width}px`, async ({
@@ -187,9 +359,7 @@ for (const width of [320, 390, 1280]) {
         const component = await mount(
             <div className="space-y-2">
                 <FarmSchedulePlantingTaskCard
-                    completionAction={
-                        <button type="button">Dovrši sijanje</button>
-                    }
+                    completionAction={completionAction('Dovrši sijanje')}
                     field={{
                         assignedUserId: null,
                         assignedUserIds: [],
@@ -206,9 +376,7 @@ for (const width of [320, 390, 1280]) {
                     assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
                 />
                 <FarmSchedulePlantingTaskCard
-                    completionAction={
-                        <button type="button">Dovrši sijanje</button>
-                    }
+                    completionAction={completionAction('Dovrši sijanje')}
                     field={{
                         assignedUserId: null,
                         assignedUserIds: [],
@@ -225,9 +393,7 @@ for (const width of [320, 390, 1280]) {
                     assignedUserByFieldIdPromise={assignedUserByFieldIdPromise}
                 />
                 <FarmSchedulePlantingTaskCard
-                    completionAction={
-                        <button type="button">Dovrši sijanje</button>
-                    }
+                    completionAction={completionAction('Dovrši sijanje')}
                     field={{
                         assignedUserId: null,
                         assignedUserIds: [],
@@ -255,6 +421,9 @@ for (const width of [320, 390, 1280]) {
         await expect(pendingCard.getByRole('checkbox')).toHaveCount(0);
         await expect(pendingCard.getByRole('button')).toHaveCount(0);
         await expect(
+            pendingCard.getByRole('link', { name: /Otvori gredicu/ }),
+        ).toHaveAttribute('href', '/raised-beds/10');
+        await expect(
             pendingCard.getByText(plantingLabels.pending),
         ).toBeVisible();
 
@@ -264,11 +433,11 @@ for (const width of [320, 390, 1280]) {
         await expect(
             completedCard.getByText('Potvrđeno', { exact: true }),
         ).toBeVisible();
-        const verifiedControl = completedCard.getByRole('checkbox', {
-            name: `Potvrđeno: ${plantingLabels.completed}`,
-        });
-        await expect(verifiedControl).toBeChecked();
-        await expect(verifiedControl).toBeDisabled();
+        await expect(completedCard.getByRole('checkbox')).toHaveCount(0);
+        await expect(completedCard.getByRole('button')).toHaveCount(0);
+        await expect(
+            completedCard.getByRole('link', { name: /Otvori gredicu/ }),
+        ).toHaveAttribute('href', '/raised-beds/10');
 
         const actionableCard = component.locator(
             '[data-task-state="actionable"]',
@@ -276,7 +445,16 @@ for (const width of [320, 390, 1280]) {
         await expect(
             actionableCard.getByRole('button', { name: 'Dovrši sijanje' }),
         ).toBeVisible();
+        await expect(
+            actionableCard.getByRole('link', { name: /Otvori gredicu/ }),
+        ).toHaveAttribute('href', '/raised-beds/10');
+        await expect(
+            actionableCard
+                .getByRole('link', { name: /Otvori gredicu/ })
+                .getByRole('button'),
+        ).toHaveCount(0);
 
         await assertCardsStayWithinViewport(component);
+        await assertPrimaryTargetsAreTouchable(component);
     });
 }

--- a/apps/farm/app/schedule/OperationCompletionAttachments.tsx
+++ b/apps/farm/app/schedule/OperationCompletionAttachments.tsx
@@ -8,7 +8,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 
-const THUMBNAIL_SIZE = 36;
+const THUMBNAIL_SIZE = 44;
 
 type OperationCompletionAttachmentsProps = {
     operationId: number;
@@ -51,6 +51,7 @@ export function OperationCompletionAttachments({
                     title="Napomena završetka"
                     trigger={
                         <IconButton
+                            size="lg"
                             variant="plain"
                             title="Prikaži napomenu završetka"
                         >
@@ -72,7 +73,7 @@ export function OperationCompletionAttachments({
                 </Modal>
             )}
             {images.length > 0 && (
-                <div className="h-9 w-9 shrink-0 overflow-visible">
+                <div className="h-11 w-11 shrink-0 overflow-visible">
                     <ImageGallery
                         images={images}
                         previewWidth={THUMBNAIL_SIZE}

--- a/apps/farm/app/schedule/ScheduleTaskCompletionButton.spec.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskCompletionButton.spec.tsx
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { ScheduleTaskCompletionButton } from './ScheduleTaskCompletionButton';
+
+for (const width of [320, 375, 390, 430]) {
+    test(`keeps real completion triggers explicit and touchable at ${width}px`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize({ width, height: 640 });
+        const component = await mount(
+            <div className="space-y-2 p-2">
+                <ScheduleTaskCompletionButton
+                    actionLabel="Dovrši radnju"
+                    label="Vrlo duga radnja pripreme zemlje za jesensku sadnju"
+                />
+                <ScheduleTaskCompletionButton
+                    actionLabel="Dovrši sijanje"
+                    label="Vrlo duga sorta rajčice za sijanje u stakleniku"
+                />
+            </div>,
+        );
+
+        const buttons = component.getByRole('button');
+        await expect(buttons).toHaveCount(2);
+        await expect(
+            component.getByRole('button', {
+                name: 'Dovrši radnju: Vrlo duga radnja pripreme zemlje za jesensku sadnju',
+            }),
+        ).toBeVisible();
+        await expect(
+            component.getByRole('button', {
+                name: 'Dovrši sijanje: Vrlo duga sorta rajčice za sijanje u stakleniku',
+            }),
+        ).toBeVisible();
+
+        const undersizedOrClipped = await buttons.evaluateAll((targets) =>
+            targets.filter((target) => {
+                const bounds = target.getBoundingClientRect();
+                return (
+                    bounds.width < 44 ||
+                    bounds.height < 44 ||
+                    bounds.left < 0 ||
+                    bounds.right > window.innerWidth
+                );
+            }),
+        );
+        expect(undersizedOrClipped).toEqual([]);
+    });
+}

--- a/apps/farm/app/schedule/ScheduleTaskCompletionButton.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskCompletionButton.tsx
@@ -1,0 +1,33 @@
+import { Button, type ButtonButtonProps } from '@gredice/ui/Button';
+import { cx } from '@gredice/ui/utils';
+
+type ScheduleTaskCompletionButtonProps = Omit<
+    ButtonButtonProps,
+    'aria-label' | 'children' | 'fullWidth' | 'size' | 'type'
+> & {
+    actionLabel: string;
+    label: string;
+};
+
+export function ScheduleTaskCompletionButton({
+    actionLabel,
+    className,
+    label,
+    ...buttonProps
+}: ScheduleTaskCompletionButtonProps) {
+    return (
+        <Button
+            {...buttonProps}
+            aria-label={`${actionLabel}: ${label}`}
+            className={cx(
+                'h-auto min-h-11 whitespace-normal py-2 [overflow-wrap:anywhere]',
+                className,
+            )}
+            fullWidth
+            size="lg"
+            type="button"
+        >
+            {actionLabel}
+        </Button>
+    );
+}

--- a/apps/farm/app/schedule/ScheduleTaskDetailsLink.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskDetailsLink.tsx
@@ -1,0 +1,29 @@
+import { Navigate } from '@gredice/ui/icons';
+import NextLink from 'next/link';
+import type { ReactNode } from 'react';
+
+interface ScheduleTaskDetailsLinkProps {
+    actionLabel: string;
+    children: ReactNode;
+    href: string;
+}
+
+export function ScheduleTaskDetailsLink({
+    actionLabel,
+    children,
+    href,
+}: ScheduleTaskDetailsLinkProps) {
+    return (
+        <NextLink
+            className="group block min-h-11 min-w-0 rounded-md px-1 py-1 transition-colors hover:bg-muted/60 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            data-schedule-task-details-link
+            href={{ pathname: href }}
+        >
+            {children}
+            <span className="mt-1.5 inline-flex min-h-6 items-center gap-1 text-xs font-semibold text-primary group-hover:underline">
+                {actionLabel}
+                <Navigate aria-hidden className="size-3.5 shrink-0" />
+            </span>
+        </NextLink>
+    );
+}

--- a/apps/farm/app/schedule/ScheduleTaskStateControl.spec.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskStateControl.spec.tsx
@@ -1,19 +1,33 @@
+import { Button } from '@gredice/ui/Button';
 import { expect, test } from '@playwright/experimental-ct-react';
 import { ScheduleTaskStateControl } from './ScheduleTaskStateControl';
 
 for (const width of [320, 1280]) {
-    test(`keeps submitted work non-actionable at ${width}px`, async ({
+    test(`keeps submitted and verified work non-actionable at ${width}px`, async ({
         mount,
         page,
     }) => {
         await page.setViewportSize({ width, height: 640 });
         const component = await mount(
-            <ScheduleTaskStateControl
-                action={<button type="button">Dovrši</button>}
-                label="Zalij gredicu broj 12"
-                state="pendingVerification"
-                unavailableTitle="Radnja nije dostupna."
-            />,
+            <div>
+                <ScheduleTaskStateControl
+                    action={
+                        <Button size="lg" type="button">
+                            Dovrši
+                        </Button>
+                    }
+                    actionLabel="Dovrši radnju"
+                    label="Zalij gredicu broj 12"
+                    state="pendingVerification"
+                    unavailableTitle="Radnja nije dostupna."
+                />
+                <ScheduleTaskStateControl
+                    actionLabel="Dovrši radnju"
+                    label="Zalij gredicu broj 13"
+                    state="completed"
+                    unavailableTitle="Radnja nije dostupna."
+                />
+            </div>,
         );
 
         await expect(component.getByRole('button')).toHaveCount(0);
@@ -21,29 +35,18 @@ for (const width of [320, 1280]) {
     });
 }
 
-test('renders only verified work as checked completion', async ({ mount }) => {
-    const component = await mount(
-        <ScheduleTaskStateControl
-            label="Posij mrkvu"
-            state="completed"
-            unavailableTitle="Sijanje nije dostupno."
-        />,
-    );
-
-    const checkbox = component.getByRole('checkbox', {
-        name: 'Potvrđeno: Posij mrkvu',
-    });
-    await expect(checkbox).toBeChecked();
-    await expect(checkbox).toBeDisabled();
-});
-
 test('keeps actionable controls available and names locked work', async ({
     mount,
     page,
 }) => {
     const actionable = await mount(
         <ScheduleTaskStateControl
-            action={<button type="button">Dovrši</button>}
+            action={
+                <Button fullWidth size="lg" type="button">
+                    Dovrši
+                </Button>
+            }
+            actionLabel="Dovrši radnju"
             label="Zalij salatu"
             state="actionable"
             unavailableTitle="Radnja nije dostupna."
@@ -54,14 +57,51 @@ test('keeps actionable controls available and names locked work', async ({
 
     await mount(
         <ScheduleTaskStateControl
+            actionLabel="Dovrši radnju"
             label="Zalij salatu"
             state="actionable"
             unavailableTitle="Radnja je dodijeljena drugom korisniku."
         />,
     );
+    const lockedButton = page.getByRole('button', {
+        name: 'Nije dostupno: Dovrši radnju za Zalij salatu. Radnja je dodijeljena drugom korisniku.',
+    });
+    await expect(lockedButton).toBeDisabled();
     await expect(
-        page.getByRole('checkbox', {
-            name: 'Nije dostupno: Zalij salatu. Radnja je dodijeljena drugom korisniku.',
-        }),
-    ).toBeDisabled();
+        page.getByText('Radnja je dodijeljena drugom korisniku.'),
+    ).toBeVisible();
+    expect(
+        await lockedButton.evaluate(
+            (button) => button.getBoundingClientRect().height,
+        ),
+    ).toBeGreaterThanOrEqual(44);
+});
+
+test('keeps a loading completion action large and unavailable to repeat input', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 640 });
+    const component = await mount(
+        <ScheduleTaskStateControl
+            action={
+                <Button aria-busy fullWidth loading size="lg" type="button">
+                    Dovrši radnju
+                </Button>
+            }
+            actionLabel="Dovrši radnju"
+            label="Vrlo duga radnja zalijevanja rajčice"
+            state="actionable"
+            unavailableTitle="Radnja nije dostupna."
+        />,
+    );
+
+    const loadingButton = component.getByRole('button');
+    await expect(loadingButton).toBeDisabled();
+    await expect(loadingButton).toHaveAttribute('aria-busy', 'true');
+    expect(
+        await loadingButton.evaluate(
+            (button) => button.getBoundingClientRect().height,
+        ),
+    ).toBeGreaterThanOrEqual(44);
 });

--- a/apps/farm/app/schedule/ScheduleTaskStateControl.tsx
+++ b/apps/farm/app/schedule/ScheduleTaskStateControl.tsx
@@ -1,9 +1,12 @@
-import { Checkbox } from '@gredice/ui/Checkbox';
+import { Button } from '@gredice/ui/Button';
+import { Lock } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
 import type { ReactNode } from 'react';
 import type { ScheduleTaskState } from './scheduleTaskState';
 
 interface ScheduleTaskStateControlProps {
     action?: ReactNode;
+    actionLabel: string;
     label: string;
     state: ScheduleTaskState;
     unavailableTitle: string;
@@ -11,36 +14,49 @@ interface ScheduleTaskStateControlProps {
 
 export function ScheduleTaskStateControl({
     action,
+    actionLabel,
     label,
     state,
     unavailableTitle,
 }: ScheduleTaskStateControlProps) {
-    if (state === 'completed') {
-        return (
-            <Checkbox
-                aria-label={`Potvrđeno: ${label}`}
-                className="size-5"
-                checked
-                disabled
-            />
-        );
-    }
-
     if (state !== 'actionable') {
         return null;
     }
 
     if (action) {
-        return action;
+        return (
+            <div
+                className="mt-2 border-t pt-2 [&>*]:w-full"
+                data-schedule-task-completion="available"
+            >
+                {action}
+            </div>
+        );
     }
 
     return (
-        <div title={unavailableTitle}>
-            <Checkbox
-                aria-label={`Nije dostupno: ${label}. ${unavailableTitle}`}
-                className="size-5"
+        <div
+            className="mt-2 space-y-1 border-t pt-2"
+            data-schedule-task-completion="locked"
+        >
+            <Button
+                aria-label={`Nije dostupno: ${actionLabel} za ${label}. ${unavailableTitle}`}
+                className="h-auto min-h-11 whitespace-normal py-2 [overflow-wrap:anywhere]"
                 disabled
-            />
+                fullWidth
+                size="lg"
+                startDecorator={<Lock aria-hidden className="size-4" />}
+                type="button"
+                variant="outlined"
+            >
+                {actionLabel}
+            </Button>
+            <Typography
+                className="text-muted-foreground [overflow-wrap:anywhere]"
+                level="body2"
+            >
+                {unavailableTitle}
+            </Typography>
         </div>
     );
 }

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -75,6 +75,7 @@ async function assertFarmerCanCompletePlanting(
 }
 
 function revalidateSchedule() {
+    revalidatePath('/');
     revalidatePath('/schedule');
 }
 

--- a/apps/farm/app/settings/page.tsx
+++ b/apps/farm/app/settings/page.tsx
@@ -1,7 +1,7 @@
 import { getUser } from '@gredice/storage';
 import { AuthProtectedSection, SignedOut } from '@gredice/ui/auth/server';
+import { Typography } from '@gredice/ui/Typography';
 import LoginDialog from '../../components/auth/LoginDialog';
-import { HomeButton } from '../../components/HomeButton';
 import { auth } from '../../lib/auth/auth';
 import { FarmSchedulePreferences } from './_components/FarmSchedulePreferences';
 import { NotificationSettings } from './_components/NotificationSettings';
@@ -14,9 +14,9 @@ async function FarmSettingsContent() {
 
     return (
         <div className="max-w-5xl mx-auto w-full p-4 space-y-4">
-            <div className="flex min-w-0 items-center gap-2">
-                <HomeButton />
-            </div>
+            <Typography component="h1" level="h5" semiBold>
+                Postavke
+            </Typography>
             <FarmSchedulePreferences
                 groupWateringOperations={
                     user?.farmScheduleGroupedWateringEnabled ?? true

--- a/apps/farm/components/analytics/FarmAnalyticsProvider.spec.tsx
+++ b/apps/farm/components/analytics/FarmAnalyticsProvider.spec.tsx
@@ -1,0 +1,412 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
+import {
+    AppRouterContext,
+    type AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { FarmTodayView } from '../../app/FarmTodayView';
+import type {
+    FarmTodayData,
+    FarmTodayOperationTask,
+} from '../../app/farmTodayModel';
+import { FarmAnalyticsHarness } from '../../playwright/FarmAnalyticsHarness';
+
+type AnalyticsEvent = {
+    eventName: string;
+    properties: Record<string, unknown>;
+};
+
+declare global {
+    interface Window {
+        recordFarmAnalyticsEvent?: (event: unknown) => void;
+    }
+}
+
+const nextNavigationRouter = {
+    back: () => undefined,
+    forward: () => undefined,
+    prefetch: () => undefined,
+    push: () => undefined,
+    refresh: () => undefined,
+    replace: () => undefined,
+} satisfies AppRouterInstance;
+
+const privateSentinels = [
+    'PRIVATE_OPERATION_LABEL_SENTINEL',
+    'PRIVATE_LOCATION_SENTINEL',
+    'PRIVATE_HREF_987654321',
+    'PRIVATE_TASK_KEY_987654321',
+    '987654321',
+    'PRIVATE_NOTE_SENTINEL',
+    'private.example/photo.jpg',
+    'PRIVATE_PHOTO_TOKEN',
+    '45.812345',
+    '15.976543',
+    'PRIVATE_CUSTOMER_CONTENT_SENTINEL',
+] as const;
+
+const suspiciousPropertyKey =
+    /label|location|href|(^|_)(key|id|ids)($|_)|note|photo|url|coord|content|private/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function exactPropertyKeysForEvent(event: AnalyticsEvent) {
+    if (event.eventName === 'farm_navigation_selected') {
+        return ['destination', 'source', 'surface'];
+    }
+    if (event.eventName === 'farm_today_task_opened') {
+        return [
+            'assignment',
+            'overdue',
+            'source',
+            'surface',
+            'task_kind',
+            'task_state',
+        ];
+    }
+    if (event.eventName === 'farm_today_first_action') {
+        return event.properties.action_type === 'navigation'
+            ? ['action_type', 'destination', 'source', 'surface']
+            : ['action_type', 'source', 'surface', 'task_kind'];
+    }
+    if (event.eventName === 'farm_today_viewed') {
+        return 'work_state' in event.properties
+            ? ['data_status', 'has_next_task', 'surface', 'work_state']
+            : ['data_status', 'has_next_task', 'surface'];
+    }
+
+    return null;
+}
+
+async function captureFarmAnalyticsEvents(page: Page) {
+    const analyticsEvents: AnalyticsEvent[] = [];
+
+    await page.exposeFunction('recordFarmAnalyticsEvent', (event: unknown) => {
+        if (
+            !isRecord(event) ||
+            typeof event.eventName !== 'string' ||
+            !isRecord(event.properties)
+        ) {
+            return;
+        }
+
+        analyticsEvents.push({
+            eventName: event.eventName,
+            properties: event.properties,
+        });
+    });
+
+    await page.evaluate(() => {
+        window.addEventListener('gredice:farm-analytics', (event) => {
+            if (event instanceof CustomEvent) {
+                window.recordFarmAnalyticsEvent?.(event.detail);
+            }
+        });
+    });
+
+    return analyticsEvents;
+}
+
+function eventsNamed(analyticsEvents: AnalyticsEvent[], eventName: string) {
+    return analyticsEvents.filter((event) => event.eventName === eventName);
+}
+
+function expectExactProperties(
+    event: AnalyticsEvent,
+    expected: Record<string, unknown>,
+) {
+    expect(event.properties).toEqual(expected);
+    expect(Object.keys(event.properties).sort()).toEqual(
+        Object.keys(expected).sort(),
+    );
+}
+
+function buildOperationTask(
+    key: string,
+    href: string,
+    state: FarmTodayOperationTask['state'] = 'actionable',
+): FarmTodayOperationTask {
+    return {
+        ageIndicator: null,
+        assignment: 'mine',
+        durationMinutes: 15,
+        href,
+        key,
+        kind: 'operation',
+        label: `Privatni naziv ${key}`,
+        location: {
+            farmId: 987654321,
+            kind: 'farm',
+            label: `Privatna lokacija ${key}`,
+        },
+        occurredAt: null,
+        operationId: 987654321,
+        overdue: false,
+        proofRequirements: { images: 'required', notes: 'optional' },
+        scheduledDate: '2026-07-15T08:00:00.000Z',
+        state,
+    };
+}
+
+test('captures the initial Today view once across rerenders with an exact allowlist', async ({
+    mount,
+    page,
+}) => {
+    const analyticsEvents = await captureFarmAnalyticsEvents(page);
+    const component = await mount(
+        <FarmAnalyticsHarness todayMountKey="stable-today" />,
+    );
+
+    await expect
+        .poll(() => eventsNamed(analyticsEvents, 'farm_today_viewed').length)
+        .toBe(1);
+
+    await component.update(
+        <FarmAnalyticsHarness
+            dataStatus="partial"
+            hasNextTask={false}
+            todayMountKey="stable-today"
+            workState="allDone"
+        />,
+    );
+
+    await expect
+        .poll(() => eventsNamed(analyticsEvents, 'farm_today_viewed').length)
+        .toBe(1);
+
+    const viewedEvent = eventsNamed(analyticsEvents, 'farm_today_viewed')[0];
+    expect(viewedEvent).toBeDefined();
+    if (!viewedEvent) {
+        return;
+    }
+
+    expectExactProperties(viewedEvent, {
+        data_status: 'ready',
+        has_next_task: true,
+        surface: 'farm',
+        work_state: 'hasWork',
+    });
+});
+
+test('captures one first recognized action per Today mount without leaking private task data', async ({
+    mount,
+    page,
+}) => {
+    const analyticsEvents = await captureFarmAnalyticsEvents(page);
+    const component = await mount(
+        <FarmAnalyticsHarness todayMountKey="task-first" />,
+    );
+
+    await expect
+        .poll(() => eventsNamed(analyticsEvents, 'farm_today_viewed').length)
+        .toBe(1);
+
+    await component.getByTestId('plain-action').click();
+    expect(
+        eventsNamed(analyticsEvents, 'farm_today_first_action'),
+    ).toHaveLength(0);
+
+    await component.getByTestId('private-task-nested-target').click();
+    await expect
+        .poll(
+            () => eventsNamed(analyticsEvents, 'farm_today_task_opened').length,
+        )
+        .toBe(1);
+    await expect
+        .poll(
+            () =>
+                eventsNamed(analyticsEvents, 'farm_today_first_action').length,
+        )
+        .toBe(1);
+
+    const taskOpened = eventsNamed(
+        analyticsEvents,
+        'farm_today_task_opened',
+    )[0];
+    const taskFirstAction = eventsNamed(
+        analyticsEvents,
+        'farm_today_first_action',
+    )[0];
+    expect(taskOpened).toBeDefined();
+    expect(taskFirstAction).toBeDefined();
+    if (!taskOpened || !taskFirstAction) {
+        return;
+    }
+
+    expectExactProperties(taskOpened, {
+        assignment: 'mine',
+        overdue: true,
+        source: 'next',
+        surface: 'farm',
+        task_kind: 'operation',
+        task_state: 'actionable',
+    });
+    expectExactProperties(taskFirstAction, {
+        action_type: 'task_opened',
+        source: 'next',
+        surface: 'farm',
+        task_kind: 'operation',
+    });
+
+    await component
+        .locator('[data-farm-navigation-destination="notifications"]')
+        .click();
+    await component.getByTestId('private-task-nested-target').click();
+
+    await expect
+        .poll(
+            () =>
+                eventsNamed(analyticsEvents, 'farm_navigation_selected').length,
+        )
+        .toBe(1);
+    await expect
+        .poll(
+            () => eventsNamed(analyticsEvents, 'farm_today_task_opened').length,
+        )
+        .toBe(2);
+    expect(
+        eventsNamed(analyticsEvents, 'farm_today_first_action'),
+    ).toHaveLength(1);
+
+    const navigationSelected = eventsNamed(
+        analyticsEvents,
+        'farm_navigation_selected',
+    )[0];
+    expect(navigationSelected).toBeDefined();
+    if (!navigationSelected) {
+        return;
+    }
+    expectExactProperties(navigationSelected, {
+        destination: 'notifications',
+        source: 'mobile_bottom',
+        surface: 'farm',
+    });
+
+    await component.update(
+        <FarmAnalyticsHarness todayMountKey="navigation-first" />,
+    );
+    await expect
+        .poll(() => eventsNamed(analyticsEvents, 'farm_today_viewed').length)
+        .toBe(2);
+
+    await component.getByTestId('settings-navigation-nested-target').click();
+    await expect
+        .poll(
+            () =>
+                eventsNamed(analyticsEvents, 'farm_today_first_action').length,
+        )
+        .toBe(2);
+
+    const navigationFirstAction = eventsNamed(
+        analyticsEvents,
+        'farm_today_first_action',
+    )[1];
+    expect(navigationFirstAction).toBeDefined();
+    if (!navigationFirstAction) {
+        return;
+    }
+    expectExactProperties(navigationFirstAction, {
+        action_type: 'navigation',
+        destination: 'settings',
+        source: 'today_tools',
+        surface: 'farm',
+    });
+
+    await component
+        .locator('[data-farm-navigation-destination="notifications"]')
+        .click();
+    expect(
+        eventsNamed(analyticsEvents, 'farm_today_first_action'),
+    ).toHaveLength(2);
+
+    const serializedProperties = JSON.stringify(
+        analyticsEvents.map((event) => event.properties),
+    );
+    for (const sentinel of privateSentinels) {
+        expect(serializedProperties).not.toContain(sentinel);
+    }
+
+    for (const event of analyticsEvents) {
+        const allowedKeys = exactPropertyKeysForEvent(event);
+        expect(allowedKeys).toBeDefined();
+        if (!allowedKeys) {
+            continue;
+        }
+
+        const actualKeys = Object.keys(event.properties).sort();
+        expect(event.properties.surface).toBe('farm');
+        expect(actualKeys).toEqual(allowedKeys.sort());
+
+        for (const propertyKey of Object.keys(event.properties)) {
+            expect(propertyKey).not.toMatch(suspiciousPropertyKey);
+        }
+    }
+});
+
+test('marks actual Today focus, queue, and attention task links with safe analytics attributes', async ({
+    mount,
+}) => {
+    const nextTask = buildOperationTask(
+        'operation:private-next',
+        '/operations/801',
+    );
+    const queuedTask = buildOperationTask(
+        'operation:private-queued',
+        '/operations/802',
+    );
+    const attentionTask = buildOperationTask(
+        'operation:private-attention',
+        '/operations/803',
+        'failed',
+    );
+    const data = {
+        attentionItems: [{ reasons: ['failed'], task: attentionTask }],
+        dataIssues: [],
+        dateKey: '2026-07-15',
+        focusQueue: [nextTask, queuedTask],
+        status: 'ready',
+        summary: {
+            assignedToMe: 3,
+            completed: 0,
+            countsComplete: true,
+            overdue: 0,
+            pendingVerification: 0,
+            remaining: 3,
+            remainingDuration: { complete: true, minutes: 45 },
+            unassigned: 0,
+        },
+        workState: 'hasWork',
+    } satisfies FarmTodayData;
+
+    const component = await mount(
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <FarmTodayView data={data} heading={<h1>Danas</h1>} />
+        </AppRouterContext.Provider>,
+    );
+
+    const nextLink = component.locator('a[href="/operations/801"]');
+    const queuedLink = component.locator('a[href="/operations/802"]');
+    const attentionLink = component.locator('a[href="/operations/803"]');
+
+    await expect(nextLink).toHaveAttribute('data-farm-analytics', 'today_task');
+    await expect(nextLink).toHaveAttribute('data-farm-task-source', 'next');
+    await expect(nextLink).toHaveAttribute('data-farm-task-kind', 'operation');
+    await expect(nextLink).toHaveAttribute('data-farm-task-assignment', 'mine');
+    await expect(nextLink).toHaveAttribute(
+        'data-farm-task-state',
+        'actionable',
+    );
+    await expect(nextLink).toHaveAttribute('data-farm-task-overdue', 'false');
+
+    await expect(queuedLink).toHaveAttribute('data-farm-task-source', 'queue');
+    await expect(attentionLink).toHaveAttribute(
+        'data-farm-task-source',
+        'attention',
+    );
+    await expect(attentionLink).toHaveAttribute(
+        'data-farm-task-state',
+        'failed',
+    );
+});

--- a/apps/farm/components/analytics/FarmAnalyticsProvider.spec.tsx
+++ b/apps/farm/components/analytics/FarmAnalyticsProvider.spec.tsx
@@ -24,6 +24,7 @@ declare global {
 
 const nextNavigationRouter = {
     back: () => undefined,
+    bfcacheId: 'farm-analytics-test',
     forward: () => undefined,
     prefetch: () => undefined,
     push: () => undefined,

--- a/apps/farm/components/analytics/FarmAnalyticsProvider.tsx
+++ b/apps/farm/components/analytics/FarmAnalyticsProvider.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { usePostHog } from '@posthog/next';
+import {
+    type MouseEvent,
+    type ReactNode,
+    useCallback,
+    useMemo,
+    useRef,
+} from 'react';
+import {
+    type FarmAnalyticsCapture,
+    type FarmAnalyticsEvent,
+    type FarmNavigationSelectedProperties,
+    type FarmTodayFirstActionProperties,
+    type FarmTodayTaskOpenedProperties,
+    type FarmTodayViewedProperties,
+    isFarmNavigationDestination,
+    isFarmNavigationSource,
+    isFarmTodayTaskAssignment,
+    isFarmTodayTaskKind,
+    isFarmTodayTaskSource,
+    isFarmTodayTaskState,
+} from './farmAnalytics';
+import {
+    FarmAnalyticsContext,
+    type FarmAnalyticsContextValue,
+} from './farmAnalyticsContext';
+
+type FarmAnalyticsProviderProps = {
+    capture?: FarmAnalyticsCapture;
+    children: ReactNode;
+};
+
+type TodayViewSession = {
+    firstActionCaptured: boolean;
+    id: number;
+};
+
+function getAnalyticsElement(event: MouseEvent<HTMLDivElement>) {
+    if (!(event.target instanceof Element)) {
+        return null;
+    }
+
+    const analyticsElement = event.target.closest<HTMLElement>(
+        '[data-farm-analytics]',
+    );
+
+    return analyticsElement && event.currentTarget.contains(analyticsElement)
+        ? analyticsElement
+        : null;
+}
+
+function getTaskOpenedProperties(
+    element: HTMLElement,
+): FarmTodayTaskOpenedProperties | null {
+    const {
+        farmTaskAssignment,
+        farmTaskKind,
+        farmTaskOverdue,
+        farmTaskSource,
+        farmTaskState,
+    } = element.dataset;
+    const overdue =
+        farmTaskOverdue === 'true'
+            ? true
+            : farmTaskOverdue === 'false'
+              ? false
+              : null;
+
+    if (
+        !isFarmTodayTaskAssignment(farmTaskAssignment) ||
+        !isFarmTodayTaskKind(farmTaskKind) ||
+        !isFarmTodayTaskSource(farmTaskSource) ||
+        !isFarmTodayTaskState(farmTaskState) ||
+        overdue === null
+    ) {
+        return null;
+    }
+
+    return {
+        assignment: farmTaskAssignment,
+        overdue,
+        source: farmTaskSource,
+        task_kind: farmTaskKind,
+        task_state: farmTaskState,
+    };
+}
+
+function getNavigationProperties(
+    element: HTMLElement,
+): FarmNavigationSelectedProperties | null {
+    const { farmNavigationDestination, farmNavigationSource } = element.dataset;
+
+    if (
+        !isFarmNavigationDestination(farmNavigationDestination) ||
+        !isFarmNavigationSource(farmNavigationSource)
+    ) {
+        return null;
+    }
+
+    return {
+        destination: farmNavigationDestination,
+        source: farmNavigationSource,
+    };
+}
+
+export function FarmAnalyticsProvider({
+    capture,
+    children,
+}: FarmAnalyticsProviderProps) {
+    const posthog = usePostHog();
+    const sessionCounter = useRef(0);
+    const todayViewSession = useRef<TodayViewSession | null>(null);
+
+    const captureEvent = useCallback(
+        (event: FarmAnalyticsEvent) => {
+            const properties = {
+                ...event.properties,
+                surface: 'farm',
+            } satisfies Parameters<FarmAnalyticsCapture>[1];
+
+            if (capture) {
+                capture(event.name, properties);
+                return;
+            }
+
+            posthog?.capture(event.name, properties);
+        },
+        [capture, posthog],
+    );
+
+    const captureFirstAction = useCallback(
+        (properties: FarmTodayFirstActionProperties) => {
+            const session = todayViewSession.current;
+            if (!session || session.firstActionCaptured) {
+                return;
+            }
+
+            session.firstActionCaptured = true;
+            captureEvent({
+                name: 'farm_today_first_action',
+                properties,
+            });
+        },
+        [captureEvent],
+    );
+
+    const handleClickCapture = useCallback(
+        (event: MouseEvent<HTMLDivElement>) => {
+            const element = getAnalyticsElement(event);
+            if (!element) {
+                return;
+            }
+
+            if (element.dataset.farmAnalytics === 'today_task') {
+                const properties = getTaskOpenedProperties(element);
+                if (!properties) {
+                    return;
+                }
+
+                captureEvent({
+                    name: 'farm_today_task_opened',
+                    properties,
+                });
+                captureFirstAction({
+                    action_type: 'task_opened',
+                    source: properties.source,
+                    task_kind: properties.task_kind,
+                });
+                return;
+            }
+
+            if (element.dataset.farmAnalytics === 'navigation') {
+                const properties = getNavigationProperties(element);
+                if (!properties) {
+                    return;
+                }
+
+                captureEvent({
+                    name: 'farm_navigation_selected',
+                    properties,
+                });
+                captureFirstAction({
+                    action_type: 'navigation',
+                    destination: properties.destination,
+                    source: properties.source,
+                });
+            }
+        },
+        [captureEvent, captureFirstAction],
+    );
+
+    const mountTodayView = useCallback(
+        (properties: FarmTodayViewedProperties, captureView: boolean) => {
+            sessionCounter.current += 1;
+            const sessionId = sessionCounter.current;
+            todayViewSession.current = {
+                firstActionCaptured: false,
+                id: sessionId,
+            };
+
+            if (captureView) {
+                captureEvent({
+                    name: 'farm_today_viewed',
+                    properties,
+                });
+            }
+
+            return sessionId;
+        },
+        [captureEvent],
+    );
+
+    const unmountTodayView = useCallback((sessionId: number) => {
+        if (todayViewSession.current?.id === sessionId) {
+            todayViewSession.current = null;
+        }
+    }, []);
+
+    const contextValue = useMemo<FarmAnalyticsContextValue>(
+        () => ({ mountTodayView, unmountTodayView }),
+        [mountTodayView, unmountTodayView],
+    );
+
+    return (
+        <FarmAnalyticsContext.Provider value={contextValue}>
+            <div className="contents" onClickCapture={handleClickCapture}>
+                {children}
+            </div>
+        </FarmAnalyticsContext.Provider>
+    );
+}

--- a/apps/farm/components/analytics/FarmPageViewTracker.tsx
+++ b/apps/farm/components/analytics/FarmPageViewTracker.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { usePostHog } from '@posthog/next';
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+import { getFarmAnalyticsPage } from './farmAnalyticsPage';
+
+export function FarmPageViewTracker() {
+    const pathname = usePathname();
+    const posthog = usePostHog();
+
+    useEffect(() => {
+        if (!posthog) {
+            return;
+        }
+
+        const page = getFarmAnalyticsPage(pathname);
+
+        posthog.capture('$pageview', {
+            route_group: page.routeGroup,
+            surface: 'farm',
+        });
+    }, [pathname, posthog]);
+
+    return null;
+}

--- a/apps/farm/components/analytics/FarmPostHogProvider.tsx
+++ b/apps/farm/components/analytics/FarmPostHogProvider.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { PostHogContext } from '@posthog/react';
+import posthog from 'posthog-js';
+import type { ReactNode } from 'react';
+import {
+    createFarmPostHogOptions,
+    purgeLegacyFarmPostHogPersistence,
+} from './farmAnalyticsPrivacy';
+
+type FarmPostHogProviderProps = {
+    apiHost: string;
+    apiKey: string;
+    children: ReactNode;
+    uiHost?: string;
+};
+
+const farmPostHogContextValue = { client: posthog };
+let configuredPostHogSignature: string | undefined;
+
+export function FarmPostHogProvider({
+    apiHost,
+    apiKey,
+    children,
+    uiHost,
+}: FarmPostHogProviderProps) {
+    const configurationSignature = `${apiKey}|${apiHost}|${uiHost ?? ''}`;
+
+    // PostHog must be privacy-configured before descendant effects can capture.
+    // This mirrors the eager client initialization used by @posthog/next.
+    if (
+        typeof window !== 'undefined' &&
+        configuredPostHogSignature !== configurationSignature
+    ) {
+        const options = createFarmPostHogOptions({
+            apiHost,
+            hostname: window.location.hostname,
+            uiHost,
+        });
+
+        if (posthog.__loaded) {
+            posthog.set_config(options);
+        } else {
+            posthog.init(apiKey, options);
+        }
+        // Disabling persistence clears the durable store; unregistering also
+        // removes sensitive values loaded into memory by older configurations.
+        purgeLegacyFarmPostHogPersistence(posthog);
+        configuredPostHogSignature = configurationSignature;
+    }
+
+    return (
+        <PostHogContext.Provider value={farmPostHogContextValue}>
+            {children}
+        </PostHogContext.Provider>
+    );
+}

--- a/apps/farm/components/analytics/FarmTodayViewTracker.tsx
+++ b/apps/farm/components/analytics/FarmTodayViewTracker.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type {
+    FarmTodayDataStatus,
+    FarmTodayViewedProperties,
+} from './farmAnalytics';
+import { useFarmAnalytics } from './farmAnalyticsContext';
+
+type FarmTodayViewTrackerProps = {
+    dataStatus: FarmTodayDataStatus;
+    hasNextTask: boolean;
+    workState?: FarmTodayViewedProperties['work_state'];
+};
+
+export function FarmTodayViewTracker({
+    dataStatus,
+    hasNextTask,
+    workState,
+}: FarmTodayViewTrackerProps) {
+    const analytics = useFarmAnalytics();
+    const capturedView = useRef(false);
+    const [initialProperties] = useState<FarmTodayViewedProperties>(() =>
+        workState
+            ? {
+                  data_status: dataStatus,
+                  has_next_task: hasNextTask,
+                  work_state: workState,
+              }
+            : {
+                  data_status: dataStatus,
+                  has_next_task: hasNextTask,
+              },
+    );
+
+    useEffect(() => {
+        if (!analytics) {
+            return;
+        }
+
+        const sessionId = analytics.mountTodayView(
+            initialProperties,
+            !capturedView.current,
+        );
+        capturedView.current = true;
+
+        return () => analytics.unmountTodayView(sessionId);
+    }, [analytics, initialProperties]);
+
+    return null;
+}

--- a/apps/farm/components/analytics/FarmWebAnalytics.tsx
+++ b/apps/farm/components/analytics/FarmWebAnalytics.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Analytics, type BeforeSendEvent } from '@vercel/analytics/react';
+import { getFarmAnalyticsSafeUrl } from './farmAnalyticsPrivacy';
+
+export function sanitizeFarmVercelAnalyticsEvent(
+    event: BeforeSendEvent,
+): BeforeSendEvent {
+    return {
+        ...event,
+        url: getFarmAnalyticsSafeUrl(event.url),
+    };
+}
+
+export function FarmWebAnalytics() {
+    return <Analytics beforeSend={sanitizeFarmVercelAnalyticsEvent} />;
+}

--- a/apps/farm/components/analytics/farmAnalytics.ts
+++ b/apps/farm/components/analytics/farmAnalytics.ts
@@ -1,0 +1,155 @@
+import type {
+    FarmTodayData,
+    FarmTodayTask,
+    FarmTodayTaskAssignment,
+    FarmTodayWorkState,
+} from '../../app/farmTodayModel';
+import type { ScheduleTaskState } from '../../app/schedule/scheduleTaskState';
+
+export type FarmTodayDataStatus = FarmTodayData['status'];
+export type FarmTodayTaskKind = FarmTodayTask['kind'];
+export type FarmTodayTaskSource = 'attention' | 'next' | 'queue';
+
+export type FarmNavigationSource =
+    | 'desktop_top'
+    | 'mobile_bottom'
+    | 'more_page'
+    | 'today_tools';
+
+export type FarmNavigationDestination =
+    | 'greenhouse'
+    | 'more'
+    | 'notifications'
+    | 'operations'
+    | 'payouts'
+    | 'plants'
+    | 'raised_beds'
+    | 'schedule'
+    | 'settings'
+    | 'today';
+
+export type FarmTodayViewedProperties = {
+    data_status: FarmTodayDataStatus;
+    has_next_task: boolean;
+    work_state?: FarmTodayWorkState;
+};
+
+export type FarmTodayTaskOpenedProperties = {
+    assignment: FarmTodayTaskAssignment;
+    overdue: boolean;
+    source: FarmTodayTaskSource;
+    task_kind: FarmTodayTaskKind;
+    task_state: ScheduleTaskState;
+};
+
+export type FarmNavigationSelectedProperties = {
+    destination: FarmNavigationDestination;
+    source: FarmNavigationSource;
+};
+
+export type FarmTodayFirstActionProperties =
+    | {
+          action_type: 'navigation';
+          destination: FarmNavigationDestination;
+          source: FarmNavigationSource;
+      }
+    | {
+          action_type: 'task_opened';
+          source: FarmTodayTaskSource;
+          task_kind: FarmTodayTaskKind;
+      };
+
+export type FarmAnalyticsEvent =
+    | {
+          name: 'farm_navigation_selected';
+          properties: FarmNavigationSelectedProperties;
+      }
+    | {
+          name: 'farm_today_first_action';
+          properties: FarmTodayFirstActionProperties;
+      }
+    | {
+          name: 'farm_today_task_opened';
+          properties: FarmTodayTaskOpenedProperties;
+      }
+    | {
+          name: 'farm_today_viewed';
+          properties: FarmTodayViewedProperties;
+      };
+
+export type FarmAnalyticsCapturedProperties =
+    FarmAnalyticsEvent['properties'] & {
+        surface: 'farm';
+    };
+
+export type FarmAnalyticsCapture = (
+    eventName: FarmAnalyticsEvent['name'],
+    properties: FarmAnalyticsCapturedProperties,
+) => void;
+
+const navigationDestinations = new Set<string>([
+    'greenhouse',
+    'more',
+    'notifications',
+    'operations',
+    'payouts',
+    'plants',
+    'raised_beds',
+    'schedule',
+    'settings',
+    'today',
+]);
+
+const navigationSources = new Set<string>([
+    'desktop_top',
+    'mobile_bottom',
+    'more_page',
+    'today_tools',
+]);
+
+const taskAssignments = new Set<string>(['mine', 'shared']);
+const taskKinds = new Set<string>(['operation', 'planting']);
+const taskSources = new Set<string>(['attention', 'next', 'queue']);
+const taskStates = new Set<string>([
+    'actionable',
+    'canceled',
+    'completed',
+    'failed',
+    'pendingVerification',
+]);
+
+export function isFarmNavigationDestination(
+    value: string | undefined,
+): value is FarmNavigationDestination {
+    return value !== undefined && navigationDestinations.has(value);
+}
+
+export function isFarmNavigationSource(
+    value: string | undefined,
+): value is FarmNavigationSource {
+    return value !== undefined && navigationSources.has(value);
+}
+
+export function isFarmTodayTaskAssignment(
+    value: string | undefined,
+): value is FarmTodayTaskAssignment {
+    return value !== undefined && taskAssignments.has(value);
+}
+
+export function isFarmTodayTaskKind(
+    value: string | undefined,
+): value is FarmTodayTaskKind {
+    return value !== undefined && taskKinds.has(value);
+}
+
+export function isFarmTodayTaskSource(
+    value: string | undefined,
+): value is FarmTodayTaskSource {
+    return value !== undefined && taskSources.has(value);
+}
+
+export function isFarmTodayTaskState(
+    value: string | undefined,
+): value is ScheduleTaskState {
+    return value !== undefined && taskStates.has(value);
+}

--- a/apps/farm/components/analytics/farmAnalyticsContext.ts
+++ b/apps/farm/components/analytics/farmAnalyticsContext.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import type { FarmTodayViewedProperties } from './farmAnalytics';
+
+export type FarmAnalyticsContextValue = {
+    mountTodayView: (
+        properties: FarmTodayViewedProperties,
+        captureView: boolean,
+    ) => number;
+    unmountTodayView: (sessionId: number) => void;
+};
+
+export const FarmAnalyticsContext =
+    createContext<FarmAnalyticsContextValue | null>(null);
+
+export function useFarmAnalytics() {
+    return useContext(FarmAnalyticsContext);
+}

--- a/apps/farm/components/analytics/farmAnalyticsPage.spec.ts
+++ b/apps/farm/components/analytics/farmAnalyticsPage.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@playwright/test';
+import { getFarmAnalyticsPage } from './farmAnalyticsPage';
+
+const currentIndexRoutes = [
+    ['/', '/', 'today'],
+    ['/raised-beds', '/raised-beds', 'raised_beds'],
+    ['/greenhouse', '/greenhouse', 'greenhouse'],
+    ['/notifications', '/notifications', 'notifications'],
+    ['/more', '/more', 'more'],
+    ['/schedule', '/schedule', 'schedule'],
+    ['/operations', '/operations', 'operations'],
+    ['/plants', '/plants', 'plants'],
+    ['/payouts', '/payouts', 'payouts'],
+    ['/settings', '/settings', 'settings'],
+] as const;
+
+for (const [pathname, path, routeGroup] of currentIndexRoutes) {
+    test(`normalizes the current ${pathname} route`, () => {
+        expect(getFarmAnalyticsPage(pathname)).toEqual({ path, routeGroup });
+    });
+}
+
+test('redacts identifiers from raised-bed, operation, and plant detail routes', () => {
+    expect(getFarmAnalyticsPage('/raised-beds/north-field-42')).toEqual({
+        path: '/raised-beds/:raisedBedId',
+        routeGroup: 'raised_beds',
+    });
+    expect(getFarmAnalyticsPage('/operations/private-operation-17')).toEqual({
+        path: '/operations/:operationId',
+        routeGroup: 'operations',
+    });
+    expect(getFarmAnalyticsPage('/plants/heirloom-tomato-8')).toEqual({
+        path: '/plants/:plantSortId',
+        routeGroup: 'plants',
+    });
+});
+
+test('redacts every descendant segment instead of leaking it into analytics', () => {
+    expect(getFarmAnalyticsPage('/operations/17/private-proof')).toEqual({
+        path: '/operations/:operationId',
+        routeGroup: 'operations',
+    });
+});
+
+test('uses a URL pathname so search values and fragments never reach analytics', () => {
+    const url = new URL(
+        'https://farma.gredice.com/raised-beds/north-field-42?note=private#photos',
+    );
+
+    expect(url.pathname).toBe('/raised-beds/north-field-42');
+    expect(getFarmAnalyticsPage(url.pathname)).toEqual({
+        path: '/raised-beds/:raisedBedId',
+        routeGroup: 'raised_beds',
+    });
+});
+
+test('normalizes authentication and debug descendants', () => {
+    expect(getFarmAnalyticsPage('/prijava/google-prijava/povratak')).toEqual({
+        path: '/prijava',
+        routeGroup: 'authentication',
+    });
+    expect(getFarmAnalyticsPage('/debug/labels')).toEqual({
+        path: '/debug',
+        routeGroup: 'debug',
+    });
+});
+
+test('normalizes unknown and non-page routes without exposing their path', () => {
+    for (const pathname of [
+        '/.well-known/security.txt',
+        '/api/users/current',
+        '/not-a-farm-page/private-value',
+    ]) {
+        expect(getFarmAnalyticsPage(pathname)).toEqual({
+            path: '/other',
+            routeGroup: 'other',
+        });
+    }
+});
+
+test('matches complete route segments instead of look-alike prefixes', () => {
+    for (const pathname of [
+        '/debugger',
+        '/greenhouses',
+        '/more-options',
+        '/notifications-archive',
+        '/operations-log',
+        '/payouts-report',
+        '/plants-and-seeds',
+        '/prijava-extra',
+        '/raised-beds-private',
+        '/scheduled',
+        '/settings-old',
+    ]) {
+        expect(getFarmAnalyticsPage(pathname)).toEqual({
+            path: '/other',
+            routeGroup: 'other',
+        });
+    }
+});

--- a/apps/farm/components/analytics/farmAnalyticsPage.ts
+++ b/apps/farm/components/analytics/farmAnalyticsPage.ts
@@ -1,0 +1,79 @@
+export type FarmAnalyticsRouteGroup =
+    | 'authentication'
+    | 'debug'
+    | 'greenhouse'
+    | 'more'
+    | 'notifications'
+    | 'operations'
+    | 'other'
+    | 'payouts'
+    | 'plants'
+    | 'raised_beds'
+    | 'schedule'
+    | 'settings'
+    | 'today';
+
+type FarmAnalyticsPage = {
+    path: string;
+    routeGroup: FarmAnalyticsRouteGroup;
+};
+
+function isRouteOrDescendant(pathname: string, route: string) {
+    return pathname === route || pathname.startsWith(`${route}/`);
+}
+
+export function getFarmAnalyticsPage(pathname: string): FarmAnalyticsPage {
+    if (pathname === '/') {
+        return { path: '/', routeGroup: 'today' };
+    }
+    if (isRouteOrDescendant(pathname, '/raised-beds')) {
+        return {
+            path:
+                pathname === '/raised-beds'
+                    ? '/raised-beds'
+                    : '/raised-beds/:raisedBedId',
+            routeGroup: 'raised_beds',
+        };
+    }
+    if (pathname === '/greenhouse') {
+        return { path: '/greenhouse', routeGroup: 'greenhouse' };
+    }
+    if (pathname === '/notifications') {
+        return { path: '/notifications', routeGroup: 'notifications' };
+    }
+    if (pathname === '/more') {
+        return { path: '/more', routeGroup: 'more' };
+    }
+    if (pathname === '/schedule') {
+        return { path: '/schedule', routeGroup: 'schedule' };
+    }
+    if (isRouteOrDescendant(pathname, '/operations')) {
+        return {
+            path:
+                pathname === '/operations'
+                    ? '/operations'
+                    : '/operations/:operationId',
+            routeGroup: 'operations',
+        };
+    }
+    if (isRouteOrDescendant(pathname, '/plants')) {
+        return {
+            path: pathname === '/plants' ? '/plants' : '/plants/:plantSortId',
+            routeGroup: 'plants',
+        };
+    }
+    if (pathname === '/payouts') {
+        return { path: '/payouts', routeGroup: 'payouts' };
+    }
+    if (pathname === '/settings') {
+        return { path: '/settings', routeGroup: 'settings' };
+    }
+    if (isRouteOrDescendant(pathname, '/prijava')) {
+        return { path: '/prijava', routeGroup: 'authentication' };
+    }
+    if (isRouteOrDescendant(pathname, '/debug')) {
+        return { path: '/debug', routeGroup: 'debug' };
+    }
+
+    return { path: '/other', routeGroup: 'other' };
+}

--- a/apps/farm/components/analytics/farmAnalyticsPrivacy.spec.tsx
+++ b/apps/farm/components/analytics/farmAnalyticsPrivacy.spec.tsx
@@ -1,0 +1,228 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { FarmPostHogProvider } from './FarmPostHogProvider';
+import { sanitizeFarmVercelAnalyticsEvent } from './FarmWebAnalytics';
+import {
+    createFarmPostHogOptions,
+    farmPostHogLegacySensitivePersistenceKeys,
+    farmPostHogPropertyDenylist,
+    getFarmAnalyticsSafeUrl,
+    purgeLegacyFarmPostHogPersistence,
+    sanitizeFarmPostHogEvent,
+} from './farmAnalyticsPrivacy';
+
+const privateSentinels = [
+    'private-note-4157',
+    'https://photos.example/private.jpg',
+    '45.812345',
+    '15.912345',
+    '/raised-beds/987654',
+] as const;
+
+test('removes SDK-added routes and private fields from the complete PostHog envelope', () => {
+    const event = {
+        $set: {
+            last_location: '45.812345,15.912345',
+            safe_account_kind: 'farmer',
+        },
+        $set_once: {
+            $initial_current_url:
+                'https://farma.gredice.com/raised-beds/987654?token=secret',
+            $initial_pathname: '/raised-beds/987654',
+            $search_keyword: 'private-note-4157',
+            safe_first_surface: 'farm',
+            utm_campaign: 'private-note-4157',
+        },
+        event: '$pageview',
+        properties: {
+            $current_url:
+                'https://farma.gredice.com/operations/987654?token=secret',
+            $pathname: '/operations/987654',
+            $prev_pageview_pathname: '/raised-beds/987654',
+            $session_entry_pathname: '/raised-beds/987654',
+            $session_entry_referrer: 'https://private.example/source',
+            $session_entry_url:
+                'https://farma.gredice.com/raised-beds/987654?token=secret',
+            title: 'Private raised bed 987654',
+            nested: {
+                coordinates: ['45.812345', '15.912345'],
+                proof: {
+                    photo_url: 'https://photos.example/private.jpg',
+                    task_note: 'private-note-4157',
+                },
+                safe_state: 'actionable',
+            },
+            route_group: 'operations',
+            surface: 'farm',
+        },
+        uuid: 'test-event',
+    };
+
+    expect(sanitizeFarmPostHogEvent(event)).toEqual({
+        $set: { safe_account_kind: 'farmer' },
+        $set_once: { safe_first_surface: 'farm' },
+        event: '$pageview',
+        properties: {
+            nested: {
+                proof: {},
+                safe_state: 'actionable',
+            },
+            route_group: 'operations',
+            surface: 'farm',
+        },
+        uuid: 'test-event',
+    });
+
+    const serializedEvent = JSON.stringify(event);
+    for (const sentinel of privateSentinels) {
+        expect(serializedEvent).not.toContain(sentinel);
+    }
+});
+
+test('denylist covers every current PostHog route and session-entry property', () => {
+    expect(farmPostHogPropertyDenylist).toEqual(
+        expect.arrayContaining([
+            '$current_url',
+            '$initial_current_url',
+            '$initial_pathname',
+            '$pathname',
+            '$prev_pageview_pathname',
+            '$session_entry_pathname',
+            '$session_entry_referrer',
+            '$session_entry_referring_domain',
+            '$session_entry_url',
+        ]),
+    );
+});
+
+test('disables unsanitized flags requests and every automatic capture surface', () => {
+    const options = createFarmPostHogOptions({
+        apiHost: '/ingest',
+        hostname: 'farma.gredice.com',
+    });
+
+    expect(options).toMatchObject({
+        advanced_disable_flags: true,
+        api_host: '/ingest',
+        autocapture: false,
+        before_send: sanitizeFarmPostHogEvent,
+        capture_exceptions: false,
+        capture_pageleave: false,
+        capture_pageview: false,
+        disable_persistence: true,
+        disable_session_recording: true,
+        save_campaign_params: false,
+        save_referrer: false,
+        tracing_headers: ['farma.gredice.com'],
+    });
+});
+
+test('purges legacy sensitive properties from durable and session analytics state', () => {
+    const durableProperties: string[] = [];
+    const sessionProperties: string[] = [];
+
+    purgeLegacyFarmPostHogPersistence({
+        unregister: (property) => durableProperties.push(property),
+        unregister_for_session: (property) => sessionProperties.push(property),
+    });
+
+    for (const property of [
+        '$initial_person_info',
+        '$client_session_props',
+        '$session_entry_url',
+        '$referrer',
+        'utm_campaign',
+        'gclid',
+        'ph_keyword',
+    ]) {
+        expect(durableProperties).toContain(property);
+        expect(sessionProperties).toContain(property);
+    }
+    expect(durableProperties).toEqual([
+        ...farmPostHogLegacySensitivePersistenceKeys,
+    ]);
+    expect(sessionProperties).toEqual(durableProperties);
+});
+
+test('removes the legacy PostHog browser store when the provider initializes', async ({
+    mount,
+    page,
+}) => {
+    const apiKey = 'phc_farm_privacy_migration_test';
+    const persistenceKey = `ph_${apiKey}_posthog`;
+    const legacyValue = JSON.stringify({
+        $initial_person_info: {
+            referrer: 'https://private.example/source',
+            url: 'https://farma.gredice.com/raised-beds/987654?token=secret#proof',
+        },
+        distinct_id: 'legacy-browser-id',
+    });
+
+    await page.evaluate(
+        ({ key, value }) => {
+            localStorage.setItem(key, value);
+            sessionStorage.setItem(key, value);
+        },
+        { key: persistenceKey, value: legacyValue },
+    );
+    await page.context().addCookies([
+        {
+            name: persistenceKey,
+            sameSite: 'Lax',
+            url: new URL(page.url()).origin,
+            value: encodeURIComponent(legacyValue),
+        },
+    ]);
+
+    await mount(
+        <FarmPostHogProvider apiHost="/ingest" apiKey={apiKey}>
+            <div>Spremno</div>
+        </FarmPostHogProvider>,
+    );
+
+    await expect
+        .poll(() =>
+            page.evaluate((key) => {
+                return {
+                    cookie: document.cookie.includes(`${key}=`),
+                    local: localStorage.getItem(key),
+                    session: sessionStorage.getItem(key),
+                };
+            }, persistenceKey),
+        )
+        .toEqual({ cookie: false, local: null, session: null });
+});
+
+test('normalizes Vercel pageview and event URLs without IDs, query values, or fragments', () => {
+    expect(
+        sanitizeFarmVercelAnalyticsEvent({
+            type: 'pageview',
+            url: 'https://farma.gredice.com/raised-beds/987654?token=secret#proof',
+        }),
+    ).toEqual({
+        type: 'pageview',
+        url: 'https://farma.gredice.com/raised-beds/:raisedBedId',
+    });
+    expect(
+        sanitizeFarmVercelAnalyticsEvent({
+            type: 'event',
+            url: 'https://farma.gredice.com/operations/987654?note=private-note-4157',
+        }),
+    ).toEqual({
+        type: 'event',
+        url: 'https://farma.gredice.com/operations/:operationId',
+    });
+    expect(
+        getFarmAnalyticsSafeUrl('/plants/987654?photo=private.jpg#details'),
+    ).toBe('/plants/:plantSortId');
+});
+
+test('keeps unknown paths and invalid relative input inside a fixed safe bucket', () => {
+    expect(
+        getFarmAnalyticsSafeUrl(
+            'https://farma.gredice.com/private/private-note-4157',
+        ),
+    ).toBe('https://farma.gredice.com/other');
+    expect(getFarmAnalyticsSafeUrl('not a URL')).toBe('/other');
+    expect(getFarmAnalyticsSafeUrl('http://[')).toBe('/other');
+    expect(sanitizeFarmPostHogEvent(null)).toBeNull();
+});

--- a/apps/farm/components/analytics/farmAnalyticsPrivacy.ts
+++ b/apps/farm/components/analytics/farmAnalyticsPrivacy.ts
@@ -1,0 +1,209 @@
+import type { PostHogConfig } from 'posthog-js';
+import { getFarmAnalyticsPage } from './farmAnalyticsPage';
+
+type SanitizablePostHogEvent = {
+    $set?: Record<string, unknown>;
+    $set_once?: Record<string, unknown>;
+    properties: Record<string, unknown>;
+};
+
+const sensitivePropertyKeyFragments = [
+    'campaign',
+    'clid',
+    'coordinate',
+    'gbraid',
+    'href',
+    'image',
+    'latitude',
+    'location',
+    'longitude',
+    'note',
+    'path',
+    'photo',
+    'referrer',
+    'referring',
+    'search_',
+    'title',
+    'utm_',
+    'url',
+    'wbraid',
+] as const;
+
+export const farmPostHogPropertyDenylist = [
+    '$current_url',
+    '$initial_current_url',
+    '$initial_pathname',
+    '$initial_referrer',
+    '$initial_referring_domain',
+    '$pathname',
+    '$prev_pageview_pathname',
+    '$referrer',
+    '$referring_domain',
+    '$session_entry_pathname',
+    '$session_entry_referrer',
+    '$session_entry_referring_domain',
+    '$session_entry_url',
+    'current_url',
+    'pathname',
+    'referrer',
+    'referring_domain',
+    'request_url',
+    'title',
+] as const;
+
+const farmPostHogCampaignPropertyKeys = [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_content',
+    'utm_term',
+    'gad_source',
+    'mc_cid',
+    'gclid',
+    'gclsrc',
+    'dclid',
+    'gbraid',
+    'wbraid',
+    'fbclid',
+    'msclkid',
+    'twclid',
+    'li_fat_id',
+    'igshid',
+    'ttclid',
+    'rdt_cid',
+    'epik',
+    'qclid',
+    'sccid',
+    'irclid',
+    '_kx',
+] as const;
+
+export const farmPostHogLegacySensitivePersistenceKeys = [
+    '$initial_person_info',
+    '$initial_campaign_params',
+    '$initial_referrer_info',
+    '$client_session_props',
+    '$search_engine',
+    'ph_keyword',
+    ...farmPostHogCampaignPropertyKeys,
+    ...farmPostHogPropertyDenylist,
+] as const;
+
+type FarmPostHogPersistenceClient = {
+    unregister: (property: string) => void;
+    unregister_for_session: (property: string) => void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function isSensitivePropertyKey(key: string) {
+    const normalizedKey = key.toLowerCase();
+
+    return (
+        normalizedKey.startsWith('$session_entry_') ||
+        sensitivePropertyKeyFragments.some((fragment) =>
+            normalizedKey.includes(fragment),
+        )
+    );
+}
+
+function removeSensitiveProperties(
+    value: unknown,
+    visited = new WeakSet<object>(),
+) {
+    if (!isRecord(value) || visited.has(value)) {
+        return;
+    }
+
+    visited.add(value);
+    for (const [key, nestedValue] of Object.entries(value)) {
+        if (isSensitivePropertyKey(key)) {
+            delete value[key];
+            continue;
+        }
+
+        if (Array.isArray(nestedValue)) {
+            for (const item of nestedValue) {
+                removeSensitiveProperties(item, visited);
+            }
+            continue;
+        }
+
+        removeSensitiveProperties(nestedValue, visited);
+    }
+}
+
+export function sanitizeFarmPostHogEvent<
+    Event extends SanitizablePostHogEvent | null,
+>(event: Event): Event {
+    if (!event) {
+        return event;
+    }
+
+    removeSensitiveProperties(event.properties);
+    removeSensitiveProperties(event.$set);
+    removeSensitiveProperties(event.$set_once);
+
+    return event;
+}
+
+export function purgeLegacyFarmPostHogPersistence(
+    client: FarmPostHogPersistenceClient,
+) {
+    for (const property of farmPostHogLegacySensitivePersistenceKeys) {
+        client.unregister(property);
+        client.unregister_for_session(property);
+    }
+}
+
+export function createFarmPostHogOptions({
+    apiHost,
+    hostname,
+    uiHost,
+}: {
+    apiHost: string;
+    hostname: string;
+    uiHost?: string;
+}) {
+    return {
+        advanced_disable_flags: true,
+        api_host: apiHost,
+        autocapture: false,
+        before_send: sanitizeFarmPostHogEvent,
+        capture_exceptions: false,
+        capture_pageleave: false,
+        capture_pageview: false,
+        debug: process.env.NODE_ENV === 'development',
+        defaults: '2026-01-30',
+        disable_capture_url_hashes: true,
+        disable_persistence: true,
+        disable_session_recording: true,
+        mask_personal_data_properties: true,
+        opt_out_capturing_persistence_type: 'cookie',
+        opt_out_persistence_by_default: true,
+        persistence: 'localStorage+cookie',
+        property_denylist: [...farmPostHogPropertyDenylist],
+        save_campaign_params: false,
+        save_referrer: false,
+        tracing_headers: hostname ? [hostname] : undefined,
+        ui_host: uiHost ?? null,
+    } satisfies Partial<PostHogConfig>;
+}
+
+export function getFarmAnalyticsSafeUrl(rawUrl: string) {
+    try {
+        const absoluteUrl = new URL(rawUrl);
+        const page = getFarmAnalyticsPage(absoluteUrl.pathname);
+
+        return `${absoluteUrl.origin}${page.path}`;
+    } catch {
+        try {
+            const relativeUrl = new URL(rawUrl, 'https://farm.invalid');
+            return getFarmAnalyticsPage(relativeUrl.pathname).path;
+        } catch {
+            return '/other';
+        }
+    }
+}

--- a/apps/farm/components/auth/LogoutButton.tsx
+++ b/apps/farm/components/auth/LogoutButton.tsx
@@ -3,6 +3,7 @@
 import { authCurrentUserQueryKeys } from '@gredice/ui/auth';
 import { IconButton } from '@gredice/ui/IconButton';
 import { LogOut } from '@gredice/ui/icons';
+import { usePostHog } from '@posthog/next';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { queryClient } from '../providers/ClientAppProvider';
@@ -12,6 +13,7 @@ export function LogoutButton({
 }: {
     size?: 'xs' | 'sm' | 'md' | 'lg';
 }) {
+    const posthog = usePostHog();
     const router = useRouter();
     const [loading, setLoading] = useState(false);
 
@@ -27,6 +29,10 @@ export function LogoutButton({
             await queryClient.invalidateQueries({
                 queryKey: authCurrentUserQueryKeys,
             });
+            queryClient.removeQueries({
+                queryKey: ['farm', 'notifications'],
+            });
+            posthog?.reset();
             router.refresh();
         } catch (cause) {
             console.error('Logout request failed', cause);

--- a/apps/farm/components/navigation/FarmAppShell.tsx
+++ b/apps/farm/components/navigation/FarmAppShell.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import type { PropsWithChildren } from 'react';
+import { FarmShellAuthGate } from './FarmShellAuthGate';
+import { isFarmWorkspacePath } from './farmNavigation';
+
+export function FarmAppShell({ children }: PropsWithChildren) {
+    const pathname = usePathname();
+
+    if (!isFarmWorkspacePath(pathname)) {
+        return children;
+    }
+
+    return (
+        <FarmShellAuthGate pathname={pathname}>{children}</FarmShellAuthGate>
+    );
+}

--- a/apps/farm/components/navigation/FarmAuthenticatedNavigation.tsx
+++ b/apps/farm/components/navigation/FarmAuthenticatedNavigation.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useFarmNotifications } from '../../app/notifications/notificationsClient';
+import { FarmPrimaryNavigation } from './FarmPrimaryNavigation';
+
+type FarmAuthenticatedNavigationProps = {
+    pathname: string;
+};
+
+export function FarmAuthenticatedNavigation({
+    pathname,
+}: FarmAuthenticatedNavigationProps) {
+    const notificationsQuery = useFarmNotifications('unread', 1);
+    const hasUnreadNotifications = Boolean(notificationsQuery.data?.length);
+
+    return (
+        <FarmPrimaryNavigation
+            hasUnreadNotifications={hasUnreadNotifications}
+            pathname={pathname}
+        />
+    );
+}

--- a/apps/farm/components/navigation/FarmAuthenticatedShell.tsx
+++ b/apps/farm/components/navigation/FarmAuthenticatedShell.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { PropsWithChildren } from 'react';
+import { FarmAuthenticatedNavigation } from './FarmAuthenticatedNavigation';
+
+type FarmAuthenticatedShellProps = PropsWithChildren<{
+    authenticated?: boolean;
+    pathname: string;
+}>;
+
+export function FarmAuthenticatedShell({
+    authenticated = true,
+    children,
+    pathname,
+}: FarmAuthenticatedShellProps) {
+    return (
+        <div className="flex min-w-0 flex-1 flex-col" data-farm-app-shell>
+            <div
+                className={`min-w-0 flex-1 [padding-top:var(--farm-safe-area-top,0px)] [padding-left:var(--farm-safe-area-left,0px)] [padding-right:var(--farm-safe-area-right,0px)] md:pt-0 ${
+                    authenticated
+                        ? 'pb-[calc(var(--farm-mobile-navigation-height,3.5rem)+var(--farm-safe-area-bottom,0px)+1px)] md:pb-[var(--farm-safe-area-bottom,0px)]'
+                        : 'pb-[var(--farm-safe-area-bottom,0px)]'
+                }`}
+                data-farm-shell-content
+            >
+                {children}
+            </div>
+            {authenticated ? (
+                <FarmAuthenticatedNavigation pathname={pathname} />
+            ) : null}
+        </div>
+    );
+}

--- a/apps/farm/components/navigation/FarmPrimaryNavigation.spec.tsx
+++ b/apps/farm/components/navigation/FarmPrimaryNavigation.spec.tsx
@@ -1,0 +1,489 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator } from '@playwright/test';
+import {
+    AppRouterContext,
+    type AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { FarmAuthenticatedShellHarness } from '../../playwright/FarmAuthenticatedShellHarness';
+import { FarmShellAuthTransitionHarness } from '../../playwright/FarmShellAuthTransitionHarness';
+import { FarmPrimaryNavigation } from './FarmPrimaryNavigation';
+
+const phoneViewports = [
+    { width: 320, height: 568 },
+    { width: 375, height: 667 },
+    { width: 390, height: 844 },
+    { width: 430, height: 932 },
+] as const;
+
+const expectedDestinations = [
+    'today',
+    'raised_beds',
+    'greenhouse',
+    'notifications',
+    'more',
+] as const;
+
+const expectedLabels = [
+    'Danas',
+    'Gredice',
+    'Staklenik',
+    'Obavijesti',
+    'Više',
+] as const;
+
+const nextNavigationRouter = {
+    back: () => undefined,
+    forward: () => undefined,
+    prefetch: () => undefined,
+    push: () => undefined,
+    refresh: () => undefined,
+    replace: () => undefined,
+} satisfies AppRouterInstance;
+
+function navigation({
+    hasUnreadNotifications = true,
+    pathname = '/raised-beds/42',
+}: {
+    hasUnreadNotifications?: boolean;
+    pathname?: string;
+} = {}) {
+    return (
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <FarmPrimaryNavigation
+                hasUnreadNotifications={hasUnreadNotifications}
+                pathname={pathname}
+            />
+        </AppRouterContext.Provider>
+    );
+}
+
+function visibleNavigation(component: Locator) {
+    return component.getByRole('navigation', {
+        name: 'Glavna navigacija farme',
+    });
+}
+
+async function expectOrderedDestinationsAndLabels(navigationElement: Locator) {
+    const links = navigationElement.getByRole('link');
+
+    await expect(links).toHaveCount(expectedDestinations.length);
+    expect(
+        await links.evaluateAll((elements) =>
+            elements.map((element) =>
+                element.getAttribute('data-farm-navigation-destination'),
+            ),
+        ),
+    ).toEqual(expectedDestinations);
+
+    for (const [index, label] of expectedLabels.entries()) {
+        await expect(links.nth(index)).toContainText(label);
+    }
+}
+
+async function expectMinimumTargetSize(navigationElement: Locator) {
+    const targetSizes = await navigationElement
+        .getByRole('link')
+        .evaluateAll((elements) =>
+            elements.map((element) => {
+                const bounds = element.getBoundingClientRect();
+                return {
+                    height: bounds.height,
+                    label: element.textContent?.trim() ?? '',
+                    width: bounds.width,
+                };
+            }),
+        );
+
+    for (const target of targetSizes) {
+        expect(target.width, target.label).toBeGreaterThanOrEqual(44);
+        expect(target.height, target.label).toBeGreaterThanOrEqual(44);
+    }
+}
+
+async function expectNoHorizontalOverflow(navigationElement: Locator) {
+    expect(
+        await navigationElement.evaluate((element) => {
+            const bounds = element.getBoundingClientRect();
+            return (
+                bounds.left >= 0 &&
+                bounds.right <= window.innerWidth &&
+                element.scrollWidth <= element.clientWidth &&
+                document.documentElement.scrollWidth <=
+                    document.documentElement.clientWidth
+            );
+        }),
+    ).toBe(true);
+
+    const linksFit = await navigationElement
+        .getByRole('link')
+        .evaluateAll((elements) =>
+            elements.every((element) => {
+                const bounds = element.getBoundingClientRect();
+                const label = element.querySelector('span:not([aria-hidden])');
+                const labelBounds = label?.getBoundingClientRect();
+
+                return (
+                    bounds.left >= 0 &&
+                    bounds.right <= window.innerWidth &&
+                    element.scrollWidth <= element.clientWidth &&
+                    (!label ||
+                        !labelBounds ||
+                        (labelBounds.left >= bounds.left &&
+                            labelBounds.right <= bounds.right &&
+                            label.scrollWidth <= label.clientWidth))
+                );
+            }),
+        );
+
+    expect(linksFit).toBe(true);
+}
+
+async function expectActiveState(navigationElement: Locator) {
+    const activeLink = navigationElement.getByRole('link', {
+        name: 'Gredice',
+    });
+    await expect(activeLink).toHaveAttribute('aria-current', 'page');
+    await expect(
+        navigationElement.locator('a[aria-current="page"]'),
+    ).toHaveCount(1);
+
+    const marker = activeLink.locator('span[aria-hidden]').first();
+    await expect(marker).toBeVisible();
+    expect(
+        await marker.evaluate((element) => {
+            const bounds = element.getBoundingClientRect();
+            const backgroundColor = getComputedStyle(element).backgroundColor;
+            return (
+                bounds.width > 0 &&
+                bounds.height >= 2 &&
+                backgroundColor !== 'rgba(0, 0, 0, 0)' &&
+                backgroundColor !== 'transparent'
+            );
+        }),
+    ).toBe(true);
+}
+
+async function expectUnreadState(navigationElement: Locator) {
+    await expect(
+        navigationElement.getByRole('link', {
+            name: 'Obavijesti, ima nepročitanih',
+        }),
+    ).toBeVisible();
+    await expect(
+        navigationElement.getByText('Novo', { exact: true }),
+    ).toBeVisible();
+    await expect(
+        navigationElement.getByText('Novo', { exact: true }),
+    ).toHaveCount(1);
+}
+
+async function expectNoFarmSelector(navigationElement: Locator) {
+    await expect(navigationElement.getByRole('combobox')).toHaveCount(0);
+    await expect(navigationElement.locator('select')).toHaveCount(0);
+    await expect(
+        navigationElement.getByText(/Sve farme|Moje farme|Odaberi farmu/i),
+    ).toHaveCount(0);
+}
+
+for (const viewport of phoneViewports) {
+    test(`keeps the complete mobile navigation usable at ${viewport.width}x${viewport.height}`, async ({
+        mount,
+        page,
+    }) => {
+        await page.setViewportSize(viewport);
+        const component = await mount(navigation());
+        const navigationElement = visibleNavigation(component);
+
+        await expect(navigationElement).toHaveCount(1);
+        await expect(navigationElement).toHaveAttribute(
+            'data-farm-navigation',
+            'mobile',
+        );
+        await expectOrderedDestinationsAndLabels(navigationElement);
+        await expectMinimumTargetSize(navigationElement);
+        await expectNoHorizontalOverflow(navigationElement);
+        await expectActiveState(navigationElement);
+        await expectUnreadState(navigationElement);
+        await expectNoFarmSelector(navigationElement);
+    });
+}
+
+test('keeps one compact desktop navigation with the same order and states', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    const component = await mount(navigation());
+    const navigationElement = visibleNavigation(component);
+
+    await expect(navigationElement).toHaveCount(1);
+    await expect(navigationElement).toHaveAttribute(
+        'data-farm-navigation',
+        'desktop',
+    );
+    await expectOrderedDestinationsAndLabels(navigationElement);
+    await expectMinimumTargetSize(navigationElement);
+    await expectNoHorizontalOverflow(navigationElement);
+    await expectActiveState(navigationElement);
+    await expectUnreadState(navigationElement);
+    await expectNoFarmSelector(navigationElement);
+});
+
+test('removes both visible and accessible unread wording when there is no unread work', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(phoneViewports[0]);
+    const component = await mount(
+        navigation({ hasUnreadNotifications: false }),
+    );
+    const navigationElement = visibleNavigation(component);
+
+    await expect(
+        navigationElement.getByRole('link', {
+            name: 'Obavijesti',
+            exact: true,
+        }),
+    ).toBeVisible();
+    await expect(
+        navigationElement.getByText('Novo', { exact: true }),
+    ).toHaveCount(0);
+    await expect(navigationElement.getByText(/nepročitan/i)).toHaveCount(0);
+});
+
+test('keeps keyboard focus in the visible navigation order', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(phoneViewports[0]);
+    const component = await mount(navigation());
+    const navigationElement = visibleNavigation(component);
+    const links = navigationElement.getByRole('link');
+
+    await page.keyboard.press('Tab');
+    for (let index = 0; index < expectedDestinations.length; index += 1) {
+        await expect(links.nth(index)).toBeFocused();
+        if (index < expectedDestinations.length - 1) {
+            await page.keyboard.press('Tab');
+        }
+    }
+});
+
+test('honors overridden mobile safe-area insets without moving targets under the screen edge', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(phoneViewports[0]);
+    await page.evaluate(() => {
+        document.documentElement.style.setProperty(
+            '--farm-safe-area-bottom',
+            '24px',
+        );
+        document.documentElement.style.setProperty(
+            '--farm-safe-area-left',
+            '12px',
+        );
+        document.documentElement.style.setProperty(
+            '--farm-safe-area-right',
+            '12px',
+        );
+    });
+
+    const component = await mount(navigation());
+    const navigationElement = visibleNavigation(component);
+    const links = navigationElement.getByRole('link');
+
+    expect(
+        await navigationElement.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return {
+                bottom: style.paddingBottom,
+                left: style.paddingLeft,
+                right: style.paddingRight,
+            };
+        }),
+    ).toEqual({ bottom: '24px', left: '12px', right: '12px' });
+
+    const firstBounds = await links.first().boundingBox();
+    const lastBounds = await links.last().boundingBox();
+    expect(firstBounds).not.toBeNull();
+    expect(lastBounds).not.toBeNull();
+    if (!firstBounds || !lastBounds) {
+        throw new Error('Expected safe-area navigation links to render.');
+    }
+
+    expect(firstBounds.x).toBeGreaterThanOrEqual(12);
+    expect(lastBounds.x + lastBounds.width).toBeLessThanOrEqual(
+        phoneViewports[0].width - 12,
+    );
+    await expectMinimumTargetSize(navigationElement);
+    await expectNoHorizontalOverflow(navigationElement);
+});
+
+test('keeps the final content action above the fixed navigation and safe area', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(phoneViewports[0]);
+    await page.evaluate(() => {
+        document.documentElement.style.setProperty(
+            '--farm-safe-area-bottom',
+            '24px',
+        );
+    });
+
+    const component = await mount(
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <FarmAuthenticatedShellHarness />
+        </AppRouterContext.Provider>,
+    );
+    const navigationElement = visibleNavigation(component);
+    const finalAction = component.locator('[data-final-content-action]');
+
+    await finalAction.scrollIntoViewIfNeeded();
+
+    const navigationBounds = await navigationElement.boundingBox();
+    const actionBounds = await finalAction.boundingBox();
+    expect(navigationBounds).not.toBeNull();
+    expect(actionBounds).not.toBeNull();
+    if (!navigationBounds || !actionBounds) {
+        throw new Error(
+            'Expected shell navigation and final action to render.',
+        );
+    }
+
+    expect(actionBounds.y + actionBounds.height).toBeLessThanOrEqual(
+        navigationBounds.y,
+    );
+});
+
+test('keeps content before the fixed mobile navigation in reading and focus order', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(phoneViewports[0]);
+    const component = await mount(
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <FarmAuthenticatedShellHarness />
+        </AppRouterContext.Provider>,
+    );
+    const navigationElement = visibleNavigation(component);
+    const finalAction = component.locator('[data-final-content-action]');
+
+    expect(
+        await component
+            .locator(
+                '[data-farm-shell-content], [data-farm-navigation="mobile"]',
+            )
+            .evaluateAll((elements) =>
+                elements.map((element) =>
+                    element.hasAttribute('data-farm-shell-content')
+                        ? 'content'
+                        : 'navigation',
+                ),
+            ),
+    ).toEqual(['content', 'navigation']);
+
+    await page.keyboard.press('Tab');
+    await expect(finalAction).toBeFocused();
+    await page.keyboard.press('Tab');
+    await expect(navigationElement.getByRole('link').first()).toBeFocused();
+});
+
+test('keeps page content clear of top and landscape safe areas', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(phoneViewports[0]);
+    await page.evaluate(() => {
+        document.documentElement.style.setProperty(
+            '--farm-safe-area-top',
+            '20px',
+        );
+        document.documentElement.style.setProperty(
+            '--farm-safe-area-left',
+            '12px',
+        );
+        document.documentElement.style.setProperty(
+            '--farm-safe-area-right',
+            '16px',
+        );
+    });
+
+    const component = await mount(
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <FarmAuthenticatedShellHarness />
+        </AppRouterContext.Provider>,
+    );
+    const content = component.locator('[data-farm-shell-content]');
+
+    expect(
+        await content.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return {
+                left: style.paddingLeft,
+                right: style.paddingRight,
+                top: style.paddingTop,
+            };
+        }),
+    ).toEqual({ left: '12px', right: '16px', top: '20px' });
+});
+
+test('keeps the desktop navigation visually above content while preserving DOM order', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.evaluate(() => {
+        document.documentElement.style.setProperty(
+            '--farm-safe-area-bottom',
+            '24px',
+        );
+    });
+    const component = await mount(
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <FarmAuthenticatedShellHarness />
+        </AppRouterContext.Provider>,
+    );
+    const navigationElement = visibleNavigation(component);
+    const content = component.locator('[data-farm-shell-content]');
+    const navigationBounds = await navigationElement.boundingBox();
+    const contentBounds = await content.boundingBox();
+
+    expect(navigationBounds).not.toBeNull();
+    expect(contentBounds).not.toBeNull();
+    if (!navigationBounds || !contentBounds) {
+        throw new Error('Expected desktop shell regions to render.');
+    }
+
+    expect(navigationBounds.y + navigationBounds.height).toBeLessThanOrEqual(
+        contentBounds.y,
+    );
+    await expect(content).toHaveCSS('padding-bottom', '24px');
+});
+
+test('does not remount or recount Today when authentication resolves', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(phoneViewports[0]);
+    await page.route('**/api/gredice/api/notifications**', async (route) => {
+        await route.fulfill({ json: [], status: 200 });
+    });
+    const component = await mount(<FarmShellAuthTransitionHarness />);
+    const mountProbe = component.locator('[data-today-mount-marker]');
+    const viewCount = component.locator('[data-today-view-count]');
+
+    await expect(mountProbe).toBeVisible();
+    await expect(viewCount).toHaveText('1');
+    const mountMarker = await mountProbe.getAttribute(
+        'data-today-mount-marker',
+    );
+    await expect(visibleNavigation(component)).toBeVisible();
+
+    await expect(mountProbe).toHaveAttribute(
+        'data-today-mount-marker',
+        mountMarker ?? '',
+    );
+    await expect(viewCount).toHaveText('1');
+});

--- a/apps/farm/components/navigation/FarmPrimaryNavigation.spec.tsx
+++ b/apps/farm/components/navigation/FarmPrimaryNavigation.spec.tsx
@@ -487,3 +487,18 @@ test('does not remount or recount Today when authentication resolves', async ({
     );
     await expect(viewCount).toHaveText('1');
 });
+
+test('keeps the farm shell hidden from signed-in users without a farm role', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize(phoneViewports[0]);
+    const component = await mount(
+        <FarmShellAuthTransitionHarness userRole="customer" />,
+    );
+
+    await expect(component.locator('[data-auth-resolution]')).toHaveText(
+        'resolved',
+    );
+    await expect(visibleNavigation(component)).toHaveCount(0);
+});

--- a/apps/farm/components/navigation/FarmPrimaryNavigation.spec.tsx
+++ b/apps/farm/components/navigation/FarmPrimaryNavigation.spec.tsx
@@ -33,6 +33,7 @@ const expectedLabels = [
 
 const nextNavigationRouter = {
     back: () => undefined,
+    bfcacheId: 'farm-navigation-test',
     forward: () => undefined,
     prefetch: () => undefined,
     push: () => undefined,

--- a/apps/farm/components/navigation/FarmPrimaryNavigation.tsx
+++ b/apps/farm/components/navigation/FarmPrimaryNavigation.tsx
@@ -58,7 +58,7 @@ export function FarmPrimaryNavigation({
                                             ? `${item.label}, ima nepročitanih`
                                             : undefined
                                     }
-                                    className={`relative flex min-h-[var(--farm-mobile-navigation-height,3.5rem)] min-w-0 flex-col items-center justify-center gap-0.5 px-0.5 outline-hidden transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+                                    className={`relative flex min-h-[var(--farm-mobile-navigation-height,3.5rem)] min-w-0 flex-col items-center justify-center gap-0.5 outline-hidden transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
                                         isActive
                                             ? 'bg-muted font-semibold text-foreground'
                                             : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground'
@@ -84,7 +84,7 @@ export function FarmPrimaryNavigation({
                                         aria-hidden
                                         className="size-5 shrink-0"
                                     />
-                                    <span className="max-w-full truncate text-[0.6875rem] leading-none">
+                                    <span className="max-w-full truncate text-[0.6875rem] leading-none tracking-tight">
                                         {item.label}
                                     </span>
                                     {hasUnread ? (

--- a/apps/farm/components/navigation/FarmPrimaryNavigation.tsx
+++ b/apps/farm/components/navigation/FarmPrimaryNavigation.tsx
@@ -1,0 +1,173 @@
+import { Inbox, ListTodo, MoreHorizontal, Sprout } from '@gredice/ui/icons';
+import { RaisedBedSimpleIcon } from '@gredice/ui/RaisedBedSimpleIcon';
+import Link from 'next/link';
+import type { ComponentType, SVGProps } from 'react';
+import type { FarmNavigationSource } from '../analytics/farmAnalytics';
+import {
+    type FarmPrimaryNavigationDestination,
+    farmPrimaryNavigationItems,
+    isFarmPrimaryNavigationItemActive,
+} from './farmNavigation';
+
+type FarmPrimaryNavigationProps = {
+    hasUnreadNotifications: boolean;
+    pathname: string;
+};
+
+type FarmNavigationIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+const farmNavigationIcons = {
+    greenhouse: Sprout,
+    more: MoreHorizontal,
+    notifications: Inbox,
+    raised_beds: RaisedBedSimpleIcon,
+    today: ListTodo,
+} satisfies Record<FarmPrimaryNavigationDestination, FarmNavigationIcon>;
+
+const mobileNavigationSource = 'mobile_bottom' satisfies FarmNavigationSource;
+const desktopNavigationSource = 'desktop_top' satisfies FarmNavigationSource;
+
+export function FarmPrimaryNavigation({
+    hasUnreadNotifications,
+    pathname,
+}: FarmPrimaryNavigationProps) {
+    return (
+        <>
+            <nav
+                aria-label="Glavna navigacija farme"
+                className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur md:hidden [padding-bottom:var(--farm-safe-area-bottom,0px)] [padding-left:var(--farm-safe-area-left,0px)] [padding-right:var(--farm-safe-area-right,0px)]"
+                data-farm-navigation="mobile"
+            >
+                <ul className="grid min-h-[var(--farm-mobile-navigation-height,3.5rem)] grid-cols-5">
+                    {farmPrimaryNavigationItems.map((item) => {
+                        const Icon = farmNavigationIcons[item.destination];
+                        const isActive = isFarmPrimaryNavigationItemActive(
+                            pathname,
+                            item.destination,
+                        );
+                        const hasUnread =
+                            item.destination === 'notifications' &&
+                            hasUnreadNotifications;
+
+                        return (
+                            <li className="min-w-0" key={item.destination}>
+                                <Link
+                                    aria-current={isActive ? 'page' : undefined}
+                                    aria-label={
+                                        hasUnread
+                                            ? `${item.label}, ima nepročitanih`
+                                            : undefined
+                                    }
+                                    className={`relative flex min-h-[var(--farm-mobile-navigation-height,3.5rem)] min-w-0 flex-col items-center justify-center gap-0.5 px-0.5 outline-hidden transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+                                        isActive
+                                            ? 'bg-muted font-semibold text-foreground'
+                                            : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground'
+                                    }`}
+                                    data-farm-analytics="navigation"
+                                    data-farm-navigation-destination={
+                                        item.destination
+                                    }
+                                    data-farm-navigation-source={
+                                        mobileNavigationSource
+                                    }
+                                    href={item.href}
+                                >
+                                    <span
+                                        aria-hidden
+                                        className={`absolute top-0 h-0.5 w-5 rounded-full ${
+                                            isActive
+                                                ? 'bg-primary'
+                                                : 'bg-transparent'
+                                        }`}
+                                    />
+                                    <Icon
+                                        aria-hidden
+                                        className="size-5 shrink-0"
+                                    />
+                                    <span className="max-w-full truncate text-[0.6875rem] leading-none">
+                                        {item.label}
+                                    </span>
+                                    {hasUnread ? (
+                                        <span
+                                            aria-hidden
+                                            className="absolute top-1 right-0.5 rounded-full bg-primary px-1 py-0.5 font-semibold text-[0.5rem] text-primary-foreground leading-none"
+                                        >
+                                            Novo
+                                        </span>
+                                    ) : null}
+                                </Link>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </nav>
+
+            <nav
+                aria-label="Glavna navigacija farme"
+                className="sticky top-0 z-40 hidden border-b bg-background/95 backdrop-blur [padding-top:var(--farm-safe-area-top,0px)] md:order-first md:block"
+                data-farm-navigation="desktop"
+            >
+                <ul className="mx-auto flex min-h-13 w-full max-w-5xl min-w-0 items-center gap-1 py-1 [padding-left:calc(1rem+var(--farm-safe-area-left,0px))] [padding-right:calc(1rem+var(--farm-safe-area-right,0px))]">
+                    {farmPrimaryNavigationItems.map((item) => {
+                        const Icon = farmNavigationIcons[item.destination];
+                        const isActive = isFarmPrimaryNavigationItemActive(
+                            pathname,
+                            item.destination,
+                        );
+                        const hasUnread =
+                            item.destination === 'notifications' &&
+                            hasUnreadNotifications;
+
+                        return (
+                            <li key={item.destination}>
+                                <Link
+                                    aria-current={isActive ? 'page' : undefined}
+                                    aria-label={
+                                        hasUnread
+                                            ? `${item.label}, ima nepročitanih`
+                                            : undefined
+                                    }
+                                    className={`relative flex min-h-11 items-center gap-2 rounded-md px-3 text-sm outline-hidden transition-colors focus-visible:ring-2 focus-visible:ring-ring ${
+                                        isActive
+                                            ? 'bg-muted font-semibold text-foreground'
+                                            : 'text-muted-foreground hover:bg-muted/70 hover:text-foreground'
+                                    }`}
+                                    data-farm-analytics="navigation"
+                                    data-farm-navigation-destination={
+                                        item.destination
+                                    }
+                                    data-farm-navigation-source={
+                                        desktopNavigationSource
+                                    }
+                                    href={item.href}
+                                >
+                                    <Icon
+                                        aria-hidden
+                                        className="size-4 shrink-0"
+                                    />
+                                    <span>{item.label}</span>
+                                    {hasUnread ? (
+                                        <span
+                                            aria-hidden
+                                            className="rounded-full bg-primary px-1.5 py-0.5 font-semibold text-[0.625rem] text-primary-foreground leading-none"
+                                        >
+                                            Novo
+                                        </span>
+                                    ) : null}
+                                    <span
+                                        aria-hidden
+                                        className={`absolute inset-x-3 bottom-0 h-0.5 rounded-full ${
+                                            isActive
+                                                ? 'bg-primary'
+                                                : 'bg-transparent'
+                                        }`}
+                                    />
+                                </Link>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </nav>
+        </>
+    );
+}

--- a/apps/farm/components/navigation/FarmShellAuthGate.tsx
+++ b/apps/farm/components/navigation/FarmShellAuthGate.tsx
@@ -2,6 +2,7 @@
 
 import { useCurrentUser } from '@gredice/ui/auth';
 import type { PropsWithChildren } from 'react';
+import { isFarmCurrentUser } from '../providers/AuthAppProvider';
 import { FarmAuthenticatedShell } from './FarmAuthenticatedShell';
 
 type FarmShellAuthGateProps = PropsWithChildren<{
@@ -13,10 +14,13 @@ export function FarmShellAuthGate({
     pathname,
 }: FarmShellAuthGateProps) {
     const currentUser = useCurrentUser();
+    const authenticated =
+        Boolean(currentUser.data?.isLogginedIn) &&
+        isFarmCurrentUser(currentUser.data?.user);
 
     return (
         <FarmAuthenticatedShell
-            authenticated={Boolean(currentUser.data?.isLogginedIn)}
+            authenticated={authenticated}
             pathname={pathname}
         >
             {children}

--- a/apps/farm/components/navigation/FarmShellAuthGate.tsx
+++ b/apps/farm/components/navigation/FarmShellAuthGate.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useCurrentUser } from '@gredice/ui/auth';
+import type { PropsWithChildren } from 'react';
+import { FarmAuthenticatedShell } from './FarmAuthenticatedShell';
+
+type FarmShellAuthGateProps = PropsWithChildren<{
+    pathname: string;
+}>;
+
+export function FarmShellAuthGate({
+    children,
+    pathname,
+}: FarmShellAuthGateProps) {
+    const currentUser = useCurrentUser();
+
+    return (
+        <FarmAuthenticatedShell
+            authenticated={Boolean(currentUser.data?.isLogginedIn)}
+            pathname={pathname}
+        >
+            {children}
+        </FarmAuthenticatedShell>
+    );
+}

--- a/apps/farm/components/navigation/farmNavigation.spec.ts
+++ b/apps/farm/components/navigation/farmNavigation.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+import {
+    type FarmPrimaryNavigationDestination,
+    farmPrimaryNavigationItems,
+    isFarmPrimaryNavigationItemActive,
+    isFarmWorkspacePath,
+} from './farmNavigation';
+
+const workspaceRouteCases = [
+    { active: 'today', pathname: '/' },
+    { active: 'raised_beds', pathname: '/raised-beds' },
+    { active: 'raised_beds', pathname: '/raised-beds/42' },
+    { active: 'greenhouse', pathname: '/greenhouse' },
+    { active: 'notifications', pathname: '/notifications' },
+    { active: 'more', pathname: '/more' },
+    { active: 'more', pathname: '/schedule' },
+    { active: 'more', pathname: '/operations' },
+    { active: 'more', pathname: '/operations/701' },
+    { active: 'more', pathname: '/plants' },
+    { active: 'more', pathname: '/plants/901' },
+    { active: 'more', pathname: '/payouts' },
+    { active: 'more', pathname: '/settings' },
+] satisfies readonly {
+    active: FarmPrimaryNavigationDestination;
+    pathname: string;
+}[];
+
+for (const routeCase of workspaceRouteCases) {
+    test(`${routeCase.pathname} stays inside the shell with ${routeCase.active} active`, () => {
+        expect(isFarmWorkspacePath(routeCase.pathname)).toBe(true);
+
+        const activeDestinations = farmPrimaryNavigationItems
+            .filter((item) =>
+                isFarmPrimaryNavigationItemActive(
+                    routeCase.pathname,
+                    item.destination,
+                ),
+            )
+            .map((item) => item.destination);
+
+        expect(activeDestinations).toEqual([routeCase.active]);
+    });
+}
+
+const excludedPaths = [
+    '/prijava',
+    '/debug',
+    '/debug/auth',
+    '/raised-beds-extra',
+    '/greenhouse/unknown',
+    '/notifications/unknown',
+    '/more/unknown',
+    '/schedule/unknown',
+    '/payouts/unknown',
+    '/settings/unknown',
+    '/operations-extra',
+    '/plants-extra',
+] as const;
+
+for (const pathname of excludedPaths) {
+    test(`${pathname} does not accidentally render or activate the farm shell`, () => {
+        expect(isFarmWorkspacePath(pathname)).toBe(false);
+        expect(
+            farmPrimaryNavigationItems.some((item) =>
+                isFarmPrimaryNavigationItemActive(pathname, item.destination),
+            ),
+        ).toBe(false);
+    });
+}

--- a/apps/farm/components/navigation/farmNavigation.ts
+++ b/apps/farm/components/navigation/farmNavigation.ts
@@ -1,0 +1,98 @@
+import type { Route } from 'next';
+import type { FarmNavigationDestination } from '../analytics/farmAnalytics';
+
+export type FarmPrimaryNavigationDestination = Extract<
+    FarmNavigationDestination,
+    'greenhouse' | 'more' | 'notifications' | 'raised_beds' | 'today'
+>;
+
+export type FarmPrimaryNavigationItem = {
+    destination: FarmPrimaryNavigationDestination;
+    href: Route;
+    label: string;
+};
+
+type FarmRouteMatch = {
+    href: Route;
+    match: 'exact' | 'segment';
+};
+
+export const farmPrimaryNavigationItems = [
+    {
+        destination: 'today',
+        href: '/',
+        label: 'Danas',
+    },
+    {
+        destination: 'raised_beds',
+        href: '/raised-beds',
+        label: 'Gredice',
+    },
+    {
+        destination: 'greenhouse',
+        href: '/greenhouse',
+        label: 'Staklenik',
+    },
+    {
+        destination: 'notifications',
+        href: '/notifications',
+        label: 'Obavijesti',
+    },
+    {
+        destination: 'more',
+        href: '/more',
+        label: 'Više',
+    },
+] satisfies readonly FarmPrimaryNavigationItem[];
+
+const farmMoreNavigationRoutes = [
+    { href: '/more', match: 'exact' },
+    { href: '/schedule', match: 'exact' },
+    { href: '/operations', match: 'segment' },
+    { href: '/plants', match: 'segment' },
+    { href: '/payouts', match: 'exact' },
+    { href: '/settings', match: 'exact' },
+] satisfies readonly FarmRouteMatch[];
+
+const farmPrimaryNavigationRoutes = {
+    greenhouse: { href: '/greenhouse', match: 'exact' },
+    more: { href: '/more', match: 'exact' },
+    notifications: { href: '/notifications', match: 'exact' },
+    raised_beds: { href: '/raised-beds', match: 'segment' },
+    today: { href: '/', match: 'exact' },
+} satisfies Record<FarmPrimaryNavigationDestination, FarmRouteMatch>;
+
+export const farmWorkspaceRoutes = [
+    { href: '/', match: 'exact' },
+    { href: '/raised-beds', match: 'segment' },
+    { href: '/greenhouse', match: 'exact' },
+    { href: '/notifications', match: 'exact' },
+    ...farmMoreNavigationRoutes,
+] satisfies readonly FarmRouteMatch[];
+
+function matchesFarmRoute(pathname: string, route: FarmRouteMatch) {
+    if (pathname === route.href) {
+        return true;
+    }
+
+    return route.match === 'segment' && pathname.startsWith(`${route.href}/`);
+}
+
+export function isFarmWorkspacePath(pathname: string) {
+    return farmWorkspaceRoutes.some((route) =>
+        matchesFarmRoute(pathname, route),
+    );
+}
+
+export function isFarmPrimaryNavigationItemActive(
+    pathname: string,
+    destination: FarmPrimaryNavigationDestination,
+) {
+    if (destination === 'more') {
+        return farmMoreNavigationRoutes.some((route) =>
+            matchesFarmRoute(pathname, route),
+        );
+    }
+
+    return matchesFarmRoute(pathname, farmPrimaryNavigationRoutes[destination]);
+}

--- a/apps/farm/components/providers/AuthAppProvider.tsx
+++ b/apps/farm/components/providers/AuthAppProvider.tsx
@@ -8,16 +8,30 @@ export type User = {
     userName: string;
     displayName?: string;
     avatarUrl?: string | null;
-    role: string;
+    role: 'admin' | 'farmer';
     createdAt?: string;
 };
+
+export function isFarmCurrentUser(value: unknown): value is User {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'id' in value &&
+        typeof value.id === 'string' &&
+        'role' in value &&
+        (value.role === 'admin' || value.role === 'farmer') &&
+        'userName' in value &&
+        typeof value.userName === 'string'
+    );
+}
 
 async function currentUserFactory() {
     const response = await fetch('/api/users/current-claims', {
         cache: 'no-store',
     });
     if (response.ok) {
-        return (await response.json()) as User;
+        const responseBody: unknown = await response.json();
+        return isFarmCurrentUser(responseBody) ? responseBody : null;
     }
 
     return null;

--- a/apps/farm/package.json
+++ b/apps/farm/package.json
@@ -22,11 +22,13 @@
         "@opentelemetry/resources": "2.9.0",
         "@opentelemetry/sdk-logs": "0.220.0",
         "@posthog/next": "0.8.0",
+        "@posthog/react": "1.10.3",
         "@vercel/blob": "2.6.1",
         "@vercel/toolbar": "0.2.6",
         "flags": "4.2.0",
         "next": "16.3.0-preview.6",
         "pg": "8.22.0",
+        "posthog-js": "1.399.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "server-only": "0.0.1"

--- a/apps/farm/playwright.config.ts
+++ b/apps/farm/playwright.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import {
     defineConfig,
     devices,
@@ -11,6 +12,9 @@ import {
 } from '../../scripts/app-registry.ts';
 
 const app = getAppByName('farm');
+const scheduleActionsMockPath = fileURLToPath(
+    new URL('./playwright/scheduleActionsMock.ts', import.meta.url),
+);
 const reporter: PlaywrightTestConfig['reporter'] = [
     ['list'],
     ['html', { open: 'never' }],
@@ -29,6 +33,22 @@ export const config: PlaywrightTestConfig = {
         baseURL: getPlaywrightBaseUrl(app),
         trace: 'on-first-retry',
         ctPort: getComponentTestPort(app),
+        ctViteConfig: {
+            plugins: [
+                {
+                    name: 'farm-component-test-schedule-actions',
+                    enforce: 'pre',
+                    resolveId(source, importer) {
+                        if (
+                            source === './actions' &&
+                            importer?.includes('/app/schedule/')
+                        ) {
+                            return scheduleActionsMockPath;
+                        }
+                    },
+                },
+            ],
+        },
     },
     projects: [
         {

--- a/apps/farm/playwright/FarmAnalyticsHarness.tsx
+++ b/apps/farm/playwright/FarmAnalyticsHarness.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useCallback } from 'react';
+import { FarmAnalyticsProvider } from '../components/analytics/FarmAnalyticsProvider';
+import { FarmTodayViewTracker } from '../components/analytics/FarmTodayViewTracker';
+import type {
+    FarmAnalyticsCapture,
+    FarmTodayDataStatus,
+    FarmTodayViewedProperties,
+} from '../components/analytics/farmAnalytics';
+
+type FarmAnalyticsHarnessProps = {
+    dataStatus?: FarmTodayDataStatus;
+    hasNextTask?: boolean;
+    todayMountKey?: string;
+    workState?: FarmTodayViewedProperties['work_state'];
+};
+
+export function FarmAnalyticsHarness({
+    dataStatus = 'ready',
+    hasNextTask = true,
+    todayMountKey = 'initial',
+    workState = 'hasWork',
+}: FarmAnalyticsHarnessProps) {
+    const capture = useCallback<FarmAnalyticsCapture>(
+        (eventName, properties) => {
+            window.dispatchEvent(
+                new CustomEvent('gredice:farm-analytics', {
+                    detail: { eventName, properties },
+                }),
+            );
+        },
+        [],
+    );
+
+    return (
+        <FarmAnalyticsProvider capture={capture}>
+            <FarmTodayViewTracker
+                dataStatus={dataStatus}
+                hasNextTask={hasNextTask}
+                key={todayMountKey}
+                workState={workState}
+            />
+
+            <button data-testid="plain-action" type="button">
+                Radnja bez analitike
+            </button>
+
+            <a
+                data-farm-analytics="today_task"
+                data-farm-task-assignment="mine"
+                data-farm-task-kind="operation"
+                data-farm-task-overdue="true"
+                data-farm-task-source="next"
+                data-farm-task-state="actionable"
+                data-farm-today-task="operation:PRIVATE_TASK_KEY_987654321"
+                data-private-content="PRIVATE_CUSTOMER_CONTENT_SENTINEL"
+                data-private-coordinates="45.812345,15.976543"
+                data-private-location="PRIVATE_LOCATION_SENTINEL"
+                data-private-note="PRIVATE_NOTE_SENTINEL"
+                data-private-operation-id="987654321"
+                data-private-photo-url="https://private.example/photo.jpg?token=PRIVATE_PHOTO_TOKEN"
+                href="/operations/PRIVATE_HREF_987654321?note=PRIVATE_NOTE_SENTINEL"
+                onClick={(event) => event.preventDefault()}
+            >
+                <span data-testid="private-task-nested-target">
+                    PRIVATE_OPERATION_LABEL_SENTINEL
+                </span>
+                <span>PRIVATE_LOCATION_SENTINEL</span>
+            </a>
+
+            <a
+                data-farm-analytics="navigation"
+                data-farm-navigation-destination="notifications"
+                data-farm-navigation-source="mobile_bottom"
+                href="/notifications"
+                onClick={(event) => event.preventDefault()}
+            >
+                Obavijesti
+            </a>
+
+            <a
+                data-farm-analytics="navigation"
+                data-farm-navigation-destination="settings"
+                data-farm-navigation-source="today_tools"
+                href="/settings"
+                onClick={(event) => event.preventDefault()}
+            >
+                <span data-testid="settings-navigation-nested-target">
+                    Postavke
+                </span>
+            </a>
+        </FarmAnalyticsProvider>
+    );
+}

--- a/apps/farm/playwright/FarmAuthenticatedShellHarness.tsx
+++ b/apps/farm/playwright/FarmAuthenticatedShellHarness.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { AuthProvider } from '@gredice/ui/auth';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+import { FarmAuthenticatedShell } from '../components/navigation/FarmAuthenticatedShell';
+
+async function noCurrentUser() {
+    return null;
+}
+
+export function FarmAuthenticatedShellHarness() {
+    const [queryClient] = useState(
+        () =>
+            new QueryClient({
+                defaultOptions: {
+                    queries: { retry: false },
+                },
+            }),
+    );
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <AuthProvider currentUserFactory={noCurrentUser}>
+                <FarmAuthenticatedShell pathname="/">
+                    <main className="flex min-h-[60rem] flex-col justify-end p-2">
+                        <button
+                            className="min-h-11 w-full"
+                            data-final-content-action
+                            type="button"
+                        >
+                            Zadnja radnja sadržaja
+                        </button>
+                    </main>
+                </FarmAuthenticatedShell>
+            </AuthProvider>
+        </QueryClientProvider>
+    );
+}

--- a/apps/farm/playwright/FarmShellAuthTransitionHarness.tsx
+++ b/apps/farm/playwright/FarmShellAuthTransitionHarness.tsx
@@ -1,17 +1,12 @@
 'use client';
 
-import { AuthProvider } from '@gredice/ui/auth';
+import { AuthProvider, useCurrentUser } from '@gredice/ui/auth';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { FarmAnalyticsProvider } from '../components/analytics/FarmAnalyticsProvider';
 import { FarmTodayViewTracker } from '../components/analytics/FarmTodayViewTracker';
 import type { FarmAnalyticsCapture } from '../components/analytics/farmAnalytics';
 import { FarmShellAuthGate } from '../components/navigation/FarmShellAuthGate';
-
-async function delayedCurrentUser() {
-    await new Promise((resolve) => window.setTimeout(resolve, 250));
-    return { id: 'farmer-test' };
-}
 
 function TodayMountProbe() {
     const [mountMarker] = useState(() => crypto.randomUUID());
@@ -28,7 +23,21 @@ function TodayMountProbe() {
     );
 }
 
-export function FarmShellAuthTransitionHarness() {
+function AuthResolutionProbe() {
+    const currentUser = useCurrentUser();
+
+    return (
+        <output data-auth-resolution>
+            {currentUser.data ? 'resolved' : 'loading'}
+        </output>
+    );
+}
+
+export function FarmShellAuthTransitionHarness({
+    userRole = 'farmer',
+}: {
+    userRole?: string;
+}) {
     const [capturedEvents, setCapturedEvents] = useState<string[]>([]);
     const [queryClient] = useState(
         () =>
@@ -41,11 +50,20 @@ export function FarmShellAuthTransitionHarness() {
     const capture = useCallback<FarmAnalyticsCapture>((eventName) => {
         setCapturedEvents((current) => [...current, eventName]);
     }, []);
+    const currentUserFactory = useCallback(async () => {
+        await new Promise((resolve) => window.setTimeout(resolve, 250));
+        return {
+            id: 'farmer-test',
+            role: userRole,
+            userName: 'Farmer Test',
+        };
+    }, [userRole]);
 
     return (
         <QueryClientProvider client={queryClient}>
-            <AuthProvider currentUserFactory={delayedCurrentUser}>
+            <AuthProvider currentUserFactory={currentUserFactory}>
                 <FarmAnalyticsProvider capture={capture}>
+                    <AuthResolutionProbe />
                     <FarmShellAuthGate pathname="/">
                         <TodayMountProbe />
                     </FarmShellAuthGate>

--- a/apps/farm/playwright/FarmShellAuthTransitionHarness.tsx
+++ b/apps/farm/playwright/FarmShellAuthTransitionHarness.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { AuthProvider } from '@gredice/ui/auth';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import { FarmAnalyticsProvider } from '../components/analytics/FarmAnalyticsProvider';
+import { FarmTodayViewTracker } from '../components/analytics/FarmTodayViewTracker';
+import type { FarmAnalyticsCapture } from '../components/analytics/farmAnalytics';
+import { FarmShellAuthGate } from '../components/navigation/FarmShellAuthGate';
+
+async function delayedCurrentUser() {
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    return { id: 'farmer-test' };
+}
+
+function TodayMountProbe() {
+    const [mountMarker] = useState(() => crypto.randomUUID());
+
+    return (
+        <main data-today-mount-marker={mountMarker}>
+            <h1>Danas</h1>
+            <FarmTodayViewTracker
+                dataStatus="ready"
+                hasNextTask
+                workState="hasWork"
+            />
+        </main>
+    );
+}
+
+export function FarmShellAuthTransitionHarness() {
+    const [capturedEvents, setCapturedEvents] = useState<string[]>([]);
+    const [queryClient] = useState(
+        () =>
+            new QueryClient({
+                defaultOptions: {
+                    queries: { retry: false },
+                },
+            }),
+    );
+    const capture = useCallback<FarmAnalyticsCapture>((eventName) => {
+        setCapturedEvents((current) => [...current, eventName]);
+    }, []);
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <AuthProvider currentUserFactory={delayedCurrentUser}>
+                <FarmAnalyticsProvider capture={capture}>
+                    <FarmShellAuthGate pathname="/">
+                        <TodayMountProbe />
+                    </FarmShellAuthGate>
+                    <output data-today-view-count>
+                        {
+                            capturedEvents.filter(
+                                (eventName) =>
+                                    eventName === 'farm_today_viewed',
+                            ).length
+                        }
+                    </output>
+                </FarmAnalyticsProvider>
+            </AuthProvider>
+        </QueryClientProvider>
+    );
+}

--- a/apps/farm/playwright/scheduleActionsMock.ts
+++ b/apps/farm/playwright/scheduleActionsMock.ts
@@ -1,0 +1,57 @@
+type ScheduleActionTestState = {
+    hold: boolean;
+    operationCalls: number;
+    plantingCalls: number;
+    release?: () => void;
+};
+
+declare global {
+    interface Window {
+        __farmScheduleActionTestState?: ScheduleActionTestState;
+    }
+}
+
+function getTestState() {
+    window.__farmScheduleActionTestState ??= {
+        hold: false,
+        operationCalls: 0,
+        plantingCalls: 0,
+    };
+
+    return window.__farmScheduleActionTestState;
+}
+
+async function waitForRelease(state: ScheduleActionTestState) {
+    if (!state.hold) {
+        return;
+    }
+
+    await new Promise<void>((resolve) => {
+        state.release = resolve;
+    });
+}
+
+export async function completeFarmOperation() {
+    const state = getTestState();
+    state.operationCalls += 1;
+    await waitForRelease(state);
+    return { success: true };
+}
+
+export async function completeFarmOperationWithImageUrls() {
+    const state = getTestState();
+    state.operationCalls += 1;
+    await waitForRelease(state);
+    return { success: true };
+}
+
+export async function completeFarmPlanting() {
+    const state = getTestState();
+    state.plantingCalls += 1;
+    await waitForRelease(state);
+    return { success: true };
+}
+
+export async function markHarvestTraceLabelsPrintedAction() {
+    return { success: true };
+}

--- a/apps/farm/src/KnownPages.ts
+++ b/apps/farm/src/KnownPages.ts
@@ -1,10 +1,18 @@
 import type { Route } from 'next';
 
 export const KnownPages = {
-    Landing: '/',
-    Greenhouse: '/greenhouse',
-    Notifications: '/notifications',
-    RaisedBeds: '/raised-beds',
+    Landing: '/' satisfies Route,
+    Today: '/' satisfies Route,
+    Greenhouse: '/greenhouse' satisfies Route,
+    More: '/more' satisfies Route,
+    Notifications: '/notifications' satisfies Route,
+    Operations: '/operations' satisfies Route,
+    Operation: (operationId: number) => `/operations/${operationId}` as Route,
+    Payouts: '/payouts' satisfies Route,
+    Plants: '/plants' satisfies Route,
+    Plant: (plantSortId: number) => `/plants/${plantSortId}` as Route,
+    RaisedBeds: '/raised-beds' satisfies Route,
     RaisedBed: (raisedBedId: number) => `/raised-beds/${raisedBedId}` as Route,
-    Schedule: '/schedule',
-};
+    Schedule: '/schedule' satisfies Route,
+    Settings: '/settings' satisfies Route,
+} as const;

--- a/apps/farm/tests/landing.spec.ts
+++ b/apps/farm/tests/landing.spec.ts
@@ -4,3 +4,14 @@ test('has title', async ({ page }) => {
     await page.goto('/');
     await expect(page).toHaveTitle(/Gredice/);
 });
+
+test('allows the mobile shell to extend into device safe areas', async ({
+    page,
+}) => {
+    await page.goto('/');
+
+    await expect(page.locator('meta[name="viewport"]')).toHaveAttribute(
+        'content',
+        /(?:^|,\s*)viewport-fit=cover(?:\s*,|$)/,
+    );
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,6 +527,9 @@ importers:
       '@posthog/next':
         specifier: 0.8.0
         version: 0.8.0(@types/react@19.2.17)(next@16.3.0-preview.6(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.101.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@posthog/react':
+        specifier: 1.10.3
+        version: 1.10.3(@types/react@19.2.17)(posthog-js@1.399.1)(react@19.2.7)
       '@vercel/blob':
         specifier: 2.6.1
         version: 2.6.1
@@ -542,6 +545,9 @@ importers:
       pg:
         specifier: 8.22.0
         version: 8.22.0
+      posthog-js:
+        specifier: 1.399.1
+        version: 1.399.1
       react:
         specifier: 19.2.7
         version: 19.2.7


### PR DESCRIPTION
## Summary

- replace schedule checkbox triggers with explicit 44px mobile completion actions
- make operation/planting information areas separately tappable without completing work
- preserve assignment locks, pending/completed states, guidance fallbacks, and completion evidence
- keep operation and planting dialogs open until the server action confirms, with same-mount double-submit guards
- add real mobile dialog, long-label, loading, accessibility, evidence, and 320–430px coverage

## Mobile-first behavior

- ordinary farmers keep the single-farm default; this slice adds no persistent farm selector
- task details and completion are separate actions
- missing operation guidance degrades to visible copy instead of a dead link
- all exposed task, proof, photo, cancel, and confirm controls are at least 44px

## Validation

- `pnpm --filter farm exec biome check .`
- `pnpm --filter farm exec tsc --noEmit`
- `NEXT_PUBLIC_POSTHOG_KEY=phc_test pnpm --filter farm build`
- `NEXT_PUBLIC_POSTHOG_KEY=phc_test pnpm --filter farm test` (166 passed)
- `git diff --check`
- independent mobile, integrity, and scope review; no remaining P1/P2 within #4158

## Stack

Base: `feat/farm-mobile-shell-analytics` / #4175.

Atomic cross-tab/device idempotency and assignment check/write serialization remain tracked in #4160 and #4166.

Closes #4158