### PR TITLE
feat(delivery): continue routes after exceptions

### DIFF
--- a/apps/api/app/api/[...route]/deliveryRoutes.ts
+++ b/apps/api/app/api/[...route]/deliveryRoutes.ts
@@ -1,6 +1,8 @@
 import {
     createDeliveryAddress,
     createDeliveryRequest,
+    DeliveryAddressMutationError,
+    DeliveryRunAssignmentError,
     deleteDeliveryAddress,
     getDeliveryAddress,
     getDeliveryAddresses,
@@ -169,7 +171,29 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 ...data,
             };
 
-            await updateDeliveryAddress(updateData, accountId);
+            try {
+                await updateDeliveryAddress(updateData, accountId);
+            } catch (error) {
+                if (error instanceof DeliveryAddressMutationError) {
+                    return context.json(
+                        {
+                            error: 'Adresa nije pronađena.',
+                            code: error.code,
+                        },
+                        404,
+                    );
+                }
+                if (error instanceof DeliveryRunAssignmentError) {
+                    return context.json(
+                        {
+                            error: 'Adresa je dio aktivne dostavne rute. Najprije dovrši ili napusti rutu.',
+                            code: error.code,
+                        },
+                        409,
+                    );
+                }
+                throw error;
+            }
             const updatedAddress = await getDeliveryAddress(id, accountId);
             return context.json(updatedAddress);
         },
@@ -188,7 +212,29 @@ const app = new Hono<{ Variables: AuthVariables }>()
             const { accountId } = context.get('authContext');
             const { id } = context.req.valid('param');
 
-            await deleteDeliveryAddress(id, accountId);
+            try {
+                await deleteDeliveryAddress(id, accountId);
+            } catch (error) {
+                if (error instanceof DeliveryAddressMutationError) {
+                    return context.json(
+                        {
+                            error: 'Adresa nije pronađena.',
+                            code: error.code,
+                        },
+                        404,
+                    );
+                }
+                if (error instanceof DeliveryRunAssignmentError) {
+                    return context.json(
+                        {
+                            error: 'Adresa je dio aktivne dostavne rute. Najprije dovrši ili napusti rutu.',
+                            code: error.code,
+                        },
+                        409,
+                    );
+                }
+                throw error;
+            }
             return context.json({ success: true });
         },
     )
@@ -327,7 +373,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
         zValidator('param', z.object({ id: z.string().uuid() })),
         zValidator('json', cancelRequestSchema),
         async (context) => {
-            const { accountId } = context.get('authContext');
+            const { accountId, userId } = context.get('authContext');
             const { id } = context.req.valid('param');
             const { cancelReason, note } = context.req.valid('json');
 
@@ -337,6 +383,7 @@ const app = new Hono<{ Variables: AuthVariables }>()
                 await cancelDeliveryRequestForCurrentAccount({
                     requestId: id,
                     accountId,
+                    actorUserId: userId,
                     cancelReason,
                     note,
                 });

--- a/apps/api/lib/delivery/cancelDeliveryRequestForAccount.ts
+++ b/apps/api/lib/delivery/cancelDeliveryRequestForAccount.ts
@@ -42,6 +42,7 @@ export async function cancelDeliveryRequestForCurrentAccount(
     input: {
         requestId: string;
         accountId: string;
+        actorUserId?: string;
         cancelReason: string;
         note?: string;
     },

--- a/apps/app/app/admin/delivery/requests/actions.ts
+++ b/apps/app/app/admin/delivery/requests/actions.ts
@@ -7,6 +7,7 @@ import {
     confirmDeliveryRequest,
     createNotification,
     DeliveryRequestStates,
+    DeliveryRunAssignmentError,
     fulfillDeliveryRequest,
     getDeliveryRequest,
     prepareDeliveryRequest,
@@ -23,11 +24,13 @@ async function applyDeliveryRequestStatus({
     status,
     cancelReason,
     notes,
+    actorUserId,
 }: {
     requestId: string;
     status: string;
     cancelReason?: string;
     notes?: string;
+    actorUserId: string;
 }) {
     const request = await getDeliveryRequest(requestId);
 
@@ -54,6 +57,7 @@ async function applyDeliveryRequestStatus({
             'admin',
             cancelReason ?? '',
             notes,
+            actorUserId,
         );
         await notifyDeliveryRequestEvent(requestId, 'cancelled', {
             reason: cancelReason,
@@ -89,7 +93,7 @@ export async function updateDeliveryRequestStatusAction(
     formData: FormData,
 ) {
     try {
-        await auth(['admin']);
+        const { userId } = await auth(['admin']);
 
         const requestIdValue = formData.get('requestId');
         const statusValue = formData.get('status');
@@ -119,6 +123,7 @@ export async function updateDeliveryRequestStatusAction(
             status,
             cancelReason,
             notes,
+            actorUserId: userId,
         });
 
         revalidatePath('/admin/delivery/requests');
@@ -141,7 +146,7 @@ export async function progressDeliveryRequestGroupStatusAction(
     formData: FormData,
 ) {
     try {
-        await auth(['admin']);
+        const { userId } = await auth(['admin']);
 
         const requestIds = formData
             .getAll('requestIds')
@@ -173,6 +178,7 @@ export async function progressDeliveryRequestGroupStatusAction(
             await applyDeliveryRequestStatus({
                 requestId,
                 status: nextStatus,
+                actorUserId: userId,
             });
             updatedCount += 1;
         }
@@ -245,6 +251,14 @@ export async function changeDeliveryRequestSlotAction(
         };
     } catch (error) {
         console.error('Error changing delivery request slot:', error);
+        if (error instanceof DeliveryRunAssignmentError) {
+            return {
+                success: false,
+                code: error.code,
+                message:
+                    'Termin je dio aktivne dostavne rute. Najprije napusti rutu ili oporavi dostavu.',
+            };
+        }
         return {
             success: false,
             message: 'Greška pri promjeni termina dostave',

--- a/apps/delivery/app/api/admin/runs/[runId]/abandon/route.ts
+++ b/apps/delivery/app/api/admin/runs/[runId]/abandon/route.ts
@@ -1,0 +1,65 @@
+import { withAuth } from '../../../../../../lib/auth/auth';
+import { abandonAdminDeliveryRun } from '../../../../../../lib/deliveryDashboard';
+import {
+    DeliveryMutationRequestError,
+    expectedRouteRevision,
+} from '../../../../../../lib/deliveryMutationRequest';
+import { deliveryRunExecutionErrorDetails } from '../../../../../../lib/deliveryRunExecutionError';
+
+const privateNoStore = { 'Cache-Control': 'private, no-store' };
+
+export async function POST(
+    request: Request,
+    { params }: { params: Promise<{ runId: string }> },
+) {
+    return await withAuth(['admin'], async ({ userId }) => {
+        const { runId } = await params;
+        const body: unknown = await request.json().catch(() => null);
+        let routeRevision: number;
+        try {
+            routeRevision = expectedRouteRevision(body);
+        } catch (error) {
+            return Response.json(
+                {
+                    error:
+                        error instanceof DeliveryMutationRequestError
+                            ? error.message
+                            : 'Neispravna promjena dostave.',
+                    code: 'invalid-delivery-mutation',
+                },
+                { status: 400, headers: privateNoStore },
+            );
+        }
+        const reason =
+            typeof body === 'object' &&
+            body !== null &&
+            'reason' in body &&
+            typeof body.reason === 'string' &&
+            body.reason.trim()
+                ? body.reason.trim().slice(0, 1_000)
+                : undefined;
+        try {
+            const result = await abandonAdminDeliveryRun({
+                adminUserId: userId,
+                runId,
+                expectedRouteRevision: routeRevision,
+                reason,
+            });
+            return Response.json(result, { headers: privateNoStore });
+        } catch (error) {
+            const executionError = deliveryRunExecutionErrorDetails(error);
+            return Response.json(
+                {
+                    error:
+                        executionError?.message ??
+                        'Rutu trenutačno nije moguće napustiti.',
+                    code: executionError?.code ?? 'delivery-mutation-failed',
+                },
+                {
+                    status: executionError ? 409 : 500,
+                    headers: privateNoStore,
+                },
+            );
+        }
+    });
+}

--- a/apps/delivery/app/api/admin/runs/[runId]/reassign/route.ts
+++ b/apps/delivery/app/api/admin/runs/[runId]/reassign/route.ts
@@ -1,0 +1,70 @@
+import { withAuth } from '../../../../../../lib/auth/auth';
+import { reassignAdminDeliveryRun } from '../../../../../../lib/deliveryDashboard';
+import {
+    DeliveryMutationRequestError,
+    expectedRouteRevision,
+} from '../../../../../../lib/deliveryMutationRequest';
+import { deliveryRunExecutionErrorDetails } from '../../../../../../lib/deliveryRunExecutionError';
+
+const privateNoStore = { 'Cache-Control': 'private, no-store' };
+
+export async function POST(
+    request: Request,
+    { params }: { params: Promise<{ runId: string }> },
+) {
+    return await withAuth(['admin'], async ({ userId }) => {
+        const { runId } = await params;
+        const body: unknown = await request.json().catch(() => null);
+        let routeRevision: number;
+        let newDriverUserId: string;
+        try {
+            routeRevision = expectedRouteRevision(body);
+            if (
+                typeof body !== 'object' ||
+                body === null ||
+                !('newDriverUserId' in body) ||
+                typeof body.newDriverUserId !== 'string' ||
+                !body.newDriverUserId.trim()
+            ) {
+                throw new DeliveryMutationRequestError(
+                    'Novi dostavljač nije valjan.',
+                );
+            }
+            newDriverUserId = body.newDriverUserId.trim();
+        } catch (error) {
+            return Response.json(
+                {
+                    error:
+                        error instanceof DeliveryMutationRequestError
+                            ? error.message
+                            : 'Neispravna promjena dostave.',
+                    code: 'invalid-delivery-mutation',
+                },
+                { status: 400, headers: privateNoStore },
+            );
+        }
+        try {
+            const result = await reassignAdminDeliveryRun({
+                adminUserId: userId,
+                runId,
+                newDriverUserId,
+                expectedRouteRevision: routeRevision,
+            });
+            return Response.json(result, { headers: privateNoStore });
+        } catch (error) {
+            const executionError = deliveryRunExecutionErrorDetails(error);
+            return Response.json(
+                {
+                    error:
+                        executionError?.message ??
+                        'Rutu trenutačno nije moguće preraspodijeliti.',
+                    code: executionError?.code ?? 'delivery-mutation-failed',
+                },
+                {
+                    status: executionError ? 409 : 500,
+                    headers: privateNoStore,
+                },
+            );
+        }
+    });
+}

--- a/apps/delivery/app/api/admin/runs/[runId]/stops/[stopId]/recover/route.ts
+++ b/apps/delivery/app/api/admin/runs/[runId]/stops/[stopId]/recover/route.ts
@@ -1,5 +1,5 @@
 import { withAuth } from '../../../../../../../../lib/auth/auth';
-import { deliverDeliveryStop } from '../../../../../../../../lib/deliveryDashboard';
+import { recoverAdminDeliveryStop } from '../../../../../../../../lib/deliveryDashboard';
 import {
     DeliveryMutationRequestError,
     expectedRouteRevision,
@@ -12,18 +12,17 @@ export async function POST(
     request: Request,
     { params }: { params: Promise<{ runId: string; stopId: string }> },
 ) {
-    return await withAuth(['driver', 'admin'], async ({ userId }) => {
+    return await withAuth(['admin'], async ({ userId }) => {
         const { runId, stopId: stopIdValue } = await params;
         const stopId = Number(stopIdValue);
-        if (!Number.isInteger(stopId)) {
-            return Response.json(
-                { error: 'Neispravna stanica.' },
-                { status: 400, headers: privateNoStore },
-            );
-        }
         const body: unknown = await request.json().catch(() => null);
         let routeRevision: number;
         try {
+            if (!Number.isInteger(stopId) || stopId <= 0) {
+                throw new DeliveryMutationRequestError(
+                    'Stanica dostave nije valjana.',
+                );
+            }
             routeRevision = expectedRouteRevision(body);
         } catch (error) {
             return Response.json(
@@ -37,49 +36,27 @@ export async function POST(
                 { status: 400, headers: privateNoStore },
             );
         }
-        const notes =
-            typeof body === 'object' &&
-            body !== null &&
-            'notes' in body &&
-            typeof body.notes === 'string' &&
-            body.notes.trim()
-                ? body.notes.trim().slice(0, 1_000)
-                : undefined;
         try {
-            const result = await deliverDeliveryStop({
-                driverUserId: userId,
+            const result = await recoverAdminDeliveryStop({
+                adminUserId: userId,
                 runId,
                 stopId,
-                notes,
                 expectedRouteRevision: routeRevision,
             });
-            return Response.json(
-                { success: true, ...result },
-                { headers: privateNoStore },
-            );
+            return Response.json(result, { headers: privateNoStore });
         } catch (error) {
             const executionError = deliveryRunExecutionErrorDetails(error);
-            const logContext = { runId, stopId, userId };
-            if (executionError) {
-                console.warn('Delivery stop completion rejected', {
-                    ...logContext,
-                    code: executionError.code,
-                });
-            } else {
-                console.error('Failed to deliver stop', {
-                    ...logContext,
-                    errorType:
-                        error instanceof Error ? error.name : typeof error,
-                });
-            }
             return Response.json(
                 {
                     error:
                         executionError?.message ??
-                        'Dostavu trenutačno nije moguće potvrditi.',
-                    code: executionError?.code,
+                        'Dostavu trenutačno nije moguće oporaviti.',
+                    code: executionError?.code ?? 'delivery-mutation-failed',
                 },
-                { status: 409, headers: privateNoStore },
+                {
+                    status: executionError ? 409 : 500,
+                    headers: privateNoStore,
+                },
             );
         }
     });

--- a/apps/delivery/app/api/driver/runs/[runId]/exceptions/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/exceptions/route.ts
@@ -1,0 +1,64 @@
+import { withAuth } from '../../../../../../lib/auth/auth';
+import { recordDriverDeliveryExceptions } from '../../../../../../lib/deliveryDashboard';
+import {
+    DeliveryMutationRequestError,
+    parseDeliveryExceptionMutation,
+} from '../../../../../../lib/deliveryMutationRequest';
+import { deliveryRunExecutionErrorDetails } from '../../../../../../lib/deliveryRunExecutionError';
+
+const privateNoStore = { 'Cache-Control': 'private, no-store' };
+
+export async function POST(
+    request: Request,
+    { params }: { params: Promise<{ runId: string }> },
+) {
+    return await withAuth(['driver', 'admin'], async ({ userId }) => {
+        const { runId } = await params;
+        const body: unknown = await request.json().catch(() => null);
+        let mutation: ReturnType<typeof parseDeliveryExceptionMutation>;
+        try {
+            mutation = parseDeliveryExceptionMutation(body);
+        } catch (error) {
+            return Response.json(
+                {
+                    error:
+                        error instanceof DeliveryMutationRequestError
+                            ? error.message
+                            : 'Neispravna promjena dostave.',
+                    code: 'invalid-delivery-mutation',
+                },
+                { status: 400, headers: privateNoStore },
+            );
+        }
+        try {
+            const result = await recordDriverDeliveryExceptions({
+                driverUserId: userId,
+                runId,
+                ...mutation,
+            });
+            return Response.json(result, { headers: privateNoStore });
+        } catch (error) {
+            const executionError = deliveryRunExecutionErrorDetails(error);
+            if (!executionError) {
+                console.error('Failed to record delivery exceptions', {
+                    runId,
+                    userId,
+                    errorType:
+                        error instanceof Error ? error.name : typeof error,
+                });
+            }
+            return Response.json(
+                {
+                    error:
+                        executionError?.message ??
+                        'Ishod dostave trenutačno nije moguće spremiti.',
+                    code: executionError?.code ?? 'delivery-mutation-failed',
+                },
+                {
+                    status: executionError ? 409 : 500,
+                    headers: privateNoStore,
+                },
+            );
+        }
+    });
+}

--- a/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/arrive/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/arrive/route.ts
@@ -1,9 +1,15 @@
 import { withAuth } from '../../../../../../../../lib/auth/auth';
 import { arriveAtDeliveryStop } from '../../../../../../../../lib/deliveryDashboard';
+import {
+    DeliveryMutationRequestError,
+    expectedRouteRevision,
+} from '../../../../../../../../lib/deliveryMutationRequest';
 import { deliveryRunExecutionErrorDetails } from '../../../../../../../../lib/deliveryRunExecutionError';
 
+const privateNoStore = { 'Cache-Control': 'private, no-store' };
+
 export async function POST(
-    _request: Request,
+    request: Request,
     { params }: { params: Promise<{ runId: string; stopId: string }> },
 ) {
     return await withAuth(['driver', 'admin'], async ({ userId }) => {
@@ -12,16 +18,36 @@ export async function POST(
         if (!Number.isInteger(stopId)) {
             return Response.json(
                 { error: 'Neispravna stanica.' },
-                { status: 400 },
+                { status: 400, headers: privateNoStore },
+            );
+        }
+        const body: unknown = await request.json().catch(() => null);
+        let routeRevision: number;
+        try {
+            routeRevision = expectedRouteRevision(body);
+        } catch (error) {
+            return Response.json(
+                {
+                    error:
+                        error instanceof DeliveryMutationRequestError
+                            ? error.message
+                            : 'Neispravna promjena dostave.',
+                    code: 'invalid-delivery-mutation',
+                },
+                { status: 400, headers: privateNoStore },
             );
         }
         try {
-            await arriveAtDeliveryStop({
+            const result = await arriveAtDeliveryStop({
                 driverUserId: userId,
                 runId,
                 stopId,
+                expectedRouteRevision: routeRevision,
             });
-            return Response.json({ success: true });
+            return Response.json(
+                { success: true, ...result },
+                { headers: privateNoStore },
+            );
         } catch (error) {
             const executionError = deliveryRunExecutionErrorDetails(error);
             const logContext = { runId, stopId, userId };
@@ -33,7 +59,8 @@ export async function POST(
             } else {
                 console.error('Failed to mark delivery stop arrived', {
                     ...logContext,
-                    error,
+                    errorType:
+                        error instanceof Error ? error.name : typeof error,
                 });
             }
             return Response.json(
@@ -43,7 +70,7 @@ export async function POST(
                         'Dolazak trenutačno nije moguće potvrditi.',
                     code: executionError?.code,
                 },
-                { status: 409 },
+                { status: 409, headers: privateNoStore },
             );
         }
     });

--- a/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/retry/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/stops/[stopId]/retry/route.ts
@@ -1,5 +1,5 @@
 import { withAuth } from '../../../../../../../../lib/auth/auth';
-import { deliverDeliveryStop } from '../../../../../../../../lib/deliveryDashboard';
+import { retryDriverDeliveryStop } from '../../../../../../../../lib/deliveryDashboard';
 import {
     DeliveryMutationRequestError,
     expectedRouteRevision,
@@ -15,15 +15,14 @@ export async function POST(
     return await withAuth(['driver', 'admin'], async ({ userId }) => {
         const { runId, stopId: stopIdValue } = await params;
         const stopId = Number(stopIdValue);
-        if (!Number.isInteger(stopId)) {
-            return Response.json(
-                { error: 'Neispravna stanica.' },
-                { status: 400, headers: privateNoStore },
-            );
-        }
         const body: unknown = await request.json().catch(() => null);
         let routeRevision: number;
         try {
+            if (!Number.isInteger(stopId) || stopId <= 0) {
+                throw new DeliveryMutationRequestError(
+                    'Stanica dostave nije valjana.',
+                );
+            }
             routeRevision = expectedRouteRevision(body);
         } catch (error) {
             return Response.json(
@@ -37,49 +36,27 @@ export async function POST(
                 { status: 400, headers: privateNoStore },
             );
         }
-        const notes =
-            typeof body === 'object' &&
-            body !== null &&
-            'notes' in body &&
-            typeof body.notes === 'string' &&
-            body.notes.trim()
-                ? body.notes.trim().slice(0, 1_000)
-                : undefined;
         try {
-            const result = await deliverDeliveryStop({
+            const result = await retryDriverDeliveryStop({
                 driverUserId: userId,
                 runId,
                 stopId,
-                notes,
                 expectedRouteRevision: routeRevision,
             });
-            return Response.json(
-                { success: true, ...result },
-                { headers: privateNoStore },
-            );
+            return Response.json(result, { headers: privateNoStore });
         } catch (error) {
             const executionError = deliveryRunExecutionErrorDetails(error);
-            const logContext = { runId, stopId, userId };
-            if (executionError) {
-                console.warn('Delivery stop completion rejected', {
-                    ...logContext,
-                    code: executionError.code,
-                });
-            } else {
-                console.error('Failed to deliver stop', {
-                    ...logContext,
-                    errorType:
-                        error instanceof Error ? error.name : typeof error,
-                });
-            }
             return Response.json(
                 {
                     error:
                         executionError?.message ??
-                        'Dostavu trenutačno nije moguće potvrditi.',
-                    code: executionError?.code,
+                        'Ponovni pokušaj trenutačno nije moguće pokrenuti.',
+                    code: executionError?.code ?? 'delivery-mutation-failed',
                 },
-                { status: 409, headers: privateNoStore },
+                {
+                    status: executionError ? 409 : 500,
+                    headers: privateNoStore,
+                },
             );
         }
     });

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -84,6 +84,12 @@ function isSafeActiveRun(value: unknown) {
     return (
         'stops' in value &&
         Array.isArray(value.stops) &&
+        'routeRevision' in value &&
+        typeof value.routeRevision === 'number' &&
+        Number.isInteger(value.routeRevision) &&
+        value.routeRevision >= 0 &&
+        'reroutePending' in value &&
+        typeof value.reroutePending === 'boolean' &&
         'routeSteps' in value &&
         Array.isArray(value.routeSteps) &&
         value.routeSteps.every((step) => {
@@ -105,6 +111,15 @@ function isSafeActiveRun(value: unknown) {
             }
             return (
                 step.kind === 'delivery' &&
+                'retryLaneRank' in step &&
+                (step.retryLaneRank === null ||
+                    (typeof step.retryLaneRank === 'number' &&
+                        Number.isInteger(step.retryLaneRank) &&
+                        step.retryLaneRank > 0)) &&
+                'retryAttempt' in step &&
+                typeof step.retryAttempt === 'number' &&
+                Number.isInteger(step.retryAttempt) &&
+                step.retryAttempt >= 0 &&
                 'stop' in step &&
                 typeof step.stop === 'object' &&
                 step.stop !== null &&
@@ -180,6 +195,7 @@ function DriverDashboardWithPickupSync({
     pendingAction,
     onSelectionChange,
     onStartRun,
+    onRetry,
     onArrive,
     onDeliver,
     onPickupError,
@@ -190,8 +206,22 @@ function DriverDashboardWithPickupSync({
     pendingAction: string | null;
     onSelectionChange: () => void;
     onStartRun: (deliveryRequestIds: string[]) => void;
-    onArrive: (runId: string, stopId: number) => void;
-    onDeliver: (runId: string, stopId: number, notes?: string) => void;
+    onRetry: (
+        runId: string,
+        stopId: number,
+        expectedRouteRevision: number,
+    ) => void;
+    onArrive: (
+        runId: string,
+        stopId: number,
+        expectedRouteRevision: number,
+    ) => void;
+    onDeliver: (
+        runId: string,
+        stopId: number,
+        expectedRouteRevision: number,
+        notes?: string,
+    ) => void;
     onPickupError: (error: unknown) => void;
     onPickupAcknowledged: () => void | Promise<void>;
 }) {
@@ -204,6 +234,7 @@ function DriverDashboardWithPickupSync({
                 pendingAction={pendingAction}
                 onSelectionChange={onSelectionChange}
                 onStartRun={onStartRun}
+                onRetry={onRetry}
                 onArrive={onArrive}
                 onDeliver={onDeliver}
                 pickupQueue={null}
@@ -224,6 +255,7 @@ function DriverDashboardWithPickupSync({
             pendingAction={pendingAction}
             onSelectionChange={onSelectionChange}
             onStartRun={onStartRun}
+            onRetry={onRetry}
             onArrive={onArrive}
             onDeliver={onDeliver}
             onPickupError={onPickupError}
@@ -239,6 +271,7 @@ function ActiveDriverDashboardWithPickupSync({
     pendingAction,
     onSelectionChange,
     onStartRun,
+    onRetry,
     onArrive,
     onDeliver,
     onPickupError,
@@ -250,8 +283,22 @@ function ActiveDriverDashboardWithPickupSync({
     pendingAction: string | null;
     onSelectionChange: () => void;
     onStartRun: (deliveryRequestIds: string[]) => void;
-    onArrive: (runId: string, stopId: number) => void;
-    onDeliver: (runId: string, stopId: number, notes?: string) => void;
+    onRetry: (
+        runId: string,
+        stopId: number,
+        expectedRouteRevision: number,
+    ) => void;
+    onArrive: (
+        runId: string,
+        stopId: number,
+        expectedRouteRevision: number,
+    ) => void;
+    onDeliver: (
+        runId: string,
+        stopId: number,
+        expectedRouteRevision: number,
+        notes?: string,
+    ) => void;
     onPickupError: (error: unknown) => void;
     onPickupAcknowledged: () => void | Promise<void>;
 }) {
@@ -275,6 +322,7 @@ function ActiveDriverDashboardWithPickupSync({
             pendingAction={pendingAction}
             onSelectionChange={onSelectionChange}
             onStartRun={onStartRun}
+            onRetry={onRetry}
             onArrive={onArrive}
             onDeliver={onDeliver}
             pickupQueue={pickupSync.snapshot}
@@ -345,6 +393,12 @@ export function DeliveryDashboard() {
             await postAction(path, body);
             await query.refetch();
         } catch (error) {
+            if (
+                error instanceof DeliveryActionError &&
+                error.code === 'route-revision-conflict'
+            ) {
+                await query.refetch();
+            }
             setActionError(
                 error instanceof Error
                     ? error.message
@@ -474,17 +528,30 @@ export function DeliveryDashboard() {
                     onStartRun={(deliveryRequestIds) =>
                         void startRun(deliveryRequestIds)
                     }
-                    onArrive={(runId, stopId) =>
+                    onRetry={(runId, stopId, expectedRouteRevision) =>
+                        void perform(
+                            `${stopId}:retry`,
+                            `/api/driver/runs/${runId}/stops/${stopId}/retry`,
+                            { expectedRouteRevision },
+                        )
+                    }
+                    onArrive={(runId, stopId, expectedRouteRevision) =>
                         void perform(
                             `${stopId}:arrive`,
                             `/api/driver/runs/${runId}/stops/${stopId}/arrive`,
+                            {
+                                expectedRouteRevision,
+                            },
                         )
                     }
-                    onDeliver={(runId, stopId, notes) =>
+                    onDeliver={(runId, stopId, expectedRouteRevision, notes) =>
                         void perform(
                             `${stopId}:deliver`,
                             `/api/driver/runs/${runId}/stops/${stopId}/deliver`,
-                            { notes },
+                            {
+                                notes,
+                                expectedRouteRevision,
+                            },
                         )
                     }
                     onPickupError={(error) =>

--- a/apps/delivery/components/DeliveryStopCard.tsx
+++ b/apps/delivery/components/DeliveryStopCard.tsx
@@ -13,6 +13,7 @@ import {
     Mobile,
     MyLocation,
     Navigate,
+    Reset,
     Timer,
     User,
     Warning,
@@ -44,12 +45,14 @@ export function DeliveryStopCard({
     stop,
     mode,
     pendingAction,
+    onRetry,
     onArrive,
     onDeliver,
 }: {
     stop: DeliveryStopSummary;
     mode: 'driver' | 'customer';
-    pendingAction?: 'arrive' | 'deliver' | null;
+    pendingAction?: 'retry' | 'arrive' | 'deliver' | null;
+    onRetry?: () => void;
     onArrive?: () => void;
     onDeliver?: (notes?: string) => void;
 }) {
@@ -185,7 +188,37 @@ export function DeliveryStopCard({
                     </div>
                 ) : null}
 
-                {driverMode && customerActionAvailable && !delivered ? (
+                {driverMode &&
+                customerActionAvailable &&
+                !delivered &&
+                stop.stopState === 'deferred' ? (
+                    <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950">
+                        <Typography level="body2" semiBold>
+                            Ponovni pokušaj je na redu
+                        </Typography>
+                        <Typography
+                            level="body3"
+                            className="text-muted-foreground"
+                        >
+                            Potvrdi početak pokušaja prije navigacije i
+                            evidentiranja dolaska.
+                        </Typography>
+                        <Button
+                            color="warning"
+                            loading={pendingAction === 'retry'}
+                            disabled={Boolean(pendingAction)}
+                            onClick={onRetry}
+                            startDecorator={<Reset className="size-4" />}
+                        >
+                            Pokreni ponovni pokušaj
+                        </Button>
+                    </div>
+                ) : null}
+
+                {driverMode &&
+                customerActionAvailable &&
+                !delivered &&
+                stop.stopState !== 'deferred' ? (
                     <div className="space-y-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
                         <Button
                             href={navigationUrl}

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -254,6 +254,7 @@ export function DriverDashboard({
     pendingAction,
     onSelectionChange,
     onStartRun,
+    onRetry,
     onArrive,
     onDeliver,
     pickupQueue,
@@ -268,8 +269,22 @@ export function DriverDashboard({
     pendingAction: string | null;
     onSelectionChange: () => void;
     onStartRun: (deliveryRequestIds: string[]) => void;
-    onArrive: (runId: string, stopId: number) => void;
-    onDeliver: (runId: string, stopId: number, notes?: string) => void;
+    onRetry: (
+        runId: string,
+        stopId: number,
+        expectedRouteRevision: number,
+    ) => void;
+    onArrive: (
+        runId: string,
+        stopId: number,
+        expectedRouteRevision: number,
+    ) => void;
+    onDeliver: (
+        runId: string,
+        stopId: number,
+        expectedRouteRevision: number,
+        notes?: string,
+    ) => void;
     pickupQueue: PickupManifestQueueSnapshot | null;
     onPickupScan: (pickupNodeId: string, scanValue: string) => void;
     onPickupItemState: (
@@ -535,6 +550,14 @@ export function DriverDashboard({
                                 }
                             >
                                 {locationMessage}
+                            </Alert>
+                        ) : null}
+                        {run.reroutePending ? (
+                            <Alert
+                                color="warning"
+                                startDecorator={<Timer className="size-5" />}
+                            >
+                                Preostala ruta i vremena dolaska se ažuriraju.
                             </Alert>
                         ) : null}
 
@@ -819,34 +842,64 @@ export function DriverDashboard({
                                             step.actionState === 'current',
                                     };
                                     return (
-                                        <DeliveryStopCard
+                                        <div
                                             key={`delivery:${stop.id ?? stop.requestId}`}
-                                            stop={stop}
-                                            mode="driver"
-                                            pendingAction={
-                                                pendingAction?.startsWith(
-                                                    `${stop.id}:`,
-                                                )
-                                                    ? pendingAction.endsWith(
-                                                          ':arrive',
-                                                      )
-                                                        ? 'arrive'
-                                                        : 'deliver'
-                                                    : null
-                                            }
-                                            onArrive={() =>
-                                                stop.id &&
-                                                onArrive(run.id, stop.id)
-                                            }
-                                            onDeliver={(notes) =>
-                                                stop.id &&
-                                                onDeliver(
-                                                    run.id,
-                                                    stop.id,
-                                                    notes,
-                                                )
-                                            }
-                                        />
+                                            className="space-y-2"
+                                        >
+                                            {step.retryLaneRank !== null ? (
+                                                <Chip color="warning" size="sm">
+                                                    Ponovni pokušaj #
+                                                    {step.retryLaneRank}
+                                                    {step.retryAttempt > 1
+                                                        ? ` · pokušaj ${step.retryAttempt}`
+                                                        : null}
+                                                </Chip>
+                                            ) : null}
+                                            <DeliveryStopCard
+                                                stop={stop}
+                                                mode="driver"
+                                                pendingAction={
+                                                    pendingAction?.startsWith(
+                                                        `${stop.id}:`,
+                                                    )
+                                                        ? pendingAction.endsWith(
+                                                              ':retry',
+                                                          )
+                                                            ? 'retry'
+                                                            : pendingAction.endsWith(
+                                                                    ':arrive',
+                                                                )
+                                                              ? 'arrive'
+                                                              : 'deliver'
+                                                        : null
+                                                }
+                                                onRetry={() =>
+                                                    stop.id &&
+                                                    onRetry(
+                                                        run.id,
+                                                        stop.id,
+                                                        run.routeRevision,
+                                                    )
+                                                }
+                                                onArrive={() =>
+                                                    stop.id &&
+                                                    onArrive(
+                                                        run.id,
+                                                        stop.id,
+                                                        run.routeRevision,
+                                                    )
+                                                }
+                                                onDeliver={(notes) =>
+                                                    stop.id &&
+                                                    onDeliver(
+                                                        run.id,
+                                                        stop.id,
+                                                        run.routeRevision,
+                                                        notes,
+                                                    )
+                                                }
+                                            />
+                                        </div>
                                     );
                                 })}
                             </div>

--- a/apps/delivery/lib/deliveryDashboard.node.spec.ts
+++ b/apps/delivery/lib/deliveryDashboard.node.spec.ts
@@ -2,10 +2,14 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     accountCanTrackCurrentDeliveryGroup,
+    deliveryMutationRouteState,
     deliveryStatusLabel,
     deliveryTrackingStopIds,
     expandLegacyCurrentDeliveryStopIds,
     pickupManifestTracePath,
+    recordedExceptionNeedsReroute,
+    visibleDeliveryRunTotals,
+    visibleDeliveryStopEstimates,
 } from './deliveryDashboard';
 
 const pending = 'pending';
@@ -335,5 +339,69 @@ test('partial bulk tracking authorizes only exact current actionable stop ids', 
             currentDeliveryStopIds,
         }),
         false,
+    );
+});
+
+test('pending reroutes suppress stale customer arrival and travel estimates', () => {
+    const previousEstimate = {
+        estimatedArrivalAt: new Date('2026-07-15T10:00:00.000Z'),
+        estimatedTravelSeconds: 600,
+        estimatedDistanceMeters: 4_000,
+    };
+    assert.deepEqual(
+        visibleDeliveryStopEstimates({
+            reroutePending: true,
+            ...previousEstimate,
+        }),
+        {
+            estimatedArrivalAt: null,
+            estimatedTravelSeconds: null,
+            estimatedDistanceMeters: null,
+        },
+    );
+    assert.deepEqual(
+        visibleDeliveryRunTotals({
+            reroutePending: true,
+            totalDistanceMeters: 4_000,
+            totalDurationSeconds: 600,
+        }),
+        { totalDistanceMeters: null, totalDurationSeconds: null },
+    );
+    assert.deepEqual(
+        visibleDeliveryStopEstimates({
+            reroutePending: false,
+            ...previousEstimate,
+        }),
+        {
+            estimatedArrivalAt: '2026-07-15T10:00:00.000Z',
+            estimatedTravelSeconds: 600,
+            estimatedDistanceMeters: 4_000,
+        },
+    );
+});
+
+test('exception receipt replay returns current revision without rerouting a stale receipt', () => {
+    assert.equal(
+        recordedExceptionNeedsReroute({
+            currentRouteRevision: 8,
+            recordedRouteRevision: 7,
+            reroutePending: false,
+        }),
+        false,
+    );
+    assert.deepEqual(
+        deliveryMutationRouteState(
+            { routeRevision: 8, rerouteRequiredAt: null },
+            7,
+        ),
+        { routeRevision: 8, reroutePending: false },
+    );
+    assert.equal(
+        recordedExceptionNeedsReroute({
+            currentRouteRevision: 7,
+            recordedRouteRevision: 7,
+            reroutePending: true,
+        }),
+        true,
     );
 });

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -1,5 +1,6 @@
 import { notifyDeliveryRequestEvent } from '@gredice/notifications';
 import {
+    abandonDeliveryRun,
     consumeDeliveryRunPreparation,
     DeliveryRequestStates,
     DeliveryRunManifestItemStates,
@@ -8,6 +9,7 @@ import {
     DeliveryRunStopStates,
     fulfillDeliveryRunStops,
     getActiveDeliveryRunForDriver,
+    getActiveDeliveryRunStopsForRequestIds,
     getDeliveryAccountContacts,
     getDeliveryRequest,
     getDeliveryRequestsWithEvents,
@@ -18,6 +20,11 @@ import {
     isDeliveryRunStopActionable,
     isDeliveryRunStopTerminal,
     markDeliveryRunStopsArrived,
+    type RecordDeliveryRunStopExceptionsInput,
+    reassignDeliveryRun,
+    recordDeliveryRunStopExceptions,
+    recoverDeliveryRunStop,
+    retryDeliveryRunStop,
     updateDeliveryRunEstimates,
     updateDeliveryRunLocation,
 } from '@gredice/storage';
@@ -49,6 +56,11 @@ import {
     prepareDeliveryRun,
     savePreparedDeliveryRun,
 } from './deliveryRunPlanning';
+import {
+    deliveryRerouteLocationIsFresh,
+    deliveryRerouteRetryIsDue,
+    reconcileDeliveryRunReroute,
+} from './deliveryRunRerouting';
 import { resolveDeliveryRunStart } from './deliveryRunStart';
 import { buildDeliveryStopKey } from './deliveryStopGrouping';
 
@@ -74,6 +86,11 @@ const batchStates: ReadonlySet<string> = new Set([
     DeliveryRequestStates.CONFIRMED,
     DeliveryRequestStates.PREPARING,
     DeliveryRequestStates.READY,
+]);
+const terminalDeliveryRequestStates: ReadonlySet<string> = new Set([
+    DeliveryRequestStates.FULFILLED,
+    DeliveryRequestStates.FAILED,
+    DeliveryRequestStates.CANCELLED,
 ]);
 const etaRefreshIntervalMs = 2 * 60 * 1000;
 
@@ -193,14 +210,16 @@ export async function resolveDeliveryRunStopGroups(
             request,
             stopKey:
                 stop.stopKey ??
-                (request
-                    ? deliveryRequestStopKey(request)
-                    : `request:${stop.deliveryRequestId}`),
+                buildDeliveryStopKey(run.timeSlotId, stop.formattedAddress),
         };
     });
     const groups = new Map<string, ResolvedDeliveryRunStop[]>();
     for (const item of items) {
-        const executionKey = `${item.stop.itinerarySequence ?? 'legacy'}:${item.stopKey}`;
+        const executionLane =
+            item.stop.retryLaneRank === null
+                ? `route:${item.stop.itinerarySequence ?? 'legacy'}`
+                : `retry:${item.stop.retryLaneRank}`;
+        const executionKey = `${executionLane}:${item.stopKey}`;
         const group = groups.get(executionKey);
         if (group) group.push(item);
         else groups.set(executionKey, [item]);
@@ -209,7 +228,26 @@ export async function resolveDeliveryRunStopGroups(
         executionKey,
         stopKey: groupedItems[0]?.stopKey ?? executionKey,
         items: groupedItems,
-    }));
+    })).sort((first, second) => {
+        const firstRetryRank = first.items[0]?.stop.retryLaneRank;
+        const secondRetryRank = second.items[0]?.stop.retryLaneRank;
+        const firstLane = firstRetryRank === null ? 0 : 1;
+        const secondLane = secondRetryRank === null ? 0 : 1;
+        const sequence = (group: ResolvedDeliveryRunStopGroup) =>
+            Math.min(
+                ...group.items.map(
+                    ({ stop }) =>
+                        stop.retryLaneRank ??
+                        stop.itinerarySequence ??
+                        stop.sequence,
+                ),
+            );
+        return (
+            firstLane - secondLane ||
+            sequence(first) - sequence(second) ||
+            first.executionKey.localeCompare(second.executionKey)
+        );
+    });
 }
 
 export function deliveryStatusLabel({
@@ -285,7 +323,49 @@ type DeliveryRunSnapshot = Pick<
     | 'currentLocationHeading'
     | 'currentLocationSpeed'
     | 'currentLocationRecordedAt'
+    | 'rerouteRequiredAt'
 >;
+
+export function visibleDeliveryStopEstimates({
+    reroutePending,
+    estimatedArrivalAt,
+    estimatedTravelSeconds,
+    estimatedDistanceMeters,
+}: {
+    reroutePending: boolean;
+    estimatedArrivalAt?: Date | null;
+    estimatedTravelSeconds?: number | null;
+    estimatedDistanceMeters?: number | null;
+}) {
+    return {
+        estimatedArrivalAt: reroutePending ? null : iso(estimatedArrivalAt),
+        estimatedTravelSeconds: reroutePending
+            ? null
+            : (estimatedTravelSeconds ?? null),
+        estimatedDistanceMeters: reroutePending
+            ? null
+            : (estimatedDistanceMeters ?? null),
+    };
+}
+
+export function visibleDeliveryRunTotals({
+    reroutePending,
+    totalDistanceMeters,
+    totalDurationSeconds,
+}: {
+    reroutePending: boolean;
+    totalDistanceMeters?: number | null;
+    totalDurationSeconds?: number | null;
+}) {
+    return {
+        totalDistanceMeters: reroutePending
+            ? null
+            : (totalDistanceMeters ?? null),
+        totalDurationSeconds: reroutePending
+            ? null
+            : (totalDurationSeconds ?? null),
+    };
+}
 
 function deliverySummaryItem(
     request: DeliveryRequest,
@@ -370,6 +450,15 @@ function deliveryStopSummary({
             : 'Adresa nije dostupna');
     const runSlot = representativeStop?.runSlot;
     const runLocation = run ? trackingLocation(run) : null;
+    const reroutePending = Boolean(
+        run?.state === DeliveryRunStates.ACTIVE && run.rerouteRequiredAt,
+    );
+    const estimates = visibleDeliveryStopEstimates({
+        reroutePending,
+        estimatedArrivalAt: representativeStop?.estimatedArrivalAt,
+        estimatedTravelSeconds: representativeStop?.estimatedTravelSeconds,
+        estimatedDistanceMeters: representativeStop?.estimatedDistanceMeters,
+    });
 
     return {
         id: representativeStop?.id ?? null,
@@ -396,11 +485,8 @@ function deliveryStopSummary({
         deliveryNotes: request.deliveryNotes ?? null,
         slotStartAt: iso(runSlot?.windowStartAt ?? request.slot?.startAt),
         slotEndAt: iso(runSlot?.windowEndAt ?? request.slot?.endAt),
-        estimatedArrivalAt: iso(representativeStop?.estimatedArrivalAt),
-        estimatedTravelSeconds:
-            representativeStop?.estimatedTravelSeconds ?? null,
-        estimatedDistanceMeters:
-            representativeStop?.estimatedDistanceMeters ?? null,
+        ...estimates,
+        reroutePending,
         arrivedAt: iso(stops.find((stop) => stop.arrivedAt)?.arrivedAt),
         deliveredAt: iso(stops.find((stop) => stop.deliveredAt)?.deliveredAt),
         harvest: harvestSummary(request),
@@ -546,6 +632,12 @@ function pickupStepSummary({
         manifests.every((manifest) => manifest.state === 'confirmed');
     const hasProgress =
         scannedCount > 0 || missingLabelCount > 0 || notReadyCount > 0;
+    const estimates = visibleDeliveryStopEstimates({
+        reroutePending: run.rerouteRequiredAt !== null,
+        estimatedArrivalAt: pickupNode.estimatedArrivalAt,
+        estimatedTravelSeconds: pickupNode.incomingTravelSeconds,
+        estimatedDistanceMeters: pickupNode.incomingDistanceMeters,
+    });
 
     return {
         id: pickupNode.id,
@@ -554,9 +646,7 @@ function pickupStepSummary({
         itinerarySequence: step.itinerarySequence,
         name: pickupNode.name,
         address: pickupNode.formattedAddress,
-        estimatedArrivalAt: iso(pickupNode.estimatedArrivalAt),
-        estimatedTravelSeconds: pickupNode.incomingTravelSeconds,
-        estimatedDistanceMeters: pickupNode.incomingDistanceMeters,
+        ...estimates,
         serviceDurationSeconds: pickupNode.serviceDurationSeconds,
         state: allConfirmed ? 'confirmed' : hasProgress ? 'partial' : 'pending',
         isCurrent: step.state === 'current',
@@ -689,20 +779,28 @@ async function activeRunSummary(
             itinerarySequence: Number.isFinite(itinerarySequence)
                 ? itinerarySequence
                 : executionStep.itinerarySequence,
+            retryLaneRank: executionStep.retryLaneRank ?? null,
+            retryAttempt: executionStep.retryAttempt ?? 0,
             actionState,
             lockedReason: stop.lockedReason ?? null,
             stop,
         });
     }
 
+    const reroutePending = run.rerouteRequiredAt !== null;
     return {
         id: run.id,
         state: run.state,
         startedAt: run.startedAt.toISOString(),
         completedAt: iso(run.completedAt),
-        totalDistanceMeters: run.totalDistanceMeters,
-        totalDurationSeconds: run.totalDurationSeconds,
+        ...visibleDeliveryRunTotals({
+            reroutePending,
+            totalDistanceMeters: run.totalDistanceMeters,
+            totalDurationSeconds: run.totalDurationSeconds,
+        }),
         routePlanVersion: run.routePlanVersion,
+        routeRevision: run.routeRevision,
+        reroutePending,
         estimateSource: run.estimateSource,
         location: trackingLocation(run),
         estimatesUpdatedAt: iso(run.estimatesUpdatedAt),
@@ -723,13 +821,29 @@ async function driverDashboard({
     userId: string;
     role: string;
 }): Promise<DeliveryDashboard> {
-    const [user, activeRun, requests] = await Promise.all([
+    const [user, initialActiveRun, requests] = await Promise.all([
         getUser(userId),
         getActiveDeliveryRunForDriver(userId),
         getDeliveryRequestsWithEvents(),
     ]);
     if (!user) {
         throw new Error('Korisnik nije pronađen.');
+    }
+    let activeRun = initialActiveRun;
+    if (
+        activeRun?.rerouteRequiredAt &&
+        deliveryRerouteLocationIsFresh(activeRun) &&
+        deliveryRerouteRetryIsDue(
+            activeRun.rerouteRequiredAt,
+            activeRun.rerouteAttemptedAt,
+        )
+    ) {
+        await reconcileDeliveryRunReroute({
+            actorUserId: userId,
+            runId: activeRun.id,
+            expectedRouteRevision: activeRun.routeRevision,
+        });
+        activeRun = await getActiveDeliveryRunForDriver(userId);
     }
 
     const now = Date.now();
@@ -742,7 +856,7 @@ async function driverDashboard({
             request.slot.endAt.getTime() >= now &&
             request.slot.startAt.getTime() <= now + 14 * 24 * 60 * 60 * 1000,
     );
-    const assigned = await getDeliveryRunStopsForRequestIds(
+    const assigned = await getActiveDeliveryRunStopsForRequestIds(
         candidateRequests.map((request) => request.id),
     );
     const assignedRequestIds = new Set(
@@ -878,7 +992,12 @@ async function customerDashboard({
 
     const deliveries = requests
         .map((request) => {
-            const row = rowsByRequestId.get(request.id);
+            const historicalRow = rowsByRequestId.get(request.id);
+            const row =
+                historicalRow?.stop.releasedAt !== null &&
+                !terminalDeliveryRequestStates.has(request.state)
+                    ? undefined
+                    : historicalRow;
             const isCurrent = row
                 ? (currentStopIdsByRunId.get(row.run.id)?.has(row.stop.id) ??
                   false)
@@ -1011,20 +1130,27 @@ export async function arriveAtDeliveryStop({
     driverUserId,
     runId,
     stopId,
+    expectedRouteRevision,
 }: {
     driverUserId: string;
     runId: string;
     stopId: number;
+    expectedRouteRevision: number;
 }) {
     const group = await getOwnedDeliveryRunStopGroup({
         driverUserId,
         runId,
         stopId,
     });
-    return await markDeliveryRunStopsArrived({
+    await markDeliveryRunStopsArrived({
         driverUserId,
         runId,
         stopIds: group.items.map(({ stop }) => stop.id),
+        expectedRouteRevision,
+    });
+    return await currentDeliveryRunMutationResult({
+        runId,
+        fallbackRouteRevision: expectedRouteRevision + 1,
     });
 }
 
@@ -1086,11 +1212,13 @@ export async function deliverDeliveryStop({
     runId,
     stopId,
     notes,
+    expectedRouteRevision,
 }: {
     driverUserId: string;
     runId: string;
     stopId: number;
     notes?: string;
+    expectedRouteRevision: number;
 }) {
     const group = await getOwnedDeliveryRunStopGroup({
         driverUserId,
@@ -1102,6 +1230,7 @@ export async function deliverDeliveryStop({
         runId,
         stopIds: group.items.map(({ stop }) => stop.id),
         deliveryNotes: notes,
+        expectedRouteRevision,
     });
     await Promise.all(
         requestIds.map((requestId) =>
@@ -1111,6 +1240,160 @@ export async function deliverDeliveryStop({
             }),
         ),
     );
+    return await currentDeliveryRunMutationResult({
+        runId,
+        fallbackRouteRevision: expectedRouteRevision + 1,
+    });
+}
+
+async function currentDeliveryRunMutationResult({
+    runId,
+    fallbackRouteRevision,
+}: {
+    runId: string;
+    fallbackRouteRevision: number;
+}) {
+    const run = await getDeliveryRun(runId);
+    return deliveryMutationRouteState(run, fallbackRouteRevision);
+}
+
+export function deliveryMutationRouteState(
+    run:
+        | { routeRevision: number; rerouteRequiredAt: Date | null }
+        | null
+        | undefined,
+    fallbackRouteRevision: number,
+) {
+    return {
+        routeRevision: run?.routeRevision ?? fallbackRouteRevision,
+        reroutePending: Boolean(run?.rerouteRequiredAt),
+    };
+}
+
+export function recordedExceptionNeedsReroute({
+    currentRouteRevision,
+    recordedRouteRevision,
+    reroutePending,
+}: {
+    currentRouteRevision?: number;
+    recordedRouteRevision: number;
+    reroutePending: boolean;
+}) {
+    return reroutePending && currentRouteRevision === recordedRouteRevision;
+}
+
+export async function recordDriverDeliveryExceptions({
+    driverUserId,
+    runId,
+    clientOperationId,
+    expectedRouteRevision,
+    occurredAt,
+    exceptions,
+}: Omit<RecordDeliveryRunStopExceptionsInput, 'driverUserId'> & {
+    driverUserId: string;
+}) {
+    const recorded = await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId,
+        clientOperationId,
+        expectedRouteRevision,
+        occurredAt,
+        exceptions,
+    });
+    const runAfterMutation = await getDeliveryRun(runId);
+    if (
+        recordedExceptionNeedsReroute({
+            currentRouteRevision: runAfterMutation?.routeRevision,
+            recordedRouteRevision: recorded.result.routeRevision,
+            reroutePending: Boolean(runAfterMutation?.rerouteRequiredAt),
+        })
+    ) {
+        await reconcileDeliveryRunReroute({
+            actorUserId: driverUserId,
+            runId,
+            expectedRouteRevision: recorded.result.routeRevision,
+            originStopId: exceptions[0]?.stopId,
+        });
+    }
+    return {
+        clientOperationId: recorded.clientOperationId,
+        replayed: recorded.replayed,
+        outcomes: recorded.result.outcomes,
+        ...(await currentDeliveryRunMutationResult({
+            runId,
+            fallbackRouteRevision: recorded.result.routeRevision,
+        })),
+    };
+}
+
+export async function retryDriverDeliveryStop({
+    driverUserId,
+    runId,
+    stopId,
+    expectedRouteRevision,
+}: {
+    driverUserId: string;
+    runId: string;
+    stopId: number;
+    expectedRouteRevision: number;
+}) {
+    const retried = await retryDeliveryRunStop({
+        driverUserId,
+        runId,
+        stopId,
+        expectedRouteRevision,
+    });
+    await reconcileDeliveryRunReroute({
+        actorUserId: driverUserId,
+        runId,
+        expectedRouteRevision: retried.routeRevision,
+    });
+    return await currentDeliveryRunMutationResult({
+        runId,
+        fallbackRouteRevision: retried.routeRevision,
+    });
+}
+
+export async function reassignAdminDeliveryRun(input: {
+    adminUserId: string;
+    runId: string;
+    newDriverUserId: string;
+    expectedRouteRevision: number;
+}) {
+    return await reassignDeliveryRun(input);
+}
+
+export async function recoverAdminDeliveryStop(input: {
+    adminUserId: string;
+    runId: string;
+    stopId: number;
+    expectedRouteRevision: number;
+}) {
+    const recovered = await recoverDeliveryRunStop(input);
+    if (recovered.resumedInRun) {
+        await reconcileDeliveryRunReroute({
+            actorUserId: input.adminUserId,
+            runId: input.runId,
+            expectedRouteRevision: recovered.routeRevision,
+            allowAdmin: true,
+        });
+    }
+    return {
+        ...recovered,
+        ...(await currentDeliveryRunMutationResult({
+            runId: input.runId,
+            fallbackRouteRevision: recovered.routeRevision,
+        })),
+    };
+}
+
+export async function abandonAdminDeliveryRun(input: {
+    adminUserId: string;
+    runId: string;
+    expectedRouteRevision: number;
+    reason?: string;
+}) {
+    return await abandonDeliveryRun(input);
 }
 
 export async function accountCanTrackDeliveryRun({
@@ -1214,6 +1497,7 @@ export async function recordDriverLocation({
     speed?: number;
     recordedAt: Date;
 }) {
+    const previousRun = await getDeliveryRun(runId);
     await updateDeliveryRunLocation({
         runId,
         driverUserId,
@@ -1227,6 +1511,23 @@ export async function recordDriverLocation({
 
     const run = await getDeliveryRun(runId);
     if (!run || run.driverUserId !== driverUserId) {
+        return;
+    }
+    if (
+        run.rerouteRequiredAt &&
+        deliveryRerouteLocationIsFresh(run) &&
+        (!previousRun ||
+            !deliveryRerouteLocationIsFresh(previousRun) ||
+            deliveryRerouteRetryIsDue(
+                run.rerouteRequiredAt,
+                run.rerouteAttemptedAt,
+            ))
+    ) {
+        await reconcileDeliveryRunReroute({
+            actorUserId: driverUserId,
+            runId,
+            expectedRouteRevision: run.routeRevision,
+        });
         return;
     }
     const estimatesAreFresh =

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -55,6 +55,7 @@ export type DeliveryStopSummary = {
     estimatedArrivalAt: string | null;
     estimatedTravelSeconds: number | null;
     estimatedDistanceMeters: number | null;
+    reroutePending: boolean;
     arrivedAt: string | null;
     deliveredAt: string | null;
     harvest: DeliveryHarvestSummary;
@@ -130,6 +131,8 @@ export type DeliveryRouteStepSummary =
     | {
           kind: 'delivery';
           itinerarySequence: number;
+          retryLaneRank: number | null;
+          retryAttempt: number;
           actionState: 'locked' | 'upcoming' | 'current' | 'completed';
           lockedReason: string | null;
           stop: DeliveryStopSummary;
@@ -167,6 +170,8 @@ export type ActiveDeliveryRunSummary = {
     totalDistanceMeters: number | null;
     totalDurationSeconds: number | null;
     routePlanVersion: number;
+    routeRevision: number;
+    reroutePending: boolean;
     estimateSource: DeliveryRunEstimateSource;
     location: DeliveryTrackingLocation | null;
     estimatesUpdatedAt: string | null;

--- a/apps/delivery/lib/deliveryMutationRequest.node.spec.ts
+++ b/apps/delivery/lib/deliveryMutationRequest.node.spec.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    DeliveryMutationRequestError,
+    expectedRouteRevision,
+    parseDeliveryExceptionMutation,
+} from './deliveryMutationRequest';
+
+test('requires a nonnegative integer route revision on delivery mutations', () => {
+    assert.equal(expectedRouteRevision({ expectedRouteRevision: 4 }), 4);
+    for (const value of [
+        {},
+        { expectedRouteRevision: -1 },
+        { expectedRouteRevision: 1.5 },
+        { expectedRouteRevision: '4' },
+    ]) {
+        assert.throws(
+            () => expectedRouteRevision(value),
+            DeliveryMutationRequestError,
+        );
+    }
+});
+
+test('parses a deterministic bulk delivery exception mutation', () => {
+    const parsed = parseDeliveryExceptionMutation({
+        expectedRouteRevision: 7,
+        clientOperationId: ' operation-1 ',
+        occurredAt: '2026-07-15T10:00:00.000Z',
+        exceptions: [
+            {
+                stopId: 11,
+                outcome: 'deferred',
+                reason: 'customer-unavailable',
+                note: '  Nazvati ponovno  ',
+            },
+            {
+                stopId: 12,
+                outcome: 'failed',
+                reason: 'harvest-damaged',
+            },
+        ],
+    });
+    assert.equal(parsed.expectedRouteRevision, 7);
+    assert.equal(parsed.clientOperationId, 'operation-1');
+    assert.equal(parsed.occurredAt.toISOString(), '2026-07-15T10:00:00.000Z');
+    assert.deepEqual(parsed.exceptions, [
+        {
+            stopId: 11,
+            outcome: 'deferred',
+            reason: 'customer-unavailable',
+            note: 'Nazvati ponovno',
+        },
+        {
+            stopId: 12,
+            outcome: 'failed',
+            reason: 'harvest-damaged',
+        },
+    ]);
+});

--- a/apps/delivery/lib/deliveryMutationRequest.ts
+++ b/apps/delivery/lib/deliveryMutationRequest.ts
@@ -1,0 +1,119 @@
+import {
+    type DeliveryRunExceptionOutcome,
+    DeliveryRunExceptionOutcomes,
+    type DeliveryRunExceptionReason,
+    DeliveryRunExceptionReasons,
+} from '@gredice/storage';
+
+export class DeliveryMutationRequestError extends Error {
+    override name = 'DeliveryMutationRequestError';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+export function expectedRouteRevision(value: unknown) {
+    if (
+        !isRecord(value) ||
+        !Number.isInteger(value.expectedRouteRevision) ||
+        typeof value.expectedRouteRevision !== 'number' ||
+        value.expectedRouteRevision < 0
+    ) {
+        throw new DeliveryMutationRequestError(
+            'Nedostaje valjana revizija rute.',
+        );
+    }
+    return value.expectedRouteRevision;
+}
+
+function exceptionOutcome(value: unknown): DeliveryRunExceptionOutcome {
+    switch (value) {
+        case DeliveryRunExceptionOutcomes.DEFERRED:
+        case DeliveryRunExceptionOutcomes.FAILED:
+        case DeliveryRunExceptionOutcomes.CANCELLED:
+            return value;
+        default:
+            throw new DeliveryMutationRequestError('Neispravan ishod dostave.');
+    }
+}
+
+function exceptionReason(value: unknown): DeliveryRunExceptionReason {
+    switch (value) {
+        case DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE:
+        case DeliveryRunExceptionReasons.ADDRESS_INACCESSIBLE:
+        case DeliveryRunExceptionReasons.ADDRESS_WRONG:
+        case DeliveryRunExceptionReasons.HARVEST_DAMAGED:
+        case DeliveryRunExceptionReasons.HARVEST_MISSING:
+        case DeliveryRunExceptionReasons.CANCELLATION:
+        case DeliveryRunExceptionReasons.OPERATIONAL_OTHER:
+            return value;
+        default:
+            throw new DeliveryMutationRequestError(
+                'Neispravan razlog dostave.',
+            );
+    }
+}
+
+export function parseDeliveryExceptionMutation(value: unknown) {
+    if (!isRecord(value)) {
+        throw new DeliveryMutationRequestError('Neispravna promjena dostave.');
+    }
+    const routeRevision = expectedRouteRevision(value);
+    if (
+        typeof value.clientOperationId !== 'string' ||
+        value.clientOperationId.trim().length === 0 ||
+        value.clientOperationId.trim().length > 128
+    ) {
+        throw new DeliveryMutationRequestError(
+            'Nedostaje identifikator promjene.',
+        );
+    }
+    if (typeof value.occurredAt !== 'string') {
+        throw new DeliveryMutationRequestError('Nedostaje vrijeme promjene.');
+    }
+    const occurredAt = new Date(value.occurredAt);
+    if (!Number.isFinite(occurredAt.getTime())) {
+        throw new DeliveryMutationRequestError(
+            'Vrijeme promjene nije valjano.',
+        );
+    }
+    if (!Array.isArray(value.exceptions) || value.exceptions.length === 0) {
+        throw new DeliveryMutationRequestError(
+            'Nedostaje ishod barem jedne dostave.',
+        );
+    }
+    const exceptions = value.exceptions.map((item) => {
+        if (
+            !isRecord(item) ||
+            typeof item.stopId !== 'number' ||
+            !Number.isInteger(item.stopId) ||
+            item.stopId <= 0
+        ) {
+            throw new DeliveryMutationRequestError(
+                'Stanica promjene nije valjana.',
+            );
+        }
+        const note =
+            typeof item.note === 'string' && item.note.trim()
+                ? item.note.trim()
+                : undefined;
+        if (note && note.length > 1_000) {
+            throw new DeliveryMutationRequestError(
+                'Napomena smije imati najviše 1000 znakova.',
+            );
+        }
+        return {
+            stopId: item.stopId,
+            outcome: exceptionOutcome(item.outcome),
+            reason: exceptionReason(item.reason),
+            ...(note ? { note } : {}),
+        };
+    });
+    return {
+        expectedRouteRevision: routeRevision,
+        clientOperationId: value.clientOperationId.trim(),
+        occurredAt,
+        exceptions,
+    };
+}

--- a/apps/delivery/lib/deliveryPickupRouting.node.spec.ts
+++ b/apps/delivery/lib/deliveryPickupRouting.node.spec.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test, { type TestContext } from 'node:test';
-import { planPickupAwareDeliveryRoute } from './deliveryPickupRouting';
+import {
+    deliveryRerouteOriginNodeKey,
+    planPickupAwareDeliveryRoute,
+    type RemainingDeliveryRouteNode,
+    recalculatePickupAwareDeliveryRoute,
+} from './deliveryPickupRouting';
 import { DeliveryRoutePlanningError } from './deliveryRouting';
 
 type Coordinates = {
@@ -13,6 +18,7 @@ type GoogleMockOptions = {
     failMatrix?: boolean;
     failFinalRoute?: boolean;
     matrixElementFailure?: 'internal' | 'malformed';
+    finalRouteDurationSeconds?: number;
 };
 
 const departureTime = new Date('2026-07-15T06:00:00.000Z');
@@ -187,7 +193,7 @@ function installGoogleMock(
                         duration: `${legCount * 60}s`,
                         legs: Array.from({ length: legCount }, () => ({
                             distanceMeters: 1_000,
-                            duration: '60s',
+                            duration: `${options.finalRouteDurationSeconds ?? 60}s`,
                         })),
                         polyline: { encodedPolyline: 'pickup-aware-route' },
                     },
@@ -561,4 +567,170 @@ test('keeps one upstream bulk group as one customer node', async (t) => {
     assert.equal(plan.pickupNodes[0]?.serviceDurationSeconds, 10 * 60);
     assert.equal(plan.stops[0]?.serviceDurationSeconds, 5 * 60);
     assert.ok(plan.totalDurationSeconds >= 10 * 60 + 60 + 5 * 60);
+});
+
+function remainingCustomer(
+    index: number,
+    overrides: Partial<
+        Extract<RemainingDeliveryRouteNode, { kind: 'customer' }>
+    > = {},
+): Extract<RemainingDeliveryRouteNode, { kind: 'customer' }> {
+    const nodeKey = `remaining-${String(index).padStart(2, '0')}`;
+    return {
+        kind: 'customer',
+        nodeKey,
+        formattedAddress: `${nodeKey} address`,
+        deliveryRequestId: `request-${index}`,
+        requiredPickupKey: deliveryRerouteOriginNodeKey,
+        latitude: 45.75 + index / 10_000,
+        longitude: 15.9 + index / 10_000,
+        serviceDurationSeconds: 0,
+        ...overrides,
+    };
+}
+
+test('reuses one Google matrix while selectively relaxing many overdue reroute windows', async (t) => {
+    const google = installGoogleMock(t);
+    const nodes = Array.from({ length: 25 }, (_value, index) =>
+        remainingCustomer(index, {
+            windowEndAt: new Date(departureTime.getTime() - 60_000),
+        }),
+    );
+
+    const plan = await recalculatePickupAwareDeliveryRoute({
+        origin: { latitude: 45.75, longitude: 15.9 },
+        nodes,
+        departureTime,
+    });
+
+    assert.equal(plan.estimateSource, 'google');
+    assert.equal(plan.visits.length, nodes.length);
+    assert.equal(google.matrixBodies.length, 2);
+    assert.equal(google.routeBodies.length, 1);
+    assert.equal(google.fetchCount(), 3);
+});
+
+test('keeps feasible reroute deadlines while relaxing only an overdue stop', async (t) => {
+    installGoogleMock(t);
+    const plan = await recalculatePickupAwareDeliveryRoute({
+        origin: { latitude: 45.75, longitude: 15.9 },
+        nodes: [
+            remainingCustomer(1, {
+                nodeKey: 'customer-a-overdue',
+                windowEndAt: new Date(departureTime.getTime() - 60_000),
+            }),
+            remainingCustomer(2, {
+                nodeKey: 'customer-z-deadline',
+                windowEndAt: new Date(departureTime.getTime() + 90_000),
+            }),
+        ],
+        departureTime,
+    });
+
+    assert.deepEqual(
+        plan.visits.map((visit) => visit.nodeKey),
+        ['customer-z-deadline', 'customer-a-overdue'],
+    );
+});
+
+test('uses linear Google connectors and preserves a large fixed retry route', async (t) => {
+    const google = installGoogleMock(t);
+    const nodes = Array.from({ length: 55 }, (_value, index) =>
+        remainingCustomer(index, { retryLaneRank: index + 1 }),
+    );
+
+    const plan = await recalculatePickupAwareDeliveryRoute({
+        origin: { latitude: 45.75, longitude: 15.9 },
+        nodes,
+        departureTime,
+    });
+
+    assert.equal(plan.estimateSource, 'google');
+    assert.equal(plan.encodedPolyline, undefined);
+    assert.deepEqual(
+        plan.visits.map((visit) => visit.nodeKey),
+        nodes.map((node) => node.nodeKey),
+    );
+    assert.equal(google.matrixBodies.length, 0);
+    assert.equal(google.routeBodies.length, 3);
+    assert.equal(google.fetchCount(), 3);
+    assert.equal(
+        google.routeBodies.reduce<number>(
+            (total, body) =>
+                total + arrayField(body, 'intermediates').length + 1,
+            0,
+        ),
+        54,
+    );
+    assert.equal(plan.visits[0]?.incomingTravelSeconds, 0);
+    for (const body of google.routeBodies) {
+        assert.ok(arrayField(body, 'intermediates').length <= 25);
+    }
+    const segmentDepartures = google.routeBodies.map((body) => {
+        assert.ok(isRecord(body));
+        assert.equal(typeof body.departureTime, 'string');
+        return Date.parse(String(body.departureTime));
+    });
+    assert.ok(
+        segmentDepartures.every(
+            (value, index) =>
+                index === 0 || value > (segmentDepartures[index - 1] ?? value),
+        ),
+    );
+});
+
+test('softens every deadline missed by final Google legs without request fan-out', async (t) => {
+    const google = installGoogleMock(t, {
+        finalRouteDurationSeconds: 300,
+    });
+    const deadline = new Date(departureTime.getTime() + 4 * 60_000);
+    const plan = await recalculatePickupAwareDeliveryRoute({
+        origin: { latitude: 45.75, longitude: 15.9 },
+        nodes: Array.from({ length: 3 }, (_value, index) =>
+            remainingCustomer(index + 1, { windowEndAt: deadline }),
+        ),
+        departureTime,
+    });
+
+    assert.equal(plan.estimateSource, 'google');
+    assert.equal(plan.visits.length, 3);
+    assert.ok(
+        plan.visits.every(
+            (visit) => visit.estimatedArrivalAt.getTime() > deadline.getTime(),
+        ),
+    );
+    assert.equal(google.matrixBodies.length, 1);
+    assert.equal(google.routeBodies.length, 1);
+    assert.equal(google.fetchCount(), 2);
+});
+
+test('keeps final Google deadlines strict when planning a new route', async (t) => {
+    const google = installGoogleMock(t, {
+        finalRouteDurationSeconds: 300,
+    });
+    await assert.rejects(
+        planPickupAwareDeliveryRoute({
+            pickupCandidates: [pickup('strict-window-pickup')],
+            candidates: [
+                {
+                    ...customer(
+                        'strict-window-customer',
+                        'strict-window-pickup',
+                    ),
+                    windowEndAt: new Date(
+                        departureTime.getTime() + 12 * 60_000,
+                    ),
+                },
+            ],
+            departureTime,
+        }),
+        (error: unknown) => {
+            assert.ok(error instanceof DeliveryRoutePlanningError);
+            assert.equal(error.code, 'route-time-window-infeasible');
+            assert.equal(error.nodeKey, 'strict-window-customer');
+            return true;
+        },
+    );
+    assert.equal(google.matrixBodies.length, 1);
+    assert.equal(google.routeBodies.length, 1);
 });

--- a/apps/delivery/lib/deliveryPickupRouting.ts
+++ b/apps/delivery/lib/deliveryPickupRouting.ts
@@ -5,6 +5,7 @@ import {
     type DeliveryRouteGraphPlan,
     DeliveryRouteGraphPlanningError,
     deliveryNodeServiceSeconds,
+    evaluateFixedDeliveryRouteGraph,
     maximumDeliveryRouteGraphNodes,
     pickupNodeServiceSeconds,
     solveDeliveryRouteGraph,
@@ -90,6 +91,8 @@ type GoogleRoute = {
 };
 
 const googleRouteMatrixMaximumElements = 625;
+const googleRouteMatrixMaximumWaypointsPerDimension = 50;
+const googleRouteMaximumIntermediates = 25;
 export const maximumPickupAwareRouteNodes = maximumDeliveryRouteGraphNodes;
 
 class GoogleRouteServiceError extends Error {
@@ -393,130 +396,151 @@ async function computeGoogleRouteMatrix({
     nodes: DeliveryRouteGraphNode[];
     departureTime: Date;
 }) {
-    const maximumOriginsPerRequest = Math.max(
-        1,
-        Math.floor(googleRouteMatrixMaximumElements / nodes.length),
-    );
     const legs: DeliveryRouteGraphLeg[] = [];
-
     for (
-        let originOffset = 0;
-        originOffset < nodes.length;
-        originOffset += maximumOriginsPerRequest
+        let destinationOffset = 0;
+        destinationOffset < nodes.length;
+        destinationOffset += googleRouteMatrixMaximumWaypointsPerDimension
     ) {
-        const originNodes = nodes.slice(
-            originOffset,
-            originOffset + maximumOriginsPerRequest,
+        const destinationNodes = nodes.slice(
+            destinationOffset,
+            destinationOffset + googleRouteMatrixMaximumWaypointsPerDimension,
         );
-        let response: Response;
-        try {
-            response = await fetch(
-                'https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix',
-                {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Goog-Api-Key': googleMapsServerApiKey(),
-                        'X-Goog-FieldMask':
-                            'originIndex,destinationIndex,duration,distanceMeters,status,condition',
+        const maximumOriginsPerRequest = Math.max(
+            1,
+            Math.min(
+                googleRouteMatrixMaximumWaypointsPerDimension,
+                Math.floor(
+                    googleRouteMatrixMaximumElements / destinationNodes.length,
+                ),
+            ),
+        );
+        for (
+            let originOffset = 0;
+            originOffset < nodes.length;
+            originOffset += maximumOriginsPerRequest
+        ) {
+            const originNodes = nodes.slice(
+                originOffset,
+                originOffset + maximumOriginsPerRequest,
+            );
+            let response: Response;
+            try {
+                response = await fetch(
+                    'https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix',
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Goog-Api-Key': googleMapsServerApiKey(),
+                            'X-Goog-FieldMask':
+                                'originIndex,destinationIndex,duration,distanceMeters,status,condition',
+                        },
+                        body: JSON.stringify({
+                            origins: originNodes.map(matrixWaypoint),
+                            destinations: destinationNodes.map(matrixWaypoint),
+                            travelMode: 'DRIVE',
+                            routingPreference: 'TRAFFIC_AWARE',
+                            departureTime: departureTime.toISOString(),
+                            languageCode: 'hr-HR',
+                            regionCode: 'HR',
+                            units: 'METRIC',
+                        }),
+                        cache: 'no-store',
                     },
-                    body: JSON.stringify({
-                        origins: originNodes.map(matrixWaypoint),
-                        destinations: nodes.map(matrixWaypoint),
-                        travelMode: 'DRIVE',
-                        routingPreference: 'TRAFFIC_AWARE',
-                        departureTime: departureTime.toISOString(),
-                        languageCode: 'hr-HR',
-                        regionCode: 'HR',
-                        units: 'METRIC',
-                    }),
-                    cache: 'no-store',
-                },
-            );
-        } catch {
-            throw new GoogleRouteServiceError(
-                'Google route matrix request failed.',
-            );
-        }
-        const body: unknown = await response.json().catch(() => null);
-        if (!response.ok || !Array.isArray(body)) {
-            throw new GoogleRouteServiceError(
-                'Google route matrix response was unavailable.',
-            );
-        }
+                );
+            } catch {
+                throw new GoogleRouteServiceError(
+                    'Google route matrix request failed.',
+                );
+            }
+            const body: unknown = await response.json().catch(() => null);
+            if (!response.ok || !Array.isArray(body)) {
+                throw new GoogleRouteServiceError(
+                    'Google route matrix response was unavailable.',
+                );
+            }
 
-        for (const value of body) {
-            if (!isRecord(value)) {
-                throw new GoogleRouteServiceError(
-                    'Google route matrix returned an invalid element.',
+            for (const value of body) {
+                if (!isRecord(value)) {
+                    throw new GoogleRouteServiceError(
+                        'Google route matrix returned an invalid element.',
+                    );
+                }
+                const localOriginIndex = nonnegativeInteger(value.originIndex);
+                const localDestinationIndex = nonnegativeInteger(
+                    value.destinationIndex,
                 );
+                if (
+                    localOriginIndex === undefined ||
+                    localDestinationIndex === undefined ||
+                    localOriginIndex >= originNodes.length ||
+                    localDestinationIndex >= destinationNodes.length
+                ) {
+                    throw new GoogleRouteServiceError(
+                        'Google route matrix returned invalid indexes.',
+                    );
+                }
+                if (value.condition === 'ROUTE_NOT_FOUND') continue;
+                if (
+                    value.condition !== 'ROUTE_EXISTS' ||
+                    !matrixStatusSucceeded(value.status)
+                ) {
+                    throw new GoogleRouteServiceError(
+                        'Google route matrix returned a failed element.',
+                    );
+                }
+                const origin = originNodes[localOriginIndex];
+                const destination = destinationNodes[localDestinationIndex];
+                if (!origin || !destination || origin.key === destination.key) {
+                    continue;
+                }
+                const travelSeconds = durationSeconds(value.duration);
+                const distanceMeters = nonnegativeInteger(value.distanceMeters);
+                if (
+                    travelSeconds === undefined ||
+                    distanceMeters === undefined
+                ) {
+                    throw new GoogleRouteServiceError(
+                        'Google route matrix omitted route metrics.',
+                    );
+                }
+                legs.push({
+                    fromKey: origin.key,
+                    toKey: destination.key,
+                    travelSeconds,
+                    distanceMeters,
+                });
             }
-            const localOriginIndex = nonnegativeInteger(value.originIndex);
-            const destinationIndex = nonnegativeInteger(value.destinationIndex);
-            if (
-                localOriginIndex === undefined ||
-                destinationIndex === undefined ||
-                localOriginIndex >= originNodes.length ||
-                destinationIndex >= nodes.length
-            ) {
-                throw new GoogleRouteServiceError(
-                    'Google route matrix returned invalid indexes.',
-                );
-            }
-            if (value.condition === 'ROUTE_NOT_FOUND') continue;
-            if (
-                value.condition !== 'ROUTE_EXISTS' ||
-                !matrixStatusSucceeded(value.status)
-            ) {
-                throw new GoogleRouteServiceError(
-                    'Google route matrix returned a failed element.',
-                );
-            }
-            const origin = originNodes[localOriginIndex];
-            const destination = nodes[destinationIndex];
-            if (!origin || !destination || origin.key === destination.key) {
-                continue;
-            }
-            const travelSeconds = durationSeconds(value.duration);
-            const distanceMeters = nonnegativeInteger(value.distanceMeters);
-            if (travelSeconds === undefined || distanceMeters === undefined) {
-                throw new GoogleRouteServiceError(
-                    'Google route matrix omitted route metrics.',
-                );
-            }
-            legs.push({
-                fromKey: origin.key,
-                toKey: destination.key,
-                travelSeconds,
-                distanceMeters,
-            });
         }
     }
     return legs;
+}
+
+function localRouteLeg(
+    origin: DeliveryRouteGraphNode,
+    destination: DeliveryRouteGraphNode,
+): DeliveryRouteGraphLeg {
+    const distanceMeters = Math.round(
+        haversineDistanceMeters(origin, destination) * 1.25,
+    );
+    const travelSeconds =
+        distanceMeters === 0
+            ? 0
+            : Math.max(60, Math.round(distanceMeters / (25_000 / 3_600)));
+    return {
+        fromKey: origin.key,
+        toKey: destination.key,
+        travelSeconds,
+        distanceMeters,
+    };
 }
 
 function localRouteLegs(nodes: readonly DeliveryRouteGraphNode[]) {
     return nodes.flatMap((origin) =>
         nodes.flatMap((destination) => {
             if (origin.key === destination.key) return [];
-            const distanceMeters = Math.round(
-                haversineDistanceMeters(origin, destination) * 1.25,
-            );
-            const travelSeconds =
-                distanceMeters === 0
-                    ? 0
-                    : Math.max(
-                          60,
-                          Math.round(distanceMeters / (25_000 / 3_600)),
-                      );
-            return [
-                {
-                    fromKey: origin.key,
-                    toKey: destination.key,
-                    travelSeconds,
-                    distanceMeters,
-                },
-            ];
+            return [localRouteLeg(origin, destination)];
         }),
     );
 }
@@ -561,6 +585,40 @@ function solveRouteGraph({
     departureTime,
     legs,
     candidatesByNodeKey,
+    maximumNodes,
+}: {
+    nodes: DeliveryRouteGraphNode[];
+    originKey: string;
+    departureTime: Date;
+    legs: DeliveryRouteGraphLeg[];
+    candidatesByNodeKey: ReadonlyMap<
+        string,
+        DeliveryPickupRouteCandidate | PickupAwareDeliveryRouteCandidate
+    >;
+    maximumNodes?: number;
+}) {
+    try {
+        return solveDeliveryRouteGraph({
+            nodes,
+            originKey,
+            departureAt: departureTime,
+            legs,
+            maximumNodes,
+        });
+    } catch (error) {
+        if (error instanceof DeliveryRouteGraphPlanningError) {
+            throw routePlanningError(error, candidatesByNodeKey);
+        }
+        throw error;
+    }
+}
+
+function evaluateFixedRouteGraph({
+    nodes,
+    originKey,
+    departureTime,
+    legs,
+    candidatesByNodeKey,
 }: {
     nodes: DeliveryRouteGraphNode[];
     originKey: string;
@@ -572,7 +630,7 @@ function solveRouteGraph({
     >;
 }) {
     try {
-        return solveDeliveryRouteGraph({
+        return evaluateFixedDeliveryRouteGraph({
             nodes,
             originKey,
             departureAt: departureTime,
@@ -594,6 +652,7 @@ async function computeFixedGoogleRoute({
     graphPlan,
     departureTime,
     candidatesByNodeKey,
+    softenMissedWindows = false,
 }: {
     graphPlan: DeliveryRouteGraphPlan;
     departureTime: Date;
@@ -601,6 +660,7 @@ async function computeFixedGoogleRoute({
         string,
         DeliveryPickupRouteCandidate | PickupAwareDeliveryRouteCandidate
     >;
+    softenMissedWindows?: boolean;
 }) {
     const orderedNodes = graphPlan.visits.map((visit) => visit.node);
     const origin = orderedNodes[0];
@@ -610,63 +670,119 @@ async function computeFixedGoogleRoute({
             'Google route requires an origin and destination.',
         );
     }
-
-    let response: Response;
-    try {
-        response = await fetch(
-            'https://routes.googleapis.com/directions/v2:computeRoutes',
-            {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Goog-Api-Key': googleMapsServerApiKey(),
-                    'X-Goog-FieldMask':
-                        'routes.legs.distanceMeters,routes.legs.duration,routes.polyline.encodedPolyline',
+    const travelEdges = orderedNodes.flatMap((to, index) => {
+        const from = orderedNodes[index - 1];
+        if (
+            !from ||
+            (from.latitude === to.latitude && from.longitude === to.longitude)
+        ) {
+            return [];
+        }
+        return [{ from, to }];
+    });
+    const requestNodes = [origin, ...travelEdges.map(({ to }) => to)];
+    const returnedFixedLegs: DeliveryRouteGraphLeg[] = [];
+    const returnedLegsByKey = new Map<string, DeliveryRouteGraphLeg>();
+    const encodedPolylines: string[] = [];
+    const maximumNodesPerRequest = googleRouteMaximumIntermediates + 2;
+    let routeClock = Math.ceil(departureTime.getTime() / 1_000) * 1_000;
+    routeClock =
+        Math.max(routeClock, origin.windowStartAt?.getTime() ?? routeClock) +
+        origin.serviceSeconds * 1_000;
+    let clockNodeIndex = 0;
+    const advanceRouteClock = () => {
+        while (clockNodeIndex < orderedNodes.length - 1) {
+            const from = orderedNodes[clockNodeIndex];
+            const to = orderedNodes[clockNodeIndex + 1];
+            if (!from || !to) break;
+            const sameCoordinates =
+                from.latitude === to.latitude &&
+                from.longitude === to.longitude;
+            const leg = sameCoordinates
+                ? { travelSeconds: 0 }
+                : returnedLegsByKey.get(`${from.key}\u0000${to.key}`);
+            if (!leg) break;
+            const arrivalAt = routeClock + leg.travelSeconds * 1_000;
+            const serviceStartedAt = Math.max(
+                arrivalAt,
+                to.windowStartAt?.getTime() ?? arrivalAt,
+            );
+            routeClock = serviceStartedAt + to.serviceSeconds * 1_000;
+            clockNodeIndex += 1;
+        }
+    };
+    advanceRouteClock();
+    for (
+        let edgeOffset = 0;
+        edgeOffset < travelEdges.length;
+        edgeOffset += maximumNodesPerRequest - 1
+    ) {
+        const segmentNodes = requestNodes.slice(
+            edgeOffset,
+            edgeOffset + maximumNodesPerRequest,
+        );
+        const segmentOrigin = segmentNodes[0];
+        const segmentDestination = segmentNodes.at(-1);
+        if (!segmentOrigin || !segmentDestination) {
+            throw new GoogleRouteServiceError(
+                'Google route segment was invalid.',
+            );
+        }
+        let response: Response;
+        try {
+            response = await fetch(
+                'https://routes.googleapis.com/directions/v2:computeRoutes',
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Goog-Api-Key': googleMapsServerApiKey(),
+                        'X-Goog-FieldMask':
+                            'routes.legs.distanceMeters,routes.legs.duration,routes.polyline.encodedPolyline',
+                    },
+                    body: JSON.stringify({
+                        origin: locationWaypoint(segmentOrigin),
+                        destination: locationWaypoint(segmentDestination),
+                        intermediates: segmentNodes
+                            .slice(1, -1)
+                            .map(locationWaypoint),
+                        travelMode: 'DRIVE',
+                        routingPreference: 'TRAFFIC_AWARE',
+                        optimizeWaypointOrder: false,
+                        departureTime: new Date(routeClock).toISOString(),
+                        languageCode: 'hr-HR',
+                        regionCode: 'HR',
+                        units: 'METRIC',
+                    }),
+                    cache: 'no-store',
                 },
-                body: JSON.stringify({
-                    origin: locationWaypoint(origin),
-                    destination: locationWaypoint(destination),
-                    intermediates: orderedNodes
-                        .slice(1, -1)
-                        .map(locationWaypoint),
-                    travelMode: 'DRIVE',
-                    routingPreference: 'TRAFFIC_AWARE',
-                    optimizeWaypointOrder: false,
-                    departureTime: departureTime.toISOString(),
-                    languageCode: 'hr-HR',
-                    regionCode: 'HR',
-                    units: 'METRIC',
-                }),
-                cache: 'no-store',
-            },
-        );
-    } catch {
-        throw new GoogleRouteServiceError('Google route request failed.');
-    }
-    const body: unknown = await response.json().catch(() => null);
-    const routeValue =
-        isRecord(body) && Array.isArray(body.routes) ? body.routes[0] : null;
-    if (!response.ok || !isRecord(routeValue)) {
-        throw new GoogleRouteServiceError(
-            'Google final route response was unavailable.',
-        );
-    }
-    const route: GoogleRoute = routeValue;
-    const returnedLegs = googleRouteLegs(route.legs);
-    if (returnedLegs.length !== orderedNodes.length - 1) {
-        throw new GoogleRouteServiceError(
-            'Google final route omitted itinerary legs.',
-        );
-    }
-    const fixedLegs: DeliveryRouteGraphLeg[] = returnedLegs.map(
-        (leg, index) => {
-            const from = orderedNodes[index];
-            const to = orderedNodes[index + 1];
+            );
+        } catch {
+            throw new GoogleRouteServiceError('Google route request failed.');
+        }
+        const body: unknown = await response.json().catch(() => null);
+        const routeValue =
+            isRecord(body) && Array.isArray(body.routes)
+                ? body.routes[0]
+                : null;
+        if (!response.ok || !isRecord(routeValue)) {
+            throw new GoogleRouteServiceError(
+                'Google final route response was unavailable.',
+            );
+        }
+        const route: GoogleRoute = routeValue;
+        const returnedLegs = googleRouteLegs(route.legs);
+        if (returnedLegs.length !== segmentNodes.length - 1) {
+            throw new GoogleRouteServiceError(
+                'Google final route omitted itinerary legs.',
+            );
+        }
+        for (const [localIndex, leg] of returnedLegs.entries()) {
+            const edge = travelEdges[edgeOffset + localIndex];
             const travelSeconds = durationSeconds(leg.duration);
             const distanceMeters = nonnegativeInteger(leg.distanceMeters);
             if (
-                !from ||
-                !to ||
+                !edge ||
                 travelSeconds === undefined ||
                 distanceMeters === undefined
             ) {
@@ -674,16 +790,73 @@ async function computeFixedGoogleRoute({
                     'Google final route returned an invalid leg.',
                 );
             }
-            return {
-                fromKey: from.key,
-                toKey: to.key,
+            const fixedLeg = {
+                fromKey: edge.from.key,
+                toKey: edge.to.key,
                 travelSeconds,
                 distanceMeters,
             };
-        },
+            returnedFixedLegs.push(fixedLeg);
+            returnedLegsByKey.set(
+                `${fixedLeg.fromKey}\u0000${fixedLeg.toKey}`,
+                fixedLeg,
+            );
+        }
+        if (typeof route.polyline?.encodedPolyline === 'string') {
+            encodedPolylines.push(route.polyline.encodedPolyline);
+        }
+        advanceRouteClock();
+    }
+    const fixedLegs = orderedNodes.slice(1).map((to, index) => {
+        const from = orderedNodes[index];
+        if (!from) {
+            throw new GoogleRouteServiceError(
+                'Google final route returned an invalid leg.',
+            );
+        }
+        if (from.latitude === to.latitude && from.longitude === to.longitude) {
+            return {
+                fromKey: from.key,
+                toKey: to.key,
+                travelSeconds: 0,
+                distanceMeters: 0,
+            };
+        }
+        const leg = returnedLegsByKey.get(`${from.key}\u0000${to.key}`);
+        if (!leg) {
+            throw new GoogleRouteServiceError(
+                'Google final route omitted an itinerary leg.',
+            );
+        }
+        return leg;
+    });
+    const fixedLegsByKey = new Map(
+        fixedLegs.map((leg) => [`${leg.fromKey}\u0000${leg.toKey}`, leg]),
     );
-    const plan = solveRouteGraph({
-        nodes: orderedNodes,
+    let availableAt = Math.ceil(departureTime.getTime() / 1_000) * 1_000;
+    const missedWindowNodeKeys = new Set<string>();
+    for (const [index, node] of orderedNodes.entries()) {
+        const previous = orderedNodes[index - 1];
+        const leg = previous
+            ? fixedLegsByKey.get(`${previous.key}\u0000${node.key}`)
+            : undefined;
+        const arrivalAt = availableAt + (leg?.travelSeconds ?? 0) * 1_000;
+        const serviceStartedAt = Math.max(
+            arrivalAt,
+            node.windowStartAt?.getTime() ?? arrivalAt,
+        );
+        if (node.windowEndAt && serviceStartedAt > node.windowEndAt.getTime()) {
+            missedWindowNodeKeys.add(node.key);
+        }
+        availableAt = serviceStartedAt + node.serviceSeconds * 1_000;
+    }
+    const evaluatedNodes = orderedNodes.map((node) =>
+        softenMissedWindows && missedWindowNodeKeys.has(node.key)
+            ? { ...node, windowEndAt: undefined }
+            : node,
+    );
+    const plan = evaluateFixedRouteGraph({
+        nodes: evaluatedNodes,
         originKey: origin.key,
         departureTime,
         legs: fixedLegs,
@@ -692,9 +865,7 @@ async function computeFixedGoogleRoute({
     return {
         plan,
         encodedPolyline:
-            typeof route.polyline?.encodedPolyline === 'string'
-                ? route.polyline.encodedPolyline
-                : undefined,
+            encodedPolylines.length === 1 ? encodedPolylines[0] : undefined,
     };
 }
 
@@ -932,4 +1103,391 @@ export async function planPickupAwareDeliveryRoute({
         pickupCandidatesByNodeKey,
         customerCandidatesByNodeKey,
     });
+}
+
+export type RemainingDeliveryRouteNode =
+    | (DeliveryCoordinates & {
+          kind: 'pickup';
+          nodeKey: string;
+          formattedAddress: string;
+          serviceDurationSeconds: number;
+      })
+    | (DeliveryCoordinates & {
+          kind: 'customer';
+          nodeKey: string;
+          formattedAddress: string;
+          deliveryRequestId: string;
+          requiredPickupKey: string;
+          serviceDurationSeconds: number;
+          windowStartAt?: Date;
+          windowEndAt?: Date;
+          retryLaneRank?: number;
+      });
+
+export type RemainingDeliveryRouteVisit = {
+    kind: 'pickup' | 'customer';
+    nodeKey: string;
+    itinerarySequence: number;
+    estimatedArrivalAt: Date;
+    incomingTravelSeconds: number;
+    incomingDistanceMeters: number;
+    serviceDurationSeconds: number;
+};
+
+export type RemainingDeliveryRoutePlan = {
+    estimateSource: 'google' | 'local';
+    encodedPolyline?: string;
+    totalDistanceMeters: number;
+    totalDurationSeconds: number;
+    visits: RemainingDeliveryRouteVisit[];
+};
+
+export const deliveryRerouteOriginNodeKey = '__delivery-reroute-origin__';
+
+function remainingRouteGraphNodes({
+    origin,
+    nodes,
+}: {
+    origin: DeliveryCoordinates;
+    nodes: RemainingDeliveryRouteNode[];
+}) {
+    const originKey = deliveryRerouteOriginNodeKey;
+    if (nodes.some((node) => node.nodeKey === originKey)) {
+        throw new DeliveryRoutePlanningError(
+            'Stanica rute koristi rezervirani ključ.',
+            'invalid-route-graph',
+        );
+    }
+    const graphNodes: DeliveryRouteGraphNode[] = [
+        {
+            kind: 'pickup',
+            key: originKey,
+            latitude: origin.latitude,
+            longitude: origin.longitude,
+            serviceSeconds: 0,
+        },
+        ...nodes.map(
+            (node): DeliveryRouteGraphNode =>
+                node.kind === 'pickup'
+                    ? {
+                          kind: 'pickup',
+                          key: node.nodeKey,
+                          latitude: node.latitude,
+                          longitude: node.longitude,
+                          serviceSeconds: node.serviceDurationSeconds,
+                      }
+                    : {
+                          kind: 'customer',
+                          key: node.nodeKey,
+                          latitude: node.latitude,
+                          longitude: node.longitude,
+                          serviceSeconds: node.serviceDurationSeconds,
+                          windowStartAt: node.windowStartAt,
+                          windowEndAt: node.windowEndAt,
+                          requiredPickupKey: node.requiredPickupKey,
+                          deliveryRequestId: node.deliveryRequestId,
+                      },
+        ),
+    ];
+    const candidatesByNodeKey = new Map<
+        string,
+        DeliveryPickupRouteCandidate | PickupAwareDeliveryRouteCandidate
+    >([
+        [
+            originKey,
+            {
+                nodeKey: originKey,
+                pickupLocationId: 0,
+                formattedAddress: 'Trenutačna lokacija vozača',
+            },
+        ],
+        ...nodes.map(
+            (
+                node,
+            ):
+                | [string, DeliveryPickupRouteCandidate]
+                | [string, PickupAwareDeliveryRouteCandidate] =>
+                node.kind === 'pickup'
+                    ? [
+                          node.nodeKey,
+                          {
+                              nodeKey: node.nodeKey,
+                              pickupLocationId: 0,
+                              formattedAddress: node.formattedAddress,
+                          },
+                      ]
+                    : [
+                          node.nodeKey,
+                          {
+                              nodeKey: node.nodeKey,
+                              requiredPickupKey: node.requiredPickupKey,
+                              deliveryRequestId: node.deliveryRequestId,
+                              formattedAddress: node.formattedAddress,
+                              windowStartAt: node.windowStartAt,
+                              windowEndAt: node.windowEndAt,
+                          },
+                      ],
+        ),
+    ]);
+    return { originKey, graphNodes, candidatesByNodeKey };
+}
+
+function fixedRemainingRoutePlan({
+    graphNodes,
+    originKey,
+    departureTime,
+    legs,
+    candidatesByNodeKey,
+    retryLaneRankByNodeKey,
+}: {
+    graphNodes: DeliveryRouteGraphNode[];
+    originKey: string;
+    departureTime: Date;
+    legs: DeliveryRouteGraphLeg[];
+    candidatesByNodeKey: ReadonlyMap<
+        string,
+        DeliveryPickupRouteCandidate | PickupAwareDeliveryRouteCandidate
+    >;
+    retryLaneRankByNodeKey: ReadonlyMap<string, number>;
+}) {
+    const normalNodeKeys = new Set(
+        graphNodes.flatMap((node) =>
+            retryLaneRankByNodeKey.has(node.key) ? [] : [node.key],
+        ),
+    );
+    const normalPlan = solveRouteGraph({
+        nodes: graphNodes.filter((node) => normalNodeKeys.has(node.key)),
+        originKey,
+        departureTime,
+        legs: legs.filter(
+            (leg) =>
+                normalNodeKeys.has(leg.fromKey) &&
+                normalNodeKeys.has(leg.toKey),
+        ),
+        candidatesByNodeKey,
+        maximumNodes: maximumDeliveryRouteGraphNodes + 1,
+    });
+    const graphNodesByKey = new Map(graphNodes.map((node) => [node.key, node]));
+    const orderedNodes = [
+        ...normalPlan.visits.map((visit) => visit.node),
+        ...Array.from(retryLaneRankByNodeKey)
+            .sort(
+                ([firstKey, firstRank], [secondKey, secondRank]) =>
+                    firstRank - secondRank || firstKey.localeCompare(secondKey),
+            )
+            .flatMap(([nodeKey]) => {
+                const node = graphNodesByKey.get(nodeKey);
+                return node ? [node] : [];
+            }),
+    ];
+    const legsByKey = new Map(
+        legs.map((leg) => [`${leg.fromKey}\u0000${leg.toKey}`, leg]),
+    );
+    const fixedLegs = orderedNodes.slice(1).map((node, index) => {
+        const previous = orderedNodes[index];
+        const leg = previous
+            ? (legsByKey.get(`${previous.key}\u0000${node.key}`) ??
+              localRouteLeg(previous, node))
+            : undefined;
+        if (!leg) {
+            throw new DeliveryRoutePlanningError(
+                'Nedostaje dionica preostale rute.',
+                'invalid-route-graph',
+                node.kind === 'customer' ? node.deliveryRequestId : undefined,
+                node.key,
+            );
+        }
+        return leg;
+    });
+    return evaluateFixedRouteGraph({
+        nodes: orderedNodes,
+        originKey,
+        departureTime,
+        legs: fixedLegs,
+        candidatesByNodeKey,
+    });
+}
+
+function formatRemainingRoutePlan({
+    plan,
+    originKey,
+    estimateSource,
+    encodedPolyline,
+}: {
+    plan: DeliveryRouteGraphPlan;
+    originKey: string;
+    estimateSource: 'google' | 'local';
+    encodedPolyline?: string;
+}): RemainingDeliveryRoutePlan {
+    return {
+        estimateSource,
+        ...(encodedPolyline ? { encodedPolyline } : {}),
+        totalDistanceMeters: plan.totalDistanceMeters,
+        totalDurationSeconds: plan.totalDurationSeconds,
+        visits: plan.visits
+            .filter((visit) => visit.node.key !== originKey)
+            .map((visit, index) => ({
+                kind: visit.node.kind,
+                nodeKey: visit.node.key,
+                itinerarySequence: index + 1,
+                estimatedArrivalAt: visit.serviceStartedAt,
+                incomingTravelSeconds: visit.incomingTravelSeconds,
+                incomingDistanceMeters: visit.incomingDistanceMeters,
+                serviceDurationSeconds: visit.serviceSeconds,
+            })),
+    };
+}
+
+async function calculateRemainingRoutePlan({
+    graphNodes,
+    originKey,
+    departureTime,
+    candidatesByNodeKey,
+    retryLaneRankByNodeKey,
+    legs,
+    estimateSource,
+}: {
+    graphNodes: DeliveryRouteGraphNode[];
+    originKey: string;
+    departureTime: Date;
+    candidatesByNodeKey: ReadonlyMap<
+        string,
+        DeliveryPickupRouteCandidate | PickupAwareDeliveryRouteCandidate
+    >;
+    retryLaneRankByNodeKey: ReadonlyMap<string, number>;
+    legs: DeliveryRouteGraphLeg[];
+    estimateSource: 'google' | 'local';
+}) {
+    const matrixPlan = fixedRemainingRoutePlan({
+        graphNodes,
+        originKey,
+        departureTime,
+        legs,
+        candidatesByNodeKey,
+        retryLaneRankByNodeKey,
+    });
+    if (estimateSource === 'local') {
+        return formatRemainingRoutePlan({
+            plan: matrixPlan,
+            originKey,
+            estimateSource,
+        });
+    }
+    const fixedRoute = await computeFixedGoogleRoute({
+        graphPlan: matrixPlan,
+        departureTime,
+        candidatesByNodeKey,
+        softenMissedWindows: true,
+    });
+    return formatRemainingRoutePlan({
+        plan: fixedRoute.plan,
+        originKey,
+        estimateSource,
+        encodedPolyline: fixedRoute.encodedPolyline,
+    });
+}
+
+export async function recalculatePickupAwareDeliveryRoute({
+    origin,
+    nodes,
+    departureTime = new Date(),
+}: {
+    origin: DeliveryCoordinates;
+    nodes: RemainingDeliveryRouteNode[];
+    departureTime?: Date;
+}): Promise<RemainingDeliveryRoutePlan> {
+    if (nodes.length === 0) {
+        return {
+            estimateSource: 'local',
+            totalDistanceMeters: 0,
+            totalDurationSeconds: 0,
+            visits: [],
+        };
+    }
+    const retryLaneRankByNodeKey = new Map(
+        nodes.flatMap((node) =>
+            node.kind === 'customer' && node.retryLaneRank !== undefined
+                ? [[node.nodeKey, node.retryLaneRank] as const]
+                : [],
+        ),
+    );
+    const baseGraph = remainingRouteGraphNodes({ origin, nodes });
+    const normalGraphNodes = baseGraph.graphNodes.filter(
+        (node) => !retryLaneRankByNodeKey.has(node.key),
+    );
+    let estimateSource: 'google' | 'local' = 'google';
+    let legs: DeliveryRouteGraphLeg[];
+    try {
+        legs =
+            normalGraphNodes.length > 1
+                ? await computeGoogleRouteMatrix({
+                      nodes: normalGraphNodes,
+                      departureTime,
+                  })
+                : [];
+    } catch (error) {
+        if (error instanceof DeliveryRoutePlanningError) throw error;
+        if (!(error instanceof GoogleRouteServiceError)) throw error;
+        console.warn(
+            'Google delivery reroute failed; using persisted-coordinate fallback',
+            { nodeCount: baseGraph.graphNodes.length, error },
+        );
+        estimateSource = 'local';
+        legs = localRouteLegs(normalGraphNodes);
+    }
+    const normalizedDepartureAt =
+        Math.ceil(departureTime.getTime() / 1_000) * 1_000;
+    const relaxedWindowNodeKeys = new Set(
+        nodes.flatMap((node) =>
+            node.kind === 'customer' &&
+            node.windowEndAt &&
+            node.windowEndAt.getTime() < normalizedDepartureAt
+                ? [node.nodeKey]
+                : [],
+        ),
+    );
+    let windowRelaxations = relaxedWindowNodeKeys.size;
+    while (windowRelaxations <= nodes.length) {
+        const planningNodes = nodes.map((node) =>
+            node.kind === 'customer' && relaxedWindowNodeKeys.has(node.nodeKey)
+                ? { ...node, windowEndAt: undefined }
+                : node,
+        );
+        try {
+            return await calculateRemainingRoutePlan({
+                ...remainingRouteGraphNodes({
+                    origin,
+                    nodes: planningNodes,
+                }),
+                departureTime,
+                retryLaneRankByNodeKey,
+                legs,
+                estimateSource,
+            });
+        } catch (error) {
+            if (error instanceof GoogleRouteServiceError) {
+                console.warn(
+                    'Google delivery reroute failed; using persisted-coordinate fallback',
+                    { nodeCount: baseGraph.graphNodes.length, error },
+                );
+                estimateSource = 'local';
+                legs = localRouteLegs(normalGraphNodes);
+                continue;
+            }
+            if (
+                !(error instanceof DeliveryRoutePlanningError) ||
+                error.code !== 'route-time-window-infeasible' ||
+                !error.nodeKey ||
+                relaxedWindowNodeKeys.has(error.nodeKey)
+            ) {
+                throw error;
+            }
+            relaxedWindowNodeKeys.add(error.nodeKey);
+            windowRelaxations += 1;
+        }
+    }
+    throw new DeliveryRoutePlanningError(
+        'Preostalu rutu nije moguće vremenski uskladiti.',
+        'route-time-window-infeasible',
+    );
 }

--- a/apps/delivery/lib/deliveryRouteGraph.ts
+++ b/apps/delivery/lib/deliveryRouteGraph.ts
@@ -83,7 +83,13 @@ export type SolveDeliveryRouteGraphInput = {
     originKey: string;
     departureAt: Date;
     legs: readonly DeliveryRouteGraphLeg[];
+    maximumNodes?: number;
 };
+
+export type EvaluateFixedDeliveryRouteGraphInput = Omit<
+    SolveDeliveryRouteGraphInput,
+    'maximumNodes'
+>;
 
 type SearchStateCore = {
     visitedMask: number;
@@ -195,10 +201,9 @@ function validateGraph(input: SolveDeliveryRouteGraphInput): ValidatedGraph {
     if (input.nodes.length === 0) {
         invalidGraph('Ruta mora sadržavati barem jednu stanicu.');
     }
-    if (input.nodes.length > maximumDeliveryRouteGraphNodes) {
-        invalidGraph(
-            `Ruta može sadržavati najviše ${maximumDeliveryRouteGraphNodes} stanica.`,
-        );
+    const maximumNodes = input.maximumNodes ?? maximumDeliveryRouteGraphNodes;
+    if (input.nodes.length > maximumNodes) {
+        invalidGraph(`Ruta može sadržavati najviše ${maximumNodes} stanica.`);
     }
 
     const nodes = [...input.nodes].sort((first, second) =>
@@ -692,6 +697,131 @@ function buildPlan(
         totalServiceSeconds,
         totalDurationSeconds:
             (availableAtMs - input.departureAt.getTime()) / 1_000,
+        visits,
+    };
+}
+
+/** Evaluates an already ordered route without bitmask-based search. */
+export function evaluateFixedDeliveryRouteGraph(
+    input: EvaluateFixedDeliveryRouteGraphInput,
+): DeliveryRouteGraphPlan {
+    if (!validDate(input.departureAt) || input.nodes.length === 0) {
+        invalidGraph('Fiksna ruta nema valjano vrijeme ili stanice.');
+    }
+    const departureAt = new Date(
+        Math.ceil(input.departureAt.getTime() / 1_000) * 1_000,
+    );
+    const nodes = [...input.nodes];
+    const nodeKeys = new Set<string>();
+    for (const node of nodes) {
+        validateNode(node);
+        if (nodeKeys.has(node.key)) {
+            invalidGraph(
+                'Ključevi stanica rute moraju biti jedinstveni.',
+                node.key,
+                deliveryRequestId(node),
+            );
+        }
+        nodeKeys.add(node.key);
+    }
+    const origin = nodes[0];
+    if (!origin || origin.key !== input.originKey || origin.kind !== 'pickup') {
+        invalidGraph(
+            'Početna stanica fiksne rute nije valjana.',
+            input.originKey,
+        );
+    }
+
+    const legsByKey = new Map<string, DeliveryRouteGraphLeg>();
+    for (const leg of input.legs) {
+        if (
+            !nodeKeys.has(leg.fromKey) ||
+            !nodeKeys.has(leg.toKey) ||
+            leg.fromKey === leg.toKey ||
+            !validNonNegativeInteger(leg.travelSeconds) ||
+            !validNonNegativeInteger(leg.distanceMeters)
+        ) {
+            invalidGraph('Fiksna ruta sadrži nevaljanu dionicu.', leg.toKey);
+        }
+        const key = `${leg.fromKey}\u0000${leg.toKey}`;
+        if (legsByKey.has(key)) {
+            invalidGraph('Fiksna ruta sadrži dupliciranu dionicu.', leg.toKey);
+        }
+        legsByKey.set(key, leg);
+    }
+
+    const visits: DeliveryRouteGraphVisit[] = [];
+    const visitedPickups = new Set<string>();
+    let availableAtMs = departureAt.getTime();
+    let totalDistanceMeters = 0;
+    let totalTravelSeconds = 0;
+    let totalWaitingSeconds = 0;
+    let totalServiceSeconds = 0;
+    for (const [index, node] of nodes.entries()) {
+        if (
+            node.kind === 'customer' &&
+            !visitedPickups.has(node.requiredPickupKey)
+        ) {
+            throw new DeliveryRouteGraphPlanningError(
+                'Fiksna ruta ne poštuje redoslijed preuzimanja.',
+                'route-infeasible',
+                node.key,
+                node.deliveryRequestId,
+            );
+        }
+        const previous = nodes[index - 1];
+        const leg = previous
+            ? legsByKey.get(`${previous.key}\u0000${node.key}`)
+            : undefined;
+        if (previous && !leg) {
+            throw new DeliveryRouteGraphPlanningError(
+                'Fiksna ruta nema potrebnu dionicu.',
+                'route-infeasible',
+                node.key,
+                deliveryRequestId(node),
+            );
+        }
+        const incomingTravelSeconds = leg?.travelSeconds ?? 0;
+        const incomingDistanceMeters = leg?.distanceMeters ?? 0;
+        const arrivalAtMs = availableAtMs + incomingTravelSeconds * 1_000;
+        const serviceStartedAtMs = serviceStartAtMs(arrivalAtMs, node);
+        if (missesWindow(serviceStartedAtMs, node)) {
+            throw new DeliveryRouteGraphPlanningError(
+                'Fiksnu rutu nije moguće završiti unutar vremenskog prozora.',
+                'route-time-window-infeasible',
+                node.key,
+                deliveryRequestId(node),
+            );
+        }
+        const waitingSeconds = (serviceStartedAtMs - arrivalAtMs) / 1_000;
+        const serviceCompletedAtMs =
+            serviceStartedAtMs + node.serviceSeconds * 1_000;
+        visits.push({
+            sequence: index + 1,
+            node,
+            incomingTravelSeconds,
+            incomingDistanceMeters,
+            arrivalAt: new Date(arrivalAtMs),
+            waitingSeconds,
+            serviceStartedAt: new Date(serviceStartedAtMs),
+            serviceSeconds: node.serviceSeconds,
+            serviceCompletedAt: new Date(serviceCompletedAtMs),
+        });
+        if (node.kind === 'pickup') visitedPickups.add(node.key);
+        availableAtMs = serviceCompletedAtMs;
+        totalDistanceMeters += incomingDistanceMeters;
+        totalTravelSeconds += incomingTravelSeconds;
+        totalWaitingSeconds += waitingSeconds;
+        totalServiceSeconds += node.serviceSeconds;
+    }
+    return {
+        startedAt: departureAt,
+        completedAt: new Date(availableAtMs),
+        totalDistanceMeters,
+        totalTravelSeconds,
+        totalWaitingSeconds,
+        totalServiceSeconds,
+        totalDurationSeconds: (availableAtMs - departureAt.getTime()) / 1_000,
         visits,
     };
 }

--- a/apps/delivery/lib/deliveryRunExecutionError.ts
+++ b/apps/delivery/lib/deliveryRunExecutionError.ts
@@ -27,6 +27,12 @@ export function deliveryRunExecutionErrorDetails(
                 code: error.code,
                 message: 'Aktivna ruta više nije dostupna.',
             };
+        case 'route-revision-conflict':
+            return {
+                code: error.code,
+                message:
+                    'Ruta je u međuvremenu promijenjena. Osvježi podatke i pokušaj ponovno.',
+            };
         default:
             return {
                 code: error.code,

--- a/apps/delivery/lib/deliveryRunPlanning.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunPlanning.node.spec.ts
@@ -128,9 +128,9 @@ function planningDependencies({
         },
         getDispatchRevision: async () =>
             Math.max(0, ...requests.map(({ routeRevision }) => routeRevision)),
-        getAssignedStops: async () => {
+        getAssignedStops: async (requestIds) => {
             counters.assignmentReads += 1;
-            return assignedRequestId
+            return assignedRequestId && requestIds.includes(assignedRequestId)
                 ? [{ stop: { deliveryRequestId: assignedRequestId } }]
                 : [];
         },
@@ -664,7 +664,33 @@ test('rejects a selection beyond the shared physical-stop limit before the plann
     assert.equal(counters.mutationCalls, 0);
 });
 
-test('rejects an assigned bulk member before route planning', async () => {
+test('excludes an assigned auto-expanded sibling from public preflight and revalidation', async () => {
+    const requests = [request({ id: 'bulk-one' }), request({ id: 'bulk-two' })];
+    const { dependencies, counters } = planningDependencies({
+        requests,
+        assignedRequestId: 'bulk-two',
+    });
+
+    const prepared = await prepareDeliveryRun(
+        {
+            driverUserId: 'driver-one',
+            deliveryRequestIds: ['bulk-one'],
+        },
+        dependencies,
+    );
+    await revalidatePreparedDeliveryRun(prepared, dependencies);
+
+    assert.deepEqual(
+        prepared.requestSnapshots.map((snapshot) => snapshot.deliveryRequestId),
+        ['bulk-one'],
+    );
+    assert.equal(prepared.summary.deliveryCount, 1);
+    assert.equal(counters.assignmentReads, 2);
+    assert.equal(counters.plannerCalls, 1);
+    assert.equal(counters.mutationCalls, 0);
+});
+
+test('rejects an explicitly selected assigned request before route planning', async () => {
     const requests = [request({ id: 'bulk-one' }), request({ id: 'bulk-two' })];
     const { dependencies, counters } = planningDependencies({
         requests,
@@ -675,7 +701,7 @@ test('rejects an assigned bulk member before route planning', async () => {
         prepareDeliveryRun(
             {
                 driverUserId: 'driver-one',
-                deliveryRequestIds: ['bulk-one'],
+                deliveryRequestIds: ['bulk-two'],
             },
             dependencies,
         ),

--- a/apps/delivery/lib/deliveryRunPlanning.ts
+++ b/apps/delivery/lib/deliveryRunPlanning.ts
@@ -4,9 +4,9 @@ import {
     DeliveryRunPersistenceError,
     type DeliveryRunRequestSnapshotInput,
     getActiveDeliveryRunForDriver,
+    getActiveDeliveryRunStopsForRequestIds,
     getDeliveryDispatchRevision,
     getDeliveryRequestsWithEvents,
-    getDeliveryRunStopsForRequestIds,
     saveDeliveryRunPreparation,
 } from '@gredice/storage';
 import 'server-only';
@@ -100,7 +100,7 @@ const defaultDependencies: DeliveryRunPlanningDependencies = {
     getActiveRunForDriver: getActiveDeliveryRunForDriver,
     getRequests: getDeliveryRequestsWithEvents,
     getDispatchRevision: getDeliveryDispatchRevision,
-    getAssignedStops: getDeliveryRunStopsForRequestIds,
+    getAssignedStops: getActiveDeliveryRunStopsForRequestIds,
     planRoute: planPickupAwareDeliveryRoute,
     now: () => new Date(),
 };
@@ -527,8 +527,25 @@ export async function prepareDeliveryRun(
         assertSelectedRequest(requestId, request, now);
         if (request) selectedStopKeys.add(stopKey(request));
     }
+    const selectedCandidates = uniqueRequestIds.flatMap((requestId) => {
+        const request = requestsById.get(requestId);
+        const candidate = request ? selectionCandidate(request) : null;
+        return candidate ? [candidate] : [];
+    });
+    const selectedInspection = inspectDeliveryRouteSelection({
+        candidates: selectedCandidates,
+        requestIds: selectedCandidates.map((candidate) => candidate.requestId),
+        maximumRouteStops: maximumDeliveryRouteStops,
+        maximumRouteWindowHours: maximumDeliveryRouteWindowHours,
+    });
+    if (selectedInspection.conflict) {
+        throw selectionPreparationError(
+            selectedInspection.conflict,
+            requestsById,
+        );
+    }
 
-    const candidates = requests.filter(
+    const bulkCandidates = requests.filter(
         (request) =>
             request.mode === 'delivery' &&
             request.address &&
@@ -536,6 +553,29 @@ export async function prepareDeliveryRun(
             request.state === DeliveryRequestStates.READY &&
             request.slot.endAt >= now &&
             selectedStopKeys.has(stopKey(request)),
+    );
+    const existingStops = await dependencies.getAssignedStops(
+        bulkCandidates.map((candidate) => candidate.id),
+    );
+    const assignedRequestIds = new Set(
+        existingStops.map((existing) => existing.stop.deliveryRequestId),
+    );
+    const assignedSelectionId = uniqueRequestIds.find((requestId) =>
+        assignedRequestIds.has(requestId),
+    );
+    if (assignedSelectionId) {
+        throw new DeliveryRunPreparationError(
+            'Jedna ili više odabranih dostava već je dodijeljena drugoj ruti. Osvježi popis i odaberi ponovno.',
+            requestConflict(
+                'delivery-already-assigned',
+                requestsById.get(assignedSelectionId),
+            ),
+        );
+    }
+    // Bulk expansion applies only to orders that are still dispatchable. A
+    // ready sibling already committed to an active run remains on that run.
+    const candidates = bulkCandidates.filter(
+        (candidate) => !assignedRequestIds.has(candidate.id),
     );
     const normalizedCandidates = candidates.flatMap((request) => {
         const candidate = selectionCandidate(request);
@@ -551,22 +591,6 @@ export async function prepareDeliveryRun(
     });
     if (inspection.conflict) {
         throw selectionPreparationError(inspection.conflict, requestsById);
-    }
-
-    const existingStops = await dependencies.getAssignedStops(
-        normalizedCandidates.map((candidate) => candidate.requestId),
-    );
-    if (existingStops.length > 0) {
-        const assignedRequestId = existingStops[0]?.stop.deliveryRequestId;
-        throw new DeliveryRunPreparationError(
-            'Jedna ili više odabranih dostava već je dodijeljena drugoj ruti. Osvježi popis i odaberi ponovno.',
-            requestConflict(
-                'delivery-already-assigned',
-                assignedRequestId
-                    ? requestsById.get(assignedRequestId)
-                    : undefined,
-            ),
-        );
     }
 
     const candidateGroups = groupByDeliveryStop(
@@ -832,7 +856,7 @@ export async function revalidatePreparedDeliveryRun(
         }
     }
 
-    const currentBulkRequestIds = requests.flatMap((request) => {
+    const currentBulkCandidates = requests.filter((request) => {
         if (
             request.mode !== 'delivery' ||
             request.state !== DeliveryRequestStates.READY ||
@@ -841,12 +865,33 @@ export async function revalidatePreparedDeliveryRun(
             request.slot.endAt < now ||
             !selectedStopKeys.has(stopKey(request))
         ) {
-            return [];
+            return false;
         }
-        return [request.id];
+        return true;
     });
     const snapshotRequestIds = preparation.requestSnapshots.map(
         (snapshot) => snapshot.deliveryRequestId,
+    );
+    const assignedStops = await dependencies.getAssignedStops(
+        currentBulkCandidates.map((request) => request.id),
+    );
+    const assignedRequestIds = new Set(
+        assignedStops.map((assigned) => assigned.stop.deliveryRequestId),
+    );
+    const assignedSnapshotId = snapshotRequestIds.find((requestId) =>
+        assignedRequestIds.has(requestId),
+    );
+    if (assignedSnapshotId) {
+        throw new DeliveryRunPreparationError(
+            'Jedna ili više odabranih dostava već je dodijeljena drugoj ruti. Osvježi popis i odaberi ponovno.',
+            requestConflict(
+                'delivery-already-assigned',
+                requestsById.get(assignedSnapshotId),
+            ),
+        );
+    }
+    const currentBulkRequestIds = currentBulkCandidates.flatMap((request) =>
+        assignedRequestIds.has(request.id) ? [] : [request.id],
     );
     if (!sameRequestIds(currentBulkRequestIds, snapshotRequestIds)) {
         const changedRequestId =
@@ -862,21 +907,6 @@ export async function revalidatePreparedDeliveryRun(
                 'delivery-bulk-selection-changed',
                 changedRequestId
                     ? requestsById.get(changedRequestId)
-                    : undefined,
-            ),
-        );
-    }
-
-    const assignedStops =
-        await dependencies.getAssignedStops(snapshotRequestIds);
-    if (assignedStops.length > 0) {
-        const assignedRequestId = assignedStops[0]?.stop.deliveryRequestId;
-        throw new DeliveryRunPreparationError(
-            'Jedna ili više odabranih dostava već je dodijeljena drugoj ruti. Osvježi popis i odaberi ponovno.',
-            requestConflict(
-                'delivery-already-assigned',
-                assignedRequestId
-                    ? requestsById.get(assignedRequestId)
                     : undefined,
             ),
         );

--- a/apps/delivery/lib/deliveryRunRerouting.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunRerouting.node.spec.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { deliveryRunRerouteLeaseMs } from '@gredice/storage';
+import {
+    deliveryRerouteLocationIsFresh,
+    deliveryRerouteRetryIntervalMs,
+    deliveryRerouteRetryIsDue,
+    deliveryRunHasActiveArrivedStop,
+} from './deliveryRunRerouting';
+
+test('reroute freshness uses the server-received GPS timestamp', () => {
+    const rerouteRequiredAt = new Date('2026-07-15T10:00:00.000Z');
+    const location = {
+        currentLatitude: 45.81,
+        currentLongitude: 15.97,
+        rerouteRequiredAt,
+    };
+
+    assert.equal(
+        deliveryRerouteLocationIsFresh({
+            ...location,
+            currentLocationReceivedAt: new Date(
+                rerouteRequiredAt.getTime() - 1,
+            ),
+        }),
+        false,
+    );
+    assert.equal(
+        deliveryRerouteLocationIsFresh({
+            ...location,
+            currentLocationReceivedAt: new Date(rerouteRequiredAt),
+        }),
+        true,
+    );
+    assert.equal(
+        deliveryRerouteLocationIsFresh({
+            ...location,
+            currentLatitude: null,
+            currentLocationReceivedAt: new Date(rerouteRequiredAt),
+        }),
+        false,
+    );
+});
+
+test('reroute retry becomes due only after the shared lease interval', () => {
+    const requiredAt = new Date('2026-07-15T10:00:00.000Z');
+    const attemptedAt = new Date('2026-07-15T10:01:00.000Z');
+
+    assert.equal(deliveryRerouteRetryIntervalMs, deliveryRunRerouteLeaseMs);
+    assert.equal(
+        deliveryRerouteRetryIsDue(
+            requiredAt,
+            attemptedAt,
+            new Date(attemptedAt.getTime() + deliveryRunRerouteLeaseMs - 1),
+        ),
+        false,
+    );
+    assert.equal(
+        deliveryRerouteRetryIsDue(
+            requiredAt,
+            attemptedAt,
+            new Date(attemptedAt.getTime() + deliveryRunRerouteLeaseMs),
+        ),
+        true,
+    );
+    assert.equal(deliveryRerouteRetryIsDue(requiredAt, null, requiredAt), true);
+    assert.equal(deliveryRerouteRetryIsDue(null, null, requiredAt), false);
+});
+
+test('an active arrived checkpoint defers rerouting but a released one does not', () => {
+    assert.equal(
+        deliveryRunHasActiveArrivedStop([
+            { state: 'arrived', releasedAt: null },
+        ]),
+        true,
+    );
+    assert.equal(
+        deliveryRunHasActiveArrivedStop([
+            { state: 'arrived', releasedAt: new Date() },
+            { state: 'pending', releasedAt: null },
+        ]),
+        false,
+    );
+});

--- a/apps/delivery/lib/deliveryRunRerouting.ts
+++ b/apps/delivery/lib/deliveryRunRerouting.ts
@@ -1,0 +1,430 @@
+import {
+    applyDeliveryRunReroute,
+    claimDeliveryRunReroute,
+    DeliveryRunExecutionError,
+    type DeliveryRunExecutionErrorCode,
+    DeliveryRunExecutionErrorCodes,
+    DeliveryRunManifestStates,
+    DeliveryRunStates,
+    DeliveryRunStopStates,
+    deliveryRunRerouteLeaseMs,
+    getDeliveryRun,
+    getDeliveryRunExecutionProgress,
+    isDeliveryRunStopTerminal,
+} from '@gredice/storage';
+import 'server-only';
+import {
+    deliveryRerouteOriginNodeKey,
+    type RemainingDeliveryRouteNode,
+    recalculatePickupAwareDeliveryRoute,
+} from './deliveryPickupRouting';
+import { deliveryNodeServiceSeconds } from './deliveryRouteGraph';
+
+type DeliveryRun = NonNullable<Awaited<ReturnType<typeof getDeliveryRun>>>;
+type DeliveryRunProgress = Awaited<
+    ReturnType<typeof getDeliveryRunExecutionProgress>
+>;
+
+export const deliveryRerouteRetryIntervalMs = deliveryRunRerouteLeaseMs;
+
+export function deliveryRerouteRetryIsDue(
+    rerouteRequiredAt: Date | null,
+    rerouteAttemptedAt: Date | null,
+    now = new Date(),
+) {
+    return Boolean(
+        rerouteRequiredAt &&
+            (!rerouteAttemptedAt ||
+                now.getTime() - rerouteAttemptedAt.getTime() >=
+                    deliveryRerouteRetryIntervalMs),
+    );
+}
+
+type DeliveryRerouteLocation = {
+    currentLatitude: number | null;
+    currentLongitude: number | null;
+    currentLocationReceivedAt: Date | null;
+    rerouteRequiredAt: Date | null;
+};
+
+export function deliveryRerouteLocationIsFresh(
+    location: DeliveryRerouteLocation,
+): location is DeliveryRerouteLocation & {
+    currentLatitude: number;
+    currentLongitude: number;
+    currentLocationReceivedAt: Date;
+    rerouteRequiredAt: Date;
+} {
+    return Boolean(
+        location.currentLatitude !== null &&
+            location.currentLongitude !== null &&
+            location.currentLocationReceivedAt &&
+            location.rerouteRequiredAt &&
+            location.currentLocationReceivedAt.getTime() >=
+                location.rerouteRequiredAt.getTime(),
+    );
+}
+
+export function deliveryRunHasActiveArrivedStop(
+    stops: readonly { state: string; releasedAt: Date | null }[],
+) {
+    return stops.some(
+        (stop) =>
+            stop.state === DeliveryRunStopStates.ARRIVED &&
+            stop.releasedAt === null,
+    );
+}
+
+function rerouteError(
+    code: DeliveryRunExecutionErrorCode,
+    message: string,
+): never {
+    throw new DeliveryRunExecutionError(code, message);
+}
+
+function deliveryNodeKey({
+    stopKey,
+    stopId,
+    retryLaneRank,
+}: {
+    stopKey: string | null;
+    stopId: number;
+    retryLaneRank?: number;
+}) {
+    const physicalKey = stopKey ?? `stop:${stopId}`;
+    return retryLaneRank === undefined
+        ? `delivery:${physicalKey}`
+        : `retry:${retryLaneRank}:${physicalKey}`;
+}
+
+function pickupNodeKey(pickupNodeId: string) {
+    return `pickup:${pickupNodeId}`;
+}
+
+function rerouteOrigin({
+    run,
+    originStopId,
+}: {
+    run: DeliveryRun;
+    originStopId?: number;
+}) {
+    const explicitStop = originStopId
+        ? run.stops.find((stop) => stop.id === originStopId)
+        : undefined;
+    if (explicitStop) {
+        return {
+            latitude: explicitStop.latitude,
+            longitude: explicitStop.longitude,
+        };
+    }
+    if (deliveryRerouteLocationIsFresh(run)) {
+        return {
+            latitude: run.currentLatitude,
+            longitude: run.currentLongitude,
+        };
+    }
+    rerouteError(
+        DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+        'Delivery reroute is waiting for a current driver location',
+    );
+}
+
+function remainingRouteNodes({
+    run,
+    progress,
+}: {
+    run: DeliveryRun;
+    progress: DeliveryRunProgress;
+}) {
+    const pickupNodesById = new Map(
+        run.pickupNodes.map((node) => [node.id, node]),
+    );
+    const remainingPickupIds = new Set(
+        progress.flatMap((step) =>
+            step.kind === 'pickup' && step.state !== 'completed'
+                ? [step.pickupNodeId]
+                : [],
+        ),
+    );
+    const nodes: RemainingDeliveryRouteNode[] = [];
+    for (const pickupNodeId of remainingPickupIds) {
+        const pickup = pickupNodesById.get(pickupNodeId);
+        if (
+            !pickup ||
+            pickup.latitude === null ||
+            pickup.longitude === null ||
+            pickup.serviceDurationSeconds === null
+        ) {
+            rerouteError(
+                DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+                'Delivery pickup checkpoint cannot be rerouted',
+            );
+        }
+        nodes.push({
+            kind: 'pickup',
+            nodeKey: pickupNodeKey(pickup.id),
+            formattedAddress: pickup.formattedAddress,
+            latitude: pickup.latitude,
+            longitude: pickup.longitude,
+            serviceDurationSeconds: pickup.serviceDurationSeconds,
+        });
+    }
+
+    const stopIdsByNodeKey = new Map<string, number[]>();
+    for (const step of progress) {
+        if (step.kind !== 'delivery' || step.state === 'completed') continue;
+        const stops = run.stops.filter(
+            (stop) =>
+                step.stopIds.includes(stop.id) &&
+                !isDeliveryRunStopTerminal(stop.state),
+        );
+        const representative = stops[0];
+        if (!representative) continue;
+        const nodeKey = deliveryNodeKey({
+            stopKey: step.stopKey,
+            stopId: representative.id,
+            retryLaneRank: step.retryLaneRank,
+        });
+        const runSlot = representative.runSlot;
+        const legacyWindow =
+            run.routePlanVersion < 2 ? run.timeSlot : undefined;
+        const dependencySatisfied =
+            run.routePlanVersion < 2 ||
+            runSlot?.manifestState === DeliveryRunManifestStates.CONFIRMED;
+        const requiredPickupKey = dependencySatisfied
+            ? deliveryRerouteOriginNodeKey
+            : runSlot?.pickupNodeId
+              ? pickupNodeKey(runSlot.pickupNodeId)
+              : null;
+        if (!requiredPickupKey) {
+            rerouteError(
+                DeliveryRunExecutionErrorCodes.PICKUP_DEPENDENCY_PENDING,
+                'Delivery pickup dependency cannot be rerouted',
+            );
+        }
+        nodes.push({
+            kind: 'customer',
+            nodeKey,
+            formattedAddress: representative.formattedAddress,
+            deliveryRequestId: representative.deliveryRequestId,
+            requiredPickupKey,
+            latitude: representative.latitude,
+            longitude: representative.longitude,
+            serviceDurationSeconds:
+                representative.serviceDurationSeconds ??
+                deliveryNodeServiceSeconds,
+            ...((runSlot?.windowStartAt ?? legacyWindow?.startAt)
+                ? {
+                      windowStartAt:
+                          runSlot?.windowStartAt ?? legacyWindow?.startAt,
+                  }
+                : {}),
+            ...((runSlot?.windowEndAt ?? legacyWindow?.endAt)
+                ? {
+                      windowEndAt: runSlot?.windowEndAt ?? legacyWindow?.endAt,
+                  }
+                : {}),
+            ...(step.retryLaneRank !== undefined
+                ? { retryLaneRank: step.retryLaneRank }
+                : {}),
+        });
+        stopIdsByNodeKey.set(
+            nodeKey,
+            stops.map((stop) => stop.id),
+        );
+    }
+    return { nodes, stopIdsByNodeKey };
+}
+
+export async function rerouteDeliveryRun({
+    actorUserId,
+    runId,
+    expectedRouteRevision,
+    allowAdmin = false,
+    originStopId,
+    departureTime = new Date(),
+}: {
+    actorUserId: string;
+    runId: string;
+    expectedRouteRevision: number;
+    allowAdmin?: boolean;
+    originStopId?: number;
+    departureTime?: Date;
+}) {
+    const run = await getDeliveryRun(runId);
+    if (
+        !run ||
+        run.state !== DeliveryRunStates.ACTIVE ||
+        (!allowAdmin && run.driverUserId !== actorUserId)
+    ) {
+        rerouteError(
+            DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+            'Active delivery run was not found',
+        );
+    }
+    if (run.routeRevision !== expectedRouteRevision) {
+        rerouteError(
+            DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+            'Delivery route changed. Refresh the active run and retry.',
+        );
+    }
+    if (run.rerouteRequiredAt === null) {
+        return {
+            applied: false,
+            routeRevision: run.routeRevision,
+            reroutePending: false,
+        };
+    }
+    if (deliveryRunHasActiveArrivedStop(run.stops)) {
+        return {
+            applied: false,
+            routeRevision: run.routeRevision,
+            reroutePending: true,
+        };
+    }
+
+    const initialProgress = await getDeliveryRunExecutionProgress(runId);
+    rerouteOrigin({ run, originStopId });
+    remainingRouteNodes({ run, progress: initialProgress });
+    const claim = await claimDeliveryRunReroute({
+        runId,
+        expectedRouteRevision,
+    });
+    if (!claim) {
+        return {
+            applied: false,
+            routeRevision: run.routeRevision,
+            reroutePending: true,
+        };
+    }
+    const claimedRun = await getDeliveryRun(runId);
+    if (
+        !claimedRun ||
+        claimedRun.state !== DeliveryRunStates.ACTIVE ||
+        claimedRun.routeRevision !== expectedRouteRevision ||
+        claimedRun.rerouteAttemptedAt?.getTime() !==
+            claim.rerouteClaimedAt.getTime() ||
+        (!allowAdmin && claimedRun.driverUserId !== actorUserId)
+    ) {
+        rerouteError(
+            DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+            'Delivery route changed. Refresh the active run and retry.',
+        );
+    }
+    if (deliveryRunHasActiveArrivedStop(claimedRun.stops)) {
+        rerouteError(
+            DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+            'Delivery checkpoint changed while the reroute was claimed.',
+        );
+    }
+    const progress = await getDeliveryRunExecutionProgress(runId);
+    const origin = rerouteOrigin({ run: claimedRun, originStopId });
+    const { nodes, stopIdsByNodeKey } = remainingRouteNodes({
+        run: claimedRun,
+        progress,
+    });
+    const plan = await recalculatePickupAwareDeliveryRoute({
+        origin,
+        nodes,
+        departureTime,
+    });
+    const completedItineraryMaximum = Math.max(
+        0,
+        ...progress.flatMap((step) =>
+            step.state === 'completed' ? [step.itinerarySequence] : [],
+        ),
+    );
+    const pickupEstimates = plan.visits.flatMap((visit) => {
+        if (visit.kind !== 'pickup') return [];
+        const pickupNodeId = visit.nodeKey.startsWith('pickup:')
+            ? visit.nodeKey.slice('pickup:'.length)
+            : '';
+        return pickupNodeId
+            ? [
+                  {
+                      pickupNodeId,
+                      itinerarySequence:
+                          completedItineraryMaximum + visit.itinerarySequence,
+                      estimatedArrivalAt: visit.estimatedArrivalAt,
+                      incomingTravelSeconds: visit.incomingTravelSeconds,
+                      incomingDistanceMeters: visit.incomingDistanceMeters,
+                  },
+              ]
+            : [];
+    });
+    let legacyNextSequence =
+        Math.max(
+            0,
+            ...claimedRun.stops.flatMap((stop) =>
+                isDeliveryRunStopTerminal(stop.state) ? [stop.sequence] : [],
+            ),
+        ) + 1;
+    const stopEstimates = plan.visits.flatMap((visit) => {
+        if (visit.kind !== 'customer') return [];
+        const stopIds = stopIdsByNodeKey.get(visit.nodeKey);
+        if (!stopIds) return [];
+        const itinerarySequence =
+            claimedRun.routePlanVersion < 2
+                ? legacyNextSequence
+                : completedItineraryMaximum + visit.itinerarySequence;
+        if (claimedRun.routePlanVersion < 2) {
+            legacyNextSequence += stopIds.length;
+        }
+        return [
+            {
+                stopIds,
+                itinerarySequence,
+                estimatedArrivalAt: visit.estimatedArrivalAt,
+                estimatedTravelSeconds: visit.incomingTravelSeconds,
+                estimatedDistanceMeters: visit.incomingDistanceMeters,
+            },
+        ];
+    });
+    const applied = await applyDeliveryRunReroute({
+        runId,
+        expectedRouteRevision,
+        rerouteClaimedAt: claim.rerouteClaimedAt,
+        encodedPolyline: plan.encodedPolyline,
+        estimateSource: plan.estimateSource,
+        totalDistanceMeters: plan.totalDistanceMeters,
+        totalDurationSeconds: plan.totalDurationSeconds,
+        pickupEstimates,
+        stopEstimates,
+    });
+    return { applied: true, ...applied };
+}
+
+export async function reconcileDeliveryRunReroute(
+    input: Parameters<typeof rerouteDeliveryRun>[0],
+) {
+    try {
+        return await rerouteDeliveryRun(input);
+    } catch (error) {
+        if (
+            error instanceof DeliveryRunExecutionError &&
+            error.code ===
+                DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT
+        ) {
+            return {
+                applied: false,
+                routeRevision: input.expectedRouteRevision,
+                reroutePending: true,
+                conflict: true,
+            };
+        }
+        console.warn('Delivery reroute remains pending', {
+            runId: input.runId,
+            routeRevision: input.expectedRouteRevision,
+            code:
+                error instanceof DeliveryRunExecutionError
+                    ? error.code
+                    : 'reroute-failed',
+        });
+        return {
+            applied: false,
+            routeRevision: input.expectedRouteRevision,
+            reroutePending: true,
+            conflict: false,
+        };
+    }
+}

--- a/packages/game/src/hooks/useDeliveryAddressMutations.ts
+++ b/packages/game/src/hooks/useDeliveryAddressMutations.ts
@@ -3,6 +3,19 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deliveryAddressesQueryKey } from './useDeliveryAddresses';
 import { tutorialChecklistKeys } from './useTutorialChecklist';
 
+async function deliveryAddressMutationError(
+    response: Response,
+    fallback: string,
+) {
+    const body: unknown = await response.json().catch(() => null);
+    return typeof body === 'object' &&
+        body !== null &&
+        'error' in body &&
+        typeof body.error === 'string'
+        ? body.error
+        : fallback;
+}
+
 export function useCreateDeliveryAddress() {
     const queryClient = useQueryClient();
 
@@ -23,7 +36,12 @@ export function useCreateDeliveryAddress() {
                     json: data,
                 });
             if (!response.ok) {
-                throw new Error('Failed to create delivery address');
+                throw new Error(
+                    await deliveryAddressMutationError(
+                        response,
+                        'Adresu nije moguće dodati.',
+                    ),
+                );
             }
             return await response.json();
         },
@@ -60,7 +78,12 @@ export function useUpdateDeliveryAddress() {
                 json: updateData,
             });
             if (!response.ok) {
-                throw new Error('Failed to update delivery address');
+                throw new Error(
+                    await deliveryAddressMutationError(
+                        response,
+                        'Adresu nije moguće ažurirati.',
+                    ),
+                );
             }
             return await response.json();
         },
@@ -84,7 +107,12 @@ export function useDeleteDeliveryAddress() {
                 param: { id: id.toString() },
             });
             if (!response.ok) {
-                throw new Error('Failed to delete delivery address');
+                throw new Error(
+                    await deliveryAddressMutationError(
+                        response,
+                        'Adresu nije moguće obrisati.',
+                    ),
+                );
             }
             return await response.json();
         },

--- a/packages/game/src/shared-ui/delivery/DeliveryAddressesSection.tsx
+++ b/packages/game/src/shared-ui/delivery/DeliveryAddressesSection.tsx
@@ -212,10 +212,12 @@ export function AddressCard({
     readonly?: boolean;
 }) {
     const [isEditing, setIsEditing] = useState(false);
+    const [mutationError, setMutationError] = useState<string | null>(null);
     const updateAddress = useUpdateDeliveryAddress();
     const deleteAddress = useDeleteDeliveryAddress();
 
     const handleUpdate = async (data: AddressFormData) => {
+        setMutationError(null);
         try {
             await updateAddress.mutateAsync({
                 id: address.id,
@@ -223,15 +225,24 @@ export function AddressCard({
             });
             setIsEditing(false);
         } catch (error) {
-            console.error('Failed to update address:', error);
+            setMutationError(
+                error instanceof Error
+                    ? error.message
+                    : 'Adresu nije moguće ažurirati.',
+            );
         }
     };
 
     const handleDelete = async () => {
+        setMutationError(null);
         try {
             await deleteAddress.mutateAsync(address.id);
         } catch (error) {
-            console.error('Failed to delete address:', error);
+            setMutationError(
+                error instanceof Error
+                    ? error.message
+                    : 'Adresu nije moguće obrisati.',
+            );
         }
     };
 
@@ -239,10 +250,21 @@ export function AddressCard({
         return (
             <Card>
                 <CardContent>
+                    {mutationError ? (
+                        <Typography
+                            className="mb-3 text-destructive"
+                            level="body2"
+                        >
+                            {mutationError}
+                        </Typography>
+                    ) : null}
                     <AddressForm
                         address={address}
                         onSubmit={handleUpdate}
-                        onCancel={() => setIsEditing(false)}
+                        onCancel={() => {
+                            setMutationError(null);
+                            setIsEditing(false);
+                        }}
                         isLoading={updateAddress.isPending}
                     />
                 </CardContent>
@@ -254,6 +276,11 @@ export function AddressCard({
         <Card>
             <CardContent>
                 <Stack spacing={4}>
+                    {mutationError ? (
+                        <Typography className="text-destructive" level="body2">
+                            {mutationError}
+                        </Typography>
+                    ) : null}
                     <Row justifyContent="space-between" alignItems="start">
                         <Stack spacing={2}>
                             <Row spacing={4}>

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -36,6 +36,7 @@ export * from './repositories/communityEditRequestsRepo';
 export * from './repositories/deliveryAddressesRepo';
 export * from './repositories/deliveryDispatchRepo';
 export * from './repositories/deliveryRequestsRepo';
+export * from './repositories/deliveryRunAssignmentsRepo';
 export * from './repositories/deliveryRunsRepo';
 export * from './repositories/deliveryUtilsRepo';
 export * from './repositories/emailsRepo';

--- a/packages/storage/src/migrations/0073_overrated_sleepwalker.sql
+++ b/packages/storage/src/migrations/0073_overrated_sleepwalker.sql
@@ -1,0 +1,213 @@
+ALTER TABLE "delivery_run_stops" DROP CONSTRAINT "delivery_run_stops_outcome_shape_check";--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD COLUMN "retry_lane_rank" integer;--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD COLUMN "retry_attempt" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD COLUMN "released_at" timestamp;--> statement-breakpoint
+ALTER TABLE "delivery_runs" ADD COLUMN "reroute_attempted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "delivery_runs" ADD COLUMN "current_location_received_at" timestamp;--> statement-breakpoint
+WITH deferred_physical_groups AS (
+    SELECT
+        stops."run_id",
+        coalesce(
+            stops."stop_key",
+            runs."time_slot_id"::text || ':' || regexp_replace(
+                regexp_replace(lower(trim(stops."formatted_address")), '\s*,\s*', ',', 'g'),
+                '\s+',
+                ' ',
+                'g'
+            )
+        ) AS "physical_key",
+        min(coalesce(stops."exception_occurred_at", stops."updated_at", stops."created_at")) AS "first_deferred_at",
+        min(stops."sequence") AS "first_sequence"
+    FROM "delivery_run_stops" stops
+    INNER JOIN "delivery_runs" runs ON runs."id" = stops."run_id"
+    WHERE stops."state" = 'deferred'
+    GROUP BY stops."run_id", "physical_key"
+), ranked_deferred_groups AS (
+    SELECT
+        "run_id",
+        "physical_key",
+        row_number() OVER (
+            PARTITION BY "run_id"
+            ORDER BY "first_sequence", "first_deferred_at", "physical_key"
+        ) AS "retry_lane_rank"
+    FROM deferred_physical_groups
+), deferred_retry_lanes AS (
+    SELECT stops."id", ranked_deferred_groups."retry_lane_rank"
+    FROM "delivery_run_stops" stops
+    INNER JOIN "delivery_runs" runs ON runs."id" = stops."run_id"
+    INNER JOIN ranked_deferred_groups
+        ON ranked_deferred_groups."run_id" = stops."run_id"
+        AND ranked_deferred_groups."physical_key" = coalesce(
+            stops."stop_key",
+            runs."time_slot_id"::text || ':' || regexp_replace(
+                regexp_replace(lower(trim(stops."formatted_address")), '\s*,\s*', ',', 'g'),
+                '\s+',
+                ' ',
+                'g'
+            )
+        )
+    WHERE stops."state" = 'deferred'
+)
+UPDATE "delivery_run_stops"
+SET
+    "retry_lane_rank" = deferred_retry_lanes."retry_lane_rank",
+    "retry_attempt" = 1
+FROM deferred_retry_lanes
+WHERE "delivery_run_stops"."id" = deferred_retry_lanes."id";--> statement-breakpoint
+WITH active_delivery_requests AS (
+    SELECT DISTINCT "delivery_run_stops"."delivery_request_id"
+    FROM "delivery_run_stops"
+    INNER JOIN "delivery_runs"
+        ON "delivery_runs"."id" = "delivery_run_stops"."run_id"
+    WHERE "delivery_runs"."state" = 'active'
+      AND "delivery_run_stops"."state" <> 'delivered'
+), latest_delivery_state AS (
+    SELECT
+        active_delivery_requests."delivery_request_id" AS "aggregate_id",
+        latest_event."type",
+        latest_event."created_at"
+    FROM active_delivery_requests
+    CROSS JOIN LATERAL (
+        SELECT "events"."type", "events"."created_at"
+        FROM "events"
+        WHERE "events"."aggregate_id" = active_delivery_requests."delivery_request_id"
+          AND "events"."type" in (
+              'delivery.request.created',
+              'delivery.request.confirmed',
+              'delivery.request.preparing',
+              'delivery.request.ready',
+              'delivery.request.fulfilled',
+              'delivery.request.user_cancelled',
+              'delivery.request.cancelled'
+          )
+        ORDER BY "events"."created_at" DESC, "events"."id" DESC
+        LIMIT 1
+    ) latest_event
+)
+UPDATE "delivery_run_stops"
+SET
+    "state" = 'cancelled',
+    "delivered_at" = null,
+    "exception_reason" = 'cancellation',
+    "exception_note" = null,
+    "exception_occurred_at" = latest_delivery_state."created_at",
+    "exception_recorded_by_user_id" = null,
+    "released_at" = latest_delivery_state."created_at"
+FROM latest_delivery_state, "delivery_runs"
+WHERE latest_delivery_state."aggregate_id" = "delivery_run_stops"."delivery_request_id"
+  AND latest_delivery_state."type" in ('delivery.request.user_cancelled', 'delivery.request.cancelled')
+  AND "delivery_runs"."id" = "delivery_run_stops"."run_id"
+  AND "delivery_runs"."state" = 'active'
+  AND "delivery_run_stops"."state" <> 'delivered';--> statement-breakpoint
+UPDATE "delivery_runs"
+SET
+    "route_revision" = "route_revision" + 1,
+    "reroute_required_at" = (
+        SELECT max("delivery_run_stops"."released_at")
+        FROM "delivery_run_stops"
+        WHERE "delivery_run_stops"."run_id" = "delivery_runs"."id"
+          AND "delivery_run_stops"."state" = 'cancelled'
+          AND "delivery_run_stops"."released_at" is not null
+    ),
+    "reroute_attempted_at" = null
+WHERE "delivery_runs"."state" = 'active'
+  AND EXISTS (
+      SELECT 1
+      FROM "delivery_run_stops"
+      WHERE "delivery_run_stops"."run_id" = "delivery_runs"."id"
+        AND "delivery_run_stops"."state" = 'cancelled'
+        AND "delivery_run_stops"."released_at" is not null
+  );--> statement-breakpoint
+UPDATE "delivery_runs"
+SET
+    "state" = 'completed',
+    "completed_at" = coalesce(
+        "completed_at",
+        (
+            SELECT max(coalesce(
+                "delivery_run_stops"."delivered_at",
+                "delivery_run_stops"."exception_occurred_at",
+                "delivery_run_stops"."updated_at",
+                "delivery_run_stops"."created_at"
+            ))
+            FROM "delivery_run_stops"
+            WHERE "delivery_run_stops"."run_id" = "delivery_runs"."id"
+        ),
+        now()
+    ),
+    "reroute_required_at" = null,
+    "current_latitude" = null,
+    "current_longitude" = null,
+    "current_location_accuracy" = null,
+    "current_location_heading" = null,
+    "current_location_speed" = null,
+    "current_location_recorded_at" = null,
+    "current_location_received_at" = null
+WHERE "delivery_runs"."state" = 'active'
+  AND EXISTS (
+      SELECT 1
+      FROM "delivery_run_stops"
+      WHERE "delivery_run_stops"."run_id" = "delivery_runs"."id"
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM "delivery_run_stops"
+      WHERE "delivery_run_stops"."run_id" = "delivery_runs"."id"
+        AND "delivery_run_stops"."state" NOT IN ('delivered', 'failed', 'cancelled')
+  );--> statement-breakpoint
+UPDATE "delivery_run_stops"
+SET "released_at" = coalesce(
+    "delivered_at",
+    "exception_occurred_at",
+    "updated_at",
+    "created_at"
+)
+WHERE "state" in ('delivered', 'cancelled')
+   OR (
+       "state" = 'failed'
+       AND EXISTS (
+           SELECT 1
+           FROM "delivery_runs"
+           WHERE "delivery_runs"."id" = "delivery_run_stops"."run_id"
+             AND "delivery_runs"."state" <> 'active'
+       )
+   );--> statement-breakpoint
+DROP INDEX "delivery_run_stops_delivery_request_id_unique";--> statement-breakpoint
+CREATE UNIQUE INDEX "delivery_run_stops_delivery_request_active_unique" ON "delivery_run_stops" USING btree ("delivery_request_id") WHERE "delivery_run_stops"."released_at" is null;--> statement-breakpoint
+CREATE INDEX "delivery_run_stops_run_retry_lane_rank_idx" ON "delivery_run_stops" USING btree ("run_id","retry_lane_rank");--> statement-breakpoint
+CREATE INDEX "delivery_run_stops_released_at_idx" ON "delivery_run_stops" USING btree ("released_at");--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD CONSTRAINT "delivery_run_stops_retry_shape_check" CHECK ((
+                "delivery_run_stops"."retry_lane_rank" is null
+                and "delivery_run_stops"."retry_attempt" = 0
+            ) or (
+                "delivery_run_stops"."retry_lane_rank" is not null
+                and "delivery_run_stops"."retry_lane_rank" > 0
+                and "delivery_run_stops"."retry_attempt" > 0
+            ));--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD CONSTRAINT "delivery_run_stops_release_shape_check" CHECK ("delivery_run_stops"."released_at" is null or "delivery_run_stops"."state" in ('delivered', 'failed', 'cancelled'));--> statement-breakpoint
+ALTER TABLE "delivery_run_stops" ADD CONSTRAINT "delivery_run_stops_outcome_shape_check" CHECK ((
+                "delivery_run_stops"."state" in ('pending', 'arrived')
+                and "delivery_run_stops"."delivered_at" is null
+                and "delivery_run_stops"."exception_reason" is null
+                and "delivery_run_stops"."exception_note" is null
+                and "delivery_run_stops"."exception_occurred_at" is null
+                and "delivery_run_stops"."exception_recorded_by_user_id" is null
+            ) or (
+                "delivery_run_stops"."state" = 'delivered'
+                and "delivery_run_stops"."delivered_at" is not null
+                and "delivery_run_stops"."exception_reason" is null
+                and "delivery_run_stops"."exception_note" is null
+                and "delivery_run_stops"."exception_occurred_at" is null
+                and "delivery_run_stops"."exception_recorded_by_user_id" is null
+            ) or (
+                "delivery_run_stops"."state" in ('deferred', 'failed')
+                and "delivery_run_stops"."delivered_at" is null
+                and "delivery_run_stops"."exception_reason" is not null
+                and "delivery_run_stops"."exception_occurred_at" is not null
+                and "delivery_run_stops"."exception_recorded_by_user_id" is not null
+            ) or (
+                "delivery_run_stops"."state" = 'cancelled'
+                and "delivery_run_stops"."delivered_at" is null
+                and "delivery_run_stops"."exception_reason" = 'cancellation'
+                and "delivery_run_stops"."exception_occurred_at" is not null
+            ));

--- a/packages/storage/src/migrations/meta/0073_snapshot.json
+++ b/packages/storage/src/migrations/meta/0073_snapshot.json
@@ -1,0 +1,17980 @@
+{
+  "id": "d2e6be6e-54db-4dc9-80dd-e8577569db99",
+  "prevId": "5996bc66-d5b9-4e22-8601-92e0ccd7960b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_achievements": {
+      "name": "account_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_key": {
+          "name": "achievement_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "achievement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reward_sunflowers": {
+          "name": "reward_sunflowers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_value": {
+          "name": "progress_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_granted_at": {
+          "name": "reward_granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_by_user_id": {
+          "name": "denied_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_achievements_account_id_idx": {
+          "name": "account_achievements_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_achievements_status_idx": {
+          "name": "account_achievements_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_achievements_account_key_uq": {
+          "name": "account_achievements_account_key_uq",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "achievement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_achievements_account_id_accounts_id_fk": {
+          "name": "account_achievements_account_id_accounts_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_achievements_approved_by_user_id_users_id_fk": {
+          "name": "account_achievements_approved_by_user_id_users_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_achievements_denied_by_user_id_users_id_fk": {
+          "name": "account_achievements_denied_by_user_id_users_id_fk",
+          "tableFrom": "account_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "denied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_account_limit_overrides": {
+      "name": "ai_account_limit_overrides",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "active_daily_limit_micro_usd": {
+          "name": "active_daily_limit_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_daily_limit_micro_usd": {
+          "name": "trial_daily_limit_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_chat_days": {
+          "name": "trial_chat_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_account_limit_overrides_disabled_idx": {
+          "name": "ai_account_limit_overrides_disabled_idx",
+          "columns": [
+            {
+              "expression": "disabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_account_limit_overrides_account_id_accounts_id_fk": {
+          "name": "ai_account_limit_overrides_account_id_accounts_id_fk",
+          "tableFrom": "ai_account_limit_overrides",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_account_limit_overrides_updated_by_user_id_users_id_fk": {
+          "name": "ai_account_limit_overrides_updated_by_user_id_users_id_fk",
+          "tableFrom": "ai_account_limit_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_conversations": {
+      "name": "ai_chat_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_chat_conversations_account_idx": {
+          "name": "ai_chat_conversations_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_conversations_user_idx": {
+          "name": "ai_chat_conversations_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_conversations_last_message_idx": {
+          "name": "ai_chat_conversations_last_message_idx",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_conversations_account_id_accounts_id_fk": {
+          "name": "ai_chat_conversations_account_id_accounts_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_user_id_users_id_fk": {
+          "name": "ai_chat_conversations_user_id_users_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_garden_id_gardens_id_fk": {
+          "name": "ai_chat_conversations_garden_id_gardens_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_chat_conversations_raised_bed_id_raised_beds_id_fk": {
+          "name": "ai_chat_conversations_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "ai_chat_conversations",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_messages": {
+      "name": "ai_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_chat_messages_conversation_idx": {
+          "name": "ai_chat_messages_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_messages_created_at_idx": {
+          "name": "ai_chat_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_messages_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_messages_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_messages",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_chat_tool_calls": {
+      "name": "ai_chat_tool_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_approval": {
+          "name": "needs_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_correlation_id": {
+          "name": "mcp_correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_chat_tool_calls_conversation_idx": {
+          "name": "ai_chat_tool_calls_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_tool_calls_tool_name_idx": {
+          "name": "ai_chat_tool_calls_tool_name_idx",
+          "columns": [
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_chat_tool_calls_created_at_idx": {
+          "name": "ai_chat_tool_calls_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_chat_tool_calls_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_chat_tool_calls_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_chat_tool_calls_message_id_ai_chat_messages_id_fk": {
+          "name": "ai_chat_tool_calls_message_id_ai_chat_messages_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "ai_chat_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ai_chat_tool_calls_approved_by_user_id_users_id_fk": {
+          "name": "ai_chat_tool_calls_approved_by_user_id_users_id_fk",
+          "tableFrom": "ai_chat_tool_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_ledger": {
+      "name": "ai_usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suncokret-chat'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_date": {
+          "name": "usage_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reserved_micro_usd": {
+          "name": "reserved_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_micro_usd": {
+          "name": "input_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_micro_usd": {
+          "name": "output_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_micro_usd": {
+          "name": "total_micro_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_usage_ledger_request_unique": {
+          "name": "ai_usage_ledger_request_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_account_date_idx": {
+          "name": "ai_usage_ledger_account_date_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_conversation_idx": {
+          "name": "ai_usage_ledger_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_status_idx": {
+          "name": "ai_usage_ledger_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_ledger_created_at_idx": {
+          "name": "ai_usage_ledger_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_usage_ledger_account_id_accounts_id_fk": {
+          "name": "ai_usage_ledger_account_id_accounts_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_usage_ledger_user_id_users_id_fk": {
+          "name": "ai_usage_ledger_user_id_users_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_usage_ledger_conversation_id_ai_chat_conversations_id_fk": {
+          "name": "ai_usage_ledger_conversation_id_ai_chat_conversations_id_fk",
+          "tableFrom": "ai_usage_ledger",
+          "tableTo": "ai_chat_conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_definitions": {
+      "name": "automation_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_definition_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "max_concurrent_runs": {
+          "name": "max_concurrent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trigger_module_key": {
+          "name": "trigger_module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_event_type": {
+          "name": "trigger_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[]}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_definitions_key_idx": {
+          "name": "automation_definitions_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_status_idx": {
+          "name": "automation_definitions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_trigger_event_type_idx": {
+          "name": "automation_definitions_trigger_event_type_idx",
+          "columns": [
+            {
+              "expression": "trigger_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_definitions_updated_at_idx": {
+          "name": "automation_definitions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_definitions_created_by_user_id_users_id_fk": {
+          "name": "automation_definitions_created_by_user_id_users_id_fk",
+          "tableFrom": "automation_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_definitions_updated_by_user_id_users_id_fk": {
+          "name": "automation_definitions_updated_by_user_id_users_id_fk",
+          "tableFrom": "automation_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_event_cursors": {
+      "name": "automation_event_cursors",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_run_steps": {
+      "name": "automation_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_key": {
+          "name": "module_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_kind": {
+          "name": "module_kind",
+          "type": "automation_module_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_run_steps_run_node_idx": {
+          "name": "automation_run_steps_run_node_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_steps_run_id_idx": {
+          "name": "automation_run_steps_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_steps_status_idx": {
+          "name": "automation_run_steps_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_run_steps_run_id_automation_runs_id_fk": {
+          "name": "automation_run_steps_run_id_automation_runs_id_fk",
+          "tableFrom": "automation_run_steps",
+          "tableTo": "automation_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "automation_definition_id": {
+          "name": "automation_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_definition_key": {
+          "name": "automation_definition_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_definition_name": {
+          "name": "automation_definition_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "automation_run_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_type": {
+          "name": "source_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_aggregate_id": {
+          "name": "source_aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_requested_by_user_id": {
+          "name": "manual_requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_snapshot": {
+          "name": "graph_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":[],\"edges\":[]}'::jsonb"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_runs_definition_source_event_idx": {
+          "name": "automation_runs_definition_source_event_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_runs\".\"source\" = 'event'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_definition_source_schedule_idx": {
+          "name": "automation_runs_definition_source_schedule_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_runs\".\"source_event_type\" in ('automation.schedule', 'automation.schedule.monthly')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_definition_id_idx": {
+          "name": "automation_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "automation_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_status_next_run_at_idx": {
+          "name": "automation_runs_status_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_source_event_type_idx": {
+          "name": "automation_runs_source_event_type_idx",
+          "columns": [
+            {
+              "expression": "source_event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_source_event_id_idx": {
+          "name": "automation_runs_source_event_id_idx",
+          "columns": [
+            {
+              "expression": "source_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_runs_created_at_idx": {
+          "name": "automation_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_runs_automation_definition_id_automation_definitions_id_fk": {
+          "name": "automation_runs_automation_definition_id_automation_definitions_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "automation_definitions",
+          "columnsFrom": [
+            "automation_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "automation_runs_source_event_id_events_id_fk": {
+          "name": "automation_runs_source_event_id_events_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_runs_manual_requested_by_user_id_users_id_fk": {
+          "name": "automation_runs_manual_requested_by_user_id_users_id_fk",
+          "tableFrom": "automation_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "manual_requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definition_categories": {
+      "name": "attribute_definition_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_adc_entity_type_name_idx": {
+          "name": "cms_adc_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_order_idx": {
+          "name": "cms_adc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_adc_is_deleted_idx": {
+          "name": "cms_adc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_definitions": {
+      "name": "attribute_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multiple": {
+          "name": "multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display": {
+          "name": "display",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_ad_category_idx": {
+          "name": "cms_ad_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_entity_type_name_idx": {
+          "name": "cms_ad_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_order_idx": {
+          "name": "cms_ad_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_ad_is_deleted_idx": {
+          "name": "cms_ad_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attribute_values": {
+      "name": "attribute_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_av_attribute_definition_id_idx": {
+          "name": "cms_av_attribute_definition_id_idx",
+          "columns": [
+            {
+              "expression": "attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_type_name_idx": {
+          "name": "cms_av_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_entity_id_idx": {
+          "name": "cms_av_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_order_idx": {
+          "name": "cms_av_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_av_is_deleted_idx": {
+          "name": "cms_av_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attribute_values_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "attribute_values_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attribute_values_entity_id_entities_id_fk": {
+          "name": "attribute_values_entity_id_entities_id_fk",
+          "tableFrom": "attribute_values",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_page_revisions": {
+      "name": "cms_page_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cms_page_id": {
+          "name": "cms_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_slug": {
+          "name": "previous_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_slug": {
+          "name": "next_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_title": {
+          "name": "previous_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_title": {
+          "name": "next_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_content": {
+          "name": "previous_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_content": {
+          "name": "next_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_content_kind": {
+          "name": "previous_content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_content_kind": {
+          "name": "next_content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_category": {
+          "name": "previous_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_category": {
+          "name": "next_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_tags": {
+          "name": "previous_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_tags": {
+          "name": "next_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_title": {
+          "name": "previous_meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_title": {
+          "name": "next_meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_description": {
+          "name": "previous_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_description": {
+          "name": "next_meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_meta_image_url": {
+          "name": "previous_meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_meta_image_url": {
+          "name": "next_meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_seo_image_url": {
+          "name": "previous_seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_seo_image_url": {
+          "name": "next_seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_canonical_path": {
+          "name": "previous_canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_canonical_path": {
+          "name": "next_canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_no_index": {
+          "name": "previous_no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_no_index": {
+          "name": "next_no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_published_at": {
+          "name": "previous_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_published_at": {
+          "name": "next_published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cms_page_revisions_page_id_idx": {
+          "name": "cms_page_revisions_page_id_idx",
+          "columns": [
+            {
+              "expression": "cms_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_page_revisions_action_idx": {
+          "name": "cms_page_revisions_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_page_revisions_created_at_idx": {
+          "name": "cms_page_revisions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cms_page_revisions_cms_page_id_cms_pages_id_fk": {
+          "name": "cms_page_revisions_cms_page_id_cms_pages_id_fk",
+          "tableFrom": "cms_page_revisions",
+          "tableTo": "cms_pages",
+          "columnsFrom": [
+            "cms_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_pages": {
+      "name": "cms_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_kind": {
+          "name": "content_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_url": {
+          "name": "meta_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_image_url": {
+          "name": "seo_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_path": {
+          "name": "canonical_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_index": {
+          "name": "no_index",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_pages_slug_active_uq": {
+          "name": "cms_pages_slug_active_uq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cms_pages\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_state_idx": {
+          "name": "cms_pages_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_content_kind_idx": {
+          "name": "cms_pages_content_kind_idx",
+          "columns": [
+            {
+              "expression": "content_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_category_idx": {
+          "name": "cms_pages_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_published_at_idx": {
+          "name": "cms_pages_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_pages_is_deleted_idx": {
+          "name": "cms_pages_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_order": {
+          "name": "hierarchy_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_e_entity_type_name_idx": {
+          "name": "cms_e_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_parent_id_idx": {
+          "name": "cms_e_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_hierarchy_order_idx": {
+          "name": "cms_e_hierarchy_order_idx",
+          "columns": [
+            {
+              "expression": "hierarchy_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_state_idx": {
+          "name": "cms_e_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_e_is_deleted_idx": {
+          "name": "cms_e_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_parent_id_entities_id_fk": {
+          "name": "entities_parent_id_entities_id_fk",
+          "tableFrom": "entities",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_revisions": {
+      "name": "entity_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_value_id": {
+          "name": "attribute_value_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_value": {
+          "name": "next_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cms_er_entity_id_idx": {
+          "name": "cms_er_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_er_entity_type_name_idx": {
+          "name": "cms_er_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_er_action_idx": {
+          "name": "cms_er_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_revisions_entity_id_entities_id_fk": {
+          "name": "entity_revisions_entity_id_entities_id_fk",
+          "tableFrom": "entity_revisions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_search_documents": {
+      "name": "entity_search_documents",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_category": {
+          "name": "public_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_category_label": {
+          "name": "public_category_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cms_esd_entity_type_idx": {
+          "name": "cms_esd_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_public_category_idx": {
+          "name": "cms_esd_public_category_idx",
+          "columns": [
+            {
+              "expression": "public_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_state_idx": {
+          "name": "cms_esd_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_published_at_idx": {
+          "name": "cms_esd_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_esd_search_vector_idx": {
+          "name": "cms_esd_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_search_documents_entity_id_entities_id_fk": {
+          "name": "entity_search_documents_entity_id_entities_id_fk",
+          "tableFrom": "entity_search_documents",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_type_categories": {
+      "name": "entity_type_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_etc_order_idx": {
+          "name": "cms_etc_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_etc_is_deleted_idx": {
+          "name": "cms_etc_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_types": {
+      "name": "entity_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchy_order": {
+          "name": "hierarchy_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_root": {
+          "name": "is_root",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "inventory_source_attribute_definition_id": {
+          "name": "inventory_source_attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "cms_et_category_id_idx": {
+          "name": "cms_et_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_order_idx": {
+          "name": "cms_et_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_parent_id_idx": {
+          "name": "cms_et_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_hierarchy_order_idx": {
+          "name": "cms_et_hierarchy_order_idx",
+          "columns": [
+            {
+              "expression": "hierarchy_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_deleted_idx": {
+          "name": "cms_et_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_is_root_idx": {
+          "name": "cms_et_is_root_idx",
+          "columns": [
+            {
+              "expression": "is_root",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cms_et_inventory_source_attr_def_idx": {
+          "name": "cms_et_inventory_source_attr_def_idx",
+          "columns": [
+            {
+              "expression": "inventory_source_attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_types_category_id_entity_type_categories_id_fk": {
+          "name": "entity_types_category_id_entity_type_categories_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_type_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_types_parent_id_entity_types_id_fk": {
+          "name": "entity_types_parent_id_entity_types_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "entity_types",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_types_inventory_source_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "entity_types_inventory_source_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "entity_types",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "inventory_source_attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_edit_request_changes": {
+      "name": "community_edit_request_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_key": {
+          "name": "section_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_definition_id": {
+          "name": "attribute_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribute_value_id": {
+          "name": "attribute_value_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribute_path": {
+          "name": "attribute_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_value": {
+          "name": "proposed_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_value_hash": {
+          "name": "base_value_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_patch": {
+          "name": "value_patch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_diff": {
+          "name": "review_diff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_edit_changes_request_id_idx": {
+          "name": "community_edit_changes_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_changes_field_key_idx": {
+          "name": "community_edit_changes_field_key_idx",
+          "columns": [
+            {
+              "expression": "field_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_changes_attribute_definition_idx": {
+          "name": "community_edit_changes_attribute_definition_idx",
+          "columns": [
+            {
+              "expression": "attribute_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_edit_request_changes_request_id_community_edit_requests_id_fk": {
+          "name": "community_edit_request_changes_request_id_community_edit_requests_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "community_edit_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_request_changes_attribute_definition_id_attribute_definitions_id_fk": {
+          "name": "community_edit_request_changes_attribute_definition_id_attribute_definitions_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "attribute_definitions",
+          "columnsFrom": [
+            "attribute_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_request_changes_attribute_value_id_attribute_values_id_fk": {
+          "name": "community_edit_request_changes_attribute_value_id_attribute_values_id_fk",
+          "tableFrom": "community_edit_request_changes",
+          "tableTo": "attribute_values",
+          "columnsFrom": [
+            "attribute_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_edit_requests": {
+      "name": "community_edit_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_path": {
+          "name": "public_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_key": {
+          "name": "section_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_user_id": {
+          "name": "submitter_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitter_name": {
+          "name": "submitter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_email": {
+          "name": "submitter_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitter_note": {
+          "name": "submitter_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_user_id": {
+          "name": "reviewer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_name": {
+          "name": "reviewer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_failure_reason": {
+          "name": "application_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "community_edit_requests_status_idx": {
+          "name": "community_edit_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_entity_type_idx": {
+          "name": "community_edit_requests_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_entity_id_idx": {
+          "name": "community_edit_requests_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_submitter_idx": {
+          "name": "community_edit_requests_submitter_idx",
+          "columns": [
+            {
+              "expression": "submitter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_edit_requests_created_at_idx": {
+          "name": "community_edit_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_edit_requests_entity_id_entities_id_fk": {
+          "name": "community_edit_requests_entity_id_entities_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_requests_submitter_user_id_users_id_fk": {
+          "name": "community_edit_requests_submitter_user_id_users_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitter_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_edit_requests_reviewer_user_id_users_id_fk": {
+          "name": "community_edit_requests_reviewer_user_id_users_id_fk",
+          "tableFrom": "community_edit_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_addresses": {
+      "name": "delivery_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HR'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_addresses_account_id_idx": {
+          "name": "delivery_addresses_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_addresses_is_default_idx": {
+          "name": "delivery_addresses_is_default_idx",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_addresses_deleted_at_idx": {
+          "name": "delivery_addresses_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_addresses_account_id_accounts_id_fk": {
+          "name": "delivery_addresses_account_id_accounts_id_fk",
+          "tableFrom": "delivery_addresses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_requests": {
+      "name": "delivery_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_requests_operation_id_idx": {
+          "name": "delivery_requests_operation_id_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_requests_created_at_idx": {
+          "name": "delivery_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_requests_operation_id_operations_id_fk": {
+          "name": "delivery_requests_operation_id_operations_id_fk",
+          "tableFrom": "delivery_requests",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_exception_operations": {
+      "name": "delivery_run_exception_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_operation_id": {
+          "name": "client_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_run_exception_operations_run_client_unique": {
+          "name": "delivery_run_exception_operations_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_exception_operations_run_id_idx": {
+          "name": "delivery_run_exception_operations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_exception_operations_driver_user_id_idx": {
+          "name": "delivery_run_exception_operations_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_exception_operations_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_exception_operations_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_exception_operations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_exception_operations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_exception_operations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_exception_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_pickup_nodes": {
+      "name": "delivery_run_pickup_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_location_id": {
+          "name": "pickup_location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itinerary_sequence": {
+          "name": "itinerary_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_arrival_at": {
+          "name": "estimated_arrival_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_travel_seconds": {
+          "name": "incoming_travel_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_distance_meters": {
+          "name": "incoming_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_duration_seconds": {
+          "name": "service_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_pickup_nodes_run_sequence_unique": {
+          "name": "delivery_run_pickup_nodes_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_location_unique": {
+          "name": "delivery_run_pickup_nodes_run_location_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pickup_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_id_id_unique": {
+          "name": "delivery_run_pickup_nodes_run_id_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_itinerary_sequence_unique": {
+          "name": "delivery_run_pickup_nodes_run_itinerary_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "itinerary_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_run_pickup_nodes\".\"itinerary_sequence\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_nodes_run_id_idx": {
+          "name": "delivery_run_pickup_nodes_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_pickup_nodes_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_pickup_nodes_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_pickup_nodes",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_nodes_pickup_location_id_pickup_locations_id_fk": {
+          "name": "delivery_run_pickup_nodes_pickup_location_id_pickup_locations_id_fk",
+          "tableFrom": "delivery_run_pickup_nodes",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "pickup_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_pickup_nodes_itinerary_shape_check": {
+          "name": "delivery_run_pickup_nodes_itinerary_shape_check",
+          "value": "(\n                \"delivery_run_pickup_nodes\".\"itinerary_sequence\" is null\n                and \"delivery_run_pickup_nodes\".\"estimated_arrival_at\" is null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" is null\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" is null\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" is null\n            ) or (\n                \"delivery_run_pickup_nodes\".\"itinerary_sequence\" is not null\n                and \"delivery_run_pickup_nodes\".\"itinerary_sequence\" > 0\n                and \"delivery_run_pickup_nodes\".\"estimated_arrival_at\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_travel_seconds\" >= 0\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" is not null\n                and \"delivery_run_pickup_nodes\".\"incoming_distance_meters\" >= 0\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" is not null\n                and \"delivery_run_pickup_nodes\".\"service_duration_seconds\" >= 0\n            )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_pickup_operations": {
+      "name": "delivery_run_pickup_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_node_id": {
+          "name": "pickup_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_operation_id": {
+          "name": "client_operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "delivery_run_pickup_operations_run_client_unique": {
+          "name": "delivery_run_pickup_operations_run_client_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_operations_run_id_idx": {
+          "name": "delivery_run_pickup_operations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_pickup_operations_pickup_node_id_idx": {
+          "name": "delivery_run_pickup_operations_pickup_node_id_idx",
+          "columns": [
+            {
+              "expression": "pickup_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_pickup_operations_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_pickup_operations_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_operations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_pickup_operations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_pickup_operations_run_pickup_node_fk": {
+          "name": "delivery_run_pickup_operations_run_pickup_node_fk",
+          "tableFrom": "delivery_run_pickup_operations",
+          "tableTo": "delivery_run_pickup_nodes",
+          "columnsFrom": [
+            "run_id",
+            "pickup_node_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_pickup_operations_kind_check": {
+          "name": "delivery_run_pickup_operations_kind_check",
+          "value": "\"delivery_run_pickup_operations\".\"kind\" in ('scan', 'mark-item', 'confirm-manifest')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_preparations": {
+      "name": "delivery_run_preparations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selection_hash": {
+          "name": "selection_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_run_id": {
+          "name": "delivery_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_preparations_driver_user_id_idx": {
+          "name": "delivery_run_preparations_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_expires_at_idx": {
+          "name": "delivery_run_preparations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_consumed_at_idx": {
+          "name": "delivery_run_preparations_consumed_at_idx",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_preparations_delivery_run_id_unique": {
+          "name": "delivery_run_preparations_delivery_run_id_unique",
+          "columns": [
+            {
+              "expression": "delivery_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_preparations_driver_user_id_users_id_fk": {
+          "name": "delivery_run_preparations_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_run_preparations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_preparations_delivery_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_preparations_delivery_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_preparations",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "delivery_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_preparations_consumption_shape_check": {
+          "name": "delivery_run_preparations_consumption_shape_check",
+          "value": "(\"delivery_run_preparations\".\"consumed_at\" is null and \"delivery_run_preparations\".\"delivery_run_id\" is null) or (\"delivery_run_preparations\".\"consumed_at\" is not null and \"delivery_run_preparations\".\"delivery_run_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_slots": {
+      "name": "delivery_run_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_node_id": {
+          "name": "pickup_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot_id": {
+          "name": "time_slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_id": {
+          "name": "manifest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_state": {
+          "name": "manifest_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confirmed'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_by_user_id": {
+          "name": "confirmed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_slots_manifest_id_unique": {
+          "name": "delivery_run_slots_manifest_id_unique",
+          "columns": [
+            {
+              "expression": "manifest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_sequence_unique": {
+          "name": "delivery_run_slots_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_time_slot_unique": {
+          "name": "delivery_run_slots_run_time_slot_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_id_id_unique": {
+          "name": "delivery_run_slots_run_id_id_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_run_id_idx": {
+          "name": "delivery_run_slots_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_slots_pickup_node_id_idx": {
+          "name": "delivery_run_slots_pickup_node_id_idx",
+          "columns": [
+            {
+              "expression": "pickup_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_slots_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_slots_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_time_slot_id_time_slots_id_fk": {
+          "name": "delivery_run_slots_time_slot_id_time_slots_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "time_slots",
+          "columnsFrom": [
+            "time_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_confirmed_by_user_id_users_id_fk": {
+          "name": "delivery_run_slots_confirmed_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "confirmed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_slots_run_pickup_node_fk": {
+          "name": "delivery_run_slots_run_pickup_node_fk",
+          "tableFrom": "delivery_run_slots",
+          "tableTo": "delivery_run_pickup_nodes",
+          "columnsFrom": [
+            "run_id",
+            "pickup_node_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_slots_manifest_state_check": {
+          "name": "delivery_run_slots_manifest_state_check",
+          "value": "\"delivery_run_slots\".\"manifest_state\" in ('pending', 'confirmed')"
+        },
+        "delivery_run_slots_manifest_confirmation_shape_check": {
+          "name": "delivery_run_slots_manifest_confirmation_shape_check",
+          "value": "\"delivery_run_slots\".\"manifest_state\" = 'confirmed' or (\"delivery_run_slots\".\"confirmed_at\" is null and \"delivery_run_slots\".\"confirmed_by_user_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_run_stops": {
+      "name": "delivery_run_stops",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_request_id": {
+          "name": "delivery_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_slot_id": {
+          "name": "run_slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itinerary_sequence": {
+          "name": "itinerary_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_duration_seconds": {
+          "name": "service_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_lane_rank": {
+          "name": "retry_lane_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_attempt": {
+          "name": "retry_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stop_key": {
+          "name": "stop_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_dispatch_event_id": {
+          "name": "request_dispatch_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_id": {
+          "name": "delivery_address_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_updated_at": {
+          "name": "delivery_address_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address_label": {
+          "name": "delivery_address_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_contact_name": {
+          "name": "delivery_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street1": {
+          "name": "delivery_street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_street2": {
+          "name": "delivery_street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_city": {
+          "name": "delivery_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_postal_code": {
+          "name": "delivery_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_country_code": {
+          "name": "delivery_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_item_state": {
+          "name": "pickup_item_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_trace_link_id": {
+          "name": "pickup_trace_link_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_trace_token": {
+          "name": "pickup_trace_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_resolved_at": {
+          "name": "pickup_resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_resolved_by_user_id": {
+          "name": "pickup_resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_arrival_at": {
+          "name": "estimated_arrival_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_travel_seconds": {
+          "name": "estimated_travel_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_distance_meters": {
+          "name": "estimated_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_reason": {
+          "name": "exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_note": {
+          "name": "exception_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_occurred_at": {
+          "name": "exception_occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_recorded_by_user_id": {
+          "name": "exception_recorded_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_run_stops_delivery_request_active_unique": {
+          "name": "delivery_run_stops_delivery_request_active_unique",
+          "columns": [
+            {
+              "expression": "delivery_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_run_stops\".\"released_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_sequence_unique": {
+          "name": "delivery_run_stops_run_sequence_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_id_idx": {
+          "name": "delivery_run_stops_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_itinerary_sequence_idx": {
+          "name": "delivery_run_stops_run_itinerary_sequence_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "itinerary_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_slot_id_idx": {
+          "name": "delivery_run_stops_run_slot_id_idx",
+          "columns": [
+            {
+              "expression": "run_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_state_idx": {
+          "name": "delivery_run_stops_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_run_retry_lane_rank_idx": {
+          "name": "delivery_run_stops_run_retry_lane_rank_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_lane_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_released_at_idx": {
+          "name": "delivery_run_stops_released_at_idx",
+          "columns": [
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_pickup_trace_token_idx": {
+          "name": "delivery_run_stops_pickup_trace_token_idx",
+          "columns": [
+            {
+              "expression": "pickup_trace_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_run_stops_pickup_item_state_idx": {
+          "name": "delivery_run_stops_pickup_item_state_idx",
+          "columns": [
+            {
+              "expression": "pickup_item_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_run_stops_run_id_delivery_runs_id_fk": {
+          "name": "delivery_run_stops_run_id_delivery_runs_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_delivery_request_id_delivery_requests_id_fk": {
+          "name": "delivery_run_stops_delivery_request_id_delivery_requests_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_requests",
+          "columnsFrom": [
+            "delivery_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_pickup_trace_link_id_harvest_trace_links_id_fk": {
+          "name": "delivery_run_stops_pickup_trace_link_id_harvest_trace_links_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "harvest_trace_links",
+          "columnsFrom": [
+            "pickup_trace_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_pickup_resolved_by_user_id_users_id_fk": {
+          "name": "delivery_run_stops_pickup_resolved_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "pickup_resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_exception_recorded_by_user_id_users_id_fk": {
+          "name": "delivery_run_stops_exception_recorded_by_user_id_users_id_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "users",
+          "columnsFrom": [
+            "exception_recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_run_stops_run_slot_fk": {
+          "name": "delivery_run_stops_run_slot_fk",
+          "tableFrom": "delivery_run_stops",
+          "tableTo": "delivery_run_slots",
+          "columnsFrom": [
+            "run_id",
+            "run_slot_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_run_stops_snapshot_shape_check": {
+          "name": "delivery_run_stops_snapshot_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"run_slot_id\" is null\n                and \"delivery_run_stops\".\"stop_key\" is null\n                and \"delivery_run_stops\".\"request_dispatch_event_id\" is null\n                and \"delivery_run_stops\".\"delivery_address_id\" is null\n                and \"delivery_run_stops\".\"delivery_address_updated_at\" is null\n                and \"delivery_run_stops\".\"delivery_address_label\" is null\n                and \"delivery_run_stops\".\"delivery_contact_name\" is null\n                and \"delivery_run_stops\".\"delivery_phone\" is null\n                and \"delivery_run_stops\".\"delivery_street1\" is null\n                and \"delivery_run_stops\".\"delivery_street2\" is null\n                and \"delivery_run_stops\".\"delivery_city\" is null\n                and \"delivery_run_stops\".\"delivery_postal_code\" is null\n                and \"delivery_run_stops\".\"delivery_country_code\" is null\n            ) or (\n                \"delivery_run_stops\".\"run_slot_id\" is not null\n                and \"delivery_run_stops\".\"stop_key\" is not null\n                and \"delivery_run_stops\".\"request_dispatch_event_id\" is not null\n                and \"delivery_run_stops\".\"delivery_address_id\" is not null\n                and \"delivery_run_stops\".\"delivery_address_updated_at\" is not null\n                and \"delivery_run_stops\".\"delivery_address_label\" is not null\n                and \"delivery_run_stops\".\"delivery_contact_name\" is not null\n                and \"delivery_run_stops\".\"delivery_phone\" is not null\n                and \"delivery_run_stops\".\"delivery_street1\" is not null\n                and \"delivery_run_stops\".\"delivery_city\" is not null\n                and \"delivery_run_stops\".\"delivery_postal_code\" is not null\n                and \"delivery_run_stops\".\"delivery_country_code\" is not null\n            )"
+        },
+        "delivery_run_stops_itinerary_shape_check": {
+          "name": "delivery_run_stops_itinerary_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"itinerary_sequence\" is null\n                and \"delivery_run_stops\".\"service_duration_seconds\" is null\n            ) or (\n                \"delivery_run_stops\".\"itinerary_sequence\" is not null\n                and \"delivery_run_stops\".\"itinerary_sequence\" > 0\n                and \"delivery_run_stops\".\"service_duration_seconds\" is not null\n                and \"delivery_run_stops\".\"service_duration_seconds\" >= 0\n            )"
+        },
+        "delivery_run_stops_retry_shape_check": {
+          "name": "delivery_run_stops_retry_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"retry_lane_rank\" is null\n                and \"delivery_run_stops\".\"retry_attempt\" = 0\n            ) or (\n                \"delivery_run_stops\".\"retry_lane_rank\" is not null\n                and \"delivery_run_stops\".\"retry_lane_rank\" > 0\n                and \"delivery_run_stops\".\"retry_attempt\" > 0\n            )"
+        },
+        "delivery_run_stops_pickup_item_state_check": {
+          "name": "delivery_run_stops_pickup_item_state_check",
+          "value": "\"delivery_run_stops\".\"pickup_item_state\" is null or \"delivery_run_stops\".\"pickup_item_state\" in ('ready', 'scanned', 'missing-label', 'not-ready')"
+        },
+        "delivery_run_stops_pickup_item_resolution_shape_check": {
+          "name": "delivery_run_stops_pickup_item_resolution_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"pickup_item_state\" is null\n                and \"delivery_run_stops\".\"pickup_trace_link_id\" is null\n                and \"delivery_run_stops\".\"pickup_trace_token\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"pickup_item_state\" = 'ready'\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is null\n                and \"delivery_run_stops\".\"pickup_resolved_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"pickup_item_state\" in ('scanned', 'missing-label', 'not-ready')\n                and \"delivery_run_stops\".\"pickup_resolved_at\" is not null\n            )"
+        },
+        "delivery_run_stops_state_check": {
+          "name": "delivery_run_stops_state_check",
+          "value": "\"delivery_run_stops\".\"state\" in ('pending', 'arrived', 'delivered', 'deferred', 'failed', 'cancelled')"
+        },
+        "delivery_run_stops_exception_reason_check": {
+          "name": "delivery_run_stops_exception_reason_check",
+          "value": "\"delivery_run_stops\".\"exception_reason\" is null or \"delivery_run_stops\".\"exception_reason\" in ('customer-unavailable', 'address-inaccessible', 'address-wrong', 'harvest-damaged', 'harvest-missing', 'cancellation', 'operational-other')"
+        },
+        "delivery_run_stops_cancellation_pair_check": {
+          "name": "delivery_run_stops_cancellation_pair_check",
+          "value": "(\"delivery_run_stops\".\"state\" = 'cancelled') = coalesce(\"delivery_run_stops\".\"exception_reason\" = 'cancellation', false)"
+        },
+        "delivery_run_stops_outcome_shape_check": {
+          "name": "delivery_run_stops_outcome_shape_check",
+          "value": "(\n                \"delivery_run_stops\".\"state\" in ('pending', 'arrived')\n                and \"delivery_run_stops\".\"delivered_at\" is null\n                and \"delivery_run_stops\".\"exception_reason\" is null\n                and \"delivery_run_stops\".\"exception_note\" is null\n                and \"delivery_run_stops\".\"exception_occurred_at\" is null\n                and \"delivery_run_stops\".\"exception_recorded_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"state\" = 'delivered'\n                and \"delivery_run_stops\".\"delivered_at\" is not null\n                and \"delivery_run_stops\".\"exception_reason\" is null\n                and \"delivery_run_stops\".\"exception_note\" is null\n                and \"delivery_run_stops\".\"exception_occurred_at\" is null\n                and \"delivery_run_stops\".\"exception_recorded_by_user_id\" is null\n            ) or (\n                \"delivery_run_stops\".\"state\" in ('deferred', 'failed')\n                and \"delivery_run_stops\".\"delivered_at\" is null\n                and \"delivery_run_stops\".\"exception_reason\" is not null\n                and \"delivery_run_stops\".\"exception_occurred_at\" is not null\n                and \"delivery_run_stops\".\"exception_recorded_by_user_id\" is not null\n            ) or (\n                \"delivery_run_stops\".\"state\" = 'cancelled'\n                and \"delivery_run_stops\".\"delivered_at\" is null\n                and \"delivery_run_stops\".\"exception_reason\" = 'cancellation'\n                and \"delivery_run_stops\".\"exception_occurred_at\" is not null\n            )"
+        },
+        "delivery_run_stops_release_shape_check": {
+          "name": "delivery_run_stops_release_shape_check",
+          "value": "\"delivery_run_stops\".\"released_at\" is null or \"delivery_run_stops\".\"state\" in ('delivered', 'failed', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.delivery_runs": {
+      "name": "delivery_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driver_user_id": {
+          "name": "driver_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot_id": {
+          "name": "time_slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "encoded_polyline": {
+          "name": "encoded_polyline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_distance_meters": {
+          "name": "total_distance_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route_plan_version": {
+          "name": "route_plan_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "route_revision": {
+          "name": "route_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reroute_required_at": {
+          "name": "reroute_required_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reroute_attempted_at": {
+          "name": "reroute_attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_source": {
+          "name": "estimate_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "current_latitude": {
+          "name": "current_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_longitude": {
+          "name": "current_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_accuracy": {
+          "name": "current_location_accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_heading": {
+          "name": "current_location_heading",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_speed": {
+          "name": "current_location_speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_recorded_at": {
+          "name": "current_location_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_location_received_at": {
+          "name": "current_location_received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimates_updated_at": {
+          "name": "estimates_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "delivery_runs_driver_user_id_idx": {
+          "name": "delivery_runs_driver_user_id_idx",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_time_slot_id_idx": {
+          "name": "delivery_runs_time_slot_id_idx",
+          "columns": [
+            {
+              "expression": "time_slot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_state_idx": {
+          "name": "delivery_runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_driver_active_unique": {
+          "name": "delivery_runs_driver_active_unique",
+          "columns": [
+            {
+              "expression": "driver_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"delivery_runs\".\"state\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "delivery_runs_location_recorded_at_idx": {
+          "name": "delivery_runs_location_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "current_location_recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_runs_driver_user_id_users_id_fk": {
+          "name": "delivery_runs_driver_user_id_users_id_fk",
+          "tableFrom": "delivery_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "driver_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delivery_runs_time_slot_id_time_slots_id_fk": {
+          "name": "delivery_runs_time_slot_id_time_slots_id_fk",
+          "tableFrom": "delivery_runs",
+          "tableTo": "time_slots",
+          "columnsFrom": [
+            "time_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_runs_route_plan_provenance_check": {
+          "name": "delivery_runs_route_plan_provenance_check",
+          "value": "(\n                \"delivery_runs\".\"route_plan_version\" = 1\n                and \"delivery_runs\".\"estimate_source\" = 'legacy'\n            ) or (\n                \"delivery_runs\".\"route_plan_version\" >= 2\n                and \"delivery_runs\".\"estimate_source\" in ('google', 'local')\n            )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pickup_locations": {
+      "name": "pickup_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street1": {
+          "name": "street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street2": {
+          "name": "street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'HR'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pickup_locations_is_active_idx": {
+          "name": "pickup_locations_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_slots": {
+      "name": "time_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closes_at": {
+          "name": "closes_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "time_slots_location_id_idx": {
+          "name": "time_slots_location_id_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_type_idx": {
+          "name": "time_slots_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_start_at_idx": {
+          "name": "time_slots_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_closes_at_idx": {
+          "name": "time_slots_closes_at_idx",
+          "columns": [
+            {
+              "expression": "closes_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_status_idx": {
+          "name": "time_slots_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "time_slots_unique_slot_idx": {
+          "name": "time_slots_unique_slot_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_slots_location_id_pickup_locations_id_fk": {
+          "name": "time_slots_location_id_pickup_locations_id_fk",
+          "tableFrom": "time_slots",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_messages": {
+      "name": "email_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'acs'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "email_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "html_body": {
+          "name": "html_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_body": {
+          "name": "text_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_at": {
+          "name": "bounced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_messages_status_idx": {
+          "name": "email_messages_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_messages_created_idx": {
+          "name": "email_messages_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_messages_provider_message_idx": {
+          "name": "email_messages_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_e_type_idx": {
+          "name": "events_e_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_aggregate_id_idx": {
+          "name": "events_e_aggregate_id_idx",
+          "columns": [
+            {
+              "expression": "aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_e_created_at_idx": {
+          "name": "events_e_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farms": {
+      "name": "farms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snow_accumulation": {
+          "name": "snow_accumulation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "farms_f_is_deleted_idx": {
+          "name": "farms_f_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedbacks": {
+      "name": "feedbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_pos_settings": {
+      "name": "fiscalization_pos_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos_id": {
+          "name": "pos_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "premise_id": {
+          "name": "premise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_pos_settings_pos_id_idx": {
+          "name": "fiscalization_pos_settings_pos_id_idx",
+          "columns": [
+            {
+              "expression": "pos_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_active_idx": {
+          "name": "fiscalization_pos_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_pos_settings_is_deleted_idx": {
+          "name": "fiscalization_pos_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fiscalization_user_settings": {
+      "name": "fiscalization_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pin": {
+          "name": "pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_vat": {
+          "name": "use_vat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "receipt_number_on_device": {
+          "name": "receipt_number_on_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'educ'"
+        },
+        "cert_base64": {
+          "name": "cert_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cert_password": {
+          "name": "cert_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "fiscalization_user_settings_is_active_idx": {
+          "name": "fiscalization_user_settings_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fiscalization_user_settings_is_deleted_idx": {
+          "name": "fiscalization_user_settings_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_blocks": {
+      "name": "garden_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation": {
+          "name": "rotation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gb_garden_id_idx": {
+          "name": "garden_gb_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gb_is_deleted_idx": {
+          "name": "garden_gb_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_blocks_garden_id_gardens_id_fk": {
+          "name": "garden_blocks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_blocks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_likes": {
+      "name": "garden_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_likes_user_garden_uq": {
+          "name": "garden_likes_user_garden_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_likes_user_id_idx": {
+          "name": "garden_likes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_likes_garden_id_idx": {
+          "name": "garden_likes_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_likes_user_id_users_id_fk": {
+          "name": "garden_likes_user_id_users_id_fk",
+          "tableFrom": "garden_likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "garden_likes_garden_id_gardens_id_fk": {
+          "name": "garden_likes_garden_id_gardens_id_fk",
+          "tableFrom": "garden_likes",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_blob_deletions": {
+      "name": "garden_preview_blob_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claim_id": {
+          "name": "claim_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_expires_at": {
+          "name": "claim_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_preview_blob_deletions_pathname_uq": {
+          "name": "garden_preview_blob_deletions_pathname_uq",
+          "columns": [
+            {
+              "expression": "pathname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_preview_blob_deletions_next_attempt_at_idx": {
+          "name": "garden_preview_blob_deletions_next_attempt_at_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_preview_blob_deletions_claim_expires_at_idx": {
+          "name": "garden_preview_blob_deletions_claim_expires_at_idx",
+          "columns": [
+            {
+              "expression": "claim_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_blob_scan_states": {
+      "name": "garden_preview_blob_scan_states",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_preview_capture_leases": {
+      "name": "garden_preview_capture_leases",
+      "schema": "",
+      "columns": {
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_preview_capture_leases_expires_at_idx": {
+          "name": "garden_preview_capture_leases_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_preview_capture_leases_garden_id_gardens_id_fk": {
+          "name": "garden_preview_capture_leases_garden_id_gardens_id_fk",
+          "tableFrom": "garden_preview_capture_leases",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_previews": {
+      "name": "garden_previews",
+      "schema": "",
+      "columns": {
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capture_request_id": {
+          "name": "capture_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_revision": {
+          "name": "source_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renderer_version": {
+          "name": "renderer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_requested_at": {
+          "name": "capture_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "garden_previews_capture_request_id_uq": {
+          "name": "garden_previews_capture_request_id_uq",
+          "columns": [
+            {
+              "expression": "capture_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_previews_pathname_uq": {
+          "name": "garden_previews_pathname_uq",
+          "columns": [
+            {
+              "expression": "pathname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_previews_captured_at_idx": {
+          "name": "garden_previews_captured_at_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_previews_garden_id_gardens_id_fk": {
+          "name": "garden_previews_garden_id_gardens_id_fk",
+          "tableFrom": "garden_previews",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_stacks": {
+      "name": "garden_stacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_gs_garden_id_idx": {
+          "name": "garden_gs_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_gs_is_deleted_idx": {
+          "name": "garden_gs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_stacks_garden_id_gardens_id_fk": {
+          "name": "garden_stacks_garden_id_gardens_id_fk",
+          "tableFrom": "garden_stacks",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.garden_visit_states": {
+      "name": "garden_visit_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_summary_seen_at": {
+          "name": "last_summary_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_summary_facts_hash": {
+          "name": "last_summary_facts_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "garden_visit_states_user_account_garden_unique": {
+          "name": "garden_visit_states_user_account_garden_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_visit_states_account_garden_idx": {
+          "name": "garden_visit_states_account_garden_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_visit_states_garden_id_idx": {
+          "name": "garden_visit_states_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "garden_visit_states_user_id_users_id_fk": {
+          "name": "garden_visit_states_user_id_users_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "garden_visit_states_account_id_accounts_id_fk": {
+          "name": "garden_visit_states_account_id_accounts_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "garden_visit_states_garden_id_gardens_id_fk": {
+          "name": "garden_visit_states_garden_id_gardens_id_fk",
+          "tableFrom": "garden_visit_states",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gardens": {
+      "name": "gardens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_palette": {
+          "name": "background_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'current'"
+        },
+        "home_camera": {
+          "name": "home_camera",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_sandbox": {
+          "name": "is_sandbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "garden_g_account_id_idx": {
+          "name": "garden_g_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_farm_id_idx": {
+          "name": "garden_g_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_deleted_idx": {
+          "name": "garden_g_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_public_idx": {
+          "name": "garden_g_is_public_idx",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "garden_g_is_sandbox_idx": {
+          "name": "garden_g_is_sandbox_idx",
+          "columns": [
+            {
+              "expression": "is_sandbox",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gardens_account_id_accounts_id_fk": {
+          "name": "gardens_account_id_accounts_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gardens_farm_id_farms_id_fk": {
+          "name": "gardens_farm_id_farms_id_fk",
+          "tableFrom": "gardens",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_fields": {
+      "name": "raised_bed_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_fields_raised_bed_id_idx": {
+          "name": "raised_bed_fields_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_fields_is_deleted_idx": {
+          "name": "raised_bed_fields_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_fields_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_fields_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_fields",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_bed_sensors": {
+      "name": "raised_bed_sensors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "sensor_signalco_id": {
+          "name": "sensor_signalco_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_bed_sensors_raised_bed_id_idx": {
+          "name": "raised_bed_sensors_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_bed_sensors_is_deleted_idx": {
+          "name": "raised_bed_sensors_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_bed_sensors_raised_bed_id_raised_beds_id_fk": {
+          "name": "raised_bed_sensors_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "raised_bed_sensors",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raised_beds": {
+      "name": "raised_beds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orientation": {
+          "name": "orientation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vertical'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "physical_id": {
+          "name": "physical_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raised_beds_account_id_idx": {
+          "name": "raised_beds_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_garden_id_idx": {
+          "name": "raised_beds_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_block_id_idx": {
+          "name": "raised_beds_block_id_idx",
+          "columns": [
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raised_beds_is_deleted_idx": {
+          "name": "raised_beds_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raised_beds_account_id_accounts_id_fk": {
+          "name": "raised_beds_account_id_accounts_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_garden_id_gardens_id_fk": {
+          "name": "raised_beds_garden_id_gardens_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raised_beds_block_id_garden_blocks_id_fk": {
+          "name": "raised_beds_block_id_garden_blocks_id_fk",
+          "tableFrom": "raised_beds",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harvest_trace_links": {
+      "name": "harvest_trace_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_token": {
+          "name": "public_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raised_bed_field_id": {
+          "name": "raised_bed_field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_position_index": {
+          "name": "field_position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_label": {
+          "name": "field_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plant_place_event_id": {
+          "name": "plant_place_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plant_sort_id": {
+          "name": "plant_sort_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harvest_operation_id": {
+          "name": "harvest_operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_path": {
+          "name": "trace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "printed_at": {
+          "name": "printed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harvest_trace_links_public_token_unique": {
+          "name": "harvest_trace_links_public_token_unique",
+          "columns": [
+            {
+              "expression": "public_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_target_unique": {
+          "name": "harvest_trace_links_target_unique",
+          "columns": [
+            {
+              "expression": "harvest_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plant_place_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_status_idx": {
+          "name": "harvest_trace_links_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_target_idx": {
+          "name": "harvest_trace_links_target_idx",
+          "columns": [
+            {
+              "expression": "harvest_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plant_place_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_raised_bed_idx": {
+          "name": "harvest_trace_links_raised_bed_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_plant_sort_idx": {
+          "name": "harvest_trace_links_plant_sort_idx",
+          "columns": [
+            {
+              "expression": "plant_sort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_links_created_at_idx": {
+          "name": "harvest_trace_links_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harvest_trace_links_account_id_accounts_id_fk": {
+          "name": "harvest_trace_links_account_id_accounts_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_garden_id_gardens_id_fk": {
+          "name": "harvest_trace_links_garden_id_gardens_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_raised_bed_id_raised_beds_id_fk": {
+          "name": "harvest_trace_links_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_raised_bed_field_id_raised_bed_fields_id_fk": {
+          "name": "harvest_trace_links_raised_bed_field_id_raised_bed_fields_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "raised_bed_fields",
+          "columnsFrom": [
+            "raised_bed_field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_plant_place_event_id_events_id_fk": {
+          "name": "harvest_trace_links_plant_place_event_id_events_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "events",
+          "columnsFrom": [
+            "plant_place_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_plant_sort_id_entities_id_fk": {
+          "name": "harvest_trace_links_plant_sort_id_entities_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "plant_sort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harvest_trace_links_harvest_operation_id_operations_id_fk": {
+          "name": "harvest_trace_links_harvest_operation_id_operations_id_fk",
+          "tableFrom": "harvest_trace_links",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "harvest_operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harvest_trace_scans": {
+      "name": "harvest_trace_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "harvest_trace_link_id": {
+          "name": "harvest_trace_link_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanned_at": {
+          "name": "scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent_family": {
+          "name": "user_agent_family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harvest_trace_scans_link_id_idx": {
+          "name": "harvest_trace_scans_link_id_idx",
+          "columns": [
+            {
+              "expression": "harvest_trace_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harvest_trace_scans_scanned_at_idx": {
+          "name": "harvest_trace_scans_scanned_at_idx",
+          "columns": [
+            {
+              "expression": "scanned_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harvest_trace_scans_harvest_trace_link_id_harvest_trace_links_id_fk": {
+          "name": "harvest_trace_scans_harvest_trace_link_id_harvest_trace_links_id_fk",
+          "tableFrom": "harvest_trace_scans",
+          "tableTo": "harvest_trace_links",
+          "columnsFrom": [
+            "harvest_trace_link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_configs": {
+      "name": "inventory_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_tracking_type": {
+          "name": "default_tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pieces'"
+        },
+        "status_attribute_name": {
+          "name": "status_attribute_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "empty_status_value": {
+          "name": "empty_status_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_attribute_name": {
+          "name": "amount_attribute_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "low_count_threshold": {
+          "name": "low_count_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_configs_entity_type_name_idx": {
+          "name": "inv_configs_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_configs_is_deleted_idx": {
+          "name": "inv_configs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_item_events": {
+      "name": "inventory_item_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_item_id": {
+          "name": "inventory_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_quantity": {
+          "name": "previous_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_quantity": {
+          "name": "new_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_state": {
+          "name": "new_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_item_events_inventory_item_id_idx": {
+          "name": "inv_item_events_inventory_item_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_item_events_is_deleted_idx": {
+          "name": "inv_item_events_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_item_events_inventory_item_id_inventory_items_id_fk": {
+          "name": "inventory_item_events_inventory_item_id_inventory_items_id_fk",
+          "tableFrom": "inventory_item_events",
+          "tableTo": "inventory_items",
+          "columnsFrom": [
+            "inventory_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_item_field_definitions": {
+      "name": "inventory_item_field_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_config_id": {
+          "name": "inventory_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_field_defs_inventory_config_id_idx": {
+          "name": "inv_field_defs_inventory_config_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_field_defs_is_deleted_idx": {
+          "name": "inv_field_defs_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_item_field_definitions_inventory_config_id_inventory_configs_id_fk": {
+          "name": "inventory_item_field_definitions_inventory_config_id_inventory_configs_id_fk",
+          "tableFrom": "inventory_item_field_definitions",
+          "tableTo": "inventory_configs",
+          "columnsFrom": [
+            "inventory_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_items": {
+      "name": "inventory_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_config_id": {
+          "name": "inventory_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_type": {
+          "name": "tracking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pieces'"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "low_count_threshold": {
+          "name": "low_count_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_fields": {
+          "name": "additional_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "inv_items_inventory_config_id_idx": {
+          "name": "inv_items_inventory_config_id_idx",
+          "columns": [
+            {
+              "expression": "inventory_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_entity_id_idx": {
+          "name": "inv_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_is_deleted_idx": {
+          "name": "inv_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inv_items_tracking_type_idx": {
+          "name": "inv_items_tracking_type_idx",
+          "columns": [
+            {
+              "expression": "tracking_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inventory_items_inventory_config_id_inventory_configs_id_fk": {
+          "name": "inventory_items_inventory_config_id_inventory_configs_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "inventory_configs",
+          "columnsFrom": [
+            "inventory_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inventory_items_entity_id_entities_id_fk": {
+          "name": "inventory_items_entity_id_entities_id_fk",
+          "tableFrom": "inventory_items",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.00'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_id_idx": {
+          "name": "invoice_items_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_id_idx": {
+          "name": "invoice_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_entity_type_idx": {
+          "name": "invoice_items_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_name": {
+          "name": "bill_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_email": {
+          "name": "bill_to_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bill_to_address": {
+          "name": "bill_to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_city": {
+          "name": "bill_to_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_state": {
+          "name": "bill_to_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_zip": {
+          "name": "bill_to_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bill_to_country": {
+          "name": "bill_to_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_invoice_number_idx": {
+          "name": "invoices_invoice_number_idx",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_account_id_idx": {
+          "name": "invoices_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_transaction_id_idx": {
+          "name": "invoices_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_status_idx": {
+          "name": "invoices_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_issue_date_idx": {
+          "name": "invoices_issue_date_idx",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_due_date_idx": {
+          "name": "invoices_due_date_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_is_deleted_idx": {
+          "name": "invoices_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_account_id_accounts_id_fk": {
+          "name": "invoices_account_id_accounts_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_transaction_id_transactions_id_fk": {
+          "name": "invoices_transaction_id_transactions_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.receipts": {
+      "name": "receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_number": {
+          "name": "receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year_receipt_number": {
+          "name": "year_receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_reference": {
+          "name": "payment_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jir": {
+          "name": "jir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zki": {
+          "name": "zki",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_status": {
+          "name": "cis_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cis_reference": {
+          "name": "cis_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_error_message": {
+          "name": "cis_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_timestamp": {
+          "name": "cis_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cis_response": {
+          "name": "cis_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "business_pin": {
+          "name": "business_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_name": {
+          "name": "business_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_address": {
+          "name": "business_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_pin": {
+          "name": "customer_pin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_address": {
+          "name": "customer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "receipts_invoice_id_idx": {
+          "name": "receipts_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_receipt_number_idx": {
+          "name": "receipts_receipt_number_idx",
+          "columns": [
+            {
+              "expression": "receipt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_jir_idx": {
+          "name": "receipts_jir_idx",
+          "columns": [
+            {
+              "expression": "jir",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_zki_idx": {
+          "name": "receipts_zki_idx",
+          "columns": [
+            {
+              "expression": "zki",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_cis_status_idx": {
+          "name": "receipts_cis_status_idx",
+          "columns": [
+            {
+              "expression": "cis_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_issued_at_idx": {
+          "name": "receipts_issued_at_idx",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_business_pin_idx": {
+          "name": "receipts_business_pin_idx",
+          "columns": [
+            {
+              "expression": "business_pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "receipts_is_deleted_idx": {
+          "name": "receipts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "receipts_invoice_id_invoices_id_fk": {
+          "name": "receipts_invoice_id_invoices_id_fk",
+          "tableFrom": "receipts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "receipts_year_receipt_number_unique": {
+          "name": "receipts_year_receipt_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year_receipt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "newsletter_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'subscribed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_email_idx": {
+          "name": "newsletter_subscribers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_campaigns": {
+      "name": "notification_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_campaign_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_policy": {
+          "name": "channel_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_image_url": {
+          "name": "safe_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_link_url": {
+          "name": "safe_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_action_url": {
+          "name": "safe_action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_channel": {
+          "name": "primary_channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "collapse_key": {
+          "name": "collapse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "delivery_metadata": {
+          "name": "delivery_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "failures": {
+          "name": "failures",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suppressed_count": {
+          "name": "suppressed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_from_account_id": {
+          "name": "created_from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_user_id": {
+          "name": "cancelled_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_campaigns_status_idx": {
+          "name": "notification_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_scheduled_at_idx": {
+          "name": "notification_campaigns_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_created_by_user_id_idx": {
+          "name": "notification_campaigns_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_category_idx": {
+          "name": "notification_campaigns_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_campaigns_event_type_idx": {
+          "name": "notification_campaigns_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_campaigns_created_by_user_id_users_id_fk": {
+          "name": "notification_campaigns_created_by_user_id_users_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "notification_campaigns_created_from_account_id_accounts_id_fk": {
+          "name": "notification_campaigns_created_from_account_id_accounts_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "created_from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_campaigns_cancelled_by_user_id_users_id_fk": {
+          "name": "notification_campaigns_cancelled_by_user_id_users_id_fk",
+          "tableFrom": "notification_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "cancelled_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_attempts": {
+      "name": "notification_delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response_code": {
+          "name": "provider_response_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_response_body": {
+          "name": "provider_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_id": {
+          "name": "bulk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_subscription_id": {
+          "name": "push_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_attempts_notification_id_idx": {
+          "name": "notification_delivery_attempts_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_delivery_attempts_status_idx": {
+          "name": "notification_delivery_attempts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_attempts_notification_id_notifications_id_fk": {
+          "name": "notification_delivery_attempts_notification_id_notifications_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_user_id_users_id_fk": {
+          "name": "notification_delivery_attempts_user_id_users_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_account_id_accounts_id_fk": {
+          "name": "notification_delivery_attempts_account_id_accounts_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_attempts_push_subscription_id_web_push_subscriptions_id_fk": {
+          "name": "notification_delivery_attempts_push_subscription_id_web_push_subscriptions_id_fk",
+          "tableFrom": "notification_delivery_attempts",
+          "tableTo": "web_push_subscriptions",
+          "columnsFrom": [
+            "push_subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery_events": {
+      "name": "notification_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "delivery_attempt_id": {
+          "name": "delivery_attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_delivery_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_events_attempt_id_idx": {
+          "name": "notification_delivery_events_attempt_id_idx",
+          "columns": [
+            {
+              "expression": "delivery_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_events_delivery_attempt_id_notification_delivery_attempts_id_fk": {
+          "name": "notification_delivery_events_delivery_attempt_id_notification_delivery_attempts_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notification_delivery_attempts",
+          "columnsFrom": [
+            "delivery_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_events_notification_id_notifications_id_fk": {
+          "name": "notification_delivery_events_notification_id_notifications_id_fk",
+          "tableFrom": "notification_delivery_events",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_email_log": {
+      "name": "notification_email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailed_at": {
+          "name": "emailed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_email_log_user_id_users_id_fk": {
+          "name": "notification_email_log_user_id_users_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_email_log_notification_id_notifications_id_fk": {
+          "name": "notification_email_log_notification_id_notifications_id_fk",
+          "tableFrom": "notification_email_log",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_user_channel_preferences": {
+      "name": "notification_user_channel_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "notification_preference_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiet_hours_start_minute": {
+          "name": "quiet_hours_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_hours_end_minute": {
+          "name": "quiet_hours_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_window_start_minute": {
+          "name": "delivery_window_start_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_window_end_minute": {
+          "name": "delivery_window_end_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "digest_frequency": {
+          "name": "digest_frequency",
+          "type": "notification_digest_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_channel_preferences_global_unique_idx": {
+          "name": "notification_user_channel_preferences_global_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification_user_channel_preferences\".\"scope\" = 'global'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_channel_preferences_account_unique_idx": {
+          "name": "notification_user_channel_preferences_account_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification_user_channel_preferences\".\"scope\" = 'account'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_channel_preferences_user_id_users_id_fk": {
+          "name": "notification_user_channel_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_user_channel_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_user_channel_preferences_account_id_accounts_id_fk": {
+          "name": "notification_user_channel_preferences_account_id_accounts_id_fk",
+          "tableFrom": "notification_user_channel_preferences",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notification_user_channel_preferences_scope_account_id_check": {
+          "name": "notification_user_channel_preferences_scope_account_id_check",
+          "value": "(scope = 'global' and account_id is null) or (scope = 'account' and account_id is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "primary_channel": {
+          "name": "primary_channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_id": {
+          "name": "bulk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collapse_key": {
+          "name": "collapse_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_label": {
+          "name": "action_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "ttl_seconds": {
+          "name": "ttl_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_image_url": {
+          "name": "safe_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_link_url": {
+          "name": "safe_link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_where": {
+          "name": "read_where",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_account_id_idx": {
+          "name": "notifications_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_readAt_idx": {
+          "name": "notifications_readAt_idx",
+          "columns": [
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_category_idx": {
+          "name": "notifications_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_campaign_id_idx": {
+          "name": "notifications_campaign_id_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_account_id_accounts_id_fk": {
+          "name": "notifications_account_id_accounts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_garden_id_gardens_id_fk": {
+          "name": "notifications_garden_id_gardens_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_raised_bed_id_raised_beds_id_fk": {
+          "name": "notifications_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_block_id_garden_blocks_id_fk": {
+          "name": "notifications_block_id_garden_blocks_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "garden_blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_settings": {
+      "name": "user_notification_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_digest": {
+          "name": "daily_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_users_id_fk": {
+          "name": "user_notification_settings_user_id_users_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.web_push_subscriptions": {
+      "name": "web_push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_label": {
+          "name": "device_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_name": {
+          "name": "browser_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_version": {
+          "name": "browser_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_state": {
+          "name": "permission_state",
+          "type": "push_permission_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "fail_count": {
+          "name": "fail_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_code": {
+          "name": "last_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "web_push_subscriptions_endpoint_unique_idx": {
+          "name": "web_push_subscriptions_endpoint_unique_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_user_id_idx": {
+          "name": "web_push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_account_id_idx": {
+          "name": "web_push_subscriptions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "web_push_subscriptions_device_id_idx": {
+          "name": "web_push_subscriptions_device_id_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "web_push_subscriptions_account_id_accounts_id_fk": {
+          "name": "web_push_subscriptions_account_id_accounts_id_fk",
+          "tableFrom": "web_push_subscriptions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "web_push_subscriptions_user_id_users_id_fk": {
+          "name": "web_push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "web_push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operations": {
+      "name": "operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_field_id": {
+          "name": "raised_bed_field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_accepted": {
+          "name": "is_accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "operations_entity_id_idx": {
+          "name": "operations_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_entity_type_name_idx": {
+          "name": "operations_entity_type_name_idx",
+          "columns": [
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_account_id_idx": {
+          "name": "operations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_farm_id_idx": {
+          "name": "operations_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_garden_id_idx": {
+          "name": "operations_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_id_idx": {
+          "name": "operations_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_raised_bed_field_id_idx": {
+          "name": "operations_raised_bed_field_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_timestamp_idx": {
+          "name": "operations_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_deleted_idx": {
+          "name": "operations_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operations_is_accepted_idx": {
+          "name": "operations_is_accepted_idx",
+          "columns": [
+            {
+              "expression": "is_accepted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlet_offer_reservations": {
+      "name": "outlet_offer_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outlet_offer_id": {
+          "name": "outlet_offer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cart_item_id": {
+          "name": "cart_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hold_expires_at": {
+          "name": "hold_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'held'"
+        },
+        "held_outlet_price_cents": {
+          "name": "held_outlet_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_compare_price_cents": {
+          "name": "held_compare_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "held_sowing_date": {
+          "name": "held_sowing_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_initial_plant_status": {
+          "name": "held_initial_plant_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sprouted'"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "converted_at": {
+          "name": "converted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "outlet_reservations_offer_id_idx": {
+          "name": "outlet_reservations_offer_id_idx",
+          "columns": [
+            {
+              "expression": "outlet_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_account_id_idx": {
+          "name": "outlet_reservations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_cart_id_idx": {
+          "name": "outlet_reservations_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_cart_item_id_idx": {
+          "name": "outlet_reservations_cart_item_id_idx",
+          "columns": [
+            {
+              "expression": "cart_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_status_idx": {
+          "name": "outlet_reservations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_reservations_hold_expires_at_idx": {
+          "name": "outlet_reservations_hold_expires_at_idx",
+          "columns": [
+            {
+              "expression": "hold_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlet_offer_reservations_outlet_offer_id_outlet_offers_id_fk": {
+          "name": "outlet_offer_reservations_outlet_offer_id_outlet_offers_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "outlet_offers",
+          "columnsFrom": [
+            "outlet_offer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_account_id_accounts_id_fk": {
+          "name": "outlet_offer_reservations_account_id_accounts_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_cart_id_shopping_carts_id_fk": {
+          "name": "outlet_offer_reservations_cart_id_shopping_carts_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "shopping_carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outlet_offer_reservations_cart_item_id_shopping_cart_items_id_fk": {
+          "name": "outlet_offer_reservations_cart_item_id_shopping_cart_items_id_fk",
+          "tableFrom": "outlet_offer_reservations",
+          "tableTo": "shopping_cart_items",
+          "columnsFrom": [
+            "cart_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outlet_offers": {
+      "name": "outlet_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plant_sort_id": {
+          "name": "plant_sort_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sowing_date": {
+          "name": "sowing_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_plant_status": {
+          "name": "initial_plant_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sprouted'"
+        },
+        "image_urls": {
+          "name": "image_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "outlet_price_cents": {
+          "name": "outlet_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compare_price_cents": {
+          "name": "compare_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "admin_notes": {
+          "name": "admin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "outlet_offers_plant_sort_id_idx": {
+          "name": "outlet_offers_plant_sort_id_idx",
+          "columns": [
+            {
+              "expression": "plant_sort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_status_idx": {
+          "name": "outlet_offers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_start_at_idx": {
+          "name": "outlet_offers_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_end_at_idx": {
+          "name": "outlet_offers_end_at_idx",
+          "columns": [
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outlet_offers_is_deleted_idx": {
+          "name": "outlet_offers_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outlet_offers_plant_sort_id_entities_id_fk": {
+          "name": "outlet_offers_plant_sort_id_entities_id_fk",
+          "tableFrom": "outlet_offers",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "plant_sort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_request_adjustments": {
+      "name": "farmer_payout_request_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payout_request_id": {
+          "name": "payout_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farmer_payout_adjustments_request_id_idx": {
+          "name": "farmer_payout_adjustments_request_id_idx",
+          "columns": [
+            {
+              "expression": "payout_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_request_adjustments_payout_request_id_farmer_payout_requests_id_fk": {
+          "name": "farmer_payout_request_adjustments_payout_request_id_farmer_payout_requests_id_fk",
+          "tableFrom": "farmer_payout_request_adjustments",
+          "tableTo": "farmer_payout_requests",
+          "columnsFrom": [
+            "payout_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_request_adjustments_created_by_user_id_users_id_fk": {
+          "name": "farmer_payout_request_adjustments_created_by_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_request_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_request_items": {
+      "name": "farmer_payout_request_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payout_request_id": {
+          "name": "payout_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_count": {
+          "name": "operation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_duration_minutes": {
+          "name": "total_duration_minutes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_per_unit": {
+          "name": "price_per_unit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "farmer_payout_items_request_id_idx": {
+          "name": "farmer_payout_items_request_id_idx",
+          "columns": [
+            {
+              "expression": "payout_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_request_items_payout_request_id_farmer_payout_requests_id_fk": {
+          "name": "farmer_payout_request_items_payout_request_id_farmer_payout_requests_id_fk",
+          "tableFrom": "farmer_payout_request_items",
+          "tableTo": "farmer_payout_requests",
+          "columnsFrom": [
+            "payout_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farmer_payout_requests": {
+      "name": "farmer_payout_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_amount": {
+          "name": "requested_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "farmer_note": {
+          "name": "farmer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_reference": {
+          "name": "bank_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farmer_payout_requests_farm_id_idx": {
+          "name": "farmer_payout_requests_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farmer_payout_requests_user_id_idx": {
+          "name": "farmer_payout_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farmer_payout_requests_status_idx": {
+          "name": "farmer_payout_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farmer_payout_requests_farm_id_farms_id_fk": {
+          "name": "farmer_payout_requests_farm_id_farms_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_user_id_users_id_fk": {
+          "name": "farmer_payout_requests_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_receipt_id_receipts_id_fk": {
+          "name": "farmer_payout_requests_receipt_id_receipts_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farmer_payout_requests_approved_by_user_id_users_id_fk": {
+          "name": "farmer_payout_requests_approved_by_user_id_users_id_fk",
+          "tableFrom": "farmer_payout_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operation_prices": {
+      "name": "operation_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_unit": {
+          "name": "price_per_unit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "operation_prices_farm_type_null_unique": {
+          "name": "operation_prices_farm_type_null_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operation_prices\".\"entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operation_prices_farm_type_entity_unique": {
+          "name": "operation_prices_farm_type_entity_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"operation_prices\".\"entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operation_prices_farm_id_idx": {
+          "name": "operation_prices_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operation_prices_farm_id_farms_id_fk": {
+          "name": "operation_prices_farm_id_farms_id_fk",
+          "tableFrom": "operation_prices",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_id_idx": {
+          "name": "refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_at_idx": {
+          "name": "refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_token_hash_idx": {
+          "name": "refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_cart_items": {
+      "name": "shopping_cart_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cart_id": {
+          "name": "cart_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type_name": {
+          "name": "entity_type_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raised_bed_id": {
+          "name": "raised_bed_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'eur'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_cart_items_cart_id_idx": {
+          "name": "shopping_cart_items_cart_id_idx",
+          "columns": [
+            {
+              "expression": "cart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_entity_id_idx": {
+          "name": "shopping_cart_items_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_garden_id_idx": {
+          "name": "shopping_cart_items_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_raised_bed_id_idx": {
+          "name": "shopping_cart_items_raised_bed_id_idx",
+          "columns": [
+            {
+              "expression": "raised_bed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_is_deleted_idx": {
+          "name": "shopping_cart_items_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_cart_items_status_idx": {
+          "name": "shopping_cart_items_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_cart_items_cart_id_shopping_carts_id_fk": {
+          "name": "shopping_cart_items_cart_id_shopping_carts_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "shopping_carts",
+          "columnsFrom": [
+            "cart_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_garden_id_gardens_id_fk": {
+          "name": "shopping_cart_items_garden_id_gardens_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shopping_cart_items_raised_bed_id_raised_beds_id_fk": {
+          "name": "shopping_cart_items_raised_bed_id_raised_beds_id_fk",
+          "tableFrom": "shopping_cart_items",
+          "tableTo": "raised_beds",
+          "columnsFrom": [
+            "raised_bed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shopping_carts": {
+      "name": "shopping_carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "shopping_carts_account_id_idx": {
+          "name": "shopping_carts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_is_deleted_idx": {
+          "name": "shopping_carts_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shopping_carts_status_idx": {
+          "name": "shopping_carts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shopping_carts_account_id_accounts_id_fk": {
+          "name": "shopping_carts_account_id_accounts_id_fk",
+          "tableFrom": "shopping_carts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_accounts": {
+      "name": "social_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_key": {
+          "name": "provider_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "social_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "default_destination": {
+          "name": "default_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_destinations": {
+          "name": "allowed_destinations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_reference": {
+          "name": "credential_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_accounts_provider_account_key_idx": {
+          "name": "social_accounts_provider_account_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_provider_idx": {
+          "name": "social_accounts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_accounts_status_idx": {
+          "name": "social_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.social_posts": {
+      "name": "social_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "social_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_key": {
+          "name": "provider_account_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "social_post_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "post_type": {
+          "name": "post_type",
+          "type": "social_post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_urls": {
+          "name": "media_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_submission_id": {
+          "name": "provider_submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_permalink": {
+          "name": "provider_permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_metadata": {
+          "name": "failure_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "social_posts_provider_idx": {
+          "name": "social_posts_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_status_idx": {
+          "name": "social_posts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_scheduled_at_idx": {
+          "name": "social_posts_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_queued_at_idx": {
+          "name": "social_posts_queued_at_idx",
+          "columns": [
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_created_at_idx": {
+          "name": "social_posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "social_posts_provider_destination_idx": {
+          "name": "social_posts_provider_destination_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sunflower_ledger_entries": {
+      "name": "sunflower_ledger_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_delta": {
+          "name": "available_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_delta": {
+          "name": "reserved_delta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_balance_after": {
+          "name": "available_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_balance_after": {
+          "name": "reserved_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_balance_after": {
+          "name": "total_balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_eur": {
+          "name": "amount_eur",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sunflower'"
+        },
+        "package_code": {
+          "name": "package_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_entity_id": {
+          "name": "package_entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_key": {
+          "name": "reservation_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sunflower_ledger_account_id_idx": {
+          "name": "sunflower_ledger_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_entry_type_idx": {
+          "name": "sunflower_ledger_entry_type_idx",
+          "columns": [
+            {
+              "expression": "entry_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_package_code_idx": {
+          "name": "sunflower_ledger_package_code_idx",
+          "columns": [
+            {
+              "expression": "package_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_package_entity_id_idx": {
+          "name": "sunflower_ledger_package_entity_id_idx",
+          "columns": [
+            {
+              "expression": "package_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_operation_id_idx": {
+          "name": "sunflower_ledger_operation_id_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_transaction_id_idx": {
+          "name": "sunflower_ledger_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_invoice_id_idx": {
+          "name": "sunflower_ledger_invoice_id_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_receipt_id_idx": {
+          "name": "sunflower_ledger_receipt_id_idx",
+          "columns": [
+            {
+              "expression": "receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_reservation_key_idx": {
+          "name": "sunflower_ledger_reservation_key_idx",
+          "columns": [
+            {
+              "expression": "reservation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_source_idx": {
+          "name": "sunflower_ledger_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_created_at_idx": {
+          "name": "sunflower_ledger_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_is_deleted_idx": {
+          "name": "sunflower_ledger_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sunflower_ledger_account_idempotency_unique": {
+          "name": "sunflower_ledger_account_idempotency_unique",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sunflower_ledger_entries_account_id_accounts_id_fk": {
+          "name": "sunflower_ledger_entries_account_id_accounts_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_package_entity_id_entities_id_fk": {
+          "name": "sunflower_ledger_entries_package_entity_id_entities_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "package_entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_operation_id_operations_id_fk": {
+          "name": "sunflower_ledger_entries_operation_id_operations_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_transaction_id_transactions_id_fk": {
+          "name": "sunflower_ledger_entries_transaction_id_transactions_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_invoice_id_invoices_id_fk": {
+          "name": "sunflower_ledger_entries_invoice_id_invoices_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sunflower_ledger_entries_receipt_id_receipts_id_fk": {
+          "name": "sunflower_ledger_entries_receipt_id_receipts_id_fk",
+          "tableFrom": "sunflower_ledger_entries",
+          "tableTo": "receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answers": {
+      "name": "survey_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_key": {
+          "name": "question_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numeric_value": {
+          "name": "numeric_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_value": {
+          "name": "text_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_value": {
+          "name": "contact_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_answers_response_question_unique": {
+          "name": "survey_answers_response_question_unique",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_response_idx": {
+          "name": "survey_answers_response_idx",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_question_idx": {
+          "name": "survey_answers_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_answers_question_key_idx": {
+          "name": "survey_answers_question_key_idx",
+          "columns": [
+            {
+              "expression": "question_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answers_response_id_survey_responses_id_fk": {
+          "name": "survey_answers_response_id_survey_responses_id_fk",
+          "tableFrom": "survey_answers",
+          "tableTo": "survey_responses",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "survey_answers_question_id_survey_questions_id_fk": {
+          "name": "survey_answers_question_id_survey_questions_id_fk",
+          "tableFrom": "survey_answers",
+          "tableTo": "survey_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_assignments": {
+      "name": "survey_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_assignments_version_target_context_unique": {
+          "name": "survey_assignments_version_target_context_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_survey_idx": {
+          "name": "survey_assignments_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_version_idx": {
+          "name": "survey_assignments_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_account_idx": {
+          "name": "survey_assignments_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_user_idx": {
+          "name": "survey_assignments_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_status_idx": {
+          "name": "survey_assignments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_assignments_send_idx": {
+          "name": "survey_assignments_send_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_assignments_survey_id_surveys_id_fk": {
+          "name": "survey_assignments_survey_id_surveys_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_version_id_survey_versions_id_fk": {
+          "name": "survey_assignments_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_send_id_survey_sends_id_fk": {
+          "name": "survey_assignments_send_id_survey_sends_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "survey_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_account_id_accounts_id_fk": {
+          "name": "survey_assignments_account_id_accounts_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_assignments_user_id_users_id_fk": {
+          "name": "survey_assignments_user_id_users_id_fk",
+          "tableFrom": "survey_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_questions": {
+      "name": "survey_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_metadata": {
+          "name": "score_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_questions_version_key_unique": {
+          "name": "survey_questions_version_key_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_questions_version_order_unique": {
+          "name": "survey_questions_version_order_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_questions_version_idx": {
+          "name": "survey_questions_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_questions_version_id_survey_versions_id_fk": {
+          "name": "survey_questions_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_questions",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_responses": {
+      "name": "survey_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "survey_response_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_app'"
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_assignment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "imported_external_id": {
+          "name": "imported_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_responses_assignment_unique": {
+          "name": "survey_responses_assignment_unique",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_imported_external_unique": {
+          "name": "survey_responses_imported_external_unique",
+          "columns": [
+            {
+              "expression": "imported_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_survey_idx": {
+          "name": "survey_responses_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_version_idx": {
+          "name": "survey_responses_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_account_idx": {
+          "name": "survey_responses_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_user_idx": {
+          "name": "survey_responses_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_source_idx": {
+          "name": "survey_responses_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_responses_submitted_at_idx": {
+          "name": "survey_responses_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_responses_assignment_id_survey_assignments_id_fk": {
+          "name": "survey_responses_assignment_id_survey_assignments_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "survey_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_responses_survey_id_surveys_id_fk": {
+          "name": "survey_responses_survey_id_surveys_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_responses_version_id_survey_versions_id_fk": {
+          "name": "survey_responses_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_responses_account_id_accounts_id_fk": {
+          "name": "survey_responses_account_id_accounts_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_responses_user_id_users_id_fk": {
+          "name": "survey_responses_user_id_users_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_send_deliveries": {
+      "name": "survey_send_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "send_id": {
+          "name": "send_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "survey_send_delivery_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_send_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_send_deliveries_send_idx": {
+          "name": "survey_send_deliveries_send_idx",
+          "columns": [
+            {
+              "expression": "send_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_assignment_idx": {
+          "name": "survey_send_deliveries_assignment_idx",
+          "columns": [
+            {
+              "expression": "assignment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_status_idx": {
+          "name": "survey_send_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_send_deliveries_notification_idx": {
+          "name": "survey_send_deliveries_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_send_deliveries_send_id_survey_sends_id_fk": {
+          "name": "survey_send_deliveries_send_id_survey_sends_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "survey_sends",
+          "columnsFrom": [
+            "send_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_assignment_id_survey_assignments_id_fk": {
+          "name": "survey_send_deliveries_assignment_id_survey_assignments_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "survey_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_account_id_accounts_id_fk": {
+          "name": "survey_send_deliveries_account_id_accounts_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_user_id_users_id_fk": {
+          "name": "survey_send_deliveries_user_id_users_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_send_deliveries_notification_id_notifications_id_fk": {
+          "name": "survey_send_deliveries_notification_id_notifications_id_fk",
+          "tableFrom": "survey_send_deliveries",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_sends": {
+      "name": "survey_sends",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_policy": {
+          "name": "channel_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_key": {
+          "name": "context_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "target_count": {
+          "name": "target_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "assigned_count": {
+          "name": "assigned_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_duplicate_count": {
+          "name": "skipped_duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_from_account_id": {
+          "name": "created_from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_sends_survey_idx": {
+          "name": "survey_sends_survey_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_version_idx": {
+          "name": "survey_sends_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_status_idx": {
+          "name": "survey_sends_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_sends_context_key_idx": {
+          "name": "survey_sends_context_key_idx",
+          "columns": [
+            {
+              "expression": "context_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_sends_survey_id_surveys_id_fk": {
+          "name": "survey_sends_survey_id_surveys_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_sends_version_id_survey_versions_id_fk": {
+          "name": "survey_sends_version_id_survey_versions_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "survey_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "survey_sends_created_by_user_id_users_id_fk": {
+          "name": "survey_sends_created_by_user_id_users_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "survey_sends_created_from_account_id_accounts_id_fk": {
+          "name": "survey_sends_created_from_account_id_accounts_id_fk",
+          "tableFrom": "survey_sends",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "created_from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_versions": {
+      "name": "survey_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_title": {
+          "name": "intro_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_description": {
+          "name": "intro_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thank_you_title": {
+          "name": "thank_you_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thank_you_description": {
+          "name": "thank_you_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_versions_survey_number_unique": {
+          "name": "survey_versions_survey_number_unique",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_versions_survey_status_idx": {
+          "name": "survey_versions_survey_status_idx",
+          "columns": [
+            {
+              "expression": "survey_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_versions_survey_id_surveys_id_fk": {
+          "name": "survey_versions_survey_id_surveys_id_fk",
+          "tableFrom": "survey_versions",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.surveys": {
+      "name": "surveys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "status": {
+          "name": "status",
+          "type": "survey_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "surveys_key_unique": {
+          "name": "surveys_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "surveys_status_idx": {
+          "name": "surveys_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "surveys_category_idx": {
+          "name": "surveys_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "surveys_created_by_user_id_users_id_fk": {
+          "name": "surveys_created_by_user_id_users_id_fk",
+          "tableFrom": "surveys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "garden_id": {
+          "name": "garden_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_id": {
+          "name": "stripe_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "transactions_account_id_idx": {
+          "name": "transactions_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_garden_id_idx": {
+          "name": "transactions_garden_id_idx",
+          "columns": [
+            {
+              "expression": "garden_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_stripe_payment_id_idx": {
+          "name": "transactions_stripe_payment_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_is_deleted_idx": {
+          "name": "transactions_is_deleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_garden_id_gardens_id_fk": {
+          "name": "transactions_garden_id_gardens_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "gardens",
+          "columnsFrom": [
+            "garden_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tutorial_checklist_task_claims": {
+      "name": "tutorial_checklist_task_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_key": {
+          "name": "task_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_sunflowers": {
+          "name": "reward_sunflowers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tutorial_checklist_claims_account_id_idx": {
+          "name": "tutorial_checklist_claims_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tutorial_checklist_claims_task_key_idx": {
+          "name": "tutorial_checklist_claims_task_key_idx",
+          "columns": [
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tutorial_checklist_claims_account_task_uq": {
+          "name": "tutorial_checklist_claims_account_task_uq",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tutorial_checklist_task_claims_account_id_accounts_id_fk": {
+          "name": "tutorial_checklist_task_claims_account_id_accounts_id_fk",
+          "tableFrom": "tutorial_checklist_task_claims",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "user_favorite_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_favorites_user_entity_uq": {
+          "name": "user_favorites_user_entity_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_id_idx": {
+          "name": "user_favorites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_entity_type_idx": {
+          "name": "user_favorites_entity_type_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_entity_id_idx": {
+          "name": "user_favorites_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_entity_id_entities_id_fk": {
+          "name": "user_favorites_entity_id_entities_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_invitations": {
+      "name": "account_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "account_invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_invitations_account_id_idx": {
+          "name": "account_invitations_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_email_idx": {
+          "name": "account_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_invitations_token_idx": {
+          "name": "account_invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_invitations_account_id_accounts_id_fk": {
+          "name": "account_invitations_account_id_accounts_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_invitations_invited_by_user_id_users_id_fk": {
+          "name": "account_invitations_invited_by_user_id_users_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_users": {
+      "name": "account_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_au_account_id_idx": {
+          "name": "users_au_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_au_user_id_idx": {
+          "name": "users_au_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_users_account_id_accounts_id_fk": {
+          "name": "account_users_account_id_accounts_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "account_users_user_id_users_id_fk": {
+          "name": "account_users_user_id_users_id_fk",
+          "tableFrom": "account_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street1": {
+          "name": "address_street1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street2": {
+          "name": "address_street2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_zip": {
+          "name": "address_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_zone": {
+          "name": "time_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Paris'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.farm_users": {
+      "name": "farm_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "farm_id": {
+          "name": "farm_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "farm_users_farm_id_idx": {
+          "name": "farm_users_farm_id_idx",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farm_users_user_id_idx": {
+          "name": "farm_users_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "farm_users_farm_user_unique": {
+          "name": "farm_users_farm_user_unique",
+          "columns": [
+            {
+              "expression": "farm_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "farm_users_farm_id_farms_id_fk": {
+          "name": "farm_users_farm_id_farms_id_fk",
+          "tableFrom": "farm_users",
+          "tableTo": "farms",
+          "columnsFrom": [
+            "farm_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "farm_users_user_id_users_id_fk": {
+          "name": "farm_users_user_id_users_id_fk",
+          "tableFrom": "farm_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_logins": {
+      "name": "user_logins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_type": {
+          "name": "login_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_id": {
+          "name": "login_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_data": {
+          "name": "login_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_attempt": {
+          "name": "last_failed_attempt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_until": {
+          "name": "blocked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_ul_user_id_idx": {
+          "name": "users_ul_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_type_idx": {
+          "name": "users_ul_login_type_idx",
+          "columns": [
+            {
+              "expression": "login_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_ul_login_id_idx": {
+          "name": "users_ul_login_id_idx",
+          "columns": [
+            {
+              "expression": "login_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_logins_user_id_users_id_fk": {
+          "name": "user_logins_user_id_users_id_fk",
+          "tableFrom": "user_logins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday_day": {
+          "name": "birthday_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_month": {
+          "name": "birthday_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_year": {
+          "name": "birthday_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_last_updated_at": {
+          "name": "birthday_last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_last_seen_at": {
+          "name": "whats_new_last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_popup_disabled": {
+          "name": "whats_new_popup_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "farm_schedule_grouped_watering_enabled": {
+          "name": "farm_schedule_grouped_watering_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_u_username_idx": {
+          "name": "users_u_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_history": {
+      "name": "weather_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rain": {
+          "name": "rain",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "wind_direction": {
+          "name": "wind_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_speed": {
+          "name": "wind_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rainy": {
+          "name": "rainy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "snowy": {
+          "name": "snowy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cloudy": {
+          "name": "cloudy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "foggy": {
+          "name": "foggy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thundery": {
+          "name": "thundery",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "weather_history_recorded_at_idx": {
+          "name": "weather_history_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.achievement_status": {
+      "name": "achievement_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "denied"
+      ]
+    },
+    "public.automation_definition_status": {
+      "name": "automation_definition_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "enabled",
+        "disabled",
+        "archived"
+      ]
+    },
+    "public.automation_module_kind": {
+      "name": "automation_module_kind",
+      "schema": "public",
+      "values": [
+        "trigger",
+        "filter",
+        "condition",
+        "action"
+      ]
+    },
+    "public.automation_run_source": {
+      "name": "automation_run_source",
+      "schema": "public",
+      "values": [
+        "event",
+        "manual",
+        "schedule",
+        "test",
+        "replay"
+      ]
+    },
+    "public.automation_run_status": {
+      "name": "automation_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "skipped",
+        "failed",
+        "retrying",
+        "canceled"
+      ]
+    },
+    "public.automation_step_status": {
+      "name": "automation_step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_status": {
+      "name": "email_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sending",
+        "sent",
+        "failed",
+        "bounced"
+      ]
+    },
+    "public.newsletter_status": {
+      "name": "newsletter_status",
+      "schema": "public",
+      "values": [
+        "subscribed",
+        "unsubscribed",
+        "pending"
+      ]
+    },
+    "public.notification_delivery_status": {
+      "name": "notification_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "accepted",
+        "sent",
+        "failed",
+        "dropped"
+      ]
+    },
+    "public.notification_delivery_event_type": {
+      "name": "notification_delivery_event_type",
+      "schema": "public",
+      "values": [
+        "queued",
+        "accepted",
+        "sent",
+        "failed",
+        "opened",
+        "clicked",
+        "dismissed",
+        "unsubscribed"
+      ]
+    },
+    "public.notification_digest_frequency": {
+      "name": "notification_digest_frequency",
+      "schema": "public",
+      "values": [
+        "off",
+        "hourly",
+        "daily",
+        "weekly"
+      ]
+    },
+    "public.notification_campaign_status": {
+      "name": "notification_campaign_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "queued",
+        "sending",
+        "sent",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "email",
+        "push",
+        "sms"
+      ]
+    },
+    "public.notification_preference_scope": {
+      "name": "notification_preference_scope",
+      "schema": "public",
+      "values": [
+        "global",
+        "account"
+      ]
+    },
+    "public.notification_priority": {
+      "name": "notification_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "critical"
+      ]
+    },
+    "public.push_permission_state": {
+      "name": "push_permission_state",
+      "schema": "public",
+      "values": [
+        "default",
+        "granted",
+        "denied"
+      ]
+    },
+    "public.social_account_status": {
+      "name": "social_account_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "disabled",
+        "needs_reauth"
+      ]
+    },
+    "public.social_post_status": {
+      "name": "social_post_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "queued",
+        "scheduled",
+        "submitting",
+        "submitted",
+        "published",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.social_post_type": {
+      "name": "social_post_type",
+      "schema": "public",
+      "values": [
+        "text",
+        "link",
+        "image",
+        "video",
+        "reel",
+        "story",
+        "carousel",
+        "other"
+      ]
+    },
+    "public.social_provider": {
+      "name": "social_provider",
+      "schema": "public",
+      "values": [
+        "reddit",
+        "instagram",
+        "facebook",
+        "google_business",
+        "x",
+        "tiktok",
+        "threads",
+        "linkedin",
+        "whatsapp"
+      ]
+    },
+    "public.survey_assignment_status": {
+      "name": "survey_assignment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "started",
+        "submitted",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.survey_question_type": {
+      "name": "survey_question_type",
+      "schema": "public",
+      "values": [
+        "opinion_scale",
+        "long_text",
+        "contact_info"
+      ]
+    },
+    "public.survey_response_source": {
+      "name": "survey_response_source",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "typeform",
+        "admin_import"
+      ]
+    },
+    "public.survey_send_delivery_channel": {
+      "name": "survey_send_delivery_channel",
+      "schema": "public",
+      "values": [
+        "in_app",
+        "email"
+      ]
+    },
+    "public.survey_send_delivery_status": {
+      "name": "survey_send_delivery_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sent",
+        "failed",
+        "skipped"
+      ]
+    },
+    "public.survey_send_status": {
+      "name": "survey_send_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "sent",
+        "canceled",
+        "failed"
+      ]
+    },
+    "public.survey_status": {
+      "name": "survey_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.survey_version_status": {
+      "name": "survey_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.user_favorite_entity_type": {
+      "name": "user_favorite_entity_type",
+      "schema": "public",
+      "values": [
+        "plant",
+        "plantSort",
+        "operation"
+      ]
+    },
+    "public.account_invitation_status": {
+      "name": "account_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage/src/migrations/meta/_journal.json
+++ b/packages/storage/src/migrations/meta/_journal.json
@@ -512,6 +512,13 @@
       "when": 1784114281670,
       "tag": "0072_slow_omega_sentinel",
       "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1784117004059,
+      "tag": "0073_overrated_sleepwalker",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage/src/repositories/deliveryAddressesRepo.ts
+++ b/packages/storage/src/repositories/deliveryAddressesRepo.ts
@@ -8,6 +8,32 @@ import {
 } from '../schema';
 import { storage } from '../storage';
 import { withDeliveryDispatchTransaction } from './deliveryDispatchRepo';
+import { assertDeliveryAddressHasNoActiveAssignment } from './deliveryRunAssignmentsRepo';
+
+export const DeliveryAddressMutationErrorCodes = {
+    NOT_FOUND_OR_FORBIDDEN: 'delivery-address-not-found',
+} as const;
+
+export type DeliveryAddressMutationErrorCode =
+    (typeof DeliveryAddressMutationErrorCodes)[keyof typeof DeliveryAddressMutationErrorCodes];
+
+export class DeliveryAddressMutationError extends Error {
+    override name = 'DeliveryAddressMutationError';
+
+    constructor(
+        readonly code: DeliveryAddressMutationErrorCode,
+        message: string,
+    ) {
+        super(message);
+    }
+}
+
+function deliveryAddressNotFound(operation: 'update' | 'delete') {
+    return new DeliveryAddressMutationError(
+        DeliveryAddressMutationErrorCodes.NOT_FOUND_OR_FORBIDDEN,
+        `Failed to ${operation} delivery address - address not found or access denied`,
+    );
+}
 
 // Get all addresses for an account (excluding soft deleted)
 export function getDeliveryAddresses(
@@ -90,6 +116,19 @@ export async function updateDeliveryAddress(
     accountId: string,
 ): Promise<void> {
     await withDeliveryDispatchTransaction(async (tx) => {
+        const ownedAddress = await tx.query.deliveryAddresses.findFirst({
+            columns: { id: true },
+            where: and(
+                eq(deliveryAddresses.id, update.id),
+                eq(deliveryAddresses.accountId, accountId),
+                isNull(deliveryAddresses.deletedAt),
+            ),
+        });
+        if (!ownedAddress) {
+            throw deliveryAddressNotFound('update');
+        }
+        await assertDeliveryAddressHasNoActiveAssignment(update.id, tx);
+
         // If setting as default, unset other defaults first
         if (update.isDefault) {
             await tx
@@ -117,9 +156,7 @@ export async function updateDeliveryAddress(
             .returning({ id: deliveryAddresses.id });
 
         if (!result[0]?.id) {
-            throw new Error(
-                'Failed to update delivery address - address not found or access denied',
-            );
+            throw deliveryAddressNotFound('update');
         }
     });
 }
@@ -130,6 +167,19 @@ export async function deleteDeliveryAddress(
     accountId: string,
 ): Promise<void> {
     await withDeliveryDispatchTransaction(async (tx) => {
+        const ownedAddress = await tx.query.deliveryAddresses.findFirst({
+            columns: { id: true },
+            where: and(
+                eq(deliveryAddresses.id, addressId),
+                eq(deliveryAddresses.accountId, accountId),
+                isNull(deliveryAddresses.deletedAt),
+            ),
+        });
+        if (!ownedAddress) {
+            throw deliveryAddressNotFound('delete');
+        }
+        await assertDeliveryAddressHasNoActiveAssignment(addressId, tx);
+
         const result = await tx
             .update(deliveryAddresses)
             .set({
@@ -146,9 +196,7 @@ export async function deleteDeliveryAddress(
             .returning({ id: deliveryAddresses.id });
 
         if (!result[0]?.id) {
-            throw new Error(
-                'Failed to delete delivery address - address not found or access denied',
-            );
+            throw deliveryAddressNotFound('delete');
         }
     });
 }

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -41,6 +41,10 @@ import {
     acquireDeliveryDispatchLock,
     withDeliveryDispatchTransaction,
 } from './deliveryDispatchRepo';
+import {
+    assertDeliveryRequestHasNoActiveAssignment,
+    cancelActiveDeliveryRunAssignment,
+} from './deliveryRunAssignmentsRepo';
 import { getEntitiesFormatted, getEntityFormatted } from './entitiesRepo';
 import {
     createEvent,
@@ -143,6 +147,7 @@ const deliveryRequestEventTypes = [
     knownEventTypes.delivery.requestReady,
     knownEventTypes.delivery.requestFulfilled,
     knownEventTypes.delivery.requestExceptionRecorded,
+    knownEventTypes.delivery.requestExceptionRecovered,
     knownEventTypes.delivery.requestSurveySent,
     knownEventTypes.delivery.requestSlotChanged,
     knownEventTypes.delivery.userCancelled,
@@ -157,6 +162,7 @@ export const deliveryDispatchEventTypes = [
     knownEventTypes.delivery.requestReady,
     knownEventTypes.delivery.requestFulfilled,
     knownEventTypes.delivery.requestExceptionRecorded,
+    knownEventTypes.delivery.requestExceptionRecovered,
     knownEventTypes.delivery.requestSlotChanged,
     knownEventTypes.delivery.userCancelled,
 ] as const;
@@ -355,6 +361,14 @@ function reconstructDeliveryRequestState(
                     data.exceptionOutcome === 'deferred' &&
                     data.exceptionRetryable === true,
             };
+        } else if (
+            event.type === knownEventTypes.delivery.requestExceptionRecovered &&
+            (state === DeliveryRequestStates.DEFERRED ||
+                state === DeliveryRequestStates.FAILED)
+        ) {
+            state = DeliveryRequestStates.READY;
+            cancelReason = undefined;
+            deliveryException = undefined;
         } else if (event.type === knownEventTypes.delivery.requestSlotChanged) {
             slotId = asNumber(data.newSlotId);
         } else if (event.type === knownEventTypes.delivery.userCancelled) {
@@ -1418,6 +1432,7 @@ export async function changeDeliveryRequestSlot(
             throw new Error('Delivery request has no slot to change');
         }
         if (request.slot.id === newSlotId) return;
+        await assertDeliveryRequestHasNoActiveAssignment(requestId, tx);
 
         await createEvent(
             knownEvents.delivery.requestSlotChangedV1(requestId, {
@@ -1438,12 +1453,27 @@ export async function cancelDeliveryRequest(
     actorId?: string,
 ): Promise<void> {
     await withDeliveryDispatchTransaction(async (tx) => {
+        const cancelledAt = new Date();
         const request = await getDeliveryRequest(requestId, tx);
 
         if (!request) {
             throw new Error('Delivery request not found');
         }
-        if (request.state === DeliveryRequestStates.CANCELLED) return;
+        const recordedByUser = actorId
+            ? await tx.query.users.findFirst({
+                  columns: { id: true },
+                  where: eq(users.id, actorId),
+              })
+            : undefined;
+        if (request.state === DeliveryRequestStates.CANCELLED) {
+            await cancelActiveDeliveryRunAssignment({
+                requestId,
+                occurredAt: cancelledAt,
+                recordedByUserId: recordedByUser?.id,
+                db: tx,
+            });
+            return;
+        }
         if (request.state === DeliveryRequestStates.FULFILLED) {
             throw new Error('Cannot cancel a fulfilled delivery request');
         }
@@ -1466,6 +1496,12 @@ export async function cancelDeliveryRequest(
             }),
             tx,
         );
+        await cancelActiveDeliveryRunAssignment({
+            requestId,
+            occurredAt: cancelledAt,
+            recordedByUserId: recordedByUser?.id,
+            db: tx,
+        });
     });
 }
 
@@ -1474,11 +1510,13 @@ export async function cancelDeliveryRequestForAccount({
     accountId,
     cancelReason,
     note,
+    actorUserId,
 }: {
     requestId: string;
     accountId: string;
     cancelReason: string;
     note?: string;
+    actorUserId?: string;
 }): Promise<void> {
     const request = await getDeliveryRequest(requestId);
 
@@ -1491,7 +1529,7 @@ export async function cancelDeliveryRequestForAccount({
         'user',
         cancelReason,
         note,
-        accountId,
+        actorUserId,
     );
 }
 

--- a/packages/storage/src/repositories/deliveryRunAssignmentsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunAssignmentsRepo.ts
@@ -1,0 +1,301 @@
+import {
+    and,
+    desc,
+    eq,
+    inArray,
+    isNull,
+    notInArray,
+    or,
+    sql,
+} from 'drizzle-orm';
+import 'server-only';
+import {
+    DeliveryRunExceptionReasons,
+    DeliveryRunStates,
+    DeliveryRunStopStates,
+    deliveryRunSlots,
+    deliveryRunStops,
+    deliveryRuns,
+    events,
+} from '../schema';
+import type { storage } from '../storage';
+
+type StorageClient = ReturnType<typeof storage>;
+type TransactionClient = Parameters<
+    Parameters<StorageClient['transaction']>[0]
+>[0];
+
+export const DeliveryRunAssignmentErrorCodes = {
+    ACTIVE_ASSIGNMENT_EXISTS: 'active-delivery-assignment-exists',
+} as const;
+
+export type DeliveryRunAssignmentErrorCode =
+    (typeof DeliveryRunAssignmentErrorCodes)[keyof typeof DeliveryRunAssignmentErrorCodes];
+
+export class DeliveryRunAssignmentError extends Error {
+    override name = 'DeliveryRunAssignmentError';
+
+    constructor(
+        readonly code: DeliveryRunAssignmentErrorCode,
+        message: string,
+    ) {
+        super(message);
+    }
+}
+
+const activelyAssignedStopStates = [
+    DeliveryRunStopStates.PENDING,
+    DeliveryRunStopStates.ARRIVED,
+    DeliveryRunStopStates.DEFERRED,
+    DeliveryRunStopStates.FAILED,
+];
+
+const terminalStopStates = [
+    DeliveryRunStopStates.DELIVERED,
+    DeliveryRunStopStates.FAILED,
+    DeliveryRunStopStates.CANCELLED,
+];
+
+function activeAssignmentError(resource: 'address' | 'slot' | 'request') {
+    const label =
+        resource === 'address'
+            ? 'Delivery address'
+            : resource === 'slot'
+              ? 'Delivery time slot'
+              : 'Delivery request';
+    return new DeliveryRunAssignmentError(
+        DeliveryRunAssignmentErrorCodes.ACTIVE_ASSIGNMENT_EXISTS,
+        `${label} belongs to an active delivery run. Abandon or recover the assignment before changing it.`,
+    );
+}
+
+export async function assertDeliveryAddressHasNoActiveAssignment(
+    addressId: number,
+    db: TransactionClient,
+) {
+    const assignment = await db
+        .select({ id: deliveryRunStops.id })
+        .from(deliveryRunStops)
+        .innerJoin(deliveryRuns, eq(deliveryRunStops.runId, deliveryRuns.id))
+        .where(
+            and(
+                or(
+                    eq(deliveryRunStops.deliveryAddressId, addressId),
+                    and(
+                        isNull(deliveryRunStops.deliveryAddressId),
+                        sql`(
+                            select legacy_address_event.data->>'addressId'
+                            from ${events} legacy_address_event
+                            where legacy_address_event.aggregate_id = ${deliveryRunStops.deliveryRequestId}
+                              and legacy_address_event.type in ('delivery.request.created', 'delivery.request.address.changed')
+                            order by legacy_address_event.created_at desc, legacy_address_event.id desc
+                            limit 1
+                        ) = ${String(addressId)}`,
+                    ),
+                ),
+                isNull(deliveryRunStops.releasedAt),
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                inArray(deliveryRunStops.state, activelyAssignedStopStates),
+            ),
+        )
+        .limit(1);
+    if (assignment[0]) throw activeAssignmentError('address');
+}
+
+export async function assertDeliveryTimeSlotHasNoActiveAssignment(
+    timeSlotId: number,
+    db: TransactionClient,
+) {
+    const assignment = await db
+        .select({ id: deliveryRunStops.id })
+        .from(deliveryRunStops)
+        .innerJoin(deliveryRuns, eq(deliveryRunStops.runId, deliveryRuns.id))
+        .leftJoin(
+            deliveryRunSlots,
+            and(
+                eq(deliveryRunStops.runId, deliveryRunSlots.runId),
+                eq(deliveryRunStops.runSlotId, deliveryRunSlots.id),
+            ),
+        )
+        .where(
+            and(
+                or(
+                    eq(deliveryRunSlots.timeSlotId, timeSlotId),
+                    and(
+                        isNull(deliveryRunStops.runSlotId),
+                        eq(deliveryRuns.timeSlotId, timeSlotId),
+                    ),
+                ),
+                isNull(deliveryRunStops.releasedAt),
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                inArray(deliveryRunStops.state, activelyAssignedStopStates),
+            ),
+        )
+        .limit(1);
+    if (assignment[0]) throw activeAssignmentError('slot');
+}
+
+export async function assertDeliveryRequestHasNoActiveAssignment(
+    requestId: string,
+    db: TransactionClient,
+) {
+    const assignment = await db
+        .select({ id: deliveryRunStops.id })
+        .from(deliveryRunStops)
+        .innerJoin(deliveryRuns, eq(deliveryRunStops.runId, deliveryRuns.id))
+        .where(
+            and(
+                eq(deliveryRunStops.deliveryRequestId, requestId),
+                isNull(deliveryRunStops.releasedAt),
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                inArray(deliveryRunStops.state, activelyAssignedStopStates),
+            ),
+        )
+        .limit(1);
+    if (assignment[0]) throw activeAssignmentError('request');
+}
+
+export type CancelActiveDeliveryRunAssignmentResult = {
+    runId: string;
+    routeRevision: number;
+    runCompleted: boolean;
+} | null;
+
+export async function cancelActiveDeliveryRunAssignment({
+    requestId,
+    occurredAt,
+    recordedByUserId,
+    db,
+}: {
+    requestId: string;
+    occurredAt: Date;
+    recordedByUserId?: string;
+    db: TransactionClient;
+}): Promise<CancelActiveDeliveryRunAssignmentResult> {
+    const candidate = await db
+        .select({ runId: deliveryRuns.id })
+        .from(deliveryRunStops)
+        .innerJoin(deliveryRuns, eq(deliveryRunStops.runId, deliveryRuns.id))
+        .where(
+            and(
+                eq(deliveryRunStops.deliveryRequestId, requestId),
+                isNull(deliveryRunStops.releasedAt),
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+            ),
+        )
+        .orderBy(desc(deliveryRunStops.createdAt))
+        .limit(1);
+    const runId = candidate[0]?.runId;
+    if (!runId) return null;
+
+    await db.execute(
+        sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${runId} for update`,
+    );
+    const stop = await db.query.deliveryRunStops.findFirst({
+        where: and(
+            eq(deliveryRunStops.runId, runId),
+            eq(deliveryRunStops.deliveryRequestId, requestId),
+            isNull(deliveryRunStops.releasedAt),
+        ),
+    });
+    if (!stop) return null;
+    if (stop.state === DeliveryRunStopStates.DELIVERED) {
+        throw new Error('Cannot cancel a fulfilled delivery request');
+    }
+
+    const [updatedStop] = await db
+        .update(deliveryRunStops)
+        .set({
+            state: DeliveryRunStopStates.CANCELLED,
+            deliveredAt: null,
+            exceptionReason: DeliveryRunExceptionReasons.CANCELLATION,
+            exceptionNote: null,
+            exceptionOccurredAt: occurredAt,
+            // Request cancellation audit data records the actor separately.
+            // This FK is populated only after the caller verifies a users.id.
+            exceptionRecordedByUserId: recordedByUserId ?? null,
+            releasedAt: occurredAt,
+        })
+        .where(
+            and(
+                eq(deliveryRunStops.id, stop.id),
+                eq(deliveryRunStops.runId, runId),
+                isNull(deliveryRunStops.releasedAt),
+            ),
+        )
+        .returning({ id: deliveryRunStops.id });
+    if (!updatedStop) {
+        throw new DeliveryRunAssignmentError(
+            DeliveryRunAssignmentErrorCodes.ACTIVE_ASSIGNMENT_EXISTS,
+            'Delivery assignment changed before cancellation could be recorded.',
+        );
+    }
+
+    const [updatedRun] = await db
+        .update(deliveryRuns)
+        .set({
+            routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
+            rerouteRequiredAt: occurredAt,
+            rerouteAttemptedAt: null,
+        })
+        .where(
+            and(
+                eq(deliveryRuns.id, runId),
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+            ),
+        )
+        .returning({ routeRevision: deliveryRuns.routeRevision });
+    if (!updatedRun) return null;
+
+    const unfinished = await db.query.deliveryRunStops.findFirst({
+        columns: { id: true },
+        where: and(
+            eq(deliveryRunStops.runId, runId),
+            notInArray(deliveryRunStops.state, terminalStopStates),
+        ),
+    });
+    if (unfinished) {
+        return {
+            runId,
+            routeRevision: updatedRun.routeRevision,
+            runCompleted: false,
+        };
+    }
+
+    await db
+        .update(deliveryRunStops)
+        .set({ releasedAt: occurredAt })
+        .where(
+            and(
+                eq(deliveryRunStops.runId, runId),
+                isNull(deliveryRunStops.releasedAt),
+                inArray(deliveryRunStops.state, terminalStopStates),
+            ),
+        );
+    await db
+        .update(deliveryRuns)
+        .set({
+            state: DeliveryRunStates.COMPLETED,
+            completedAt: occurredAt,
+            rerouteRequiredAt: null,
+            rerouteAttemptedAt: null,
+            currentLatitude: null,
+            currentLongitude: null,
+            currentLocationAccuracy: null,
+            currentLocationHeading: null,
+            currentLocationSpeed: null,
+            currentLocationRecordedAt: null,
+            currentLocationReceivedAt: null,
+        })
+        .where(
+            and(
+                eq(deliveryRuns.id, runId),
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+            ),
+        );
+    return {
+        runId,
+        routeRevision: updatedRun.routeRevision,
+        runCompleted: true,
+    };
+}

--- a/packages/storage/src/repositories/deliveryRunsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunsRepo.ts
@@ -7,8 +7,10 @@ import {
 import {
     and,
     asc,
+    desc,
     eq,
     inArray,
+    isNotNull,
     isNull,
     lte,
     notInArray,
@@ -65,6 +67,7 @@ import {
 import {
     deliveryDispatchEventTypes,
     fulfillDeliveryRequest,
+    getDeliveryRequest,
     getDeliveryRequestDispatchSnapshots,
 } from './deliveryRequestsRepo';
 import { createEvent, knownEvents } from './eventsRepo';
@@ -274,9 +277,12 @@ export const DeliveryRunExecutionErrorCodes = {
     PICKUP_OPERATION_CONFLICT: 'pickup-operation-conflict',
     PICKUP_DEPENDENCY_PENDING: 'pickup-dependency-pending',
     ROUTE_ORDER: 'route-order',
+    ROUTE_REVISION_CONFLICT: 'route-revision-conflict',
     EXCEPTION_OPERATION_CONFLICT: 'exception-operation-conflict',
     EXCEPTION_INVALID: 'exception-invalid',
     EXCEPTION_TRANSITION_INVALID: 'exception-transition-invalid',
+    RUN_DRIVER_CONFLICT: 'run-driver-conflict',
+    RUN_MUTATION_INVALID: 'run-mutation-invalid',
 } as const;
 
 export type DeliveryRunExecutionErrorCode =
@@ -308,6 +314,8 @@ export type DeliveryRunExecutionStep =
           stopIds: number[];
           actionableStopIds: number[];
           pickupConfirmed: boolean;
+          retryLaneRank?: number;
+          retryAttempt?: number;
           state: 'completed' | 'current' | 'upcoming';
       };
 
@@ -347,6 +355,7 @@ export type DeliveryRunStopExceptionInput = {
 export type RecordDeliveryRunStopExceptionsInput = {
     driverUserId: string;
     runId: string;
+    expectedRouteRevision?: number;
     clientOperationId: string;
     occurredAt: Date;
     exceptions: DeliveryRunStopExceptionInput[];
@@ -1420,6 +1429,23 @@ async function validatePreparedBulkMembership(
                 ),
             ),
         );
+    const activeAssignments = await db
+        .select({ deliveryRequestId: deliveryRunStops.deliveryRequestId })
+        .from(deliveryRunStops)
+        .innerJoin(deliveryRuns, eq(deliveryRunStops.runId, deliveryRuns.id))
+        .where(
+            and(
+                inArray(
+                    deliveryRunStops.deliveryRequestId,
+                    requestRows.map((request) => request.id),
+                ),
+                isNull(deliveryRunStops.releasedAt),
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+            ),
+        );
+    const activelyAssignedRequestIds = new Set(
+        activeAssignments.map((assignment) => assignment.deliveryRequestId),
+    );
     const currentSnapshots = await getDeliveryRequestDispatchSnapshots(
         requestRows.map((request) => request.id),
         db,
@@ -1434,6 +1460,7 @@ async function validatePreparedBulkMembership(
             !snapshot.address ||
             snapshot.address.deletedAt !== null ||
             !snapshot.slot ||
+            activelyAssignedRequestIds.has(snapshot.deliveryRequestId) ||
             !preparedStopKeys.has(stopKey(snapshot.slot.id, snapshot.address))
         ) {
             return [];
@@ -1485,7 +1512,10 @@ async function ensurePreparationCanCreateRun(
     );
     const assigned = await db.query.deliveryRunStops.findFirst({
         columns: { deliveryRequestId: true },
-        where: inArray(deliveryRunStops.deliveryRequestId, requestIds),
+        where: and(
+            inArray(deliveryRunStops.deliveryRequestId, requestIds),
+            isNull(deliveryRunStops.releasedAt),
+        ),
     });
     if (assigned) {
         throw new DeliveryRunPersistenceError(
@@ -1932,29 +1962,67 @@ async function getDeliveryRunExecutionProgressFromDb(
 ): Promise<DeliveryRunExecutionStep[]> {
     const run = await getDeliveryRunExecutionSource(runId, db);
     if (!run) return [];
+    const legacyPhysicalStopKey = (formattedAddress: string) =>
+        `${run.timeSlotId}:${formattedAddress
+            .normalize('NFKC')
+            .toLocaleLowerCase('hr-HR')
+            .replace(/\s*,\s*/g, ',')
+            .replace(/\s+/g, ' ')
+            .trim()}`;
 
     type PendingExecutionStep =
         | (Omit<
               Extract<DeliveryRunExecutionStep, { kind: 'pickup' }>,
               'state'
-          > & { completed: boolean })
+          > & { completed: boolean; sortLane: number; sortSequence: number })
         | (Omit<
               Extract<DeliveryRunExecutionStep, { kind: 'delivery' }>,
               'state'
-          > & { completed: boolean });
+          > & { completed: boolean; sortLane: number; sortSequence: number });
     const pendingSteps: PendingExecutionStep[] = [];
+    const baseItineraryMaximum = Math.max(
+        0,
+        ...run.pickupNodes.map((node) => node.itinerarySequence ?? 0),
+        ...run.stops
+            .filter((stop) => stop.retryLaneRank === null)
+            .map(
+                (stop) =>
+                    stop.itinerarySequence ??
+                    (run.routePlanVersion < 2 ? stop.sequence : 0),
+            ),
+    );
     if (run.routePlanVersion < 2) {
-        for (const stop of run.stops) {
+        const stopsByPhysicalKey = new Map<string, typeof run.stops>();
+        for (const stop of run.stops.filter(
+            (candidate) => candidate.retryLaneRank === null,
+        )) {
+            const key =
+                stop.stopKey ?? legacyPhysicalStopKey(stop.formattedAddress);
+            const stops = stopsByPhysicalKey.get(key) ?? [];
+            stops.push(stop);
+            stopsByPhysicalKey.set(key, stops);
+        }
+        for (const stops of stopsByPhysicalKey.values()) {
+            const firstStop = stops[0];
+            if (!firstStop) continue;
             pendingSteps.push({
                 kind: 'delivery',
-                itinerarySequence: stop.sequence,
-                stopKey: stop.stopKey,
-                stopIds: [stop.id],
-                actionableStopIds: isDeliveryRunStopActionable(stop.state)
-                    ? [stop.id]
-                    : [],
+                itinerarySequence: Math.min(
+                    ...stops.map((stop) => stop.sequence),
+                ),
+                stopKey:
+                    firstStop.stopKey ??
+                    legacyPhysicalStopKey(firstStop.formattedAddress),
+                stopIds: stops.map((stop) => stop.id),
+                actionableStopIds: stops.flatMap((stop) =>
+                    isDeliveryRunStopActionable(stop.state) ? [stop.id] : [],
+                ),
                 pickupConfirmed: true,
-                completed: isDeliveryRunStopTerminal(stop.state),
+                completed: stops.every((stop) =>
+                    isDeliveryRunStopTerminal(stop.state),
+                ),
+                sortLane: 0,
+                sortSequence: Math.min(...stops.map((stop) => stop.sequence)),
             });
         }
     } else {
@@ -1980,6 +2048,8 @@ async function getDeliveryRunExecutionProgressFromDb(
                             slot.manifestState ===
                             DeliveryRunManifestStates.CONFIRMED,
                     ),
+                sortLane: 0,
+                sortSequence: pickupNode.itinerarySequence,
             });
         }
 
@@ -1988,7 +2058,12 @@ async function getDeliveryRunExecutionProgressFromDb(
             { itinerarySequence: number; stops: typeof run.stops }
         >();
         for (const stop of run.stops) {
-            if (stop.itinerarySequence === null) continue;
+            if (
+                stop.itinerarySequence === null ||
+                stop.retryLaneRank !== null
+            ) {
+                continue;
+            }
             const executionKey = `${stop.itinerarySequence}\u0000${stop.stopKey ?? `stop:${stop.id}`}`;
             const checkpoint = stopsByExecutionKey.get(executionKey) ?? {
                 itinerarySequence: stop.itinerarySequence,
@@ -2021,22 +2096,84 @@ async function getDeliveryRunExecutionProgressFromDb(
                 completed: stops.every((stop) =>
                     isDeliveryRunStopTerminal(stop.state),
                 ),
+                sortLane: 0,
+                sortSequence: itinerarySequence,
             });
         }
     }
 
+    const retryCheckpoints = new Map<
+        string,
+        {
+            retryLaneRank: number;
+            itinerarySequence: number;
+            stopKey: string | null;
+            stops: typeof run.stops;
+        }
+    >();
+    for (const stop of run.stops) {
+        if (stop.retryLaneRank === null) continue;
+        const physicalStopKey =
+            stop.stopKey ?? legacyPhysicalStopKey(stop.formattedAddress);
+        const key = `${stop.retryLaneRank}\u0000${physicalStopKey}`;
+        const checkpoint = retryCheckpoints.get(key) ?? {
+            retryLaneRank: stop.retryLaneRank,
+            itinerarySequence:
+                stop.itinerarySequence ??
+                baseItineraryMaximum + stop.retryLaneRank,
+            stopKey: physicalStopKey,
+            stops: [],
+        };
+        checkpoint.stops.push(stop);
+        retryCheckpoints.set(key, checkpoint);
+    }
+    for (const checkpoint of retryCheckpoints.values()) {
+        pendingSteps.push({
+            kind: 'delivery',
+            itinerarySequence: checkpoint.itinerarySequence,
+            stopKey: checkpoint.stopKey,
+            stopIds: checkpoint.stops.map((stop) => stop.id),
+            actionableStopIds: checkpoint.stops.flatMap((stop) =>
+                isDeliveryRunStopActionable(stop.state) ? [stop.id] : [],
+            ),
+            pickupConfirmed: true,
+            retryLaneRank: checkpoint.retryLaneRank,
+            retryAttempt: Math.max(
+                ...checkpoint.stops.map((stop) => stop.retryAttempt),
+            ),
+            completed: checkpoint.stops.every((stop) =>
+                isDeliveryRunStopTerminal(stop.state),
+            ),
+            sortLane: 1,
+            sortSequence: checkpoint.retryLaneRank,
+        });
+    }
+
     pendingSteps.sort(
-        (first, second) => first.itinerarySequence - second.itinerarySequence,
+        (first, second) =>
+            first.sortLane - second.sortLane ||
+            first.sortSequence - second.sortSequence ||
+            first.itinerarySequence - second.itinerarySequence,
     );
     const currentIndex = pendingSteps.findIndex((step) => !step.completed);
-    return pendingSteps.map(({ completed, ...step }, index) => ({
-        ...step,
-        state: completed
-            ? 'completed'
-            : index === currentIndex
-              ? 'current'
-              : 'upcoming',
-    }));
+    return pendingSteps.map(
+        (
+            {
+                completed,
+                sortLane: _sortLane,
+                sortSequence: _sortSequence,
+                ...step
+            },
+            index,
+        ) => ({
+            ...step,
+            state: completed
+                ? 'completed'
+                : index === currentIndex
+                  ? 'current'
+                  : 'upcoming',
+        }),
+    );
 }
 
 export function getDeliveryRunExecutionProgress(runId: string) {
@@ -2595,18 +2732,31 @@ async function completeDeliveryRunIfEligible({
     });
     if (remaining) return false;
 
+    await db
+        .update(deliveryRunStops)
+        .set({ releasedAt: completedAt })
+        .where(
+            and(
+                eq(deliveryRunStops.runId, runId),
+                isNull(deliveryRunStops.releasedAt),
+                inArray(deliveryRunStops.state, deliveryRunTerminalStopStates),
+            ),
+        );
+
     const [completedRun] = await db
         .update(deliveryRuns)
         .set({
             state: DeliveryRunStates.COMPLETED,
             completedAt,
             rerouteRequiredAt: null,
+            rerouteAttemptedAt: null,
             currentLatitude: null,
             currentLongitude: null,
             currentLocationAccuracy: null,
             currentLocationHeading: null,
             currentLocationSpeed: null,
             currentLocationRecordedAt: null,
+            currentLocationReceivedAt: null,
         })
         .where(
             and(
@@ -2656,6 +2806,13 @@ function normalizeDeliveryRunStopExceptionInput(
         invalidDeliveryRunException(
             'Delivery exception occurrence time is invalid',
         );
+    }
+    if (
+        input.expectedRouteRevision !== undefined &&
+        (!Number.isInteger(input.expectedRouteRevision) ||
+            input.expectedRouteRevision < 0)
+    ) {
+        invalidDeliveryRunException('Delivery route revision is invalid');
     }
     if (!Array.isArray(input.exceptions) || input.exceptions.length === 0) {
         invalidDeliveryRunException(
@@ -2720,6 +2877,7 @@ function deliveryRunStopExceptionPayloadHash(
     return hashValue(
         JSON.stringify({
             clientOperationId: input.clientOperationId,
+            expectedRouteRevision: input.expectedRouteRevision,
             occurredAt: input.occurredAt.toISOString(),
             exceptions: input.exceptions,
         }),
@@ -2825,6 +2983,15 @@ async function recordDeliveryRunStopExceptionsInDatabase(
             'Active delivery run was not found',
         );
     }
+    if (
+        input.expectedRouteRevision !== undefined &&
+        run.routeRevision !== input.expectedRouteRevision
+    ) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+            'Delivery route changed. Refresh the active run and retry.',
+        );
+    }
 
     const progress = await getDeliveryRunExecutionProgressFromDb(
         input.runId,
@@ -2907,6 +3074,16 @@ async function recordDeliveryRunStopExceptionsInDatabase(
         }
     }
 
+    const defersCheckpoint = input.exceptions.some(
+        (exception) =>
+            exception.outcome === DeliveryRunExceptionOutcomes.DEFERRED,
+    );
+    const sourceStop = stops[0];
+    const retryLaneRank =
+        defersCheckpoint && sourceStop
+            ? await retryLaneRankForStop(sourceStop, db)
+            : 0;
+
     for (const stop of stops) {
         const exception = exceptionsByStopId.get(stop.id);
         if (!exception) continue;
@@ -2918,6 +3095,15 @@ async function recordDeliveryRunStopExceptionsInDatabase(
                 exceptionNote: exception.note ?? null,
                 exceptionOccurredAt: input.occurredAt,
                 exceptionRecordedByUserId: input.driverUserId,
+                ...(exception.outcome === DeliveryRunExceptionOutcomes.DEFERRED
+                    ? {
+                          retryLaneRank,
+                          retryAttempt: stop.retryAttempt + 1,
+                      }
+                    : exception.outcome ===
+                        DeliveryRunExceptionOutcomes.CANCELLED
+                      ? { releasedAt: input.occurredAt }
+                      : {}),
             })
             .where(
                 and(
@@ -2940,6 +3126,7 @@ async function recordDeliveryRunStopExceptionsInDatabase(
         .set({
             routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
             rerouteRequiredAt: appliedAt,
+            rerouteAttemptedAt: null,
         })
         .where(
             and(
@@ -3033,6 +3220,1039 @@ export async function recordDeliveryRunStopExceptions(
     );
 }
 
+function ensureRouteRevisionInput(value: number) {
+    if (!Number.isInteger(value) || value < 0) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+            'Delivery route revision is invalid',
+        );
+    }
+}
+
+function assertRouteRevision(current: number, expected: number) {
+    if (current !== expected) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+            'Delivery route changed. Refresh the active run and retry.',
+        );
+    }
+}
+
+async function nextDeliveryRunRetryLaneRank(
+    runId: string,
+    db: TransactionClient,
+) {
+    const [row] = await db
+        .select({
+            value: sql<number>`coalesce(max(${deliveryRunStops.retryLaneRank}), 0) + 1`,
+        })
+        .from(deliveryRunStops)
+        .where(eq(deliveryRunStops.runId, runId));
+    return Number(row?.value ?? 1);
+}
+
+async function retryLaneRankForStop(
+    stop: typeof deliveryRunStops.$inferSelect,
+    db: TransactionClient,
+) {
+    const samePhysicalStop = stop.stopKey
+        ? eq(deliveryRunStops.stopKey, stop.stopKey)
+        : and(
+              isNull(deliveryRunStops.stopKey),
+              eq(deliveryRunStops.formattedAddress, stop.formattedAddress),
+          );
+    if (stop.retryLaneRank !== null) {
+        const reusableNextAttempt = await db.query.deliveryRunStops.findFirst({
+            columns: { retryLaneRank: true },
+            where: and(
+                eq(deliveryRunStops.runId, stop.runId),
+                samePhysicalStop,
+                isNotNull(deliveryRunStops.retryLaneRank),
+                isNull(deliveryRunStops.releasedAt),
+                eq(deliveryRunStops.retryAttempt, stop.retryAttempt + 1),
+                inArray(deliveryRunStops.state, [
+                    DeliveryRunStopStates.PENDING,
+                    DeliveryRunStopStates.ARRIVED,
+                    DeliveryRunStopStates.DEFERRED,
+                ]),
+            ),
+            orderBy: [asc(deliveryRunStops.retryLaneRank)],
+        });
+        return (
+            reusableNextAttempt?.retryLaneRank ??
+            (await nextDeliveryRunRetryLaneRank(stop.runId, db))
+        );
+    }
+    const reusable = await db.query.deliveryRunStops.findFirst({
+        columns: { retryLaneRank: true },
+        where: and(
+            eq(deliveryRunStops.runId, stop.runId),
+            samePhysicalStop,
+            isNotNull(deliveryRunStops.retryLaneRank),
+            isNull(deliveryRunStops.releasedAt),
+            inArray(deliveryRunStops.state, [
+                DeliveryRunStopStates.PENDING,
+                DeliveryRunStopStates.ARRIVED,
+                DeliveryRunStopStates.DEFERRED,
+            ]),
+        ),
+        orderBy: [asc(deliveryRunStops.retryLaneRank)],
+    });
+    return (
+        reusable?.retryLaneRank ??
+        (await nextDeliveryRunRetryLaneRank(stop.runId, db))
+    );
+}
+
+export type RetryDeliveryRunStopResult = {
+    stopIds: number[];
+    routeRevision: number;
+    reroutePending: true;
+};
+
+export async function retryDeliveryRunStop({
+    driverUserId,
+    runId,
+    stopId,
+    expectedRouteRevision,
+    occurredAt = new Date(),
+}: {
+    driverUserId: string;
+    runId: string;
+    stopId: number;
+    expectedRouteRevision: number;
+    occurredAt?: Date;
+}): Promise<RetryDeliveryRunStopResult> {
+    ensureRouteRevisionInput(expectedRouteRevision);
+    return await withDeliveryDispatchTransaction(async (tx) => {
+        await tx.execute(
+            sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${runId} for update`,
+        );
+        const run = await tx.query.deliveryRuns.findFirst({
+            where: eq(deliveryRuns.id, runId),
+        });
+        if (
+            !run ||
+            run.state !== DeliveryRunStates.ACTIVE ||
+            run.driverUserId !== driverUserId
+        ) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+                'Active delivery run was not found',
+            );
+        }
+        assertRouteRevision(run.routeRevision, expectedRouteRevision);
+
+        const progress = await getDeliveryRunExecutionProgressFromDb(runId, tx);
+        const current = progress.find((step) => step.state === 'current');
+        if (
+            current?.kind !== 'delivery' ||
+            current.retryLaneRank === undefined ||
+            !current.stopIds.includes(stopId)
+        ) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ROUTE_ORDER,
+                'Deferred delivery retry is not the current checkpoint',
+            );
+        }
+        const stops = await tx.query.deliveryRunStops.findMany({
+            where: and(
+                eq(deliveryRunStops.runId, runId),
+                inArray(deliveryRunStops.id, current.stopIds),
+                eq(deliveryRunStops.state, DeliveryRunStopStates.DEFERRED),
+                isNull(deliveryRunStops.releasedAt),
+            ),
+            orderBy: [asc(deliveryRunStops.sequence)],
+        });
+        if (stops.length === 0) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
+                'Deferred delivery checkpoint is no longer retryable',
+            );
+        }
+        if (!stops.some((stop) => stop.id === stopId)) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
+                'Only a deferred delivery stop can start its retry checkpoint',
+            );
+        }
+
+        await tx
+            .update(deliveryRunStops)
+            .set({
+                state: DeliveryRunStopStates.PENDING,
+                arrivedAt: null,
+                deliveredAt: null,
+                exceptionReason: null,
+                exceptionNote: null,
+                exceptionOccurredAt: null,
+                exceptionRecordedByUserId: null,
+            })
+            .where(
+                inArray(
+                    deliveryRunStops.id,
+                    stops.map((stop) => stop.id),
+                ),
+            );
+        const [updatedRun] = await tx
+            .update(deliveryRuns)
+            .set({
+                routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
+                rerouteRequiredAt: occurredAt,
+                rerouteAttemptedAt: null,
+            })
+            .where(
+                and(
+                    eq(deliveryRuns.id, runId),
+                    eq(deliveryRuns.routeRevision, expectedRouteRevision),
+                    eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                ),
+            )
+            .returning({ routeRevision: deliveryRuns.routeRevision });
+        if (!updatedRun) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+                'Delivery route changed. Refresh the active run and retry.',
+            );
+        }
+        for (const stop of stops) {
+            await createEvent(
+                knownEvents.delivery.requestExceptionRecoveredV1(
+                    stop.deliveryRequestId,
+                    {
+                        runId,
+                        stopId: stop.id,
+                        recovery: 'retry',
+                        recoveredAt: occurredAt.toISOString(),
+                        recoveredByUserId: driverUserId,
+                        routeRevision: updatedRun.routeRevision,
+                    },
+                ),
+                tx,
+            );
+        }
+        return {
+            stopIds: stops.map((stop) => stop.id),
+            routeRevision: updatedRun.routeRevision,
+            reroutePending: true,
+        };
+    });
+}
+
+export type RecoverDeliveryRunStopResult = {
+    requestId: string;
+    routeRevision: number;
+    resumedInRun: boolean;
+    reroutePending: boolean;
+};
+
+export async function recoverDeliveryRunStop({
+    adminUserId,
+    runId,
+    stopId,
+    expectedRouteRevision,
+    occurredAt = new Date(),
+}: {
+    adminUserId: string;
+    runId: string;
+    stopId: number;
+    expectedRouteRevision: number;
+    occurredAt?: Date;
+}): Promise<RecoverDeliveryRunStopResult> {
+    ensureRouteRevisionInput(expectedRouteRevision);
+    return await withDeliveryDispatchTransaction(async (tx) => {
+        await tx.execute(
+            sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${runId} for update`,
+        );
+        const run = await tx.query.deliveryRuns.findFirst({
+            where: eq(deliveryRuns.id, runId),
+        });
+        if (!run) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+                'Delivery run was not found',
+            );
+        }
+        assertRouteRevision(run.routeRevision, expectedRouteRevision);
+        const stop = await tx.query.deliveryRunStops.findFirst({
+            where: and(
+                eq(deliveryRunStops.id, stopId),
+                eq(deliveryRunStops.runId, runId),
+            ),
+        });
+        if (!stop || stop.state !== DeliveryRunStopStates.FAILED) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
+                'Only a failed delivery stop can be recovered',
+            );
+        }
+        const [request, latestStop] = await Promise.all([
+            getDeliveryRequest(stop.deliveryRequestId, tx),
+            tx.query.deliveryRunStops.findFirst({
+                columns: { id: true },
+                where: eq(
+                    deliveryRunStops.deliveryRequestId,
+                    stop.deliveryRequestId,
+                ),
+                orderBy: [desc(deliveryRunStops.id)],
+            }),
+        ]);
+        if (
+            request?.state !== DeliveryRequestStates.FAILED ||
+            latestStop?.id !== stop.id
+        ) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
+                'Failed delivery recovery is stale or already applied',
+            );
+        }
+
+        const resumedInRun = run.state === DeliveryRunStates.ACTIVE;
+        if (resumedInRun) {
+            const retryLaneRank = await retryLaneRankForStop(stop, tx);
+            await tx
+                .update(deliveryRunStops)
+                .set({
+                    state: DeliveryRunStopStates.PENDING,
+                    retryLaneRank,
+                    retryAttempt: stop.retryAttempt + 1,
+                    arrivedAt: null,
+                    deliveredAt: null,
+                    exceptionReason: null,
+                    exceptionNote: null,
+                    exceptionOccurredAt: null,
+                    exceptionRecordedByUserId: null,
+                    releasedAt: null,
+                })
+                .where(
+                    and(
+                        eq(deliveryRunStops.id, stop.id),
+                        eq(
+                            deliveryRunStops.state,
+                            DeliveryRunStopStates.FAILED,
+                        ),
+                    ),
+                );
+        }
+        const [updatedRun] = await tx
+            .update(deliveryRuns)
+            .set({
+                routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
+                ...(resumedInRun
+                    ? {
+                          rerouteRequiredAt: occurredAt,
+                          rerouteAttemptedAt: null,
+                      }
+                    : {}),
+            })
+            .where(
+                and(
+                    eq(deliveryRuns.id, runId),
+                    eq(deliveryRuns.routeRevision, expectedRouteRevision),
+                ),
+            )
+            .returning({ routeRevision: deliveryRuns.routeRevision });
+        if (!updatedRun) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+                'Delivery route changed. Refresh the delivery run and retry.',
+            );
+        }
+        await createEvent(
+            knownEvents.delivery.requestExceptionRecoveredV1(
+                stop.deliveryRequestId,
+                {
+                    runId,
+                    stopId: stop.id,
+                    recovery: 'admin-recovery',
+                    recoveredAt: occurredAt.toISOString(),
+                    recoveredByUserId: adminUserId,
+                    routeRevision: updatedRun.routeRevision,
+                },
+            ),
+            tx,
+        );
+        return {
+            requestId: stop.deliveryRequestId,
+            routeRevision: updatedRun.routeRevision,
+            resumedInRun,
+            reroutePending: resumedInRun,
+        };
+    });
+}
+
+export async function reassignDeliveryRun({
+    adminUserId,
+    runId,
+    newDriverUserId,
+    expectedRouteRevision,
+    occurredAt = new Date(),
+}: {
+    adminUserId: string;
+    runId: string;
+    newDriverUserId: string;
+    expectedRouteRevision: number;
+    occurredAt?: Date;
+}) {
+    ensureRouteRevisionInput(expectedRouteRevision);
+    return await withDeliveryDispatchTransaction(async (tx) => {
+        await tx.execute(
+            sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${runId} for update`,
+        );
+        const run = await tx.query.deliveryRuns.findFirst({
+            where: eq(deliveryRuns.id, runId),
+        });
+        if (!run || run.state !== DeliveryRunStates.ACTIVE) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+                'Active delivery run was not found',
+            );
+        }
+        assertRouteRevision(run.routeRevision, expectedRouteRevision);
+        if (run.driverUserId === newDriverUserId) {
+            return {
+                driverUserId: newDriverUserId,
+                routeRevision: run.routeRevision,
+                reroutePending: run.rerouteRequiredAt !== null,
+            };
+        }
+        const driver = await tx.query.users.findFirst({
+            columns: { id: true, role: true },
+            where: eq(users.id, newDriverUserId),
+        });
+        if (!driver || !['driver', 'admin'].includes(driver.role)) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+                'New delivery driver is invalid',
+            );
+        }
+        const targetRun = await tx.query.deliveryRuns.findFirst({
+            columns: { id: true },
+            where: and(
+                eq(deliveryRuns.driverUserId, newDriverUserId),
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+            ),
+        });
+        if (targetRun) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.RUN_DRIVER_CONFLICT,
+                'The selected driver already has an active delivery run',
+            );
+        }
+        await tx
+            .update(deliveryRunStops)
+            .set({
+                state: DeliveryRunStopStates.PENDING,
+                arrivedAt: null,
+            })
+            .where(
+                and(
+                    eq(deliveryRunStops.runId, runId),
+                    eq(deliveryRunStops.state, DeliveryRunStopStates.ARRIVED),
+                    isNull(deliveryRunStops.releasedAt),
+                ),
+            );
+        const [updatedRun] = await tx
+            .update(deliveryRuns)
+            .set({
+                driverUserId: newDriverUserId,
+                routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
+                rerouteRequiredAt: occurredAt,
+                rerouteAttemptedAt: null,
+                currentLatitude: null,
+                currentLongitude: null,
+                currentLocationAccuracy: null,
+                currentLocationHeading: null,
+                currentLocationSpeed: null,
+                currentLocationRecordedAt: null,
+                currentLocationReceivedAt: null,
+            })
+            .where(
+                and(
+                    eq(deliveryRuns.id, runId),
+                    eq(deliveryRuns.routeRevision, expectedRouteRevision),
+                    eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                ),
+            )
+            .returning({ routeRevision: deliveryRuns.routeRevision });
+        if (!updatedRun) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+                'Delivery route changed. Refresh the active run and retry.',
+            );
+        }
+        await createEvent(
+            knownEvents.delivery.runReassignedV1(runId, {
+                previousDriverUserId: run.driverUserId,
+                newDriverUserId,
+                reassignedAt: occurredAt.toISOString(),
+                reassignedByUserId: adminUserId,
+                routeRevision: updatedRun.routeRevision,
+            }),
+            tx,
+        );
+        return {
+            driverUserId: newDriverUserId,
+            routeRevision: updatedRun.routeRevision,
+            reroutePending: true,
+        };
+    });
+}
+
+export async function abandonDeliveryRun({
+    adminUserId,
+    runId,
+    expectedRouteRevision,
+    reason,
+    occurredAt = new Date(),
+}: {
+    adminUserId: string;
+    runId: string;
+    expectedRouteRevision: number;
+    reason?: string;
+    occurredAt?: Date;
+}) {
+    ensureRouteRevisionInput(expectedRouteRevision);
+    const normalizedReason = reason?.trim().slice(0, 1_000);
+    return await withDeliveryDispatchTransaction(async (tx) => {
+        await tx.execute(
+            sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${runId} for update`,
+        );
+        const run = await tx.query.deliveryRuns.findFirst({
+            where: eq(deliveryRuns.id, runId),
+        });
+        if (!run || run.state !== DeliveryRunStates.ACTIVE) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+                'Active delivery run was not found',
+            );
+        }
+        assertRouteRevision(run.routeRevision, expectedRouteRevision);
+        const stops = await tx.query.deliveryRunStops.findMany({
+            where: eq(deliveryRunStops.runId, runId),
+            orderBy: [asc(deliveryRunStops.sequence)],
+        });
+        const recoverableStops = stops.filter(
+            (stop) =>
+                stop.state !== DeliveryRunStopStates.DELIVERED &&
+                stop.state !== DeliveryRunStopStates.CANCELLED,
+        );
+        for (const stop of recoverableStops) {
+            if (stop.state === DeliveryRunStopStates.FAILED) {
+                await tx
+                    .update(deliveryRunStops)
+                    .set({ releasedAt: occurredAt })
+                    .where(eq(deliveryRunStops.id, stop.id));
+                continue;
+            }
+            await tx
+                .update(deliveryRunStops)
+                .set({
+                    state: DeliveryRunStopStates.CANCELLED,
+                    deliveredAt: null,
+                    exceptionReason: DeliveryRunExceptionReasons.CANCELLATION,
+                    exceptionNote: normalizedReason ?? null,
+                    exceptionOccurredAt: occurredAt,
+                    exceptionRecordedByUserId: adminUserId,
+                    releasedAt: occurredAt,
+                })
+                .where(eq(deliveryRunStops.id, stop.id));
+        }
+        await tx
+            .update(deliveryRunStops)
+            .set({ releasedAt: occurredAt })
+            .where(
+                and(
+                    eq(deliveryRunStops.runId, runId),
+                    isNull(deliveryRunStops.releasedAt),
+                    inArray(deliveryRunStops.state, [
+                        DeliveryRunStopStates.DELIVERED,
+                        DeliveryRunStopStates.CANCELLED,
+                    ]),
+                ),
+            );
+        const [updatedRun] = await tx
+            .update(deliveryRuns)
+            .set({
+                state: DeliveryRunStates.CANCELLED,
+                completedAt: occurredAt,
+                routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
+                rerouteRequiredAt: null,
+                rerouteAttemptedAt: null,
+                currentLatitude: null,
+                currentLongitude: null,
+                currentLocationAccuracy: null,
+                currentLocationHeading: null,
+                currentLocationSpeed: null,
+                currentLocationRecordedAt: null,
+                currentLocationReceivedAt: null,
+            })
+            .where(
+                and(
+                    eq(deliveryRuns.id, runId),
+                    eq(deliveryRuns.routeRevision, expectedRouteRevision),
+                    eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                ),
+            )
+            .returning({ routeRevision: deliveryRuns.routeRevision });
+        if (!updatedRun) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+                'Delivery route changed. Refresh the active run and retry.',
+            );
+        }
+        for (const stop of recoverableStops) {
+            await createEvent(
+                knownEvents.delivery.requestExceptionRecoveredV1(
+                    stop.deliveryRequestId,
+                    {
+                        runId,
+                        stopId: stop.id,
+                        recovery: 'route-abandonment',
+                        recoveredAt: occurredAt.toISOString(),
+                        recoveredByUserId: adminUserId,
+                        routeRevision: updatedRun.routeRevision,
+                    },
+                ),
+                tx,
+            );
+        }
+        await createEvent(
+            knownEvents.delivery.runAbandonedV1(runId, {
+                abandonedAt: occurredAt.toISOString(),
+                abandonedByUserId: adminUserId,
+                ...(normalizedReason ? { reason: normalizedReason } : {}),
+                releasedRequestIds: recoverableStops.map(
+                    (stop) => stop.deliveryRequestId,
+                ),
+                routeRevision: updatedRun.routeRevision,
+            }),
+            tx,
+        );
+        return {
+            releasedRequestIds: recoverableStops.map(
+                (stop) => stop.deliveryRequestId,
+            ),
+            routeRevision: updatedRun.routeRevision,
+        };
+    });
+}
+
+export type ApplyDeliveryRunRerouteInput = {
+    runId: string;
+    expectedRouteRevision: number;
+    rerouteClaimedAt: Date;
+    encodedPolyline?: string;
+    estimateSource: PreparedDeliveryRunEstimateSource;
+    totalDistanceMeters: number;
+    totalDurationSeconds: number;
+    pickupEstimates: Array<{
+        pickupNodeId: string;
+        itinerarySequence: number;
+        estimatedArrivalAt: Date;
+        incomingTravelSeconds: number;
+        incomingDistanceMeters: number;
+    }>;
+    stopEstimates: Array<{
+        stopIds: number[];
+        itinerarySequence: number;
+        estimatedArrivalAt: Date;
+        estimatedTravelSeconds: number;
+        estimatedDistanceMeters: number;
+    }>;
+};
+
+export async function applyDeliveryRunReroute(
+    input: ApplyDeliveryRunRerouteInput,
+) {
+    ensureRouteRevisionInput(input.expectedRouteRevision);
+    const invalidPickupEstimate = input.pickupEstimates.some(
+        (estimate) =>
+            !Number.isInteger(estimate.itinerarySequence) ||
+            estimate.itinerarySequence <= 0 ||
+            !(estimate.estimatedArrivalAt instanceof Date) ||
+            !Number.isFinite(estimate.estimatedArrivalAt.getTime()) ||
+            !isNonnegativeInteger(estimate.incomingTravelSeconds) ||
+            !isNonnegativeInteger(estimate.incomingDistanceMeters),
+    );
+    const invalidStopEstimate = input.stopEstimates.some(
+        (estimate) =>
+            !Number.isInteger(estimate.itinerarySequence) ||
+            estimate.itinerarySequence <= 0 ||
+            !(estimate.estimatedArrivalAt instanceof Date) ||
+            !Number.isFinite(estimate.estimatedArrivalAt.getTime()) ||
+            !isNonnegativeInteger(estimate.estimatedTravelSeconds) ||
+            !isNonnegativeInteger(estimate.estimatedDistanceMeters),
+    );
+    if (
+        !isPreparedEstimateSource(input.estimateSource) ||
+        !(input.rerouteClaimedAt instanceof Date) ||
+        !Number.isFinite(input.rerouteClaimedAt.getTime()) ||
+        !isNonnegativeInteger(input.totalDistanceMeters) ||
+        !isNonnegativeInteger(input.totalDurationSeconds) ||
+        invalidPickupEstimate ||
+        invalidStopEstimate
+    ) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+            'Delivery reroute estimates are invalid',
+        );
+    }
+    return await withDeliveryDispatchTransaction(async (tx) => {
+        await tx.execute(
+            sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${input.runId} for update`,
+        );
+        const run = await tx.query.deliveryRuns.findFirst({
+            where: eq(deliveryRuns.id, input.runId),
+        });
+        if (!run || run.state !== DeliveryRunStates.ACTIVE) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+                'Active delivery run was not found',
+            );
+        }
+        assertRouteRevision(run.routeRevision, input.expectedRouteRevision);
+        if (
+            run.rerouteRequiredAt === null ||
+            run.rerouteAttemptedAt?.getTime() !==
+                input.rerouteClaimedAt.getTime()
+        ) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+                'Delivery reroute was already applied',
+            );
+        }
+
+        const progress = await getDeliveryRunExecutionProgressFromDb(
+            input.runId,
+            tx,
+        );
+        const allRunStops = await tx.query.deliveryRunStops.findMany({
+            columns: { id: true, sequence: true, state: true },
+            where: eq(deliveryRunStops.runId, input.runId),
+        });
+        const nonterminalStops = allRunStops.filter(
+            (stop) => !deliveryRunTerminalStopStates.includes(stop.state),
+        );
+        const originalSequenceByStopId = new Map(
+            allRunStops.map((stop) => [stop.id, stop.sequence]),
+        );
+        const nonterminalStopIds = new Set(
+            nonterminalStops.map((stop) => stop.id),
+        );
+        const canonicalStopGroup = (stopIds: readonly number[]) =>
+            [...stopIds].sort((first, second) => first - second).join(',');
+        const expectedPickupIds = new Set(
+            progress.flatMap((step) =>
+                step.kind === 'pickup' && step.state !== 'completed'
+                    ? [step.pickupNodeId]
+                    : [],
+            ),
+        );
+        const providedPickupIds = new Set(
+            input.pickupEstimates.map((estimate) => estimate.pickupNodeId),
+        );
+        if (
+            providedPickupIds.size !== input.pickupEstimates.length ||
+            providedPickupIds.size !== expectedPickupIds.size ||
+            [...providedPickupIds].some(
+                (pickupNodeId) => !expectedPickupIds.has(pickupNodeId),
+            )
+        ) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+                'Delivery reroute pickup checkpoints changed',
+            );
+        }
+
+        const expectedStopGroups = new Set(
+            progress.flatMap((step) => {
+                if (step.kind !== 'delivery' || step.state === 'completed') {
+                    return [];
+                }
+                const stopIds = step.stopIds.filter((stopId) =>
+                    nonterminalStopIds.has(stopId),
+                );
+                return stopIds.length > 0 ? [canonicalStopGroup(stopIds)] : [];
+            }),
+        );
+        const providedStopIds = input.stopEstimates.flatMap(
+            (estimate) => estimate.stopIds,
+        );
+        const providedStopGroups = new Set(
+            input.stopEstimates.map((estimate) =>
+                canonicalStopGroup(estimate.stopIds),
+            ),
+        );
+        if (
+            input.stopEstimates.some(
+                (estimate) =>
+                    estimate.stopIds.length === 0 ||
+                    new Set(estimate.stopIds).size !== estimate.stopIds.length,
+            ) ||
+            new Set(providedStopIds).size !== providedStopIds.length ||
+            providedStopGroups.size !== input.stopEstimates.length ||
+            providedStopGroups.size !== expectedStopGroups.size ||
+            [...providedStopGroups].some(
+                (stopGroup) => !expectedStopGroups.has(stopGroup),
+            )
+        ) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+                'Delivery reroute stop checkpoints changed',
+            );
+        }
+
+        const proposedCheckpointSequences = [
+            ...input.pickupEstimates.map(
+                (estimate) => estimate.itinerarySequence,
+            ),
+            ...input.stopEstimates.flatMap((estimate) =>
+                run.routePlanVersion < 2
+                    ? estimate.stopIds.map(
+                          (_stopId, index) =>
+                              estimate.itinerarySequence + index,
+                      )
+                    : [estimate.itinerarySequence],
+            ),
+        ];
+        const completedCheckpointSequences = new Set(
+            progress.flatMap((step) =>
+                step.state === 'completed' ? [step.itinerarySequence] : [],
+            ),
+        );
+        const providedStopIdSet = new Set(providedStopIds);
+        const legacyOccupiedSequences = new Set(
+            run.routePlanVersion < 2
+                ? allRunStops.flatMap((stop) =>
+                      providedStopIdSet.has(stop.id) ? [] : [stop.sequence],
+                  )
+                : [],
+        );
+        if (
+            new Set(proposedCheckpointSequences).size !==
+                proposedCheckpointSequences.length ||
+            proposedCheckpointSequences.some(
+                (sequence) =>
+                    completedCheckpointSequences.has(sequence) ||
+                    legacyOccupiedSequences.has(sequence),
+            )
+        ) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+                'Delivery reroute itinerary sequences conflict',
+            );
+        }
+
+        if (input.pickupEstimates.length > 0) {
+            const [maximum] = await tx
+                .select({
+                    value: sql<number>`coalesce(max(${deliveryRunPickupNodes.itinerarySequence}), 0)`,
+                })
+                .from(deliveryRunPickupNodes)
+                .where(eq(deliveryRunPickupNodes.runId, input.runId));
+            const temporaryBase = Number(maximum?.value ?? 0) + 1;
+            for (const [index, estimate] of input.pickupEstimates.entries()) {
+                const [updated] = await tx
+                    .update(deliveryRunPickupNodes)
+                    .set({ itinerarySequence: temporaryBase + index })
+                    .where(
+                        and(
+                            eq(
+                                deliveryRunPickupNodes.id,
+                                estimate.pickupNodeId,
+                            ),
+                            eq(deliveryRunPickupNodes.runId, input.runId),
+                        ),
+                    )
+                    .returning({ id: deliveryRunPickupNodes.id });
+                if (!updated) {
+                    throw new DeliveryRunExecutionError(
+                        DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+                        'Delivery reroute pickup checkpoint is invalid',
+                    );
+                }
+            }
+        }
+        if (run.routePlanVersion < 2 && providedStopIds.length > 0) {
+            const temporaryBase =
+                Math.max(0, ...allRunStops.map((stop) => stop.sequence)) + 1;
+            for (const [index, stopId] of providedStopIds.entries()) {
+                const [updated] = await tx
+                    .update(deliveryRunStops)
+                    .set({ sequence: temporaryBase + index })
+                    .where(
+                        and(
+                            eq(deliveryRunStops.runId, input.runId),
+                            eq(deliveryRunStops.id, stopId),
+                            notInArray(
+                                deliveryRunStops.state,
+                                deliveryRunTerminalStopStates,
+                            ),
+                        ),
+                    )
+                    .returning({ id: deliveryRunStops.id });
+                if (!updated) {
+                    throw new DeliveryRunExecutionError(
+                        DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+                        'Delivery stops changed while the reroute was calculated',
+                    );
+                }
+            }
+        }
+
+        for (const estimate of input.pickupEstimates) {
+            const rows = await tx
+                .update(deliveryRunPickupNodes)
+                .set({
+                    itinerarySequence: estimate.itinerarySequence,
+                    estimatedArrivalAt: estimate.estimatedArrivalAt,
+                    incomingTravelSeconds: estimate.incomingTravelSeconds,
+                    incomingDistanceMeters: estimate.incomingDistanceMeters,
+                })
+                .where(
+                    and(
+                        eq(deliveryRunPickupNodes.id, estimate.pickupNodeId),
+                        eq(deliveryRunPickupNodes.runId, input.runId),
+                    ),
+                )
+                .returning({ id: deliveryRunPickupNodes.id });
+            if (!rows[0]) {
+                throw new DeliveryRunExecutionError(
+                    DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+                    'Delivery reroute pickup checkpoint is invalid',
+                );
+            }
+        }
+        for (const estimate of input.stopEstimates) {
+            if (estimate.stopIds.length === 0) {
+                throw new DeliveryRunExecutionError(
+                    DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+                    'Delivery reroute stop checkpoint is empty',
+                );
+            }
+            const orderedStopIds = [...estimate.stopIds].sort(
+                (first, second) =>
+                    (originalSequenceByStopId.get(first) ?? first) -
+                    (originalSequenceByStopId.get(second) ?? second),
+            );
+            let updatedCount = 0;
+            for (const [index, stopId] of orderedStopIds.entries()) {
+                const updated = await tx
+                    .update(deliveryRunStops)
+                    .set({
+                        ...(run.routePlanVersion < 2
+                            ? {
+                                  sequence: estimate.itinerarySequence + index,
+                              }
+                            : {
+                                  itinerarySequence: estimate.itinerarySequence,
+                              }),
+                        estimatedArrivalAt: estimate.estimatedArrivalAt,
+                        estimatedTravelSeconds: estimate.estimatedTravelSeconds,
+                        estimatedDistanceMeters:
+                            estimate.estimatedDistanceMeters,
+                    })
+                    .where(
+                        and(
+                            eq(deliveryRunStops.runId, input.runId),
+                            eq(deliveryRunStops.id, stopId),
+                            notInArray(
+                                deliveryRunStops.state,
+                                deliveryRunTerminalStopStates,
+                            ),
+                        ),
+                    )
+                    .returning({ id: deliveryRunStops.id });
+                updatedCount += updated.length;
+            }
+            if (updatedCount !== orderedStopIds.length) {
+                throw new DeliveryRunExecutionError(
+                    DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+                    'Delivery stops changed while the reroute was calculated',
+                );
+            }
+        }
+        const appliedAt = new Date();
+        const [updatedRun] = await tx
+            .update(deliveryRuns)
+            .set({
+                encodedPolyline: input.encodedPolyline ?? null,
+                totalDistanceMeters: input.totalDistanceMeters,
+                totalDurationSeconds: input.totalDurationSeconds,
+                estimateSource:
+                    run.routePlanVersion < 2
+                        ? DeliveryRunEstimateSources.LEGACY
+                        : input.estimateSource,
+                estimatesUpdatedAt: appliedAt,
+                rerouteRequiredAt: null,
+                rerouteAttemptedAt: null,
+                routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
+            })
+            .where(
+                and(
+                    eq(deliveryRuns.id, input.runId),
+                    eq(deliveryRuns.routeRevision, input.expectedRouteRevision),
+                    isNotNull(deliveryRuns.rerouteRequiredAt),
+                    eq(deliveryRuns.rerouteAttemptedAt, input.rerouteClaimedAt),
+                    eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                ),
+            )
+            .returning({ routeRevision: deliveryRuns.routeRevision });
+        if (!updatedRun) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+                'Delivery route changed while the reroute was calculated',
+            );
+        }
+        return {
+            routeRevision: updatedRun.routeRevision,
+            reroutePending: false,
+            estimatesUpdatedAt: appliedAt,
+        };
+    });
+}
+
+export const deliveryRunRerouteLeaseMs = 30_000;
+
+export async function claimDeliveryRunReroute({
+    runId,
+    expectedRouteRevision,
+    claimedAt = new Date(),
+}: {
+    runId: string;
+    expectedRouteRevision: number;
+    claimedAt?: Date;
+}) {
+    ensureRouteRevisionInput(expectedRouteRevision);
+    if (!(claimedAt instanceof Date) || !Number.isFinite(claimedAt.getTime())) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+            'Delivery reroute claim time is invalid',
+        );
+    }
+    const availableBefore = new Date(
+        claimedAt.getTime() - deliveryRunRerouteLeaseMs,
+    );
+    const [claimed] = await storage()
+        .update(deliveryRuns)
+        .set({ rerouteAttemptedAt: claimedAt })
+        .where(
+            and(
+                eq(deliveryRuns.id, runId),
+                eq(deliveryRuns.routeRevision, expectedRouteRevision),
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                isNotNull(deliveryRuns.rerouteRequiredAt),
+                or(
+                    isNull(deliveryRuns.rerouteAttemptedAt),
+                    lte(deliveryRuns.rerouteAttemptedAt, availableBefore),
+                ),
+            ),
+        )
+        .returning({ claimedAt: deliveryRuns.rerouteAttemptedAt });
+    return claimed?.claimedAt ? { rerouteClaimedAt: claimed.claimedAt } : null;
+}
+
 export function getDeliveryRunStop(stopId: number) {
     return storage().query.deliveryRunStops.findFirst({
         where: eq(deliveryRunStops.id, stopId),
@@ -3065,10 +4285,64 @@ export async function getDeliveryRunStopsForRequestIds(requestIds: string[]) {
         )
         .where(inArray(deliveryRunStops.deliveryRequestId, requestIds));
 
-    return rows.map(({ run, stop, runSlot }) => ({
-        run,
-        stop: { ...stop, runSlot },
-    }));
+    const preferredByRequestId = new Map<string, (typeof rows)[number]>();
+    for (const row of rows) {
+        const current = preferredByRequestId.get(row.stop.deliveryRequestId);
+        if (
+            !current ||
+            (current.stop.releasedAt !== null &&
+                row.stop.releasedAt === null) ||
+            ((current.stop.releasedAt === null) ===
+                (row.stop.releasedAt === null) &&
+                row.stop.id > current.stop.id)
+        ) {
+            preferredByRequestId.set(row.stop.deliveryRequestId, row);
+        }
+    }
+
+    return requestIds.flatMap((requestId) => {
+        const row = preferredByRequestId.get(requestId);
+        return row
+            ? [{ run: row.run, stop: { ...row.stop, runSlot: row.runSlot } }]
+            : [];
+    });
+}
+
+export async function getActiveDeliveryRunStopsForRequestIds(
+    requestIds: string[],
+) {
+    if (requestIds.length === 0) {
+        return [];
+    }
+
+    return await storage()
+        .select({
+            run: deliveryRuns,
+            stop: deliveryRunStops,
+            runSlot: deliveryRunSlots,
+        })
+        .from(deliveryRunStops)
+        .innerJoin(deliveryRuns, eq(deliveryRunStops.runId, deliveryRuns.id))
+        .leftJoin(
+            deliveryRunSlots,
+            and(
+                eq(deliveryRunStops.runId, deliveryRunSlots.runId),
+                eq(deliveryRunStops.runSlotId, deliveryRunSlots.id),
+            ),
+        )
+        .where(
+            and(
+                inArray(deliveryRunStops.deliveryRequestId, requestIds),
+                isNull(deliveryRunStops.releasedAt),
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+            ),
+        )
+        .then((rows) =>
+            rows.map((row) => ({
+                run: row.run,
+                stop: { ...row.stop, runSlot: row.runSlot },
+            })),
+        );
 }
 
 export async function getDeliveryAccountContacts(accountIds: string[]) {
@@ -3160,6 +4434,7 @@ export async function updateDeliveryRunLocation({
             currentLocationHeading: heading,
             currentLocationSpeed: speed,
             currentLocationRecordedAt: recordedAt,
+            currentLocationReceivedAt: new Date(),
         })
         .where(
             and(
@@ -3237,11 +4512,13 @@ async function ensureOwnedDeliveryRunStops({
     driverUserId,
     runId,
     stopIds,
+    expectedRouteRevision,
     db,
 }: {
     driverUserId: string;
     runId: string;
     stopIds: number[];
+    expectedRouteRevision?: number;
     db: TransactionClient;
 }) {
     const uniqueStopIds = Array.from(new Set(stopIds));
@@ -3273,6 +4550,15 @@ async function ensureOwnedDeliveryRunStops({
         run.state !== DeliveryRunStates.ACTIVE
     ) {
         throw new Error('Active delivery stop not found');
+    }
+    if (
+        expectedRouteRevision !== undefined &&
+        run.routeRevision !== expectedRouteRevision
+    ) {
+        throw new DeliveryRunExecutionError(
+            DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+            'Delivery route changed. Refresh the active run and retry.',
+        );
     }
 
     const actionableStops = stops.filter((stop) =>
@@ -3323,18 +4609,17 @@ async function ensureOwnedDeliveryRunStops({
                 );
             }
         } else {
-            const currentStop = await db.query.deliveryRunStops.findFirst({
-                columns: { id: true },
-                where: and(
-                    eq(deliveryRunStops.runId, runId),
-                    inArray(deliveryRunStops.state, [
-                        DeliveryRunStopStates.PENDING,
-                        DeliveryRunStopStates.ARRIVED,
-                    ]),
-                ),
-                orderBy: [asc(deliveryRunStops.sequence)],
-            });
-            if (currentStop && !uniqueStopIds.includes(currentStop.id)) {
+            const progress = await getDeliveryRunExecutionProgressFromDb(
+                runId,
+                db,
+            );
+            const current = progress.find((step) => step.state === 'current');
+            if (
+                current?.kind !== 'delivery' ||
+                current.actionableStopIds.some(
+                    (stopId) => !uniqueStopIds.includes(stopId),
+                )
+            ) {
                 throw new DeliveryRunExecutionError(
                     DeliveryRunExecutionErrorCodes.ROUTE_ORDER,
                     'Delivery stops must be completed in route order',
@@ -3361,19 +4646,25 @@ export async function markDeliveryRunStopsArrived({
     driverUserId,
     runId,
     stopIds,
+    expectedRouteRevision,
 }: {
     driverUserId: string;
     runId: string;
     stopIds: number[];
+    expectedRouteRevision?: number;
 }) {
     return await storage().transaction(async (tx) => {
         const stops = await ensureOwnedDeliveryRunStops({
             driverUserId,
             runId,
             stopIds,
+            expectedRouteRevision,
             db: tx,
         });
         const now = new Date();
+        const advancesExecution = stops.some(
+            (stop) => stop.state === DeliveryRunStopStates.PENDING,
+        );
 
         for (const stop of stops) {
             if (!isDeliveryRunStopActionable(stop.state)) {
@@ -3403,6 +4694,21 @@ export async function markDeliveryRunStopsArrived({
             }
         }
 
+        if (advancesExecution) {
+            await tx
+                .update(deliveryRuns)
+                .set({
+                    routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
+                    rerouteAttemptedAt: null,
+                })
+                .where(
+                    and(
+                        eq(deliveryRuns.id, runId),
+                        eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                    ),
+                );
+        }
+
         return stops;
     });
 }
@@ -3411,15 +4717,18 @@ export async function markDeliveryRunStopArrived({
     driverUserId,
     runId,
     stopId,
+    expectedRouteRevision,
 }: {
     driverUserId: string;
     runId: string;
     stopId: number;
+    expectedRouteRevision?: number;
 }) {
     const stops = await markDeliveryRunStopsArrived({
         driverUserId,
         runId,
         stopIds: [stopId],
+        expectedRouteRevision,
     });
     return stops[0];
 }
@@ -3428,16 +4737,19 @@ export async function markDeliveryRunStopDelivered({
     driverUserId,
     runId,
     stopId,
+    expectedRouteRevision,
 }: {
     driverUserId: string;
     runId: string;
     stopId: number;
+    expectedRouteRevision?: number;
 }) {
     const requestIds = await storage().transaction(async (tx) =>
         markDeliveryRunStopsDeliveredInDatabase({
             driverUserId,
             runId,
             stopIds: [stopId],
+            expectedRouteRevision,
             db: tx,
         }),
     );
@@ -3448,20 +4760,26 @@ async function markDeliveryRunStopsDeliveredInDatabase({
     driverUserId,
     runId,
     stopIds,
+    expectedRouteRevision,
     db,
 }: {
     driverUserId: string;
     runId: string;
     stopIds: number[];
+    expectedRouteRevision?: number;
     db: TransactionClient;
 }) {
     const stops = await ensureOwnedDeliveryRunStops({
         driverUserId,
         runId,
         stopIds,
+        expectedRouteRevision,
         db,
     });
     const now = new Date();
+    const advancesExecution = stops.some((stop) =>
+        isDeliveryRunStopActionable(stop.state),
+    );
 
     for (const stop of stops) {
         if (!isDeliveryRunStopActionable(stop.state)) {
@@ -3493,6 +4811,21 @@ async function markDeliveryRunStopsDeliveredInDatabase({
         }
     }
 
+    if (advancesExecution) {
+        await db
+            .update(deliveryRuns)
+            .set({
+                routeRevision: sql`${deliveryRuns.routeRevision} + 1`,
+                rerouteAttemptedAt: null,
+            })
+            .where(
+                and(
+                    eq(deliveryRuns.id, runId),
+                    eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                ),
+            );
+    }
+
     await completeDeliveryRunIfEligible({ runId, completedAt: now, db });
 
     return stops.flatMap((stop) =>
@@ -3508,17 +4841,20 @@ export async function fulfillDeliveryRunStops({
     runId,
     stopIds,
     deliveryNotes,
+    expectedRouteRevision,
 }: {
     driverUserId: string;
     runId: string;
     stopIds: number[];
     deliveryNotes?: string;
+    expectedRouteRevision?: number;
 }) {
     return await withDeliveryDispatchTransaction(async (tx) => {
         const stops = await ensureOwnedDeliveryRunStops({
             driverUserId,
             runId,
             stopIds,
+            expectedRouteRevision,
             db: tx,
         });
         for (const stop of stops) {
@@ -3533,6 +4869,7 @@ export async function fulfillDeliveryRunStops({
             driverUserId,
             runId,
             stopIds,
+            expectedRouteRevision,
             db: tx,
         });
     });
@@ -3543,17 +4880,20 @@ export async function fulfillDeliveryRunStop({
     runId,
     stopId,
     deliveryNotes,
+    expectedRouteRevision,
 }: {
     driverUserId: string;
     runId: string;
     stopId: number;
     deliveryNotes?: string;
+    expectedRouteRevision?: number;
 }) {
     const requestIds = await fulfillDeliveryRunStops({
         driverUserId,
         runId,
         stopIds: [stopId],
         deliveryNotes,
+        expectedRouteRevision,
     });
     return requestIds[0];
 }

--- a/packages/storage/src/repositories/events/index.ts
+++ b/packages/storage/src/repositories/events/index.ts
@@ -48,10 +48,13 @@ export type {
     DeliveryRequestEventsAnyPayload,
     DeliveryRequestEventsPayload,
     DeliveryRequestExceptionRecordedPayload,
+    DeliveryRequestExceptionRecoveredPayload,
     DeliveryRequestFulfilledPayload,
     DeliveryRequestSlotChangedPayload,
     DeliveryRequestStatusPayload,
     DeliveryRequestSurveySentPayload,
+    DeliveryRunAbandonedPayload,
+    DeliveryRunReassignedPayload,
     // Generic
     Event,
     GardenBlockPlacePayload,

--- a/packages/storage/src/repositories/events/knownEventTypes.ts
+++ b/packages/storage/src/repositories/events/knownEventTypes.ts
@@ -78,8 +78,11 @@ export const knownEventTypes = {
         requestCancelled: 'delivery.request.cancelled',
         requestFulfilled: 'delivery.request.fulfilled',
         requestExceptionRecorded: 'delivery.request.exception.recorded',
+        requestExceptionRecovered: 'delivery.request.exception.recovered',
         requestSurveySent: 'delivery.request.survey_sent',
         userCancelled: 'delivery.request.user_cancelled',
+        runReassigned: 'delivery.run.reassigned',
+        runAbandoned: 'delivery.run.abandoned',
     },
     occasions: {
         adventCalendarOpen: 'occasion.advent.calendar.open',

--- a/packages/storage/src/repositories/events/knownEvents.ts
+++ b/packages/storage/src/repositories/events/knownEvents.ts
@@ -12,11 +12,14 @@ import type {
     DeliveryRequestCancelledPayload,
     DeliveryRequestCreatePayload,
     DeliveryRequestExceptionRecordedPayload,
+    DeliveryRequestExceptionRecoveredPayload,
     DeliveryRequestFulfilledPayload,
     DeliveryRequestReadyEmailProcessedPayload,
     DeliveryRequestSlotChangedPayload,
     DeliveryRequestStatusPayload,
     DeliveryRequestSurveySentPayload,
+    DeliveryRunAbandonedPayload,
+    DeliveryRunReassignedPayload,
     GardenBlockPlacePayload,
     GardenBlockRemovePayload,
     GardenCreatePayload,
@@ -512,6 +515,15 @@ export const knownEvents = {
             aggregateId,
             data,
         }),
+        requestExceptionRecoveredV1: (
+            aggregateId: string,
+            data: DeliveryRequestExceptionRecoveredPayload,
+        ) => ({
+            type: knownEventTypes.delivery.requestExceptionRecovered,
+            version: 1,
+            aggregateId,
+            data,
+        }),
         requestSurveySentV1: (
             aggregateId: string,
             data: DeliveryRequestSurveySentPayload,
@@ -525,6 +537,24 @@ export const knownEvents = {
             type: knownEventTypes.delivery.userCancelled,
             version: 1,
             aggregateId,
+        }),
+        runReassignedV1: (
+            aggregateId: string,
+            data: DeliveryRunReassignedPayload,
+        ) => ({
+            type: knownEventTypes.delivery.runReassigned,
+            version: 1,
+            aggregateId,
+            data,
+        }),
+        runAbandonedV1: (
+            aggregateId: string,
+            data: DeliveryRunAbandonedPayload,
+        ) => ({
+            type: knownEventTypes.delivery.runAbandoned,
+            version: 1,
+            aggregateId,
+            data,
         }),
     },
     occasions: {

--- a/packages/storage/src/repositories/events/queries.ts
+++ b/packages/storage/src/repositories/events/queries.ts
@@ -115,9 +115,12 @@ const deliveryInvalidatingEventTypes = new Set<string>([
     knownEventTypes.delivery.requestReady,
     knownEventTypes.delivery.requestFulfilled,
     knownEventTypes.delivery.requestExceptionRecorded,
+    knownEventTypes.delivery.requestExceptionRecovered,
     knownEventTypes.delivery.requestSurveySent,
     knownEventTypes.delivery.requestSlotChanged,
     knownEventTypes.delivery.userCancelled,
+    knownEventTypes.delivery.runReassigned,
+    knownEventTypes.delivery.runAbandoned,
 ]);
 
 function eventTypeFilter(type: string | string[]) {

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -440,6 +440,15 @@ export type DeliveryRequestExceptionRecordedPayload = {
     routeRevision: number;
 };
 
+export type DeliveryRequestExceptionRecoveredPayload = {
+    runId: string;
+    stopId: number;
+    recovery: 'retry' | 'admin-recovery' | 'route-abandonment';
+    recoveredAt: string;
+    recoveredByUserId: string;
+    routeRevision: number;
+};
+
 export type DeliveryRequestSurveySentPayload = {
     sentTo: string[];
 };
@@ -452,6 +461,22 @@ export type DeliveryRequestReadyEmailProcessedPayload = {
     skipped?: boolean;
 };
 
+export type DeliveryRunReassignedPayload = {
+    previousDriverUserId: string;
+    newDriverUserId: string;
+    reassignedAt: string;
+    reassignedByUserId: string;
+    routeRevision: number;
+};
+
+export type DeliveryRunAbandonedPayload = {
+    abandonedAt: string;
+    abandonedByUserId: string;
+    reason?: string;
+    releasedRequestIds: string[];
+    routeRevision: number;
+};
+
 export type DeliveryRequestEventsPayload =
     | DeliveryRequestCreatePayload
     | DeliveryRequestSlotChangedPayload
@@ -460,6 +485,7 @@ export type DeliveryRequestEventsPayload =
     | DeliveryRequestStatusPayload
     | DeliveryRequestFulfilledPayload
     | DeliveryRequestExceptionRecordedPayload
+    | DeliveryRequestExceptionRecoveredPayload
     | DeliveryRequestSurveySentPayload
     | DeliveryRequestReadyEmailProcessedPayload;
 
@@ -471,6 +497,7 @@ export type DeliveryRequestEventsAnyPayload = Partial<
         DeliveryRequestStatusPayload &
         DeliveryRequestFulfilledPayload &
         DeliveryRequestExceptionRecordedPayload &
+        DeliveryRequestExceptionRecoveredPayload &
         DeliveryRequestSurveySentPayload &
         DeliveryRequestReadyEmailProcessedPayload
 >;

--- a/packages/storage/src/repositories/timeSlotsRepo.ts
+++ b/packages/storage/src/repositories/timeSlotsRepo.ts
@@ -11,6 +11,8 @@ import {
     type UpdateTimeSlot,
 } from '../schema';
 import { storage } from '../storage';
+import { withDeliveryDispatchTransaction } from './deliveryDispatchRepo';
+import { assertDeliveryTimeSlotHasNoActiveAssignment } from './deliveryRunAssignmentsRepo';
 
 export async function getTimeSlot(
     slotId: number,
@@ -100,33 +102,44 @@ export async function createTimeSlot(data: InsertTimeSlot): Promise<number> {
 
 // Update a time slot
 export async function updateTimeSlot(update: UpdateTimeSlot): Promise<void> {
-    if (update.startAt !== undefined || update.closesAt !== undefined) {
-        const existingSlot = await storage().query.timeSlots.findFirst({
-            where: eq(timeSlots.id, update.id),
-        });
-
-        if (!existingSlot) {
-            throw new Error('Failed to update time slot - slot not found');
+    await withDeliveryDispatchTransaction(async (tx) => {
+        if (
+            update.locationId !== undefined ||
+            update.type !== undefined ||
+            update.startAt !== undefined ||
+            update.endAt !== undefined
+        ) {
+            await assertDeliveryTimeSlotHasNoActiveAssignment(update.id, tx);
         }
 
-        assertTimeSlotClosesBeforeStart({
-            startAt: update.startAt ?? existingSlot.startAt,
-            closesAt:
-                update.closesAt === undefined
-                    ? existingSlot.closesAt
-                    : update.closesAt,
-        });
-    }
+        if (update.startAt !== undefined || update.closesAt !== undefined) {
+            const existingSlot = await tx.query.timeSlots.findFirst({
+                where: eq(timeSlots.id, update.id),
+            });
 
-    const result = await storage()
-        .update(timeSlots)
-        .set(update)
-        .where(eq(timeSlots.id, update.id))
-        .returning({ id: timeSlots.id });
+            if (!existingSlot) {
+                throw new Error('Failed to update time slot - slot not found');
+            }
 
-    if (!result[0]?.id) {
-        throw new Error('Failed to update time slot - slot not found');
-    }
+            assertTimeSlotClosesBeforeStart({
+                startAt: update.startAt ?? existingSlot.startAt,
+                closesAt:
+                    update.closesAt === undefined
+                        ? existingSlot.closesAt
+                        : update.closesAt,
+            });
+        }
+
+        const result = await tx
+            .update(timeSlots)
+            .set(update)
+            .where(eq(timeSlots.id, update.id))
+            .returning({ id: timeSlots.id });
+
+        if (!result[0]?.id) {
+            throw new Error('Failed to update time slot - slot not found');
+        }
+    });
     await bustDeliveryRequestsCache();
 }
 

--- a/packages/storage/src/schema/deliverySchema.ts
+++ b/packages/storage/src/schema/deliverySchema.ts
@@ -262,6 +262,7 @@ export const deliveryRuns = pgTable(
         routePlanVersion: integer('route_plan_version').notNull().default(1),
         routeRevision: integer('route_revision').notNull().default(0),
         rerouteRequiredAt: timestamp('reroute_required_at'),
+        rerouteAttemptedAt: timestamp('reroute_attempted_at'),
         estimateSource: text('estimate_source')
             .$type<DeliveryRunEstimateSource>()
             .notNull()
@@ -272,6 +273,7 @@ export const deliveryRuns = pgTable(
         currentLocationHeading: doublePrecision('current_location_heading'),
         currentLocationSpeed: doublePrecision('current_location_speed'),
         currentLocationRecordedAt: timestamp('current_location_recorded_at'),
+        currentLocationReceivedAt: timestamp('current_location_received_at'),
         estimatesUpdatedAt: timestamp('estimates_updated_at'),
         startedAt: timestamp('started_at').notNull().defaultNow(),
         completedAt: timestamp('completed_at'),
@@ -650,6 +652,8 @@ export const deliveryRunStops = pgTable(
         sequence: integer('sequence').notNull(),
         itinerarySequence: integer('itinerary_sequence'),
         serviceDurationSeconds: integer('service_duration_seconds'),
+        retryLaneRank: integer('retry_lane_rank'),
+        retryAttempt: integer('retry_attempt').notNull().default(0),
         stopKey: text('stop_key'),
         requestDispatchEventId: integer('request_dispatch_event_id'),
         deliveryAddressId: integer('delivery_address_id'),
@@ -689,9 +693,13 @@ export const deliveryRunStops = pgTable(
             text('exception_reason').$type<DeliveryRunExceptionReason>(),
         exceptionNote: text('exception_note'),
         exceptionOccurredAt: timestamp('exception_occurred_at'),
+        // Driver-recorded exceptions always carry this FK. Request cancellation
+        // may originate from an account/system actor, whose provenance remains
+        // on the audited delivery.request.cancelled event instead of this FK.
         exceptionRecordedByUserId: text(
             'exception_recorded_by_user_id',
         ).references(() => users.id),
+        releasedAt: timestamp('released_at'),
         createdAt: timestamp('created_at').notNull().defaultNow(),
         updatedAt: timestamp('updated_at')
             .notNull()
@@ -747,6 +755,17 @@ export const deliveryRunStops = pgTable(
             )`,
         ),
         check(
+            'delivery_run_stops_retry_shape_check',
+            sql`(
+                ${table.retryLaneRank} is null
+                and ${table.retryAttempt} = 0
+            ) or (
+                ${table.retryLaneRank} is not null
+                and ${table.retryLaneRank} > 0
+                and ${table.retryAttempt} > 0
+            )`,
+        ),
+        check(
             'delivery_run_stops_pickup_item_state_check',
             sql`${table.pickupItemState} is null or ${table.pickupItemState} in ('ready', 'scanned', 'missing-label', 'not-ready')`,
         ),
@@ -796,16 +815,25 @@ export const deliveryRunStops = pgTable(
                 and ${table.exceptionOccurredAt} is null
                 and ${table.exceptionRecordedByUserId} is null
             ) or (
-                ${table.state} in ('deferred', 'failed', 'cancelled')
+                ${table.state} in ('deferred', 'failed')
                 and ${table.deliveredAt} is null
                 and ${table.exceptionReason} is not null
                 and ${table.exceptionOccurredAt} is not null
                 and ${table.exceptionRecordedByUserId} is not null
+            ) or (
+                ${table.state} = 'cancelled'
+                and ${table.deliveredAt} is null
+                and ${table.exceptionReason} = 'cancellation'
+                and ${table.exceptionOccurredAt} is not null
             )`,
         ),
-        uniqueIndex('delivery_run_stops_delivery_request_id_unique').on(
-            table.deliveryRequestId,
+        check(
+            'delivery_run_stops_release_shape_check',
+            sql`${table.releasedAt} is null or ${table.state} in ('delivered', 'failed', 'cancelled')`,
         ),
+        uniqueIndex('delivery_run_stops_delivery_request_active_unique')
+            .on(table.deliveryRequestId)
+            .where(sql`${table.releasedAt} is null`),
         uniqueIndex('delivery_run_stops_run_sequence_unique').on(
             table.runId,
             table.sequence,
@@ -817,6 +845,11 @@ export const deliveryRunStops = pgTable(
         ),
         index('delivery_run_stops_run_slot_id_idx').on(table.runSlotId),
         index('delivery_run_stops_state_idx').on(table.state),
+        index('delivery_run_stops_run_retry_lane_rank_idx').on(
+            table.runId,
+            table.retryLaneRank,
+        ),
+        index('delivery_run_stops_released_at_idx').on(table.releasedAt),
         index('delivery_run_stops_pickup_trace_token_idx').on(
             table.pickupTraceToken,
         ),

--- a/packages/storage/tests/deliveryMigration0073.node.spec.ts
+++ b/packages/storage/tests/deliveryMigration0073.node.spec.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import { PGlite } from '@electric-sql/pglite';
+
+const preMigrationSchema = `
+CREATE TABLE delivery_runs (
+    id text PRIMARY KEY,
+    state text NOT NULL,
+    time_slot_id integer NOT NULL,
+    route_revision integer DEFAULT 0 NOT NULL,
+    reroute_required_at timestamp,
+    completed_at timestamp,
+    current_latitude double precision,
+    current_longitude double precision,
+    current_location_accuracy double precision,
+    current_location_heading double precision,
+    current_location_speed double precision,
+    current_location_recorded_at timestamp
+);
+CREATE TABLE delivery_run_stops (
+    id integer PRIMARY KEY,
+    run_id text NOT NULL REFERENCES delivery_runs(id),
+    delivery_request_id text NOT NULL,
+    state text NOT NULL,
+    stop_key text,
+    formatted_address text NOT NULL,
+    sequence integer NOT NULL,
+    delivered_at timestamp,
+    exception_reason text,
+    exception_note text,
+    exception_occurred_at timestamp,
+    exception_recorded_by_user_id text,
+    created_at timestamp DEFAULT now() NOT NULL,
+    updated_at timestamp DEFAULT now() NOT NULL,
+    CONSTRAINT delivery_run_stops_outcome_shape_check CHECK (true)
+);
+CREATE UNIQUE INDEX delivery_run_stops_delivery_request_id_unique
+    ON delivery_run_stops(delivery_request_id);
+CREATE TABLE events (
+    id integer PRIMARY KEY,
+    aggregate_id text NOT NULL,
+    type text NOT NULL,
+    created_at timestamp NOT NULL
+);
+`;
+
+const seedSql = `
+INSERT INTO delivery_runs (id, state, time_slot_id, route_revision) VALUES
+    ('legacy', 'active', 10, 0),
+    ('partial-cancel', 'active', 20, 5),
+    ('full-cancel', 'active', 30, 1),
+    ('completed-failed', 'completed', 40, 2);
+
+INSERT INTO delivery_run_stops (
+    id, run_id, delivery_request_id, state, stop_key, formatted_address,
+    sequence, exception_reason, exception_note, exception_occurred_at,
+    exception_recorded_by_user_id, created_at, updated_at
+) VALUES
+    (1, 'legacy', 'legacy-early', 'deferred', null, 'Avenija 1, Zagreb', 1,
+        'customer-unavailable', null, '2026-07-15 11:00:00', 'driver-1',
+        '2026-07-15 08:00:00', '2026-07-15 11:00:00'),
+    (2, 'legacy', 'legacy-bulk-1', 'deferred', null, 'Ilica 1, Zagreb', 3,
+        'address-inaccessible', null, '2026-07-15 09:00:00', 'driver-1',
+        '2026-07-15 08:00:00', '2026-07-15 09:00:00'),
+    (3, 'legacy', 'legacy-bulk-2', 'deferred', null, '  ilica 1 ,   zagreb ', 4,
+        'address-inaccessible', null, '2026-07-15 09:01:00', 'driver-1',
+        '2026-07-15 08:00:00', '2026-07-15 09:01:00'),
+    (4, 'partial-cancel', 'partial-cancelled', 'pending', 'partial-1', 'P 1', 1,
+        null, null, null, null, '2026-07-15 08:00:00', '2026-07-15 08:00:00'),
+    (5, 'partial-cancel', 'partial-ready', 'pending', 'partial-2', 'P 2', 2,
+        null, null, null, null, '2026-07-15 08:00:00', '2026-07-15 08:00:00'),
+    (6, 'full-cancel', 'full-cancelled', 'pending', 'full-1', 'F 1', 1,
+        null, null, null, null, '2026-07-15 08:00:00', '2026-07-15 08:00:00'),
+    (7, 'completed-failed', 'completed-failed-request', 'failed', 'failed-1', 'C 1', 1,
+        'operational-other', 'audit note', '2026-07-15 08:30:00', 'driver-2',
+        '2026-07-15 08:00:00', '2026-07-15 08:30:00');
+
+INSERT INTO events (id, aggregate_id, type, created_at) VALUES
+    (1, 'partial-cancelled', 'delivery.request.ready', '2026-07-15 08:00:00'),
+    (2, 'partial-cancelled', 'delivery.request.user_cancelled', '2026-07-15 09:00:00'),
+    (3, 'partial-ready', 'delivery.request.ready', '2026-07-15 08:00:00'),
+    (4, 'full-cancelled', 'delivery.request.ready', '2026-07-15 08:00:00'),
+    (5, 'full-cancelled', 'delivery.request.cancelled', '2026-07-15 09:30:00');
+`;
+
+test('0073 keeps legacy bulk retries together and reconciles active cancellation projections', async () => {
+    const database = new PGlite();
+    await database.exec(preMigrationSchema);
+    await database.exec(seedSql);
+    const migration = await readFile(
+        new URL(
+            '../src/migrations/0073_overrated_sleepwalker.sql',
+            import.meta.url,
+        ),
+        'utf8',
+    );
+    for (const statement of migration.split('--> statement-breakpoint')) {
+        if (statement.trim()) await database.exec(statement);
+    }
+
+    const legacy = await database.query<{
+        id: number;
+        retry_lane_rank: number;
+        retry_attempt: number;
+    }>(`
+        SELECT id, retry_lane_rank, retry_attempt
+        FROM delivery_run_stops
+        WHERE run_id = 'legacy'
+        ORDER BY id
+    `);
+    assert.deepEqual(legacy.rows, [
+        { id: 1, retry_lane_rank: 1, retry_attempt: 1 },
+        { id: 2, retry_lane_rank: 2, retry_attempt: 1 },
+        { id: 3, retry_lane_rank: 2, retry_attempt: 1 },
+    ]);
+
+    const partialRun = await database.query<{
+        state: string;
+        route_revision: number;
+        reroute_required_at: Date | null;
+    }>(`
+        SELECT state, route_revision, reroute_required_at
+        FROM delivery_runs WHERE id = 'partial-cancel'
+    `);
+    assert.equal(partialRun.rows[0]?.state, 'active');
+    assert.equal(partialRun.rows[0]?.route_revision, 6);
+    assert.ok(partialRun.rows[0]?.reroute_required_at);
+    const partialStops = await database.query<{
+        delivery_request_id: string;
+        state: string;
+        released_at: Date | null;
+    }>(`
+        SELECT delivery_request_id, state, released_at
+        FROM delivery_run_stops
+        WHERE run_id = 'partial-cancel'
+        ORDER BY id
+    `);
+    assert.equal(partialStops.rows[0]?.state, 'cancelled');
+    assert.ok(partialStops.rows[0]?.released_at);
+    assert.equal(partialStops.rows[1]?.state, 'pending');
+    assert.equal(partialStops.rows[1]?.released_at, null);
+
+    const fullRun = await database.query<{
+        state: string;
+        route_revision: number;
+        reroute_required_at: Date | null;
+    }>(`
+        SELECT state, route_revision, reroute_required_at
+        FROM delivery_runs WHERE id = 'full-cancel'
+    `);
+    assert.equal(fullRun.rows[0]?.state, 'completed');
+    assert.equal(fullRun.rows[0]?.route_revision, 2);
+    assert.equal(fullRun.rows[0]?.reroute_required_at, null);
+
+    const failed = await database.query<{
+        state: string;
+        exception_reason: string;
+        exception_note: string;
+        released_at: Date | null;
+    }>(`
+        SELECT state, exception_reason, exception_note, released_at
+        FROM delivery_run_stops WHERE id = 7
+    `);
+    assert.deepEqual(
+        {
+            state: failed.rows[0]?.state,
+            reason: failed.rows[0]?.exception_reason,
+            note: failed.rows[0]?.exception_note,
+        },
+        {
+            state: 'failed',
+            reason: 'operational-other',
+            note: 'audit note',
+        },
+    );
+    assert.ok(failed.rows[0]?.released_at);
+    await database.close();
+});

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -2,15 +2,22 @@ import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import test from 'node:test';
 import {
+    abandonDeliveryRun,
     accountCanTrackDeliveryRun,
     applyDeliveryRunPickupMutations,
+    applyDeliveryRunReroute,
     type CreatePreparedDeliveryRunInput,
     cancelDeliveryRequest,
     changeDeliveryRequestSlot,
+    claimDeliveryRunReroute,
     consumeDeliveryRunPreparation,
     createDeliveryAddress,
     createDeliveryRun,
     createEvent,
+    DeliveryAddressMutationError,
+    DeliveryRunAssignmentError,
+    DeliveryRunAssignmentErrorCodes,
+    DeliveryRunEstimateSources,
     DeliveryRunExceptionOutcomes,
     DeliveryRunExceptionReasons,
     DeliveryRunExecutionError,
@@ -26,11 +33,13 @@ import {
     type DeliveryRunRequestSnapshotInput,
     DeliveryRunStates,
     DeliveryRunStopStates,
+    deleteDeliveryAddress,
     deliveryRequests,
     deliveryRunExceptionOperations,
     deliveryRunPickupNodes,
     deliveryRunPickupOperations,
     deliveryRunPreparations,
+    deliveryRunRerouteLeaseMs,
     deliveryRunStops,
     deliveryRunStopsAllowCompletion,
     deliveryRuns,
@@ -39,6 +48,7 @@ import {
     fulfillDeliveryRunStop,
     fulfillDeliveryRunStops,
     gardens,
+    getActiveDeliveryRunStopsForRequestIds,
     getDeliveryDispatchRevision,
     getDeliveryRequest,
     getDeliveryRequestDispatchSnapshots,
@@ -55,10 +65,15 @@ import {
     type RecordDeliveryRunStopExceptionsInput,
     raisedBedFields,
     raisedBeds,
+    readyDeliveryRequest,
+    reassignDeliveryRun,
     recordDeliveryRunStopExceptions,
+    recoverDeliveryRunStop,
+    retryDeliveryRunStop,
     saveDeliveryRunPreparation,
     storage,
     timeSlots,
+    uncancelDeliveryRequest,
     updateDeliveryAddress,
     updateDeliveryRunLocation,
     updatePickupLocation,
@@ -70,7 +85,20 @@ import { createTestAccount } from './helpers/testHelpers';
 import { createTestDb } from './testDb';
 
 type DeliveryRunFixture = Awaited<ReturnType<typeof createDeliveryRunFixture>>;
+type DeliveryRunExecutionStep = Awaited<
+    ReturnType<typeof getDeliveryRunExecutionProgress>
+>[number];
+type DeliveryRunExecutionDeliveryStep = Extract<
+    DeliveryRunExecutionStep,
+    { kind: 'delivery' }
+>;
 let nextSupplementalOperationEntityId = 10_000;
+
+function isRetryDeliveryStep(
+    step: DeliveryRunExecutionStep,
+): step is DeliveryRunExecutionDeliveryStep {
+    return step.kind === 'delivery' && step.retryLaneRank !== undefined;
+}
 
 async function createDeliveryRunFixture({
     accountIndexes = [0],
@@ -559,8 +587,15 @@ async function createPreparedRunFixture({
     };
 }
 
-async function startPreparedBulkRunWithConfirmedPickup() {
-    const prepared = await createPreparedRunFixture({ bulk: true });
+async function startPreparedBulkRunWithConfirmedPickup({
+    driverCount = 1,
+}: {
+    driverCount?: number;
+} = {}) {
+    const prepared = await createPreparedRunFixture({
+        bulk: true,
+        driverCount,
+    });
     const driverUserId = prepared.fixture.driverUserIds[0];
     assert.ok(driverUserId);
     const saved = await saveDeliveryRunPreparation(prepared);
@@ -640,6 +675,61 @@ async function addReadyDeliveryRequest({
         knownEvents.delivery.requestReadyV1(requestId, { status: 'ready' }),
     );
     return requestId;
+}
+
+async function singleRequestPreparation({
+    prepared,
+    requestId,
+    driverUserId,
+}: {
+    prepared: Awaited<ReturnType<typeof createPreparedRunFixture>>;
+    requestId: string;
+    driverUserId: string;
+}) {
+    const [dispatchSnapshot] = await getDeliveryRequestDispatchSnapshots([
+        requestId,
+    ]);
+    const requestSnapshot = prepared.requestSnapshots.find(
+        (snapshot) => snapshot.deliveryRequestId === requestId,
+    );
+    const stop = prepared.createRunInput.stops.find(
+        (candidate) => candidate.deliveryRequestId === requestId,
+    );
+    const manifestItem = prepared.createRunInput.manifestItems.find(
+        (candidate) => candidate.deliveryRequestId === requestId,
+    );
+    assert.ok(dispatchSnapshot);
+    assert.ok(requestSnapshot);
+    assert.ok(stop);
+    assert.ok(manifestItem);
+    return {
+        dispatchRevision: await getDeliveryDispatchRevision(),
+        selectionRequestIds: [requestId],
+        requestSnapshots: [
+            {
+                ...requestSnapshot,
+                state: dispatchSnapshot.state,
+                requestDispatchEventId: dispatchSnapshot.requestDispatchEventId,
+            },
+        ],
+        createRunInput: {
+            ...prepared.createRunInput,
+            driverUserId,
+            runSlots: prepared.createRunInput.runSlots.map((slot) => ({
+                ...slot,
+                manifestId: `manifest-${randomUUID()}`,
+            })),
+            stops: [
+                {
+                    ...stop,
+                    sequence: 1,
+                    requestDispatchEventId:
+                        dispatchSnapshot.requestDispatchEventId,
+                },
+            ],
+            manifestItems: [manifestItem],
+        },
+    };
 }
 
 async function assertPersistenceError(promise: Promise<unknown>, code: string) {
@@ -1100,7 +1190,7 @@ test('cancelled bulk member rolls back fulfillment of the current route group', 
     );
 });
 
-test('[legacy] active run keeps snapshots while the source address and slot mutate', async () => {
+test('[legacy] active run rejects source address and slot mutations while keeping snapshots', async () => {
     const fixture = await createDeliveryRunFixture();
     const [accountId] = fixture.accountIds;
     const [driverUserId] = fixture.driverUserIds;
@@ -1155,21 +1245,28 @@ test('[legacy] active run keeps snapshots while the source address and slot muta
     });
     assert.equal(run.stops[0]?.formattedAddress, snapshotAddress);
 
-    await updateDeliveryAddress(
-        { id: addressId, street1: 'Nova 2' },
-        accountId,
-    );
-    await changeDeliveryRequestSlot(requestId, newSlot.id);
+    for (const mutation of [
+        updateDeliveryAddress({ id: addressId, street1: 'Nova 2' }, accountId),
+        changeDeliveryRequestSlot(requestId, newSlot.id),
+    ]) {
+        await assert.rejects(
+            mutation,
+            (error) =>
+                error instanceof DeliveryRunAssignmentError &&
+                error.code ===
+                    DeliveryRunAssignmentErrorCodes.ACTIVE_ASSIGNMENT_EXISTS,
+        );
+    }
 
     const changedRequest = await getDeliveryRequest(requestId);
     const unchangedRun = await getDeliveryRun(run.id);
-    assert.equal(changedRequest?.address?.street1, 'Nova 2');
-    assert.equal(changedRequest?.slot?.id, newSlot.id);
+    assert.equal(changedRequest?.address?.street1, 'Stara 1');
+    assert.equal(changedRequest?.slot?.id, fixture.timeSlotId);
     assert.equal(unchangedRun?.timeSlotId, fixture.timeSlotId);
     assert.equal(unchangedRun?.stops[0]?.formattedAddress, snapshotAddress);
 });
 
-test('[legacy] bulk fulfillment accepts a non-contiguous set containing the current stop', async () => {
+test('[legacy] bulk fulfillment completes the current physical group atomically', async () => {
     const fixture = await createDeliveryRunFixture({
         accountIndexes: [0, 0, 0],
     });
@@ -1189,24 +1286,24 @@ test('[legacy] bulk fulfillment accepts a non-contiguous set containing the curr
     await fulfillDeliveryRunStops({
         driverUserId,
         runId: run.id,
-        stopIds: [firstStop.id, thirdStop.id],
+        stopIds: [firstStop.id, secondStop.id],
     });
 
     const skippedRun = await getDeliveryRun(run.id);
     assert.equal(skippedRun?.state, 'active');
     assert.deepEqual(
         skippedRun?.stops.map((stop) => stop.state),
-        ['delivered', 'pending', 'delivered'],
+        ['delivered', 'delivered', 'pending'],
     );
     assert.notEqual(
-        (await getDeliveryRequest(secondStop.deliveryRequestId))?.state,
+        (await getDeliveryRequest(thirdStop.deliveryRequestId))?.state,
         'fulfilled',
     );
 
     await fulfillDeliveryRunStop({
         driverUserId,
         runId: run.id,
-        stopId: secondStop.id,
+        stopId: thirdStop.id,
     });
     assert.equal((await getDeliveryRun(run.id))?.state, 'completed');
 });
@@ -1311,18 +1408,30 @@ test('prepared run persists multiple pickup locations, slots, manifests, and sta
     assert.ok(firstStop);
     assert.ok(firstNode.pickupLocationId);
     assert.ok(firstRunSlot.timeSlotId);
-    await updateDeliveryAddress(
-        { id: firstAddressId, street1: 'Promijenjena 99' },
-        prepared.fixture.accountIds[0] ?? '',
+    await assert.rejects(
+        updateDeliveryAddress(
+            { id: firstAddressId, street1: 'Promijenjena 99' },
+            prepared.fixture.accountIds[0] ?? '',
+        ),
+        (error) =>
+            error instanceof DeliveryRunAssignmentError &&
+            error.code ===
+                DeliveryRunAssignmentErrorCodes.ACTIVE_ASSIGNMENT_EXISTS,
     );
     await updatePickupLocation({
         id: firstNode.pickupLocationId,
         name: 'Promijenjeno skladište',
     });
-    await updateTimeSlot({
-        id: firstRunSlot.timeSlotId,
-        endAt: new Date('2026-07-13T10:30:00.000Z'),
-    });
+    await assert.rejects(
+        updateTimeSlot({
+            id: firstRunSlot.timeSlotId,
+            endAt: new Date('2026-07-13T10:30:00.000Z'),
+        }),
+        (error) =>
+            error instanceof DeliveryRunAssignmentError &&
+            error.code ===
+                DeliveryRunAssignmentErrorCodes.ACTIVE_ASSIGNMENT_EXISTS,
+    );
 
     const unchanged = await getDeliveryRun(run.id);
     assert.equal(unchanged?.pickupNodes[0]?.name, firstNode.name);
@@ -2768,10 +2877,27 @@ test('delivery exceptions persist item outcomes, replay safely, and keep custome
             kind: 'delivery',
             itinerarySequence: firstStop.itinerarySequence,
             stopKey: firstStop.stopKey,
-            stopIds: [firstStop.id, secondStop.id],
+            stopIds: [secondStop.id],
             actionableStopIds: [secondStop.id],
             pickupConfirmed: true,
             state: 'current',
+        },
+    );
+    assert.deepEqual(
+        (await getDeliveryRunExecutionProgress(run.id)).find(
+            (step) =>
+                step.kind === 'delivery' && step.retryLaneRank !== undefined,
+        ),
+        {
+            kind: 'delivery',
+            itinerarySequence: firstStop.itinerarySequence,
+            stopKey: firstStop.stopKey,
+            stopIds: [firstStop.id],
+            actionableStopIds: [],
+            pickupConfirmed: true,
+            retryLaneRank: 1,
+            retryAttempt: 1,
+            state: 'upcoming',
         },
     );
 
@@ -2870,9 +2996,14 @@ test('delivery exceptions persist item outcomes, replay safely, and keep custome
                 },
             ],
         }),
-        DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
+        DeliveryRunExecutionErrorCodes.ROUTE_ORDER,
     );
 
+    await fulfillDeliveryRunStops({
+        driverUserId,
+        runId: run.id,
+        stopIds: [secondStop.id],
+    });
     const failed = await recordDeliveryRunStopExceptions({
         driverUserId,
         runId: run.id,
@@ -2886,8 +3017,11 @@ test('delivery exceptions persist item outcomes, replay safely, and keep custome
             },
         ],
     });
-    assert.equal(failed.result.runCompleted, false);
-    assert.equal(failed.result.routeRevision, 2);
+    assert.equal(failed.result.runCompleted, true);
+    assert.equal(
+        failed.result.routeRevision,
+        deferred.result.routeRevision + 2,
+    );
     assert.equal(
         (await getDeliveryRequest(firstStop.deliveryRequestId))?.state,
         DeliveryRunStopStates.FAILED,
@@ -2906,13 +3040,8 @@ test('delivery exceptions persist item outcomes, replay safely, and keep custome
                 },
             ],
         }),
-        DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
+        DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
     );
-    await fulfillDeliveryRunStops({
-        driverUserId,
-        runId: run.id,
-        stopIds: [firstStop.id, secondStop.id],
-    });
     const completed = await getDeliveryRun(run.id);
     assert.equal(completed?.state, DeliveryRunStates.COMPLETED);
     assert.equal(completed?.rerouteRequiredAt, null);
@@ -2989,11 +3118,11 @@ test('cancelled and fulfilled request projections are absorbing for late excepti
                 },
             ],
         }),
-        DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
+        DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
     );
     assert.equal(
         (await getDeliveryRun(run.id))?.stops[0]?.state,
-        DeliveryRunStopStates.PENDING,
+        DeliveryRunStopStates.CANCELLED,
     );
     assert.equal(
         (
@@ -3022,6 +3151,17 @@ test('cancelled and fulfilled request projections are absorbing for late excepti
     const cancelled = await getDeliveryRequest(requestId);
     assert.equal(cancelled?.state, 'cancelled');
     assert.equal(cancelled?.deliveryException, undefined);
+    await createEvent(
+        knownEvents.delivery.requestExceptionRecoveredV1(requestId, {
+            runId: run.id,
+            stopId: stop.id,
+            recovery: 'admin-recovery',
+            recoveredAt: new Date('2026-07-13T09:01:30.000Z').toISOString(),
+            recoveredByUserId: driverUserId,
+            routeRevision: 2,
+        }),
+    );
+    assert.equal((await getDeliveryRequest(requestId))?.state, 'cancelled');
 
     const fulfilledFixture = await createDeliveryRunFixture();
     const fulfilledDriverUserId = fulfilledFixture.driverUserIds[0];
@@ -3056,6 +3196,20 @@ test('cancelled and fulfilled request projections are absorbing for late excepti
     const fulfilled = await getDeliveryRequest(fulfilledRequestId);
     assert.equal(fulfilled?.state, 'fulfilled');
     assert.equal(fulfilled?.deliveryException, undefined);
+    await createEvent(
+        knownEvents.delivery.requestExceptionRecoveredV1(fulfilledRequestId, {
+            runId: fulfilledRun.id,
+            stopId: fulfilledStop.id,
+            recovery: 'admin-recovery',
+            recoveredAt: new Date('2026-07-13T09:02:30.000Z').toISOString(),
+            recoveredByUserId: fulfilledDriverUserId,
+            routeRevision: 2,
+        }),
+    );
+    assert.equal(
+        (await getDeliveryRequest(fulfilledRequestId))?.state,
+        'fulfilled',
+    );
 });
 
 test('delivery exception reasons and completion semantics are explicit', () => {
@@ -3149,12 +3303,6 @@ test('all delivery exception reasons follow legal pending, arrived, and deferred
         outcome: DeliveryRunExceptionOutcomes.DEFERRED,
         reason: DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE,
     });
-    await command({
-        index: 0,
-        operation: 'deferred-to-failed',
-        outcome: DeliveryRunExceptionOutcomes.FAILED,
-        reason: DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE,
-    });
     const secondStop = stops[1];
     assert.ok(secondStop);
     await markDeliveryRunStopArrived({
@@ -3168,13 +3316,6 @@ test('all delivery exception reasons follow legal pending, arrived, and deferred
         outcome: DeliveryRunExceptionOutcomes.DEFERRED,
         reason: DeliveryRunExceptionReasons.ADDRESS_INACCESSIBLE,
     });
-    await command({
-        index: 1,
-        operation: 'deferred-to-cancelled',
-        outcome: DeliveryRunExceptionOutcomes.CANCELLED,
-        reason: DeliveryRunExceptionReasons.CANCELLATION,
-    });
-
     const terminalCases = [
         {
             index: 2,
@@ -3208,16 +3349,27 @@ test('all delivery exception reasons follow legal pending, arrived, and deferred
             operation: `pending-terminal-${terminalCase.index}`,
         });
     }
+    await command({
+        index: 0,
+        operation: 'deferred-to-failed',
+        outcome: DeliveryRunExceptionOutcomes.FAILED,
+        reason: DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE,
+    });
+    await command({
+        index: 1,
+        operation: 'deferred-to-cancelled',
+        outcome: DeliveryRunExceptionOutcomes.CANCELLED,
+        reason: DeliveryRunExceptionReasons.CANCELLATION,
+    });
 
     const completed = await getDeliveryRun(run.id);
     assert.equal(completed?.state, DeliveryRunStates.COMPLETED);
     assert.equal(completed?.rerouteRequiredAt, null);
     assert.ok(
-        completed?.stops.every((stop) =>
-            [
-                DeliveryRunStopStates.FAILED,
-                DeliveryRunStopStates.CANCELLED,
-            ].includes(stop.state),
+        completed?.stops.every(
+            (stop) =>
+                stop.state === DeliveryRunStopStates.FAILED ||
+                stop.state === DeliveryRunStopStates.CANCELLED,
         ),
     );
     const auditEvents = await storage()
@@ -3444,10 +3596,20 @@ test('delivery exception commands reject invalid shapes and future checkpoints',
     const fixture = await createDeliveryRunFixture({ accountIndexes: [0, 0] });
     const driverUserId = fixture.driverUserIds[0];
     assert.ok(driverUserId);
+    const [currentPlan, futurePlan] = createRunStops(fixture.requestIds);
+    assert.ok(currentPlan);
+    assert.ok(futurePlan);
     const run = await createRun({
         fixture,
         driverUserId,
         requestIds: fixture.requestIds,
+        stops: [
+            currentPlan,
+            {
+                ...futurePlan,
+                formattedAddress: 'Druga buduća 2, Zagreb, HR',
+            },
+        ],
     });
     const [currentStop, futureStop] = run.stops;
     assert.ok(currentStop);
@@ -3586,4 +3748,906 @@ test('database constraints reject mismatched cancellation outcomes and reasons',
                 error.cause.message.includes('cancellation_pair_check'),
         );
     }
+});
+
+test('completed failed recovery can be reassigned once without reopening newer fulfillment', async () => {
+    const { prepared, run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup({ driverCount: 2 });
+    const [firstStop, secondStop] = run.stops;
+    const secondDriverUserId = prepared.fixture.driverUserIds[1];
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+    assert.ok(secondDriverUserId);
+
+    const failed = await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        clientOperationId: 'complete-failed-run-for-recovery',
+        occurredAt: new Date('2026-07-13T12:00:00.000Z'),
+        exceptions: [firstStop, secondStop].map((stop) => ({
+            stopId: stop.id,
+            outcome: DeliveryRunExceptionOutcomes.FAILED,
+            reason: DeliveryRunExceptionReasons.OPERATIONAL_OTHER,
+        })),
+    });
+    assert.equal(failed.result.runCompleted, true);
+    assert.ok(
+        (await getDeliveryRun(run.id))?.stops.every(
+            (stop) => stop.releasedAt instanceof Date,
+        ),
+    );
+
+    const recovered = await recoverDeliveryRunStop({
+        adminUserId: driverUserId,
+        runId: run.id,
+        stopId: firstStop.id,
+        expectedRouteRevision: failed.result.routeRevision,
+    });
+    assert.equal(recovered.resumedInRun, false);
+    assert.equal(
+        (await getDeliveryRequest(firstStop.deliveryRequestId))?.state,
+        'ready',
+    );
+
+    const nextPreparation = await singleRequestPreparation({
+        prepared,
+        requestId: firstStop.deliveryRequestId,
+        driverUserId: secondDriverUserId,
+    });
+    const saved = await saveDeliveryRunPreparation(nextPreparation);
+    const nextRun = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId: secondDriverUserId,
+        deliveryRequestIds: [firstStop.deliveryRequestId],
+    });
+    assert.notEqual(nextRun.id, run.id);
+    assert.equal(
+        (
+            await getActiveDeliveryRunStopsForRequestIds([
+                firstStop.deliveryRequestId,
+            ])
+        )[0]?.run.id,
+        nextRun.id,
+    );
+    await assertPersistenceError(
+        saveDeliveryRunPreparation({
+            ...nextPreparation,
+            createRunInput: {
+                ...nextPreparation.createRunInput,
+                driverUserId,
+            },
+        }),
+        DeliveryRunPersistenceErrorCodes.ALREADY_ASSIGNED,
+    );
+
+    const [pickup] = nextRun.pickupNodes;
+    const [manifest] = nextRun.runSlots;
+    const [nextStop] = nextRun.stops;
+    const [manifestItem] = nextPreparation.createRunInput.manifestItems;
+    assert.ok(pickup);
+    assert.ok(manifest);
+    assert.ok(nextStop);
+    assert.ok(manifestItem);
+    const traceToken = manifestItem.traceToken;
+    assert.ok(traceToken);
+    await applyDeliveryRunPickupMutations({
+        driverUserId: secondDriverUserId,
+        runId: nextRun.id,
+        pickupNodeId: pickup.id,
+        mutations: [
+            {
+                clientOperationId: 'recovered-run-scan',
+                occurredAt: new Date('2026-07-13T12:01:00.000Z'),
+                kind: DeliveryRunPickupOperationKinds.SCAN,
+                traceToken,
+            },
+            {
+                clientOperationId: 'recovered-run-confirm',
+                occurredAt: new Date('2026-07-13T12:02:00.000Z'),
+                kind: DeliveryRunPickupOperationKinds.CONFIRM_MANIFEST,
+                manifestId: manifest.manifestId,
+            },
+        ],
+    });
+    await fulfillDeliveryRunStop({
+        driverUserId: secondDriverUserId,
+        runId: nextRun.id,
+        stopId: nextStop.id,
+    });
+    await assertExecutionError(
+        recoverDeliveryRunStop({
+            adminUserId: driverUserId,
+            runId: run.id,
+            stopId: firstStop.id,
+            expectedRouteRevision: recovered.routeRevision,
+        }),
+        DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
+    );
+    assert.equal(
+        (await getDeliveryRequest(firstStop.deliveryRequestId))?.state,
+        'fulfilled',
+    );
+});
+
+test('reroute apply is exact, single-use, and keeps partial bulk retries in one lane', async () => {
+    const { run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup();
+    const [firstStop, secondStop] = run.stops;
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+    const deferred = await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        clientOperationId: 'partial-bulk-before-reroute',
+        occurredAt: new Date('2026-07-13T08:10:00.000Z'),
+        exceptions: [
+            {
+                stopId: firstStop.id,
+                outcome: DeliveryRunExceptionOutcomes.DEFERRED,
+                reason: DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE,
+            },
+        ],
+    });
+    const estimate = (stopIds: number[], itinerarySequence: number) => ({
+        stopIds,
+        itinerarySequence,
+        estimatedArrivalAt: new Date(
+            Date.parse('2026-07-13T08:20:00.000Z') + itinerarySequence * 60_000,
+        ),
+        estimatedTravelSeconds: 60,
+        estimatedDistanceMeters: 500,
+    });
+    const baseReroute = {
+        runId: run.id,
+        expectedRouteRevision: deferred.result.routeRevision,
+        rerouteClaimedAt: new Date(),
+        estimateSource: 'local' as const,
+        totalDistanceMeters: 1_000,
+        totalDurationSeconds: 420,
+        pickupEstimates: [],
+    };
+    const claim = await claimDeliveryRunReroute({
+        runId: run.id,
+        expectedRouteRevision: deferred.result.routeRevision,
+        claimedAt: baseReroute.rerouteClaimedAt,
+    });
+    assert.equal(
+        claim?.rerouteClaimedAt.getTime(),
+        baseReroute.rerouteClaimedAt.getTime(),
+    );
+    assert.equal(
+        await claimDeliveryRunReroute({
+            runId: run.id,
+            expectedRouteRevision: deferred.result.routeRevision,
+        }),
+        null,
+    );
+    await assertExecutionError(
+        applyDeliveryRunReroute({
+            ...baseReroute,
+            stopEstimates: [estimate([secondStop.id], 2)],
+        }),
+        DeliveryRunExecutionErrorCodes.RUN_MUTATION_INVALID,
+    );
+    assert.equal(
+        (await getDeliveryRun(run.id))?.routeRevision,
+        deferred.result.routeRevision,
+    );
+
+    const exactReroute = {
+        ...baseReroute,
+        stopEstimates: [
+            estimate([secondStop.id], 2),
+            estimate([firstStop.id], 3),
+        ],
+    };
+    const attempts = await Promise.allSettled([
+        applyDeliveryRunReroute(exactReroute),
+        applyDeliveryRunReroute(exactReroute),
+    ]);
+    assert.equal(
+        attempts.filter((attempt) => attempt.status === 'fulfilled').length,
+        1,
+    );
+    const rejected = attempts.find(
+        (attempt): attempt is PromiseRejectedResult =>
+            attempt.status === 'rejected',
+    );
+    assert.ok(rejected?.reason instanceof DeliveryRunExecutionError);
+    assert.equal(
+        rejected.reason.code,
+        DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+    );
+    const appliedRun = await getDeliveryRun(run.id);
+    assert.equal(appliedRun?.routeRevision, deferred.result.routeRevision + 1);
+    assert.equal(appliedRun?.rerouteRequiredAt, null);
+
+    const replay = await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        clientOperationId: 'partial-bulk-before-reroute',
+        occurredAt: new Date('2026-07-13T08:10:00.000Z'),
+        exceptions: [
+            {
+                stopId: firstStop.id,
+                outcome: DeliveryRunExceptionOutcomes.DEFERRED,
+                reason: DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE,
+            },
+        ],
+    });
+    assert.equal(replay.replayed, true);
+    assert.equal(replay.result.routeRevision, deferred.result.routeRevision);
+    assert.equal(
+        (await getDeliveryRun(run.id))?.routeRevision,
+        deferred.result.routeRevision + 1,
+    );
+
+    await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        clientOperationId: 'defer-bulk-sibling-after-reroute',
+        occurredAt: new Date('2026-07-13T08:30:00.000Z'),
+        exceptions: [
+            {
+                stopId: secondStop.id,
+                outcome: DeliveryRunExceptionOutcomes.DEFERRED,
+                reason: DeliveryRunExceptionReasons.ADDRESS_INACCESSIBLE,
+            },
+        ],
+    });
+    const retrySteps = (await getDeliveryRunExecutionProgress(run.id)).filter(
+        isRetryDeliveryStep,
+    );
+    assert.equal(retrySteps.length, 1);
+    assert.deepEqual(
+        retrySteps[0]?.stopIds.sort((a, b) => a - b),
+        [firstStop.id, secondStop.id],
+    );
+});
+
+test('arrival and a newer lease invalidate stale reroute calculations', async () => {
+    const arrivalFixture = await startPreparedBulkRunWithConfirmedPickup();
+    const [deferredStop, currentStop] = arrivalFixture.run.stops;
+    assert.ok(deferredStop);
+    assert.ok(currentStop);
+    const deferred = await recordDeliveryRunStopExceptions({
+        driverUserId: arrivalFixture.driverUserId,
+        runId: arrivalFixture.run.id,
+        clientOperationId: 'defer-before-arrival-reroute-race',
+        occurredAt: new Date('2026-07-13T08:40:00.000Z'),
+        exceptions: [
+            {
+                stopId: deferredStop.id,
+                outcome: DeliveryRunExceptionOutcomes.DEFERRED,
+                reason: DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE,
+            },
+        ],
+    });
+    const claimedAt = new Date();
+    const claim = await claimDeliveryRunReroute({
+        runId: arrivalFixture.run.id,
+        expectedRouteRevision: deferred.result.routeRevision,
+        claimedAt,
+    });
+    assert.ok(claim);
+    const originalSequences = arrivalFixture.run.stops.map(
+        (stop) => stop.itinerarySequence,
+    );
+    await markDeliveryRunStopArrived({
+        driverUserId: arrivalFixture.driverUserId,
+        runId: arrivalFixture.run.id,
+        stopId: currentStop.id,
+        expectedRouteRevision: deferred.result.routeRevision,
+    });
+    const arrived = await getDeliveryRun(arrivalFixture.run.id);
+    assert.equal(arrived?.routeRevision, deferred.result.routeRevision + 1);
+    assert.equal(arrived?.rerouteAttemptedAt, null);
+    assert.equal(arrived?.stops[1]?.state, DeliveryRunStopStates.ARRIVED);
+    await assertExecutionError(
+        applyDeliveryRunReroute({
+            runId: arrivalFixture.run.id,
+            expectedRouteRevision: deferred.result.routeRevision,
+            rerouteClaimedAt: claimedAt,
+            estimateSource: 'local',
+            totalDistanceMeters: 1_000,
+            totalDurationSeconds: 600,
+            pickupEstimates: [],
+            stopEstimates: [
+                {
+                    stopIds: [currentStop.id],
+                    itinerarySequence: 2,
+                    estimatedArrivalAt: new Date('2026-07-13T08:50:00.000Z'),
+                    estimatedTravelSeconds: 60,
+                    estimatedDistanceMeters: 500,
+                },
+                {
+                    stopIds: [deferredStop.id],
+                    itinerarySequence: 3,
+                    estimatedArrivalAt: new Date('2026-07-13T09:00:00.000Z'),
+                    estimatedTravelSeconds: 60,
+                    estimatedDistanceMeters: 500,
+                },
+            ],
+        }),
+        DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+    );
+    assert.deepEqual(
+        (await getDeliveryRun(arrivalFixture.run.id))?.stops.map(
+            (stop) => stop.itinerarySequence,
+        ),
+        originalSequences,
+    );
+
+    const leaseFixture = await startPreparedBulkRunWithConfirmedPickup();
+    const [leaseDeferredStop] = leaseFixture.run.stops;
+    assert.ok(leaseDeferredStop);
+    const leaseDeferred = await recordDeliveryRunStopExceptions({
+        driverUserId: leaseFixture.driverUserId,
+        runId: leaseFixture.run.id,
+        clientOperationId: 'defer-before-expired-lease',
+        occurredAt: new Date('2026-07-13T09:10:00.000Z'),
+        exceptions: [
+            {
+                stopId: leaseDeferredStop.id,
+                outcome: DeliveryRunExceptionOutcomes.DEFERRED,
+                reason: DeliveryRunExceptionReasons.ADDRESS_INACCESSIBLE,
+            },
+        ],
+    });
+    const oldClaimedAt = new Date();
+    assert.ok(
+        await claimDeliveryRunReroute({
+            runId: leaseFixture.run.id,
+            expectedRouteRevision: leaseDeferred.result.routeRevision,
+            claimedAt: oldClaimedAt,
+        }),
+    );
+    const newerClaim = await claimDeliveryRunReroute({
+        runId: leaseFixture.run.id,
+        expectedRouteRevision: leaseDeferred.result.routeRevision,
+        claimedAt: new Date(
+            oldClaimedAt.getTime() + deliveryRunRerouteLeaseMs + 1,
+        ),
+    });
+    assert.ok(newerClaim);
+    await assertExecutionError(
+        applyDeliveryRunReroute({
+            runId: leaseFixture.run.id,
+            expectedRouteRevision: leaseDeferred.result.routeRevision,
+            rerouteClaimedAt: oldClaimedAt,
+            estimateSource: 'local',
+            totalDistanceMeters: 1_000,
+            totalDurationSeconds: 600,
+            pickupEstimates: [],
+            stopEstimates: [],
+        }),
+        DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+    );
+});
+
+test('retry anchor must itself be deferred in a mixed terminal checkpoint', async () => {
+    const { run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup();
+    const [firstStop, secondStop] = run.stops;
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+    const deferred = await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        clientOperationId: 'defer-entire-bulk-checkpoint',
+        occurredAt: new Date('2026-07-13T09:00:00.000Z'),
+        exceptions: [firstStop, secondStop].map((stop) => ({
+            stopId: stop.id,
+            outcome: DeliveryRunExceptionOutcomes.DEFERRED,
+            reason: DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE,
+        })),
+    });
+    await cancelDeliveryRequest(
+        firstStop.deliveryRequestId,
+        'admin',
+        'Kupac je otkazao jedan dio skupne dostave',
+    );
+    const cancelledRun = await getDeliveryRun(run.id);
+    assert.ok(cancelledRun);
+    assert.equal(cancelledRun.stops[0]?.state, DeliveryRunStopStates.CANCELLED);
+    await assertExecutionError(
+        retryDeliveryRunStop({
+            driverUserId,
+            runId: run.id,
+            stopId: firstStop.id,
+            expectedRouteRevision: cancelledRun.routeRevision,
+        }),
+        DeliveryRunExecutionErrorCodes.EXCEPTION_TRANSITION_INVALID,
+    );
+    const retried = await retryDeliveryRunStop({
+        driverUserId,
+        runId: run.id,
+        stopId: secondStop.id,
+        expectedRouteRevision: cancelledRun.routeRevision,
+    });
+    assert.deepEqual(retried.stopIds, [secondStop.id]);
+    assert.equal(
+        (await getDeliveryRun(run.id))?.stops[1]?.state,
+        DeliveryRunStopStates.PENDING,
+    );
+    assert.ok(retried.routeRevision > deferred.result.routeRevision);
+});
+
+test('foreign-account address mutations preserve not-found semantics for assigned addresses', async () => {
+    const prepared = await createPreparedRunFixture();
+    const driverUserId = prepared.fixture.driverUserIds[0];
+    const addressId = prepared.addressIds[0];
+    assert.ok(driverUserId);
+    assert.ok(addressId);
+    const saved = await saveDeliveryRunPreparation(prepared);
+    await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId,
+        deliveryRequestIds: prepared.fixture.requestIds,
+    });
+    const foreignAccountId = await createTestAccount();
+    await assert.rejects(
+        updateDeliveryAddress(
+            { id: addressId, street1: 'Neovlaštena promjena' },
+            foreignAccountId,
+        ),
+        (error) =>
+            error instanceof DeliveryAddressMutationError &&
+            !(error instanceof DeliveryRunAssignmentError) &&
+            error.message ===
+                'Failed to update delivery address - address not found or access denied',
+    );
+    await assert.rejects(
+        deleteDeliveryAddress(addressId, foreignAccountId),
+        (error) =>
+            error instanceof DeliveryAddressMutationError &&
+            !(error instanceof DeliveryRunAssignmentError) &&
+            error.message ===
+                'Failed to delete delivery address - address not found or access denied',
+    );
+});
+
+test('whole-run reassignment clears stale GPS and requires the current route revision', async () => {
+    const { prepared, run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup({ driverCount: 2 });
+    const nextDriverUserId = prepared.fixture.driverUserIds[1];
+    assert.ok(nextDriverUserId);
+    await updateDeliveryRunLocation({
+        runId: run.id,
+        driverUserId,
+        latitude: 45.8,
+        longitude: 15.97,
+        recordedAt: new Date('2026-07-13T12:00:00.000Z'),
+    });
+    await markDeliveryRunStopsArrived({
+        driverUserId,
+        runId: run.id,
+        stopIds: run.stops.map((stop) => stop.id),
+        expectedRouteRevision: run.routeRevision,
+    });
+    const arrivedRun = await getDeliveryRun(run.id);
+    assert.equal(arrivedRun?.routeRevision, run.routeRevision + 1);
+    assert.equal(arrivedRun?.stops[0]?.state, DeliveryRunStopStates.ARRIVED);
+
+    const reassigned = await reassignDeliveryRun({
+        adminUserId: driverUserId,
+        runId: run.id,
+        newDriverUserId: nextDriverUserId,
+        expectedRouteRevision: arrivedRun?.routeRevision ?? -1,
+        occurredAt: new Date('2026-07-13T12:01:00.000Z'),
+    });
+    assert.equal(reassigned.driverUserId, nextDriverUserId);
+    assert.equal(
+        reassigned.routeRevision,
+        (arrivedRun?.routeRevision ?? 0) + 1,
+    );
+    assert.equal(reassigned.reroutePending, true);
+
+    const persisted = await getDeliveryRun(run.id);
+    assert.equal(persisted?.driverUserId, nextDriverUserId);
+    assert.equal(persisted?.currentLatitude, null);
+    assert.equal(persisted?.currentLongitude, null);
+    assert.equal(persisted?.currentLocationRecordedAt, null);
+    assert.equal(persisted?.currentLocationReceivedAt, null);
+    assert.ok(
+        persisted?.stops.every(
+            (stop) =>
+                stop.state === DeliveryRunStopStates.PENDING &&
+                stop.arrivedAt === null,
+        ),
+    );
+    assert.ok(persisted?.rerouteRequiredAt instanceof Date);
+    await assertExecutionError(
+        reassignDeliveryRun({
+            adminUserId: driverUserId,
+            runId: run.id,
+            newDriverUserId: driverUserId,
+            expectedRouteRevision: run.routeRevision,
+        }),
+        DeliveryRunExecutionErrorCodes.ROUTE_REVISION_CONFLICT,
+    );
+});
+
+test('route abandonment releases requests but preserves a failed stop audit outcome', async () => {
+    const { run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup();
+    const [failedStop, pendingStop] = run.stops;
+    assert.ok(failedStop);
+    assert.ok(pendingStop);
+    const failure = await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        clientOperationId: 'failure-before-abandonment',
+        occurredAt: new Date('2026-07-13T12:10:00.000Z'),
+        exceptions: [
+            {
+                stopId: failedStop.id,
+                outcome: DeliveryRunExceptionOutcomes.FAILED,
+                reason: DeliveryRunExceptionReasons.HARVEST_DAMAGED,
+                note: 'Oštećenje potvrđeno pri dostavi',
+            },
+        ],
+    });
+
+    const abandoned = await abandonDeliveryRun({
+        adminUserId: driverUserId,
+        runId: run.id,
+        expectedRouteRevision: failure.result.routeRevision,
+        reason: 'Vozilo više nije dostupno',
+        occurredAt: new Date('2026-07-13T12:11:00.000Z'),
+    });
+    assert.deepEqual(
+        new Set(abandoned.releasedRequestIds),
+        new Set([failedStop.deliveryRequestId, pendingStop.deliveryRequestId]),
+    );
+
+    const persisted = await getDeliveryRun(run.id);
+    assert.equal(persisted?.state, DeliveryRunStates.CANCELLED);
+    const persistedFailed = persisted?.stops.find(
+        (stop) => stop.id === failedStop.id,
+    );
+    const persistedPending = persisted?.stops.find(
+        (stop) => stop.id === pendingStop.id,
+    );
+    assert.equal(persistedFailed?.state, DeliveryRunStopStates.FAILED);
+    assert.equal(
+        persistedFailed?.exceptionReason,
+        DeliveryRunExceptionReasons.HARVEST_DAMAGED,
+    );
+    assert.equal(
+        persistedFailed?.exceptionNote,
+        'Oštećenje potvrđeno pri dostavi',
+    );
+    assert.ok(persistedFailed?.releasedAt instanceof Date);
+    assert.equal(persistedPending?.state, DeliveryRunStopStates.CANCELLED);
+    assert.ok(persistedPending?.releasedAt instanceof Date);
+    assert.equal(
+        (await getDeliveryRequest(failedStop.deliveryRequestId))?.state,
+        'ready',
+    );
+    assert.equal(
+        (await getDeliveryRequest(pendingStop.deliveryRequestId))?.state,
+        'ready',
+    );
+    assert.equal(
+        (
+            await getActiveDeliveryRunStopsForRequestIds([
+                failedStop.deliveryRequestId,
+                pendingStop.deliveryRequestId,
+            ])
+        ).length,
+        0,
+    );
+});
+
+test('bulk siblings reuse one deterministic lane on a later retry attempt', async () => {
+    const { run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup();
+    const [firstStop, secondStop] = run.stops;
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+    const firstDeferral = await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        clientOperationId: 'bulk-first-attempt-deferred',
+        occurredAt: new Date('2026-07-13T12:20:00.000Z'),
+        exceptions: [firstStop, secondStop].map((stop) => ({
+            stopId: stop.id,
+            outcome: DeliveryRunExceptionOutcomes.DEFERRED,
+            reason: DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE,
+        })),
+    });
+    const retried = await retryDeliveryRunStop({
+        driverUserId,
+        runId: run.id,
+        stopId: firstStop.id,
+        expectedRouteRevision: firstDeferral.result.routeRevision,
+    });
+    const secondAttemptFirst = await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        clientOperationId: 'bulk-second-attempt-first-item',
+        occurredAt: new Date('2026-07-13T12:21:00.000Z'),
+        exceptions: [
+            {
+                stopId: firstStop.id,
+                outcome: DeliveryRunExceptionOutcomes.DEFERRED,
+                reason: DeliveryRunExceptionReasons.ADDRESS_INACCESSIBLE,
+            },
+        ],
+    });
+    await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        clientOperationId: 'bulk-second-attempt-second-item',
+        occurredAt: new Date('2026-07-13T12:22:00.000Z'),
+        exceptions: [
+            {
+                stopId: secondStop.id,
+                outcome: DeliveryRunExceptionOutcomes.DEFERRED,
+                reason: DeliveryRunExceptionReasons.ADDRESS_INACCESSIBLE,
+            },
+        ],
+    });
+    assert.ok(secondAttemptFirst.result.routeRevision > retried.routeRevision);
+
+    const retrySteps = (await getDeliveryRunExecutionProgress(run.id)).filter(
+        isRetryDeliveryStep,
+    );
+    assert.equal(retrySteps.length, 1);
+    assert.equal(retrySteps[0]?.retryAttempt, 2);
+    assert.deepEqual(
+        retrySteps[0]?.stopIds.sort((a, b) => a - b),
+        [firstStop.id, secondStop.id],
+    );
+    const persisted = await getDeliveryRun(run.id);
+    assert.equal(persisted?.stops[0]?.retryLaneRank, 2);
+    assert.equal(persisted?.stops[1]?.retryLaneRank, 2);
+    assert.equal(persisted?.stops[0]?.retryAttempt, 2);
+    assert.equal(persisted?.stops[1]?.retryAttempt, 2);
+});
+
+test('active assignment lookup ignores an unreleased stale stop in a terminal run', async () => {
+    const fixture = await createDeliveryRunFixture();
+    const driverUserId = fixture.driverUserIds[0];
+    const requestId = fixture.requestIds[0];
+    assert.ok(driverUserId);
+    assert.ok(requestId);
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [requestId],
+    });
+    await storage()
+        .update(deliveryRuns)
+        .set({
+            state: DeliveryRunStates.COMPLETED,
+            completedAt: new Date('2026-07-13T12:30:00.000Z'),
+        })
+        .where(eq(deliveryRuns.id, run.id));
+
+    assert.equal(
+        (await getActiveDeliveryRunStopsForRequestIds([requestId])).length,
+        0,
+    );
+    assert.equal(
+        (await getDeliveryRunStopsForRequestIds([requestId]))[0]?.run.id,
+        run.id,
+    );
+});
+
+test('legacy reroute keeps completed bulk sequences and legacy estimate provenance', async () => {
+    const fixture = await createDeliveryRunFixture({
+        accountIndexes: [0, 0, 0, 0],
+    });
+    const driverUserId = fixture.driverUserIds[0];
+    assert.ok(driverUserId);
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: fixture.requestIds,
+    });
+    const [firstStop, secondStop, deferredStop, currentStop] = run.stops;
+    assert.ok(firstStop);
+    assert.ok(secondStop);
+    assert.ok(deferredStop);
+    assert.ok(currentStop);
+    await fulfillDeliveryRunStops({
+        driverUserId,
+        runId: run.id,
+        stopIds: [firstStop.id, secondStop.id],
+        expectedRouteRevision: run.routeRevision,
+    });
+    const progressed = await getDeliveryRun(run.id);
+    assert.ok(progressed);
+    const deferred = await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        expectedRouteRevision: progressed.routeRevision,
+        clientOperationId: 'legacy-deferred-before-reroute',
+        occurredAt: new Date('2026-07-13T13:00:00.000Z'),
+        exceptions: [
+            {
+                stopId: deferredStop.id,
+                outcome: DeliveryRunExceptionOutcomes.DEFERRED,
+                reason: DeliveryRunExceptionReasons.CUSTOMER_UNAVAILABLE,
+            },
+        ],
+    });
+    const claimedAt = new Date();
+    assert.ok(
+        await claimDeliveryRunReroute({
+            runId: run.id,
+            expectedRouteRevision: deferred.result.routeRevision,
+            claimedAt,
+        }),
+    );
+    await applyDeliveryRunReroute({
+        runId: run.id,
+        expectedRouteRevision: deferred.result.routeRevision,
+        rerouteClaimedAt: claimedAt,
+        estimateSource: DeliveryRunEstimateSources.GOOGLE,
+        totalDistanceMeters: 2_000,
+        totalDurationSeconds: 900,
+        pickupEstimates: [],
+        stopEstimates: [
+            {
+                stopIds: [currentStop.id],
+                itinerarySequence: 3,
+                estimatedArrivalAt: new Date('2026-07-13T13:10:00.000Z'),
+                estimatedTravelSeconds: 120,
+                estimatedDistanceMeters: 1_000,
+            },
+            {
+                stopIds: [deferredStop.id],
+                itinerarySequence: 4,
+                estimatedArrivalAt: new Date('2026-07-13T13:20:00.000Z'),
+                estimatedTravelSeconds: 120,
+                estimatedDistanceMeters: 1_000,
+            },
+        ],
+    });
+
+    const rerouted = await getDeliveryRun(run.id);
+    assert.equal(rerouted?.routePlanVersion, 1);
+    assert.equal(rerouted?.estimateSource, DeliveryRunEstimateSources.LEGACY);
+    assert.equal(
+        rerouted?.stops.find((stop) => stop.id === currentStop.id)?.sequence,
+        3,
+    );
+    assert.equal(
+        rerouted?.stops.find((stop) => stop.id === deferredStop.id)?.sequence,
+        4,
+    );
+    assert.deepEqual(
+        rerouted?.stops.slice(0, 2).map((stop) => stop.state),
+        [DeliveryRunStopStates.DELIVERED, DeliveryRunStopStates.DELIVERED],
+    );
+});
+
+test('reroute swaps pending pickup itinerary positions without uniqueness collisions', async () => {
+    const prepared = await createPreparedRunFixture();
+    const driverUserId = prepared.fixture.driverUserIds[0];
+    assert.ok(driverUserId);
+    const saved = await saveDeliveryRunPreparation(prepared);
+    const run = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId,
+        deliveryRequestIds: prepared.fixture.requestIds,
+    });
+    const [firstPickup, secondPickup] = run.pickupNodes;
+    assert.ok(firstPickup);
+    assert.ok(secondPickup);
+    const rerouteRequiredAt = new Date('2026-07-13T13:30:00.000Z');
+    await storage()
+        .update(deliveryRuns)
+        .set({ rerouteRequiredAt })
+        .where(eq(deliveryRuns.id, run.id));
+    const claimedAt = new Date();
+    assert.ok(
+        await claimDeliveryRunReroute({
+            runId: run.id,
+            expectedRouteRevision: run.routeRevision,
+            claimedAt,
+        }),
+    );
+    await applyDeliveryRunReroute({
+        runId: run.id,
+        expectedRouteRevision: run.routeRevision,
+        rerouteClaimedAt: claimedAt,
+        estimateSource: DeliveryRunEstimateSources.LOCAL,
+        totalDistanceMeters: 3_000,
+        totalDurationSeconds: 1_200,
+        pickupEstimates: [
+            {
+                pickupNodeId: firstPickup.id,
+                itinerarySequence: secondPickup.itinerarySequence ?? 2,
+                estimatedArrivalAt: new Date('2026-07-13T13:35:00.000Z'),
+                incomingTravelSeconds: 60,
+                incomingDistanceMeters: 500,
+            },
+            {
+                pickupNodeId: secondPickup.id,
+                itinerarySequence: firstPickup.itinerarySequence ?? 1,
+                estimatedArrivalAt: new Date('2026-07-13T13:40:00.000Z'),
+                incomingTravelSeconds: 60,
+                incomingDistanceMeters: 500,
+            },
+        ],
+        stopEstimates: run.stops.map((stop, index) => ({
+            stopIds: [stop.id],
+            itinerarySequence: stop.itinerarySequence ?? index + 3,
+            estimatedArrivalAt: new Date(
+                Date.parse('2026-07-13T13:45:00.000Z') + index * 60_000,
+            ),
+            estimatedTravelSeconds: 60,
+            estimatedDistanceMeters: 500,
+        })),
+    });
+
+    const rerouted = await getDeliveryRun(run.id);
+    assert.deepEqual(
+        rerouted?.pickupNodes.map((pickup) => pickup.itinerarySequence),
+        [secondPickup.itinerarySequence, firstPickup.itinerarySequence],
+    );
+});
+
+test('a partially cancelled stop is released for explicit admin reactivation', async () => {
+    const { prepared, run, driverUserId } =
+        await startPreparedBulkRunWithConfirmedPickup({ driverCount: 2 });
+    const [cancelledStop, remainingStop] = run.stops;
+    const nextDriverUserId = prepared.fixture.driverUserIds[1];
+    assert.ok(cancelledStop);
+    assert.ok(remainingStop);
+    assert.ok(nextDriverUserId);
+    await recordDeliveryRunStopExceptions({
+        driverUserId,
+        runId: run.id,
+        clientOperationId: 'partial-cancel-before-reactivation',
+        occurredAt: new Date('2026-07-13T14:00:00.000Z'),
+        exceptions: [
+            {
+                stopId: cancelledStop.id,
+                outcome: DeliveryRunExceptionOutcomes.CANCELLED,
+                reason: DeliveryRunExceptionReasons.CANCELLATION,
+            },
+        ],
+    });
+    const activeRun = await getDeliveryRun(run.id);
+    assert.equal(activeRun?.state, DeliveryRunStates.ACTIVE);
+    assert.equal(
+        activeRun?.stops.find((stop) => stop.id === cancelledStop.id)?.state,
+        DeliveryRunStopStates.CANCELLED,
+    );
+    assert.ok(
+        activeRun?.stops.find((stop) => stop.id === cancelledStop.id)
+            ?.releasedAt,
+    );
+    assert.equal(
+        activeRun?.stops.find((stop) => stop.id === remainingStop.id)?.state,
+        DeliveryRunStopStates.PENDING,
+    );
+
+    await uncancelDeliveryRequest(cancelledStop.deliveryRequestId);
+    await readyDeliveryRequest(cancelledStop.deliveryRequestId);
+    const nextPreparation = await singleRequestPreparation({
+        prepared,
+        requestId: cancelledStop.deliveryRequestId,
+        driverUserId: nextDriverUserId,
+    });
+    const saved = await saveDeliveryRunPreparation(nextPreparation);
+    const nextRun = await consumeDeliveryRunPreparation({
+        preparationToken: saved.preparationToken,
+        driverUserId: nextDriverUserId,
+        deliveryRequestIds: [cancelledStop.deliveryRequestId],
+    });
+    assert.notEqual(nextRun.id, run.id);
+    assert.equal(
+        (
+            await getActiveDeliveryRunStopsForRequestIds([
+                cancelledStop.deliveryRequestId,
+            ])
+        )[0]?.run.id,
+        nextRun.id,
+    );
 });


### PR DESCRIPTION
Closes #4126

## Summary
- continue active routes after audited deferred, failed, or cancelled handoff outcomes
- add deterministic retry lanes, route-revision conflicts, leased rerouting, fresh GPS gating, and updated ETA suppression
- add safe admin cancellation, recovery, reassignment, and abandonment behavior
- expose private driver/admin mutation APIs and a minimal deferred-stop retry command
- migrate legacy runs and reconcile assigned cancellations without breaking bulk delivery semantics

## Validation
- delivery tests: 132/132
- storage delivery-run tests: 52/52
- migration 0073 fixture: 1/1
- delivery and game typechecks
- delivery, API, and admin production builds
- Biome checks for all changed packages
- db-generate twice: no schema changes
- independent review: no actionable P1/P2 findings