### PR TITLE
feat(farm): build mobile sign-in shell

### DIFF
--- a/apps/farm/components/auth/FarmSignInShell.tsx
+++ b/apps/farm/components/auth/FarmSignInShell.tsx
@@ -1,0 +1,55 @@
+import Image from 'next/image';
+import type { ReactNode } from 'react';
+
+interface FarmSignInShellProps {
+    children: ReactNode;
+}
+
+export function FarmSignInShell({ children }: FarmSignInShellProps) {
+    return (
+        <main
+            className="relative isolate flex min-h-[100dvh] w-full min-w-0 items-center justify-center overflow-hidden [padding-bottom:calc(var(--farm-safe-area-bottom,0px)+1rem)] [padding-left:calc(var(--farm-safe-area-left,0px)+1rem)] [padding-right:calc(var(--farm-safe-area-right,0px)+1rem)] [padding-top:calc(var(--farm-safe-area-top,0px)+1rem)] sm:[padding-bottom:calc(var(--farm-safe-area-bottom,0px)+1.5rem)] sm:[padding-left:calc(var(--farm-safe-area-left,0px)+1.5rem)] sm:[padding-right:calc(var(--farm-safe-area-right,0px)+1.5rem)] sm:[padding-top:calc(var(--farm-safe-area-top,0px)+1.5rem)]"
+            data-farm-sign-in-shell
+        >
+            <div aria-hidden="true" className="absolute inset-0 -z-20">
+                <Image
+                    alt=""
+                    className="object-cover"
+                    fill
+                    priority
+                    quality={90}
+                    sizes="100vw"
+                    src="/login-bg.webp"
+                />
+            </div>
+            <div
+                aria-hidden="true"
+                className="absolute inset-0 -z-10 bg-background/78 backdrop-blur-[2px] dark:bg-background/88"
+            />
+
+            <section
+                aria-labelledby="farm-sign-in-heading"
+                className="relative w-full max-w-md rounded-2xl border border-border/80 bg-background/95 p-5 shadow-xl shadow-black/10 backdrop-blur sm:p-7"
+                data-farm-sign-in-panel
+            >
+                <header className="mb-7 space-y-2">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">
+                        Prijava za farmere
+                    </p>
+                    <h1
+                        className="text-3xl font-semibold tracking-tight text-foreground"
+                        id="farm-sign-in-heading"
+                    >
+                        Gredice Farm
+                    </h1>
+                    <p className="max-w-sm text-sm leading-6 text-muted-foreground">
+                        Dnevni zadaci, gredice i evidencija rada na jednom
+                        mjestu.
+                    </p>
+                </header>
+
+                {children}
+            </section>
+        </main>
+    );
+}

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -10,14 +10,13 @@ import {
 import { Button } from '@gredice/ui/Button';
 import { Input } from '@gredice/ui/Input';
 import { Mail, Warning } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { usePostHog } from '@posthog/next';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useActionState, useCallback, useState } from 'react';
 import { queryClient } from '../providers/ClientAppProvider';
+import { FarmSignInShell } from './FarmSignInShell';
 
 type OAuthProvider = 'google' | 'facebook';
 
