### PR TITLE
feat(delivery): add pickup manifests and route activation

### DIFF
--- a/apps/delivery/app/api/driver/runs/[runId]/pickups/[pickupNodeId]/mutations/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/pickups/[pickupNodeId]/mutations/route.ts
@@ -1,0 +1,110 @@
+import {
+    applyDeliveryRunPickupMutations,
+    DeliveryRunExecutionError,
+} from '@gredice/storage';
+import { withAuth } from '../../../../../../../../lib/auth/auth';
+import { parseDeliveryPickupMutationRequest } from '../../../../../../../../lib/deliveryPickupMutationRequest';
+
+const privateNoStoreHeaders = {
+    'Cache-Control': 'private, no-store',
+};
+
+function executionErrorMessage(code: string) {
+    switch (code) {
+        case 'pickup-not-current':
+        case 'route-order':
+            return 'Ovo preuzimanje još nije na redu rute.';
+        case 'pickup-dependency-pending':
+            return 'Najprije dovrši trenutačno preuzimanje uroda.';
+        case 'pickup-manifest-incomplete':
+            return 'Manifest još sadrži urode koji nisu potvrđeni.';
+        case 'pickup-operation-conflict':
+            return 'Ova je promjena već poslana s drugim podacima. Osvježi manifest.';
+        case 'pickup-trace-invalid':
+        case 'pickup-item-not-found':
+        case 'pickup-item-state-invalid':
+        case 'pickup-manifest-not-found':
+            return 'Manifest se promijenio. Osvježi podatke i provjeri označene urode.';
+        case 'active-run-not-found':
+            return 'Aktivna ruta više nije dostupna.';
+        default:
+            return 'Promjenu preuzimanja nije moguće primijeniti.';
+    }
+}
+
+export async function POST(
+    request: Request,
+    {
+        params,
+    }: {
+        params: Promise<{ runId: string; pickupNodeId: string }>;
+    },
+) {
+    return await withAuth(['driver', 'admin'], async ({ userId }) => {
+        const { runId, pickupNodeId } = await params;
+        if (
+            !runId ||
+            runId.length > 256 ||
+            !pickupNodeId ||
+            pickupNodeId.length > 256
+        ) {
+            return Response.json(
+                { error: 'Neispravno preuzimanje.' },
+                { status: 400, headers: privateNoStoreHeaders },
+            );
+        }
+        const body: unknown = await request.json().catch(() => null);
+        const mutations = parseDeliveryPickupMutationRequest(body);
+        if (!mutations) {
+            return Response.json(
+                { error: 'Promjene manifesta nisu valjane.' },
+                { status: 400, headers: privateNoStoreHeaders },
+            );
+        }
+
+        try {
+            const results = await applyDeliveryRunPickupMutations({
+                driverUserId: userId,
+                runId,
+                pickupNodeId,
+                mutations,
+            });
+            return Response.json(
+                { results },
+                { headers: privateNoStoreHeaders },
+            );
+        } catch (error) {
+            const code =
+                error instanceof DeliveryRunExecutionError
+                    ? error.code
+                    : 'pickup-mutation-failed';
+            if (error instanceof DeliveryRunExecutionError) {
+                console.warn('Delivery pickup mutation rejected', {
+                    code,
+                    runId,
+                    pickupNodeId,
+                    mutationCount: mutations.length,
+                    userId,
+                });
+                return Response.json(
+                    { error: executionErrorMessage(code), code },
+                    { status: 409, headers: privateNoStoreHeaders },
+                );
+            }
+            console.error('Delivery pickup mutation failed', {
+                error,
+                runId,
+                pickupNodeId,
+                mutationCount: mutations.length,
+                userId,
+            });
+            return Response.json(
+                {
+                    error: 'Manifest trenutačno nije moguće sinkronizirati.',
+                    code,
+                },
+                { status: 503, headers: privateNoStoreHeaders },
+            );
+        }
+    });
+}

--- a/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/arrive/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/arrive/route.ts
@@ -1,5 +1,6 @@
 import { withAuth } from '../../../../../../../../lib/auth/auth';
 import { arriveAtDeliveryStop } from '../../../../../../../../lib/deliveryDashboard';
+import { deliveryRunExecutionErrorDetails } from '../../../../../../../../lib/deliveryRunExecutionError';
 
 export async function POST(
     _request: Request,
@@ -22,14 +23,26 @@ export async function POST(
             });
             return Response.json({ success: true });
         } catch (error) {
-            console.error('Failed to mark delivery stop arrived', {
-                error,
-                runId,
-                stopId,
-                userId,
-            });
+            const executionError = deliveryRunExecutionErrorDetails(error);
+            const logContext = { runId, stopId, userId };
+            if (executionError) {
+                console.warn('Delivery stop arrival rejected', {
+                    ...logContext,
+                    code: executionError.code,
+                });
+            } else {
+                console.error('Failed to mark delivery stop arrived', {
+                    ...logContext,
+                    error,
+                });
+            }
             return Response.json(
-                { error: 'Dolazak nije moguće potvrditi.' },
+                {
+                    error:
+                        executionError?.message ??
+                        'Dolazak trenutačno nije moguće potvrditi.',
+                    code: executionError?.code,
+                },
                 { status: 409 },
             );
         }

--- a/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/deliver/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/deliver/route.ts
@@ -1,5 +1,6 @@
 import { withAuth } from '../../../../../../../../lib/auth/auth';
 import { deliverDeliveryStop } from '../../../../../../../../lib/deliveryDashboard';
+import { deliveryRunExecutionErrorDetails } from '../../../../../../../../lib/deliveryRunExecutionError';
 
 export async function POST(
     request: Request,
@@ -32,14 +33,26 @@ export async function POST(
             });
             return Response.json({ success: true });
         } catch (error) {
-            console.error('Failed to deliver stop', {
-                error,
-                runId,
-                stopId,
-                userId,
-            });
+            const executionError = deliveryRunExecutionErrorDetails(error);
+            const logContext = { runId, stopId, userId };
+            if (executionError) {
+                console.warn('Delivery stop completion rejected', {
+                    ...logContext,
+                    code: executionError.code,
+                });
+            } else {
+                console.error('Failed to deliver stop', {
+                    ...logContext,
+                    error,
+                });
+            }
             return Response.json(
-                { error: 'Dostavu nije moguće potvrditi.' },
+                {
+                    error:
+                        executionError?.message ??
+                        'Dostavu trenutačno nije moguće potvrditi.',
+                    code: executionError?.code,
+                },
                 { status: 409 },
             );
         }

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -6,11 +6,30 @@ import { Card, CardContent } from '@gredice/ui/Card';
 import { LoaderSpinner, Reset, Warning } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDriverTracking } from '../hooks/useDriverTracking';
-import type { DeliveryDashboard as DeliveryDashboardData } from '../lib/deliveryDashboardTypes';
+import { usePickupManifestSync } from '../hooks/usePickupManifestSync';
+import type {
+    DeliveryDashboard as DeliveryDashboardData,
+    DriverDeliveryDashboard,
+} from '../lib/deliveryDashboardTypes';
+import {
+    clearPickupManifestQueueScope,
+    createWebStoragePickupManifestQueuePersistence,
+} from '../lib/pickupManifestQueue';
 import { CustomerDashboard } from './CustomerDashboard';
 import { DriverDashboard } from './DriverDashboard';
+
+async function clearStoredPickupQueues(userId: string) {
+    try {
+        await clearPickupManifestQueueScope(
+            createWebStoragePickupManifestQueuePersistence(window.localStorage),
+            { userId },
+        );
+    } catch {
+        // Storage may be unavailable in private/restricted browser contexts.
+    }
+}
 
 async function readDashboard() {
     const response = await fetch('/api/dashboard', { cache: 'no-store' });
@@ -45,7 +64,9 @@ function isDeliveryDashboard(value: unknown): value is DeliveryDashboardData {
     }
 
     return value.kind === 'driver'
-        ? 'batches' in value &&
+        ? 'activeRun' in value &&
+              isSafeActiveRun(value.activeRun) &&
+              'batches' in value &&
               Array.isArray(value.batches) &&
               'maximumRouteStops' in value &&
               typeof value.maximumRouteStops === 'number' &&
@@ -54,6 +75,44 @@ function isDeliveryDashboard(value: unknown): value is DeliveryDashboardData {
         : value.kind === 'customer' &&
               'deliveries' in value &&
               Array.isArray(value.deliveries);
+}
+
+function isSafeActiveRun(value: unknown) {
+    if (value === null) return true;
+    if (typeof value !== 'object') return false;
+
+    return (
+        'stops' in value &&
+        Array.isArray(value.stops) &&
+        'routeSteps' in value &&
+        Array.isArray(value.routeSteps) &&
+        value.routeSteps.every((step) => {
+            if (
+                typeof step !== 'object' ||
+                step === null ||
+                !('kind' in step)
+            ) {
+                return false;
+            }
+            if (step.kind === 'pickup') {
+                return (
+                    'pickup' in step &&
+                    typeof step.pickup === 'object' &&
+                    step.pickup !== null &&
+                    'manifests' in step.pickup &&
+                    Array.isArray(step.pickup.manifests)
+                );
+            }
+            return (
+                step.kind === 'delivery' &&
+                'stop' in step &&
+                typeof step.stop === 'object' &&
+                step.stop !== null &&
+                'deliveries' in step.stop &&
+                Array.isArray(step.stop.deliveries)
+            );
+        })
+    );
 }
 
 async function postAction(path: string, body?: object) {
@@ -115,6 +174,136 @@ const refreshPreparationCodes = new Set([
     'preparation-not-found',
 ]);
 
+function DriverDashboardWithPickupSync({
+    dashboard,
+    trackingState,
+    pendingAction,
+    onSelectionChange,
+    onStartRun,
+    onArrive,
+    onDeliver,
+    onPickupError,
+    onPickupAcknowledged,
+}: {
+    dashboard: DriverDeliveryDashboard;
+    trackingState: ReturnType<typeof useDriverTracking>;
+    pendingAction: string | null;
+    onSelectionChange: () => void;
+    onStartRun: (deliveryRequestIds: string[]) => void;
+    onArrive: (runId: string, stopId: number) => void;
+    onDeliver: (runId: string, stopId: number, notes?: string) => void;
+    onPickupError: (error: unknown) => void;
+    onPickupAcknowledged: () => void | Promise<void>;
+}) {
+    const activeRun = dashboard.activeRun;
+    if (!activeRun) {
+        return (
+            <DriverDashboard
+                dashboard={dashboard}
+                trackingState={trackingState}
+                pendingAction={pendingAction}
+                onSelectionChange={onSelectionChange}
+                onStartRun={onStartRun}
+                onArrive={onArrive}
+                onDeliver={onDeliver}
+                pickupQueue={null}
+                onPickupScan={() => undefined}
+                onPickupItemState={() => undefined}
+                onConfirmPickupManifest={() => undefined}
+                onRetryPickupSync={() => undefined}
+                onDiscardPickupSync={() => undefined}
+            />
+        );
+    }
+
+    return (
+        <ActiveDriverDashboardWithPickupSync
+            dashboard={dashboard}
+            activeRunId={activeRun.id}
+            trackingState={trackingState}
+            pendingAction={pendingAction}
+            onSelectionChange={onSelectionChange}
+            onStartRun={onStartRun}
+            onArrive={onArrive}
+            onDeliver={onDeliver}
+            onPickupError={onPickupError}
+            onPickupAcknowledged={onPickupAcknowledged}
+        />
+    );
+}
+
+function ActiveDriverDashboardWithPickupSync({
+    dashboard,
+    activeRunId,
+    trackingState,
+    pendingAction,
+    onSelectionChange,
+    onStartRun,
+    onArrive,
+    onDeliver,
+    onPickupError,
+    onPickupAcknowledged,
+}: {
+    dashboard: DriverDeliveryDashboard;
+    activeRunId: string;
+    trackingState: ReturnType<typeof useDriverTracking>;
+    pendingAction: string | null;
+    onSelectionChange: () => void;
+    onStartRun: (deliveryRequestIds: string[]) => void;
+    onArrive: (runId: string, stopId: number) => void;
+    onDeliver: (runId: string, stopId: number, notes?: string) => void;
+    onPickupError: (error: unknown) => void;
+    onPickupAcknowledged: () => void | Promise<void>;
+}) {
+    const pickupSync = usePickupManifestSync({
+        userId: dashboard.user.id,
+        runId: activeRunId,
+        onAcknowledged: onPickupAcknowledged,
+    });
+    const report = async (action: Promise<unknown>) => {
+        try {
+            await action;
+        } catch (error) {
+            onPickupError(error);
+        }
+    };
+
+    return (
+        <DriverDashboard
+            dashboard={dashboard}
+            trackingState={trackingState}
+            pendingAction={pendingAction}
+            onSelectionChange={onSelectionChange}
+            onStartRun={onStartRun}
+            onArrive={onArrive}
+            onDeliver={onDeliver}
+            pickupQueue={pickupSync.snapshot}
+            onPickupScan={(pickupNodeId, scanValue) =>
+                report(pickupSync.enqueueScan(pickupNodeId, scanValue))
+            }
+            onPickupItemState={(pickupNodeId, manifestId, stopId, outcome) =>
+                report(
+                    pickupSync.enqueueItemOutcome({
+                        pickupNodeId,
+                        manifestId,
+                        stopId,
+                        outcome,
+                    }),
+                )
+            }
+            onConfirmPickupManifest={(pickupNodeId, manifestId) =>
+                report(pickupSync.enqueueConfirm(pickupNodeId, manifestId))
+            }
+            onRetryPickupSync={(operationId) =>
+                report(pickupSync.retryEntry(operationId))
+            }
+            onDiscardPickupSync={(operationId) =>
+                report(pickupSync.discardEntry(operationId))
+            }
+        />
+    );
+}
+
 export function DeliveryDashboard() {
     const [pendingAction, setPendingAction] = useState<string | null>(null);
     const [actionError, setActionError] = useState<string | null>(null);
@@ -128,6 +317,26 @@ export function DeliveryDashboard() {
             ? (query.data.activeRun?.id ?? null)
             : null;
     const trackingState = useDriverTracking(activeRunId);
+    const driverWithoutActiveRun =
+        query.data?.kind === 'driver' && !query.data.activeRun
+            ? query.data.user.id
+            : null;
+    const currentDriverUserId =
+        query.data?.kind === 'driver' ? query.data.user.id : null;
+    const previousDriverUserIdRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!driverWithoutActiveRun) return;
+        void clearStoredPickupQueues(driverWithoutActiveRun);
+    }, [driverWithoutActiveRun]);
+
+    useEffect(() => {
+        const previousUserId = previousDriverUserIdRef.current;
+        if (previousUserId && previousUserId !== currentDriverUserId) {
+            void clearStoredPickupQueues(previousUserId);
+        }
+        previousDriverUserIdRef.current = currentDriverUserId;
+    }, [currentDriverUserId]);
 
     const perform = async (key: string, path: string, body?: object) => {
         setPendingAction(key);
@@ -257,7 +466,7 @@ export function DeliveryDashboard() {
                 </div>
             ) : null}
             {dashboard.kind === 'driver' ? (
-                <DriverDashboard
+                <DriverDashboardWithPickupSync
                     dashboard={dashboard}
                     trackingState={trackingState}
                     pendingAction={pendingAction}
@@ -278,6 +487,16 @@ export function DeliveryDashboard() {
                             { notes },
                         )
                     }
+                    onPickupError={(error) =>
+                        setActionError(
+                            error instanceof Error
+                                ? error.message
+                                : 'Promjenu preuzimanja nije moguće spremiti.',
+                        )
+                    }
+                    onPickupAcknowledged={async () => {
+                        await query.refetch();
+                    }}
                 />
             ) : (
                 <CustomerDashboard dashboard={dashboard} />

--- a/apps/delivery/components/DeliveryPickupCard.tsx
+++ b/apps/delivery/components/DeliveryPickupCard.tsx
@@ -1,0 +1,623 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Card, CardContent } from '@gredice/ui/Card';
+import { Chip } from '@gredice/ui/Chip';
+import {
+    Approved,
+    Calendar,
+    Check,
+    Leaf,
+    MapPin,
+    Navigate,
+    Reset,
+    Timer,
+    Warning,
+} from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import { useRef, useState } from 'react';
+import type {
+    DeliveryPickupManifestItemState,
+    DeliveryPickupManifestSummary,
+    DeliveryPickupStepSummary,
+} from '../lib/deliveryDashboardTypes';
+import {
+    formatDeliveryDateTime,
+    formatDeliveryTime,
+    formatDistance,
+    formatTravelDuration,
+} from '../lib/deliveryFormatting';
+import {
+    HarvestTraceScanner,
+    type PickupManifestScanResult,
+} from './HarvestTraceScanner';
+
+export type PickupManifestSyncSummary = {
+    state: 'idle' | 'queued' | 'sending' | 'failed' | 'conflicted';
+    pendingCount: number;
+    durability: 'durable' | 'memory';
+    coordination: 'coordinated' | 'best-effort';
+    blockingOperationId: string | null;
+    message?: string | null;
+};
+
+function itemStateLabel(state: DeliveryPickupManifestItemState) {
+    switch (state) {
+        case 'scanned':
+            return 'Skenirano';
+        case 'missing-label':
+            return 'Bez etikete';
+        case 'not-ready':
+            return 'Nije spremno';
+        case 'ready':
+            return 'Spremno';
+    }
+}
+
+function itemStateColor(
+    state: DeliveryPickupManifestItemState,
+): 'success' | 'warning' | 'neutral' {
+    if (state === 'scanned' || state === 'missing-label') return 'success';
+    if (state === 'not-ready') return 'warning';
+    return 'neutral';
+}
+
+function syncAlert(sync: PickupManifestSyncSummary) {
+    switch (sync.state) {
+        case 'queued':
+            return {
+                color: 'info' as const,
+                message: `Spremljeno na uređaju · ${sync.pendingCount} ${sync.pendingCount === 1 ? 'promjena čeka' : 'promjene čekaju'} sinkronizaciju.`,
+            };
+        case 'sending':
+            return {
+                color: 'info' as const,
+                message: `Sinkronizacija ${sync.pendingCount} ${sync.pendingCount === 1 ? 'promjene' : 'promjena'}…`,
+            };
+        case 'failed':
+            return {
+                color: 'warning' as const,
+                message:
+                    sync.message ??
+                    'Promjena je spremljena na uređaju i pokušat će se ponovno poslati.',
+            };
+        case 'conflicted':
+            return {
+                color: 'danger' as const,
+                message:
+                    sync.message ??
+                    'Stanje preuzimanja promijenilo se na poslužitelju. Osvježi popis i provjeri označene urode.',
+            };
+        case 'idle':
+            return null;
+    }
+}
+
+export function DeliveryPickupCard({
+    pickup,
+    actionState,
+    pendingAction,
+    sync,
+    onScan,
+    onSetItemState,
+    onResolveRemaining,
+    onConfirmManifest,
+    onRetrySync,
+    onDiscardSync,
+}: {
+    pickup: DeliveryPickupStepSummary;
+    actionState: 'locked' | 'current' | 'completed';
+    pendingAction: string | null;
+    sync: PickupManifestSyncSummary;
+    onScan: (value: string) => PickupManifestScanResult;
+    onSetItemState: (
+        pickupNodeId: string,
+        manifestId: string,
+        stopId: number,
+        state: 'missing-label' | 'not-ready' | 'ready',
+    ) => void;
+    onResolveRemaining: (
+        pickupNodeId: string,
+        manifest: DeliveryPickupManifestSummary,
+    ) => void;
+    onConfirmManifest: (
+        pickupNodeId: string,
+        manifestId: string,
+    ) => void | Promise<void>;
+    onRetrySync: (operationId: string) => void | Promise<void>;
+    onDiscardSync: (operationId: string) => void | Promise<void>;
+}) {
+    const navigationUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(pickup.address)}`;
+    const current = actionState === 'current';
+    const completed = actionState === 'completed';
+    const syncMessage = syncAlert(sync);
+    const collectedCount = pickup.scannedCount + pickup.missingLabelCount;
+    const scannableTraceCount = new Set(
+        pickup.manifests.flatMap((manifest) =>
+            manifest.items.flatMap((item) =>
+                item.tracePath ? [item.tracePath] : [],
+            ),
+        ),
+    ).size;
+    const pickupMutationsDisabled =
+        Boolean(pendingAction) || sync.state === 'conflicted';
+    const confirmingManifestIdsRef = useRef(new Set<string>());
+    const [confirmingManifestIds, setConfirmingManifestIds] = useState(
+        () => new Set<string>(),
+    );
+
+    async function confirmManifest(manifestId: string) {
+        if (
+            pickupMutationsDisabled ||
+            sync.pendingCount > 0 ||
+            confirmingManifestIdsRef.current.has(manifestId)
+        ) {
+            return;
+        }
+
+        confirmingManifestIdsRef.current.add(manifestId);
+        setConfirmingManifestIds((current) => new Set(current).add(manifestId));
+        try {
+            await onConfirmManifest(pickup.id, manifestId);
+        } finally {
+            confirmingManifestIdsRef.current.delete(manifestId);
+            setConfirmingManifestIds((current) => {
+                const next = new Set(current);
+                next.delete(manifestId);
+                return next;
+            });
+        }
+    }
+
+    return (
+        <Card
+            className={
+                current
+                    ? 'border-primary shadow-md ring-1 ring-primary/20'
+                    : undefined
+            }
+        >
+            <CardContent noHeader className="space-y-4 p-4">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-amber-500 text-sm font-bold text-white">
+                            P{pickup.sequence}
+                        </div>
+                        <div className="min-w-0">
+                            <Typography
+                                level="body1"
+                                semiBold
+                                className="truncate"
+                            >
+                                {current ? 'Sljedeće preuzimanje' : pickup.name}
+                            </Typography>
+                            <Typography
+                                level="body3"
+                                className="mt-0.5 text-muted-foreground"
+                            >
+                                {current ? pickup.name : 'Lokacija preuzimanja'}
+                            </Typography>
+                        </div>
+                    </div>
+                    <Chip
+                        color={
+                            completed
+                                ? 'success'
+                                : current
+                                  ? 'warning'
+                                  : 'neutral'
+                        }
+                        size="sm"
+                    >
+                        {completed
+                            ? 'Preuzeto'
+                            : current
+                              ? 'Na redu'
+                              : 'Zaključano'}
+                    </Chip>
+                </div>
+
+                <div className="grid grid-cols-3 gap-2 rounded-lg bg-muted/70 p-3 text-center">
+                    <div>
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Dolazak
+                        </Typography>
+                        <Typography level="body2" semiBold>
+                            {formatDeliveryTime(pickup.estimatedArrivalAt)}
+                        </Typography>
+                    </div>
+                    <div className="border-x">
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Vožnja
+                        </Typography>
+                        <Typography level="body2" semiBold>
+                            {formatTravelDuration(
+                                pickup.estimatedTravelSeconds,
+                            )}
+                        </Typography>
+                    </div>
+                    <div>
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Udaljenost
+                        </Typography>
+                        <Typography level="body2" semiBold>
+                            {formatDistance(pickup.estimatedDistanceMeters)}
+                        </Typography>
+                    </div>
+                </div>
+
+                <div className="space-y-2 text-sm">
+                    <div className="flex items-start gap-2">
+                        <MapPin className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                        <span>{pickup.address}</span>
+                    </div>
+                    {pickup.serviceDurationSeconds ? (
+                        <div className="flex items-start gap-2">
+                            <Timer className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                            <span>
+                                Planirano preuzimanje:{' '}
+                                {formatTravelDuration(
+                                    pickup.serviceDurationSeconds,
+                                )}
+                            </span>
+                        </div>
+                    ) : null}
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                    <Chip color="success" size="sm">
+                        Skenirano {pickup.scannedCount}
+                    </Chip>
+                    <Chip color="info" size="sm">
+                        Bez etikete {pickup.missingLabelCount}
+                    </Chip>
+                    <Chip
+                        color={pickup.notReadyCount ? 'warning' : 'neutral'}
+                        size="sm"
+                    >
+                        Nije spremno {pickup.notReadyCount}
+                    </Chip>
+                    <Chip color="neutral" size="sm">
+                        Preostalo {pickup.remainingCount}
+                    </Chip>
+                </div>
+
+                {syncMessage ? (
+                    <Alert
+                        color={syncMessage.color}
+                        startDecorator={<Reset className="size-5" />}
+                    >
+                        <div className="space-y-2">
+                            <span className="block">{syncMessage.message}</span>
+                            {(sync.state === 'failed' ||
+                                sync.state === 'conflicted') &&
+                            sync.blockingOperationId ? (
+                                <div className="flex flex-wrap gap-2">
+                                    {sync.state === 'failed' ? (
+                                        <Button
+                                            size="sm"
+                                            variant="outlined"
+                                            onClick={() =>
+                                                void onRetrySync(
+                                                    sync.blockingOperationId ??
+                                                        '',
+                                                )
+                                            }
+                                        >
+                                            Pokušaj ponovno
+                                        </Button>
+                                    ) : null}
+                                    <Button
+                                        size="sm"
+                                        variant="plain"
+                                        onClick={() =>
+                                            void onDiscardSync(
+                                                sync.blockingOperationId ?? '',
+                                            )
+                                        }
+                                    >
+                                        Odbaci promjenu i osvježi
+                                    </Button>
+                                </div>
+                            ) : null}
+                        </div>
+                    </Alert>
+                ) : null}
+
+                {sync.durability === 'memory' && current ? (
+                    <Alert
+                        color="warning"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        Preglednik ne dopušta trajnu lokalnu pohranu. Ostani na
+                        ovoj stranici dok se promjene ne sinkroniziraju.
+                    </Alert>
+                ) : null}
+
+                {sync.coordination === 'best-effort' && current ? (
+                    <Alert
+                        color="info"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        Promjene su spremljene na uređaju, ali ovaj preglednik
+                        ne može sigurno uskladiti istodobni rad u više kartica.
+                        Za ovu rutu koristi samo ovu karticu.
+                    </Alert>
+                ) : null}
+
+                {current ? (
+                    <div className="flex flex-wrap gap-2">
+                        <Button
+                            href={navigationUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            variant="outlined"
+                            startDecorator={<Navigate className="size-4" />}
+                        >
+                            Navigacija
+                        </Button>
+                        {scannableTraceCount > 0 ? (
+                            <HarvestTraceScanner
+                                variant="manifest"
+                                availableTraceCount={pickup.expectedCount}
+                                completedTraceCount={collectedCount}
+                                disabled={pickupMutationsDisabled}
+                                onScan={onScan}
+                            />
+                        ) : null}
+                    </div>
+                ) : null}
+
+                <div className="space-y-3">
+                    {pickup.manifests.map((manifest) => {
+                        const unresolvedReady = manifest.items.filter(
+                            (item) => item.state === 'ready',
+                        );
+                        const confirmable =
+                            manifest.state === 'pending' &&
+                            manifest.remainingCount === 0 &&
+                            manifest.notReadyCount === 0;
+
+                        return (
+                            <section
+                                key={manifest.id}
+                                className="space-y-3 rounded-lg border p-3"
+                                aria-label={`Manifest ${formatDeliveryDateTime(manifest.startAt)}`}
+                            >
+                                <div className="flex flex-wrap items-start justify-between gap-2">
+                                    <div>
+                                        <Typography level="body2" semiBold>
+                                            Manifest termina
+                                        </Typography>
+                                        <Typography
+                                            level="body3"
+                                            className="mt-0.5 flex items-center gap-1 text-muted-foreground"
+                                        >
+                                            <Calendar className="size-4" />
+                                            {formatDeliveryDateTime(
+                                                manifest.startAt,
+                                            )}{' '}
+                                            –{' '}
+                                            {formatDeliveryTime(manifest.endAt)}
+                                        </Typography>
+                                    </div>
+                                    <Chip
+                                        color={
+                                            manifest.state === 'confirmed'
+                                                ? 'success'
+                                                : 'neutral'
+                                        }
+                                        size="sm"
+                                    >
+                                        {manifest.state === 'confirmed'
+                                            ? 'Potvrđen'
+                                            : `${manifest.scannedCount + manifest.missingLabelCount}/${manifest.expectedCount}`}
+                                    </Chip>
+                                </div>
+
+                                <ul
+                                    className="space-y-2"
+                                    aria-label="Urodi u manifestu"
+                                >
+                                    {manifest.items.map((item) => (
+                                        <li
+                                            key={item.id}
+                                            className="flex flex-col gap-2 rounded-md bg-muted/70 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+                                        >
+                                            <div className="min-w-0">
+                                                <Typography
+                                                    level="body3"
+                                                    semiBold
+                                                    className="flex items-center gap-2 truncate"
+                                                >
+                                                    <Leaf className="size-4 shrink-0" />
+                                                    {item.harvest.plantName}
+                                                </Typography>
+                                                <Typography
+                                                    level="body3"
+                                                    className="truncate text-muted-foreground"
+                                                >
+                                                    {[
+                                                        item.harvest
+                                                            .raisedBedName,
+                                                        item.harvest.fieldName,
+                                                    ]
+                                                        .filter(Boolean)
+                                                        .join(' · ') ||
+                                                        'Urod za dostavu'}
+                                                </Typography>
+                                            </div>
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <Chip
+                                                    color={itemStateColor(
+                                                        item.state,
+                                                    )}
+                                                    size="sm"
+                                                >
+                                                    {itemStateLabel(item.state)}
+                                                </Chip>
+                                                {current &&
+                                                manifest.state === 'pending' &&
+                                                item.state === 'ready' ? (
+                                                    <>
+                                                        <Button
+                                                            size="sm"
+                                                            variant="plain"
+                                                            disabled={
+                                                                pickupMutationsDisabled
+                                                            }
+                                                            onClick={() =>
+                                                                onSetItemState(
+                                                                    pickup.id,
+                                                                    manifest.id,
+                                                                    item.stopId,
+                                                                    'missing-label',
+                                                                )
+                                                            }
+                                                        >
+                                                            Preuzeto bez QR
+                                                            etikete
+                                                        </Button>
+                                                        <Button
+                                                            size="sm"
+                                                            color="warning"
+                                                            variant="plain"
+                                                            disabled={
+                                                                pickupMutationsDisabled
+                                                            }
+                                                            onClick={() =>
+                                                                onSetItemState(
+                                                                    pickup.id,
+                                                                    manifest.id,
+                                                                    item.stopId,
+                                                                    'not-ready',
+                                                                )
+                                                            }
+                                                        >
+                                                            Nije spremno
+                                                        </Button>
+                                                    </>
+                                                ) : null}
+                                                {current &&
+                                                manifest.state === 'pending' &&
+                                                item.state === 'not-ready' ? (
+                                                    <Button
+                                                        size="sm"
+                                                        variant="plain"
+                                                        disabled={
+                                                            pickupMutationsDisabled
+                                                        }
+                                                        onClick={() =>
+                                                            onSetItemState(
+                                                                pickup.id,
+                                                                manifest.id,
+                                                                item.stopId,
+                                                                'ready',
+                                                            )
+                                                        }
+                                                    >
+                                                        Ponovno spremno
+                                                    </Button>
+                                                ) : null}
+                                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+
+                                {current && manifest.state === 'pending' ? (
+                                    <div className="space-y-2 border-t pt-3">
+                                        {unresolvedReady.length > 0 ? (
+                                            <Button
+                                                variant="outlined"
+                                                disabled={
+                                                    pickupMutationsDisabled
+                                                }
+                                                onClick={() =>
+                                                    onResolveRemaining(
+                                                        pickup.id,
+                                                        manifest,
+                                                    )
+                                                }
+                                            >
+                                                Preuzmi preostalih{' '}
+                                                {unresolvedReady.length} bez
+                                                etikete
+                                            </Button>
+                                        ) : null}
+                                        {manifest.notReadyCount > 0 ? (
+                                            <Alert
+                                                color="warning"
+                                                startDecorator={
+                                                    <Warning className="size-5" />
+                                                }
+                                            >
+                                                Jedan ili više uroda nisu
+                                                preuzeti. Njihove dostave ostaju
+                                                zaključane.
+                                            </Alert>
+                                        ) : null}
+                                        <Button
+                                            color="success"
+                                            loading={confirmingManifestIds.has(
+                                                manifest.id,
+                                            )}
+                                            disabled={
+                                                !confirmable ||
+                                                pickupMutationsDisabled ||
+                                                sync.pendingCount > 0 ||
+                                                confirmingManifestIds.has(
+                                                    manifest.id,
+                                                )
+                                            }
+                                            onClick={() =>
+                                                void confirmManifest(
+                                                    manifest.id,
+                                                )
+                                            }
+                                            startDecorator={
+                                                <Approved className="size-4" />
+                                            }
+                                        >
+                                            Potvrdi preuzimanje i nastavi
+                                        </Button>
+                                        {manifest.remainingCount > 0 ? (
+                                            <Typography
+                                                level="body3"
+                                                className="text-muted-foreground"
+                                            >
+                                                Prije potvrde skeniraj urode ili
+                                                označi one bez QR etikete.
+                                            </Typography>
+                                        ) : null}
+                                    </div>
+                                ) : null}
+
+                                {manifest.confirmedAt ? (
+                                    <Typography
+                                        level="body3"
+                                        className="flex items-center gap-2 text-muted-foreground"
+                                    >
+                                        <Check className="size-4" /> Potvrđeno{' '}
+                                        {formatDeliveryDateTime(
+                                            manifest.confirmedAt,
+                                        )}
+                                    </Typography>
+                                ) : null}
+                            </section>
+                        );
+                    })}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/apps/delivery/components/DeliveryStopCard.tsx
+++ b/apps/delivery/components/DeliveryStopCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Alert } from '@gredice/ui/Alert';
 import { Button } from '@gredice/ui/Button';
 import { Card, CardContent } from '@gredice/ui/Card';
 import { Chip } from '@gredice/ui/Chip';
@@ -56,6 +57,10 @@ export function DeliveryStopCard({
     const navigationUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(stop.address)}`;
     const driverMode = mode === 'driver';
     const delivered = stop.statusLabel === 'Dostavljeno';
+    const driverActionState =
+        stop.actionState ??
+        (delivered ? 'completed' : stop.isCurrent ? 'current' : 'upcoming');
+    const customerActionAvailable = driverActionState === 'current';
     const estimatedOutsideWindow = Boolean(
         stop.estimatedArrivalAt &&
             stop.slotEndAt &&
@@ -151,23 +156,110 @@ export function DeliveryStopCard({
                     </div>
                 ) : null}
 
-                <div className="space-y-2 text-sm">
-                    {driverMode && stop.slotStartAt && stop.slotEndAt ? (
-                        <div className="flex items-start gap-2">
-                            <Calendar className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                            <span>
-                                Termin:{' '}
-                                {formatDeliveryDateTime(stop.slotStartAt)} –{' '}
-                                {formatDeliveryTime(stop.slotEndAt)}
-                            </span>
-                        </div>
-                    ) : null}
-                    {driverMode ? (
+                {driverMode ? (
+                    <div className="space-y-2 text-sm">
+                        {stop.slotStartAt && stop.slotEndAt ? (
+                            <div className="flex items-start gap-2">
+                                <Calendar className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                                <span>
+                                    Termin:{' '}
+                                    {formatDeliveryDateTime(stop.slotStartAt)} –{' '}
+                                    {formatDeliveryTime(stop.slotEndAt)}
+                                </span>
+                            </div>
+                        ) : null}
                         <div className="flex items-start gap-2">
                             <MapPin className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
                             <span>{stop.address}</span>
                         </div>
-                    ) : null}
+                        {estimatedOutsideWindow && !delivered ? (
+                            <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                                <Warning className="mt-0.5 size-4 shrink-0" />
+                                <span>
+                                    Trenutačna procjena dolaska je nakon
+                                    završetka termina. Obavijesti korisnika o
+                                    kašnjenju.
+                                </span>
+                            </div>
+                        ) : null}
+                    </div>
+                ) : null}
+
+                {driverMode && customerActionAvailable && !delivered ? (
+                    <div className="space-y-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
+                        <Button
+                            href={navigationUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            variant="outlined"
+                            startDecorator={<Navigate className="size-4" />}
+                        >
+                            Navigacija
+                        </Button>
+                        {stop.stopState === 'arrived' ? (
+                            <DeliveryHarvestVerification
+                                deliveries={stop.deliveries}
+                                disabled={Boolean(pendingAction)}
+                            />
+                        ) : (
+                            <Typography
+                                level="body3"
+                                className="rounded-md bg-muted/70 p-3 text-muted-foreground"
+                            >
+                                Nakon potvrde dolaska možeš opcionalno skenirati
+                                QR etikete i provjeriti urode za ovu stanicu.
+                            </Typography>
+                        )}
+                        <label
+                            className="block text-sm font-medium"
+                            htmlFor={`notes-${stop.id}`}
+                        >
+                            {stop.deliveryCount > 1
+                                ? 'Napomena za skupnu dostavu'
+                                : 'Napomena o dostavi'}
+                        </label>
+                        <textarea
+                            id={`notes-${stop.id}`}
+                            value={notes}
+                            onChange={(event) => setNotes(event.target.value)}
+                            rows={2}
+                            maxLength={1_000}
+                            placeholder="Npr. predano članu kućanstva"
+                            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+                        />
+                        <div className="grid gap-2 sm:grid-cols-2">
+                            <Button
+                                variant="outlined"
+                                loading={pendingAction === 'arrive'}
+                                disabled={
+                                    Boolean(pendingAction) ||
+                                    stop.stopState === 'arrived'
+                                }
+                                onClick={onArrive}
+                                startDecorator={
+                                    <MyLocation className="size-4" />
+                                }
+                            >
+                                {stop.stopState === 'arrived'
+                                    ? 'Dolazak potvrđen'
+                                    : 'Stigao sam'}
+                            </Button>
+                            <Button
+                                color="success"
+                                loading={pendingAction === 'deliver'}
+                                disabled={Boolean(pendingAction)}
+                                onClick={() => onDeliver?.(notes || undefined)}
+                                startDecorator={<Approved className="size-4" />}
+                            >
+                                {stop.deliveryCount > 1
+                                    ? `Dostavi ${stop.deliveryCount} uroda · dalje`
+                                    : 'Dostavljeno · dalje'}
+                            </Button>
+                        </div>
+                    </div>
+                ) : null}
+
+                <div className="space-y-2 text-sm">
                     {driverMode ? (
                         <div className="space-y-2">
                             {stop.deliveries.map((delivery) => (
@@ -275,7 +367,7 @@ export function DeliveryStopCard({
                             ) : null}
                         </>
                     )}
-                    {estimatedOutsideWindow && !delivered ? (
+                    {!driverMode && estimatedOutsideWindow && !delivered ? (
                         <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
                             <Warning className="mt-0.5 size-4 shrink-0" />
                             <span>
@@ -286,19 +378,8 @@ export function DeliveryStopCard({
                     ) : null}
                 </div>
 
-                <div className="flex flex-wrap gap-2">
-                    {driverMode ? (
-                        <Button
-                            href={navigationUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            variant="outlined"
-                            startDecorator={<Navigate className="size-4" />}
-                        >
-                            Navigacija
-                        </Button>
-                    ) : null}
-                    {!driverMode && stop.harvest.tracePath ? (
+                {!driverMode && stop.harvest.tracePath ? (
+                    <div className="flex flex-wrap gap-2">
                         <Button
                             href={`https://www.gredice.com${stop.harvest.tracePath}`}
                             target="_blank"
@@ -308,68 +389,24 @@ export function DeliveryStopCard({
                         >
                             Trag uroda
                         </Button>
-                    ) : null}
-                </div>
-
-                {driverMode && stop.isCurrent && !delivered ? (
-                    <div className="space-y-3 border-t pt-4">
-                        {stop.stopState === 'arrived' ? (
-                            <DeliveryHarvestVerification
-                                deliveries={stop.deliveries}
-                                disabled={Boolean(pendingAction)}
-                            />
-                        ) : (
-                            <Typography
-                                level="body3"
-                                className="rounded-md bg-muted/70 p-3 text-muted-foreground"
-                            >
-                                Nakon potvrde dolaska možeš opcionalno skenirati
-                                QR etikete i provjeriti urode za ovu stanicu.
-                            </Typography>
-                        )}
-                        <label
-                            className="block text-sm font-medium"
-                            htmlFor={`notes-${stop.id}`}
-                        >
-                            {stop.deliveryCount > 1
-                                ? 'Napomena za skupnu dostavu'
-                                : 'Napomena o dostavi'}
-                        </label>
-                        <textarea
-                            id={`notes-${stop.id}`}
-                            value={notes}
-                            onChange={(event) => setNotes(event.target.value)}
-                            rows={2}
-                            maxLength={1_000}
-                            placeholder="Npr. predano članu kućanstva"
-                            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
-                        />
-                        <div className="grid gap-2 sm:grid-cols-2">
-                            <Button
-                                variant="outlined"
-                                loading={pendingAction === 'arrive'}
-                                disabled={stop.stopState === 'arrived'}
-                                onClick={onArrive}
-                                startDecorator={
-                                    <MyLocation className="size-4" />
-                                }
-                            >
-                                {stop.stopState === 'arrived'
-                                    ? 'Dolazak potvrđen'
-                                    : 'Stigao sam'}
-                            </Button>
-                            <Button
-                                color="success"
-                                loading={pendingAction === 'deliver'}
-                                onClick={() => onDeliver?.(notes || undefined)}
-                                startDecorator={<Approved className="size-4" />}
-                            >
-                                {stop.deliveryCount > 1
-                                    ? `Dostavi ${stop.deliveryCount} uroda · dalje`
-                                    : 'Dostavljeno · dalje'}
-                            </Button>
-                        </div>
                     </div>
+                ) : null}
+
+                {driverMode &&
+                (driverActionState === 'locked' ||
+                    driverActionState === 'upcoming') &&
+                !delivered ? (
+                    <Alert
+                        color={
+                            driverActionState === 'locked' ? 'warning' : 'info'
+                        }
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        {stop.lockedReason ??
+                            (driverActionState === 'locked'
+                                ? 'Dostava će se otključati nakon potvrde svih uroda za ovu stanicu.'
+                                : 'Ova je stanica spremna i otključat će se kada dođe na red rute.')}
+                    </Alert>
                 ) : null}
 
                 {stop.deliveredAt ? (

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -19,6 +19,8 @@ import { useRef, useState } from 'react';
 import type { DriverTrackingState } from '../hooks/useDriverTracking';
 import type {
     ActiveDeliveryRunSummary,
+    DeliveryPickupStepSummary,
+    DeliveryRouteOrderSummary,
     DriverDeliveryDashboard,
 } from '../lib/deliveryDashboardTypes';
 import {
@@ -32,17 +34,28 @@ import {
     inspectDeliveryRouteSelection,
 } from '../lib/deliveryRouteSelection';
 import { groupByDeliveryStop } from '../lib/deliveryStopGrouping';
-import { selectDeliveryStopFromHarvestTrace } from '../lib/harvestTraceScan';
+import {
+    normalizeHarvestTraceScanValue,
+    selectDeliveryStopFromHarvestTrace,
+} from '../lib/harvestTraceScan';
+import type {
+    PickupManifestQueueEntry,
+    PickupManifestQueueSnapshot,
+} from '../lib/pickupManifestQueue';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
 import { DeliveryBatchCard } from './DeliveryBatchCard';
 import { DeliveryMap } from './DeliveryMap';
+import {
+    DeliveryPickupCard,
+    type PickupManifestSyncSummary,
+} from './DeliveryPickupCard';
 import { DeliveryStopCard } from './DeliveryStopCard';
 import { HarvestTraceScanner } from './HarvestTraceScanner';
 
 function trackingMessage(state: DriverTrackingState) {
     switch (state) {
         case 'active':
-            return 'GPS praćenje je aktivno. Korisnici vide tvoju zadnju lokaciju dok je ruta otvorena.';
+            return 'GPS praćenje je aktivno. Lokaciju vidi samo korisnik trenutačne dostavne stanice kada je ona na redu.';
         case 'requesting':
             return 'Čeka se dopuštenje za GPS lokaciju…';
         case 'denied':
@@ -69,6 +82,172 @@ function routeEstimateSourceLabel(
     }
 }
 
+function queuedPickup(
+    pickup: DeliveryPickupStepSummary,
+    entries: readonly PickupManifestQueueEntry[],
+) {
+    const applicableEntries = entries.filter(
+        (entry) =>
+            entry.command.pickupNodeId === pickup.id &&
+            entry.state !== 'conflicted',
+    );
+    if (applicableEntries.length === 0) return pickup;
+
+    const manifests = pickup.manifests.map((manifest) => ({
+        ...manifest,
+        items: manifest.items.map((item) => ({ ...item })),
+    }));
+    for (const entry of applicableEntries) {
+        const command = entry.command;
+        if (command.kind === 'scan') {
+            for (const manifest of manifests) {
+                for (const item of manifest.items) {
+                    if (
+                        item.tracePath === command.tracePath &&
+                        item.state !== 'scanned' &&
+                        item.state !== 'missing-label'
+                    ) {
+                        item.state = 'scanned';
+                    }
+                }
+            }
+            continue;
+        }
+        if (command.kind === 'manual-outcome') {
+            const manifest = manifests.find(
+                (candidate) => candidate.id === command.manifestId,
+            );
+            const item = manifest?.items.find(
+                (candidate) => candidate.stopId === command.stopId,
+            );
+            if (item) item.state = command.outcome;
+        }
+    }
+
+    const summarizedManifests = manifests.map((manifest) => {
+        const scannedCount = manifest.items.filter(
+            (item) => item.state === 'scanned',
+        ).length;
+        const missingLabelCount = manifest.items.filter(
+            (item) => item.state === 'missing-label',
+        ).length;
+        const notReadyCount = manifest.items.filter(
+            (item) => item.state === 'not-ready',
+        ).length;
+        return {
+            ...manifest,
+            scannedCount,
+            missingLabelCount,
+            notReadyCount,
+            remainingCount:
+                manifest.expectedCount - scannedCount - missingLabelCount,
+        };
+    });
+    return {
+        ...pickup,
+        manifests: summarizedManifests,
+        scannedCount: summarizedManifests.reduce(
+            (count, manifest) => count + manifest.scannedCount,
+            0,
+        ),
+        missingLabelCount: summarizedManifests.reduce(
+            (count, manifest) => count + manifest.missingLabelCount,
+            0,
+        ),
+        notReadyCount: summarizedManifests.reduce(
+            (count, manifest) => count + manifest.notReadyCount,
+            0,
+        ),
+        remainingCount: summarizedManifests.reduce(
+            (count, manifest) => count + manifest.remainingCount,
+            0,
+        ),
+    };
+}
+
+function pickupSyncSummary(
+    pickupNodeId: string,
+    snapshot: PickupManifestQueueSnapshot | null,
+): PickupManifestSyncSummary {
+    const entries =
+        snapshot?.entries.filter(
+            (entry) => entry.command.pickupNodeId === pickupNodeId,
+        ) ?? [];
+    const coordination = snapshot?.coordination ?? 'coordinated';
+    const pendingEntries = entries.filter((entry) => entry.state !== 'synced');
+    const conflicted = pendingEntries.find(
+        (entry) => entry.state === 'conflicted',
+    );
+    if (conflicted) {
+        return {
+            state: 'conflicted',
+            pendingCount: pendingEntries.length,
+            durability: snapshot?.durability ?? 'durable',
+            coordination,
+            blockingOperationId: conflicted.command.operationId,
+            message: pickupQueueErrorMessage(conflicted.errorCode, false),
+        };
+    }
+    const failed = pendingEntries.find((entry) => entry.state === 'failed');
+    if (failed) {
+        return {
+            state: 'failed',
+            pendingCount: pendingEntries.length,
+            durability: snapshot?.durability ?? 'durable',
+            coordination,
+            blockingOperationId: failed.command.operationId,
+            message: pickupQueueErrorMessage(failed.errorCode, true),
+        };
+    }
+    if (pendingEntries.some((entry) => entry.state === 'sending')) {
+        return {
+            state: 'sending',
+            pendingCount: pendingEntries.length,
+            durability: snapshot?.durability ?? 'durable',
+            coordination,
+            blockingOperationId: null,
+        };
+    }
+    if (pendingEntries.length > 0) {
+        return {
+            state: 'queued',
+            pendingCount: pendingEntries.length,
+            durability: snapshot?.durability ?? 'durable',
+            coordination,
+            blockingOperationId: null,
+        };
+    }
+    return {
+        state: 'idle',
+        pendingCount: 0,
+        durability: snapshot?.durability ?? 'durable',
+        coordination,
+        blockingOperationId: null,
+    };
+}
+
+function pickupQueueErrorMessage(code: string | undefined, retryable: boolean) {
+    switch (code) {
+        case 'pickup-trace-not-found':
+            return 'Očitani QR nije pronađen na ovom manifestu. Provjeri etiketu ili odbaci očitanje.';
+        case 'pickup-trace-ambiguous':
+            return 'Očitani QR pripada različitim skupnim stanicama. Provjeri urode ručno i odbaci očitanje.';
+        case 'pickup-operation-conflict':
+            return 'Promjena je već poslana s drugim podacima. Odbaci lokalnu kopiju i osvježi manifest.';
+        case 'pickup-not-current':
+        case 'route-order':
+        case 'pickup-dependency-pending':
+            return 'Ruta se promijenila. Odbaci lokalnu promjenu i učitaj trenutačni korak.';
+        case 'offline':
+        case 'transport-error':
+            return 'Promjena je spremljena na uređaju. Provjeri vezu i pokušaj ponovno.';
+        default:
+            return retryable
+                ? 'Promjena čeka provjeru. Pokušaj ponovno nakon provjere veze.'
+                : 'Promjenu nije moguće ponovno poslati. Odbaci je i provjeri trenutačni manifest.';
+    }
+}
+
 export function DriverDashboard({
     dashboard,
     trackingState,
@@ -77,6 +256,12 @@ export function DriverDashboard({
     onStartRun,
     onArrive,
     onDeliver,
+    pickupQueue,
+    onPickupScan,
+    onPickupItemState,
+    onConfirmPickupManifest,
+    onRetryPickupSync,
+    onDiscardPickupSync,
 }: {
     dashboard: DriverDeliveryDashboard;
     trackingState: DriverTrackingState;
@@ -85,6 +270,20 @@ export function DriverDashboard({
     onStartRun: (deliveryRequestIds: string[]) => void;
     onArrive: (runId: string, stopId: number) => void;
     onDeliver: (runId: string, stopId: number, notes?: string) => void;
+    pickupQueue: PickupManifestQueueSnapshot | null;
+    onPickupScan: (pickupNodeId: string, scanValue: string) => void;
+    onPickupItemState: (
+        pickupNodeId: string,
+        manifestId: string,
+        stopId: number,
+        outcome: 'ready' | 'missing-label' | 'not-ready',
+    ) => void;
+    onConfirmPickupManifest: (
+        pickupNodeId: string,
+        manifestId: string,
+    ) => void | Promise<void>;
+    onRetryPickupSync: (operationId: string) => void | Promise<void>;
+    onDiscardPickupSync: (operationId: string) => void | Promise<void>;
 }) {
     const run = dashboard.activeRun;
     const locationMessage = trackingMessage(trackingState);
@@ -128,7 +327,8 @@ export function DriverDashboard({
         maximumRouteWindowHours: dashboard.maximumRouteWindowHours,
     });
     const selectionLimitReached =
-        selectionInspection.summary.stopCount >= dashboard.maximumRouteStops;
+        selectionInspection.summary.routeNodeCount >=
+        dashboard.maximumRouteStops + 1;
     const selectedSlotCount = selectionInspection.summary.slots.length;
     const selectedPickupLocationCount =
         selectionInspection.summary.pickupLocations.length;
@@ -148,18 +348,6 @@ export function DriverDashboard({
         reconciledRejectedSelection?.status === 'rejected'
             ? reconciledRejectedSelection.conflict
             : selectionInspection.conflict;
-    const separateRouteLocation =
-        activeSelectionConflict?.pickupLocations.find((location) =>
-            location.requestIds.some((requestId) =>
-                activeSelectionConflict.separateRouteRequestIds.includes(
-                    requestId,
-                ),
-            ),
-        ) ?? null;
-    const separateRouteLocationLabel =
-        separateRouteLocation?.name ??
-        separateRouteLocation?.address ??
-        'odabranu lokaciju';
     const availableTraceCount = new Set(
         selectableOrders.flatMap((order) =>
             order.harvest.tracePath ? [order.harvest.tracePath] : [],
@@ -201,6 +389,32 @@ export function DriverDashboard({
         return applySelectedRequestIds(nextRequestIds);
     };
 
+    const appendCompatibleStopGroups = (
+        currentRequestIds: string[],
+        groups: Array<{
+            stopKey: string;
+            items: DeliveryRouteOrderSummary[];
+        }>,
+    ) => {
+        let acceptedRequestIds = currentRequestIds;
+        for (const group of groups) {
+            const result = applyDeliveryRouteSelection({
+                candidates: selectionCandidates,
+                currentRequestIds: acceptedRequestIds,
+                nextRequestIds: [
+                    ...acceptedRequestIds,
+                    ...group.items.map((order) => order.requestId),
+                ],
+                maximumRouteStops: dashboard.maximumRouteStops,
+                maximumRouteWindowHours: dashboard.maximumRouteWindowHours,
+            });
+            if (result.status === 'accepted') {
+                acceptedRequestIds = result.requestIds;
+            }
+        }
+        return acceptedRequestIds;
+    };
+
     const toggleOrder = (requestId: string, checked: boolean) => {
         const order = ordersByRequestId.get(requestId);
         if (!order?.readyForPickup) return;
@@ -216,18 +430,6 @@ export function DriverDashboard({
                 return availableCurrent.filter(
                     (id) => !groupedRequestIdSet.has(id),
                 );
-            }
-            const currentStopKeys = new Set(
-                availableCurrent.flatMap((id) => {
-                    const currentOrder = ordersByRequestId.get(id);
-                    return currentOrder ? [currentOrder.stopKey] : [];
-                }),
-            );
-            if (
-                !currentStopKeys.has(order.stopKey) &&
-                currentStopKeys.size >= dashboard.maximumRouteStops
-            ) {
-                return availableCurrent;
             }
             return Array.from(
                 new Set([...availableCurrent, ...groupedRequestIds]),
@@ -253,35 +455,16 @@ export function DriverDashboard({
                 return availableCurrent.filter((id) => !batchIds.has(id));
             }
 
-            const next = new Set(availableCurrent);
-            const nextStopKeys = new Set(
-                availableCurrent.flatMap((id) => {
-                    const order = ordersByRequestId.get(id);
-                    return order ? [order.stopKey] : [];
-                }),
+            return appendCompatibleStopGroups(
+                availableCurrent,
+                groupByDeliveryStop(readyBatchOrders),
             );
-            for (const group of groupByDeliveryStop(readyBatchOrders)) {
-                if (!nextStopKeys.has(group.stopKey)) {
-                    if (nextStopKeys.size >= dashboard.maximumRouteStops) {
-                        continue;
-                    }
-                    nextStopKeys.add(group.stopKey);
-                }
-                for (const order of group.items) {
-                    next.add(order.requestId);
-                }
-            }
-            return Array.from(next);
         });
     };
 
     const selectAllAvailable = () => {
         applySelectedRequestIds(
-            availableStopGroups
-                .slice(0, dashboard.maximumRouteStops)
-                .flatMap((group) =>
-                    group.items.map((order) => order.requestId),
-                ),
+            appendCompatibleStopGroups([], availableStopGroups),
         );
     };
 
@@ -465,35 +648,207 @@ export function DriverDashboard({
                             <div className="flex items-center gap-2">
                                 <MapPin className="size-5 text-primary" />
                                 <Typography level="h3" semiBold>
-                                    Stanice rute
+                                    Tijek rute
                                 </Typography>
                             </div>
                             <div className="grid gap-3 lg:grid-cols-2">
-                                {run.stops.map((stop) => (
-                                    <DeliveryStopCard
-                                        key={stop.id ?? stop.requestId}
-                                        stop={stop}
-                                        mode="driver"
-                                        pendingAction={
-                                            pendingAction?.startsWith(
-                                                `${stop.id}:`,
-                                            )
-                                                ? pendingAction.endsWith(
-                                                      ':arrive',
-                                                  )
-                                                    ? 'arrive'
-                                                    : 'deliver'
-                                                : null
-                                        }
-                                        onArrive={() =>
-                                            stop.id && onArrive(run.id, stop.id)
-                                        }
-                                        onDeliver={(notes) =>
-                                            stop.id &&
-                                            onDeliver(run.id, stop.id, notes)
-                                        }
-                                    />
-                                ))}
+                                {run.routeSteps.map((step) => {
+                                    if (step.kind === 'pickup') {
+                                        const pickup = queuedPickup(
+                                            step.pickup,
+                                            pickupQueue?.entries ?? [],
+                                        );
+                                        return (
+                                            <DeliveryPickupCard
+                                                key={`pickup:${pickup.id}`}
+                                                pickup={pickup}
+                                                actionState={step.actionState}
+                                                pendingAction={pendingAction}
+                                                sync={pickupSyncSummary(
+                                                    pickup.id,
+                                                    pickupQueue,
+                                                )}
+                                                onScan={(scanValue) => {
+                                                    const tracePath =
+                                                        normalizeHarvestTraceScanValue(
+                                                            scanValue,
+                                                        );
+                                                    if (!tracePath) {
+                                                        return {
+                                                            status: 'pickup-invalid',
+                                                        };
+                                                    }
+                                                    const matchingItems =
+                                                        pickup.manifests.flatMap(
+                                                            (manifest) =>
+                                                                manifest.items.filter(
+                                                                    (item) =>
+                                                                        item.tracePath ===
+                                                                        tracePath,
+                                                                ),
+                                                        );
+                                                    if (
+                                                        matchingItems.length ===
+                                                        0
+                                                    ) {
+                                                        return {
+                                                            status: 'pickup-not-at-location',
+                                                            tracePath,
+                                                        };
+                                                    }
+                                                    if (
+                                                        new Set(
+                                                            matchingItems.map(
+                                                                (item) =>
+                                                                    item.stopKey,
+                                                            ),
+                                                        ).size > 1
+                                                    ) {
+                                                        return {
+                                                            status: 'pickup-ambiguous',
+                                                            tracePath,
+                                                        };
+                                                    }
+                                                    const pendingItems =
+                                                        matchingItems.filter(
+                                                            (item) =>
+                                                                item.state ===
+                                                                    'ready' ||
+                                                                item.state ===
+                                                                    'not-ready',
+                                                        );
+                                                    const firstItem =
+                                                        matchingItems[0];
+                                                    if (!firstItem) {
+                                                        return {
+                                                            status: 'pickup-not-at-location',
+                                                            tracePath,
+                                                        };
+                                                    }
+                                                    if (
+                                                        pendingItems.length >
+                                                            0 &&
+                                                        pendingItems.every(
+                                                            (item) =>
+                                                                item.state ===
+                                                                'not-ready',
+                                                        )
+                                                    ) {
+                                                        return {
+                                                            status: 'pickup-not-ready',
+                                                            tracePath,
+                                                            plantName:
+                                                                firstItem
+                                                                    .harvest
+                                                                    .plantName,
+                                                        };
+                                                    }
+                                                    if (
+                                                        pendingItems.length ===
+                                                        0
+                                                    ) {
+                                                        return {
+                                                            status: 'pickup-already-collected',
+                                                            tracePath,
+                                                            plantName:
+                                                                firstItem
+                                                                    .harvest
+                                                                    .plantName,
+                                                        };
+                                                    }
+                                                    onPickupScan(
+                                                        pickup.id,
+                                                        tracePath,
+                                                    );
+                                                    return {
+                                                        status: 'pickup-queued',
+                                                        tracePath,
+                                                        plantName:
+                                                            firstItem.harvest
+                                                                .plantName,
+                                                        matchedCount:
+                                                            pendingItems.length,
+                                                    };
+                                                }}
+                                                onSetItemState={(
+                                                    pickupNodeId,
+                                                    manifestId,
+                                                    stopId,
+                                                    outcome,
+                                                ) =>
+                                                    onPickupItemState(
+                                                        pickupNodeId,
+                                                        manifestId,
+                                                        stopId,
+                                                        outcome,
+                                                    )
+                                                }
+                                                onResolveRemaining={(
+                                                    pickupNodeId,
+                                                    manifest,
+                                                ) => {
+                                                    for (const item of manifest.items) {
+                                                        if (
+                                                            item.state ===
+                                                            'ready'
+                                                        ) {
+                                                            onPickupItemState(
+                                                                pickupNodeId,
+                                                                manifest.id,
+                                                                item.stopId,
+                                                                'missing-label',
+                                                            );
+                                                        }
+                                                    }
+                                                }}
+                                                onConfirmManifest={
+                                                    onConfirmPickupManifest
+                                                }
+                                                onRetrySync={onRetryPickupSync}
+                                                onDiscardSync={
+                                                    onDiscardPickupSync
+                                                }
+                                            />
+                                        );
+                                    }
+                                    const stop = {
+                                        ...step.stop,
+                                        actionState: step.actionState,
+                                        lockedReason: step.lockedReason,
+                                        isCurrent:
+                                            step.actionState === 'current',
+                                    };
+                                    return (
+                                        <DeliveryStopCard
+                                            key={`delivery:${stop.id ?? stop.requestId}`}
+                                            stop={stop}
+                                            mode="driver"
+                                            pendingAction={
+                                                pendingAction?.startsWith(
+                                                    `${stop.id}:`,
+                                                )
+                                                    ? pendingAction.endsWith(
+                                                          ':arrive',
+                                                      )
+                                                        ? 'arrive'
+                                                        : 'deliver'
+                                                    : null
+                                            }
+                                            onArrive={() =>
+                                                stop.id &&
+                                                onArrive(run.id, stop.id)
+                                            }
+                                            onDeliver={(notes) =>
+                                                stop.id &&
+                                                onDeliver(
+                                                    run.id,
+                                                    stop.id,
+                                                    notes,
+                                                )
+                                            }
+                                        />
+                                    );
+                                })}
                             </div>
                         </section>
                     </>
@@ -521,13 +876,12 @@ export function DriverDashboard({
                                                         : 'uroda'}
                                                 </Chip>
                                                 <Chip color="neutral" size="sm">
-                                                    {selectedStopKeys.size}{' '}
-                                                    {selectedStopKeys.size === 1
-                                                        ? 'stanica'
-                                                        : selectedStopKeys.size <
-                                                            5
-                                                          ? 'stanice'
-                                                          : 'stanica'}
+                                                    {
+                                                        selectionInspection
+                                                            .summary
+                                                            .routeNodeCount
+                                                    }{' '}
+                                                    fizičkih lokacija
                                                 </Chip>
                                                 <Chip color="neutral" size="sm">
                                                     {selectedSlotCount}{' '}
@@ -562,8 +916,10 @@ export function DriverDashboard({
                                                 className="mt-2 text-muted-foreground"
                                             >
                                                 Najviše{' '}
-                                                {dashboard.maximumRouteStops}{' '}
-                                                fizičkih stanica po ruti. Svi
+                                                {dashboard.maximumRouteStops +
+                                                    1}{' '}
+                                                fizičkih lokacija po ruti,
+                                                uključujući preuzimanja. Svi
                                                 urodi za istu adresu u istom
                                                 terminu računaju se kao jedna
                                                 skupna stanica. Termini moraju
@@ -572,10 +928,7 @@ export function DriverDashboard({
                                                     dashboard.maximumRouteWindowHours
                                                 }{' '}
                                                 sata i poštuju se pri izračunu
-                                                dolazaka. Dok povezane lokacije
-                                                preuzimanja nisu dio plana,
-                                                jedna ruta kreće s jedne
-                                                lokacije. Urodi koji se još
+                                                dolazaka. Urodi koji se još
                                                 pripremaju ostaju vidljivi, ali
                                                 ih nije moguće odabrati.
                                             </Typography>
@@ -659,7 +1012,7 @@ export function DriverDashboard({
                                                     <Play className="size-4" />
                                                 }
                                             >
-                                                Preuzmi{' '}
+                                                Pokreni rutu s{' '}
                                                 {
                                                     effectiveSelectedRequestIds.length
                                                 }{' '}
@@ -699,10 +1052,8 @@ export function DriverDashboard({
                                                             )
                                                         }
                                                     >
-                                                        {activeSelectionConflict.code ===
-                                                        'mixed-pickup-locations'
-                                                            ? `Zadrži samo ${separateRouteLocationLabel}`
-                                                            : 'Zadrži kompatibilan odabir'}
+                                                        Zadrži kompatibilan
+                                                        odabir
                                                     </Button>
                                                 ) : null}
                                                 <Button
@@ -722,8 +1073,8 @@ export function DriverDashboard({
                                 ) : null}
 
                                 {selectionLimitReached &&
-                                availableStopGroups.length >
-                                    dashboard.maximumRouteStops ? (
+                                selectionInspection.summary.routeNodeCount >=
+                                    dashboard.maximumRouteStops + 1 ? (
                                     <Alert
                                         color="info"
                                         startDecorator={
@@ -731,9 +1082,10 @@ export function DriverDashboard({
                                         }
                                     >
                                         Dosegnut je najveći broj fizičkih
-                                        stanica za jednu rutu. Urodi na već
-                                        odabranoj adresi i u istom terminu i
-                                        dalje se dodaju skupno.
+                                        lokacija za jednu rutu, uključujući
+                                        preuzimanja. Urodi na već odabranoj
+                                        adresi i u istom terminu i dalje se
+                                        dodaju skupno.
                                     </Alert>
                                 ) : null}
 

--- a/apps/delivery/components/HarvestTraceScanner.tsx
+++ b/apps/delivery/components/HarvestTraceScanner.tsx
@@ -44,9 +44,33 @@ type PickupRouteConflict = Extract<
     { status: 'route-conflict' }
 >;
 
+export type PickupManifestScanResult =
+    | { status: 'pickup-invalid' }
+    | { status: 'pickup-not-at-location'; tracePath: string }
+    | { status: 'pickup-ambiguous'; tracePath: string }
+    | {
+          status: 'pickup-already-collected';
+          tracePath: string;
+          plantName: string;
+      }
+    | {
+          status: 'pickup-not-ready';
+          tracePath: string;
+          plantName: string;
+      }
+    | {
+          status: 'pickup-queued';
+          tracePath: string;
+          plantName: string;
+          matchedCount: number;
+      };
+
 function scanHistoryItem(
     id: number,
-    result: HarvestTraceSelectionResult | HarvestTraceVerificationResult,
+    result:
+        | HarvestTraceSelectionResult
+        | HarvestTraceVerificationResult
+        | PickupManifestScanResult,
 ): ScanHistoryItem {
     switch (result.status) {
         case 'selected':
@@ -125,6 +149,44 @@ function scanHistoryItem(
                 color: 'danger',
                 message: 'Kod nije valjana Gredice poveznica traga uroda.',
             };
+        case 'pickup-queued':
+            return {
+                id,
+                color: 'success',
+                message: `${result.plantName} · očitano ${result.matchedCount === 1 ? 'za manifest' : `za ${result.matchedCount} povezana uroda`}.`,
+            };
+        case 'pickup-already-collected':
+            return {
+                id,
+                color: 'info',
+                message: `${result.plantName} već je potvrđen na ovoj lokaciji preuzimanja.`,
+            };
+        case 'pickup-not-ready':
+            return {
+                id,
+                color: 'warning',
+                message: `${result.plantName} je označen kao nespreman i ostaje u manifestu.`,
+            };
+        case 'pickup-not-at-location':
+            return {
+                id,
+                color: 'warning',
+                message:
+                    'Ovaj QR kod nije na manifestu trenutačne lokacije preuzimanja.',
+            };
+        case 'pickup-ambiguous':
+            return {
+                id,
+                color: 'warning',
+                message:
+                    'Ovaj QR kod pripada različitim skupnim stanicama. Provjeri urode ručno.',
+            };
+        case 'pickup-invalid':
+            return {
+                id,
+                color: 'danger',
+                message: 'Kod nije valjana Gredice poveznica traga uroda.',
+            };
     }
 }
 
@@ -153,13 +215,16 @@ export function HarvestTraceScanner({
     onScan,
     onReplacePickupSelection,
 }: {
-    variant: 'pickup' | 'verification';
+    variant: 'pickup' | 'manifest' | 'verification';
     availableTraceCount: number;
     disabled: boolean;
     completedTraceCount: number;
     onScan: (
         value: string,
-    ) => HarvestTraceSelectionResult | HarvestTraceVerificationResult;
+    ) =>
+        | HarvestTraceSelectionResult
+        | HarvestTraceVerificationResult
+        | PickupManifestScanResult;
     onReplacePickupSelection?: (requestIds: string[]) => boolean;
 }) {
     const [open, setOpen] = useState(false);
@@ -183,6 +248,10 @@ export function HarvestTraceScanner({
         onScanRef.current = onScan;
     }, [onScan]);
 
+    useEffect(() => {
+        if (disabled) setOpen(false);
+    }, [disabled]);
+
     const pushHistory = useCallback((item: Omit<ScanHistoryItem, 'id'>) => {
         historyIdRef.current += 1;
         setHistory((current) => [
@@ -193,6 +262,7 @@ export function HarvestTraceScanner({
 
     const processScan = useCallback(
         (value: string, source: 'camera' | 'manual') => {
+            if (disabled) return;
             const normalizedValue = value.trim();
             if (!normalizedValue) return;
 
@@ -237,15 +307,19 @@ export function HarvestTraceScanner({
                 ...current.slice(0, 3),
             ]);
 
-            if (result.status === 'selected' || result.status === 'verified') {
+            if (
+                result.status === 'selected' ||
+                result.status === 'verified' ||
+                result.status === 'pickup-queued'
+            ) {
                 navigator.vibrate?.(80);
             }
         },
-        [pushHistory],
+        [disabled, pushHistory],
     );
 
     useEffect(() => {
-        if (!open) return;
+        if (!open || disabled) return;
 
         if (!navigator.mediaDevices?.getUserMedia) {
             setCameraState('unsupported');
@@ -340,7 +414,7 @@ export function HarvestTraceScanner({
                 video.srcObject = null;
             }
         };
-    }, [open, processScan]);
+    }, [disabled, open, processScan]);
 
     function openScanner() {
         seenValuesRef.current.clear();
@@ -382,6 +456,7 @@ export function HarvestTraceScanner({
     }
 
     const verificationMode = variant === 'verification';
+    const manifestMode = variant === 'manifest';
 
     return (
         <>
@@ -391,7 +466,11 @@ export function HarvestTraceScanner({
                 onClick={openScanner}
                 startDecorator={<Camera className="size-4" />}
             >
-                {verificationMode ? 'Provjeri QR kodove' : 'Skeniraj QR kodove'}
+                {verificationMode
+                    ? 'Provjeri QR kodove'
+                    : manifestMode
+                      ? 'Skeniraj urode'
+                      : 'Skeniraj QR kodove'}
             </Button>
             <Modal
                 open={open}
@@ -399,12 +478,16 @@ export function HarvestTraceScanner({
                 title={
                     verificationMode
                         ? 'Provjera uroda za dostavu'
-                        : 'Skeniranje tragova uroda'
+                        : manifestMode
+                          ? 'Preuzimanje uroda'
+                          : 'Skeniranje tragova uroda'
                 }
                 description={
                     verificationMode
                         ? 'Skeniranje je pomoćna provjera i nikada ne blokira potvrdu dostave.'
-                        : 'Kamera ostaje aktivna kako bi se više QR kodova moglo očitati bez zatvaranja skenera.'
+                        : manifestMode
+                          ? 'Kamera ostaje aktivna za brzo skeniranje svih uroda na trenutačnoj lokaciji.'
+                          : 'Kamera ostaje aktivna kako bi se više QR kodova moglo očitati bez zatvaranja skenera.'
                 }
                 className="md:max-w-xl"
             >
@@ -413,7 +496,9 @@ export function HarvestTraceScanner({
                         <Typography level="h3" semiBold>
                             {verificationMode
                                 ? 'Provjeri urode na stanici'
-                                : 'Skeniraj tragove uroda'}
+                                : manifestMode
+                                  ? 'Skeniraj manifest preuzimanja'
+                                  : 'Skeniraj tragove uroda'}
                         </Typography>
                         <Typography
                             level="body3"
@@ -421,7 +506,9 @@ export function HarvestTraceScanner({
                         >
                             {verificationMode
                                 ? 'Kamera ostaje uključena. Skeniraj etikete uroda koje predaješ korisniku.'
-                                : 'Kamera ostaje uključena. Svaki novi QR automatski odabire cijelu skupnu stanicu dostave.'}
+                                : manifestMode
+                                  ? 'Kamera ostaje uključena. Svaki očitani QR potvrđuje odgovarajući urod na ovoj lokaciji.'
+                                  : 'Kamera ostaje uključena. Svaki novi QR automatski odabire cijelu skupnu stanicu dostave.'}
                         </Typography>
                     </div>
 
@@ -433,13 +520,19 @@ export function HarvestTraceScanner({
                         <Chip color="success" size="sm">
                             <Check className="mr-1 size-4" />
                             {completedTraceCount}{' '}
-                            {verificationMode ? 'provjereno' : 'odabrano'}
+                            {verificationMode
+                                ? 'provjereno'
+                                : manifestMode
+                                  ? 'preuzeto'
+                                  : 'odabrano'}
                         </Chip>
                         <Chip color="neutral" size="sm">
                             {availableTraceCount}{' '}
                             {verificationMode
                                 ? 'očekivanih QR kodova'
-                                : 'dostupnih QR kodova'}
+                                : manifestMode
+                                  ? 'uroda u manifestu'
+                                  : 'dostupnih QR kodova'}
                         </Chip>
                     </div>
 
@@ -508,10 +601,7 @@ export function HarvestTraceScanner({
                                                 )
                                             }
                                         >
-                                            {pickupRouteConflict.code ===
-                                            'mixed-pickup-locations'
-                                                ? 'Prebaci na skeniranu lokaciju'
-                                                : 'Prebaci na skenirani termin'}
+                                            Odaberi izdvojenu skupinu
                                         </Button>
                                     ) : null}
                                     {pickupRouteConflict.separateRouteRequestIds

--- a/apps/delivery/hooks/usePickupManifestSync.ts
+++ b/apps/delivery/hooks/usePickupManifestSync.ts
@@ -1,0 +1,323 @@
+'use client';
+
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useSyncExternalStore,
+} from 'react';
+import {
+    createMemoryPickupManifestQueuePersistence,
+    createPickupManifestConfirmCommand,
+    createPickupManifestManualOutcomeCommand,
+    createPickupManifestScanCommand,
+    createWebStoragePickupManifestQueuePersistence,
+    type PickupManifestAcknowledgement,
+    type PickupManifestCommand,
+    type PickupManifestManualOutcome,
+    PickupManifestQueue,
+    type PickupManifestQueueCoordinator,
+    type PickupManifestQueuePersistence,
+    type PickupManifestTransportResult,
+    pickupManifestQueueStorageKey,
+} from '../lib/pickupManifestQueue';
+import {
+    pickupManifestHttpFailure,
+    pickupManifestTransportResult,
+} from '../lib/pickupManifestTransport';
+
+function operationId() {
+    return (
+        globalThis.crypto?.randomUUID?.() ??
+        `pickup-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+}
+
+function mutationForCommand(command: PickupManifestCommand) {
+    const common = {
+        clientOperationId: command.operationId,
+        occurredAt: command.occurredAt,
+    };
+    switch (command.kind) {
+        case 'scan':
+            return {
+                ...common,
+                kind: 'scan' as const,
+                traceToken: command.tracePath,
+            };
+        case 'manual-outcome':
+            return {
+                ...common,
+                kind: 'mark-item' as const,
+                stopId: command.stopId,
+                outcome: command.outcome,
+            };
+        case 'confirm':
+            return {
+                ...common,
+                kind: 'confirm-manifest' as const,
+                manifestId: command.manifestId,
+            };
+    }
+}
+
+async function sendPickupManifestCommand(
+    command: PickupManifestCommand,
+): Promise<PickupManifestTransportResult> {
+    let response: Response;
+    try {
+        response = await fetch(
+            `/api/driver/runs/${encodeURIComponent(command.runId)}/pickups/${encodeURIComponent(command.pickupNodeId)}/mutations`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    mutations: [mutationForCommand(command)],
+                }),
+            },
+        );
+    } catch {
+        return { status: 'retryable-failure', code: 'offline' };
+    }
+    const data: unknown = await response.json().catch(() => null);
+    if (!response.ok) {
+        return pickupManifestHttpFailure(response.status, data);
+    }
+    return pickupManifestTransportResult(data, command);
+}
+
+function pickupManifestQueueLockName({
+    userId,
+    runId,
+    purpose,
+}: {
+    userId: string;
+    runId: string;
+    purpose: 'state' | 'replay';
+}) {
+    return `gredice:delivery:pickup-manifest:${purpose}:${encodeURIComponent(userId)}:${encodeURIComponent(runId)}`;
+}
+
+function pickupManifestLockCoordinator(
+    lockManager: LockManager,
+    purpose: 'state' | 'replay',
+): PickupManifestQueueCoordinator {
+    return {
+        runExclusive: async (scope, task) =>
+            await lockManager.request(
+                pickupManifestQueueLockName({ ...scope, purpose }),
+                { mode: 'exclusive' },
+                async () => await task(),
+            ),
+    };
+}
+
+function pickupManifestQueueResources(): {
+    persistence: PickupManifestQueuePersistence;
+    coordinator?: PickupManifestQueueCoordinator;
+    replayCoordinator?: PickupManifestQueueCoordinator;
+} {
+    const memory = createMemoryPickupManifestQueuePersistence();
+    if (typeof window === 'undefined') return { persistence: memory };
+
+    try {
+        const persistence = createWebStoragePickupManifestQueuePersistence(
+            window.localStorage,
+        );
+        if (!navigator.locks) return { persistence };
+        const lockManager = navigator.locks;
+        return {
+            persistence,
+            coordinator: pickupManifestLockCoordinator(lockManager, 'state'),
+            replayCoordinator: pickupManifestLockCoordinator(
+                lockManager,
+                'replay',
+            ),
+        };
+    } catch {
+        return { persistence: memory };
+    }
+}
+
+export function usePickupManifestSync({
+    userId,
+    runId,
+    onAcknowledged,
+}: {
+    userId: string;
+    runId: string;
+    onAcknowledged: () => void | Promise<void>;
+}) {
+    const onAcknowledgedRef = useRef(onAcknowledged);
+    useEffect(() => {
+        onAcknowledgedRef.current = onAcknowledged;
+    }, [onAcknowledged]);
+
+    const resources = useMemo(pickupManifestQueueResources, []);
+    const queue = useMemo(
+        () =>
+            new PickupManifestQueue({
+                scope: { userId, runId },
+                persistence: resources.persistence,
+                transport: sendPickupManifestCommand,
+                coordinator: resources.coordinator,
+                replayCoordinator: resources.replayCoordinator,
+            }),
+        [resources, runId, userId],
+    );
+    const snapshot = useSyncExternalStore(
+        queue.subscribe,
+        queue.getSnapshot,
+        queue.getServerSnapshot,
+    );
+
+    const replay = useCallback(async () => {
+        const before = queue.getSnapshot().syncedCount;
+        const result = await queue.replay();
+        if (result.syncedCount > before) {
+            await onAcknowledgedRef.current();
+        }
+        return result;
+    }, [queue]);
+
+    useEffect(() => {
+        let active = true;
+        void queue
+            .restore()
+            .then(() => {
+                if (active && navigator.onLine) {
+                    void replay().catch(() => undefined);
+                }
+            })
+            .catch(() => undefined);
+        const handleOnline = () => void replay().catch(() => undefined);
+        const handleStorage = (event: StorageEvent) => {
+            let storage: Storage;
+            try {
+                storage = window.localStorage;
+            } catch {
+                return;
+            }
+            if (
+                event.storageArea !== storage ||
+                event.key !== pickupManifestQueueStorageKey({ userId, runId })
+            ) {
+                return;
+            }
+            void queue
+                .refresh()
+                .then((next) => {
+                    if (
+                        active &&
+                        navigator.onLine &&
+                        next.failedCount === 0 &&
+                        next.conflictedCount === 0 &&
+                        next.queuedCount + next.sendingCount > 0
+                    ) {
+                        void replay().catch(() => undefined);
+                    }
+                })
+                .catch(() => undefined);
+        };
+        window.addEventListener('online', handleOnline);
+        window.addEventListener('storage', handleStorage);
+        return () => {
+            active = false;
+            window.removeEventListener('online', handleOnline);
+            window.removeEventListener('storage', handleStorage);
+        };
+    }, [queue, replay, runId, userId]);
+
+    const enqueue = useCallback(
+        async (command: PickupManifestCommand) => {
+            await queue.enqueue(command);
+            if (navigator.onLine) void replay().catch(() => undefined);
+        },
+        [queue, replay],
+    );
+
+    const retryEntry = useCallback(
+        async (operationIdValue: string) => {
+            const changed = await queue.retryEntry(operationIdValue);
+            if (changed && navigator.onLine) await replay();
+            return changed;
+        },
+        [queue, replay],
+    );
+    const discardEntry = useCallback(
+        async (operationIdValue: string) => {
+            const changed = await queue.discardEntry(operationIdValue);
+            if (changed) await onAcknowledgedRef.current();
+            if (changed && navigator.onLine) await replay();
+            return changed;
+        },
+        [queue, replay],
+    );
+    const reconcileEntry = useCallback(
+        async (
+            operationIdValue: string,
+            acknowledgement: PickupManifestAcknowledgement = 'applied',
+        ) => {
+            const changed = await queue.reconcileEntry(
+                operationIdValue,
+                acknowledgement,
+            );
+            if (changed) await onAcknowledgedRef.current();
+            if (changed && navigator.onLine) await replay();
+            return changed;
+        },
+        [queue, replay],
+    );
+
+    return {
+        snapshot,
+        durability: snapshot.durability,
+        isDurable: snapshot.durability === 'durable',
+        coordination: snapshot.coordination,
+        enqueueScan: (pickupNodeId: string, scanValue: string) =>
+            enqueue(
+                createPickupManifestScanCommand({
+                    operationId: operationId(),
+                    runId,
+                    pickupNodeId,
+                    scanValue,
+                }),
+            ),
+        enqueueItemOutcome: ({
+            pickupNodeId,
+            manifestId,
+            stopId,
+            outcome,
+        }: {
+            pickupNodeId: string;
+            manifestId: string;
+            stopId: number;
+            outcome: PickupManifestManualOutcome;
+        }) =>
+            enqueue(
+                createPickupManifestManualOutcomeCommand({
+                    operationId: operationId(),
+                    runId,
+                    pickupNodeId,
+                    manifestId,
+                    stopId,
+                    outcome,
+                }),
+            ),
+        enqueueConfirm: (pickupNodeId: string, manifestId: string) =>
+            enqueue(
+                createPickupManifestConfirmCommand({
+                    operationId: operationId(),
+                    runId,
+                    pickupNodeId,
+                    manifestId,
+                }),
+            ),
+        retry: replay,
+        retryEntry,
+        discardEntry,
+        reconcileEntry,
+        clear: () => queue.clear(),
+    };
+}

--- a/apps/delivery/lib/deliveryDashboard.node.spec.ts
+++ b/apps/delivery/lib/deliveryDashboard.node.spec.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     accountCanTrackCurrentDeliveryGroup,
+    deliveryTrackingStopIds,
     expandLegacyCurrentDeliveryStopIds,
     pickupManifestTracePath,
 } from './deliveryDashboard';
@@ -164,6 +165,51 @@ test('legacy current delivery keeps the execution stop when its group cannot be 
     });
 
     assert.deepEqual([...currentStopIds], [21]);
+});
+
+test('legacy route tracking authorizes every account in the current bulk group', () => {
+    const groups = [
+        group([{ id: 11, state: pending, accountId: 'account-1' }]),
+        group([
+            { id: 21, state: pending, accountId: 'account-2' },
+            { id: 22, state: pending, accountId: 'account-3' },
+        ]),
+    ];
+    const currentDeliveryStopIds = deliveryTrackingStopIds({
+        routePlanVersion: 1,
+        currentStopIds: new Set([21]),
+        groups,
+    });
+
+    assert.equal(
+        accountCanTrackCurrentDeliveryGroup({
+            accountId: 'account-3',
+            runState: 'active',
+            groups,
+            currentDeliveryStopIds,
+        }),
+        true,
+    );
+});
+
+test('current route tracking keeps the server-confirmed physical stop ids', () => {
+    const groups = [
+        group([
+            { id: 21, state: pending, accountId: 'account-2' },
+            { id: 22, state: pending, accountId: 'account-3' },
+        ]),
+    ];
+
+    assert.deepEqual(
+        [
+            ...deliveryTrackingStopIds({
+                routePlanVersion: 2,
+                currentStopIds: new Set([21]),
+                groups,
+            }),
+        ],
+        [21],
+    );
 });
 
 test('pickup manifest advertises only persisted trace provenance', () => {

--- a/apps/delivery/lib/deliveryDashboard.node.spec.ts
+++ b/apps/delivery/lib/deliveryDashboard.node.spec.ts
@@ -1,19 +1,24 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { accountCanTrackCurrentDeliveryGroup } from './deliveryDashboard';
+import {
+    accountCanTrackCurrentDeliveryGroup,
+    expandLegacyCurrentDeliveryStopIds,
+    pickupManifestTracePath,
+} from './deliveryDashboard';
 
 const pending = 'pending';
 const delivered = 'delivered';
 
 function group(
     items: Array<{
+        id?: number;
         state: string;
         accountId?: string;
     }>,
 ) {
     return {
         items: items.map((item) => ({
-            stop: { state: item.state },
+            stop: { id: item.id, state: item.state },
             request: item.accountId ? { accountId: item.accountId } : undefined,
         })),
     };
@@ -88,4 +93,83 @@ test('customer map denies tracking when the delivery run is not active', () => {
         }),
         false,
     );
+});
+
+test('customer map denies tracking while a pickup checkpoint is current', () => {
+    assert.equal(
+        accountCanTrackCurrentDeliveryGroup({
+            accountId: 'account-1',
+            runState: 'active',
+            groups: [
+                group([{ id: 11, state: pending, accountId: 'account-1' }]),
+            ],
+            currentDeliveryStopIds: null,
+        }),
+        false,
+    );
+});
+
+test('customer map allows only accounts in the server-confirmed current delivery checkpoint', () => {
+    const groups = [
+        group([{ id: 11, state: pending, accountId: 'account-1' }]),
+        group([
+            { id: 21, state: pending, accountId: 'account-2' },
+            { id: 22, state: pending, accountId: 'account-3' },
+        ]),
+    ];
+    const currentDeliveryStopIds = new Set([21, 22]);
+
+    assert.equal(
+        accountCanTrackCurrentDeliveryGroup({
+            accountId: 'account-1',
+            runState: 'active',
+            groups,
+            currentDeliveryStopIds,
+        }),
+        false,
+    );
+    assert.equal(
+        accountCanTrackCurrentDeliveryGroup({
+            accountId: 'account-3',
+            runState: 'active',
+            groups,
+            currentDeliveryStopIds,
+        }),
+        true,
+    );
+});
+
+test('legacy current delivery expands to every stop in the bulk group', () => {
+    const currentStopIds = expandLegacyCurrentDeliveryStopIds({
+        currentStopIds: new Set([21]),
+        groups: [
+            group([{ id: 11, state: pending, accountId: 'account-1' }]),
+            group([
+                { id: 21, state: pending, accountId: 'account-2' },
+                { id: 22, state: pending, accountId: 'account-3' },
+            ]),
+        ],
+    });
+
+    assert.deepEqual(
+        [...currentStopIds].sort((a, b) => a - b),
+        [21, 22],
+    );
+});
+
+test('legacy current delivery keeps the execution stop when its group cannot be resolved', () => {
+    const currentStopIds = expandLegacyCurrentDeliveryStopIds({
+        currentStopIds: new Set([21]),
+        groups: [group([{ id: 11, state: pending, accountId: 'account-1' }])],
+    });
+
+    assert.deepEqual([...currentStopIds], [21]);
+});
+
+test('pickup manifest advertises only persisted trace provenance', () => {
+    assert.equal(
+        pickupManifestTracePath('persisted-token'),
+        '/trag/persisted-token',
+    );
+    assert.equal(pickupManifestTracePath(null), null);
 });

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -2,6 +2,8 @@ import { notifyDeliveryRequestEvent } from '@gredice/notifications';
 import {
     consumeDeliveryRunPreparation,
     DeliveryRequestStates,
+    DeliveryRunManifestItemStates,
+    DeliveryRunManifestStates,
     DeliveryRunStates,
     DeliveryRunStopStates,
     fulfillDeliveryRunStops,
@@ -10,6 +12,7 @@ import {
     getDeliveryRequest,
     getDeliveryRequestsWithEvents,
     getDeliveryRun,
+    getDeliveryRunExecutionProgress,
     getDeliveryRunStopsForRequestIds,
     getUser,
     markDeliveryRunStopsArrived,
@@ -22,7 +25,11 @@ import type {
     DeliveryContactSummary,
     DeliveryDashboard,
     DeliveryHarvestSummary,
+    DeliveryPickupManifestItemState,
+    DeliveryPickupManifestSummary,
+    DeliveryPickupStepSummary,
     DeliveryRouteOrderSummary,
+    DeliveryRouteStepSummary,
     DeliveryStopDeliverySummary,
     DeliveryStopSummary,
     DeliveryTrackingLocation,
@@ -56,6 +63,9 @@ export type DeliveryRun = NonNullable<
     Awaited<ReturnType<typeof getDeliveryRun>>
 >;
 type DeliveryRunStop = DeliveryRun['stops'][number];
+type DeliveryRunExecutionStep = Awaited<
+    ReturnType<typeof getDeliveryRunExecutionProgress>
+>[number];
 type DeliveryAccountContact = Awaited<
     ReturnType<typeof getDeliveryAccountContacts>
 >[number];
@@ -283,6 +293,8 @@ function deliveryStopSummary({
     contacts,
     includeTracking,
     sequence,
+    actionState,
+    lockedReason,
 }: {
     items: { request: DeliveryRequest; stop?: DeliveryRunStop | null }[];
     run?: DeliveryRunSnapshot | null;
@@ -290,6 +302,8 @@ function deliveryStopSummary({
     contacts: DeliveryAccountContact[];
     includeTracking: boolean;
     sequence?: number | null;
+    actionState?: DeliveryStopSummary['actionState'];
+    lockedReason?: string | null;
 }): DeliveryStopSummary {
     const primary = items[0];
     if (!primary) {
@@ -356,6 +370,164 @@ function deliveryStopSummary({
         deliveries: items.map((item) =>
             deliverySummaryItem(item.request, contacts, item.stop),
         ),
+        ...(actionState
+            ? { actionState, lockedReason: lockedReason ?? null }
+            : {}),
+    };
+}
+
+function deliveryManifestItemState(
+    state: DeliveryRunStop['pickupItemState'],
+    manifestConfirmed: boolean,
+): DeliveryPickupManifestItemState {
+    switch (state) {
+        case DeliveryRunManifestItemStates.READY:
+        case DeliveryRunManifestItemStates.SCANNED:
+        case DeliveryRunManifestItemStates.MISSING_LABEL:
+        case DeliveryRunManifestItemStates.NOT_READY:
+            return state;
+        default:
+            return manifestConfirmed
+                ? DeliveryRunManifestItemStates.SCANNED
+                : DeliveryRunManifestItemStates.READY;
+    }
+}
+
+export function pickupManifestTracePath(
+    pickupTraceToken: string | null | undefined,
+) {
+    return pickupTraceToken ? `/trag/${pickupTraceToken}` : null;
+}
+
+function pickupManifestSummary({
+    run,
+    slot,
+    requestsById,
+}: {
+    run: DeliveryRun;
+    slot: DeliveryRun['runSlots'][number];
+    requestsById: ReadonlyMap<string, DeliveryRequest>;
+}): DeliveryPickupManifestSummary {
+    const confirmed =
+        slot.manifestState === DeliveryRunManifestStates.CONFIRMED;
+    const items = run.stops
+        .filter((stop) => stop.runSlotId === slot.id)
+        .map((stop) => {
+            const request = requestsById.get(stop.deliveryRequestId);
+            const tracePath = pickupManifestTracePath(stop.pickupTraceToken);
+            return {
+                id: String(stop.id),
+                stopId: stop.id,
+                requestId: stop.deliveryRequestId,
+                stopKey:
+                    stop.stopKey ??
+                    (request
+                        ? deliveryRequestStopKey(request)
+                        : `request:${stop.deliveryRequestId}`),
+                state: deliveryManifestItemState(
+                    stop.pickupItemState,
+                    confirmed,
+                ),
+                resolvedAt: iso(stop.pickupResolvedAt),
+                tracePath,
+                harvest: request
+                    ? { ...harvestSummary(request), tracePath }
+                    : {
+                          plantName: 'Urod',
+                          operationName: null,
+                          raisedBedName: null,
+                          fieldName: null,
+                          tracePath: null,
+                      },
+            };
+        });
+    const scannedCount = items.filter(
+        (item) => item.state === DeliveryRunManifestItemStates.SCANNED,
+    ).length;
+    const missingLabelCount = items.filter(
+        (item) => item.state === DeliveryRunManifestItemStates.MISSING_LABEL,
+    ).length;
+    const notReadyCount = items.filter(
+        (item) => item.state === DeliveryRunManifestItemStates.NOT_READY,
+    ).length;
+
+    return {
+        id: slot.manifestId,
+        timeSlotId: slot.timeSlotId,
+        startAt: slot.windowStartAt.toISOString(),
+        endAt: slot.windowEndAt.toISOString(),
+        state: confirmed ? 'confirmed' : 'pending',
+        confirmedAt: iso(slot.confirmedAt),
+        expectedCount: items.length,
+        scannedCount,
+        missingLabelCount,
+        notReadyCount,
+        remainingCount: items.length - scannedCount - missingLabelCount,
+        items,
+    };
+}
+
+function pickupStepSummary({
+    run,
+    step,
+    requestsById,
+}: {
+    run: DeliveryRun;
+    step: Extract<DeliveryRunExecutionStep, { kind: 'pickup' }>;
+    requestsById: ReadonlyMap<string, DeliveryRequest>;
+}): DeliveryPickupStepSummary | null {
+    const pickupNode = run.pickupNodes.find(
+        (node) => node.id === step.pickupNodeId,
+    );
+    if (!pickupNode) return null;
+
+    const manifests = run.runSlots
+        .filter((slot) => slot.pickupNodeId === pickupNode.id)
+        .map((slot) => pickupManifestSummary({ run, slot, requestsById }));
+    const scannedCount = manifests.reduce(
+        (count, manifest) => count + manifest.scannedCount,
+        0,
+    );
+    const missingLabelCount = manifests.reduce(
+        (count, manifest) => count + manifest.missingLabelCount,
+        0,
+    );
+    const notReadyCount = manifests.reduce(
+        (count, manifest) => count + manifest.notReadyCount,
+        0,
+    );
+    const remainingCount = manifests.reduce(
+        (count, manifest) => count + manifest.remainingCount,
+        0,
+    );
+    const allConfirmed =
+        manifests.length > 0 &&
+        manifests.every((manifest) => manifest.state === 'confirmed');
+    const hasProgress =
+        scannedCount > 0 || missingLabelCount > 0 || notReadyCount > 0;
+
+    return {
+        id: pickupNode.id,
+        pickupLocationId: pickupNode.pickupLocationId,
+        sequence: pickupNode.sequence,
+        itinerarySequence: step.itinerarySequence,
+        name: pickupNode.name,
+        address: pickupNode.formattedAddress,
+        estimatedArrivalAt: iso(pickupNode.estimatedArrivalAt),
+        estimatedTravelSeconds: pickupNode.incomingTravelSeconds,
+        estimatedDistanceMeters: pickupNode.incomingDistanceMeters,
+        serviceDurationSeconds: pickupNode.serviceDurationSeconds,
+        state: allConfirmed ? 'confirmed' : hasProgress ? 'partial' : 'pending',
+        isCurrent: step.state === 'current',
+        expectedCount: manifests.reduce(
+            (count, manifest) => count + manifest.expectedCount,
+            0,
+        ),
+        scannedCount,
+        missingLabelCount,
+        notReadyCount,
+        remainingCount,
+        manifests,
     };
 }
 
@@ -366,6 +538,9 @@ async function activeRunSummary(
     const requests = groups.flatMap((group) =>
         group.items.flatMap((item) => (item.request ? [item.request] : [])),
     );
+    const requestsById = new Map(
+        requests.map((request) => [request.id, request]),
+    );
     const accountIds = Array.from(
         new Set(
             requests
@@ -373,28 +548,110 @@ async function activeRunSummary(
                 .filter((accountId): accountId is string => Boolean(accountId)),
         ),
     );
-    const contacts = await getDeliveryAccountContacts(accountIds);
-    const currentGroup = groups.find((group) =>
-        group.items.some(
-            ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,
-        ),
-    );
-    const stops: DeliveryStopSummary[] = [];
+    const [contacts, executionSteps] = await Promise.all([
+        getDeliveryAccountContacts(accountIds),
+        getDeliveryRunExecutionProgress(run.id),
+    ]);
+    const groupsByStopId = new Map<number, ResolvedDeliveryRunStopGroup>();
     for (const group of groups) {
+        for (const { stop } of group.items) {
+            groupsByStopId.set(stop.id, group);
+        }
+    }
+    const stops: DeliveryStopSummary[] = [];
+    const routeSteps: DeliveryRouteStepSummary[] = [];
+    const includedDeliveryGroups = new Set<string>();
+    for (const executionStep of executionSteps) {
+        if (executionStep.kind === 'pickup') {
+            const pickup = pickupStepSummary({
+                run,
+                step: executionStep,
+                requestsById,
+            });
+            if (!pickup) continue;
+            routeSteps.push({
+                kind: 'pickup',
+                itinerarySequence: executionStep.itinerarySequence,
+                actionState:
+                    executionStep.state === 'completed'
+                        ? 'completed'
+                        : executionStep.state === 'current'
+                          ? 'current'
+                          : 'locked',
+                pickup,
+            });
+            continue;
+        }
+
+        const group = executionStep.stopIds.flatMap((stopId) => {
+            const candidate = groupsByStopId.get(stopId);
+            return candidate ? [candidate] : [];
+        })[0];
+        if (!group || includedDeliveryGroups.has(group.stopKey)) continue;
+        includedDeliveryGroups.add(group.stopKey);
+
+        const groupStopIds = new Set(group.items.map(({ stop }) => stop.id));
+        const groupExecutionSteps = executionSteps.filter(
+            (
+                candidate,
+            ): candidate is Extract<
+                DeliveryRunExecutionStep,
+                { kind: 'delivery' }
+            > =>
+                candidate.kind === 'delivery' &&
+                candidate.stopIds.some((stopId) => groupStopIds.has(stopId)),
+        );
         const items = group.items.flatMap(({ request, stop }) =>
             request ? [{ request, stop }] : [],
         );
         if (items.length === 0) continue;
-        stops.push(
-            deliveryStopSummary({
-                items,
-                run,
-                isCurrent: currentGroup?.stopKey === group.stopKey,
-                contacts,
-                includeTracking: true,
-                sequence: stops.length + 1,
-            }),
+        const complete = group.items.every(
+            ({ stop }) => stop.state === DeliveryRunStopStates.DELIVERED,
         );
+        const dependencySatisfied = groupExecutionSteps.every(
+            (candidate) => candidate.pickupConfirmed,
+        );
+        const current = groupExecutionSteps.some(
+            (candidate) => candidate.state === 'current',
+        );
+        const actionState: NonNullable<DeliveryStopSummary['actionState']> =
+            complete
+                ? 'completed'
+                : !dependencySatisfied
+                  ? 'locked'
+                  : current
+                    ? 'current'
+                    : 'upcoming';
+        const itinerarySequence = Math.min(
+            ...groupExecutionSteps.map(
+                (candidate) => candidate.itinerarySequence,
+            ),
+        );
+        const stop = deliveryStopSummary({
+            items,
+            run,
+            isCurrent: actionState === 'current',
+            contacts,
+            includeTracking: true,
+            sequence: Number.isFinite(itinerarySequence)
+                ? itinerarySequence
+                : stops.length + 1,
+            actionState,
+            lockedReason:
+                actionState === 'locked'
+                    ? 'Najprije potvrdi preuzimanje svih uroda za ovu stanicu.'
+                    : null,
+        });
+        stops.push(stop);
+        routeSteps.push({
+            kind: 'delivery',
+            itinerarySequence: Number.isFinite(itinerarySequence)
+                ? itinerarySequence
+                : executionStep.itinerarySequence,
+            actionState,
+            lockedReason: stop.lockedReason ?? null,
+            stop,
+        });
     }
 
     return {
@@ -414,6 +671,7 @@ async function activeRunSummary(
             0,
         ),
         stops,
+        routeSteps,
     };
 }
 
@@ -558,21 +816,25 @@ async function customerDashboard({
         ),
     );
     const activeRuns = await Promise.all(activeRunIds.map(getDeliveryRun));
-    const currentStopIdsByRunId = new Map<string, Set<number>>();
+    const currentStopIdsByRunId = new Map<string, Set<number> | null>();
     for (const run of activeRuns) {
         if (!run) continue;
-        const groups = await resolveDeliveryRunStopGroups(run);
-        const currentGroup = groups.find((group) =>
-            group.items.some(
-                ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,
-            ),
-        );
-        if (currentGroup) {
-            currentStopIdsByRunId.set(
-                run.id,
-                new Set(currentGroup.items.map(({ stop }) => stop.id)),
-            );
+        const progress = await getDeliveryRunExecutionProgress(run.id);
+        const current = progress.find((step) => step.state === 'current');
+        if (current?.kind !== 'delivery' || !current.pickupConfirmed) {
+            currentStopIdsByRunId.set(run.id, null);
+            continue;
         }
+        const currentStopIds = new Set(current.stopIds);
+        currentStopIdsByRunId.set(
+            run.id,
+            run.routePlanVersion < 2
+                ? expandLegacyCurrentDeliveryStopIds({
+                      currentStopIds,
+                      groups: await resolveDeliveryRunStopGroups(run),
+                  })
+                : currentStopIds,
+        );
     }
 
     const deliveries = requests
@@ -609,6 +871,31 @@ async function customerDashboard({
         deliveries,
         refreshedAt: new Date().toISOString(),
     };
+}
+
+export function expandLegacyCurrentDeliveryStopIds({
+    currentStopIds,
+    groups,
+}: {
+    currentStopIds: ReadonlySet<number>;
+    groups: ReadonlyArray<{
+        items: ReadonlyArray<{ stop: { id?: number } }>;
+    }>;
+}) {
+    const currentGroup = groups.find((group) =>
+        group.items.some(
+            ({ stop }) => stop.id !== undefined && currentStopIds.has(stop.id),
+        ),
+    );
+    if (!currentGroup) {
+        return new Set(currentStopIds);
+    }
+
+    return new Set(
+        currentGroup.items.flatMap(({ stop }) =>
+            stop.id === undefined ? [] : [stop.id],
+        ),
+    );
 }
 
 export async function getDeliveryDashboard({
@@ -715,13 +1002,15 @@ async function getOwnedDeliveryRunStopGroup({
     if (run.state !== DeliveryRunStates.ACTIVE) {
         throw new Error('Aktivna dostava nije pronađena.');
     }
-    const currentGroup = groups.find((group) =>
-        group.items.some(
-            ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,
-        ),
-    );
-    if (currentGroup?.stopKey !== targetGroup.stopKey) {
-        throw new Error('Dostave se moraju završiti redoslijedom rute.');
+    if (run.routePlanVersion < 2) {
+        const currentGroup = groups.find((group) =>
+            group.items.some(
+                ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,
+            ),
+        );
+        if (currentGroup?.stopKey !== targetGroup.stopKey) {
+            throw new Error('Dostave se moraju završiti redoslijedom rute.');
+        }
     }
     if (targetGroup.items.some(({ request }) => !request)) {
         throw new Error('Dostava u ruti nije pronađena.');
@@ -773,11 +1062,19 @@ export async function accountCanTrackDeliveryRun({
     if (!run || run.state !== DeliveryRunStates.ACTIVE) {
         return false;
     }
-    const groups = await resolveDeliveryRunStopGroups(run);
+    const [groups, progress] = await Promise.all([
+        resolveDeliveryRunStopGroups(run),
+        getDeliveryRunExecutionProgress(run.id),
+    ]);
+    const current = progress.find((step) => step.state === 'current');
     return accountCanTrackCurrentDeliveryGroup({
         accountId,
         runState: run.state,
         groups,
+        currentDeliveryStopIds:
+            current?.kind === 'delivery' && current.pickupConfirmed
+                ? new Set(current.stopIds)
+                : null,
     });
 }
 
@@ -785,24 +1082,38 @@ export function accountCanTrackCurrentDeliveryGroup({
     accountId,
     runState,
     groups,
+    currentDeliveryStopIds,
 }: {
     accountId: string;
     runState: string;
     groups: ReadonlyArray<{
         items: ReadonlyArray<{
-            stop: { state: string };
+            stop: { id?: number; state: string };
             request?: { accountId?: string | null };
         }>;
     }>;
+    currentDeliveryStopIds?: ReadonlySet<number> | null;
 }) {
     if (runState !== DeliveryRunStates.ACTIVE) {
         return false;
     }
-    const currentGroup = groups.find((group) =>
-        group.items.some(
-            ({ stop }) => stop.state !== DeliveryRunStopStates.DELIVERED,
-        ),
-    );
+    const currentGroup =
+        currentDeliveryStopIds === undefined
+            ? groups.find((group) =>
+                  group.items.some(
+                      ({ stop }) =>
+                          stop.state !== DeliveryRunStopStates.DELIVERED,
+                  ),
+              )
+            : currentDeliveryStopIds === null
+              ? undefined
+              : groups.find((group) =>
+                    group.items.some(
+                        ({ stop }) =>
+                            stop.id !== undefined &&
+                            currentDeliveryStopIds.has(stop.id),
+                    ),
+                );
 
     return Boolean(
         currentGroup?.items.some(
@@ -849,6 +1160,11 @@ export async function recordDriverLocation({
         run.estimatesUpdatedAt &&
         Date.now() - run.estimatesUpdatedAt.getTime() < etaRefreshIntervalMs;
     if (estimatesAreFresh) {
+        return;
+    }
+    // Pickup-aware plans contain interleaved pickup and delivery checkpoints.
+    // Rebuilding only the customer portion would corrupt their itinerary.
+    if (run.routePlanVersion >= 2) {
         return;
     }
 

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -825,15 +825,13 @@ async function customerDashboard({
             currentStopIdsByRunId.set(run.id, null);
             continue;
         }
-        const currentStopIds = new Set(current.stopIds);
         currentStopIdsByRunId.set(
             run.id,
-            run.routePlanVersion < 2
-                ? expandLegacyCurrentDeliveryStopIds({
-                      currentStopIds,
-                      groups: await resolveDeliveryRunStopGroups(run),
-                  })
-                : currentStopIds,
+            deliveryTrackingStopIds({
+                routePlanVersion: run.routePlanVersion,
+                currentStopIds: new Set(current.stopIds),
+                groups: await resolveDeliveryRunStopGroups(run),
+            }),
         );
     }
 
@@ -896,6 +894,22 @@ export function expandLegacyCurrentDeliveryStopIds({
             stop.id === undefined ? [] : [stop.id],
         ),
     );
+}
+
+export function deliveryTrackingStopIds({
+    routePlanVersion,
+    currentStopIds,
+    groups,
+}: {
+    routePlanVersion: number;
+    currentStopIds: ReadonlySet<number>;
+    groups: ReadonlyArray<{
+        items: ReadonlyArray<{ stop: { id?: number } }>;
+    }>;
+}) {
+    return routePlanVersion < 2
+        ? expandLegacyCurrentDeliveryStopIds({ currentStopIds, groups })
+        : new Set(currentStopIds);
 }
 
 export async function getDeliveryDashboard({
@@ -1067,14 +1081,19 @@ export async function accountCanTrackDeliveryRun({
         getDeliveryRunExecutionProgress(run.id),
     ]);
     const current = progress.find((step) => step.state === 'current');
+    const currentDeliveryStopIds =
+        current?.kind === 'delivery' && current.pickupConfirmed
+            ? deliveryTrackingStopIds({
+                  routePlanVersion: run.routePlanVersion,
+                  currentStopIds: new Set(current.stopIds),
+                  groups,
+              })
+            : null;
     return accountCanTrackCurrentDeliveryGroup({
         accountId,
         runState: run.state,
         groups,
-        currentDeliveryStopIds:
-            current?.kind === 'delivery' && current.pickupConfirmed
-                ? new Set(current.stopIds)
-                : null,
+        currentDeliveryStopIds,
     });
 }
 

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -63,7 +63,77 @@ export type DeliveryStopSummary = {
     runId: string | null;
     deliveryCount: number;
     deliveries: DeliveryStopDeliverySummary[];
+    actionState?: 'locked' | 'upcoming' | 'current' | 'completed';
+    lockedReason?: string | null;
 };
+
+export type DeliveryPickupManifestItemState =
+    | 'ready'
+    | 'scanned'
+    | 'missing-label'
+    | 'not-ready';
+
+export type DeliveryPickupManifestItemSummary = {
+    id: string;
+    stopId: number;
+    requestId: string;
+    stopKey: string;
+    state: DeliveryPickupManifestItemState;
+    resolvedAt: string | null;
+    tracePath: string | null;
+    harvest: DeliveryHarvestSummary;
+};
+
+export type DeliveryPickupManifestSummary = {
+    id: string;
+    timeSlotId: number | null;
+    startAt: string;
+    endAt: string;
+    state: 'pending' | 'confirmed';
+    confirmedAt: string | null;
+    expectedCount: number;
+    scannedCount: number;
+    missingLabelCount: number;
+    notReadyCount: number;
+    remainingCount: number;
+    items: DeliveryPickupManifestItemSummary[];
+};
+
+export type DeliveryPickupStepSummary = {
+    id: string;
+    pickupLocationId: number | null;
+    sequence: number;
+    itinerarySequence: number;
+    name: string;
+    address: string;
+    estimatedArrivalAt: string | null;
+    estimatedTravelSeconds: number | null;
+    estimatedDistanceMeters: number | null;
+    serviceDurationSeconds: number | null;
+    state: 'pending' | 'partial' | 'confirmed';
+    isCurrent: boolean;
+    expectedCount: number;
+    scannedCount: number;
+    missingLabelCount: number;
+    notReadyCount: number;
+    remainingCount: number;
+    manifests: DeliveryPickupManifestSummary[];
+};
+
+export type DeliveryRouteStepSummary =
+    | {
+          kind: 'pickup';
+          itinerarySequence: number;
+          actionState: 'locked' | 'current' | 'completed';
+          pickup: DeliveryPickupStepSummary;
+      }
+    | {
+          kind: 'delivery';
+          itinerarySequence: number;
+          actionState: 'locked' | 'upcoming' | 'current' | 'completed';
+          lockedReason: string | null;
+          stop: DeliveryStopSummary;
+      };
 
 export type DeliveryBatchSummary = {
     slotId: number;
@@ -103,6 +173,7 @@ export type ActiveDeliveryRunSummary = {
     mapUrl: string;
     deliveryCount: number;
     stops: DeliveryStopSummary[];
+    routeSteps: DeliveryRouteStepSummary[];
 };
 
 export type DriverDeliveryDashboard = {

--- a/apps/delivery/lib/deliveryPickupMutationRequest.node.spec.ts
+++ b/apps/delivery/lib/deliveryPickupMutationRequest.node.spec.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseDeliveryPickupMutationRequest } from './deliveryPickupMutationRequest';
+
+const now = new Date('2026-07-15T08:00:00.000Z');
+const occurredAt = '2026-07-15T07:59:00.000Z';
+const traceToken = 'pickup-manifest-trace-token-2026';
+
+test('parses and normalizes an ordered pickup mutation batch', () => {
+    const result = parseDeliveryPickupMutationRequest(
+        {
+            mutations: [
+                {
+                    clientOperationId: 'operation-scan-1',
+                    occurredAt,
+                    kind: 'scan',
+                    traceToken: `https://www.gredice.com/trag/${traceToken}?camera=1`,
+                },
+                {
+                    clientOperationId: 'operation-item-1',
+                    occurredAt,
+                    kind: 'mark-item',
+                    stopId: 42,
+                    outcome: 'missing-label',
+                },
+                {
+                    clientOperationId: 'operation-confirm-1',
+                    occurredAt,
+                    kind: 'confirm-manifest',
+                    manifestId: 'manifest-1',
+                },
+            ],
+        },
+        now,
+    );
+
+    assert.ok(result);
+    assert.equal(result.length, 3);
+    assert.deepEqual(result[0], {
+        clientOperationId: 'operation-scan-1',
+        occurredAt: new Date(occurredAt),
+        kind: 'scan',
+        traceToken: `/trag/${traceToken}`,
+    });
+});
+
+test('rejects duplicate operation IDs, invalid outcomes, and malformed scans', () => {
+    const common = {
+        clientOperationId: 'operation-shared',
+        occurredAt,
+    };
+    assert.equal(
+        parseDeliveryPickupMutationRequest(
+            {
+                mutations: [
+                    { ...common, kind: 'scan', traceToken },
+                    {
+                        ...common,
+                        kind: 'confirm-manifest',
+                        manifestId: 'manifest-1',
+                    },
+                ],
+            },
+            now,
+        ),
+        null,
+    );
+    assert.equal(
+        parseDeliveryPickupMutationRequest(
+            {
+                mutations: [
+                    {
+                        ...common,
+                        kind: 'mark-item',
+                        stopId: 1,
+                        outcome: 'collected',
+                    },
+                ],
+            },
+            now,
+        ),
+        null,
+    );
+    assert.equal(
+        parseDeliveryPickupMutationRequest(
+            {
+                mutations: [{ ...common, kind: 'scan', traceToken: 'invalid' }],
+            },
+            now,
+        ),
+        null,
+    );
+});
+
+test('rejects empty and oversized batches', () => {
+    assert.equal(
+        parseDeliveryPickupMutationRequest({ mutations: [] }, now),
+        null,
+    );
+    assert.equal(
+        parseDeliveryPickupMutationRequest(
+            {
+                mutations: Array.from({ length: 101 }, (_, index) => ({
+                    clientOperationId: `operation-${index}`,
+                    occurredAt,
+                    kind: 'confirm-manifest',
+                    manifestId: `manifest-${index}`,
+                })),
+            },
+            now,
+        ),
+        null,
+    );
+});
+
+test('accepts replay timestamps regardless of age or clock skew but rejects invalid dates', () => {
+    const result = parseDeliveryPickupMutationRequest(
+        {
+            mutations: [
+                {
+                    clientOperationId: 'operation-stale',
+                    occurredAt: '2026-07-01T08:00:00.000Z',
+                    kind: 'confirm-manifest',
+                    manifestId: 'manifest-1',
+                },
+                {
+                    clientOperationId: 'operation-future',
+                    occurredAt: '2026-07-15T09:00:00.000Z',
+                    kind: 'confirm-manifest',
+                    manifestId: 'manifest-2',
+                },
+            ],
+        },
+        now,
+    );
+    assert.ok(result);
+    assert.deepEqual(
+        result.map((mutation) => mutation.occurredAt.toISOString()),
+        ['2026-07-01T08:00:00.000Z', '2026-07-15T09:00:00.000Z'],
+    );
+    assert.equal(
+        parseDeliveryPickupMutationRequest({
+            mutations: [
+                {
+                    clientOperationId: 'operation-invalid-date',
+                    occurredAt: 'not-a-date',
+                    kind: 'confirm-manifest',
+                    manifestId: 'manifest-1',
+                },
+            ],
+        }),
+        null,
+    );
+});

--- a/apps/delivery/lib/deliveryPickupMutationRequest.ts
+++ b/apps/delivery/lib/deliveryPickupMutationRequest.ts
@@ -1,0 +1,112 @@
+import { normalizeHarvestTraceScanValue } from './harvestTraceScan';
+
+type DeliveryPickupMutationBase = {
+    clientOperationId: string;
+    occurredAt: Date;
+};
+
+export type DeliveryPickupMutationRequest =
+    | (DeliveryPickupMutationBase & {
+          kind: 'scan';
+          traceToken: string;
+      })
+    | (DeliveryPickupMutationBase & {
+          kind: 'mark-item';
+          stopId: number;
+          outcome: 'ready' | 'missing-label' | 'not-ready';
+      })
+    | (DeliveryPickupMutationBase & {
+          kind: 'confirm-manifest';
+          manifestId: string;
+      });
+
+const operationIdPattern = /^[A-Za-z0-9_-]{8,128}$/;
+const maximumPickupMutationBatchSize = 100;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function mutationBase(value: Record<string, unknown>) {
+    if (
+        typeof value.clientOperationId !== 'string' ||
+        !operationIdPattern.test(value.clientOperationId) ||
+        typeof value.occurredAt !== 'string'
+    ) {
+        return null;
+    }
+    const occurredAt = new Date(value.occurredAt);
+    if (!Number.isFinite(occurredAt.getTime())) return null;
+    return {
+        clientOperationId: value.clientOperationId,
+        occurredAt,
+    };
+}
+
+function parseMutation(value: unknown): DeliveryPickupMutationRequest | null {
+    if (!isRecord(value)) return null;
+    const base = mutationBase(value);
+    if (!base) return null;
+
+    switch (value.kind) {
+        case 'scan': {
+            if (typeof value.traceToken !== 'string') return null;
+            const traceToken = normalizeHarvestTraceScanValue(value.traceToken);
+            return traceToken ? { ...base, kind: 'scan', traceToken } : null;
+        }
+        case 'mark-item':
+            return typeof value.stopId === 'number' &&
+                Number.isInteger(value.stopId) &&
+                value.stopId > 0 &&
+                (value.outcome === 'ready' ||
+                    value.outcome === 'missing-label' ||
+                    value.outcome === 'not-ready')
+                ? {
+                      ...base,
+                      kind: 'mark-item',
+                      stopId: value.stopId,
+                      outcome: value.outcome,
+                  }
+                : null;
+        case 'confirm-manifest':
+            return typeof value.manifestId === 'string' &&
+                value.manifestId.trim() === value.manifestId &&
+                value.manifestId.length > 0 &&
+                value.manifestId.length <= 256
+                ? {
+                      ...base,
+                      kind: 'confirm-manifest',
+                      manifestId: value.manifestId,
+                  }
+                : null;
+        default:
+            return null;
+    }
+}
+
+export function parseDeliveryPickupMutationRequest(
+    value: unknown,
+    _now = new Date(),
+) {
+    if (
+        !isRecord(value) ||
+        !Array.isArray(value.mutations) ||
+        value.mutations.length === 0 ||
+        value.mutations.length > maximumPickupMutationBatchSize
+    ) {
+        return null;
+    }
+    const mutations = value.mutations.map(parseMutation);
+    if (mutations.some((mutation) => mutation === null)) return null;
+    const parsed = mutations.filter(
+        (mutation): mutation is DeliveryPickupMutationRequest =>
+            mutation !== null,
+    );
+    if (
+        new Set(parsed.map((mutation) => mutation.clientOperationId)).size !==
+        parsed.length
+    ) {
+        return null;
+    }
+    return parsed;
+}

--- a/apps/delivery/lib/deliveryRouteSelection.node.spec.ts
+++ b/apps/delivery/lib/deliveryRouteSelection.node.spec.ts
@@ -88,6 +88,7 @@ test('manual bulk selection keeps every ready harvest at one physical stop', () 
     assert.deepEqual(result.requestIds, ['bulk-one', 'bulk-two']);
     assert.equal(result.summary.deliveryCount, 2);
     assert.equal(result.summary.stopCount, 1);
+    assert.equal(result.summary.routeNodeCount, 2);
     assert.deepEqual(result.summary.pickupLocations[0]?.requestIds, [
         'bulk-one',
         'bulk-two',
@@ -114,6 +115,7 @@ test('same-location selections across compatible slots are accepted and summariz
     assert.equal(result.status, 'accepted');
     assert.deepEqual(result.requestIds, ['morning', 'afternoon']);
     assert.equal(result.summary.pickupLocations.length, 1);
+    assert.equal(result.summary.routeNodeCount, 3);
     assert.deepEqual(
         result.summary.slots.map((slot) => slot.id),
         [10, 11],
@@ -123,7 +125,7 @@ test('same-location selections across compatible slots are accepted and summariz
     assert.equal(result.summary.windowSpanMinutes, 360);
 });
 
-test('mixed pickup locations reject the attempted manual change and preserve current IDs', () => {
+test('mixed pickup locations are accepted and included in the route-node summary', () => {
     const candidates = [
         candidate({ requestId: 'selected' }),
         candidate({
@@ -141,13 +143,12 @@ test('mixed pickup locations reject the attempted manual change and preserve cur
         nextRequestIds: ['selected', 'other-location'],
     });
 
-    assert.equal(result.status, 'rejected');
-    assert.deepEqual(result.requestIds, ['selected']);
-    assert.deepEqual(result.summary.requestIds, ['selected']);
-    assert.equal(result.conflict.code, 'mixed-pickup-locations');
-    assert.deepEqual(result.conflict.conflictingRequestIds, ['other-location']);
+    assert.equal(result.status, 'accepted');
+    assert.deepEqual(result.requestIds, ['selected', 'other-location']);
+    assert.equal(result.summary.stopCount, 2);
+    assert.equal(result.summary.routeNodeCount, 4);
     assert.deepEqual(
-        result.conflict.pickupLocations.map((location) => ({
+        result.summary.pickupLocations.map((location) => ({
             id: location.id,
             name: location.name,
             address: location.address,
@@ -165,11 +166,9 @@ test('mixed pickup locations reject the attempted manual change and preserve cur
             },
         ],
     );
-    assert.deepEqual(result.conflict.separateRouteRequestIds, ['selected']);
-    assert.match(result.conflict.message, /Istočno skladište/);
 });
 
-test('batch selection rejects mixed-location additions atomically', () => {
+test('batch selection accepts additions from another pickup location atomically', () => {
     const candidates = [
         candidate({ requestId: 'current', stopKey: 'current-stop' }),
         candidate({
@@ -194,16 +193,13 @@ test('batch selection rejects mixed-location additions atomically', () => {
         nextRequestIds: ['current', 'batch-one', 'batch-two'],
     });
 
-    assert.equal(result.status, 'rejected');
-    assert.deepEqual(result.requestIds, ['current']);
-    assert.deepEqual(result.conflict.conflictingRequestIds, [
-        'batch-one',
-        'batch-two',
-    ]);
-    assert.deepEqual(result.conflict.separateRouteRequestIds, ['current']);
+    assert.equal(result.status, 'accepted');
+    assert.deepEqual(result.requestIds, ['current', 'batch-one', 'batch-two']);
+    assert.equal(result.summary.pickupLocations.length, 2);
+    assert.equal(result.summary.routeNodeCount, 5);
 });
 
-test('select-all conflict returns the same deterministic compatible suggestion', () => {
+test('select-all across pickup locations is accepted deterministically', () => {
     const candidates = [
         candidate({ requestId: 'hq-one', stopKey: 'hq-bulk' }),
         candidate({ requestId: 'hq-two', stopKey: 'hq-bulk' }),
@@ -235,15 +231,11 @@ test('select-all conflict returns the same deterministic compatible suggestion',
         maximumRouteWindowHours: 24,
     });
 
-    assert.equal(first.conflict?.code, 'mixed-pickup-locations');
-    assert.deepEqual(first.conflict?.separateRouteRequestIds, [
-        'hq-one',
-        'hq-two',
-    ]);
-    assert.deepEqual(
-        second.conflict?.separateRouteRequestIds,
-        first.conflict?.separateRouteRequestIds,
-    );
+    assert.equal(first.conflict, null);
+    assert.equal(second.conflict, null);
+    assert.deepEqual(first.summary.requestIds, requestIds);
+    assert.deepEqual(second.summary.requestIds, requestIds);
+    assert.equal(first.summary.routeNodeCount, 5);
 });
 
 test('a selection spanning more than 24 hours is rejected with its conflicting slot', () => {
@@ -331,6 +323,7 @@ test('physical-stop limits count a bulk address once and reject only the excess 
     assert.equal(accepted.status, 'accepted');
     assert.equal(accepted.summary.deliveryCount, 3);
     assert.equal(accepted.summary.stopCount, 2);
+    assert.equal(accepted.summary.routeNodeCount, 3);
 
     const rejected = apply({
         candidates,
@@ -360,6 +353,51 @@ test('physical-stop limits count a bulk address once and reject only the excess 
         'bulk-two',
         'second-stop',
     ]);
+});
+
+test('route validation accepts 27 physical nodes and rejects the 28th', () => {
+    const candidates = Array.from({ length: 26 }, (_, index) =>
+        candidate({
+            requestId: `delivery-${index + 1}`,
+            stopKey: `stop-${index + 1}`,
+            pickupLocationId: index === 24 ? 2 : 1,
+            pickupLocationName:
+                index === 24 ? 'Drugo skladište' : 'Glavno sjedište',
+            pickupAddress:
+                index === 24
+                    ? 'Druga 2, Zagreb'
+                    : 'Ulica Julija Knifera 3, Zagreb',
+            slotId: index === 24 ? 20 : 10,
+        }),
+    );
+    const acceptedRequestIds = candidates
+        .slice(0, 25)
+        .map(({ requestId }) => requestId);
+
+    const accepted = apply({
+        candidates,
+        nextRequestIds: acceptedRequestIds,
+    });
+    assert.equal(accepted.status, 'accepted');
+    assert.equal(accepted.summary.stopCount, 25);
+    assert.equal(accepted.summary.pickupLocations.length, 2);
+    assert.equal(accepted.summary.routeNodeCount, 27);
+
+    const rejected = apply({
+        candidates,
+        currentRequestIds: acceptedRequestIds,
+        nextRequestIds: candidates.map(({ requestId }) => requestId),
+    });
+    assert.equal(rejected.status, 'rejected');
+    if (rejected.status !== 'rejected') return;
+    assert.equal(rejected.summary.routeNodeCount, 27);
+    assert.equal(rejected.conflict.code, 'route-stop-limit-exceeded');
+    assert.deepEqual(rejected.conflict.conflictingRequestIds, ['delivery-26']);
+    assert.deepEqual(
+        rejected.conflict.separateRouteRequestIds,
+        acceptedRequestIds,
+    );
+    assert.match(rejected.conflict.message, /27 fizičkih lokacija/);
 });
 
 test('stale, duplicate, and no-longer-ready request IDs are pruned', () => {
@@ -392,6 +430,7 @@ test('reset accepts an empty replacement and clears all summary counts', () => {
     assert.deepEqual(result.requestIds, []);
     assert.equal(result.summary.deliveryCount, 0);
     assert.equal(result.summary.stopCount, 0);
+    assert.equal(result.summary.routeNodeCount, 0);
     assert.deepEqual(result.summary.pickupLocations, []);
     assert.deepEqual(result.summary.slots, []);
     assert.equal(result.summary.windowStartAt, null);
@@ -399,7 +438,7 @@ test('reset accepts an empty replacement and clears all summary counts', () => {
     assert.equal(result.summary.windowSpanMinutes, 0);
 });
 
-test('QR-proposed IDs use the same atomic mixed-location guard', () => {
+test('QR-proposed IDs accumulate atomically across pickup locations', () => {
     const candidates = [
         candidate({ requestId: 'scanned-first', stopKey: 'first-bulk' }),
         candidate({ requestId: 'first-sibling', stopKey: 'first-bulk' }),
@@ -435,13 +474,16 @@ test('QR-proposed IDs use the same atomic mixed-location guard', () => {
         ],
     });
 
-    assert.equal(secondScan.status, 'rejected');
-    assert.deepEqual(secondScan.requestIds, ['scanned-first', 'first-sibling']);
-    assert.equal(secondScan.conflict.code, 'mixed-pickup-locations');
-    assert.deepEqual(secondScan.conflict.conflictingRequestIds, [
+    assert.equal(secondScan.status, 'accepted');
+    assert.deepEqual(secondScan.requestIds, [
+        'scanned-first',
+        'first-sibling',
         'scanned-remote',
         'remote-sibling',
     ]);
+    assert.equal(secondScan.summary.stopCount, 2);
+    assert.equal(secondScan.summary.pickupLocations.length, 2);
+    assert.equal(secondScan.summary.routeNodeCount, 4);
 });
 
 test('invalid delivery windows report the exact request and address', () => {

--- a/apps/delivery/lib/deliveryRouteSelection.ts
+++ b/apps/delivery/lib/deliveryRouteSelection.ts
@@ -30,7 +30,6 @@ export type DeliveryRouteSelectionSlot = {
 export type DeliveryRouteSelectionConflict = {
     code:
         | 'delivery-window-invalid'
-        | 'mixed-pickup-locations'
         | 'route-stop-limit-exceeded'
         | 'route-window-span-exceeded';
     message: string;
@@ -45,6 +44,7 @@ export type DeliveryRouteSelectionSummary = {
     requestIds: string[];
     deliveryCount: number;
     stopCount: number;
+    routeNodeCount: number;
     pickupLocations: DeliveryRouteSelectionPickupLocation[];
     slots: DeliveryRouteSelectionSlot[];
     windowStartAt: string | null;
@@ -69,14 +69,6 @@ export type DeliveryRouteSelectionChange =
           summary: DeliveryRouteSelectionSummary;
           conflict: DeliveryRouteSelectionConflict;
       };
-
-function pickupLocationLabel(location: DeliveryRouteSelectionPickupLocation) {
-    return (
-        location.name?.trim() ||
-        location.address?.trim() ||
-        `Lokacija preuzimanja ${location.id}`
-    );
-}
 
 function formatSlotDateTime(value: number) {
     return new Intl.DateTimeFormat('hr-HR', {
@@ -160,13 +152,16 @@ function buildSummary(
         timestamps.length > 0
             ? Math.max(...timestamps.map(({ endAt }) => endAt))
             : null;
+    const selectedPickupLocations = pickupLocations(candidates);
+    const stopCount = new Set(candidates.map((candidate) => candidate.stopKey))
+        .size;
 
     return {
         requestIds: candidates.map((candidate) => candidate.requestId),
         deliveryCount: candidates.length,
-        stopCount: new Set(candidates.map((candidate) => candidate.stopKey))
-            .size,
-        pickupLocations: pickupLocations(candidates),
+        stopCount,
+        routeNodeCount: stopCount + selectedPickupLocations.length,
+        pickupLocations: selectedPickupLocations,
         slots: slots(candidates),
         windowStartAt:
             windowStart === null ? null : new Date(windowStart).toISOString(),
@@ -210,40 +205,38 @@ function findConflict({
         };
     }
 
-    if (selectedPickupLocations.length > 1) {
-        const [firstLocation, secondLocation] = selectedPickupLocations;
-        if (firstLocation && secondLocation) {
-            return {
-                code: 'mixed-pickup-locations',
-                message: `Odabrani urodi čekaju na više lokacija preuzimanja: ${pickupLocationLabel(firstLocation)} i ${pickupLocationLabel(secondLocation)}. Pokreni zasebnu rutu za svaku lokaciju.`,
-                conflictingRequestIds: secondLocation.requestIds,
-                pickupLocations: selectedPickupLocations,
-                slots: selectedSlots,
-                deliveryAddress: null,
-            };
-        }
-    }
-
     const stopGroups = new Map<string, DeliveryRouteSelectionCandidate[]>();
     for (const candidate of candidates) {
         const group = stopGroups.get(candidate.stopKey);
         if (group) group.push(candidate);
         else stopGroups.set(candidate.stopKey, [candidate]);
     }
-    if (stopGroups.size > maximumRouteStops) {
-        const conflictingGroup = Array.from(stopGroups.values())[
-            maximumRouteStops
-        ];
-        const conflictingCandidate = conflictingGroup?.[0];
-        return {
-            code: 'route-stop-limit-exceeded',
-            message: `Jedna ruta može sadržavati najviše ${maximumRouteStops} fizičkih stanica. Adresu ${conflictingCandidate?.deliveryAddress ?? 'sljedeće dostave'} ostavi za zasebnu rutu.`,
-            conflictingRequestIds:
-                conflictingGroup?.map((candidate) => candidate.requestId) ?? [],
-            pickupLocations: selectedPickupLocations,
-            slots: selectedSlots,
-            deliveryAddress: conflictingCandidate?.deliveryAddress ?? null,
-        };
+    const maximumRouteNodes = maximumRouteStops + 1;
+    const acceptedCandidates: DeliveryRouteSelectionCandidate[] = [];
+    let acceptedStopCount = 0;
+    for (const group of stopGroups.values()) {
+        const proposedCandidates = [...acceptedCandidates, ...group];
+        const proposedPickupLocationCount = new Set(
+            proposedCandidates.map((candidate) => candidate.pickupLocationId),
+        ).size;
+        if (
+            acceptedStopCount + 1 + proposedPickupLocationCount >
+            maximumRouteNodes
+        ) {
+            const conflictingCandidate = group[0];
+            return {
+                code: 'route-stop-limit-exceeded',
+                message: `Jedna ruta može sadržavati najviše ${maximumRouteNodes} fizičkih lokacija, uključujući preuzimanja. Adresu ${conflictingCandidate?.deliveryAddress ?? 'sljedeće dostave'} ostavi za zasebnu rutu.`,
+                conflictingRequestIds: group.map(
+                    (candidate) => candidate.requestId,
+                ),
+                pickupLocations: selectedPickupLocations,
+                slots: selectedSlots,
+                deliveryAddress: conflictingCandidate?.deliveryAddress ?? null,
+            };
+        }
+        acceptedCandidates.push(...group);
+        acceptedStopCount += 1;
     }
 
     const timestamps = candidates.map((candidate) => ({

--- a/apps/delivery/lib/deliveryRunExecutionError.ts
+++ b/apps/delivery/lib/deliveryRunExecutionError.ts
@@ -1,0 +1,36 @@
+import { DeliveryRunExecutionError } from '@gredice/storage';
+
+export type DeliveryRunExecutionErrorDetails = {
+    code: string;
+    message: string;
+};
+
+export function deliveryRunExecutionErrorDetails(
+    error: unknown,
+): DeliveryRunExecutionErrorDetails | null {
+    if (!(error instanceof DeliveryRunExecutionError)) return null;
+
+    switch (error.code) {
+        case 'pickup-dependency-pending':
+            return {
+                code: error.code,
+                message:
+                    'Najprije potvrdi preuzimanje svih uroda na trenutačnoj lokaciji.',
+            };
+        case 'route-order':
+            return {
+                code: error.code,
+                message: 'Ova dostava još nije na redu rute.',
+            };
+        case 'active-run-not-found':
+            return {
+                code: error.code,
+                message: 'Aktivna ruta više nije dostupna.',
+            };
+        default:
+            return {
+                code: error.code,
+                message: 'Radnju nije moguće primijeniti na trenutačnu rutu.',
+            };
+    }
+}

--- a/apps/delivery/lib/deliveryRunPlanning.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunPlanning.node.spec.ts
@@ -39,6 +39,8 @@ function request({
     slotEndAt = '2026-07-15T10:00:00.000Z',
     addressId = 100,
     street1 = 'Ilica 1',
+    traceToken,
+    traceLinkId = 900,
     withAddress = true,
     withSlot = true,
 }: {
@@ -52,6 +54,8 @@ function request({
     slotEndAt?: string;
     addressId?: number;
     street1?: string;
+    traceToken?: string;
+    traceLinkId?: number;
     withAddress?: boolean;
     withSlot?: boolean;
 }): DeliveryRunPlanningRequest {
@@ -60,6 +64,7 @@ function request({
         routeRevision,
         mode: 'delivery',
         state,
+        trace: traceToken ? { id: traceLinkId, publicToken: traceToken } : null,
         address: withAddress
             ? {
                   id: addressId,
@@ -202,7 +207,12 @@ async function preparationError(
 
 test('prepares a valid single-location run and expands every ready delivery at a bulk stop', async () => {
     const requests = [
-        request({ id: 'bulk-one', addressId: 100 }),
+        request({
+            id: 'bulk-one',
+            addressId: 100,
+            traceLinkId: 901,
+            traceToken: 'planning-trace-token-0001',
+        }),
         request({ id: 'bulk-two', addressId: 100 }),
         request({
             id: 'later-stop',
@@ -317,6 +327,16 @@ test('prepares a valid single-location run and expands every ready delivery at a
         prepared.createRunInput.stops.map((stop) => stop.timeSlotId),
         [1, 1, 2],
     );
+    assert.deepEqual(prepared.createRunInput.manifestItems, [
+        {
+            deliveryRequestId: 'bulk-one',
+            timeSlotId: 1,
+            harvestTraceLinkId: 901,
+            traceToken: 'planning-trace-token-0001',
+        },
+        { deliveryRequestId: 'bulk-two', timeSlotId: 1 },
+        { deliveryRequestId: 'later-stop', timeSlotId: 2 },
+    ]);
     assert.equal(
         prepared.createRunInput.stops[0]?.stopKey,
         prepared.createRunInput.stops[1]?.stopKey,
@@ -534,7 +554,7 @@ test('rejects unavailable selections before assignment checks or route planning'
     }
 });
 
-test('rejects mixed pickup locations through the shared policy before the planner', async () => {
+test('prepares mixed pickup locations with one manifest dependency per delivery', async () => {
     const requests = [
         request({ id: 'hq', locationId: 10, locationName: 'HQ Zagreb' }),
         request({
@@ -548,27 +568,32 @@ test('rejects mixed pickup locations through the shared policy before the planne
     ];
     const { dependencies, counters } = planningDependencies({ requests });
 
-    const error = await preparationError(
-        prepareDeliveryRun(
-            {
-                driverUserId: 'driver-one',
-                deliveryRequestIds: ['hq', 'east'],
-            },
-            dependencies,
-        ),
+    const prepared = await prepareDeliveryRun(
+        {
+            driverUserId: 'driver-one',
+            deliveryRequestIds: ['hq', 'east'],
+        },
+        dependencies,
     );
 
-    assert.equal(error.code, 'mixed-pickup-locations');
-    assert.equal(error.conflict.deliveryRequestId, 'east');
-    assert.deepEqual(error.conflict.selection?.conflictingRequestIds, ['east']);
     assert.deepEqual(
-        error.conflict.selection?.pickupLocations.map(
-            (location) => location.id,
+        prepared.createRunInput.pickupNodes.map(
+            (node) => node.pickupLocationId,
         ),
         [10, 20],
     );
-    assert.equal(counters.assignmentReads, 0);
-    assert.equal(counters.plannerCalls, 0);
+    assert.deepEqual(
+        prepared.createRunInput.manifestItems.map((item) => ({
+            deliveryRequestId: item.deliveryRequestId,
+            timeSlotId: item.timeSlotId,
+        })),
+        [
+            { deliveryRequestId: 'hq', timeSlotId: 1 },
+            { deliveryRequestId: 'east', timeSlotId: 2 },
+        ],
+    );
+    assert.equal(counters.assignmentReads, 1);
+    assert.equal(counters.plannerCalls, 1);
     assert.equal(counters.mutationCalls, 0);
 });
 

--- a/apps/delivery/lib/deliveryRunPlanning.ts
+++ b/apps/delivery/lib/deliveryRunPlanning.ts
@@ -58,9 +58,14 @@ type DeliveryRunPlanningPickupLocation = {
 
 export type DeliveryRunPlanningRequest = {
     id: string;
+    operationId?: number;
     routeRevision: number;
     mode?: string;
     state: string;
+    trace?: {
+        id: number;
+        publicToken: string;
+    } | null;
     address?: DeliveryRunPlanningAddress;
     slot?: {
         id: number;
@@ -375,6 +380,29 @@ function createRunSlotInputs(
                 sourceUpdatedAt: slot.updatedAt,
             };
         });
+}
+
+function createManifestItemInputs(
+    requests: readonly DeliveryRunPlanningRequest[],
+): CreatePreparedDeliveryRunInput['manifestItems'] {
+    return requests.map((request) => {
+        if (!request.slot) {
+            throw new DeliveryRunPreparationError(
+                'Dostava nema valjani termin za manifest preuzimanja.',
+                requestConflict('delivery-slot-invalid', request),
+            );
+        }
+        return {
+            deliveryRequestId: request.id,
+            timeSlotId: request.slot.id,
+            ...(request.trace
+                ? {
+                      harvestTraceLinkId: request.trace.id,
+                      traceToken: request.trace.publicToken,
+                  }
+                : {}),
+        };
+    });
 }
 
 function requestConflict(
@@ -706,6 +734,7 @@ export async function prepareDeliveryRun(
             pickupNodes: createPickupNodeInputs(candidates, plan.pickupNodes),
             runSlots: createRunSlotInputs(candidates),
             stops: storedStops,
+            manifestItems: createManifestItemInputs(candidates),
         },
         summary: {
             ...inspection.summary,

--- a/apps/delivery/lib/harvestTraceScan.node.spec.ts
+++ b/apps/delivery/lib/harvestTraceScan.node.spec.ts
@@ -217,7 +217,7 @@ test('accumulates delivery stops across consecutive live scans', () => {
     ]);
 });
 
-test('keeps the current QR selection when a live scan belongs to another pickup location', () => {
+test('accumulates live QR scans across pickup locations', () => {
     const orders = [
         order({ requestId: 'one', stopKey: 'slot:1', token: firstToken }),
         order({ requestId: 'two', stopKey: 'slot:2', token: secondToken }),
@@ -282,13 +282,14 @@ test('keeps the current QR selection when a live scan belongs to another pickup 
         maximumRouteWindowHours: 24,
     });
 
-    assert.equal(secondSelection.status, 'rejected');
-    if (secondSelection.status !== 'rejected') return;
-    assert.equal(secondSelection.conflict.code, 'mixed-pickup-locations');
-    assert.deepEqual(secondSelection.requestIds, ['one']);
+    assert.equal(secondSelection.status, 'accepted');
+    if (secondSelection.status !== 'accepted') return;
+    assert.deepEqual(secondSelection.requestIds, ['one', 'two']);
+    assert.equal(secondSelection.summary.pickupLocations.length, 2);
+    assert.equal(secondSelection.summary.routeNodeCount, 4);
 });
 
-test('reports duplicate, unavailable, ambiguous, and route-limit scans', () => {
+test('reports duplicate, unavailable, and ambiguous scans without pre-empting route validation', () => {
     const orders = [
         order({ requestId: 'one', stopKey: 'slot:1', token: firstToken }),
         order({ requestId: 'two', stopKey: 'slot:2', token: secondToken }),
@@ -312,15 +313,15 @@ test('reports duplicate, unavailable, ambiguous, and route-limit scans', () => {
         }).status,
         'not-found',
     );
-    assert.equal(
-        selectDeliveryStopFromHarvestTrace({
-            orders,
-            selectedRequestIds: ['one'],
-            maximumRouteStops: 1,
-            scanValue: secondToken,
-        }).status,
-        'limit-reached',
-    );
+    const nextStop = selectDeliveryStopFromHarvestTrace({
+        orders,
+        selectedRequestIds: ['one'],
+        maximumRouteStops: 1,
+        scanValue: secondToken,
+    });
+    assert.equal(nextStop.status, 'selected');
+    if (nextStop.status !== 'selected') return;
+    assert.deepEqual(nextStop.nextSelectedRequestIds, ['one', 'two']);
 
     const ambiguousOrders = [
         order({ requestId: 'one', stopKey: 'slot:1', token: firstToken }),

--- a/apps/delivery/lib/harvestTraceScan.ts
+++ b/apps/delivery/lib/harvestTraceScan.ts
@@ -100,7 +100,7 @@ export type HarvestTraceVerificationResult =
 export function selectDeliveryStopFromHarvestTrace({
     orders,
     selectedRequestIds,
-    maximumRouteStops,
+    maximumRouteStops: _maximumRouteStops,
     scanValue,
 }: {
     orders: DeliveryRouteOrderSummary[];
@@ -177,22 +177,6 @@ export function selectDeliveryStopFromHarvestTrace({
         stopOrders.every((order) => selectedRequestIdSet.has(order.requestId))
     ) {
         return { status: 'already-selected', ...context };
-    }
-
-    const ordersByRequestId = new Map(
-        orders.map((order) => [order.requestId, order]),
-    );
-    const selectedStopKeys = new Set(
-        availableSelectedRequestIds.flatMap((requestId) => {
-            const order = ordersByRequestId.get(requestId);
-            return order ? [order.stopKey] : [];
-        }),
-    );
-    if (
-        !selectedStopKeys.has(matchedOrder.stopKey) &&
-        selectedStopKeys.size >= maximumRouteStops
-    ) {
-        return { status: 'limit-reached', ...context };
     }
 
     const newlySelectedCount = stopOrders.filter(

--- a/apps/delivery/lib/pickupManifestQueue.node.spec.ts
+++ b/apps/delivery/lib/pickupManifestQueue.node.spec.ts
@@ -1,0 +1,600 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    clearPickupManifestQueueScope,
+    createMemoryPickupManifestQueuePersistence,
+    createPickupManifestConfirmCommand,
+    createPickupManifestManualOutcomeCommand,
+    createPickupManifestScanCommand,
+    createWebStoragePickupManifestQueuePersistence,
+    type PickupManifestCommand,
+    PickupManifestOperationConflictError,
+    PickupManifestQueue,
+    type PickupManifestQueueCoordinator,
+    type PickupManifestQueuePersistence,
+    type PickupManifestQueueScope,
+    type PickupManifestTransportResult,
+    type PickupManifestWebStorage,
+    pickupManifestQueueStorageKey,
+} from './pickupManifestQueue';
+
+const occurredAt = '2026-07-15T08:00:00.000Z';
+const traceToken = 'pickup-manifest-trace-token-2026';
+const defaultScope = { userId: 'driver-1', runId: 'run-1' };
+
+function scanCommand(
+    operationId: string,
+    {
+        runId = defaultScope.runId,
+        pickupNodeId = 'pickup-1',
+        token = traceToken,
+    }: {
+        runId?: string;
+        pickupNodeId?: string;
+        token?: string;
+    } = {},
+) {
+    return createPickupManifestScanCommand({
+        operationId,
+        runId,
+        pickupNodeId,
+        scanValue: token,
+        occurredAt,
+    });
+}
+
+function queue({
+    persistence,
+    transport,
+    scope = defaultScope,
+    coordinator,
+    replayCoordinator,
+}: {
+    persistence: PickupManifestQueuePersistence;
+    transport?: (
+        command: PickupManifestCommand,
+    ) => Promise<PickupManifestTransportResult>;
+    scope?: PickupManifestQueueScope;
+    coordinator?: PickupManifestQueueCoordinator;
+    replayCoordinator?: PickupManifestQueueCoordinator;
+}) {
+    return new PickupManifestQueue({
+        scope,
+        persistence,
+        transport: transport ?? (async () => ({ status: 'applied' })),
+        coordinator,
+        replayCoordinator,
+        now: () => new Date(occurredAt),
+    });
+}
+
+function memoryWebStorage(): PickupManifestWebStorage {
+    const values = new Map<string, string>();
+    return {
+        get length() {
+            return values.size;
+        },
+        key(index) {
+            return Array.from(values.keys())[index] ?? null;
+        },
+        getItem(key) {
+            return values.get(key) ?? null;
+        },
+        setItem(key, value) {
+            values.set(key, value);
+        },
+        removeItem(key) {
+            values.delete(key);
+        },
+    };
+}
+
+function serialCoordinator(): PickupManifestQueueCoordinator {
+    let tail = Promise.resolve();
+    return {
+        async runExclusive(_scope, task) {
+            const previous = tail;
+            let release: (() => void) | undefined;
+            tail = new Promise<void>((resolve) => {
+                release = () => resolve();
+            });
+            await previous;
+            try {
+                return await task();
+            } finally {
+                release?.();
+            }
+        },
+    };
+}
+
+test('command factories keep only replay identifiers and a normalized trace path', () => {
+    const scan = createPickupManifestScanCommand({
+        operationId: 'operation-scan',
+        runId: 'run-1',
+        pickupNodeId: 'pickup-1',
+        scanValue: `https://www.gredice.com/trag/${traceToken}?camera=1`,
+        occurredAt,
+    });
+    const manual = createPickupManifestManualOutcomeCommand({
+        operationId: 'operation-manual',
+        runId: 'run-1',
+        pickupNodeId: 'pickup-1',
+        manifestId: 'manifest-1',
+        stopId: 17,
+        outcome: 'missing-label',
+        occurredAt,
+    });
+    const confirm = createPickupManifestConfirmCommand({
+        operationId: 'operation-confirm',
+        runId: 'run-1',
+        pickupNodeId: 'pickup-1',
+        manifestId: 'manifest-1',
+        occurredAt,
+    });
+
+    assert.deepEqual(scan, {
+        operationId: 'operation-scan',
+        runId: 'run-1',
+        pickupNodeId: 'pickup-1',
+        kind: 'scan',
+        tracePath: `/trag/${traceToken}`,
+        occurredAt,
+    });
+    assert.deepEqual(Object.keys(manual).sort(), [
+        'kind',
+        'manifestId',
+        'occurredAt',
+        'operationId',
+        'outcome',
+        'pickupNodeId',
+        'runId',
+        'stopId',
+    ]);
+    assert.deepEqual(Object.keys(confirm).sort(), [
+        'kind',
+        'manifestId',
+        'occurredAt',
+        'operationId',
+        'pickupNodeId',
+        'runId',
+    ]);
+    assert.throws(
+        () =>
+            createPickupManifestScanCommand({
+                operationId: 'invalid-scan',
+                runId: 'run-1',
+                pickupNodeId: 'pickup-1',
+                scanValue: 'not-a-trace',
+                occurredAt,
+            }),
+        /valid harvest trace/,
+    );
+});
+
+test('replays commands in queue order and treats an exact duplicate as synced', async () => {
+    const persistence = createMemoryPickupManifestQueuePersistence();
+    const transported: string[] = [];
+    const states: string[] = [];
+    const manifestQueue = queue({
+        persistence,
+        transport: async (command) => {
+            transported.push(command.operationId);
+            return command.operationId === 'second'
+                ? { status: 'exact-duplicate' }
+                : { status: 'applied' };
+        },
+    });
+    manifestQueue.subscribe(() =>
+        states.push(manifestQueue.getSnapshot().status),
+    );
+
+    await manifestQueue.enqueue(scanCommand('first'));
+    await manifestQueue.enqueue(
+        scanCommand('second', { token: `${traceToken}-2` }),
+    );
+    const result = await manifestQueue.replay();
+
+    assert.deepEqual(transported, ['first', 'second']);
+    assert.equal(result.status, 'synced');
+    assert.equal(result.syncedCount, 2);
+    assert.equal(result.entries[0]?.acknowledgement, 'applied');
+    assert.equal(result.entries[1]?.acknowledgement, 'exact-duplicate');
+    assert.ok(states.includes('queued'));
+    assert.ok(states.includes('sending'));
+    assert.equal(states.at(-1), 'synced');
+});
+
+test('durably enqueues rapid scans while an earlier transport request is in flight', async () => {
+    const persistence = createMemoryPickupManifestQueuePersistence();
+    let releaseTransport: (() => void) | undefined;
+    let markTransportStarted: (() => void) | undefined;
+    const transportStarted = new Promise<void>((resolve) => {
+        markTransportStarted = resolve;
+    });
+    const transportGate = new Promise<void>((resolve) => {
+        releaseTransport = resolve;
+    });
+    const transported: string[] = [];
+    const manifestQueue = queue({
+        persistence,
+        coordinator: serialCoordinator(),
+        replayCoordinator: serialCoordinator(),
+        transport: async (command) => {
+            transported.push(command.operationId);
+            if (command.operationId === 'first-in-flight') {
+                markTransportStarted?.();
+                await transportGate;
+            }
+            return { status: 'applied' };
+        },
+    });
+    await manifestQueue.enqueue(scanCommand('first-in-flight'));
+    const replay = manifestQueue.replay();
+    await transportStarted;
+
+    const secondEnqueue = manifestQueue.enqueue(
+        scanCommand('second-durable', { token: `${traceToken}-2` }),
+    );
+    const persistedBeforeTransportFinished = await Promise.race([
+        secondEnqueue.then(() => true),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 100)),
+    ]);
+    assert.equal(persistedBeforeTransportFinished, true);
+
+    const reloaded = queue({ persistence });
+    const restored = await reloaded.restore();
+    assert.deepEqual(
+        restored.entries.map((entry) => entry.command.operationId),
+        ['first-in-flight', 'second-durable'],
+    );
+
+    releaseTransport?.();
+    await replay;
+    assert.deepEqual(transported, ['first-in-flight', 'second-durable']);
+    assert.equal(manifestQueue.getSnapshot().status, 'synced');
+});
+
+test('exact duplicate enqueue is harmless and a reused operation ID with another payload is rejected', async () => {
+    const persistence = createMemoryPickupManifestQueuePersistence();
+    const manifestQueue = queue({ persistence });
+    const command = scanCommand('same-operation');
+
+    await manifestQueue.enqueue(command);
+    await manifestQueue.enqueue({ ...command });
+    assert.equal(manifestQueue.getSnapshot().entries.length, 1);
+
+    await assert.rejects(
+        manifestQueue.enqueue(
+            scanCommand('same-operation', { token: `${traceToken}-changed` }),
+        ),
+        PickupManifestOperationConflictError,
+    );
+});
+
+test('stops on transport failure and resumes from that command before later work', async () => {
+    const persistence = createMemoryPickupManifestQueuePersistence();
+    const transported: string[] = [];
+    let firstAttempt = true;
+    const manifestQueue = queue({
+        persistence,
+        transport: async (command) => {
+            transported.push(command.operationId);
+            if (command.operationId === 'first' && firstAttempt) {
+                firstAttempt = false;
+                return { status: 'retryable-failure', code: 'offline' };
+            }
+            return { status: 'applied' };
+        },
+    });
+    await manifestQueue.enqueue(scanCommand('first'));
+    await manifestQueue.enqueue(
+        scanCommand('second', { token: `${traceToken}-2` }),
+    );
+
+    const failed = await manifestQueue.replay();
+    assert.deepEqual(transported, ['first']);
+    assert.equal(failed.status, 'failed');
+    assert.equal(failed.entries[0]?.errorCode, 'offline');
+    assert.equal(failed.entries[1]?.state, 'queued');
+
+    assert.equal(await manifestQueue.retryEntry('first'), true);
+    const recovered = await manifestQueue.replay();
+    assert.deepEqual(transported, ['first', 'first', 'second']);
+    assert.equal(recovered.status, 'synced');
+    assert.equal(recovered.entries[0]?.attemptCount, 2);
+    assert.equal(recovered.entries[1]?.attemptCount, 1);
+});
+
+test('keeps permanent conflicts discard-only and unblocks later work after discard', async () => {
+    const persistence = createMemoryPickupManifestQueuePersistence();
+    const transported: string[] = [];
+    const manifestQueue = queue({
+        persistence,
+        transport: async (command) => {
+            transported.push(command.operationId);
+            if (command.operationId === 'second') {
+                return {
+                    status: 'permanent-failure',
+                    code: 'manifest-revision-conflict',
+                };
+            }
+            return { status: 'applied' };
+        },
+    });
+    await manifestQueue.enqueue(scanCommand('first'));
+    await manifestQueue.enqueue(
+        scanCommand('second', { token: `${traceToken}-2` }),
+    );
+    await manifestQueue.enqueue(
+        scanCommand('third', { token: `${traceToken}-3` }),
+    );
+
+    const conflicted = await manifestQueue.replay();
+    assert.deepEqual(transported, ['first', 'second']);
+    assert.equal(conflicted.status, 'conflicted');
+    assert.equal(
+        conflicted.entries[1]?.errorCode,
+        'manifest-revision-conflict',
+    );
+    assert.equal(conflicted.entries[2]?.state, 'queued');
+
+    assert.equal(await manifestQueue.retryEntry('second'), false);
+    assert.equal(await manifestQueue.discardEntry('second'), true);
+    const recovered = await manifestQueue.replay();
+    assert.deepEqual(transported, ['first', 'second', 'third']);
+    assert.equal(recovered.status, 'synced');
+});
+
+test('discarding or reconciling a permanent failure unblocks later work', async () => {
+    const persistence = createMemoryPickupManifestQueuePersistence();
+    const transported: string[] = [];
+    const manifestQueue = queue({
+        persistence,
+        transport: async (command) => {
+            transported.push(command.operationId);
+            return command.operationId === 'blocked'
+                ? {
+                      status: 'permanent-failure',
+                      code: 'pickup-trace-not-found',
+                  }
+                : { status: 'applied' };
+        },
+    });
+    await manifestQueue.enqueue(scanCommand('blocked'));
+    await manifestQueue.enqueue(
+        scanCommand('after-blocked', { token: `${traceToken}-2` }),
+    );
+
+    assert.equal((await manifestQueue.replay()).status, 'conflicted');
+    assert.equal(await manifestQueue.discardEntry('blocked'), true);
+    assert.equal((await manifestQueue.replay()).status, 'synced');
+    assert.deepEqual(transported, ['blocked', 'after-blocked']);
+
+    const reconciledQueue = queue({ persistence });
+    await reconciledQueue.enqueue(
+        scanCommand('reconcile-me', { token: `${traceToken}-3` }),
+    );
+    assert.equal(
+        await reconciledQueue.reconcileEntry('reconcile-me', 'exact-duplicate'),
+        true,
+    );
+    const reconciled = reconciledQueue
+        .getSnapshot()
+        .entries.find((entry) => entry.command.operationId === 'reconcile-me');
+    assert.equal(reconciled?.state, 'synced');
+    assert.equal(reconciled?.acknowledgement, 'exact-duplicate');
+});
+
+test('restores queued work after reload and converts interrupted sending back to queued', async () => {
+    const initialCommand = scanCommand('interrupted');
+    let stored: unknown = {
+        version: 1,
+        entries: [
+            {
+                sequence: 4,
+                command: initialCommand,
+                state: 'sending',
+                attemptCount: 1,
+                updatedAt: occurredAt,
+            },
+        ],
+    };
+    const persistence: PickupManifestQueuePersistence = {
+        durability: 'durable',
+        async load() {
+            return stored;
+        },
+        async save(_scope, entries) {
+            stored = { version: 1, entries };
+        },
+        async clear() {},
+    };
+    const transported: string[] = [];
+    const restoredQueue = queue({
+        persistence,
+        transport: async (command) => {
+            transported.push(command.operationId);
+            return { status: 'exact-duplicate' };
+        },
+    });
+
+    const restored = await restoredQueue.restore();
+    assert.equal(restored.entries[0]?.state, 'queued');
+    assert.equal(restored.entries[0]?.attemptCount, 1);
+    const replayed = await restoredQueue.replay();
+    assert.deepEqual(transported, ['interrupted']);
+    assert.equal(replayed.entries[0]?.attemptCount, 2);
+    assert.equal(replayed.entries[0]?.acknowledgement, 'exact-duplicate');
+});
+
+test('durable persistence restores work and cleanup can target one run or every run for a user', async () => {
+    const persistence = createMemoryPickupManifestQueuePersistence();
+    const firstScope = { userId: 'driver-1', runId: 'run-1' };
+    const secondScope = { userId: 'driver-1', runId: 'run-2' };
+    const otherUserScope = { userId: 'driver-2', runId: 'run-3' };
+
+    await queue({ persistence, scope: firstScope }).enqueue(scanCommand('one'));
+    await queue({ persistence, scope: secondScope }).enqueue(
+        scanCommand('two', { runId: 'run-2' }),
+    );
+    await queue({ persistence, scope: otherUserScope }).enqueue(
+        scanCommand('three', { runId: 'run-3' }),
+    );
+
+    const reloaded = queue({ persistence, scope: firstScope });
+    assert.equal((await reloaded.restore()).queuedCount, 1);
+
+    await clearPickupManifestQueueScope(persistence, firstScope);
+    assert.equal(
+        (await queue({ persistence, scope: firstScope }).restore()).entries
+            .length,
+        0,
+    );
+    assert.equal(
+        (await queue({ persistence, scope: secondScope }).restore()).entries
+            .length,
+        1,
+    );
+
+    await clearPickupManifestQueueScope(persistence, { userId: 'driver-1' });
+    assert.equal(
+        (await queue({ persistence, scope: secondScope }).restore()).entries
+            .length,
+        0,
+    );
+    assert.equal(
+        (await queue({ persistence, scope: otherUserScope }).restore()).entries
+            .length,
+        1,
+    );
+});
+
+test('web storage remains durable without a cross-tab lock coordinator', async () => {
+    const storage = memoryWebStorage();
+    const persistence = createWebStoragePickupManifestQueuePersistence(storage);
+    const firstQueue = queue({ persistence });
+    await firstQueue.enqueue(scanCommand('web-storage'));
+
+    const restoredQueue = queue({ persistence });
+    const restored = await restoredQueue.restore();
+    assert.equal(restored.entries.length, 1);
+    assert.equal(restored.entries[0]?.command.operationId, 'web-storage');
+    assert.equal(restored.durability, 'durable');
+    assert.equal(restored.coordination, 'best-effort');
+
+    await restoredQueue.clear();
+    assert.equal((await queue({ persistence }).restore()).entries.length, 0);
+});
+
+test('an existing queue can refresh scoped changes written by another context', async () => {
+    const storage = memoryWebStorage();
+    const persistence = createWebStoragePickupManifestQueuePersistence(storage);
+    const firstQueue = queue({ persistence });
+    const observingQueue = queue({ persistence });
+    assert.equal((await observingQueue.restore()).entries.length, 0);
+
+    await firstQueue.enqueue(scanCommand('cross-context-observed'));
+    const observed = await observingQueue.refresh();
+
+    assert.deepEqual(
+        observed.entries.map((entry) => entry.command.operationId),
+        ['cross-context-observed'],
+    );
+    assert.notEqual(
+        pickupManifestQueueStorageKey(defaultScope),
+        pickupManifestQueueStorageKey({
+            userId: defaultScope.userId,
+            runId: 'another-run',
+        }),
+    );
+    assert.notEqual(
+        pickupManifestQueueStorageKey(defaultScope),
+        pickupManifestQueueStorageKey({
+            userId: 'another-driver',
+            runId: defaultScope.runId,
+        }),
+    );
+});
+
+test('shared coordination serializes cross-context writes and replay order', async () => {
+    const persistence = createWebStoragePickupManifestQueuePersistence(
+        memoryWebStorage(),
+    );
+    const coordinator = serialCoordinator();
+    const replayCoordinator = serialCoordinator();
+    const firstQueue = queue({
+        persistence,
+        coordinator,
+        replayCoordinator,
+    });
+    const secondQueue = queue({
+        persistence,
+        coordinator,
+        replayCoordinator,
+    });
+
+    await Promise.all([
+        firstQueue.enqueue(scanCommand('cross-tab-first')),
+        secondQueue.enqueue(
+            scanCommand('cross-tab-second', { token: `${traceToken}-2` }),
+        ),
+    ]);
+
+    const transported: string[] = [];
+    const replayQueue = queue({
+        persistence,
+        coordinator,
+        replayCoordinator,
+        transport: async (command) => {
+            transported.push(command.operationId);
+            return { status: 'applied' };
+        },
+    });
+    const restored = await replayQueue.restore();
+    assert.deepEqual(
+        restored.entries.map((entry) => entry.command.operationId),
+        ['cross-tab-first', 'cross-tab-second'],
+    );
+    assert.deepEqual(
+        restored.entries.map((entry) => entry.sequence),
+        [0, 1],
+    );
+    assert.equal(restored.coordination, 'coordinated');
+    await replayQueue.replay();
+    assert.deepEqual(transported, ['cross-tab-first', 'cross-tab-second']);
+});
+
+test('web storage failures fall back to surfaced non-durable memory persistence', async () => {
+    const unavailableStorage: PickupManifestWebStorage = {
+        get length(): number {
+            throw new Error('storage denied');
+        },
+        key() {
+            throw new Error('storage denied');
+        },
+        getItem() {
+            throw new Error('storage denied');
+        },
+        setItem() {
+            throw new Error('storage denied');
+        },
+        removeItem() {
+            throw new Error('storage denied');
+        },
+    };
+    const persistence =
+        createWebStoragePickupManifestQueuePersistence(unavailableStorage);
+    const manifestQueue = queue({ persistence });
+
+    assert.equal(manifestQueue.getServerSnapshot().durability, 'memory');
+    assert.equal((await manifestQueue.restore()).durability, 'memory');
+    await manifestQueue.enqueue(scanCommand('memory-fallback'));
+    assert.equal((await manifestQueue.replay()).status, 'synced');
+    assert.equal(manifestQueue.getSnapshot().durability, 'memory');
+    assert.equal(
+        (await queue({ persistence }).restore()).entries[0]?.command
+            .operationId,
+        'memory-fallback',
+    );
+});

--- a/apps/delivery/lib/pickupManifestQueue.ts
+++ b/apps/delivery/lib/pickupManifestQueue.ts
@@ -1,0 +1,922 @@
+import { normalizeHarvestTraceScanValue } from './harvestTraceScan';
+
+export type PickupManifestQueueScope = {
+    userId: string;
+    runId: string;
+};
+
+type PickupManifestCommandBase = {
+    operationId: string;
+    runId: string;
+    pickupNodeId: string;
+    occurredAt: string;
+};
+
+export type PickupManifestScanCommand = PickupManifestCommandBase & {
+    kind: 'scan';
+    tracePath: string;
+};
+
+export type PickupManifestManualOutcome =
+    | 'ready'
+    | 'missing-label'
+    | 'not-ready';
+
+export type PickupManifestManualOutcomeCommand = PickupManifestCommandBase & {
+    kind: 'manual-outcome';
+    manifestId: string;
+    stopId: number;
+    outcome: PickupManifestManualOutcome;
+};
+
+export type PickupManifestConfirmCommand = PickupManifestCommandBase & {
+    kind: 'confirm';
+    manifestId: string;
+};
+
+export type PickupManifestCommand =
+    | PickupManifestScanCommand
+    | PickupManifestManualOutcomeCommand
+    | PickupManifestConfirmCommand;
+
+export type PickupManifestCommandState =
+    | 'queued'
+    | 'sending'
+    | 'synced'
+    | 'failed'
+    | 'conflicted';
+
+export type PickupManifestAcknowledgement = 'applied' | 'exact-duplicate';
+
+export type PickupManifestQueueEntry = {
+    sequence: number;
+    command: PickupManifestCommand;
+    state: PickupManifestCommandState;
+    attemptCount: number;
+    updatedAt: string;
+    acknowledgement?: PickupManifestAcknowledgement;
+    errorCode?: string;
+};
+
+export type PickupManifestQueueStatus =
+    | 'idle'
+    | 'queued'
+    | 'sending'
+    | 'synced'
+    | 'failed'
+    | 'conflicted';
+
+export type PickupManifestQueueDurability = 'durable' | 'memory';
+export type PickupManifestQueueCoordination = 'coordinated' | 'best-effort';
+
+export type PickupManifestQueueSnapshot = {
+    scope: PickupManifestQueueScope;
+    status: PickupManifestQueueStatus;
+    durability: PickupManifestQueueDurability;
+    coordination: PickupManifestQueueCoordination;
+    entries: readonly PickupManifestQueueEntry[];
+    queuedCount: number;
+    sendingCount: number;
+    syncedCount: number;
+    failedCount: number;
+    conflictedCount: number;
+};
+
+export type PickupManifestTransportResult =
+    | { status: 'applied' }
+    | { status: 'exact-duplicate' }
+    | { status: 'retryable-failure'; code?: string }
+    | { status: 'permanent-failure'; code?: string };
+
+export type PickupManifestTransport = (
+    command: PickupManifestCommand,
+) => Promise<PickupManifestTransportResult>;
+
+export type PickupManifestQueuePersistence = {
+    readonly durability: PickupManifestQueueDurability;
+    load: (scope: PickupManifestQueueScope) => Promise<unknown>;
+    save: (
+        scope: PickupManifestQueueScope,
+        entries: readonly PickupManifestQueueEntry[],
+    ) => Promise<void>;
+    clear: (scope: { userId: string; runId?: string }) => Promise<void>;
+};
+
+export type PickupManifestQueueCoordinator = {
+    runExclusive: <Result>(
+        scope: PickupManifestQueueScope,
+        task: () => Promise<Result>,
+    ) => Promise<Result>;
+};
+
+export type PickupManifestWebStorage = {
+    readonly length: number;
+    key: (index: number) => string | null;
+    getItem: (key: string) => string | null;
+    setItem: (key: string, value: string) => void;
+    removeItem: (key: string) => void;
+};
+
+type QueueOptions = {
+    scope: PickupManifestQueueScope;
+    persistence: PickupManifestQueuePersistence;
+    transport: PickupManifestTransport;
+    coordinator?: PickupManifestQueueCoordinator;
+    replayCoordinator?: PickupManifestQueueCoordinator;
+    now?: () => Date;
+};
+
+type PickupManifestCommandInputBase = {
+    operationId: string;
+    runId: string;
+    pickupNodeId: string;
+    occurredAt?: string;
+};
+
+const persistenceVersion = 1;
+const webStoragePrefix = 'gredice:delivery:pickup-manifest-queue:v1:';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function validIdentifier(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        value.trim() === value &&
+        value.length > 0 &&
+        value.length <= 256
+    );
+}
+
+function validOccurredAt(value: unknown): value is string {
+    return (
+        typeof value === 'string' && Number.isFinite(new Date(value).getTime())
+    );
+}
+
+function validStopId(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function validErrorCode(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        value.length > 0 &&
+        value.length <= 128 &&
+        /^[a-z0-9-]+$/.test(value)
+    );
+}
+
+function isPickupManifestCommand(
+    value: unknown,
+): value is PickupManifestCommand {
+    if (
+        !isRecord(value) ||
+        !validIdentifier(value.operationId) ||
+        !validIdentifier(value.runId) ||
+        !validIdentifier(value.pickupNodeId) ||
+        !validOccurredAt(value.occurredAt)
+    ) {
+        return false;
+    }
+
+    switch (value.kind) {
+        case 'scan': {
+            if (typeof value.tracePath !== 'string') return false;
+            return (
+                normalizeHarvestTraceScanValue(value.tracePath) ===
+                value.tracePath
+            );
+        }
+        case 'manual-outcome':
+            return (
+                validIdentifier(value.manifestId) &&
+                validStopId(value.stopId) &&
+                (value.outcome === 'ready' ||
+                    value.outcome === 'missing-label' ||
+                    value.outcome === 'not-ready')
+            );
+        case 'confirm':
+            return validIdentifier(value.manifestId);
+        default:
+            return false;
+    }
+}
+
+function isCommandState(value: unknown): value is PickupManifestCommandState {
+    return (
+        value === 'queued' ||
+        value === 'sending' ||
+        value === 'synced' ||
+        value === 'failed' ||
+        value === 'conflicted'
+    );
+}
+
+function isQueueEntry(value: unknown): value is PickupManifestQueueEntry {
+    return (
+        isRecord(value) &&
+        typeof value.sequence === 'number' &&
+        Number.isInteger(value.sequence) &&
+        value.sequence >= 0 &&
+        isPickupManifestCommand(value.command) &&
+        isCommandState(value.state) &&
+        typeof value.attemptCount === 'number' &&
+        Number.isInteger(value.attemptCount) &&
+        value.attemptCount >= 0 &&
+        validOccurredAt(value.updatedAt) &&
+        (value.acknowledgement === undefined ||
+            value.acknowledgement === 'applied' ||
+            value.acknowledgement === 'exact-duplicate') &&
+        (value.errorCode === undefined || validErrorCode(value.errorCode))
+    );
+}
+
+function restoredEntries(
+    value: unknown,
+    scope: PickupManifestQueueScope,
+    recoverInterruptedSending: boolean,
+) {
+    if (!isRecord(value) || value.version !== persistenceVersion) return [];
+    if (!Array.isArray(value.entries)) return [];
+
+    const entriesByOperationId = new Map<string, PickupManifestQueueEntry>();
+    for (const candidate of value.entries) {
+        if (
+            !isQueueEntry(candidate) ||
+            candidate.command.runId !== scope.runId
+        ) {
+            continue;
+        }
+        const restored =
+            recoverInterruptedSending && candidate.state === 'sending'
+                ? { ...candidate, state: 'queued' as const }
+                : candidate;
+        const existing = entriesByOperationId.get(restored.command.operationId);
+        if (!existing) {
+            entriesByOperationId.set(restored.command.operationId, restored);
+            continue;
+        }
+        if (
+            commandFingerprint(existing.command) !==
+            commandFingerprint(restored.command)
+        ) {
+            throw new PickupManifestOperationConflictError(
+                restored.command.operationId,
+            );
+        }
+    }
+
+    return Array.from(entriesByOperationId.values()).sort(
+        (first, second) => first.sequence - second.sequence,
+    );
+}
+
+function commandFingerprint(command: PickupManifestCommand) {
+    const common = [
+        command.operationId,
+        command.runId,
+        command.pickupNodeId,
+        command.kind,
+        command.occurredAt,
+    ];
+    switch (command.kind) {
+        case 'scan':
+            return JSON.stringify([...common, command.tracePath]);
+        case 'manual-outcome':
+            return JSON.stringify([
+                ...common,
+                command.manifestId,
+                command.stopId,
+                command.outcome,
+            ]);
+        case 'confirm':
+            return JSON.stringify([...common, command.manifestId]);
+    }
+}
+
+function cloneEntry(entry: PickupManifestQueueEntry): PickupManifestQueueEntry {
+    return { ...entry, command: { ...entry.command } };
+}
+
+function snapshotFor(
+    scope: PickupManifestQueueScope,
+    entries: readonly PickupManifestQueueEntry[],
+    durability: PickupManifestQueueDurability,
+    coordination: PickupManifestQueueCoordination,
+): PickupManifestQueueSnapshot {
+    const clonedEntries = entries.map(cloneEntry);
+    const queuedCount = entries.filter(
+        (entry) => entry.state === 'queued',
+    ).length;
+    const sendingCount = entries.filter(
+        (entry) => entry.state === 'sending',
+    ).length;
+    const syncedCount = entries.filter(
+        (entry) => entry.state === 'synced',
+    ).length;
+    const failedCount = entries.filter(
+        (entry) => entry.state === 'failed',
+    ).length;
+    const conflictedCount = entries.filter(
+        (entry) => entry.state === 'conflicted',
+    ).length;
+    const status: PickupManifestQueueStatus = sendingCount
+        ? 'sending'
+        : conflictedCount
+          ? 'conflicted'
+          : failedCount
+            ? 'failed'
+            : queuedCount
+              ? 'queued'
+              : entries.length
+                ? 'synced'
+                : 'idle';
+
+    return {
+        scope: { ...scope },
+        status,
+        durability,
+        coordination,
+        entries: clonedEntries,
+        queuedCount,
+        sendingCount,
+        syncedCount,
+        failedCount,
+        conflictedCount,
+    };
+}
+
+export function pickupManifestQueueStorageKey(scope: PickupManifestQueueScope) {
+    return `${webStoragePrefix}${encodeURIComponent(scope.userId)}:${encodeURIComponent(scope.runId)}`;
+}
+
+function storageUserPrefix(userId: string) {
+    return `${webStoragePrefix}${encodeURIComponent(userId)}:`;
+}
+
+function persistencePayload(entries: readonly PickupManifestQueueEntry[]) {
+    return { version: persistenceVersion, entries };
+}
+
+function clonePersistedValue(value: unknown) {
+    return value === undefined
+        ? undefined
+        : (JSON.parse(JSON.stringify(value)) as unknown);
+}
+
+function occurredAt(value: string | undefined, now: () => Date) {
+    const resolved = value ?? now().toISOString();
+    if (!validOccurredAt(resolved)) {
+        throw new TypeError(
+            'Pickup manifest command has an invalid occurredAt value',
+        );
+    }
+    return resolved;
+}
+
+export class PickupManifestOperationConflictError extends Error {
+    override name = 'PickupManifestOperationConflictError';
+
+    constructor(readonly operationId: string) {
+        super(
+            `Pickup manifest operation ${operationId} has conflicting payloads`,
+        );
+    }
+}
+
+export function createPickupManifestScanCommand({
+    operationId,
+    runId,
+    pickupNodeId,
+    scanValue,
+    occurredAt: occurredAtValue,
+    now = () => new Date(),
+}: PickupManifestCommandInputBase & {
+    scanValue: string;
+    now?: () => Date;
+}): PickupManifestScanCommand {
+    const tracePath = normalizeHarvestTraceScanValue(scanValue);
+    if (!tracePath) {
+        throw new TypeError(
+            'Pickup manifest scan is not a valid harvest trace',
+        );
+    }
+    const command: PickupManifestScanCommand = {
+        operationId,
+        runId,
+        pickupNodeId,
+        kind: 'scan',
+        tracePath,
+        occurredAt: occurredAt(occurredAtValue, now),
+    };
+    if (!isPickupManifestCommand(command)) {
+        throw new TypeError('Pickup manifest scan command is invalid');
+    }
+    return command;
+}
+
+export function createPickupManifestManualOutcomeCommand({
+    operationId,
+    runId,
+    pickupNodeId,
+    manifestId,
+    stopId,
+    outcome,
+    occurredAt: occurredAtValue,
+    now = () => new Date(),
+}: PickupManifestCommandInputBase & {
+    manifestId: string;
+    stopId: number;
+    outcome: PickupManifestManualOutcome;
+    now?: () => Date;
+}): PickupManifestManualOutcomeCommand {
+    const command: PickupManifestManualOutcomeCommand = {
+        operationId,
+        runId,
+        pickupNodeId,
+        kind: 'manual-outcome',
+        manifestId,
+        stopId,
+        outcome,
+        occurredAt: occurredAt(occurredAtValue, now),
+    };
+    if (!isPickupManifestCommand(command)) {
+        throw new TypeError(
+            'Pickup manifest manual outcome command is invalid',
+        );
+    }
+    return command;
+}
+
+export function createPickupManifestConfirmCommand({
+    operationId,
+    runId,
+    pickupNodeId,
+    manifestId,
+    occurredAt: occurredAtValue,
+    now = () => new Date(),
+}: PickupManifestCommandInputBase & {
+    manifestId: string;
+    now?: () => Date;
+}): PickupManifestConfirmCommand {
+    const command: PickupManifestConfirmCommand = {
+        operationId,
+        runId,
+        pickupNodeId,
+        kind: 'confirm',
+        manifestId,
+        occurredAt: occurredAt(occurredAtValue, now),
+    };
+    if (!isPickupManifestCommand(command)) {
+        throw new TypeError('Pickup manifest confirm command is invalid');
+    }
+    return command;
+}
+
+export function createMemoryPickupManifestQueuePersistence(): PickupManifestQueuePersistence {
+    const values = new Map<string, unknown>();
+    return {
+        durability: 'memory',
+        async load(scope) {
+            return clonePersistedValue(
+                values.get(pickupManifestQueueStorageKey(scope)),
+            );
+        },
+        async save(scope, entries) {
+            values.set(
+                pickupManifestQueueStorageKey(scope),
+                clonePersistedValue(persistencePayload(entries)),
+            );
+        },
+        async clear(scope) {
+            if (scope.runId) {
+                values.delete(
+                    pickupManifestQueueStorageKey({
+                        userId: scope.userId,
+                        runId: scope.runId,
+                    }),
+                );
+                return;
+            }
+            const prefix = storageUserPrefix(scope.userId);
+            for (const key of values.keys()) {
+                if (key.startsWith(prefix)) values.delete(key);
+            }
+        },
+    };
+}
+
+export function createWebStoragePickupManifestQueuePersistence(
+    storage: PickupManifestWebStorage,
+): PickupManifestQueuePersistence {
+    const fallbackValues = new Map<string, string>();
+    let durable = true;
+
+    function parsedValue(value: string | null) {
+        if (!value) return undefined;
+        try {
+            return JSON.parse(value) as unknown;
+        } catch {
+            return undefined;
+        }
+    }
+
+    return {
+        get durability() {
+            return durable ? 'durable' : 'memory';
+        },
+        async load(scope) {
+            const key = pickupManifestQueueStorageKey(scope);
+            if (durable) {
+                try {
+                    const value = storage.getItem(key);
+                    if (value === null) fallbackValues.delete(key);
+                    else fallbackValues.set(key, value);
+                    return parsedValue(value);
+                } catch {
+                    durable = false;
+                }
+            }
+            return parsedValue(fallbackValues.get(key) ?? null);
+        },
+        async save(scope, entries) {
+            const key = pickupManifestQueueStorageKey(scope);
+            const value = JSON.stringify(persistencePayload(entries));
+            fallbackValues.set(key, value);
+            if (!durable) return;
+            try {
+                storage.setItem(key, value);
+            } catch {
+                durable = false;
+            }
+        },
+        async clear(scope) {
+            if (scope.runId) {
+                const key = pickupManifestQueueStorageKey({
+                    userId: scope.userId,
+                    runId: scope.runId,
+                });
+                fallbackValues.delete(key);
+                if (!durable) return;
+                try {
+                    storage.removeItem(key);
+                } catch {
+                    durable = false;
+                }
+                return;
+            }
+            const prefix = storageUserPrefix(scope.userId);
+            for (const key of fallbackValues.keys()) {
+                if (key.startsWith(prefix)) fallbackValues.delete(key);
+            }
+            if (!durable) return;
+            try {
+                const keys = Array.from(
+                    { length: storage.length },
+                    (_, index) => storage.key(index),
+                );
+                for (const key of keys) {
+                    if (key?.startsWith(prefix)) storage.removeItem(key);
+                }
+            } catch {
+                durable = false;
+            }
+        },
+    };
+}
+
+export async function clearPickupManifestQueueScope(
+    persistence: PickupManifestQueuePersistence,
+    scope: { userId: string; runId?: string },
+) {
+    await persistence.clear(scope);
+}
+
+export class PickupManifestQueue {
+    private entries: PickupManifestQueueEntry[] = [];
+    private snapshot: PickupManifestQueueSnapshot;
+    private readonly serverSnapshot: PickupManifestQueueSnapshot;
+    private readonly listeners = new Set<() => void>();
+    private operationChain: Promise<void> = Promise.resolve();
+    private replayPromise: Promise<PickupManifestQueueSnapshot> | null = null;
+    private nextSequence = 0;
+    private generation = 0;
+    private readonly now: () => Date;
+
+    constructor(private readonly options: QueueOptions) {
+        if (
+            !validIdentifier(options.scope.userId) ||
+            !validIdentifier(options.scope.runId)
+        ) {
+            throw new TypeError('Pickup manifest queue scope is invalid');
+        }
+        this.now = options.now ?? (() => new Date());
+        const coordination =
+            options.coordinator && options.replayCoordinator
+                ? 'coordinated'
+                : 'best-effort';
+        this.serverSnapshot = snapshotFor(
+            options.scope,
+            [],
+            'memory',
+            'best-effort',
+        );
+        this.snapshot = snapshotFor(
+            options.scope,
+            [],
+            options.persistence.durability,
+            coordination,
+        );
+    }
+
+    getSnapshot = () => this.snapshot;
+    getServerSnapshot = () => this.serverSnapshot;
+
+    subscribe = (listener: () => void) => {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+    };
+
+    async restore() {
+        return await this.runExclusive(async () => {
+            await this.synchronizeFromPersistence(true);
+            return this.snapshot;
+        });
+    }
+
+    async refresh() {
+        return await this.runExclusive(async () => {
+            await this.synchronizeFromPersistence(false);
+            return this.snapshot;
+        });
+    }
+
+    async enqueue(command: PickupManifestCommand) {
+        if (
+            !isPickupManifestCommand(command) ||
+            command.runId !== this.options.scope.runId
+        ) {
+            throw new TypeError(
+                'Pickup manifest command does not match its queue',
+            );
+        }
+
+        return await this.runExclusive(async () => {
+            await this.synchronizeFromPersistence(false);
+            const existing = this.entries.find(
+                (entry) => entry.command.operationId === command.operationId,
+            );
+            if (existing) {
+                if (
+                    commandFingerprint(existing.command) !==
+                    commandFingerprint(command)
+                ) {
+                    throw new PickupManifestOperationConflictError(
+                        command.operationId,
+                    );
+                }
+                return cloneEntry(existing);
+            }
+
+            const entry: PickupManifestQueueEntry = {
+                sequence: this.nextSequence,
+                command: { ...command },
+                state: 'queued',
+                attemptCount: 0,
+                updatedAt: this.now().toISOString(),
+            };
+            this.nextSequence += 1;
+            this.entries.push(entry);
+            this.publish();
+            await this.persist();
+            return cloneEntry(entry);
+        });
+    }
+
+    async replay(): Promise<PickupManifestQueueSnapshot> {
+        if (this.replayPromise) {
+            await this.replayPromise;
+            const current = this.getSnapshot();
+            if (
+                current.queuedCount > 0 &&
+                current.failedCount === 0 &&
+                current.conflictedCount === 0
+            ) {
+                return await this.replay();
+            }
+            return current;
+        }
+
+        const replayTask = () => this.replayEntries(this.generation);
+        this.replayPromise = (
+            this.options.replayCoordinator
+                ? this.options.replayCoordinator.runExclusive(
+                      this.options.scope,
+                      replayTask,
+                  )
+                : replayTask()
+        ).finally(() => {
+            this.replayPromise = null;
+        });
+        return await this.replayPromise;
+    }
+
+    async retryEntry(operationId: string) {
+        return await this.runExclusive(async () => {
+            await this.synchronizeFromPersistence(false);
+            const entry = this.entries.find(
+                (candidate) => candidate.command.operationId === operationId,
+            );
+            if (entry?.state !== 'failed') {
+                return false;
+            }
+            entry.state = 'queued';
+            entry.updatedAt = this.now().toISOString();
+            delete entry.acknowledgement;
+            delete entry.errorCode;
+            this.publish();
+            await this.persist();
+            return true;
+        });
+    }
+
+    async discardEntry(operationId: string) {
+        return await this.runExclusive(async () => {
+            await this.synchronizeFromPersistence(false);
+            const nextEntries = this.entries.filter(
+                (entry) => entry.command.operationId !== operationId,
+            );
+            if (nextEntries.length === this.entries.length) return false;
+            this.entries = nextEntries;
+            this.publish();
+            await this.persist();
+            return true;
+        });
+    }
+
+    async discard(operationId: string) {
+        return await this.discardEntry(operationId);
+    }
+
+    async reconcileEntry(
+        operationId: string,
+        acknowledgement: PickupManifestAcknowledgement = 'applied',
+    ) {
+        return await this.runExclusive(async () => {
+            await this.synchronizeFromPersistence(false);
+            const entry = this.entries.find(
+                (candidate) => candidate.command.operationId === operationId,
+            );
+            if (!entry || entry.state === 'synced') return false;
+            entry.state = 'synced';
+            entry.acknowledgement = acknowledgement;
+            entry.updatedAt = this.now().toISOString();
+            delete entry.errorCode;
+            this.publish();
+            await this.persist();
+            return true;
+        });
+    }
+
+    async clear() {
+        await this.runExclusive(async () => {
+            await this.synchronizeFromPersistence(false);
+            this.generation += 1;
+            this.entries = [];
+            this.nextSequence = 0;
+            this.publish();
+            await this.options.persistence.clear(this.options.scope);
+            this.publish();
+        });
+    }
+
+    private runExclusive<Result>(task: () => Promise<Result>) {
+        const coordinatedTask = () =>
+            this.options.coordinator
+                ? this.options.coordinator.runExclusive(
+                      this.options.scope,
+                      task,
+                  )
+                : task();
+        const result = this.operationChain.then(
+            coordinatedTask,
+            coordinatedTask,
+        );
+        this.operationChain = result.then(
+            () => undefined,
+            () => undefined,
+        );
+        return result;
+    }
+
+    private async synchronizeFromPersistence(
+        recoverInterruptedSending: boolean,
+    ) {
+        const value = await this.options.persistence.load(this.options.scope);
+        this.entries = restoredEntries(
+            value,
+            this.options.scope,
+            recoverInterruptedSending,
+        );
+        this.nextSequence =
+            Math.max(-1, ...this.entries.map((entry) => entry.sequence)) + 1;
+        this.publish();
+    }
+
+    private async replayEntries(replayGeneration: number) {
+        while (replayGeneration === this.generation) {
+            const command = await this.runExclusive(async () => {
+                if (replayGeneration !== this.generation) return null;
+                await this.synchronizeFromPersistence(false);
+                const entry = this.entries.find(
+                    (candidate) => candidate.state !== 'synced',
+                );
+                if (!entry || entry.state === 'conflicted') return null;
+
+                entry.state = 'sending';
+                entry.attemptCount += 1;
+                entry.updatedAt = this.now().toISOString();
+                delete entry.acknowledgement;
+                delete entry.errorCode;
+                this.publish();
+                await this.persist();
+                return { ...entry.command };
+            });
+            if (!command) break;
+
+            let result: PickupManifestTransportResult;
+            try {
+                result = await this.options.transport(command);
+            } catch {
+                result = {
+                    status: 'retryable-failure',
+                    code: 'transport-error',
+                };
+            }
+            if (replayGeneration !== this.generation) break;
+
+            const shouldStop = await this.runExclusive(async () => {
+                if (replayGeneration !== this.generation) return true;
+                await this.synchronizeFromPersistence(false);
+                const entry = this.entries.find(
+                    (candidate) =>
+                        candidate.command.operationId === command.operationId,
+                );
+                if (!entry) return false;
+                if (entry.state === 'synced') return false;
+                if (entry.state === 'conflicted') return true;
+
+                entry.updatedAt = this.now().toISOString();
+                switch (result.status) {
+                    case 'applied':
+                        entry.state = 'synced';
+                        entry.acknowledgement = 'applied';
+                        break;
+                    case 'exact-duplicate':
+                        entry.state = 'synced';
+                        entry.acknowledgement = 'exact-duplicate';
+                        break;
+                    case 'permanent-failure':
+                        entry.state = 'conflicted';
+                        entry.errorCode = validErrorCode(result.code)
+                            ? result.code
+                            : 'pickup-manifest-conflict';
+                        break;
+                    case 'retryable-failure':
+                        entry.state = 'failed';
+                        entry.errorCode = validErrorCode(result.code)
+                            ? result.code
+                            : 'pickup-manifest-sync-failed';
+                        break;
+                }
+                this.publish();
+                await this.persist();
+                return entry.state === 'failed' || entry.state === 'conflicted';
+            });
+            if (shouldStop) break;
+        }
+        return this.snapshot;
+    }
+
+    private publish() {
+        this.snapshot = snapshotFor(
+            this.options.scope,
+            this.entries,
+            this.options.persistence.durability,
+            this.options.coordinator && this.options.replayCoordinator
+                ? 'coordinated'
+                : 'best-effort',
+        );
+        for (const listener of this.listeners) listener();
+    }
+
+    private async persist() {
+        await this.options.persistence.save(
+            this.options.scope,
+            this.entries.map(cloneEntry),
+        );
+        this.publish();
+    }
+}

--- a/apps/delivery/lib/pickupManifestTransport.node.spec.ts
+++ b/apps/delivery/lib/pickupManifestTransport.node.spec.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createPickupManifestConfirmCommand,
+    createPickupManifestManualOutcomeCommand,
+    createPickupManifestScanCommand,
+    type PickupManifestCommand,
+} from './pickupManifestQueue';
+import {
+    pickupManifestHttpFailure,
+    pickupManifestTransportResult,
+} from './pickupManifestTransport';
+
+const occurredAt = '2026-07-15T08:00:00.000Z';
+const traceToken = 'pickup-manifest-trace-token-2026';
+
+function scanCommand() {
+    return createPickupManifestScanCommand({
+        operationId: 'operation-scan-1',
+        runId: 'run-1',
+        pickupNodeId: 'pickup-1',
+        scanValue: traceToken,
+        occurredAt,
+    });
+}
+
+function responseFor(
+    command: PickupManifestCommand,
+    result: Record<string, unknown>,
+    replayed = false,
+) {
+    return {
+        results: [
+            {
+                clientOperationId: command.operationId,
+                replayed,
+                result,
+            },
+        ],
+    };
+}
+
+test('validates complete applied and duplicate pickup acknowledgements', () => {
+    const scan = scanCommand();
+    const scanResult = {
+        kind: 'scan',
+        outcome: 'applied',
+        affectedStopIds: [17],
+        itemState: 'scanned',
+    };
+    assert.deepEqual(
+        pickupManifestTransportResult(responseFor(scan, scanResult), scan),
+        { status: 'applied' },
+    );
+    assert.deepEqual(
+        pickupManifestTransportResult(
+            responseFor(scan, scanResult, true),
+            scan,
+        ),
+        { status: 'exact-duplicate' },
+    );
+
+    const manual = createPickupManifestManualOutcomeCommand({
+        operationId: 'operation-item-1',
+        runId: 'run-1',
+        pickupNodeId: 'pickup-1',
+        manifestId: 'manifest-1',
+        stopId: 17,
+        outcome: 'missing-label',
+        occurredAt,
+    });
+    assert.deepEqual(
+        pickupManifestTransportResult(
+            responseFor(manual, {
+                kind: 'mark-item',
+                outcome: 'applied',
+                affectedStopIds: [17],
+                itemState: 'missing-label',
+            }),
+            manual,
+        ),
+        { status: 'applied' },
+    );
+
+    const confirm = createPickupManifestConfirmCommand({
+        operationId: 'operation-confirm-1',
+        runId: 'run-1',
+        pickupNodeId: 'pickup-1',
+        manifestId: 'manifest-1',
+        occurredAt,
+    });
+    assert.deepEqual(
+        pickupManifestTransportResult(
+            responseFor(confirm, {
+                kind: 'confirm-manifest',
+                outcome: 'already-applied',
+                affectedStopIds: [],
+                manifestId: 'manifest-1',
+                manifestState: 'confirmed',
+            }),
+            confirm,
+        ),
+        { status: 'applied' },
+    );
+});
+
+test('keeps scan not-found and ambiguous outcomes recoverable instead of acknowledging them', () => {
+    const command = scanCommand();
+    assert.deepEqual(
+        pickupManifestTransportResult(
+            responseFor(command, {
+                kind: 'scan',
+                outcome: 'not-found',
+                affectedStopIds: [],
+            }),
+            command,
+        ),
+        {
+            status: 'permanent-failure',
+            code: 'pickup-trace-not-found',
+        },
+    );
+    assert.deepEqual(
+        pickupManifestTransportResult(
+            responseFor(
+                command,
+                {
+                    kind: 'scan',
+                    outcome: 'ambiguous',
+                    affectedStopIds: [],
+                },
+                true,
+            ),
+            command,
+        ),
+        {
+            status: 'permanent-failure',
+            code: 'pickup-trace-ambiguous',
+        },
+    );
+});
+
+test('rejects partial success payloads and classifies HTTP failures', () => {
+    const command = scanCommand();
+    assert.deepEqual(
+        pickupManifestTransportResult(
+            {
+                results: [
+                    {
+                        clientOperationId: command.operationId,
+                        replayed: false,
+                    },
+                ],
+            },
+            command,
+        ),
+        {
+            status: 'retryable-failure',
+            code: 'invalid-server-response',
+        },
+    );
+    assert.deepEqual(pickupManifestHttpFailure(503, null), {
+        status: 'retryable-failure',
+        code: 'pickup-manifest-sync-failed',
+    });
+    assert.deepEqual(
+        pickupManifestHttpFailure(409, {
+            code: 'pickup-operation-conflict',
+        }),
+        {
+            status: 'permanent-failure',
+            code: 'pickup-operation-conflict',
+        },
+    );
+    assert.deepEqual(pickupManifestHttpFailure(400, null), {
+        status: 'permanent-failure',
+        code: 'pickup-manifest-request-rejected',
+    });
+});

--- a/apps/delivery/lib/pickupManifestTransport.ts
+++ b/apps/delivery/lib/pickupManifestTransport.ts
@@ -1,0 +1,143 @@
+import type {
+    PickupManifestCommand,
+    PickupManifestTransportResult,
+} from './pickupManifestQueue';
+
+function responseCode(value: unknown) {
+    return typeof value === 'object' &&
+        value !== null &&
+        'code' in value &&
+        typeof value.code === 'string'
+        ? value.code
+        : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function hasValidAffectedStopIds(value: unknown): value is number[] {
+    return (
+        Array.isArray(value) &&
+        value.every(
+            (stopId) =>
+                typeof stopId === 'number' &&
+                Number.isInteger(stopId) &&
+                stopId > 0,
+        )
+    );
+}
+
+function validateStoredResult(
+    value: unknown,
+    command: PickupManifestCommand,
+): 'success' | 'scan-not-found' | 'scan-ambiguous' | 'invalid' {
+    if (!isRecord(value)) return 'invalid';
+    const affectedStopIds = value.affectedStopIds;
+    if (!hasValidAffectedStopIds(affectedStopIds)) return 'invalid';
+
+    if (command.kind === 'scan') {
+        if (value.kind !== 'scan') return 'invalid';
+        if (value.outcome === 'not-found') {
+            return affectedStopIds.length === 0 ? 'scan-not-found' : 'invalid';
+        }
+        if (value.outcome === 'ambiguous') {
+            return affectedStopIds.length === 0 ? 'scan-ambiguous' : 'invalid';
+        }
+        return (value.outcome === 'applied' ||
+            value.outcome === 'already-applied') &&
+            value.itemState === 'scanned' &&
+            affectedStopIds.length > 0
+            ? 'success'
+            : 'invalid';
+    }
+
+    if (command.kind === 'manual-outcome') {
+        return value.kind === 'mark-item' &&
+            (value.outcome === 'applied' ||
+                value.outcome === 'already-applied') &&
+            value.itemState === command.outcome &&
+            affectedStopIds.length > 0
+            ? 'success'
+            : 'invalid';
+    }
+
+    return value.kind === 'confirm-manifest' &&
+        (value.outcome === 'applied' || value.outcome === 'already-applied') &&
+        value.manifestId === command.manifestId &&
+        value.manifestState === 'confirmed'
+        ? 'success'
+        : 'invalid';
+}
+
+export function pickupManifestTransportResult(
+    value: unknown,
+    command: PickupManifestCommand,
+): PickupManifestTransportResult {
+    if (!isRecord(value) || !Array.isArray(value.results)) {
+        return {
+            status: 'retryable-failure',
+            code: 'invalid-server-response',
+        };
+    }
+    const matchingResults = value.results.filter(
+        (candidate) =>
+            isRecord(candidate) &&
+            candidate.clientOperationId === command.operationId,
+    );
+    if (matchingResults.length !== 1) {
+        return {
+            status: 'retryable-failure',
+            code: 'missing-operation-result',
+        };
+    }
+    const result = matchingResults[0];
+    if (
+        !result ||
+        typeof result.replayed !== 'boolean' ||
+        !('result' in result)
+    ) {
+        return {
+            status: 'retryable-failure',
+            code: 'invalid-server-response',
+        };
+    }
+    const storedResult = validateStoredResult(result.result, command);
+    if (storedResult === 'scan-not-found') {
+        return {
+            status: 'permanent-failure',
+            code: 'pickup-trace-not-found',
+        };
+    }
+    if (storedResult === 'scan-ambiguous') {
+        return {
+            status: 'permanent-failure',
+            code: 'pickup-trace-ambiguous',
+        };
+    }
+    if (storedResult === 'invalid') {
+        return {
+            status: 'retryable-failure',
+            code: 'invalid-server-response',
+        };
+    }
+    return result.replayed
+        ? { status: 'exact-duplicate' }
+        : { status: 'applied' };
+}
+
+export function pickupManifestHttpFailure(
+    status: number,
+    value: unknown,
+): PickupManifestTransportResult {
+    const retryable =
+        status === 408 || status === 425 || status === 429 || status >= 500;
+    return {
+        status: retryable ? 'retryable-failure' : 'permanent-failure',
+        code:
+            responseCode(value) ??
+            (retryable
+                ? 'pickup-manifest-sync-failed'
+                : 'pickup-manifest-request-rejected'),
+    };
+}

--- a/packages/storage/src/migrations/0071_omniscient_rhino.sql
+++ b/packages/storage/src/migrations/0071_omniscient_rhino.sql
@@ -1,0 +1,50 @@
+CREATE TABLE "delivery_run_pickup_operations" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"run_id" text NOT NULL,
+	"pickup_node_id" text NOT NULL,
+	"driver_user_id" text NOT NULL,
+	"client_operation_id" text NOT NULL,
+	"kind" text NOT NULL,
+	"payload_hash" text NOT NULL,
+	"result" jsonb NOT NULL,
+	"occurred_at" timestamp NOT NULL,
+	"applied_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "delivery_run_pickup_operations_kind_check" CHECK ("delivery_run_pickup_operations"."kind" in ('scan', 'mark-item', 'confirm-manifest'))
+);
+--> statement-breakpoint
+ALTER TABLE "delivery_run_slots" ADD COLUMN "manifest_state" text DEFAULT 'confirmed' NOT NULL;--> statement-breakpoint
+ALTER TABLE "delivery_run_slots" ADD COLUMN "confirmed_at" timestamp;--> statement-breakpoint
+ALTER TABLE "delivery_run_slots" ADD COLUMN "confirmed_by_user_id" text;--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD COLUMN "pickup_item_state" text;--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD COLUMN "pickup_trace_link_id" integer;--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD COLUMN "pickup_trace_token" text;--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD COLUMN "pickup_resolved_at" timestamp;--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD COLUMN "pickup_resolved_by_user_id" text;--> statement-breakpoint
+ALTER TABLE "delivery_run_pickup_operations" ADD CONSTRAINT "delivery_run_pickup_operations_run_id_delivery_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."delivery_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "delivery_run_pickup_operations" ADD CONSTRAINT "delivery_run_pickup_operations_driver_user_id_users_id_fk" FOREIGN KEY ("driver_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "delivery_run_pickup_operations" ADD CONSTRAINT "delivery_run_pickup_operations_run_pickup_node_fk" FOREIGN KEY ("run_id","pickup_node_id") REFERENCES "public"."delivery_run_pickup_nodes"("run_id","id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "delivery_run_pickup_operations_run_client_unique" ON "delivery_run_pickup_operations" USING btree ("run_id","client_operation_id");--> statement-breakpoint
+CREATE INDEX "delivery_run_pickup_operations_run_id_idx" ON "delivery_run_pickup_operations" USING btree ("run_id");--> statement-breakpoint
+CREATE INDEX "delivery_run_pickup_operations_pickup_node_id_idx" ON "delivery_run_pickup_operations" USING btree ("pickup_node_id");--> statement-breakpoint
+ALTER TABLE "delivery_run_slots" ADD CONSTRAINT "delivery_run_slots_confirmed_by_user_id_users_id_fk" FOREIGN KEY ("confirmed_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD CONSTRAINT "delivery_run_stops_pickup_trace_link_id_harvest_trace_links_id_fk" FOREIGN KEY ("pickup_trace_link_id") REFERENCES "public"."harvest_trace_links"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD CONSTRAINT "delivery_run_stops_pickup_resolved_by_user_id_users_id_fk" FOREIGN KEY ("pickup_resolved_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "delivery_run_stops_pickup_trace_token_idx" ON "delivery_run_stops" USING btree ("pickup_trace_token");--> statement-breakpoint
+CREATE INDEX "delivery_run_stops_pickup_item_state_idx" ON "delivery_run_stops" USING btree ("pickup_item_state");--> statement-breakpoint
+ALTER TABLE "delivery_run_slots" ADD CONSTRAINT "delivery_run_slots_manifest_state_check" CHECK ("delivery_run_slots"."manifest_state" in ('pending', 'confirmed'));--> statement-breakpoint
+ALTER TABLE "delivery_run_slots" ADD CONSTRAINT "delivery_run_slots_manifest_confirmation_shape_check" CHECK ("delivery_run_slots"."manifest_state" = 'confirmed' or ("delivery_run_slots"."confirmed_at" is null and "delivery_run_slots"."confirmed_by_user_id" is null));--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD CONSTRAINT "delivery_run_stops_pickup_item_state_check" CHECK ("delivery_run_stops"."pickup_item_state" is null or "delivery_run_stops"."pickup_item_state" in ('ready', 'scanned', 'missing-label', 'not-ready'));--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD CONSTRAINT "delivery_run_stops_pickup_item_resolution_shape_check" CHECK ((
+                "delivery_run_stops"."pickup_item_state" is null
+                and "delivery_run_stops"."pickup_trace_link_id" is null
+                and "delivery_run_stops"."pickup_trace_token" is null
+                and "delivery_run_stops"."pickup_resolved_at" is null
+                and "delivery_run_stops"."pickup_resolved_by_user_id" is null
+            ) or (
+                "delivery_run_stops"."pickup_item_state" = 'ready'
+                and "delivery_run_stops"."pickup_resolved_at" is null
+                and "delivery_run_stops"."pickup_resolved_by_user_id" is null
+            ) or (
+                "delivery_run_stops"."pickup_item_state" in ('scanned', 'missing-label', 'not-ready')
+                and "delivery_run_stops"."pickup_resolved_at" is not null
+            ));

--- a/packages/storage/src/migrations/meta/0071_snapshot.json
+++ b/packages/storage/src/migrations/meta/0071_snapshot.json
@@ -1,0 +1,17697 @@
+{
+  "id": "d9745baa-b425-49ad-8c58-83a448e664ea",
+  "prevId": "74a026f3-90af-4af9-89b0-5d08e08390d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_achievements": {
+      "name": "account_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_key": {
+          "name": "achievement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "achievement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reward_sunflowers": {
+          "name": "reward_sunflowers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_value": {
+          "name": "progress_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_granted_at": {
+          "name": "reward_granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_by_user_id": {
+          "name": "denied_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_achievements_account_id_idx": {
+          "name": "account_achievements_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_achievements_status_idx": {
+          "name": "account_achievements_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_achievements_account_key_uq": {
+          "name": "account_achievements_account_key_uq",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "achievement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_achievements_account_id_accounts_id_fk": {
+          "name": "account_achievements_account_id_accounts_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_achievements_approved_by_user_id_users_id_fk": {
+          "name": "account_achievements_approved_by_user_id_users_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_achievements_denied_by_user_id_users_id_fk": {
+          "name": "account_achievements_denied_by_user_id_users_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "denied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_account_limit_overrides": {
+      "name": "ai_account_limit_overrides",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_daily_limit_micro_usd": {
+          "name": "active_daily_limit_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_daily_limit_micro_usd": {
+          "name": "trial_daily_limit_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_chat_days": {
+          "name": "trial_chat_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_account_limit_overrides_disabled_idx": {
+          "name": "ai_account_limit_overrides_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_account_limit_overrides_account_id_accounts_id_fk": {
+          "name": "ai_account_limit_overrides_account_id_accounts_id_fk",
+          "tableFrom": "ai_account_limit_overrides",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_account_limit_overrides_updated_by_user_id_users_id_fk": {
+          "name": "ai_account_limit_overrides_updated_by_user_id_users_id_fk",
+          "tableFrom": "ai_account_limit_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_conversations": {
+      "name": "ai_chat_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_chat_conversations_account_idx": {
+          "name": "ai_chat_conversations_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_conversations_user_idx": {
+          "name": "ai_chat_conversations_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_conversations_last_message_idx": {
+          "name": "ai_chat_conversations_last_message_idx",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_conversations_account_id_accounts_id_fk": {
+          "name": "ai_chat_conversations_account_id_accounts_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_user_id_users_id_fk": {
+          "name": "ai_chat_conversations_user_id_users_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_garden_id_gardens_id_fk": {
+          "name": "ai_chat_conversations_garden_id_gardens_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_raised_bed_id_raised_beds_id_fk": {
+          "name": "ai_chat_conversations_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_messages": {
+      "name": "ai_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_chat_messages_conversation_idx": {
+          "name": "ai_chat_messages_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_messages_created_at_idx": {
+          "name": "ai_chat_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_messages_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_messages_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_messages",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_tool_calls": {
+      "name": "ai_chat_tool_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_approval": {
+          "name": "needs_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_correlation_id": {
+          "name": "mcp_correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_chat_tool_calls_conversation_idx": {
+          "name": "ai_chat_tool_calls_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_tool_calls_tool_name_idx": {
+          "name": "ai_chat_tool_calls_tool_name_idx",
+          "columns": [
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_tool_calls_created_at_idx": {
+          "name": "ai_chat_tool_calls_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_tool_calls_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_tool_calls_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_chat_tool_calls_message_id_ai_chat_messages_id_fk": {
+          "name": "ai_chat_tool_calls_message_id_ai_chat_messages_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "ai_chat_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_chat_tool_calls_approved_by_user_id_users_id_fk": {
+          "name": "ai_chat_tool_calls_approved_by_user_id_users_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_ledger": {
+      "name": "ai_usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suncokret-chat'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_date": {
+          "name": "usage_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reserved_micro_usd": {
+          "name": "reserved_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_micro_usd": {
+          "name": "input_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_micro_usd": {
+          "name": "output_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_micro_usd": {
+          "name": "total_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_usage_ledger_request_unique": {
+          "name": "ai_usage_ledger_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_account_date_idx": {
+          "name": "ai_usage_ledger_account_date_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_conversation_idx": {
+          "name": "ai_usage_ledger_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_status_idx": {
+          "name": "ai_usage_ledger_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_created_at_idx": {
+          "name": "ai_usage_ledger_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_ledger_account_id_accounts_id_fk": {
+          "name": "ai_usage_ledger_account_id_accounts_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_usage_ledger_user_id_users_id_fk": {
+          "name": "ai_usage_ledger_user_id_users_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_usage_ledger_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_usage_ledger_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_definitions": {
+      "name": "automation_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_definition_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trigger_module_key": {
+          "name": "trigger_module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_event_type": {
+          "name": "trigger_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[]}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_definitions_key_idx": {
+          "name": "automation_definitions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_status_idx": {
+          "name": "automation_definitions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_trigger_event_type_idx": {
+          "name": "automation_definitions_trigger_event_type_idx",
+          "columns": [
+            {
+              "expression": "trigger_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_updated_at_idx": {
+          "name": "automation_definitions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_definitions_created_by_user_id_users_id_fk": {
+          "name": "automation_definitions_created_by_user_id_users_id_fk",
+          "tableFrom": "automation_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_definitions_updated_by_user_id_users_id_fk": {
+          "name": "automation_definitions_updated_by_user_id_users_id_fk",
+          "tableFrom": "automation_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_event_cursors": {
+      "name": "automation_event_cursors",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_run_steps": {
+      "name": "automation_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_kind": {
+          "name": "module_kind",
+          "type": "automation_module_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_run_steps_run_node_idx": {
+          "name": "automation_run_steps_run_node_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_steps_run_id_idx": {
+          "name": "automation_run_steps_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_steps_status_idx": {
+          "name": "automation_run_steps_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_run_steps_run_id_automation_runs_id_fk": {
+          "name": "automation_run_steps_run_id_automation_runs_id_fk",
+          "tableFrom": "automation_run_steps",
+          "tableTo": "automation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "automation_definition_id": {
+          "name": "automation_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_definition_key": {
+          "name": "automation_definition_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_definition_name": {
+          "name": "automation_definition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "automation_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_type": {
+          "name": "source_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_aggregate_id": {
+          "name": "source_aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_requested_by_user_id": {
+          "name": "manual_requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_snapshot": {
+          "name": "graph_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[]}'::jsonb"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_runs_definition_source_event_idx": {
+          "name": "automation_runs_definition_source_event_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_runs\".\"source\" = 'event'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_definition_source_schedule_idx": {
+          "name": "automation_runs_definition_source_schedule_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_runs\".\"source_event_type\" in ('automation.schedule', 'automation.schedule.monthly')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_definition_id_idx": {
+          "name": "automation_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_status_next_run_at_idx": {
+          "name": "automation_runs_status_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_source_event_type_idx": {
+          "name": "automation_runs_source_event_type_idx",
+          "columns": [
+            {
+              "expression": "source_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_source_event_id_idx": {
+          "name": "automation_runs_source_event_id_idx",
+          "columns": [
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_created_at_idx": {
+          "name": "automation_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_definition_id_automation_definitions_id_fk": {
+          "name": "automation_runs_automation_definition_id_automation_definitions_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automation_definitions",
+          "columnsFrom": [
+            "automation_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "automation_runs_source_event_id_events_id_fk": {
+          "name": "automation_runs_source_event_id_events_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_runs_manual_requested_by_user_id_users_id_fk": {
+          "name": "automation_runs_manual_requested_by_user_id_users_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "manual_requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definition_categories": {
+      "name": "attribute_definition_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_adc_entity_type_name_idx": {
+          "name": "cms_adc_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_order_idx": {
+          "name": "cms_adc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_is_deleted_idx": {
+          "name": "cms_adc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definitions": {
+      "name": "attribute_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multiple": {
+          "name": "multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display": {
+          "name": "display",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_ad_category_idx": {
+          "name": "cms_ad_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_entity_type_name_idx": {
+          "name": "cms_ad_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_order_idx": {
+          "name": "cms_ad_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_is_deleted_idx": {
+          "name": "cms_ad_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_values": {
+      "name": "attribute_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_av_attribute_definition_id_idx": {
+          "name": "cms_av_attribute_definition_id_idx",
+          "columns": [
+            {
+              "expression": "attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_type_name_idx": {
+          "name": "cms_av_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_id_idx": {
+          "name": "cms_av_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_order_idx": {
+          "name": "cms_av_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_is_deleted_idx": {
+          "name": "cms_av_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attribute_values_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "attribute_values_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attribute_values_entity_id_entities_id_fk": {
+          "name": "attribute_values_entity_id_entities_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_page_revisions": {
+      "name": "cms_page_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_page_id": {
+          "name": "cms_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_slug": {
+          "name": "previous_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_slug": {
+          "name": "next_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_title": {
+          "name": "previous_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_title": {
+          "name": "next_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_content": {
+          "name": "previous_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_content": {
+          "name": "next_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_content_kind": {
+          "name": "previous_content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_content_kind": {
+          "name": "next_content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category": {
+          "name": "previous_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_category": {
+          "name": "next_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_tags": {
+          "name": "previous_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_tags": {
+          "name": "next_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_title": {
+          "name": "previous_meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_title": {
+          "name": "next_meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_description": {
+          "name": "previous_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_description": {
+          "name": "next_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_image_url": {
+          "name": "previous_meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_image_url": {
+          "name": "next_meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_seo_image_url": {
+          "name": "previous_seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_seo_image_url": {
+          "name": "next_seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_canonical_path": {
+          "name": "previous_canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_canonical_path": {
+          "name": "next_canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_no_index": {
+          "name": "previous_no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_no_index": {
+          "name": "next_no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_published_at": {
+          "name": "previous_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_published_at": {
+          "name": "next_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cms_page_revisions_page_id_idx": {
+          "name": "cms_page_revisions_page_id_idx",
+          "columns": [
+            {
+              "expression": "cms_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_page_revisions_action_idx": {
+          "name": "cms_page_revisions_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_page_revisions_created_at_idx": {
+          "name": "cms_page_revisions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cms_page_revisions_cms_page_id_cms_pages_id_fk": {
+          "name": "cms_page_revisions_cms_page_id_cms_pages_id_fk",
+          "tableFrom": "cms_page_revisions",
+          "tableTo": "cms_pages",
+          "columnsFrom": [
+            "cms_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_pages": {
+      "name": "cms_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_kind": {
+          "name": "content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_url": {
+          "name": "meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_image_url": {
+          "name": "seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_index": {
+          "name": "no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_pages_slug_active_uq": {
+          "name": "cms_pages_slug_active_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cms_pages\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_state_idx": {
+          "name": "cms_pages_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_content_kind_idx": {
+          "name": "cms_pages_content_kind_idx",
+          "columns": [
+            {
+              "expression": "content_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_category_idx": {
+          "name": "cms_pages_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_published_at_idx": {
+          "name": "cms_pages_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_is_deleted_idx": {
+          "name": "cms_pages_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_order": {
+          "name": "hierarchy_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_e_entity_type_name_idx": {
+          "name": "cms_e_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_parent_id_idx": {
+          "name": "cms_e_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_hierarchy_order_idx": {
+          "name": "cms_e_hierarchy_order_idx",
+          "columns": [
+            {
+              "expression": "hierarchy_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_state_idx": {
+          "name": "cms_e_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_is_deleted_idx": {
+          "name": "cms_e_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_parent_id_entities_id_fk": {
+          "name": "entities_parent_id_entities_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_revisions": {
+      "name": "entity_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_value_id": {
+          "name": "attribute_value_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_value": {
+          "name": "next_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cms_er_entity_id_idx": {
+          "name": "cms_er_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_er_entity_type_name_idx": {
+          "name": "cms_er_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_er_action_idx": {
+          "name": "cms_er_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_revisions_entity_id_entities_id_fk": {
+          "name": "entity_revisions_entity_id_entities_id_fk",
+          "tableFrom": "entity_revisions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_search_documents": {
+      "name": "entity_search_documents",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_category": {
+          "name": "public_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_category_label": {
+          "name": "public_category_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cms_esd_entity_type_idx": {
+          "name": "cms_esd_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_public_category_idx": {
+          "name": "cms_esd_public_category_idx",
+          "columns": [
+            {
+              "expression": "public_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_state_idx": {
+          "name": "cms_esd_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_published_at_idx": {
+          "name": "cms_esd_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_search_vector_idx": {
+          "name": "cms_esd_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_search_documents_entity_id_entities_id_fk": {
+          "name": "entity_search_documents_entity_id_entities_id_fk",
+          "tableFrom": "entity_search_documents",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_type_categories": {
+      "name": "entity_type_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_etc_order_idx": {
+          "name": "cms_etc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_etc_is_deleted_idx": {
+          "name": "cms_etc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_types": {
+      "name": "entity_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_order": {
+          "name": "hierarchy_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_root": {
+          "name": "is_root",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "inventory_source_attribute_definition_id": {
+          "name": "inventory_source_attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_et_category_id_idx": {
+          "name": "cms_et_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_order_idx": {
+          "name": "cms_et_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_parent_id_idx": {
+          "name": "cms_et_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_hierarchy_order_idx": {
+          "name": "cms_et_hierarchy_order_idx",
+          "columns": [
+            {
+              "expression": "hierarchy_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_deleted_idx": {
+          "name": "cms_et_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_root_idx": {
+          "name": "cms_et_is_root_idx",
+          "columns": [
+            {
+              "expression": "is_root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_inventory_source_attr_def_idx": {
+          "name": "cms_et_inventory_source_attr_def_idx",
+          "columns": [
+            {
+              "expression": "inventory_source_attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_types_category_id_entity_type_categories_id_fk": {
+          "name": "entity_types_category_id_entity_type_categories_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_type_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_types_parent_id_entity_types_id_fk": {
+          "name": "entity_types_parent_id_entity_types_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_types",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_types_inventory_source_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "entity_types_inventory_source_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "inventory_source_attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_edit_request_changes": {
+      "name": "community_edit_request_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_key": {
+          "name": "section_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribute_value_id": {
+          "name": "attribute_value_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_path": {
+          "name": "attribute_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_value_hash": {
+          "name": "base_value_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_patch": {
+          "name": "value_patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_diff": {
+          "name": "review_diff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_edit_changes_request_id_idx": {
+          "name": "community_edit_changes_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_changes_field_key_idx": {
+          "name": "community_edit_changes_field_key_idx",
+          "columns": [
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_changes_attribute_definition_idx": {
+          "name": "community_edit_changes_attribute_definition_idx",
+          "columns": [
+            {
+              "expression": "attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_edit_request_changes_request_id_community_edit_requests_id_fk": {
+          "name": "community_edit_request_changes_request_id_community_edit_requests_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "community_edit_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_request_changes_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "community_edit_request_changes_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_request_changes_attribute_value_id_attribute_values_id_fk": {
+          "name": "community_edit_request_changes_attribute_value_id_attribute_values_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "attribute_values",
+          "columnsFrom": [
+            "attribute_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_edit_requests": {
+      "name": "community_edit_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_key": {
+          "name": "section_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_user_id": {
+          "name": "submitter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_email": {
+          "name": "submitter_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_note": {
+          "name": "submitter_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_user_id": {
+          "name": "reviewer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_name": {
+          "name": "reviewer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_failure_reason": {
+          "name": "application_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "community_edit_requests_status_idx": {
+          "name": "community_edit_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_entity_type_idx": {
+          "name": "community_edit_requests_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_entity_id_idx": {
+          "name": "community_edit_requests_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_submitter_idx": {
+          "name": "community_edit_requests_submitter_idx",
+          "columns": [
+            {
+              "expression": "submitter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_created_at_idx": {
+          "name": "community_edit_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_edit_requests_entity_id_entities_id_fk": {
+          "name": "community_edit_requests_entity_id_entities_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_requests_submitter_user_id_users_id_fk": {
+          "name": "community_edit_requests_submitter_user_id_users_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_requests_reviewer_user_id_users_id_fk": {
+          "name": "community_edit_requests_reviewer_user_id_users_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_addresses": {
+      "name": "delivery_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HR'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_addresses_account_id_idx": {
+          "name": "delivery_addresses_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_addresses_is_default_idx": {
+          "name": "delivery_addresses_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_addresses_deleted_at_idx": {
+          "name": "delivery_addresses_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_addresses_account_id_accounts_id_fk": {
+          "name": "delivery_addresses_account_id_accounts_id_fk",
+          "tableFrom": "delivery_addresses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_requests": {
+      "name": "delivery_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_requests_operation_id_idx": {
+          "name": "delivery_requests_operation_id_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_requests_created_at_idx": {
+          "name": "delivery_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_requests_operation_id_operations_id_fk": {
+          "name": "delivery_requests_operation_id_operations_id_fk",
+          "tableFrom": "delivery_requests",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_pickup_nodes": {
+      "name": "delivery_run_pickup_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_location_id": {
+          "name": "pickup_location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itinerary_sequence": {
+          "name": "itinerary_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_arrival_at": {
+          "name": "estimated_arrival_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_travel_seconds": {
+          "name": "incoming_travel_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_distance_meters": {
+          "name": "incoming_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_duration_seconds": {
+          "name": "service_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_pickup_nodes_run_sequence_unique": {
+          "name": "delivery_run_pickup_nodes_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_location_unique": {
+          "name": "delivery_run_pickup_nodes_run_location_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pickup_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_id_id_unique": {
+          "name": "delivery_run_pickup_nodes_run_id_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_itinerary_sequence_unique": {
+          "name": "delivery_run_pickup_nodes_run_itinerary_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "itinerary_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_run_pickup_nodes\".\"itinerary_sequence\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_id_idx": {
+          "name": "delivery_run_pickup_nodes_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_pickup_nodes_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_pickup_nodes_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_pickup_nodes",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_nodes_pickup_location_id_pickup_locations_id_fk": {
+          "name": "delivery_run_pickup_nodes_pickup_location_id_pickup_locations_id_fk",
+          "tableFrom": "delivery_run_pickup_nodes",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "pickup_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_pickup_nodes_itinerary_shape_check": {
+          "name": "delivery_run_pickup_nodes_itinerary_shape_check",
+          "value": "(\n                \"delivery_run_pickup_nodes\".\"itinerary_sequence\" is null\n                and \"delivery_run_pickup_nodes\".\"estimated_arrival_at\" is null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" is null\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" is null\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" is null\n            ) or (\n                \"delivery_run_pickup_nodes\".\"itinerary_sequence\" is not null\n                and \"delivery_run_pickup_nodes\".\"itinerary_sequence\" > 0\n                and \"delivery_run_pickup_nodes\".\"estimated_arrival_at\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" >= 0\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" >= 0\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" is not null\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" >= 0\n            )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_pickup_operations": {
+      "name": "delivery_run_pickup_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_node_id": {
+          "name": "pickup_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_operation_id": {
+          "name": "client_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_run_pickup_operations_run_client_unique": {
+          "name": "delivery_run_pickup_operations_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_operations_run_id_idx": {
+          "name": "delivery_run_pickup_operations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_operations_pickup_node_id_idx": {
+          "name": "delivery_run_pickup_operations_pickup_node_id_idx",
+          "columns": [
+            {
+              "expression": "pickup_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_pickup_operations_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_pickup_operations_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_operations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_pickup_operations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_operations_run_pickup_node_fk": {
+          "name": "delivery_run_pickup_operations_run_pickup_node_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "delivery_run_pickup_nodes",
+          "columnsFrom": [
+            "run_id",
+            "pickup_node_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_pickup_operations_kind_check": {
+          "name": "delivery_run_pickup_operations_kind_check",
+          "value": "\"delivery_run_pickup_operations\".\"kind\" in ('scan', 'mark-item', 'confirm-manifest')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_preparations": {
+      "name": "delivery_run_preparations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selection_hash": {
+          "name": "selection_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_run_id": {
+          "name": "delivery_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_preparations_driver_user_id_idx": {
+          "name": "delivery_run_preparations_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_expires_at_idx": {
+          "name": "delivery_run_preparations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_consumed_at_idx": {
+          "name": "delivery_run_preparations_consumed_at_idx",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_delivery_run_id_unique": {
+          "name": "delivery_run_preparations_delivery_run_id_unique",
+          "columns": [
+            {
+              "expression": "delivery_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_preparations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_preparations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_preparations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_preparations_delivery_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_preparations_delivery_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_preparations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "delivery_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_preparations_consumption_shape_check": {
+          "name": "delivery_run_preparations_consumption_shape_check",
+          "value": "(\"delivery_run_preparations\".\"consumed_at\" is null and \"delivery_run_preparations\".\"delivery_run_id\" is null) or (\"delivery_run_preparations\".\"consumed_at\" is not null and \"delivery_run_preparations\".\"delivery_run_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_slots": {
+      "name": "delivery_run_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_node_id": {
+          "name": "pickup_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot_id": {
+          "name": "time_slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_id": {
+          "name": "manifest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_state": {
+          "name": "manifest_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirmed'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by_user_id": {
+          "name": "confirmed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_slots_manifest_id_unique": {
+          "name": "delivery_run_slots_manifest_id_unique",
+          "columns": [
+            {
+              "expression": "manifest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_sequence_unique": {
+          "name": "delivery_run_slots_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_time_slot_unique": {
+          "name": "delivery_run_slots_run_time_slot_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_id_id_unique": {
+          "name": "delivery_run_slots_run_id_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_id_idx": {
+          "name": "delivery_run_slots_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_pickup_node_id_idx": {
+          "name": "delivery_run_slots_pickup_node_id_idx",
+          "columns": [
+            {
+              "expression": "pickup_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_slots_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_slots_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_time_slot_id_time_slots_id_fk": {
+          "name": "delivery_run_slots_time_slot_id_time_slots_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "time_slots",
+          "columnsFrom": [
+            "time_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_confirmed_by_user_id_users_id_fk": {
+          "name": "delivery_run_slots_confirmed_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_run_pickup_node_fk": {
+          "name": "delivery_run_slots_run_pickup_node_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "delivery_run_pickup_nodes",
+          "columnsFrom": [
+            "run_id",
+            "pickup_node_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_slots_manifest_state_check": {
+          "name": "delivery_run_slots_manifest_state_check",
+          "value": "\"delivery_run_slots\".\"manifest_state\" in ('pending', 'confirmed')"
+        },
+        "delivery_run_slots_manifest_confirmation_shape_check": {
+          "name": "delivery_run_slots_manifest_confirmation_shape_check",
+          "value": "\"delivery_run_slots\".\"manifest_state\" = 'confirmed' or (\"delivery_run_slots\".\"confirmed_at\" is null and \"delivery_run_slots\".\"confirmed_by_user_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_stops": {
+      "name": "delivery_run_stops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_request_id": {
+          "name": "delivery_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_slot_id": {
+          "name": "run_slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itinerary_sequence": {
+          "name": "itinerary_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_duration_seconds": {
+          "name": "service_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_key": {
+          "name": "stop_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_dispatch_event_id": {
+          "name": "request_dispatch_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_id": {
+          "name": "delivery_address_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_updated_at": {
+          "name": "delivery_address_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_label": {
+          "name": "delivery_address_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_contact_name": {
+          "name": "delivery_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street1": {
+          "name": "delivery_street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street2": {
+          "name": "delivery_street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_postal_code": {
+          "name": "delivery_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_code": {
+          "name": "delivery_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_item_state": {
+          "name": "pickup_item_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_trace_link_id": {
+          "name": "pickup_trace_link_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_trace_token": {
+          "name": "pickup_trace_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_resolved_at": {
+          "name": "pickup_resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_resolved_by_user_id": {
+          "name": "pickup_resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_arrival_at": {
+          "name": "estimated_arrival_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_travel_seconds": {
+          "name": "estimated_travel_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_distance_meters": {
+          "name": "estimated_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_stops_delivery_request_id_unique": {
+          "name": "delivery_run_stops_delivery_request_id_unique",
+          "columns": [
+            {
+              "expression": "delivery_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_sequence_unique": {
+          "name": "delivery_run_stops_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_id_idx": {
+          "name": "delivery_run_stops_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_itinerary_sequence_idx": {
+          "name": "delivery_run_stops_run_itinerary_sequence_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "itinerary_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_slot_id_idx": {
+          "name": "delivery_run_stops_run_slot_id_idx",
+          "columns": [
+            {
+              "expression": "run_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_state_idx": {
+          "name": "delivery_run_stops_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_pickup_trace_token_idx": {
+          "name": "delivery_run_stops_pickup_trace_token_idx",
+          "columns": [
+            {
+              "expression": "pickup_trace_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_pickup_item_state_idx": {
+          "name": "delivery_run_stops_pickup_item_state_idx",
+          "columns": [
+            {
+              "expression": "pickup_item_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_stops_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_stops_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_delivery_request_id_delivery_requests_id_fk": {
+          "name": "delivery_run_stops_delivery_request_id_delivery_requests_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_requests",
+          "columnsFrom": [
+            "delivery_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_pickup_trace_link_id_harvest_trace_links_id_fk": {
+          "name": "delivery_run_stops_pickup_trace_link_id_harvest_trace_links_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "harvest_trace_links",
+          "columnsFrom": [
+            "pickup_trace_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_pickup_resolved_by_user_id_users_id_fk": {
+          "name": "delivery_run_stops_pickup_resolved_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "pickup_resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_run_slot_fk": {
+          "name": "delivery_run_stops_run_slot_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_run_slots",
+          "columnsFrom": [
+            "run_id",
+            "run_slot_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_stops_snapshot_shape_check": {
+          "name": "delivery_run_stops_snapshot_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"run_slot_id\" is null\n                and \"delivery_run_stops\".\"stop_key\" is null\n                and \"delivery_run_stops\".\"request_dispatch_event_id\" is null\n                and \"delivery_run_stops\".\"delivery_address_id\" is null\n                and \"delivery_run_stops\".\"delivery_address_updated_at\" is null\n                and \"delivery_run_stops\".\"delivery_address_label\" is null\n                and \"delivery_run_stops\".\"delivery_contact_name\" is null\n                and \"delivery_run_stops\".\"delivery_phone\" is null\n                and \"delivery_run_stops\".\"delivery_street1\" is null\n                and \"delivery_run_stops\".\"delivery_street2\" is null\n                and \"delivery_run_stops\".\"delivery_city\" is null\n                and \"delivery_run_stops\".\"delivery_postal_code\" is null\n                and \"delivery_run_stops\".\"delivery_country_code\" is null\n            ) or (\n                \"delivery_run_stops\".\"run_slot_id\" is not null\n                and \"delivery_run_stops\".\"stop_key\" is not null\n                and \"delivery_run_stops\".\"request_dispatch_event_id\" is not null\n                and \"delivery_run_stops\".\"delivery_address_id\" is not null\n                and \"delivery_run_stops\".\"delivery_address_updated_at\" is not null\n                and \"delivery_run_stops\".\"delivery_address_label\" is not null\n                and \"delivery_run_stops\".\"delivery_contact_name\" is not null\n                and \"delivery_run_stops\".\"delivery_phone\" is not null\n                and \"delivery_run_stops\".\"delivery_street1\" is not null\n                and \"delivery_run_stops\".\"delivery_city\" is not null\n                and \"delivery_run_stops\".\"delivery_postal_code\" is not null\n                and \"delivery_run_stops\".\"delivery_country_code\" is not null\n            )"
+        },
+        "delivery_run_stops_itinerary_shape_check": {
+          "name": "delivery_run_stops_itinerary_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"itinerary_sequence\" is null\n                and \"delivery_run_stops\".\"service_duration_seconds\" is null\n            ) or (\n                \"delivery_run_stops\".\"itinerary_sequence\" is not null\n                and \"delivery_run_stops\".\"itinerary_sequence\" > 0\n                and \"delivery_run_stops\".\"service_duration_seconds\" is not null\n                and \"delivery_run_stops\".\"service_duration_seconds\" >= 0\n            )"
+        },
+        "delivery_run_stops_pickup_item_state_check": {
+          "name": "delivery_run_stops_pickup_item_state_check",
+          "value": "\"delivery_run_stops\".\"pickup_item_state\" is null or \"delivery_run_stops\".\"pickup_item_state\" in ('ready', 'scanned', 'missing-label', 'not-ready')"
+        },
+        "delivery_run_stops_pickup_item_resolution_shape_check": {
+          "name": "delivery_run_stops_pickup_item_resolution_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"pickup_item_state\" is null\n                and \"delivery_run_stops\".\"pickup_trace_link_id\" is null\n                and \"delivery_run_stops\".\"pickup_trace_token\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"pickup_item_state\" = 'ready'\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"pickup_item_state\" in ('scanned', 'missing-label', 'not-ready')\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is not null\n            )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_runs": {
+      "name": "delivery_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot_id": {
+          "name": "time_slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "encoded_polyline": {
+          "name": "encoded_polyline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_distance_meters": {
+          "name": "total_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_plan_version": {
+          "name": "route_plan_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "estimate_source": {
+          "name": "estimate_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "current_latitude": {
+          "name": "current_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_longitude": {
+          "name": "current_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_accuracy": {
+          "name": "current_location_accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_heading": {
+          "name": "current_location_heading",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_speed": {
+          "name": "current_location_speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_recorded_at": {
+          "name": "current_location_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimates_updated_at": {
+          "name": "estimates_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_runs_driver_user_id_idx": {
+          "name": "delivery_runs_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_time_slot_id_idx": {
+          "name": "delivery_runs_time_slot_id_idx",
+          "columns": [
+            {
+              "expression": "time_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_state_idx": {
+          "name": "delivery_runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_driver_active_unique": {
+          "name": "delivery_runs_driver_active_unique",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_runs\".\"state\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_location_recorded_at_idx": {
+          "name": "delivery_runs_location_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "current_location_recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_runs_driver_user_id_users_id_fk": {
+          "name": "delivery_runs_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_runs_time_slot_id_time_slots_id_fk": {
+          "name": "delivery_runs_time_slot_id_time_slots_id_fk",
+          "tableFrom": "delivery_runs",
+          "tableTo": "time_slots",
+          "columnsFrom": [
+            "time_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_runs_route_plan_provenance_check": {
+          "name": "delivery_runs_route_plan_provenance_check",
+          "value": "(\n                \"delivery_runs\".\"route_plan_version\" = 1\n                and \"delivery_runs\".\"estimate_source\" = 'legacy'\n            ) or (\n                \"delivery_runs\".\"route_plan_version\" >= 2\n                and \"delivery_runs\".\"estimate_source\" in ('google', 'local')\n            )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pickup_locations": {
+      "name": "pickup_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HR'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pickup_locations_is_active_idx": {
+          "name": "pickup_locations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_slots": {
+      "name": "time_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "time_slots_location_id_idx": {
+          "name": "time_slots_location_id_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_type_idx": {
+          "name": "time_slots_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_start_at_idx": {
+          "name": "time_slots_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_closes_at_idx": {
+          "name": "time_slots_closes_at_idx",
+          "columns": [
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_status_idx": {
+          "name": "time_slots_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_unique_slot_idx": {
+          "name": "time_slots_unique_slot_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_slots_location_id_pickup_locations_id_fk": {
+          "name": "time_slots_location_id_pickup_locations_id_fk",
+          "tableFrom": "time_slots",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_messages": {
+      "name": "email_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'acs'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "email_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_at": {
+          "name": "bounced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_messages_status_idx": {
+          "name": "email_messages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_messages_created_idx": {
+          "name": "email_messages_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_messages_provider_message_idx": {
+          "name": "email_messages_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_e_type_idx": {
+          "name": "events_e_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_aggregate_id_idx": {
+          "name": "events_e_aggregate_id_idx",
+          "columns": [
+            {
+              "expression": "aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_created_at_idx": {
+          "name": "events_e_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farms": {
+      "name": "farms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snow_accumulation": {
+          "name": "snow_accumulation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "farms_f_is_deleted_idx": {
+          "name": "farms_f_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedbacks": {
+      "name": "feedbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_pos_settings": {
+      "name": "fiscalization_pos_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos_id": {
+          "name": "pos_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_pos_settings_pos_id_idx": {
+          "name": "fiscalization_pos_settings_pos_id_idx",
+          "columns": [
+            {
+              "expression": "pos_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_active_idx": {
+          "name": "fiscalization_pos_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_deleted_idx": {
+          "name": "fiscalization_pos_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_user_settings": {
+      "name": "fiscalization_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_vat": {
+          "name": "use_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "receipt_number_on_device": {
+          "name": "receipt_number_on_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'educ'"
+        },
+        "cert_base64": {
+          "name": "cert_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cert_password": {
+          "name": "cert_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_user_settings_is_active_idx": {
+          "name": "fiscalization_user_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_user_settings_is_deleted_idx": {
+          "name": "fiscalization_user_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_blocks": {
+      "name": "garden_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gb_garden_id_idx": {
+          "name": "garden_gb_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gb_is_deleted_idx": {
+          "name": "garden_gb_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_blocks_garden_id_gardens_id_fk": {
+          "name": "garden_blocks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_blocks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_likes": {
+      "name": "garden_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_likes_user_garden_uq": {
+          "name": "garden_likes_user_garden_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_likes_user_id_idx": {
+          "name": "garden_likes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_likes_garden_id_idx": {
+          "name": "garden_likes_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_likes_user_id_users_id_fk": {
+          "name": "garden_likes_user_id_users_id_fk",
+          "tableFrom": "garden_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "garden_likes_garden_id_gardens_id_fk": {
+          "name": "garden_likes_garden_id_gardens_id_fk",
+          "tableFrom": "garden_likes",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_blob_deletions": {
+      "name": "garden_preview_blob_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_preview_blob_deletions_pathname_uq": {
+          "name": "garden_preview_blob_deletions_pathname_uq",
+          "columns": [
+            {
+              "expression": "pathname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_preview_blob_deletions_next_attempt_at_idx": {
+          "name": "garden_preview_blob_deletions_next_attempt_at_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_preview_blob_deletions_claim_expires_at_idx": {
+          "name": "garden_preview_blob_deletions_claim_expires_at_idx",
+          "columns": [
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_blob_scan_states": {
+      "name": "garden_preview_blob_scan_states",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_capture_leases": {
+      "name": "garden_preview_capture_leases",
+      "schema": "",
+      "columns": {
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_preview_capture_leases_expires_at_idx": {
+          "name": "garden_preview_capture_leases_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_preview_capture_leases_garden_id_gardens_id_fk": {
+          "name": "garden_preview_capture_leases_garden_id_gardens_id_fk",
+          "tableFrom": "garden_preview_capture_leases",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_previews": {
+      "name": "garden_previews",
+      "schema": "",
+      "columns": {
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capture_request_id": {
+          "name": "capture_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renderer_version": {
+          "name": "renderer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_requested_at": {
+          "name": "capture_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_previews_capture_request_id_uq": {
+          "name": "garden_previews_capture_request_id_uq",
+          "columns": [
+            {
+              "expression": "capture_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_previews_pathname_uq": {
+          "name": "garden_previews_pathname_uq",
+          "columns": [
+            {
+              "expression": "pathname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_previews_captured_at_idx": {
+          "name": "garden_previews_captured_at_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_previews_garden_id_gardens_id_fk": {
+          "name": "garden_previews_garden_id_gardens_id_fk",
+          "tableFrom": "garden_previews",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_stacks": {
+      "name": "garden_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gs_garden_id_idx": {
+          "name": "garden_gs_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gs_is_deleted_idx": {
+          "name": "garden_gs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_stacks_garden_id_gardens_id_fk": {
+          "name": "garden_stacks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_stacks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_visit_states": {
+      "name": "garden_visit_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_summary_seen_at": {
+          "name": "last_summary_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_summary_facts_hash": {
+          "name": "last_summary_facts_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "garden_visit_states_user_account_garden_unique": {
+          "name": "garden_visit_states_user_account_garden_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_visit_states_account_garden_idx": {
+          "name": "garden_visit_states_account_garden_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_visit_states_garden_id_idx": {
+          "name": "garden_visit_states_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_visit_states_user_id_users_id_fk": {
+          "name": "garden_visit_states_user_id_users_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "garden_visit_states_account_id_accounts_id_fk": {
+          "name": "garden_visit_states_account_id_accounts_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "garden_visit_states_garden_id_gardens_id_fk": {
+          "name": "garden_visit_states_garden_id_gardens_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gardens": {
+      "name": "gardens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_palette": {
+          "name": "background_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'current'"
+        },
+        "home_camera": {
+          "name": "home_camera",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sandbox": {
+          "name": "is_sandbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_g_account_id_idx": {
+          "name": "garden_g_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_farm_id_idx": {
+          "name": "garden_g_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_deleted_idx": {
+          "name": "garden_g_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_public_idx": {
+          "name": "garden_g_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_sandbox_idx": {
+          "name": "garden_g_is_sandbox_idx",
+          "columns": [
+            {
+              "expression": "is_sandbox",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gardens_account_id_accounts_id_fk": {
+          "name": "gardens_account_id_accounts_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gardens_farm_id_farms_id_fk": {
+          "name": "gardens_farm_id_farms_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_fields": {
+      "name": "raised_bed_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_fields_raised_bed_id_idx": {
+          "name": "raised_bed_fields_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_fields_is_deleted_idx": {
+          "name": "raised_bed_fields_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_fields_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_fields_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_fields",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_sensors": {
+      "name": "raised_bed_sensors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "sensor_signalco_id": {
+          "name": "sensor_signalco_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_sensors_raised_bed_id_idx": {
+          "name": "raised_bed_sensors_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_sensors_is_deleted_idx": {
+          "name": "raised_bed_sensors_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_sensors_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_sensors_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_sensors",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_beds": {
+      "name": "raised_beds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vertical'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "physical_id": {
+          "name": "physical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_beds_account_id_idx": {
+          "name": "raised_beds_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_garden_id_idx": {
+          "name": "raised_beds_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_block_id_idx": {
+          "name": "raised_beds_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_is_deleted_idx": {
+          "name": "raised_beds_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_beds_account_id_accounts_id_fk": {
+          "name": "raised_beds_account_id_accounts_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_garden_id_gardens_id_fk": {
+          "name": "raised_beds_garden_id_gardens_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_block_id_garden_blocks_id_fk": {
+          "name": "raised_beds_block_id_garden_blocks_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harvest_trace_links": {
+      "name": "harvest_trace_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_token": {
+          "name": "public_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raised_bed_field_id": {
+          "name": "raised_bed_field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_position_index": {
+          "name": "field_position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_label": {
+          "name": "field_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plant_place_event_id": {
+          "name": "plant_place_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plant_sort_id": {
+          "name": "plant_sort_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harvest_operation_id": {
+          "name": "harvest_operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_path": {
+          "name": "trace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "printed_at": {
+          "name": "printed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harvest_trace_links_public_token_unique": {
+          "name": "harvest_trace_links_public_token_unique",
+          "columns": [
+            {
+              "expression": "public_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_target_unique": {
+          "name": "harvest_trace_links_target_unique",
+          "columns": [
+            {
+              "expression": "harvest_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plant_place_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_status_idx": {
+          "name": "harvest_trace_links_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_target_idx": {
+          "name": "harvest_trace_links_target_idx",
+          "columns": [
+            {
+              "expression": "harvest_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plant_place_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_raised_bed_idx": {
+          "name": "harvest_trace_links_raised_bed_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_plant_sort_idx": {
+          "name": "harvest_trace_links_plant_sort_idx",
+          "columns": [
+            {
+              "expression": "plant_sort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_created_at_idx": {
+          "name": "harvest_trace_links_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harvest_trace_links_account_id_accounts_id_fk": {
+          "name": "harvest_trace_links_account_id_accounts_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_garden_id_gardens_id_fk": {
+          "name": "harvest_trace_links_garden_id_gardens_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_raised_bed_id_raised_beds_id_fk": {
+          "name": "harvest_trace_links_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_raised_bed_field_id_raised_bed_fields_id_fk": {
+          "name": "harvest_trace_links_raised_bed_field_id_raised_bed_fields_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "raised_bed_fields",
+          "columnsFrom": [
+            "raised_bed_field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_plant_place_event_id_events_id_fk": {
+          "name": "harvest_trace_links_plant_place_event_id_events_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "events",
+          "columnsFrom": [
+            "plant_place_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_plant_sort_id_entities_id_fk": {
+          "name": "harvest_trace_links_plant_sort_id_entities_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "plant_sort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_harvest_operation_id_operations_id_fk": {
+          "name": "harvest_trace_links_harvest_operation_id_operations_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "harvest_operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harvest_trace_scans": {
+      "name": "harvest_trace_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "harvest_trace_link_id": {
+          "name": "harvest_trace_link_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent_family": {
+          "name": "user_agent_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harvest_trace_scans_link_id_idx": {
+          "name": "harvest_trace_scans_link_id_idx",
+          "columns": [
+            {
+              "expression": "harvest_trace_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_scans_scanned_at_idx": {
+          "name": "harvest_trace_scans_scanned_at_idx",
+          "columns": [
+            {
+              "expression": "scanned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harvest_trace_scans_harvest_trace_link_id_harvest_trace_links_id_fk": {
+          "name": "harvest_trace_scans_harvest_trace_link_id_harvest_trace_links_id_fk",
+          "tableFrom": "harvest_trace_scans",
+          "tableTo": "harvest_trace_links",
+          "columnsFrom": [
+            "harvest_trace_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_configs": {
+      "name": "inventory_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_tracking_type": {
+          "name": "default_tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pieces'"
+        },
+        "status_attribute_name": {
+          "name": "status_attribute_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "empty_status_value": {
+          "name": "empty_status_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_attribute_name": {
+          "name": "amount_attribute_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_count_threshold": {
+          "name": "low_count_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_configs_entity_type_name_idx": {
+          "name": "inv_configs_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_configs_is_deleted_idx": {
+          "name": "inv_configs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_item_events": {
+      "name": "inventory_item_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_quantity": {
+          "name": "previous_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_quantity": {
+          "name": "new_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_state": {
+          "name": "new_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_item_events_inventory_item_id_idx": {
+          "name": "inv_item_events_inventory_item_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_item_events_is_deleted_idx": {
+          "name": "inv_item_events_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_item_events_inventory_item_id_inventory_items_id_fk": {
+          "name": "inventory_item_events_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_item_events",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_item_field_definitions": {
+      "name": "inventory_item_field_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_config_id": {
+          "name": "inventory_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_field_defs_inventory_config_id_idx": {
+          "name": "inv_field_defs_inventory_config_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_field_defs_is_deleted_idx": {
+          "name": "inv_field_defs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_item_field_definitions_inventory_config_id_inventory_configs_id_fk": {
+          "name": "inventory_item_field_definitions_inventory_config_id_inventory_configs_id_fk",
+          "tableFrom": "inventory_item_field_definitions",
+          "tableTo": "inventory_configs",
+          "columnsFrom": [
+            "inventory_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_items": {
+      "name": "inventory_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_config_id": {
+          "name": "inventory_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pieces'"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "low_count_threshold": {
+          "name": "low_count_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_fields": {
+          "name": "additional_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_items_inventory_config_id_idx": {
+          "name": "inv_items_inventory_config_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_entity_id_idx": {
+          "name": "inv_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_is_deleted_idx": {
+          "name": "inv_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_tracking_type_idx": {
+          "name": "inv_items_tracking_type_idx",
+          "columns": [
+            {
+              "expression": "tracking_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_items_inventory_config_id_inventory_configs_id_fk": {
+          "name": "inventory_items_inventory_config_id_inventory_configs_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "inventory_configs",
+          "columnsFrom": [
+            "inventory_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_items_entity_id_entities_id_fk": {
+          "name": "inventory_items_entity_id_entities_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.00'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_id_idx": {
+          "name": "invoice_items_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_id_idx": {
+          "name": "invoice_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_type_idx": {
+          "name": "invoice_items_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_name": {
+          "name": "bill_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_email": {
+          "name": "bill_to_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_to_address": {
+          "name": "bill_to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_city": {
+          "name": "bill_to_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_state": {
+          "name": "bill_to_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_zip": {
+          "name": "bill_to_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_country": {
+          "name": "bill_to_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_account_id_idx": {
+          "name": "invoices_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_transaction_id_idx": {
+          "name": "invoices_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_status_idx": {
+          "name": "invoices_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_issue_date_idx": {
+          "name": "invoices_issue_date_idx",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_due_date_idx": {
+          "name": "invoices_due_date_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_is_deleted_idx": {
+          "name": "invoices_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_account_id_accounts_id_fk": {
+          "name": "invoices_account_id_accounts_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_transaction_id_transactions_id_fk": {
+          "name": "invoices_transaction_id_transactions_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipts": {
+      "name": "receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_receipt_number": {
+          "name": "year_receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_reference": {
+          "name": "payment_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jir": {
+          "name": "jir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zki": {
+          "name": "zki",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_status": {
+          "name": "cis_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cis_reference": {
+          "name": "cis_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_error_message": {
+          "name": "cis_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_timestamp": {
+          "name": "cis_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_response": {
+          "name": "cis_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "business_pin": {
+          "name": "business_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_name": {
+          "name": "business_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_address": {
+          "name": "business_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_pin": {
+          "name": "customer_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_address": {
+          "name": "customer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "receipts_invoice_id_idx": {
+          "name": "receipts_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_receipt_number_idx": {
+          "name": "receipts_receipt_number_idx",
+          "columns": [
+            {
+              "expression": "receipt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_jir_idx": {
+          "name": "receipts_jir_idx",
+          "columns": [
+            {
+              "expression": "jir",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_zki_idx": {
+          "name": "receipts_zki_idx",
+          "columns": [
+            {
+              "expression": "zki",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_cis_status_idx": {
+          "name": "receipts_cis_status_idx",
+          "columns": [
+            {
+              "expression": "cis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_issued_at_idx": {
+          "name": "receipts_issued_at_idx",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_business_pin_idx": {
+          "name": "receipts_business_pin_idx",
+          "columns": [
+            {
+              "expression": "business_pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_is_deleted_idx": {
+          "name": "receipts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "receipts_invoice_id_invoices_id_fk": {
+          "name": "receipts_invoice_id_invoices_id_fk",
+          "tableFrom": "receipts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipts_year_receipt_number_unique": {
+          "name": "receipts_year_receipt_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year_receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "newsletter_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_email_idx": {
+          "name": "newsletter_subscribers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_campaigns": {
+      "name": "notification_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_campaign_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_policy": {
+          "name": "channel_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_image_url": {
+          "name": "safe_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_link_url": {
+          "name": "safe_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_action_url": {
+          "name": "safe_action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_channel": {
+          "name": "primary_channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "collapse_key": {
+          "name": "collapse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "delivery_metadata": {
+          "name": "delivery_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "failures": {
+          "name": "failures",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suppressed_count": {
+          "name": "suppressed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_from_account_id": {
+          "name": "created_from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_user_id": {
+          "name": "cancelled_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_campaigns_status_idx": {
+          "name": "notification_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_scheduled_at_idx": {
+          "name": "notification_campaigns_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_created_by_user_id_idx": {
+          "name": "notification_campaigns_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_category_idx": {
+          "name": "notification_campaigns_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_event_type_idx": {
+          "name": "notification_campaigns_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_campaigns_created_by_user_id_users_id_fk": {
+          "name": "notification_campaigns_created_by_user_id_users_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "notification_campaigns_created_from_account_id_accounts_id_fk": {
+          "name": "notification_campaigns_created_from_account_id_accounts_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "created_from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_campaigns_cancelled_by_user_id_users_id_fk": {
+          "name": "notification_campaigns_cancelled_by_user_id_users_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "cancelled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_attempts": {
+      "name": "notification_delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response_code": {
+          "name": "provider_response_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response_body": {
+          "name": "provider_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_id": {
+          "name": "bulk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_subscription_id": {
+          "name": "push_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_attempts_notification_id_idx": {
+          "name": "notification_delivery_attempts_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_delivery_attempts_status_idx": {
+          "name": "notification_delivery_attempts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_attempts_notification_id_notifications_id_fk": {
+          "name": "notification_delivery_attempts_notification_id_notifications_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_user_id_users_id_fk": {
+          "name": "notification_delivery_attempts_user_id_users_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_account_id_accounts_id_fk": {
+          "name": "notification_delivery_attempts_account_id_accounts_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_push_subscription_id_web_push_subscriptions_id_fk": {
+          "name": "notification_delivery_attempts_push_subscription_id_web_push_subscriptions_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "web_push_subscriptions",
+          "columnsFrom": [
+            "push_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_events": {
+      "name": "notification_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "delivery_attempt_id": {
+          "name": "delivery_attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_delivery_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_events_attempt_id_idx": {
+          "name": "notification_delivery_events_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "delivery_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_events_delivery_attempt_id_notification_delivery_attempts_id_fk": {
+          "name": "notification_delivery_events_delivery_attempt_id_notification_delivery_attempts_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notification_delivery_attempts",
+          "columnsFrom": [
+            "delivery_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_events_notification_id_notifications_id_fk": {
+          "name": "notification_delivery_events_notification_id_notifications_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_email_log": {
+      "name": "notification_email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailed_at": {
+          "name": "emailed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_email_log_user_id_users_id_fk": {
+          "name": "notification_email_log_user_id_users_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_email_log_notification_id_notifications_id_fk": {
+          "name": "notification_email_log_notification_id_notifications_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_user_channel_preferences": {
+      "name": "notification_user_channel_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "notification_preference_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiet_hours_start_minute": {
+          "name": "quiet_hours_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end_minute": {
+          "name": "quiet_hours_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_window_start_minute": {
+          "name": "delivery_window_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_window_end_minute": {
+          "name": "delivery_window_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_frequency": {
+          "name": "digest_frequency",
+          "type": "notification_digest_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_channel_preferences_global_unique_idx": {
+          "name": "notification_user_channel_preferences_global_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification_user_channel_preferences\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_channel_preferences_account_unique_idx": {
+          "name": "notification_user_channel_preferences_account_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification_user_channel_preferences\".\"scope\" = 'account'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_channel_preferences_user_id_users_id_fk": {
+          "name": "notification_user_channel_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_user_channel_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_user_channel_preferences_account_id_accounts_id_fk": {
+          "name": "notification_user_channel_preferences_account_id_accounts_id_fk",
+          "tableFrom": "notification_user_channel_preferences",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_user_channel_preferences_scope_account_id_check": {
+          "name": "notification_user_channel_preferences_scope_account_id_check",
+          "value": "(scope = 'global' and account_id is null) or (scope = 'account' and account_id is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "primary_channel": {
+          "name": "primary_channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_id": {
+          "name": "bulk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collapse_key": {
+          "name": "collapse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_image_url": {
+          "name": "safe_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_link_url": {
+          "name": "safe_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_where": {
+          "name": "read_where",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_account_id_idx": {
+          "name": "notifications_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_readAt_idx": {
+          "name": "notifications_readAt_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_category_idx": {
+          "name": "notifications_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_campaign_id_idx": {
+          "name": "notifications_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_account_id_accounts_id_fk": {
+          "name": "notifications_account_id_accounts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_garden_id_gardens_id_fk": {
+          "name": "notifications_garden_id_gardens_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_raised_bed_id_raised_beds_id_fk": {
+          "name": "notifications_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_block_id_garden_blocks_id_fk": {
+          "name": "notifications_block_id_garden_blocks_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_digest": {
+          "name": "daily_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_push_subscriptions": {
+      "name": "web_push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_label": {
+          "name": "device_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_version": {
+          "name": "browser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_state": {
+          "name": "permission_state",
+          "type": "push_permission_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "fail_count": {
+          "name": "fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_code": {
+          "name": "last_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "web_push_subscriptions_endpoint_unique_idx": {
+          "name": "web_push_subscriptions_endpoint_unique_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_user_id_idx": {
+          "name": "web_push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_account_id_idx": {
+          "name": "web_push_subscriptions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_device_id_idx": {
+          "name": "web_push_subscriptions_device_id_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "web_push_subscriptions_account_id_accounts_id_fk": {
+          "name": "web_push_subscriptions_account_id_accounts_id_fk",
+          "tableFrom": "web_push_subscriptions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "web_push_subscriptions_user_id_users_id_fk": {
+          "name": "web_push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "web_push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operations": {
+      "name": "operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_field_id": {
+          "name": "raised_bed_field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_accepted": {
+          "name": "is_accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "operations_entity_id_idx": {
+          "name": "operations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_entity_type_name_idx": {
+          "name": "operations_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_account_id_idx": {
+          "name": "operations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_farm_id_idx": {
+          "name": "operations_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_garden_id_idx": {
+          "name": "operations_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_id_idx": {
+          "name": "operations_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_field_id_idx": {
+          "name": "operations_raised_bed_field_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_timestamp_idx": {
+          "name": "operations_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_deleted_idx": {
+          "name": "operations_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_accepted_idx": {
+          "name": "operations_is_accepted_idx",
+          "columns": [
+            {
+              "expression": "is_accepted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlet_offer_reservations": {
+      "name": "outlet_offer_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outlet_offer_id": {
+          "name": "outlet_offer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cart_item_id": {
+          "name": "cart_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_expires_at": {
+          "name": "hold_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'held'"
+        },
+        "held_outlet_price_cents": {
+          "name": "held_outlet_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_compare_price_cents": {
+          "name": "held_compare_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "held_sowing_date": {
+          "name": "held_sowing_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_initial_plant_status": {
+          "name": "held_initial_plant_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sprouted'"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "converted_at": {
+          "name": "converted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "outlet_reservations_offer_id_idx": {
+          "name": "outlet_reservations_offer_id_idx",
+          "columns": [
+            {
+              "expression": "outlet_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_account_id_idx": {
+          "name": "outlet_reservations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_cart_id_idx": {
+          "name": "outlet_reservations_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_cart_item_id_idx": {
+          "name": "outlet_reservations_cart_item_id_idx",
+          "columns": [
+            {
+              "expression": "cart_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_status_idx": {
+          "name": "outlet_reservations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_hold_expires_at_idx": {
+          "name": "outlet_reservations_hold_expires_at_idx",
+          "columns": [
+            {
+              "expression": "hold_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlet_offer_reservations_outlet_offer_id_outlet_offers_id_fk": {
+          "name": "outlet_offer_reservations_outlet_offer_id_outlet_offers_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "outlet_offers",
+          "columnsFrom": [
+            "outlet_offer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_account_id_accounts_id_fk": {
+          "name": "outlet_offer_reservations_account_id_accounts_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_cart_id_shopping_carts_id_fk": {
+          "name": "outlet_offer_reservations_cart_id_shopping_carts_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "shopping_carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_cart_item_id_shopping_cart_items_id_fk": {
+          "name": "outlet_offer_reservations_cart_item_id_shopping_cart_items_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "shopping_cart_items",
+          "columnsFrom": [
+            "cart_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlet_offers": {
+      "name": "outlet_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plant_sort_id": {
+          "name": "plant_sort_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sowing_date": {
+          "name": "sowing_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_plant_status": {
+          "name": "initial_plant_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sprouted'"
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "outlet_price_cents": {
+          "name": "outlet_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compare_price_cents": {
+          "name": "compare_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "admin_notes": {
+          "name": "admin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "outlet_offers_plant_sort_id_idx": {
+          "name": "outlet_offers_plant_sort_id_idx",
+          "columns": [
+            {
+              "expression": "plant_sort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_status_idx": {
+          "name": "outlet_offers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_start_at_idx": {
+          "name": "outlet_offers_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_end_at_idx": {
+          "name": "outlet_offers_end_at_idx",
+          "columns": [
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_is_deleted_idx": {
+          "name": "outlet_offers_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlet_offers_plant_sort_id_entities_id_fk": {
+          "name": "outlet_offers_plant_sort_id_entities_id_fk",
+          "tableFrom": "outlet_offers",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "plant_sort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_request_adjustments": {
+      "name": "farmer_payout_request_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payout_request_id": {
+          "name": "payout_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farmer_payout_adjustments_request_id_idx": {
+          "name": "farmer_payout_adjustments_request_id_idx",
+          "columns": [
+            {
+              "expression": "payout_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_request_adjustments_payout_request_id_farmer_payout_requests_id_fk": {
+          "name": "farmer_payout_request_adjustments_payout_request_id_farmer_payout_requests_id_fk",
+          "tableFrom": "farmer_payout_request_adjustments",
+          "tableTo": "farmer_payout_requests",
+          "columnsFrom": [
+            "payout_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_request_adjustments_created_by_user_id_users_id_fk": {
+          "name": "farmer_payout_request_adjustments_created_by_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_request_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_request_items": {
+      "name": "farmer_payout_request_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payout_request_id": {
+          "name": "payout_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_count": {
+          "name": "operation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration_minutes": {
+          "name": "total_duration_minutes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_per_unit": {
+          "name": "price_per_unit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "farmer_payout_items_request_id_idx": {
+          "name": "farmer_payout_items_request_id_idx",
+          "columns": [
+            {
+              "expression": "payout_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_request_items_payout_request_id_farmer_payout_requests_id_fk": {
+          "name": "farmer_payout_request_items_payout_request_id_farmer_payout_requests_id_fk",
+          "tableFrom": "farmer_payout_request_items",
+          "tableTo": "farmer_payout_requests",
+          "columnsFrom": [
+            "payout_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_requests": {
+      "name": "farmer_payout_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_amount": {
+          "name": "requested_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "farmer_note": {
+          "name": "farmer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_reference": {
+          "name": "bank_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farmer_payout_requests_farm_id_idx": {
+          "name": "farmer_payout_requests_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farmer_payout_requests_user_id_idx": {
+          "name": "farmer_payout_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farmer_payout_requests_status_idx": {
+          "name": "farmer_payout_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_requests_farm_id_farms_id_fk": {
+          "name": "farmer_payout_requests_farm_id_farms_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_user_id_users_id_fk": {
+          "name": "farmer_payout_requests_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_receipt_id_receipts_id_fk": {
+          "name": "farmer_payout_requests_receipt_id_receipts_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_approved_by_user_id_users_id_fk": {
+          "name": "farmer_payout_requests_approved_by_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operation_prices": {
+      "name": "operation_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_unit": {
+          "name": "price_per_unit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operation_prices_farm_type_null_unique": {
+          "name": "operation_prices_farm_type_null_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operation_prices\".\"entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operation_prices_farm_type_entity_unique": {
+          "name": "operation_prices_farm_type_entity_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operation_prices\".\"entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operation_prices_farm_id_idx": {
+          "name": "operation_prices_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operation_prices_farm_id_farms_id_fk": {
+          "name": "operation_prices_farm_id_farms_id_fk",
+          "tableFrom": "operation_prices",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_id_idx": {
+          "name": "refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_at_idx": {
+          "name": "refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_token_hash_idx": {
+          "name": "refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_cart_items": {
+      "name": "shopping_cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_cart_items_cart_id_idx": {
+          "name": "shopping_cart_items_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_entity_id_idx": {
+          "name": "shopping_cart_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_garden_id_idx": {
+          "name": "shopping_cart_items_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_raised_bed_id_idx": {
+          "name": "shopping_cart_items_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_is_deleted_idx": {
+          "name": "shopping_cart_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_status_idx": {
+          "name": "shopping_cart_items_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_cart_items_cart_id_shopping_carts_id_fk": {
+          "name": "shopping_cart_items_cart_id_shopping_carts_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "shopping_carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_garden_id_gardens_id_fk": {
+          "name": "shopping_cart_items_garden_id_gardens_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_raised_bed_id_raised_beds_id_fk": {
+          "name": "shopping_cart_items_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_carts": {
+      "name": "shopping_carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_carts_account_id_idx": {
+          "name": "shopping_carts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_is_deleted_idx": {
+          "name": "shopping_carts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_status_idx": {
+          "name": "shopping_carts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_carts_account_id_accounts_id_fk": {
+          "name": "shopping_carts_account_id_accounts_id_fk",
+          "tableFrom": "shopping_carts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_accounts": {
+      "name": "social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_key": {
+          "name": "provider_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "social_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "default_destination": {
+          "name": "default_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_destinations": {
+          "name": "allowed_destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_reference": {
+          "name": "credential_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_accounts_provider_account_key_idx": {
+          "name": "social_accounts_provider_account_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_provider_idx": {
+          "name": "social_accounts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_status_idx": {
+          "name": "social_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_posts": {
+      "name": "social_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_key": {
+          "name": "provider_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "post_type": {
+          "name": "post_type",
+          "type": "social_post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_urls": {
+          "name": "media_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_submission_id": {
+          "name": "provider_submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_permalink": {
+          "name": "provider_permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_metadata": {
+          "name": "failure_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_posts_provider_idx": {
+          "name": "social_posts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_status_idx": {
+          "name": "social_posts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_scheduled_at_idx": {
+          "name": "social_posts_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_queued_at_idx": {
+          "name": "social_posts_queued_at_idx",
+          "columns": [
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_created_at_idx": {
+          "name": "social_posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_provider_destination_idx": {
+          "name": "social_posts_provider_destination_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sunflower_ledger_entries": {
+      "name": "sunflower_ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_delta": {
+          "name": "available_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_delta": {
+          "name": "reserved_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_balance_after": {
+          "name": "available_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_balance_after": {
+          "name": "reserved_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_balance_after": {
+          "name": "total_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_eur": {
+          "name": "amount_eur",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sunflower'"
+        },
+        "package_code": {
+          "name": "package_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_entity_id": {
+          "name": "package_entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_key": {
+          "name": "reservation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sunflower_ledger_account_id_idx": {
+          "name": "sunflower_ledger_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_entry_type_idx": {
+          "name": "sunflower_ledger_entry_type_idx",
+          "columns": [
+            {
+              "expression": "entry_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_package_code_idx": {
+          "name": "sunflower_ledger_package_code_idx",
+          "columns": [
+            {
+              "expression": "package_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_package_entity_id_idx": {
+          "name": "sunflower_ledger_package_entity_id_idx",
+          "columns": [
+            {
+              "expression": "package_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_operation_id_idx": {
+          "name": "sunflower_ledger_operation_id_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_transaction_id_idx": {
+          "name": "sunflower_ledger_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_invoice_id_idx": {
+          "name": "sunflower_ledger_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_receipt_id_idx": {
+          "name": "sunflower_ledger_receipt_id_idx",
+          "columns": [
+            {
+              "expression": "receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_reservation_key_idx": {
+          "name": "sunflower_ledger_reservation_key_idx",
+          "columns": [
+            {
+              "expression": "reservation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_source_idx": {
+          "name": "sunflower_ledger_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_created_at_idx": {
+          "name": "sunflower_ledger_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_is_deleted_idx": {
+          "name": "sunflower_ledger_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_account_idempotency_unique": {
+          "name": "sunflower_ledger_account_idempotency_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sunflower_ledger_entries_account_id_accounts_id_fk": {
+          "name": "sunflower_ledger_entries_account_id_accounts_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_package_entity_id_entities_id_fk": {
+          "name": "sunflower_ledger_entries_package_entity_id_entities_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "package_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_operation_id_operations_id_fk": {
+          "name": "sunflower_ledger_entries_operation_id_operations_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_transaction_id_transactions_id_fk": {
+          "name": "sunflower_ledger_entries_transaction_id_transactions_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_invoice_id_invoices_id_fk": {
+          "name": "sunflower_ledger_entries_invoice_id_invoices_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_receipt_id_receipts_id_fk": {
+          "name": "sunflower_ledger_entries_receipt_id_receipts_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answers": {
+      "name": "survey_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_key": {
+          "name": "question_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numeric_value": {
+          "name": "numeric_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_value": {
+          "name": "text_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_value": {
+          "name": "contact_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_answers_response_question_unique": {
+          "name": "survey_answers_response_question_unique",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_response_idx": {
+          "name": "survey_answers_response_idx",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_question_idx": {
+          "name": "survey_answers_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_question_key_idx": {
+          "name": "survey_answers_question_key_idx",
+          "columns": [
+            {
+              "expression": "question_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answers_response_id_survey_responses_id_fk": {
+          "name": "survey_answers_response_id_survey_responses_id_fk",
+          "tableFrom": "survey_answers",
+          "tableTo": "survey_responses",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "survey_answers_question_id_survey_questions_id_fk": {
+          "name": "survey_answers_question_id_survey_questions_id_fk",
+          "tableFrom": "survey_answers",
+          "tableTo": "survey_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_assignments": {
+      "name": "survey_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_assignments_version_target_context_unique": {
+          "name": "survey_assignments_version_target_context_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_survey_idx": {
+          "name": "survey_assignments_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_version_idx": {
+          "name": "survey_assignments_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_account_idx": {
+          "name": "survey_assignments_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_user_idx": {
+          "name": "survey_assignments_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_status_idx": {
+          "name": "survey_assignments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_send_idx": {
+          "name": "survey_assignments_send_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_assignments_survey_id_surveys_id_fk": {
+          "name": "survey_assignments_survey_id_surveys_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_version_id_survey_versions_id_fk": {
+          "name": "survey_assignments_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_send_id_survey_sends_id_fk": {
+          "name": "survey_assignments_send_id_survey_sends_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "survey_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_account_id_accounts_id_fk": {
+          "name": "survey_assignments_account_id_accounts_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_user_id_users_id_fk": {
+          "name": "survey_assignments_user_id_users_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_questions": {
+      "name": "survey_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_metadata": {
+          "name": "score_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_questions_version_key_unique": {
+          "name": "survey_questions_version_key_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_questions_version_order_unique": {
+          "name": "survey_questions_version_order_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_questions_version_idx": {
+          "name": "survey_questions_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_questions_version_id_survey_versions_id_fk": {
+          "name": "survey_questions_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_questions",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_responses": {
+      "name": "survey_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "survey_response_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "imported_external_id": {
+          "name": "imported_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_responses_assignment_unique": {
+          "name": "survey_responses_assignment_unique",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_imported_external_unique": {
+          "name": "survey_responses_imported_external_unique",
+          "columns": [
+            {
+              "expression": "imported_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_survey_idx": {
+          "name": "survey_responses_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_version_idx": {
+          "name": "survey_responses_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_account_idx": {
+          "name": "survey_responses_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_user_idx": {
+          "name": "survey_responses_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_source_idx": {
+          "name": "survey_responses_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_submitted_at_idx": {
+          "name": "survey_responses_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_responses_assignment_id_survey_assignments_id_fk": {
+          "name": "survey_responses_assignment_id_survey_assignments_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "survey_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_responses_survey_id_surveys_id_fk": {
+          "name": "survey_responses_survey_id_surveys_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_responses_version_id_survey_versions_id_fk": {
+          "name": "survey_responses_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_responses_account_id_accounts_id_fk": {
+          "name": "survey_responses_account_id_accounts_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_responses_user_id_users_id_fk": {
+          "name": "survey_responses_user_id_users_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_send_deliveries": {
+      "name": "survey_send_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "survey_send_delivery_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_send_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_send_deliveries_send_idx": {
+          "name": "survey_send_deliveries_send_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_assignment_idx": {
+          "name": "survey_send_deliveries_assignment_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_status_idx": {
+          "name": "survey_send_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_notification_idx": {
+          "name": "survey_send_deliveries_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_send_deliveries_send_id_survey_sends_id_fk": {
+          "name": "survey_send_deliveries_send_id_survey_sends_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "survey_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_assignment_id_survey_assignments_id_fk": {
+          "name": "survey_send_deliveries_assignment_id_survey_assignments_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "survey_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_account_id_accounts_id_fk": {
+          "name": "survey_send_deliveries_account_id_accounts_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_user_id_users_id_fk": {
+          "name": "survey_send_deliveries_user_id_users_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_notification_id_notifications_id_fk": {
+          "name": "survey_send_deliveries_notification_id_notifications_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_sends": {
+      "name": "survey_sends",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_policy": {
+          "name": "channel_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "assigned_count": {
+          "name": "assigned_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_duplicate_count": {
+          "name": "skipped_duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_account_id": {
+          "name": "created_from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_sends_survey_idx": {
+          "name": "survey_sends_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_version_idx": {
+          "name": "survey_sends_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_status_idx": {
+          "name": "survey_sends_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_context_key_idx": {
+          "name": "survey_sends_context_key_idx",
+          "columns": [
+            {
+              "expression": "context_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_sends_survey_id_surveys_id_fk": {
+          "name": "survey_sends_survey_id_surveys_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_sends_version_id_survey_versions_id_fk": {
+          "name": "survey_sends_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_sends_created_by_user_id_users_id_fk": {
+          "name": "survey_sends_created_by_user_id_users_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_sends_created_from_account_id_accounts_id_fk": {
+          "name": "survey_sends_created_from_account_id_accounts_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "created_from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_versions": {
+      "name": "survey_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_title": {
+          "name": "intro_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_description": {
+          "name": "intro_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thank_you_title": {
+          "name": "thank_you_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thank_you_description": {
+          "name": "thank_you_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_versions_survey_number_unique": {
+          "name": "survey_versions_survey_number_unique",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_versions_survey_status_idx": {
+          "name": "survey_versions_survey_status_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_versions_survey_id_surveys_id_fk": {
+          "name": "survey_versions_survey_id_surveys_id_fk",
+          "tableFrom": "survey_versions",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.surveys": {
+      "name": "surveys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "surveys_key_unique": {
+          "name": "surveys_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "surveys_status_idx": {
+          "name": "surveys_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "surveys_category_idx": {
+          "name": "surveys_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "surveys_created_by_user_id_users_id_fk": {
+          "name": "surveys_created_by_user_id_users_id_fk",
+          "tableFrom": "surveys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "transactions_account_id_idx": {
+          "name": "transactions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_garden_id_idx": {
+          "name": "transactions_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripe_payment_id_idx": {
+          "name": "transactions_stripe_payment_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_is_deleted_idx": {
+          "name": "transactions_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_garden_id_gardens_id_fk": {
+          "name": "transactions_garden_id_gardens_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tutorial_checklist_task_claims": {
+      "name": "tutorial_checklist_task_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_key": {
+          "name": "task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_sunflowers": {
+          "name": "reward_sunflowers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tutorial_checklist_claims_account_id_idx": {
+          "name": "tutorial_checklist_claims_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tutorial_checklist_claims_task_key_idx": {
+          "name": "tutorial_checklist_claims_task_key_idx",
+          "columns": [
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tutorial_checklist_claims_account_task_uq": {
+          "name": "tutorial_checklist_claims_account_task_uq",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tutorial_checklist_task_claims_account_id_accounts_id_fk": {
+          "name": "tutorial_checklist_task_claims_account_id_accounts_id_fk",
+          "tableFrom": "tutorial_checklist_task_claims",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "user_favorite_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_favorites_user_entity_uq": {
+          "name": "user_favorites_user_entity_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_id_idx": {
+          "name": "user_favorites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_entity_type_idx": {
+          "name": "user_favorites_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_entity_id_idx": {
+          "name": "user_favorites_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_entity_id_entities_id_fk": {
+          "name": "user_favorites_entity_id_entities_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_invitations": {
+      "name": "account_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "account_invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_invitations_account_id_idx": {
+          "name": "account_invitations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_email_idx": {
+          "name": "account_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_token_idx": {
+          "name": "account_invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_invitations_account_id_accounts_id_fk": {
+          "name": "account_invitations_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_invitations_invited_by_user_id_users_id_fk": {
+          "name": "account_invitations_invited_by_user_id_users_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_users": {
+      "name": "account_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_au_account_id_idx": {
+          "name": "users_au_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_au_user_id_idx": {
+          "name": "users_au_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_users_account_id_accounts_id_fk": {
+          "name": "account_users_account_id_accounts_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_users_user_id_users_id_fk": {
+          "name": "account_users_user_id_users_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street1": {
+          "name": "address_street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street2": {
+          "name": "address_street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Paris'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farm_users": {
+      "name": "farm_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farm_users_farm_id_idx": {
+          "name": "farm_users_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farm_users_user_id_idx": {
+          "name": "farm_users_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farm_users_farm_user_unique": {
+          "name": "farm_users_farm_user_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farm_users_farm_id_farms_id_fk": {
+          "name": "farm_users_farm_id_farms_id_fk",
+          "tableFrom": "farm_users",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farm_users_user_id_users_id_fk": {
+          "name": "farm_users_user_id_users_id_fk",
+          "tableFrom": "farm_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_logins": {
+      "name": "user_logins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_type": {
+          "name": "login_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_id": {
+          "name": "login_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_data": {
+          "name": "login_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_attempt": {
+          "name": "last_failed_attempt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_until": {
+          "name": "blocked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_ul_user_id_idx": {
+          "name": "users_ul_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_type_idx": {
+          "name": "users_ul_login_type_idx",
+          "columns": [
+            {
+              "expression": "login_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_id_idx": {
+          "name": "users_ul_login_id_idx",
+          "columns": [
+            {
+              "expression": "login_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_logins_user_id_users_id_fk": {
+          "name": "user_logins_user_id_users_id_fk",
+          "tableFrom": "user_logins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday_day": {
+          "name": "birthday_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_month": {
+          "name": "birthday_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_year": {
+          "name": "birthday_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_last_updated_at": {
+          "name": "birthday_last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_last_seen_at": {
+          "name": "whats_new_last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_popup_disabled": {
+          "name": "whats_new_popup_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "farm_schedule_grouped_watering_enabled": {
+          "name": "farm_schedule_grouped_watering_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_u_username_idx": {
+          "name": "users_u_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_history": {
+      "name": "weather_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rain": {
+          "name": "rain",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wind_direction": {
+          "name": "wind_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_speed": {
+          "name": "wind_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rainy": {
+          "name": "rainy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "snowy": {
+          "name": "snowy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cloudy": {
+          "name": "cloudy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "foggy": {
+          "name": "foggy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thundery": {
+          "name": "thundery",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weather_history_recorded_at_idx": {
+          "name": "weather_history_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_status": {
+      "name": "achievement_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.automation_definition_status": {
+      "name": "automation_definition_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "enabled",
+        "disabled",
+        "archived"
+      ]
+    },
+    "public.automation_module_kind": {
+      "name": "automation_module_kind",
+      "schema": "public",
+      "values": [
+        "trigger",
+        "filter",
+        "condition",
+        "action"
+      ]
+    },
+    "public.automation_run_source": {
+      "name": "automation_run_source",
+      "schema": "public",
+      "values": [
+        "event",
+        "manual",
+        "schedule",
+        "test",
+        "replay"
+      ]
+    },
+    "public.automation_run_status": {
+      "name": "automation_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "skipped",
+        "failed",
+        "retrying",
+        "canceled"
+      ]
+    },
+    "public.automation_step_status": {
+      "name": "automation_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_status": {
+      "name": "email_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sending",
+        "sent",
+        "failed",
+        "bounced"
+      ]
+    },
+    "public.newsletter_status": {
+      "name": "newsletter_status",
+      "schema": "public",
+      "values": [
+        "subscribed",
+        "unsubscribed",
+        "pending"
+      ]
+    },
+    "public.notification_delivery_status": {
+      "name": "notification_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "accepted",
+        "sent",
+        "failed",
+        "dropped"
+      ]
+    },
+    "public.notification_delivery_event_type": {
+      "name": "notification_delivery_event_type",
+      "schema": "public",
+      "values": [
+        "queued",
+        "accepted",
+        "sent",
+        "failed",
+        "opened",
+        "clicked",
+        "dismissed",
+        "unsubscribed"
+      ]
+    },
+    "public.notification_digest_frequency": {
+      "name": "notification_digest_frequency",
+      "schema": "public",
+      "values": [
+        "off",
+        "hourly",
+        "daily",
+        "weekly"
+      ]
+    },
+    "public.notification_campaign_status": {
+      "name": "notification_campaign_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "queued",
+        "sending",
+        "sent",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "email",
+        "push",
+        "sms"
+      ]
+    },
+    "public.notification_preference_scope": {
+      "name": "notification_preference_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "account"
+      ]
+    },
+    "public.notification_priority": {
+      "name": "notification_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "critical"
+      ]
+    },
+    "public.push_permission_state": {
+      "name": "push_permission_state",
+      "schema": "public",
+      "values": [
+        "default",
+        "granted",
+        "denied"
+      ]
+    },
+    "public.social_account_status": {
+      "name": "social_account_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disabled",
+        "needs_reauth"
+      ]
+    },
+    "public.social_post_status": {
+      "name": "social_post_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "queued",
+        "scheduled",
+        "submitting",
+        "submitted",
+        "published",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.social_post_type": {
+      "name": "social_post_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "link",
+        "image",
+        "video",
+        "reel",
+        "story",
+        "carousel",
+        "other"
+      ]
+    },
+    "public.social_provider": {
+      "name": "social_provider",
+      "schema": "public",
+      "values": [
+        "reddit",
+        "instagram",
+        "facebook",
+        "google_business",
+        "x",
+        "tiktok",
+        "threads",
+        "linkedin",
+        "whatsapp"
+      ]
+    },
+    "public.survey_assignment_status": {
+      "name": "survey_assignment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "started",
+        "submitted",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.survey_question_type": {
+      "name": "survey_question_type",
+      "schema": "public",
+      "values": [
+        "opinion_scale",
+        "long_text",
+        "contact_info"
+      ]
+    },
+    "public.survey_response_source": {
+      "name": "survey_response_source",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "typeform",
+        "admin_import"
+      ]
+    },
+    "public.survey_send_delivery_channel": {
+      "name": "survey_send_delivery_channel",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "email"
+      ]
+    },
+    "public.survey_send_delivery_status": {
+      "name": "survey_send_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.survey_send_status": {
+      "name": "survey_send_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "sent",
+        "canceled",
+        "failed"
+      ]
+    },
+    "public.survey_status": {
+      "name": "survey_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.survey_version_status": {
+      "name": "survey_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.user_favorite_entity_type": {
+      "name": "user_favorite_entity_type",
+      "schema": "public",
+      "values": [
+        "plant",
+        "plantSort",
+        "operation"
+      ]
+    },
+    "public.account_invitation_status": {
+      "name": "account_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage/src/migrations/meta/_journal.json
+++ b/packages/storage/src/migrations/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1784087489488,
       "tag": "0070_open_rawhide_kid",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1784108556188,
+      "tag": "0071_omniscient_rhino",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage/src/repositories/deliveryRunsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunsRepo.ts
@@ -11,19 +11,27 @@ import {
     DeliveryRequestStates,
     type DeliveryRunEstimateSource,
     DeliveryRunEstimateSources,
+    type DeliveryRunManifestItemState,
+    DeliveryRunManifestItemStates,
+    DeliveryRunManifestStates,
+    DeliveryRunPickupOperationKinds,
+    type DeliveryRunPickupOperationStoredResult,
     type DeliveryRunPreparationPlanPayload,
     type DeliveryRunPreparationPlanPayloadV1,
     type DeliveryRunPreparationPlanPayloadV2,
+    type DeliveryRunPreparationPlanPayloadV3,
     DeliveryRunStates,
     DeliveryRunStopStates,
     deliveryAddresses,
     deliveryRequests,
     deliveryRunPickupNodes,
+    deliveryRunPickupOperations,
     deliveryRunPreparations,
     deliveryRunSlots,
     deliveryRunStops,
     deliveryRuns,
     events,
+    harvestTraceLinks,
     operations,
     type PreparedDeliveryRunEstimateSource,
     pickupLocations,
@@ -40,6 +48,7 @@ import {
     fulfillDeliveryRequest,
     getDeliveryRequestDispatchSnapshots,
 } from './deliveryRequestsRepo';
+import { normalizeHarvestTraceToken } from './harvestTraceLinksRepo';
 
 type StorageClient = ReturnType<typeof storage>;
 type TransactionClient = Parameters<
@@ -131,6 +140,13 @@ export type CreatePreparedDeliveryRunStopInput = CreateDeliveryRunStopInput & {
     deliveryAddressUpdatedAt: Date;
 };
 
+export type CreatePreparedDeliveryRunManifestItemInput = {
+    deliveryRequestId: string;
+    timeSlotId: number;
+    harvestTraceLinkId?: number;
+    traceToken?: string;
+};
+
 export type CreatePreparedDeliveryRunInput = Omit<
     CreateDeliveryRunInput,
     | 'totalDistanceMeters'
@@ -148,6 +164,7 @@ export type CreatePreparedDeliveryRunInput = Omit<
     pickupNodes: CreatePreparedDeliveryRunPickupNodeInput[];
     runSlots: CreateDeliveryRunSlotInput[];
     stops: CreatePreparedDeliveryRunStopInput[];
+    manifestItems: CreatePreparedDeliveryRunManifestItemInput[];
 };
 
 export type DeliveryRunRequestSnapshotInput = {
@@ -224,6 +241,76 @@ export class DeliveryRunPersistenceError extends Error {
         return this.context.activeRunId;
     }
 }
+
+export const DeliveryRunExecutionErrorCodes = {
+    ACTIVE_RUN_NOT_FOUND: 'active-run-not-found',
+    PICKUP_NOT_CURRENT: 'pickup-not-current',
+    PICKUP_TRACE_INVALID: 'pickup-trace-invalid',
+    PICKUP_ITEM_NOT_FOUND: 'pickup-item-not-found',
+    PICKUP_ITEM_STATE_INVALID: 'pickup-item-state-invalid',
+    PICKUP_MANIFEST_NOT_FOUND: 'pickup-manifest-not-found',
+    PICKUP_MANIFEST_INCOMPLETE: 'pickup-manifest-incomplete',
+    PICKUP_OPERATION_CONFLICT: 'pickup-operation-conflict',
+    PICKUP_DEPENDENCY_PENDING: 'pickup-dependency-pending',
+    ROUTE_ORDER: 'route-order',
+} as const;
+
+export type DeliveryRunExecutionErrorCode =
+    (typeof DeliveryRunExecutionErrorCodes)[keyof typeof DeliveryRunExecutionErrorCodes];
+
+export class DeliveryRunExecutionError extends Error {
+    override name = 'DeliveryRunExecutionError';
+
+    constructor(
+        readonly code: DeliveryRunExecutionErrorCode,
+        message: string,
+    ) {
+        super(message);
+    }
+}
+
+export type DeliveryRunExecutionStep =
+    | {
+          kind: 'pickup';
+          pickupNodeId: string;
+          itinerarySequence: number;
+          manifestIds: string[];
+          state: 'completed' | 'current' | 'upcoming';
+      }
+    | {
+          kind: 'delivery';
+          itinerarySequence: number;
+          stopKey: string | null;
+          stopIds: number[];
+          pickupConfirmed: boolean;
+          state: 'completed' | 'current' | 'upcoming';
+      };
+
+type DeliveryRunPickupMutationBase = {
+    clientOperationId: string;
+    occurredAt: Date;
+};
+
+export type DeliveryRunPickupMutation =
+    | (DeliveryRunPickupMutationBase & {
+          kind: 'scan';
+          traceToken: string;
+      })
+    | (DeliveryRunPickupMutationBase & {
+          kind: 'mark-item';
+          stopId: number;
+          outcome: Exclude<DeliveryRunManifestItemState, 'scanned'>;
+      })
+    | (DeliveryRunPickupMutationBase & {
+          kind: 'confirm-manifest';
+          manifestId: string;
+      });
+
+export type DeliveryRunPickupMutationResult = {
+    clientOperationId: string;
+    replayed: boolean;
+    result: DeliveryRunPickupOperationStoredResult;
+};
 
 export type SaveDeliveryRunPreparationInput = {
     dispatchRevision: number;
@@ -348,7 +435,7 @@ function normalizePreparationPlan({
     selectionRequestIds,
     createRunInput,
     requestSnapshots,
-}: SaveDeliveryRunPreparationInput): DeliveryRunPreparationPlanPayload {
+}: SaveDeliveryRunPreparationInput): DeliveryRunPreparationPlanPayloadV3 {
     if (!Number.isInteger(dispatchRevision) || dispatchRevision < 0) {
         throw new DeliveryRunPersistenceError(
             DeliveryRunPersistenceErrorCodes.INVALID_PLAN,
@@ -369,11 +456,13 @@ function normalizePreparationPlan({
     }
     const pickupNodes = createRunInput.pickupNodes;
     const runSlots = createRunInput.runSlots;
+    const manifestItems = createRunInput.manifestItems;
     if (
         !pickupNodes?.length ||
         !runSlots?.length ||
         createRunInput.stops.length === 0 ||
-        requestSnapshots.length !== createRunInput.stops.length
+        requestSnapshots.length !== createRunInput.stops.length ||
+        manifestItems.length !== createRunInput.stops.length
     ) {
         throw new DeliveryRunPersistenceError(
             DeliveryRunPersistenceErrorCodes.INVALID_PLAN,
@@ -760,8 +849,59 @@ function normalizePreparationPlan({
         );
     }
 
+    const stopsByRequestId = new Map(
+        normalizedStops.map((stop) => [stop.deliveryRequestId, stop]),
+    );
+    const manifestRequestIds = new Set<string>();
+    const normalizedManifestItems = manifestItems.map((item) => {
+        const stop = stopsByRequestId.get(item.deliveryRequestId);
+        const hasTraceLinkId = item.harvestTraceLinkId !== undefined;
+        const normalizedTraceToken = item.traceToken
+            ? normalizeHarvestTraceToken(item.traceToken)
+            : null;
+        const hasTraceToken = normalizedTraceToken !== null;
+        if (
+            !stop ||
+            manifestRequestIds.has(item.deliveryRequestId) ||
+            item.timeSlotId !== stop.timeSlotId ||
+            hasTraceLinkId !== hasTraceToken ||
+            (hasTraceLinkId &&
+                (!Number.isInteger(item.harvestTraceLinkId) ||
+                    Number(item.harvestTraceLinkId) <= 0)) ||
+            (item.traceToken !== undefined && !normalizedTraceToken)
+        ) {
+            throw new DeliveryRunPersistenceError(
+                DeliveryRunPersistenceErrorCodes.INVALID_PLAN,
+                'Delivery pickup manifest items are invalid',
+                { deliveryRequestId: item.deliveryRequestId },
+            );
+        }
+        manifestRequestIds.add(item.deliveryRequestId);
+        return {
+            deliveryRequestId: item.deliveryRequestId,
+            timeSlotId: item.timeSlotId,
+            ...(item.harvestTraceLinkId !== undefined && normalizedTraceToken
+                ? {
+                      harvestTraceLinkId: item.harvestTraceLinkId,
+                      traceToken: normalizedTraceToken,
+                  }
+                : {}),
+        };
+    });
+    if (
+        stopRequestIds.size !== manifestRequestIds.size ||
+        Array.from(stopRequestIds).some(
+            (requestId) => !manifestRequestIds.has(requestId),
+        )
+    ) {
+        throw new DeliveryRunPersistenceError(
+            DeliveryRunPersistenceErrorCodes.INVALID_PLAN,
+            'Delivery pickup manifest must contain every delivery exactly once',
+        );
+    }
+
     return {
-        formatVersion: 2,
+        formatVersion: 3,
         dispatchRevision,
         selectionRequestIds: [...selectionRequestIds],
         createRunInput: {
@@ -781,6 +921,7 @@ function normalizePreparationPlan({
             })),
             runSlots: normalizedSlots,
             stops: normalizedStops,
+            manifestItems: normalizedManifestItems,
         },
         requestSnapshots: requestSnapshots.map((snapshot) => ({
             deliveryRequestId: snapshot.deliveryRequestId,
@@ -806,6 +947,62 @@ function normalizePreparationPlan({
 }
 
 function normalizePersistedV2Plan(plan: DeliveryRunPreparationPlanPayloadV2) {
+    const normalized = normalizePreparationPlan({
+        dispatchRevision: plan.dispatchRevision,
+        selectionRequestIds: plan.selectionRequestIds,
+        createRunInput: {
+            ...plan.createRunInput,
+            manifestItems: plan.createRunInput.stops.map((stop) => ({
+                deliveryRequestId: stop.deliveryRequestId,
+                timeSlotId: stop.timeSlotId,
+            })),
+            pickupNodes: plan.createRunInput.pickupNodes.map((node) => ({
+                ...node,
+                sourceUpdatedAt: new Date(node.sourceUpdatedAt),
+                estimatedArrivalAt: new Date(node.estimatedArrivalAt),
+            })),
+            runSlots: plan.createRunInput.runSlots.map((slot) => ({
+                ...slot,
+                windowStartAt: new Date(slot.windowStartAt),
+                windowEndAt: new Date(slot.windowEndAt),
+                sourceUpdatedAt: new Date(slot.sourceUpdatedAt),
+            })),
+            stops: plan.createRunInput.stops.map((stop) => ({
+                ...stop,
+                estimatedArrivalAt: new Date(stop.estimatedArrivalAt),
+                deliveryAddressUpdatedAt: new Date(
+                    stop.deliveryAddressUpdatedAt,
+                ),
+            })),
+        },
+        requestSnapshots: plan.requestSnapshots.map((snapshot) => ({
+            ...snapshot,
+            address: {
+                ...snapshot.address,
+                updatedAt: new Date(snapshot.address.updatedAt),
+            },
+            slot: {
+                ...snapshot.slot,
+                updatedAt: new Date(snapshot.slot.updatedAt),
+                startAt: new Date(snapshot.slot.startAt),
+                endAt: new Date(snapshot.slot.endAt),
+            },
+            pickupLocation: {
+                ...snapshot.pickupLocation,
+                updatedAt: new Date(snapshot.pickupLocation.updatedAt),
+            },
+        })),
+    });
+    const { manifestItems: _manifestItems, ...createRunInput } =
+        normalized.createRunInput;
+    return {
+        ...normalized,
+        formatVersion: 2,
+        createRunInput,
+    } satisfies DeliveryRunPreparationPlanPayloadV2;
+}
+
+function normalizePersistedV3Plan(plan: DeliveryRunPreparationPlanPayloadV3) {
     return normalizePreparationPlan({
         dispatchRevision: plan.dispatchRevision,
         selectionRequestIds: plan.selectionRequestIds,
@@ -828,6 +1025,9 @@ function normalizePersistedV2Plan(plan: DeliveryRunPreparationPlanPayloadV2) {
                 deliveryAddressUpdatedAt: new Date(
                     stop.deliveryAddressUpdatedAt,
                 ),
+            })),
+            manifestItems: plan.createRunInput.manifestItems.map((item) => ({
+                ...item,
             })),
         },
         requestSnapshots: plan.requestSnapshots.map((snapshot) => ({
@@ -875,6 +1075,151 @@ function sourceTextEqual(
     expected: string | null | undefined,
 ) {
     return (current ?? null) === (expected ?? null);
+}
+
+type DeliveryRunTraceSource = {
+    id: number;
+    publicToken: string;
+    harvestOperationId: number;
+    raisedBedFieldId: number;
+};
+
+function resolveDeliveryRunTraceSource({
+    operationId,
+    raisedBedFieldId,
+    links,
+}: {
+    operationId: number;
+    raisedBedFieldId: number | null;
+    links: readonly DeliveryRunTraceSource[];
+}) {
+    const operationLinks = links.filter(
+        (link) => link.harvestOperationId === operationId,
+    );
+    if (raisedBedFieldId !== null) {
+        const exact = operationLinks.find(
+            (link) => link.raisedBedFieldId === raisedBedFieldId,
+        );
+        if (exact) return exact;
+    }
+    return operationLinks.length === 1 ? operationLinks[0] : null;
+}
+
+async function lockAndReadDeliveryRunTraceSources({
+    requestIds,
+    db,
+}: {
+    requestIds: readonly string[];
+    db: TransactionClient;
+}) {
+    const initialRequestSources = await db
+        .select({
+            deliveryRequestId: deliveryRequests.id,
+            operationId: deliveryRequests.operationId,
+            raisedBedFieldId: operations.raisedBedFieldId,
+        })
+        .from(deliveryRequests)
+        .innerJoin(operations, eq(deliveryRequests.operationId, operations.id))
+        .where(inArray(deliveryRequests.id, [...requestIds]));
+    const operationIds = Array.from(
+        new Set(initialRequestSources.map((source) => source.operationId)),
+    ).sort((first, second) => first - second);
+
+    for (const operationId of operationIds) {
+        await db.execute(
+            sql`select ${operations.id} from ${operations} where ${operations.id} = ${operationId} for update`,
+        );
+    }
+
+    const requestSources = await db
+        .select({
+            deliveryRequestId: deliveryRequests.id,
+            operationId: deliveryRequests.operationId,
+            raisedBedFieldId: operations.raisedBedFieldId,
+        })
+        .from(deliveryRequests)
+        .innerJoin(operations, eq(deliveryRequests.operationId, operations.id))
+        .where(inArray(deliveryRequests.id, [...requestIds]));
+    for (const operationId of operationIds) {
+        await db.execute(
+            sql`select ${harvestTraceLinks.id} from ${harvestTraceLinks} where ${harvestTraceLinks.harvestOperationId} = ${operationId} for update`,
+        );
+    }
+
+    const activeLinks =
+        operationIds.length > 0
+            ? await db.query.harvestTraceLinks.findMany({
+                  columns: {
+                      id: true,
+                      publicToken: true,
+                      harvestOperationId: true,
+                      raisedBedFieldId: true,
+                  },
+                  where: and(
+                      inArray(
+                          harvestTraceLinks.harvestOperationId,
+                          operationIds,
+                      ),
+                      eq(harvestTraceLinks.status, 'active'),
+                  ),
+              })
+            : [];
+
+    return { activeLinks, requestSources };
+}
+
+async function validateDeliveryRunTraceSources(
+    plan: DeliveryRunPreparationPlanPayloadV3,
+    db: TransactionClient,
+) {
+    const requestIds = plan.requestSnapshots.map(
+        (snapshot) => snapshot.deliveryRequestId,
+    );
+    const { activeLinks, requestSources } =
+        await lockAndReadDeliveryRunTraceSources({ requestIds, db });
+    const sourcesByRequestId = new Map(
+        requestSources.map((source) => [source.deliveryRequestId, source]),
+    );
+    const manifestItemsByRequestId = new Map(
+        plan.createRunInput.manifestItems.map((item) => [
+            item.deliveryRequestId,
+            item,
+        ]),
+    );
+
+    for (const snapshot of plan.requestSnapshots) {
+        const source = sourcesByRequestId.get(snapshot.deliveryRequestId);
+        const manifestItem = manifestItemsByRequestId.get(
+            snapshot.deliveryRequestId,
+        );
+        const currentTrace = source
+            ? resolveDeliveryRunTraceSource({
+                  operationId: source.operationId,
+                  raisedBedFieldId: source.raisedBedFieldId,
+                  links: activeLinks,
+              })
+            : null;
+        const expectedTrace =
+            manifestItem?.harvestTraceLinkId !== undefined &&
+            manifestItem.traceToken !== undefined
+                ? {
+                      id: manifestItem.harvestTraceLinkId,
+                      publicToken: manifestItem.traceToken,
+                  }
+                : null;
+        if (
+            !source ||
+            !manifestItem ||
+            currentTrace?.id !== expectedTrace?.id ||
+            currentTrace?.publicToken !== expectedTrace?.publicToken
+        ) {
+            throw new DeliveryRunPersistenceError(
+                DeliveryRunPersistenceErrorCodes.SOURCE_CHANGED,
+                'Delivery harvest trace changed after route preparation',
+                { deliveryRequestId: snapshot.deliveryRequestId },
+            );
+        }
+    }
 }
 
 async function lockPreparationSources(
@@ -988,6 +1333,9 @@ async function validatePreparationSnapshot(
                 { deliveryRequestId: expected.deliveryRequestId },
             );
         }
+    }
+    if (plan.formatVersion === 3) {
+        await validateDeliveryRunTraceSources(plan, db);
     }
 }
 
@@ -1156,11 +1504,11 @@ async function insertPreparedDeliveryRun(
         totalDistanceMeters: plan.createRunInput.totalDistanceMeters,
         totalDurationSeconds: plan.createRunInput.totalDurationSeconds,
         routePlanVersion:
-            plan.formatVersion === 2 ? plan.createRunInput.routePlanVersion : 1,
+            plan.formatVersion === 1 ? 1 : plan.createRunInput.routePlanVersion,
         estimateSource:
-            plan.formatVersion === 2
-                ? plan.createRunInput.estimateSource
-                : DeliveryRunEstimateSources.LEGACY,
+            plan.formatVersion === 1
+                ? DeliveryRunEstimateSources.LEGACY
+                : plan.createRunInput.estimateSource,
         estimatesUpdatedAt: new Date(),
     });
 
@@ -1188,7 +1536,7 @@ async function insertPreparedDeliveryRun(
         };
     };
     const pickupNodeRows =
-        plan.formatVersion === 2
+        plan.formatVersion !== 1
             ? plan.createRunInput.pickupNodes.map((node) => ({
                   ...createPickupNodeRow(node),
                   itinerarySequence: node.itinerarySequence,
@@ -1220,6 +1568,10 @@ async function insertPreparedDeliveryRun(
             timeSlotId: slot.timeSlotId,
             sequence: slot.sequence,
             manifestId: slot.manifestId,
+            manifestState:
+                plan.formatVersion === 3
+                    ? DeliveryRunManifestStates.PENDING
+                    : DeliveryRunManifestStates.CONFIRMED,
             windowStartAt: new Date(slot.windowStartAt),
             windowEndAt: new Date(slot.windowEndAt),
             sourceUpdatedAt: new Date(slot.sourceUpdatedAt),
@@ -1233,6 +1585,14 @@ async function insertPreparedDeliveryRun(
             snapshot,
         ]),
     );
+    const manifestItemsByRequestId = new Map(
+        plan.formatVersion === 3
+            ? plan.createRunInput.manifestItems.map((item) => [
+                  item.deliveryRequestId,
+                  item,
+              ])
+            : [],
+    );
     const createStopRow = (
         stop: DeliveryRunPreparationPlanPayloadV1['createRunInput']['stops'][number],
     ) => {
@@ -1242,6 +1602,16 @@ async function insertPreparedDeliveryRun(
             throw new DeliveryRunPersistenceError(
                 DeliveryRunPersistenceErrorCodes.INVALID_PLAN,
                 'Delivery stop has no persisted slot or request snapshot',
+                { deliveryRequestId: stop.deliveryRequestId },
+            );
+        }
+        const manifestItem = manifestItemsByRequestId.get(
+            stop.deliveryRequestId,
+        );
+        if (plan.formatVersion === 3 && !manifestItem) {
+            throw new DeliveryRunPersistenceError(
+                DeliveryRunPersistenceErrorCodes.INVALID_PLAN,
+                'Delivery stop has no persisted pickup manifest item',
                 { deliveryRequestId: stop.deliveryRequestId },
             );
         }
@@ -1262,6 +1632,13 @@ async function insertPreparedDeliveryRun(
             deliveryCity: snapshot.address.city,
             deliveryPostalCode: snapshot.address.postalCode,
             deliveryCountryCode: snapshot.address.countryCode,
+            ...(manifestItem
+                ? {
+                      pickupItemState: DeliveryRunManifestItemStates.READY,
+                      pickupTraceLinkId: manifestItem.harvestTraceLinkId,
+                      pickupTraceToken: manifestItem.traceToken,
+                  }
+                : {}),
             latitude: stop.latitude,
             longitude: stop.longitude,
             formattedAddress: stop.formattedAddress,
@@ -1273,7 +1650,7 @@ async function insertPreparedDeliveryRun(
         };
     };
     const stopRows =
-        plan.formatVersion === 2
+        plan.formatVersion !== 1
             ? plan.createRunInput.stops.map((stop) => ({
                   ...createStopRow(stop),
                   itinerarySequence: stop.itinerarySequence,
@@ -1354,7 +1731,8 @@ export async function consumeDeliveryRunPreparation({
         }
         if (
             (preparation.plan.formatVersion !== 1 &&
-                preparation.plan.formatVersion !== 2) ||
+                preparation.plan.formatVersion !== 2 &&
+                preparation.plan.formatVersion !== 3) ||
             preparation.plan.createRunInput.driverUserId !== driverUserId
         ) {
             throw new DeliveryRunPersistenceError(
@@ -1364,9 +1742,11 @@ export async function consumeDeliveryRunPreparation({
         }
 
         const plan =
-            preparation.plan.formatVersion === 2
-                ? normalizePersistedV2Plan(preparation.plan)
-                : preparation.plan;
+            preparation.plan.formatVersion === 3
+                ? normalizePersistedV3Plan(preparation.plan)
+                : preparation.plan.formatVersion === 2
+                  ? normalizePersistedV2Plan(preparation.plan)
+                  : preparation.plan;
 
         await ensurePreparationCanCreateRun(plan, tx);
         await validatePreparationSnapshot(plan, tx);
@@ -1480,6 +1860,643 @@ export function getActiveDeliveryRunForDriver(driverUserId: string) {
     });
 }
 
+async function getDeliveryRunExecutionSource(
+    runId: string,
+    db: DatabaseClient,
+) {
+    return await db.query.deliveryRuns.findFirst({
+        where: eq(deliveryRuns.id, runId),
+        with: {
+            pickupNodes: {
+                orderBy: [asc(deliveryRunPickupNodes.sequence)],
+            },
+            runSlots: {
+                orderBy: [asc(deliveryRunSlots.sequence)],
+            },
+            stops: {
+                orderBy: [asc(deliveryRunStops.sequence)],
+            },
+        },
+    });
+}
+
+async function getDeliveryRunExecutionProgressFromDb(
+    runId: string,
+    db: DatabaseClient,
+): Promise<DeliveryRunExecutionStep[]> {
+    const run = await getDeliveryRunExecutionSource(runId, db);
+    if (!run) return [];
+
+    type PendingExecutionStep =
+        | (Omit<
+              Extract<DeliveryRunExecutionStep, { kind: 'pickup' }>,
+              'state'
+          > & { completed: boolean })
+        | (Omit<
+              Extract<DeliveryRunExecutionStep, { kind: 'delivery' }>,
+              'state'
+          > & { completed: boolean });
+    const pendingSteps: PendingExecutionStep[] = [];
+    if (run.routePlanVersion < 2) {
+        for (const stop of run.stops) {
+            pendingSteps.push({
+                kind: 'delivery',
+                itinerarySequence: stop.sequence,
+                stopKey: stop.stopKey,
+                stopIds: [stop.id],
+                pickupConfirmed: true,
+                completed: stop.state === DeliveryRunStopStates.DELIVERED,
+            });
+        }
+    } else {
+        const slotsByPickupNodeId = new Map<string, typeof run.runSlots>();
+        const slotsById = new Map(run.runSlots.map((slot) => [slot.id, slot]));
+        for (const slot of run.runSlots) {
+            const slots = slotsByPickupNodeId.get(slot.pickupNodeId) ?? [];
+            slots.push(slot);
+            slotsByPickupNodeId.set(slot.pickupNodeId, slots);
+        }
+        for (const pickupNode of run.pickupNodes) {
+            if (pickupNode.itinerarySequence === null) continue;
+            const slots = slotsByPickupNodeId.get(pickupNode.id) ?? [];
+            pendingSteps.push({
+                kind: 'pickup',
+                pickupNodeId: pickupNode.id,
+                itinerarySequence: pickupNode.itinerarySequence,
+                manifestIds: slots.map((slot) => slot.manifestId),
+                completed:
+                    slots.length > 0 &&
+                    slots.every(
+                        (slot) =>
+                            slot.manifestState ===
+                            DeliveryRunManifestStates.CONFIRMED,
+                    ),
+            });
+        }
+
+        const stopsByItinerarySequence = new Map<number, typeof run.stops>();
+        for (const stop of run.stops) {
+            if (stop.itinerarySequence === null) continue;
+            const stops =
+                stopsByItinerarySequence.get(stop.itinerarySequence) ?? [];
+            stops.push(stop);
+            stopsByItinerarySequence.set(stop.itinerarySequence, stops);
+        }
+        for (const [itinerarySequence, stops] of stopsByItinerarySequence) {
+            pendingSteps.push({
+                kind: 'delivery',
+                itinerarySequence,
+                stopKey: stops[0]?.stopKey ?? null,
+                stopIds: stops.map((stop) => stop.id),
+                pickupConfirmed: stops.every((stop) => {
+                    const slot = stop.runSlotId
+                        ? slotsById.get(stop.runSlotId)
+                        : undefined;
+                    return (
+                        slot?.manifestState ===
+                        DeliveryRunManifestStates.CONFIRMED
+                    );
+                }),
+                completed: stops.every(
+                    (stop) => stop.state === DeliveryRunStopStates.DELIVERED,
+                ),
+            });
+        }
+    }
+
+    pendingSteps.sort(
+        (first, second) => first.itinerarySequence - second.itinerarySequence,
+    );
+    const currentIndex = pendingSteps.findIndex((step) => !step.completed);
+    return pendingSteps.map(({ completed, ...step }, index) => ({
+        ...step,
+        state: completed
+            ? 'completed'
+            : index === currentIndex
+              ? 'current'
+              : 'upcoming',
+    }));
+}
+
+export function getDeliveryRunExecutionProgress(runId: string) {
+    return getDeliveryRunExecutionProgressFromDb(runId, storage());
+}
+
+function normalizeDeliveryPickupTrace(value: string) {
+    const trimmed = value.trim();
+    const pathMatch = /^\/trag\/([^/?#]+)\/?$/.exec(trimmed);
+    return normalizeHarvestTraceToken(pathMatch?.[1] ?? trimmed);
+}
+
+function pickupMutationPayloadHash(
+    pickupNodeId: string,
+    mutation: DeliveryRunPickupMutation,
+) {
+    if (mutation.kind === DeliveryRunPickupOperationKinds.SCAN) {
+        const traceToken = normalizeDeliveryPickupTrace(mutation.traceToken);
+        if (!traceToken) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.PICKUP_TRACE_INVALID,
+                'Pickup trace is invalid',
+            );
+        }
+        return {
+            payloadHash: hashValue(
+                [
+                    pickupNodeId,
+                    mutation.kind,
+                    mutation.clientOperationId,
+                    mutation.occurredAt.toISOString(),
+                    traceToken,
+                ].join('\n'),
+            ),
+            mutation: { ...mutation, traceToken },
+        };
+    }
+    if (mutation.kind === DeliveryRunPickupOperationKinds.MARK_ITEM) {
+        return {
+            payloadHash: hashValue(
+                [
+                    pickupNodeId,
+                    mutation.kind,
+                    mutation.clientOperationId,
+                    mutation.occurredAt.toISOString(),
+                    mutation.stopId,
+                    mutation.outcome,
+                ].join('\n'),
+            ),
+            mutation,
+        };
+    }
+    return {
+        payloadHash: hashValue(
+            [
+                pickupNodeId,
+                mutation.kind,
+                mutation.clientOperationId,
+                mutation.occurredAt.toISOString(),
+                mutation.manifestId,
+            ].join('\n'),
+        ),
+        mutation,
+    };
+}
+
+function ensurePickupMutationShape(mutation: DeliveryRunPickupMutation) {
+    if (
+        !mutation.clientOperationId.trim() ||
+        mutation.clientOperationId.length > 128 ||
+        !(mutation.occurredAt instanceof Date) ||
+        !Number.isFinite(mutation.occurredAt.getTime())
+    ) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.PICKUP_ITEM_STATE_INVALID,
+            'Pickup operation is invalid',
+        );
+    }
+    if (
+        mutation.kind === DeliveryRunPickupOperationKinds.MARK_ITEM &&
+        (mutation.stopId <= 0 ||
+            !Number.isInteger(mutation.stopId) ||
+            ![
+                DeliveryRunManifestItemStates.READY,
+                DeliveryRunManifestItemStates.MISSING_LABEL,
+                DeliveryRunManifestItemStates.NOT_READY,
+            ].includes(mutation.outcome))
+    ) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.PICKUP_ITEM_STATE_INVALID,
+            'Pickup item outcome is invalid',
+        );
+    }
+}
+
+async function ensureCurrentPickupNode({
+    runId,
+    pickupNodeId,
+    db,
+}: {
+    runId: string;
+    pickupNodeId: string;
+    db: DatabaseClient;
+}) {
+    const progress = await getDeliveryRunExecutionProgressFromDb(runId, db);
+    const current = progress.find((step) => step.state === 'current');
+    if (current?.kind !== 'pickup' || current.pickupNodeId !== pickupNodeId) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.PICKUP_NOT_CURRENT,
+            'Pickup checkpoint is not current',
+        );
+    }
+}
+
+async function applyPickupScan({
+    runId,
+    pickupNodeId,
+    driverUserId,
+    traceToken,
+    db,
+}: {
+    runId: string;
+    pickupNodeId: string;
+    driverUserId: string;
+    traceToken: string;
+    db: TransactionClient;
+}): Promise<DeliveryRunPickupOperationStoredResult> {
+    const rows = await db
+        .select({ stop: deliveryRunStops })
+        .from(deliveryRunStops)
+        .innerJoin(
+            deliveryRunSlots,
+            and(
+                eq(deliveryRunStops.runId, deliveryRunSlots.runId),
+                eq(deliveryRunStops.runSlotId, deliveryRunSlots.id),
+            ),
+        )
+        .where(
+            and(
+                eq(deliveryRunStops.runId, runId),
+                eq(deliveryRunSlots.pickupNodeId, pickupNodeId),
+                eq(deliveryRunStops.pickupTraceToken, traceToken),
+            ),
+        )
+        .orderBy(asc(deliveryRunStops.sequence));
+    if (rows.length === 0) {
+        return {
+            kind: DeliveryRunPickupOperationKinds.SCAN,
+            outcome: 'not-found',
+            affectedStopIds: [],
+        };
+    }
+    const { activeLinks, requestSources } =
+        await lockAndReadDeliveryRunTraceSources({
+            requestIds: rows.map(({ stop }) => stop.deliveryRequestId),
+            db,
+        });
+    const sourcesByRequestId = new Map(
+        requestSources.map((source) => [source.deliveryRequestId, source]),
+    );
+    const hasInvalidProvenance = rows.some(({ stop }) => {
+        const source = sourcesByRequestId.get(stop.deliveryRequestId);
+        const currentTrace = source
+            ? resolveDeliveryRunTraceSource({
+                  operationId: source.operationId,
+                  raisedBedFieldId: source.raisedBedFieldId,
+                  links: activeLinks,
+              })
+            : null;
+        return (
+            currentTrace?.id !== stop.pickupTraceLinkId ||
+            currentTrace?.publicToken !== stop.pickupTraceToken
+        );
+    });
+    if (hasInvalidProvenance) {
+        return {
+            kind: DeliveryRunPickupOperationKinds.SCAN,
+            outcome: 'not-found',
+            affectedStopIds: [],
+        };
+    }
+    const stopKeys = new Set(rows.map(({ stop }) => stop.stopKey));
+    if (stopKeys.size > 1) {
+        return {
+            kind: DeliveryRunPickupOperationKinds.SCAN,
+            outcome: 'ambiguous',
+            affectedStopIds: [],
+        };
+    }
+
+    const affectedStopIds = rows.map(({ stop }) => stop.id);
+    const toScan = rows.filter(
+        ({ stop }) =>
+            stop.pickupItemState !== DeliveryRunManifestItemStates.SCANNED,
+    );
+    if (toScan.length > 0) {
+        await db
+            .update(deliveryRunStops)
+            .set({
+                pickupItemState: DeliveryRunManifestItemStates.SCANNED,
+                pickupResolvedAt: new Date(),
+                pickupResolvedByUserId: driverUserId,
+            })
+            .where(
+                inArray(
+                    deliveryRunStops.id,
+                    toScan.map(({ stop }) => stop.id),
+                ),
+            );
+    }
+    return {
+        kind: DeliveryRunPickupOperationKinds.SCAN,
+        outcome: toScan.length > 0 ? 'applied' : 'already-applied',
+        affectedStopIds,
+        itemState: DeliveryRunManifestItemStates.SCANNED,
+    };
+}
+
+async function applyPickupItemOutcome({
+    runId,
+    pickupNodeId,
+    driverUserId,
+    stopId,
+    outcome,
+    db,
+}: {
+    runId: string;
+    pickupNodeId: string;
+    driverUserId: string;
+    stopId: number;
+    outcome: Exclude<DeliveryRunManifestItemState, 'scanned'>;
+    db: TransactionClient;
+}): Promise<DeliveryRunPickupOperationStoredResult> {
+    const rows = await db
+        .select({ stop: deliveryRunStops })
+        .from(deliveryRunStops)
+        .innerJoin(
+            deliveryRunSlots,
+            and(
+                eq(deliveryRunStops.runId, deliveryRunSlots.runId),
+                eq(deliveryRunStops.runSlotId, deliveryRunSlots.id),
+            ),
+        )
+        .where(
+            and(
+                eq(deliveryRunStops.runId, runId),
+                eq(deliveryRunStops.id, stopId),
+                eq(deliveryRunSlots.pickupNodeId, pickupNodeId),
+            ),
+        );
+    const stop = rows[0]?.stop;
+    if (!stop || stop.pickupItemState === null) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.PICKUP_ITEM_NOT_FOUND,
+            'Pickup manifest item was not found',
+        );
+    }
+    if (
+        (stop.pickupItemState === DeliveryRunManifestItemStates.SCANNED ||
+            stop.pickupItemState ===
+                DeliveryRunManifestItemStates.MISSING_LABEL) &&
+        stop.pickupItemState !== outcome
+    ) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.PICKUP_ITEM_STATE_INVALID,
+            'Collected pickup item cannot be changed',
+        );
+    }
+    if (stop.pickupItemState === outcome) {
+        return {
+            kind: DeliveryRunPickupOperationKinds.MARK_ITEM,
+            outcome: 'already-applied',
+            affectedStopIds: [stop.id],
+            itemState: outcome,
+        };
+    }
+
+    await db
+        .update(deliveryRunStops)
+        .set(
+            outcome === DeliveryRunManifestItemStates.READY
+                ? {
+                      pickupItemState: outcome,
+                      pickupResolvedAt: null,
+                      pickupResolvedByUserId: null,
+                  }
+                : {
+                      pickupItemState: outcome,
+                      pickupResolvedAt: new Date(),
+                      pickupResolvedByUserId: driverUserId,
+                  },
+        )
+        .where(eq(deliveryRunStops.id, stop.id));
+    return {
+        kind: DeliveryRunPickupOperationKinds.MARK_ITEM,
+        outcome: 'applied',
+        affectedStopIds: [stop.id],
+        itemState: outcome,
+    };
+}
+
+async function applyPickupManifestConfirmation({
+    runId,
+    pickupNodeId,
+    driverUserId,
+    manifestId,
+    db,
+}: {
+    runId: string;
+    pickupNodeId: string;
+    driverUserId: string;
+    manifestId: string;
+    db: TransactionClient;
+}): Promise<DeliveryRunPickupOperationStoredResult> {
+    const slot = await db.query.deliveryRunSlots.findFirst({
+        where: and(
+            eq(deliveryRunSlots.runId, runId),
+            eq(deliveryRunSlots.pickupNodeId, pickupNodeId),
+            eq(deliveryRunSlots.manifestId, manifestId),
+        ),
+    });
+    if (!slot) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.PICKUP_MANIFEST_NOT_FOUND,
+            'Pickup manifest was not found',
+        );
+    }
+    if (slot.manifestState === DeliveryRunManifestStates.CONFIRMED) {
+        return {
+            kind: DeliveryRunPickupOperationKinds.CONFIRM_MANIFEST,
+            outcome: 'already-applied',
+            affectedStopIds: [],
+            manifestId,
+            manifestState: DeliveryRunManifestStates.CONFIRMED,
+        };
+    }
+
+    const items = await db.query.deliveryRunStops.findMany({
+        columns: { id: true, pickupItemState: true },
+        where: and(
+            eq(deliveryRunStops.runId, runId),
+            eq(deliveryRunStops.runSlotId, slot.id),
+        ),
+    });
+    const isCollected = (state: DeliveryRunManifestItemState | null) =>
+        state === DeliveryRunManifestItemStates.SCANNED ||
+        state === DeliveryRunManifestItemStates.MISSING_LABEL;
+    if (
+        items.length === 0 ||
+        items.some((item) => !isCollected(item.pickupItemState))
+    ) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.PICKUP_MANIFEST_INCOMPLETE,
+            'Pickup manifest is incomplete',
+        );
+    }
+    await db
+        .update(deliveryRunSlots)
+        .set({
+            manifestState: DeliveryRunManifestStates.CONFIRMED,
+            confirmedAt: new Date(),
+            confirmedByUserId: driverUserId,
+        })
+        .where(eq(deliveryRunSlots.id, slot.id));
+    return {
+        kind: DeliveryRunPickupOperationKinds.CONFIRM_MANIFEST,
+        outcome: 'applied',
+        affectedStopIds: items.map((item) => item.id),
+        manifestId,
+        manifestState: DeliveryRunManifestStates.CONFIRMED,
+    };
+}
+
+async function pickupManifestIsAlreadyConfirmed({
+    runId,
+    pickupNodeId,
+    manifestId,
+    db,
+}: {
+    runId: string;
+    pickupNodeId: string;
+    manifestId: string;
+    db: DatabaseClient;
+}) {
+    const slot = await db.query.deliveryRunSlots.findFirst({
+        columns: { manifestState: true },
+        where: and(
+            eq(deliveryRunSlots.runId, runId),
+            eq(deliveryRunSlots.pickupNodeId, pickupNodeId),
+            eq(deliveryRunSlots.manifestId, manifestId),
+        ),
+    });
+    return slot?.manifestState === DeliveryRunManifestStates.CONFIRMED;
+}
+
+export async function applyDeliveryRunPickupMutations({
+    driverUserId,
+    runId,
+    pickupNodeId,
+    mutations,
+}: {
+    driverUserId: string;
+    runId: string;
+    pickupNodeId: string;
+    mutations: DeliveryRunPickupMutation[];
+}): Promise<DeliveryRunPickupMutationResult[]> {
+    if (mutations.length === 0) return [];
+
+    return await storage().transaction(async (tx) => {
+        await tx.execute(
+            sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${runId} for update`,
+        );
+        const run = await tx.query.deliveryRuns.findFirst({
+            where: and(
+                eq(deliveryRuns.id, runId),
+                eq(deliveryRuns.driverUserId, driverUserId),
+            ),
+        });
+        if (!run) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+                'Active delivery run was not found',
+            );
+        }
+
+        const results: DeliveryRunPickupMutationResult[] = [];
+        for (const inputMutation of mutations) {
+            ensurePickupMutationShape(inputMutation);
+            const { payloadHash, mutation } = pickupMutationPayloadHash(
+                pickupNodeId,
+                inputMutation,
+            );
+            const receipt =
+                await tx.query.deliveryRunPickupOperations.findFirst({
+                    where: and(
+                        eq(deliveryRunPickupOperations.runId, runId),
+                        eq(
+                            deliveryRunPickupOperations.clientOperationId,
+                            mutation.clientOperationId,
+                        ),
+                    ),
+                });
+            if (receipt) {
+                if (receipt.payloadHash !== payloadHash) {
+                    throw new DeliveryRunExecutionError(
+                        DeliveryRunExecutionErrorCodes.PICKUP_OPERATION_CONFLICT,
+                        'Pickup operation ID was reused with different content',
+                    );
+                }
+                results.push({
+                    clientOperationId: mutation.clientOperationId,
+                    replayed: true,
+                    result: receipt.result,
+                });
+                continue;
+            }
+            if (run.state !== DeliveryRunStates.ACTIVE) {
+                throw new DeliveryRunExecutionError(
+                    DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+                    'Active delivery run was not found',
+                );
+            }
+            const alreadyConfirmed =
+                mutation.kind ===
+                    DeliveryRunPickupOperationKinds.CONFIRM_MANIFEST &&
+                (await pickupManifestIsAlreadyConfirmed({
+                    runId,
+                    pickupNodeId,
+                    manifestId: mutation.manifestId,
+                    db: tx,
+                }));
+            if (!alreadyConfirmed) {
+                await ensureCurrentPickupNode({ runId, pickupNodeId, db: tx });
+            }
+
+            const result =
+                mutation.kind === DeliveryRunPickupOperationKinds.SCAN
+                    ? await applyPickupScan({
+                          runId,
+                          pickupNodeId,
+                          driverUserId,
+                          traceToken: mutation.traceToken,
+                          db: tx,
+                      })
+                    : mutation.kind ===
+                        DeliveryRunPickupOperationKinds.MARK_ITEM
+                      ? await applyPickupItemOutcome({
+                            runId,
+                            pickupNodeId,
+                            driverUserId,
+                            stopId: mutation.stopId,
+                            outcome: mutation.outcome,
+                            db: tx,
+                        })
+                      : await applyPickupManifestConfirmation({
+                            runId,
+                            pickupNodeId,
+                            driverUserId,
+                            manifestId: mutation.manifestId,
+                            db: tx,
+                        });
+            await tx.insert(deliveryRunPickupOperations).values({
+                runId,
+                pickupNodeId,
+                driverUserId,
+                clientOperationId: mutation.clientOperationId,
+                kind: mutation.kind,
+                payloadHash,
+                result,
+                occurredAt: mutation.occurredAt,
+            });
+            results.push({
+                clientOperationId: mutation.clientOperationId,
+                replayed: false,
+                result,
+            });
+        }
+        return results;
+    });
+}
+
 export function getDeliveryRunStop(stopId: number) {
     return storage().query.deliveryRunStops.findFirst({
         where: eq(deliveryRunStops.id, stopId),
@@ -1544,8 +2561,13 @@ export async function accountCanTrackDeliveryRun({
     accountId: string;
     runId: string;
 }) {
+    const progress = await getDeliveryRunExecutionProgress(runId);
+    const current = progress.find((step) => step.state === 'current');
+    if (current?.kind !== 'delivery' || !current.pickupConfirmed) {
+        return false;
+    }
     const rows = await storage()
-        .select({ accountId: operations.accountId })
+        .selectDistinct({ accountId: operations.accountId })
         .from(deliveryRunStops)
         .innerJoin(deliveryRuns, eq(deliveryRunStops.runId, deliveryRuns.id))
         .innerJoin(
@@ -1557,13 +2579,12 @@ export async function accountCanTrackDeliveryRun({
             and(
                 eq(deliveryRunStops.runId, runId),
                 eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                inArray(deliveryRunStops.id, current.stopIds),
                 ne(deliveryRunStops.state, DeliveryRunStopStates.DELIVERED),
             ),
-        )
-        .orderBy(asc(deliveryRunStops.sequence))
-        .limit(1);
+        );
 
-    return rows[0]?.accountId === accountId;
+    return rows.some((row) => row.accountId === accountId);
 }
 
 export async function updateDeliveryRunLocation({
@@ -1673,17 +2694,24 @@ async function ensureOwnedDeliveryRunStops({
     driverUserId,
     runId,
     stopIds,
-    db = storage(),
+    db,
 }: {
     driverUserId: string;
     runId: string;
     stopIds: number[];
-    db?: DatabaseClient;
+    db: TransactionClient;
 }) {
     const uniqueStopIds = Array.from(new Set(stopIds));
     if (uniqueStopIds.length === 0) {
         throw new Error('Active delivery stop not found');
     }
+
+    // Serialize every arrival/delivery transition for this run before reading
+    // stop state. Without this lock, a late arrival write can overwrite a
+    // concurrently committed delivered state.
+    await db.execute(
+        sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${runId} for update`,
+    );
 
     const stops = await db.query.deliveryRunStops.findMany({
         where: and(
@@ -1708,16 +2736,55 @@ async function ensureOwnedDeliveryRunStops({
         (stop) => stop.state !== DeliveryRunStopStates.DELIVERED,
     );
     if (hasUndeliveredStops) {
-        const currentStop = await db.query.deliveryRunStops.findFirst({
-            columns: { id: true },
-            where: and(
-                eq(deliveryRunStops.runId, runId),
-                ne(deliveryRunStops.state, DeliveryRunStopStates.DELIVERED),
-            ),
-            orderBy: [asc(deliveryRunStops.sequence)],
-        });
-        if (currentStop && !uniqueStopIds.includes(currentStop.id)) {
-            throw new Error('Delivery stops must be completed in route order');
+        if (run.routePlanVersion >= 2) {
+            const progress = await getDeliveryRunExecutionProgressFromDb(
+                runId,
+                db,
+            );
+            const current = progress.find((step) => step.state === 'current');
+            if (current?.kind === 'pickup') {
+                throw new DeliveryRunExecutionError(
+                    DeliveryRunExecutionErrorCodes.PICKUP_DEPENDENCY_PENDING,
+                    'Delivery pickup dependency is pending',
+                );
+            }
+            if (current?.kind !== 'delivery') {
+                throw new DeliveryRunExecutionError(
+                    DeliveryRunExecutionErrorCodes.ROUTE_ORDER,
+                    'Delivery stops must be completed in route order',
+                );
+            }
+            if (!current.pickupConfirmed) {
+                throw new DeliveryRunExecutionError(
+                    DeliveryRunExecutionErrorCodes.PICKUP_DEPENDENCY_PENDING,
+                    'Delivery pickup dependency is pending',
+                );
+            }
+            const currentStopIds = new Set(current.stopIds);
+            if (
+                currentStopIds.size !== uniqueStopIds.length ||
+                uniqueStopIds.some((stopId) => !currentStopIds.has(stopId))
+            ) {
+                throw new DeliveryRunExecutionError(
+                    DeliveryRunExecutionErrorCodes.ROUTE_ORDER,
+                    'Bulk delivery stops must be completed atomically in route order',
+                );
+            }
+        } else {
+            const currentStop = await db.query.deliveryRunStops.findFirst({
+                columns: { id: true },
+                where: and(
+                    eq(deliveryRunStops.runId, runId),
+                    ne(deliveryRunStops.state, DeliveryRunStopStates.DELIVERED),
+                ),
+                orderBy: [asc(deliveryRunStops.sequence)],
+            });
+            if (currentStop && !uniqueStopIds.includes(currentStop.id)) {
+                throw new DeliveryRunExecutionError(
+                    DeliveryRunExecutionErrorCodes.ROUTE_ORDER,
+                    'Delivery stops must be completed in route order',
+                );
+            }
         }
     }
 
@@ -1752,7 +2819,15 @@ export async function markDeliveryRunStopsArrived({
                     state: DeliveryRunStopStates.ARRIVED,
                     arrivedAt: stop.arrivedAt ?? now,
                 })
-                .where(eq(deliveryRunStops.id, stop.id));
+                .where(
+                    and(
+                        eq(deliveryRunStops.id, stop.id),
+                        ne(
+                            deliveryRunStops.state,
+                            DeliveryRunStopStates.DELIVERED,
+                        ),
+                    ),
+                );
         }
 
         return stops;
@@ -1805,7 +2880,7 @@ async function markDeliveryRunStopsDeliveredInDatabase({
     driverUserId: string;
     runId: string;
     stopIds: number[];
-    db: DatabaseClient;
+    db: TransactionClient;
 }) {
     const stops = await ensureOwnedDeliveryRunStops({
         driverUserId,

--- a/packages/storage/src/schema/deliverySchema.ts
+++ b/packages/storage/src/schema/deliverySchema.ts
@@ -13,6 +13,7 @@ import {
     timestamp,
     uniqueIndex,
 } from 'drizzle-orm/pg-core';
+import { harvestTraceLinks } from './harvestTraceSchema';
 import { operations } from './operationsSchema';
 import { accounts, users } from './usersSchema';
 
@@ -173,6 +174,42 @@ export type PreparedDeliveryRunEstimateSource = Exclude<
     typeof DeliveryRunEstimateSources.LEGACY
 >;
 
+export const DeliveryRunManifestStates = {
+    PENDING: 'pending',
+    CONFIRMED: 'confirmed',
+} as const;
+
+export type DeliveryRunManifestState =
+    (typeof DeliveryRunManifestStates)[keyof typeof DeliveryRunManifestStates];
+
+export const DeliveryRunManifestItemStates = {
+    READY: 'ready',
+    SCANNED: 'scanned',
+    MISSING_LABEL: 'missing-label',
+    NOT_READY: 'not-ready',
+} as const;
+
+export type DeliveryRunManifestItemState =
+    (typeof DeliveryRunManifestItemStates)[keyof typeof DeliveryRunManifestItemStates];
+
+export const DeliveryRunPickupOperationKinds = {
+    SCAN: 'scan',
+    MARK_ITEM: 'mark-item',
+    CONFIRM_MANIFEST: 'confirm-manifest',
+} as const;
+
+export type DeliveryRunPickupOperationKind =
+    (typeof DeliveryRunPickupOperationKinds)[keyof typeof DeliveryRunPickupOperationKinds];
+
+export type DeliveryRunPickupOperationStoredResult = {
+    kind: DeliveryRunPickupOperationKind;
+    outcome: 'applied' | 'already-applied' | 'not-found' | 'ambiguous';
+    affectedStopIds: number[];
+    manifestId?: string;
+    itemState?: DeliveryRunManifestItemState;
+    manifestState?: DeliveryRunManifestState;
+};
+
 // Delivery Runs - one optimized route picked up and driven by a driver/admin.
 export const deliveryRuns = pgTable(
     'delivery_runs',
@@ -270,6 +307,13 @@ type DeliveryRunPreparationStopPayloadV1 = {
     deliveryAddressUpdatedAt: string;
 };
 
+type DeliveryRunPreparationManifestItemPayload = {
+    deliveryRequestId: string;
+    timeSlotId: number;
+    harvestTraceLinkId?: number;
+    traceToken?: string;
+};
+
 type DeliveryRunPreparationRequestSnapshotPayload = {
     deliveryRequestId: string;
     requestDispatchEventId: number;
@@ -360,9 +404,20 @@ export type DeliveryRunPreparationPlanPayloadV2 = {
     requestSnapshots: DeliveryRunPreparationRequestSnapshotPayload[];
 };
 
+export type DeliveryRunPreparationPlanPayloadV3 = Omit<
+    DeliveryRunPreparationPlanPayloadV2,
+    'formatVersion' | 'createRunInput'
+> & {
+    formatVersion: 3;
+    createRunInput: DeliveryRunPreparationPlanPayloadV2['createRunInput'] & {
+        manifestItems: DeliveryRunPreparationManifestItemPayload[];
+    };
+};
+
 export type DeliveryRunPreparationPlanPayload =
     | DeliveryRunPreparationPlanPayloadV1
-    | DeliveryRunPreparationPlanPayloadV2;
+    | DeliveryRunPreparationPlanPayloadV2
+    | DeliveryRunPreparationPlanPayloadV3;
 
 // Private, short-lived route plans. Only a hash of the bearer secret is stored.
 export const deliveryRunPreparations = pgTable(
@@ -490,6 +545,15 @@ export const deliveryRunSlots = pgTable(
         }),
         sequence: integer('sequence').notNull(),
         manifestId: text('manifest_id').notNull(),
+        manifestState: text('manifest_state')
+            .$type<DeliveryRunManifestState>()
+            .notNull()
+            .default(DeliveryRunManifestStates.CONFIRMED),
+        confirmedAt: timestamp('confirmed_at'),
+        confirmedByUserId: text('confirmed_by_user_id').references(
+            () => users.id,
+            { onDelete: 'set null' },
+        ),
         windowStartAt: timestamp('window_start_at').notNull(),
         windowEndAt: timestamp('window_end_at').notNull(),
         sourceUpdatedAt: timestamp('source_updated_at').notNull(),
@@ -521,6 +585,14 @@ export const deliveryRunSlots = pgTable(
         uniqueIndex('delivery_run_slots_run_id_id_unique').on(
             table.runId,
             table.id,
+        ),
+        check(
+            'delivery_run_slots_manifest_state_check',
+            sql`${table.manifestState} in ('pending', 'confirmed')`,
+        ),
+        check(
+            'delivery_run_slots_manifest_confirmation_shape_check',
+            sql`${table.manifestState} = 'confirmed' or (${table.confirmedAt} is null and ${table.confirmedByUserId} is null)`,
         ),
         index('delivery_run_slots_run_id_idx').on(table.runId),
         index('delivery_run_slots_pickup_node_id_idx').on(table.pickupNodeId),
@@ -554,6 +626,17 @@ export const deliveryRunStops = pgTable(
         deliveryCity: text('delivery_city'),
         deliveryPostalCode: text('delivery_postal_code'),
         deliveryCountryCode: text('delivery_country_code'),
+        pickupItemState:
+            text('pickup_item_state').$type<DeliveryRunManifestItemState>(),
+        pickupTraceLinkId: integer('pickup_trace_link_id').references(
+            () => harvestTraceLinks.id,
+        ),
+        pickupTraceToken: text('pickup_trace_token'),
+        pickupResolvedAt: timestamp('pickup_resolved_at'),
+        pickupResolvedByUserId: text('pickup_resolved_by_user_id').references(
+            () => users.id,
+            { onDelete: 'set null' },
+        ),
         state: text('state').notNull().default('pending'),
         latitude: doublePrecision('latitude').notNull(),
         longitude: doublePrecision('longitude').notNull(),
@@ -617,6 +700,27 @@ export const deliveryRunStops = pgTable(
                 and ${table.serviceDurationSeconds} >= 0
             )`,
         ),
+        check(
+            'delivery_run_stops_pickup_item_state_check',
+            sql`${table.pickupItemState} is null or ${table.pickupItemState} in ('ready', 'scanned', 'missing-label', 'not-ready')`,
+        ),
+        check(
+            'delivery_run_stops_pickup_item_resolution_shape_check',
+            sql`(
+                ${table.pickupItemState} is null
+                and ${table.pickupTraceLinkId} is null
+                and ${table.pickupTraceToken} is null
+                and ${table.pickupResolvedAt} is null
+                and ${table.pickupResolvedByUserId} is null
+            ) or (
+                ${table.pickupItemState} = 'ready'
+                and ${table.pickupResolvedAt} is null
+                and ${table.pickupResolvedByUserId} is null
+            ) or (
+                ${table.pickupItemState} in ('scanned', 'missing-label', 'not-ready')
+                and ${table.pickupResolvedAt} is not null
+            )`,
+        ),
         uniqueIndex('delivery_run_stops_delivery_request_id_unique').on(
             table.deliveryRequestId,
         ),
@@ -631,6 +735,58 @@ export const deliveryRunStops = pgTable(
         ),
         index('delivery_run_stops_run_slot_id_idx').on(table.runSlotId),
         index('delivery_run_stops_state_idx').on(table.state),
+        index('delivery_run_stops_pickup_trace_token_idx').on(
+            table.pickupTraceToken,
+        ),
+        index('delivery_run_stops_pickup_item_state_idx').on(
+            table.pickupItemState,
+        ),
+    ],
+);
+
+// Durable idempotency receipts for pickup actions queued by a driver's device.
+// The payload is represented only by a digest; raw QR values are never stored here.
+export const deliveryRunPickupOperations = pgTable(
+    'delivery_run_pickup_operations',
+    {
+        id: serial('id').primaryKey(),
+        runId: text('run_id')
+            .notNull()
+            .references(() => deliveryRuns.id, { onDelete: 'cascade' }),
+        pickupNodeId: text('pickup_node_id').notNull(),
+        driverUserId: text('driver_user_id')
+            .notNull()
+            .references(() => users.id),
+        clientOperationId: text('client_operation_id').notNull(),
+        kind: text('kind').$type<DeliveryRunPickupOperationKind>().notNull(),
+        payloadHash: text('payload_hash').notNull(),
+        result: jsonb('result')
+            .$type<DeliveryRunPickupOperationStoredResult>()
+            .notNull(),
+        occurredAt: timestamp('occurred_at').notNull(),
+        appliedAt: timestamp('applied_at').notNull().defaultNow(),
+    },
+    (table) => [
+        foreignKey({
+            columns: [table.runId, table.pickupNodeId],
+            foreignColumns: [
+                deliveryRunPickupNodes.runId,
+                deliveryRunPickupNodes.id,
+            ],
+            name: 'delivery_run_pickup_operations_run_pickup_node_fk',
+        }).onDelete('cascade'),
+        uniqueIndex('delivery_run_pickup_operations_run_client_unique').on(
+            table.runId,
+            table.clientOperationId,
+        ),
+        check(
+            'delivery_run_pickup_operations_kind_check',
+            sql`${table.kind} in ('scan', 'mark-item', 'confirm-manifest')`,
+        ),
+        index('delivery_run_pickup_operations_run_id_idx').on(table.runId),
+        index('delivery_run_pickup_operations_pickup_node_id_idx').on(
+            table.pickupNodeId,
+        ),
     ],
 );
 
@@ -658,6 +814,9 @@ export const deliveryRunsRelations = relations(
         }),
         preparations: many(deliveryRunPreparations, {
             relationName: 'deliveryRunPreparations',
+        }),
+        pickupOperations: many(deliveryRunPickupOperations, {
+            relationName: 'deliveryRunPickupOperations',
         }),
     }),
 );
@@ -693,6 +852,9 @@ export const deliveryRunPickupNodesRelations = relations(
         }),
         runSlots: many(deliveryRunSlots, {
             relationName: 'deliveryRunPickupNodeSlots',
+        }),
+        pickupOperations: many(deliveryRunPickupOperations, {
+            relationName: 'deliveryRunPickupNodeOperations',
         }),
     }),
 );
@@ -741,6 +903,33 @@ export const deliveryRunStopsRelations = relations(
             fields: [deliveryRunStops.runId, deliveryRunStops.runSlotId],
             references: [deliveryRunSlots.runId, deliveryRunSlots.id],
             relationName: 'deliveryRunSlotStops',
+        }),
+    }),
+);
+
+export const deliveryRunPickupOperationsRelations = relations(
+    deliveryRunPickupOperations,
+    ({ one }) => ({
+        run: one(deliveryRuns, {
+            fields: [deliveryRunPickupOperations.runId],
+            references: [deliveryRuns.id],
+            relationName: 'deliveryRunPickupOperations',
+        }),
+        pickupNode: one(deliveryRunPickupNodes, {
+            fields: [
+                deliveryRunPickupOperations.runId,
+                deliveryRunPickupOperations.pickupNodeId,
+            ],
+            references: [
+                deliveryRunPickupNodes.runId,
+                deliveryRunPickupNodes.id,
+            ],
+            relationName: 'deliveryRunPickupNodeOperations',
+        }),
+        driver: one(users, {
+            fields: [deliveryRunPickupOperations.driverUserId],
+            references: [users.id],
+            relationName: 'driverDeliveryRunPickupOperations',
         }),
     }),
 );
@@ -795,6 +984,8 @@ export type SelectDeliveryRunPickupNode =
     typeof deliveryRunPickupNodes.$inferSelect;
 export type SelectDeliveryRunSlot = typeof deliveryRunSlots.$inferSelect;
 export type SelectDeliveryRunStop = typeof deliveryRunStops.$inferSelect;
+export type SelectDeliveryRunPickupOperation =
+    typeof deliveryRunPickupOperations.$inferSelect;
 
 // Enums for type safety
 export const DeliveryModes = {

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
     accountCanTrackDeliveryRun,
+    applyDeliveryRunPickupMutations,
     type CreatePreparedDeliveryRunInput,
     cancelDeliveryRequest,
     changeDeliveryRequestSlot,
@@ -10,28 +11,43 @@ import {
     createDeliveryAddress,
     createDeliveryRun,
     createEvent,
+    DeliveryRunExecutionError,
+    DeliveryRunExecutionErrorCodes,
+    DeliveryRunManifestItemStates,
+    DeliveryRunManifestStates,
     DeliveryRunPersistenceError,
     DeliveryRunPersistenceErrorCodes,
     type DeliveryRunPreparationPlanPayloadV1,
     type DeliveryRunPreparationPlanPayloadV2,
+    type DeliveryRunPreparationPlanPayloadV3,
     type DeliveryRunRequestSnapshotInput,
+    DeliveryRunStates,
+    DeliveryRunStopStates,
     deliveryRequests,
     deliveryRunPickupNodes,
+    deliveryRunPickupOperations,
     deliveryRunPreparations,
     deliveryRunStops,
     deliveryRuns,
+    events,
+    farms,
     fulfillDeliveryRunStop,
     fulfillDeliveryRunStops,
+    gardens,
     getDeliveryDispatchRevision,
     getDeliveryRequest,
     getDeliveryRequestDispatchSnapshots,
     getDeliveryRun,
+    getDeliveryRunExecutionProgress,
     getDeliveryRunStopsForRequestIds,
+    harvestTraceLinks,
     knownEvents,
     markDeliveryRunStopArrived,
     markDeliveryRunStopsArrived,
     operations,
     pickupLocations,
+    raisedBedFields,
+    raisedBeds,
     saveDeliveryRunPreparation,
     storage,
     timeSlots,
@@ -249,6 +265,85 @@ async function createPreparedRunFixture({
     assert.ok(firstOperationId);
     assert.ok(secondOperationId);
 
+    const deliveryOperationIds = [firstOperationId, secondOperationId];
+    const [farm] = await storage()
+        .insert(farms)
+        .values({
+            name: `Delivery trace farm ${randomUUID()}`,
+            latitude: 45.8,
+            longitude: 15.97,
+        })
+        .returning();
+    assert.ok(farm);
+    const [garden] = await storage()
+        .insert(gardens)
+        .values({
+            accountId,
+            farmId: farm.id,
+            name: `Delivery trace garden ${randomUUID()}`,
+        })
+        .returning();
+    assert.ok(garden);
+    const [raisedBed] = await storage()
+        .insert(raisedBeds)
+        .values({
+            accountId,
+            gardenId: garden.id,
+            name: `Delivery trace bed ${randomUUID()}`,
+        })
+        .returning();
+    assert.ok(raisedBed);
+    const traceLinksByOperationId = new Map<
+        number,
+        typeof harvestTraceLinks.$inferSelect
+    >();
+    for (const [index, operationId] of Array.from(
+        new Set(deliveryOperationIds),
+    ).entries()) {
+        const [field] = await storage()
+            .insert(raisedBedFields)
+            .values({ raisedBedId: raisedBed.id, positionIndex: index })
+            .returning();
+        assert.ok(field);
+        const [plantPlaceEvent] = await storage()
+            .insert(events)
+            .values({
+                type: 'test.delivery.harvest-trace',
+                version: 1,
+                aggregateId: `delivery-trace-${randomUUID()}`,
+                data: {},
+            })
+            .returning({ id: events.id });
+        assert.ok(plantPlaceEvent);
+        await storage()
+            .update(operations)
+            .set({
+                farmId: farm.id,
+                gardenId: garden.id,
+                raisedBedId: raisedBed.id,
+                raisedBedFieldId: field.id,
+            })
+            .where(eq(operations.id, operationId));
+        const publicToken = `${bulk ? 'bulk' : 'route'}-trace-${randomUUID()}`;
+        const [traceLink] = await storage()
+            .insert(harvestTraceLinks)
+            .values({
+                publicToken,
+                accountId,
+                gardenId: garden.id,
+                raisedBedId: raisedBed.id,
+                raisedBedFieldId: field.id,
+                fieldPositionIndex: field.positionIndex,
+                fieldLabel: `Polje ${index + 1}`,
+                plantPlaceEventId: plantPlaceEvent.id,
+                harvestOperationId: operationId,
+                tracePath: `/trag/${publicToken}`,
+            })
+            .returning();
+        assert.ok(traceLink);
+        traceLinksByOperationId.set(operationId, traceLink);
+    }
+
     const firstLocation = await storage().query.pickupLocations.findFirst({
         where: eq(pickupLocations.id, fixture.locationId),
     });
@@ -295,7 +390,7 @@ async function createPreparedRunFixture({
     );
     const slotIds = [firstSlot.id, secondSlot.id];
     for (const [index, requestId] of fixture.requestIds.entries()) {
-        const operationId = fixture.operationIds[index];
+        const operationId = deliveryOperationIds[index];
         const addressId = addressIds[bulk ? 0 : index];
         const slotId = slotIds[bulk ? 0 : index];
         assert.ok(operationId);
@@ -430,6 +525,19 @@ async function createPreparedRunFixture({
                 deliveryAddressUpdatedAt: snapshot.address.updatedAt,
             };
         }),
+        manifestItems: fixture.requestIds.map((deliveryRequestId, index) => {
+            const operationId = deliveryOperationIds[index];
+            const traceLink = operationId
+                ? traceLinksByOperationId.get(operationId)
+                : undefined;
+            assert.ok(traceLink);
+            return {
+                deliveryRequestId,
+                timeSlotId: slotIds[bulk ? 0 : index] ?? firstSlot.id,
+                harvestTraceLinkId: traceLink.id,
+                traceToken: traceLink.publicToken,
+            };
+        }),
     };
 
     return {
@@ -437,6 +545,7 @@ async function createPreparedRunFixture({
         addressIds,
         createRunInput,
         requestSnapshots,
+        traceLinks: Array.from(traceLinksByOperationId.values()),
         selectionRequestIds: [...fixture.requestIds],
         dispatchRevision: await getDeliveryDispatchRevision(),
     };
@@ -488,6 +597,26 @@ async function assertPersistenceError(promise: Promise<unknown>, code: string) {
         (error) =>
             error instanceof DeliveryRunPersistenceError && error.code === code,
     );
+}
+
+async function assertExecutionError(promise: Promise<unknown>, code: string) {
+    await assert.rejects(
+        promise,
+        (error) =>
+            error instanceof DeliveryRunExecutionError && error.code === code,
+    );
+}
+
+function asV2PreparationPlan(
+    plan: DeliveryRunPreparationPlanPayloadV3,
+): DeliveryRunPreparationPlanPayloadV2 {
+    const { manifestItems: _manifestItems, ...createRunInput } =
+        plan.createRunInput;
+    return {
+        ...plan,
+        formatVersion: 2,
+        createRunInput,
+    };
 }
 
 function asLegacyPreparationPlan(
@@ -689,6 +818,49 @@ test('delivery run fulfills a current bulk stop atomically and preserves route o
     });
     assert.notEqual(nextRun.id, run.id);
     assert.equal(nextRun.state, 'active');
+});
+
+test('concurrent arrival and delivery never regress a delivered stop', async () => {
+    const fixture = await createDeliveryRunFixture();
+    const [driverUserId] = fixture.driverUserIds;
+    const [requestId] = fixture.requestIds;
+    assert.ok(driverUserId);
+    assert.ok(requestId);
+
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [requestId],
+    });
+    const [stop] = run.stops;
+    assert.ok(stop);
+
+    const [arrival, delivery] = await Promise.allSettled([
+        markDeliveryRunStopArrived({
+            driverUserId,
+            runId: run.id,
+            stopId: stop.id,
+        }),
+        fulfillDeliveryRunStop({
+            driverUserId,
+            runId: run.id,
+            stopId: stop.id,
+        }),
+    ]);
+
+    assert.equal(delivery.status, 'fulfilled');
+    assert.ok(
+        arrival.status === 'fulfilled' ||
+            (arrival.reason instanceof Error &&
+                /Active delivery stop not found/.test(arrival.reason.message)),
+    );
+    const completedRun = await getDeliveryRun(run.id);
+    assert.equal(completedRun?.state, DeliveryRunStates.COMPLETED);
+    assert.equal(
+        completedRun?.stops[0]?.state,
+        DeliveryRunStopStates.DELIVERED,
+    );
+    assert.ok(completedRun?.stops[0]?.deliveredAt);
 });
 
 test('same-driver route creation replays the active run and ignores a new selection', async () => {
@@ -1024,6 +1196,17 @@ test('prepared run persists multiple pickup locations, slots, manifests, and sta
     assert.equal(run.pickupNodes.length, 2);
     assert.equal(run.runSlots.length, 2);
     assert.equal(new Set(run.runSlots.map((slot) => slot.manifestId)).size, 2);
+    assert.ok(
+        run.runSlots.every(
+            (slot) => slot.manifestState === DeliveryRunManifestStates.PENDING,
+        ),
+    );
+    assert.ok(
+        run.stops.every(
+            (stop) =>
+                stop.pickupItemState === DeliveryRunManifestItemStates.READY,
+        ),
+    );
     assert.deepEqual(
         run.stops.map((stop) => stop.runSlot?.id),
         run.runSlots.map((slot) => slot.id),
@@ -1065,7 +1248,7 @@ test('prepared run persists multiple pickup locations, slots, manifests, and sta
         await storage().query.deliveryRunPreparations.findFirst({
             where: eq(deliveryRunPreparations.id, saved.preparationId),
         });
-    assert.equal(savedPreparation?.plan.formatVersion, 2);
+    assert.equal(savedPreparation?.plan.formatVersion, 3);
 
     const [firstAddressId] = prepared.addressIds;
     const [firstNode] = run.pickupNodes;
@@ -1110,6 +1293,129 @@ test('prepared run persists multiple pickup locations, slots, manifests, and sta
     assert.equal(requestRows[0]?.stop.runSlot?.id, firstRunSlot.id);
 });
 
+test('preparation rejects a manifest trace that is not the request current active trace', async () => {
+    const prepared = await createPreparedRunFixture();
+    const [firstItem, secondItem] = prepared.createRunInput.manifestItems;
+    assert.ok(firstItem);
+    assert.ok(secondItem?.traceToken);
+
+    await assertPersistenceError(
+        saveDeliveryRunPreparation({
+            ...prepared,
+            createRunInput: {
+                ...prepared.createRunInput,
+                manifestItems: [
+                    { ...firstItem, traceToken: secondItem.traceToken },
+                    secondItem,
+                ],
+            },
+        }),
+        DeliveryRunPersistenceErrorCodes.SOURCE_CHANGED,
+    );
+});
+
+test('preparation consumption rejects revoked or newly activated trace provenance', async () => {
+    const revokedPrepared = await createPreparedRunFixture();
+    const revokedDriverUserId = revokedPrepared.fixture.driverUserIds[0];
+    const [revokedTrace] = revokedPrepared.traceLinks;
+    assert.ok(revokedDriverUserId);
+    assert.ok(revokedTrace);
+    const revokedSaved = await saveDeliveryRunPreparation(revokedPrepared);
+    await storage()
+        .update(harvestTraceLinks)
+        .set({ status: 'revoked', revokedAt: new Date() })
+        .where(eq(harvestTraceLinks.id, revokedTrace.id));
+    await assertPersistenceError(
+        consumeDeliveryRunPreparation({
+            preparationToken: revokedSaved.preparationToken,
+            driverUserId: revokedDriverUserId,
+            deliveryRequestIds: revokedPrepared.fixture.requestIds,
+        }),
+        DeliveryRunPersistenceErrorCodes.SOURCE_CHANGED,
+    );
+
+    const activatedPrepared = await createPreparedRunFixture();
+    const activatedDriverUserId = activatedPrepared.fixture.driverUserIds[0];
+    const [activatedTrace] = activatedPrepared.traceLinks;
+    const [firstItem, ...remainingItems] =
+        activatedPrepared.createRunInput.manifestItems;
+    assert.ok(activatedDriverUserId);
+    assert.ok(activatedTrace);
+    assert.ok(firstItem);
+    await storage()
+        .update(harvestTraceLinks)
+        .set({ status: 'revoked', revokedAt: new Date() })
+        .where(eq(harvestTraceLinks.id, activatedTrace.id));
+    const preparedWithoutTrace = {
+        ...activatedPrepared,
+        createRunInput: {
+            ...activatedPrepared.createRunInput,
+            manifestItems: [
+                {
+                    deliveryRequestId: firstItem.deliveryRequestId,
+                    timeSlotId: firstItem.timeSlotId,
+                },
+                ...remainingItems,
+            ],
+        },
+    };
+    const activatedSaved =
+        await saveDeliveryRunPreparation(preparedWithoutTrace);
+    await storage()
+        .update(harvestTraceLinks)
+        .set({ status: 'active', revokedAt: null })
+        .where(eq(harvestTraceLinks.id, activatedTrace.id));
+    await assertPersistenceError(
+        consumeDeliveryRunPreparation({
+            preparationToken: activatedSaved.preparationToken,
+            driverUserId: activatedDriverUserId,
+            deliveryRequestIds: activatedPrepared.fixture.requestIds,
+        }),
+        DeliveryRunPersistenceErrorCodes.SOURCE_CHANGED,
+    );
+});
+
+test('pickup scan rejects trace provenance revoked after route creation', async () => {
+    const prepared = await createPreparedRunFixture();
+    const driverUserId = prepared.fixture.driverUserIds[0];
+    const [trace] = prepared.traceLinks;
+    assert.ok(driverUserId);
+    assert.ok(trace);
+    const saved = await saveDeliveryRunPreparation(prepared);
+    const run = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId,
+        deliveryRequestIds: prepared.fixture.requestIds,
+    });
+    const [pickup] = run.pickupNodes;
+    const [stop] = run.stops;
+    assert.ok(pickup);
+    assert.ok(stop);
+    await storage()
+        .update(harvestTraceLinks)
+        .set({ status: 'revoked', revokedAt: new Date() })
+        .where(eq(harvestTraceLinks.id, trace.id));
+
+    const [result] = await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: pickup.id,
+        mutations: [
+            {
+                clientOperationId: 'scan-revoked-trace',
+                occurredAt: new Date('2026-07-13T08:01:00.000Z'),
+                kind: 'scan',
+                traceToken: trace.publicToken,
+            },
+        ],
+    });
+    assert.equal(result?.result.outcome, 'not-found');
+    assert.equal(
+        (await getDeliveryRun(run.id))?.stops[0]?.pickupItemState,
+        DeliveryRunManifestItemStates.READY,
+    );
+});
+
 test('original selection can consume a preparation expanded with bulk siblings', async () => {
     const prepared = await createPreparedRunFixture({ bulk: true });
     const [driverUserId, selectedRequestId] = [
@@ -1138,6 +1444,521 @@ test('original selection can consume a preparation expanded with bulk siblings',
         [2, 2],
     );
     assert.equal(new Set(run.stops.map((stop) => stop.stopKey)).size, 1);
+});
+
+test('pickup mutations persist, replay safely, and activate a multi-location itinerary in order', async () => {
+    const prepared = await createPreparedRunFixture();
+    const driverUserId = prepared.fixture.driverUserIds[0];
+    const accountId = prepared.fixture.accountIds[0];
+    assert.ok(driverUserId);
+    assert.ok(accountId);
+    const saved = await saveDeliveryRunPreparation(prepared);
+    const run = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId,
+        deliveryRequestIds: prepared.fixture.requestIds,
+    });
+    const [firstPickup, secondPickup] = run.pickupNodes;
+    const [firstManifest, secondManifest] = run.runSlots;
+    const [firstStop, secondStop] = run.stops;
+    const [firstTrace, secondTrace] = prepared.traceLinks;
+    assert.ok(firstPickup);
+    assert.ok(secondPickup);
+    assert.ok(firstManifest);
+    assert.ok(secondManifest);
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+    assert.ok(firstTrace);
+    assert.ok(secondTrace);
+
+    assert.deepEqual(
+        (await getDeliveryRunExecutionProgress(run.id)).map((step) => ({
+            kind: step.kind,
+            sequence: step.itinerarySequence,
+            state: step.state,
+        })),
+        [
+            { kind: 'pickup', sequence: 1, state: 'current' },
+            { kind: 'delivery', sequence: 2, state: 'upcoming' },
+            { kind: 'pickup', sequence: 3, state: 'upcoming' },
+            { kind: 'delivery', sequence: 4, state: 'upcoming' },
+        ],
+    );
+    assert.equal(
+        await accountCanTrackDeliveryRun({ accountId, runId: run.id }),
+        false,
+    );
+    await assertExecutionError(
+        markDeliveryRunStopArrived({
+            driverUserId,
+            runId: run.id,
+            stopId: firstStop.id,
+        }),
+        DeliveryRunExecutionErrorCodes.PICKUP_DEPENDENCY_PENDING,
+    );
+
+    const scanOccurredAt = new Date('2026-07-13T08:01:00.000Z');
+    const [scanResult] = await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: firstPickup.id,
+        mutations: [
+            {
+                clientOperationId: 'scan-first-pickup',
+                occurredAt: scanOccurredAt,
+                kind: 'scan',
+                traceToken: `/trag/${firstTrace.publicToken}`,
+            },
+        ],
+    });
+    assert.equal(scanResult?.replayed, false);
+    assert.deepEqual(scanResult?.result.affectedStopIds, [firstStop.id]);
+    assert.equal(scanResult?.result.itemState, 'scanned');
+
+    const [replayResult] = await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: firstPickup.id,
+        mutations: [
+            {
+                clientOperationId: 'scan-first-pickup',
+                occurredAt: scanOccurredAt,
+                kind: 'scan',
+                traceToken: firstTrace.publicToken,
+            },
+        ],
+    });
+    assert.equal(replayResult?.replayed, true);
+    await assertExecutionError(
+        applyDeliveryRunPickupMutations({
+            driverUserId,
+            runId: run.id,
+            pickupNodeId: firstPickup.id,
+            mutations: [
+                {
+                    clientOperationId: 'scan-first-pickup',
+                    occurredAt: scanOccurredAt,
+                    kind: 'scan',
+                    traceToken: secondTrace.publicToken,
+                },
+            ],
+        }),
+        DeliveryRunExecutionErrorCodes.PICKUP_OPERATION_CONFLICT,
+    );
+
+    const [receipt] = await storage()
+        .select()
+        .from(deliveryRunPickupOperations)
+        .where(eq(deliveryRunPickupOperations.runId, run.id));
+    assert.ok(receipt);
+    assert.match(receipt.payloadHash, /^[a-f0-9]{64}$/);
+    assert.ok(!JSON.stringify(receipt).includes(firstTrace.publicToken));
+
+    await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: firstPickup.id,
+        mutations: [
+            {
+                clientOperationId: 'confirm-first-manifest',
+                occurredAt: new Date('2026-07-13T08:02:00.000Z'),
+                kind: 'confirm-manifest',
+                manifestId: firstManifest.manifestId,
+            },
+        ],
+    });
+    const [semanticConfirmationReplay] = await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: firstPickup.id,
+        mutations: [
+            {
+                clientOperationId: 'confirm-first-manifest-again',
+                occurredAt: new Date('2026-07-13T08:02:30.000Z'),
+                kind: 'confirm-manifest',
+                manifestId: firstManifest.manifestId,
+            },
+        ],
+    });
+    assert.equal(semanticConfirmationReplay?.replayed, false);
+    assert.equal(semanticConfirmationReplay?.result.outcome, 'already-applied');
+    assert.equal(
+        await accountCanTrackDeliveryRun({ accountId, runId: run.id }),
+        true,
+    );
+    await assertExecutionError(
+        applyDeliveryRunPickupMutations({
+            driverUserId,
+            runId: run.id,
+            pickupNodeId: secondPickup.id,
+            mutations: [
+                {
+                    clientOperationId: 'future-pickup-change',
+                    occurredAt: new Date('2026-07-13T08:03:00.000Z'),
+                    kind: 'mark-item',
+                    stopId: secondStop.id,
+                    outcome: 'not-ready',
+                },
+            ],
+        }),
+        DeliveryRunExecutionErrorCodes.PICKUP_NOT_CURRENT,
+    );
+
+    await markDeliveryRunStopArrived({
+        driverUserId,
+        runId: run.id,
+        stopId: firstStop.id,
+    });
+    await fulfillDeliveryRunStop({
+        driverUserId,
+        runId: run.id,
+        stopId: firstStop.id,
+    });
+    assert.equal(
+        (await getDeliveryRunExecutionProgress(run.id)).find(
+            (step) => step.state === 'current',
+        )?.kind,
+        'pickup',
+    );
+    await assertExecutionError(
+        applyDeliveryRunPickupMutations({
+            driverUserId,
+            runId: run.id,
+            pickupNodeId: secondPickup.id,
+            mutations: [
+                {
+                    clientOperationId: 'scan-first-pickup',
+                    occurredAt: scanOccurredAt,
+                    kind: 'scan',
+                    traceToken: firstTrace.publicToken,
+                },
+            ],
+        }),
+        DeliveryRunExecutionErrorCodes.PICKUP_OPERATION_CONFLICT,
+    );
+
+    await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: secondPickup.id,
+        mutations: [
+            {
+                clientOperationId: 'second-not-ready',
+                occurredAt: new Date('2026-07-13T10:00:00.000Z'),
+                kind: 'mark-item',
+                stopId: secondStop.id,
+                outcome: 'not-ready',
+            },
+        ],
+    });
+    await assertExecutionError(
+        applyDeliveryRunPickupMutations({
+            driverUserId,
+            runId: run.id,
+            pickupNodeId: secondPickup.id,
+            mutations: [
+                {
+                    clientOperationId: 'confirm-incomplete-second',
+                    occurredAt: new Date('2026-07-13T10:01:00.000Z'),
+                    kind: 'confirm-manifest',
+                    manifestId: secondManifest.manifestId,
+                },
+            ],
+        }),
+        DeliveryRunExecutionErrorCodes.PICKUP_MANIFEST_INCOMPLETE,
+    );
+    await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: secondPickup.id,
+        mutations: [
+            {
+                clientOperationId: 'second-missing-label',
+                occurredAt: new Date('2026-07-13T10:02:00.000Z'),
+                kind: 'mark-item',
+                stopId: secondStop.id,
+                outcome: 'missing-label',
+            },
+            {
+                clientOperationId: 'confirm-second-manifest',
+                occurredAt: new Date('2026-07-13T10:03:00.000Z'),
+                kind: 'confirm-manifest',
+                manifestId: secondManifest.manifestId,
+            },
+        ],
+    });
+    const current = (await getDeliveryRunExecutionProgress(run.id)).find(
+        (step) => step.state === 'current',
+    );
+    assert.equal(current?.kind, 'delivery');
+    assert.deepEqual(current?.kind === 'delivery' ? current.stopIds : [], [
+        secondStop.id,
+    ]);
+});
+
+test('bulk pickup scans and customer completion remain atomic', async () => {
+    const prepared = await createPreparedRunFixture({ bulk: true });
+    const driverUserId = prepared.fixture.driverUserIds[0];
+    assert.ok(driverUserId);
+    const saved = await saveDeliveryRunPreparation(prepared);
+    const run = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId,
+        deliveryRequestIds: prepared.fixture.requestIds,
+    });
+    const [pickup] = run.pickupNodes;
+    const [manifest] = run.runSlots;
+    const [firstStop, secondStop] = run.stops;
+    const [firstTrace, secondTrace] = prepared.traceLinks;
+    assert.ok(pickup);
+    assert.ok(manifest);
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+    assert.ok(firstTrace);
+    assert.ok(secondTrace);
+
+    const scans = await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: pickup.id,
+        mutations: [
+            {
+                clientOperationId: 'scan-first-bulk-label',
+                occurredAt: new Date('2026-07-13T08:01:00.000Z'),
+                kind: 'scan',
+                traceToken: firstTrace.publicToken,
+            },
+            {
+                clientOperationId: 'scan-second-bulk-label',
+                occurredAt: new Date('2026-07-13T08:01:05.000Z'),
+                kind: 'scan',
+                traceToken: secondTrace.publicToken,
+            },
+        ],
+    });
+    assert.deepEqual(
+        scans.map((scan) => scan.result.affectedStopIds),
+        [[firstStop.id], [secondStop.id]],
+    );
+    await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: pickup.id,
+        mutations: [
+            {
+                clientOperationId: 'confirm-bulk-manifest',
+                occurredAt: new Date('2026-07-13T08:02:00.000Z'),
+                kind: 'confirm-manifest',
+                manifestId: manifest.manifestId,
+            },
+        ],
+    });
+    await assertExecutionError(
+        fulfillDeliveryRunStop({
+            driverUserId,
+            runId: run.id,
+            stopId: firstStop.id,
+        }),
+        DeliveryRunExecutionErrorCodes.ROUTE_ORDER,
+    );
+    await fulfillDeliveryRunStops({
+        driverUserId,
+        runId: run.id,
+        stopIds: [firstStop.id, secondStop.id],
+    });
+    assert.equal((await getDeliveryRun(run.id))?.state, 'completed');
+});
+
+test('a valid pickup scan promotes missing-label state and persists a matching receipt', async () => {
+    const prepared = await createPreparedRunFixture();
+    const driverUserId = prepared.fixture.driverUserIds[0];
+    const [trace] = prepared.traceLinks;
+    assert.ok(driverUserId);
+    assert.ok(trace);
+    const saved = await saveDeliveryRunPreparation(prepared);
+    const run = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId,
+        deliveryRequestIds: prepared.fixture.requestIds,
+    });
+    const [pickup] = run.pickupNodes;
+    const [stop] = run.stops;
+    assert.ok(pickup);
+    assert.ok(stop);
+
+    await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: pickup.id,
+        mutations: [
+            {
+                clientOperationId: 'mark-missing-before-scan',
+                occurredAt: new Date('2026-07-13T08:00:00.000Z'),
+                kind: 'mark-item',
+                stopId: stop.id,
+                outcome: 'missing-label',
+            },
+        ],
+    });
+    assert.equal(
+        (await getDeliveryRun(run.id))?.stops[0]?.pickupItemState,
+        DeliveryRunManifestItemStates.MISSING_LABEL,
+    );
+
+    const [scanResult] = await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: pickup.id,
+        mutations: [
+            {
+                clientOperationId: 'scan-after-missing-label',
+                occurredAt: new Date('2026-07-13T08:01:00.000Z'),
+                kind: 'scan',
+                traceToken: trace.publicToken,
+            },
+        ],
+    });
+    assert.equal(scanResult?.result.outcome, 'applied');
+    assert.equal(
+        scanResult?.result.itemState,
+        DeliveryRunManifestItemStates.SCANNED,
+    );
+    assert.equal(
+        (await getDeliveryRun(run.id))?.stops[0]?.pickupItemState,
+        DeliveryRunManifestItemStates.SCANNED,
+    );
+
+    const receipts = await storage()
+        .select()
+        .from(deliveryRunPickupOperations)
+        .where(eq(deliveryRunPickupOperations.runId, run.id));
+    const scanReceipt = receipts.find(
+        (receipt) => receipt.clientOperationId === 'scan-after-missing-label',
+    );
+    assert.equal(
+        scanReceipt?.result.itemState,
+        DeliveryRunManifestItemStates.SCANNED,
+    );
+});
+
+test('partial manifests remain pending until every item is scanned or marked missing-label', async () => {
+    const prepared = await createPreparedRunFixture({ bulk: true });
+    const [firstTrace] = prepared.traceLinks;
+    assert.ok(firstTrace);
+    const driverUserId = prepared.fixture.driverUserIds[0];
+    assert.ok(driverUserId);
+    const saved = await saveDeliveryRunPreparation(prepared);
+    const run = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId,
+        deliveryRequestIds: prepared.fixture.requestIds,
+    });
+    const [pickup] = run.pickupNodes;
+    const [manifest] = run.runSlots;
+    const [firstStop, secondStop] = run.stops;
+    assert.ok(pickup);
+    assert.ok(manifest);
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+
+    await assertExecutionError(
+        applyDeliveryRunPickupMutations({
+            driverUserId,
+            runId: run.id,
+            pickupNodeId: pickup.id,
+            mutations: [
+                {
+                    clientOperationId: 'rolled-back-manual-item',
+                    occurredAt: new Date('2026-07-13T08:00:00.000Z'),
+                    kind: 'mark-item',
+                    stopId: firstStop.id,
+                    outcome: 'missing-label',
+                },
+                {
+                    clientOperationId: 'rolled-back-confirm',
+                    occurredAt: new Date('2026-07-13T08:00:30.000Z'),
+                    kind: 'confirm-manifest',
+                    manifestId: manifest.manifestId,
+                },
+            ],
+        }),
+        DeliveryRunExecutionErrorCodes.PICKUP_MANIFEST_INCOMPLETE,
+    );
+    const afterRollback = await getDeliveryRun(run.id);
+    assert.ok(
+        afterRollback?.stops.every(
+            (stop) =>
+                stop.pickupItemState === DeliveryRunManifestItemStates.READY,
+        ),
+    );
+    assert.equal(
+        (
+            await storage()
+                .select()
+                .from(deliveryRunPickupOperations)
+                .where(eq(deliveryRunPickupOperations.runId, run.id))
+        ).length,
+        0,
+    );
+
+    await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: pickup.id,
+        mutations: [
+            {
+                clientOperationId: 'scan-one-of-two',
+                occurredAt: new Date('2026-07-13T08:01:00.000Z'),
+                kind: 'scan',
+                traceToken: firstTrace.publicToken,
+            },
+        ],
+    });
+    await assertExecutionError(
+        applyDeliveryRunPickupMutations({
+            driverUserId,
+            runId: run.id,
+            pickupNodeId: pickup.id,
+            mutations: [
+                {
+                    clientOperationId: 'confirm-partial',
+                    occurredAt: new Date('2026-07-13T08:02:00.000Z'),
+                    kind: 'confirm-manifest',
+                    manifestId: manifest.manifestId,
+                },
+            ],
+        }),
+        DeliveryRunExecutionErrorCodes.PICKUP_MANIFEST_INCOMPLETE,
+    );
+    assert.equal(
+        (await getDeliveryRun(run.id))?.runSlots[0]?.manifestState,
+        DeliveryRunManifestStates.PENDING,
+    );
+
+    await applyDeliveryRunPickupMutations({
+        driverUserId,
+        runId: run.id,
+        pickupNodeId: pickup.id,
+        mutations: [
+            {
+                clientOperationId: 'manual-missing-label',
+                occurredAt: new Date('2026-07-13T08:03:00.000Z'),
+                kind: 'mark-item',
+                stopId: secondStop.id,
+                outcome: 'missing-label',
+            },
+            {
+                clientOperationId: 'confirm-complete',
+                occurredAt: new Date('2026-07-13T08:04:00.000Z'),
+                kind: 'confirm-manifest',
+                manifestId: manifest.manifestId,
+            },
+        ],
+    });
+    assert.equal(
+        (await getDeliveryRun(run.id))?.runSlots[0]?.manifestState,
+        DeliveryRunManifestStates.CONFIRMED,
+    );
 });
 
 test('tampered pickup-node and run-slot snapshots are rejected', async () => {
@@ -1290,7 +2111,7 @@ test('v2 itinerary gaps, dependency violations, bulk splits, and invalid provena
     );
 });
 
-test('persisted v2 itinerary tampering is rejected before run creation', async () => {
+test('persisted v3 itinerary tampering is rejected before run creation', async () => {
     const prepared = await createPreparedRunFixture();
     const driverUserId = prepared.fixture.driverUserIds[0];
     assert.ok(driverUserId);
@@ -1300,9 +2121,9 @@ test('persisted v2 itinerary tampering is rejected before run creation', async (
             where: eq(deliveryRunPreparations.id, saved.preparationId),
         },
     );
-    assert.equal(preparation?.plan.formatVersion, 2);
-    if (preparation?.plan.formatVersion !== 2) {
-        assert.fail('Expected a v2 delivery run preparation');
+    assert.equal(preparation?.plan.formatVersion, 3);
+    if (preparation?.plan.formatVersion !== 3) {
+        assert.fail('Expected a v3 delivery run preparation');
     }
     const [firstStop, ...remainingStops] =
         preparation.plan.createRunInput.stops;
@@ -1349,12 +2170,16 @@ test('existing v1 preparation tokens remain consumable as legacy routes', async 
             where: eq(deliveryRunPreparations.id, saved.preparationId),
         },
     );
-    if (preparation?.plan.formatVersion !== 2) {
-        assert.fail('Expected a v2 delivery run preparation');
+    if (preparation?.plan.formatVersion !== 3) {
+        assert.fail('Expected a v3 delivery run preparation');
     }
     await storage()
         .update(deliveryRunPreparations)
-        .set({ plan: asLegacyPreparationPlan(preparation.plan) })
+        .set({
+            plan: asLegacyPreparationPlan(
+                asV2PreparationPlan(preparation.plan),
+            ),
+        })
         .where(eq(deliveryRunPreparations.id, saved.preparationId));
 
     const run = await consumeDeliveryRunPreparation({
@@ -1381,6 +2206,50 @@ test('existing v1 preparation tokens remain consumable as legacy routes', async 
                 stop.serviceDurationSeconds === null,
         ),
     );
+});
+
+test('existing v2 preparation tokens remain consumable with confirmed pickup dependencies', async () => {
+    const prepared = await createPreparedRunFixture();
+    const driverUserId = prepared.fixture.driverUserIds[0];
+    assert.ok(driverUserId);
+    const saved = await saveDeliveryRunPreparation(prepared);
+    const preparation = await storage().query.deliveryRunPreparations.findFirst(
+        {
+            where: eq(deliveryRunPreparations.id, saved.preparationId),
+        },
+    );
+    if (preparation?.plan.formatVersion !== 3) {
+        assert.fail('Expected a v3 delivery run preparation');
+    }
+    await storage()
+        .update(deliveryRunPreparations)
+        .set({ plan: asV2PreparationPlan(preparation.plan) })
+        .where(eq(deliveryRunPreparations.id, saved.preparationId));
+
+    const run = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId,
+        deliveryRequestIds: prepared.fixture.requestIds,
+    });
+    assert.equal(run.routePlanVersion, 2);
+    assert.ok(
+        run.runSlots.every(
+            (slot) =>
+                slot.manifestState === DeliveryRunManifestStates.CONFIRMED,
+        ),
+    );
+    assert.ok(run.stops.every((stop) => stop.pickupItemState === null));
+    const current = (await getDeliveryRunExecutionProgress(run.id)).find(
+        (step) => step.state === 'current',
+    );
+    assert.equal(current?.kind, 'delivery');
+    const firstStop = run.stops[0];
+    assert.ok(firstStop);
+    await markDeliveryRunStopArrived({
+        driverUserId,
+        runId: run.id,
+        stopId: firstStop.id,
+    });
 });
 
 test('preparation rejects wrong owner or selection and expires without creating a run', async () => {


### PR DESCRIPTION
Closes #4124

## Summary

- persist pickup manifests for every collection location and interleave collection nodes with customer delivery stops
- support rapid QR scanning, explicit missing-label handling, bulk confirmation, and durable offline replay
- keep customer stops gated until required pickup manifests are confirmed, including multi-location and bulk-address routes
- harden idempotency, trace provenance, cross-tab queue coordination, concurrent arrival/delivery transitions, and legacy bulk tracking authorization
- expose only customer-safe progress and tracking data

## Validation

- pnpm --filter delivery typecheck
- pnpm --filter delivery test (116/116)
- pnpm --filter delivery build
- pnpm --filter @gredice/storage test (495/495)
- focused deliveryRunsRepo storage spec (31/31)
- delivery and storage lint checks
- git diff --check
- pnpm --filter @gredice/storage db-generate produced no additional schema changes