### PR TITLE
fix(www): stabilize navbar spacing test

### DIFF
--- a/apps/www/tests/landing.spec.ts
+++ b/apps/www/tests/landing.spec.ts
@@ -232,6 +232,8 @@ test('navbar floats on scroll and landing game frame is rounded', async ({
 test('desktop floating navbar keeps its width and balanced CTA spacing', async ({
     page,
 }) => {
+    test.slow();
+
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto('/');
 
@@ -240,21 +242,24 @@ test('desktop floating navbar keeps its width and balanced CTA spacing', async (
     const gardenCtaIcon = gardenCta.locator('svg:visible').last();
 
     await expect
-        .poll(async () => {
-            const [buttonBox, iconBox] = await Promise.all([
-                gardenCta.boundingBox(),
-                gardenCtaIcon.boundingBox(),
-            ]);
-            if (!buttonBox || !iconBox) {
-                return Number.POSITIVE_INFINITY;
-            }
+        .poll(
+            async () => {
+                const [buttonBox, iconBox] = await Promise.all([
+                    gardenCta.boundingBox(),
+                    gardenCtaIcon.boundingBox(),
+                ]);
+                if (!buttonBox || !iconBox) {
+                    return Number.POSITIVE_INFINITY;
+                }
 
-            const trailingSpace =
-                buttonBox.x + buttonBox.width - (iconBox.x + iconBox.width);
-            const verticalSpace = (buttonBox.height - iconBox.height) / 2;
+                const trailingSpace =
+                    buttonBox.x + buttonBox.width - (iconBox.x + iconBox.width);
+                const verticalSpace = (buttonBox.height - iconBox.height) / 2;
 
-            return Math.abs(trailingSpace - verticalSpace);
-        })
+                return Math.abs(trailingSpace - verticalSpace);
+            },
+            { timeout: 15_000 },
+        )
         .toBeLessThanOrEqual(0.5);
 
     await page.evaluate(() => window.scrollTo(0, 160));


### PR DESCRIPTION
## Summary

- mark the desktop navbar spacing test as slow so its overall budget reflects CI load
- give the layout-stabilization poll an explicit 15-second timeout
- keep product behavior and the assertion itself unchanged

## Root cause

CI runs [29407565454](https://github.com/gredice/gredice/actions/runs/29407565454) and [29408208498](https://github.com/gredice/gredice/actions/runs/29408208498) both show the same unrelated timing race. The test exhausted its default 5-second poll and then collided with the 10-second test timeout under the loaded `www` shard; one run passed on retry while the next exhausted all retries.

## Validation

- `pnpm --filter www exec biome check tests/landing.spec.ts`
- focused Chromium test repeated 10 times with 4 CI workers: 10/10 passed
- `pnpm build --filter www`
- `git diff --check`