@@ -117,107 +116,130 @@ export function LoginDialog() {
     };
 
     return (
-        <div className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-primary/10 via-transparent to-success/10 p-4">
-            <Image
-                src="/login-bg.webp"
-                alt="Pozadina"
-                fill
-                className="object-cover"
-                quality={100}
-                priority
-            />
-            <Modal
-                open
-                dismissible={false}
-                title="Prijava u Gredice farmu"
-                className="md:max-w-md"
-            >
-                <Stack spacing={8}>
-                    <Stack spacing={2}>
-                        <Typography level="h3" className="text-2xl" semiBold>
-                            Dobrodošli
-                        </Typography>
-                        <Typography className="text-muted-foreground">
-                            Prijavi se s Gredice računom kako bi upravljao
-                            svojom farmom.
-                        </Typography>
-                    </Stack>
-                    {!emailExpanded ? (
-                        <Stack spacing={2}>
-                            <GoogleLoginButton
-                                onClick={() => handleOAuthLogin('google')}
-                                lastUsed={lastLoginProvider === 'google'}
-                            >
-                                Google prijava
-                            </GoogleLoginButton>
-                            <FacebookLoginButton
-                                onClick={() => handleOAuthLogin('facebook')}
-                                lastUsed={lastLoginProvider === 'facebook'}
-                            >
-                                Facebook prijava
-                            </FacebookLoginButton>
-                            <Button
-                                type="button"
-                                variant="outlined"
-                                color="neutral"
-                                fullWidth
-                                startDecorator={
-                                    <Mail className="h-4 w-4 shrink-0" />
-                                }
-                                onClick={() => setEmailExpanded(true)}
-                            >
-                                Email prijava
-                            </Button>
-                        </Stack>
-                    ) : (
-                        <form
-                            action={submitAction}
-                            className="w-full space-y-4"
-                        >
-                            <Stack spacing={6}>
-                                <Stack spacing={2}>
-                                    <Input
-                                        name="email"
-                                        label="Email"
-                                        placeholder="ime@primjer.com"
-                                        type="email"
-                                        autoComplete="email"
-                                        fullWidth
-                                        required
-                                    />
-                                    <Input
-                                        name="password"
-                                        label="Zaporka"
-                                        type="password"
-                                        autoComplete="current-password"
-                                        fullWidth
-                                        required
-                                    />
-                                </Stack>
-                                <Button
-                                    type="submit"
-                                    loading={isPending}
-                                    variant="solid"
-                                    fullWidth
-                                >
-                                    Prijavi se
-                                </Button>
-                                {error && (
-                                    <Alert
-                                        color="danger"
-                                        startDecorator={
-                                            <Warning className="size-5" />
-                                        }
-                                    >
-                                        {error}
-                                    </Alert>
-                                )}
-                            </Stack>
-                        </form>
-                    )}
+        <FarmSignInShell>
+            <Stack spacing={7}>
+                <Stack spacing={2}>
+                    <Typography level="h2" className="text-xl" semiBold>
+                        Dobrodošli
+                    </Typography>
+                    <Typography className="text-muted-foreground">
+                        Prijavi se s Gredice računom kako bi upravljao svojom
+                        farmom.
+                    </Typography>
                 </Stack>
-            </Modal>
-        </div>
+                {!emailExpanded ? (
+                    <Stack spacing={2}>
+                        <GoogleLoginButton
+                            aria-describedby={
+                                lastLoginProvider === 'google'
+                                    ? 'farm-google-last-used'
+                                    : undefined
+                            }
+                            lastUsed={lastLoginProvider === 'google'}
+                            onClick={() => handleOAuthLogin('google')}
+                            size="lg"
+                        >
+                            Google prijava
+                        </GoogleLoginButton>
+                        {lastLoginProvider === 'google' ? (
+                            <Typography
+                                className="text-center text-xs text-muted-foreground sm:sr-only"
+                                id="farm-google-last-used"
+                                level="body3"
+                            >
+                                Zadnje korišteno
+                            </Typography>
+                        ) : null}
+                        <FacebookLoginButton
+                            aria-describedby={
+                                lastLoginProvider === 'facebook'
+                                    ? 'farm-facebook-last-used'
+                                    : undefined
+                            }
+                            lastUsed={lastLoginProvider === 'facebook'}
+                            onClick={() => handleOAuthLogin('facebook')}
+                            size="lg"
+                        >
+                            Facebook prijava
+                        </FacebookLoginButton>
+                        {lastLoginProvider === 'facebook' ? (
+                            <Typography
+                                className="text-center text-xs text-muted-foreground sm:sr-only"
+                                id="farm-facebook-last-used"
+                                level="body3"
+                            >
+                                Zadnje korišteno
+                            </Typography>
+                        ) : null}
+                        <Button
+                            color="neutral"
+                            fullWidth
+                            onClick={() => setEmailExpanded(true)}
+                            size="lg"
+                            startDecorator={
+                                <Mail
+                                    aria-hidden="true"
+                                    className="h-4 w-4 shrink-0"
+                                />
+                            }
+                            type="button"
+                            variant="outlined"
+                        >
+                            Email prijava
+                        </Button>
+                    </Stack>
+                ) : (
+                    <form action={submitAction} className="w-full space-y-4">
+                        <Stack spacing={6}>
+                            <Stack spacing={2}>
+                                <Input
+                                    autoComplete="email"
+                                    className="h-11 [&>input]:h-full"
+                                    fullWidth
+                                    label="Email"
+                                    name="email"
+                                    placeholder="ime@primjer.com"
+                                    required
+                                    type="email"
+                                />
+                                <Input
+                                    autoComplete="current-password"
+                                    className="h-11 [&>input]:h-full"
+                                    fullWidth
+                                    label="Zaporka"
+                                    name="password"
+                                    required
+                                    type="password"
+                                />
+                            </Stack>
+                            <Button
+                                fullWidth
+                                loading={isPending}
+                                size="lg"
+                                type="submit"
+                                variant="solid"
+                            >
+                                Prijavi se
+                            </Button>
+                            {error && (
+                                <Alert
+                                    color="danger"
+                                    role="alert"
+                                    startDecorator={
+                                        <Warning
+                                            aria-hidden="true"
+                                            className="size-5"
+                                        />
+                                    }
+                                >
+                                    {error}
+                                </Alert>
+                            )}
+                        </Stack>
+                    </form>
+                )}
+            </Stack>
+        </FarmSignInShell>
     );
 }
 

