### PR TITLE
fix(storage): make diary completion test deterministic

### DIFF
--- a/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
+++ b/packages/storage/tests/gardenDiaryRescheduleRepo.node.spec.ts
@@ -1199,6 +1199,10 @@ test('raised bed diary entries display and order completed operations by complet
         gardenId,
         raisedBedId,
     });
+    const scheduledOperationCompletedAt = new Date(Date.now() + 60_000);
+    const unscheduledOperationCompletedAt = new Date(
+        scheduledOperationCompletedAt.getTime() + 60_000,
+    );
 
     await createEvent({
         ...knownEvents.operations.completedV1(
@@ -1207,13 +1211,13 @@ test('raised bed diary entries display and order completed operations by complet
                 completedBy: 'test-user',
             },
         ),
-        createdAt: new Date('2026-07-15T08:00:00.000Z'),
+        createdAt: scheduledOperationCompletedAt,
     });
     await createEvent({
         ...knownEvents.operations.completedV1(completedOperationId.toString(), {
             completedBy: 'test-user',
         }),
-        createdAt: new Date('2026-07-16T08:00:00.000Z'),
+        createdAt: unscheduledOperationCompletedAt,
     });
 
     const raisedBedEntries = await getRaisedBedDiaryEntries(raisedBedId);
@@ -1221,7 +1225,7 @@ test('raised bed diary entries display and order completed operations by complet
         raisedBedEntries
             .find((entry) => entry.id === scheduledCompletedOperationId)
             ?.timestamp.toISOString(),
-        '2026-07-15T08:00:00.000Z',
+        scheduledOperationCompletedAt.toISOString(),
     );
     const operationEntryIds = raisedBedEntries
         .map((entry) => entry.id)


### PR DESCRIPTION
## Summary

- derive completion timestamps after the schedule event is created
- keep the two completion events strictly ordered
- assert against the derived timestamp instead of a date that ages into the past

## Root cause

The test created its schedule event at the current time but hard-coded completion to July 2026. Once the current time passed that timestamp, ascending event reconstruction processed completion before scheduling and made the test fail deterministically.

## Impact

Test-only change; production behavior is unchanged.

## Validation

- `pnpm --filter @gredice/storage test gardenDiaryRescheduleRepo.node.spec.ts` (21/21 passed)
- `pnpm --filter @gredice/storage exec biome check tests/gardenDiaryRescheduleRepo.node.spec.ts`
- `git diff --check`