--- a/apps/farm/package.json
+++ b/apps/farm/package.json
@@ -34,6 +34,7 @@
         "server-only": "0.0.1"
     },
     "devDependencies": {
+        "@axe-core/playwright": "4.12.1",
         "@biomejs/biome": "2.5.3",
         "@gredice/auth": "workspace:*",
         "@gredice/client": "workspace:*",

--- a/apps/farm/tests/auth.spec.ts
+++ b/apps/farm/tests/auth.spec.ts
@@ -1,37 +1,190 @@
+import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
+const signInViewports = [
+    { name: '320px phone', width: 320, height: 568 },
+    { name: '375px phone', width: 375, height: 667 },
+    { name: '390px phone', width: 390, height: 844 },
+    { name: '430px phone', width: 430, height: 932 },
+    { name: 'desktop', width: 1280, height: 800 },
+] as const;
+
+async function expectContainedInViewport(
+    locator: import('@playwright/test').Locator,
+    viewport: { height: number; width: number },
+) {
+    const box = await locator.boundingBox();
+    expect(box).not.toBeNull();
+
+    if (!box) {
+        return;
+    }
+
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.y).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);
+    expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
+}
+
+async function expectMinimumTouchTarget(
+    locator: import('@playwright/test').Locator,
+) {
+    const box = await locator.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box?.height).toBeGreaterThanOrEqual(44);
+    expect(box?.width).toBeGreaterThanOrEqual(44);
+}
+
 test.describe('Authentication Flow', () => {
-    test.describe('Login Dialog', () => {
-        test('should show login dialog with social login options', async ({
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/gredice/api/auth/last-login', (route) =>
+            route.fulfill({ status: 200, json: { provider: null } }),
+        );
+    });
+
+    test.describe('Login shell', () => {
+        for (const viewport of signInViewports) {
+            test(`keeps the ${viewport.name} sign-in shell visible and unclipped`, async ({
+                page,
+            }) => {
+                await page.setViewportSize(viewport);
+                await page.goto('/');
+
+                const shell = page.locator('[data-farm-sign-in-shell]');
+                const panel = page.locator('[data-farm-sign-in-panel]');
+
+                await expect(page.getByRole('main')).toBeVisible();
+                await expect(
+                    page.getByRole('heading', {
+                        exact: true,
+                        level: 1,
+                        name: 'Gredice Farm',
+                    }),
+                ).toBeVisible();
+                await expect(page.getByRole('dialog')).toHaveCount(0);
+                await expect(shell).toBeVisible();
+                await expect(panel).toBeVisible();
+                await expect(page.locator('img[alt=""]')).toHaveCount(1);
+                await expectContainedInViewport(shell, viewport);
+                await expectContainedInViewport(panel, viewport);
+
+                const pageWidths = await page.evaluate(() => ({
+                    clientWidth: document.documentElement.clientWidth,
+                    scrollWidth: document.documentElement.scrollWidth,
+                }));
+                expect(pageWidths.scrollWidth).toBeLessThanOrEqual(
+                    pageWidths.clientWidth,
+                );
+
+                for (const name of [
+                    'Google prijava',
+                    'Facebook prijava',
+                    'Email prijava',
+                ]) {
+                    await expectMinimumTouchTarget(
+                        page.getByRole('button', { name }),
+                    );
+                }
+            });
+        }
+
+        for (const viewport of [
+            { width: 320, height: 568 },
+            { width: 390, height: 844 },
+        ]) {
+            test(`keeps the last-used provider visible at ${viewport.width}px`, async ({
+                page,
+            }) => {
+                await page.unroute('**/api/gredice/api/auth/last-login');
+                await page.route(
+                    '**/api/gredice/api/auth/last-login',
+                    (route) =>
+                        route.fulfill({
+                            status: 200,
+                            json: { provider: 'google' },
+                        }),
+                );
+                await page.setViewportSize(viewport);
+                await page.goto('/');
+
+                const googleButton = page.getByRole('button', {
+                    name: 'Google prijava',
+                });
+                const lastUsed = page.locator('#farm-google-last-used');
+
+                await expect(lastUsed).toBeVisible();
+                await expect(lastUsed).toHaveText('Zadnje korišteno');
+                await expect(googleButton).toHaveAttribute(
+                    'aria-describedby',
+                    'farm-google-last-used',
+                );
+            });
+        }
+
+        test('follows a predictable keyboard order through sign-in choices', async ({
             page,
         }) => {
+            await page.setViewportSize({ width: 390, height: 844 });
             await page.goto('/');
 
-            // Check for login dialog presence - look for Google login button
             const googleButton = page.getByRole('button', {
-                name: /Google/i,
+                name: 'Google prijava',
             });
-            await expect(googleButton).toBeVisible();
-        });
-
-        test('should have Google login button', async ({ page }) => {
-            await page.goto('/');
-
-            // Look for Google login option (it's a button, not a link)
-            const googleButton = page.getByRole('button', {
-                name: /Google/i,
-            });
-            await expect(googleButton).toBeVisible();
-        });
-
-        test('should have Facebook login button', async ({ page }) => {
-            await page.goto('/');
-
-            // Look for Facebook login option (it's a button, not a link)
             const facebookButton = page.getByRole('button', {
-                name: /Facebook/i,
+                name: 'Facebook prijava',
             });
-            await expect(facebookButton).toBeVisible();
+            const emailButton = page.getByRole('button', {
+                name: 'Email prijava',
+            });
+
+            await page.locator('body').click({ position: { x: 1, y: 1 } });
+            await page.keyboard.press('Tab');
+            await expect(googleButton).toBeFocused();
+            await page.keyboard.press('Tab');
+            await expect(facebookButton).toBeFocused();
+            await page.keyboard.press('Tab');
+            await expect(emailButton).toBeFocused();
+        });
+
+        test('keeps the email form and submit action reachable at reduced height', async ({
+            page,
+        }) => {
+            const viewport = { width: 390, height: 480 };
+            await page.setViewportSize(viewport);
+            await page.goto('/');
+            await page.getByRole('button', { name: 'Email prijava' }).click();
+
+            await expect(page.getByLabel('Email')).toBeVisible();
+            await expect(page.getByLabel('Zaporka')).toBeVisible();
+
+            const submitButton = page.getByRole('button', {
+                name: 'Prijavi se',
+            });
+            await submitButton.scrollIntoViewIfNeeded();
+            await expect(submitButton).toBeVisible();
+            await expectContainedInViewport(submitButton, viewport);
+            await expectMinimumTouchTarget(submitButton);
+        });
+
+        test('has no serious or critical automated accessibility violations', async ({
+            page,
+        }) => {
+            await page.setViewportSize({ width: 390, height: 844 });
+            await page.goto('/');
+
+            const results = await new AxeBuilder({ page })
+                .withTags(['wcag2a', 'wcag2aa'])
+                .analyze();
+            const seriousViolations = results.violations.filter(
+                (violation) =>
+                    violation.impact === 'serious' ||
+                    violation.impact === 'critical',
+            );
+
+            expect(
+                seriousViolations,
+                JSON.stringify(seriousViolations, null, 2),
+            ).toEqual([]);
         });
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,6 +534,9 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.12.1
+        version: 4.12.1(playwright-core@1.61.1)
       '@biomejs/biome':
         specifier: 2.5.3
         version: 2.5.3


### PR DESCRIPTION
## Summary

- replace the whole-page, non-dismissible modal with a semantic Farm-owned sign-in shell
- keep the single-farm farmer journey focused, with no farm selector or admin-oriented switching controls
- preserve Google, Facebook, email, and last-used-provider affordances with 44px touch targets
- add safe-area-aware, keyboard-stable layouts for 320–430px phones and desktop
- mark the photographic background as decorative and expose one visible Gredice Farm heading/main landmark

## Validation

- Farm production build
- focused Farm auth suite: 19/19
- full Farm suite: 252/252
- axe WCAG A/AA serious and critical scan
- live browser verification at 390x844 and 1280x800: no overlay, console errors, or horizontal overflow
- Farm Biome and git diff --check

Closes #4161