### PR TITLE
feat(delivery): add exception recovery experiences

### DIFF
--- a/apps/delivery/.gitignore
+++ b/apps/delivery/.gitignore
@@ -9,3 +9,9 @@
 .vercel
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/apps/delivery/components/DeliveryCustomerRecovery.tsx
+++ b/apps/delivery/components/DeliveryCustomerRecovery.tsx
@@ -1,0 +1,153 @@
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Info, Mail, MapPin, Reset, Warning } from '@gredice/ui/icons';
+import { PublicPagePaths, publicChromeHref } from '@gredice/ui/PublicChrome';
+import { Typography } from '@gredice/ui/Typography';
+import type { CustomerDeliveryRecoverySummary } from '../lib/deliveryDashboardTypes';
+import { formatDeliveryDateTime } from '../lib/deliveryFormatting';
+
+export function DeliveryCustomerRecovery({
+    recovery,
+}: {
+    recovery: CustomerDeliveryRecoverySummary;
+}) {
+    const supportHref = publicChromeHref(PublicPagePaths.Contact, 'www-origin');
+    if (recovery.kind === 'retry-planned') {
+        return (
+            <Alert
+                color="warning"
+                startDecorator={<Reset className="size-5" />}
+            >
+                <Typography level="body2" semiBold>
+                    Ponovni pokušaj je planiran
+                </Typography>
+                <Typography level="body3" className="mt-1">
+                    Vozač nastavlja rutu i vratit će se kasnije. Novo vrijeme
+                    dolaska prikazat će se čim ruta bude ažurirana.
+                </Typography>
+            </Alert>
+        );
+    }
+
+    if (recovery.kind === 'hq-pickup') {
+        const navigationUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(recovery.pickupAddress)}`;
+        return (
+            <Alert color="info" startDecorator={<Info className="size-5" />}>
+                <div className="space-y-3">
+                    <div>
+                        <Typography level="body2" semiBold>
+                            Osobno preuzimanje u HQ-u
+                        </Typography>
+                        <Typography level="body3" className="mt-1">
+                            Urod možeš preuzeti na lokaciji Gredice HQ
+                            najkasnije{' '}
+                            <strong>
+                                {formatDeliveryDateTime(
+                                    recovery.pickupDeadlineAt,
+                                )}
+                            </strong>{' '}
+                            (rok od {recovery.pickupWindowHours} sata).
+                        </Typography>
+                        <Typography level="body3" className="mt-1">
+                            Prije dolaska potvrdi s podrškom da je urod vraćen
+                            na lokaciju.
+                        </Typography>
+                        <Typography
+                            level="body3"
+                            className="mt-1 text-muted-foreground"
+                        >
+                            {recovery.pickupAddress}
+                        </Typography>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                        <Button
+                            href={supportHref}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            size="sm"
+                            variant="outlined"
+                            startDecorator={<Mail className="size-4" />}
+                        >
+                            Potvrdi preuzimanje
+                        </Button>
+                        <Button
+                            href={navigationUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            size="sm"
+                            variant="outlined"
+                            startDecorator={<MapPin className="size-4" />}
+                        >
+                            Otvori lokaciju HQ
+                        </Button>
+                    </div>
+                </div>
+            </Alert>
+        );
+    }
+
+    if (recovery.kind === 'hq-pickup-expired') {
+        return (
+            <Alert
+                color="warning"
+                startDecorator={<Warning className="size-5" />}
+            >
+                <div className="space-y-3">
+                    <div>
+                        <Typography level="body2" semiBold>
+                            Rok za osobno preuzimanje je istekao
+                        </Typography>
+                        <Typography level="body3" className="mt-1">
+                            Rok od 72 sata za preuzimanje u HQ-u više nije
+                            aktivan. Javi nam se kako bismo provjerili status
+                            uroda i sljedeći korak.
+                        </Typography>
+                    </div>
+                    <Button
+                        href={supportHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        size="sm"
+                        variant="outlined"
+                        startDecorator={<Mail className="size-4" />}
+                    >
+                        Kontaktiraj podršku
+                    </Button>
+                </div>
+            </Alert>
+        );
+    }
+
+    const cancelled = recovery.kind === 'cancelled';
+    return (
+        <Alert
+            color={cancelled ? 'warning' : 'danger'}
+            startDecorator={<Warning className="size-5" />}
+        >
+            <div className="space-y-3">
+                <div>
+                    <Typography level="body2" semiBold>
+                        {cancelled
+                            ? 'Dostava je otkazana'
+                            : 'Podrška će dogovoriti sljedeći korak'}
+                    </Typography>
+                    <Typography level="body3" className="mt-1">
+                        {cancelled
+                            ? 'Ako otkazivanje nisi očekivao/la, javi nam se kako bismo provjerili dostavu.'
+                            : 'Ovaj urod nije moguće odmah preuzeti na HQ-u. Javi nam se za provjeru i dogovor.'}
+                    </Typography>
+                </div>
+                <Button
+                    href={supportHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    size="sm"
+                    variant="outlined"
+                    startDecorator={<Mail className="size-4" />}
+                >
+                    Kontaktiraj podršku
+                </Button>
+            </div>
+        </Alert>
+    );
+}

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -14,6 +14,11 @@ import type {
     DriverDeliveryDashboard,
 } from '../lib/deliveryDashboardTypes';
 import {
+    type DeliveryExceptionMutation,
+    type DeliveryExceptionSubmitResult,
+    deliveryExceptionConfirmation,
+} from '../lib/deliveryExceptionPresentation';
+import {
     clearPickupManifestQueueScope,
     createWebStoragePickupManifestQueuePersistence,
 } from '../lib/pickupManifestQueue';
@@ -189,6 +194,21 @@ const refreshPreparationCodes = new Set([
     'preparation-not-found',
 ]);
 
+type DeliveryExceptionAction = (
+    runId: string,
+    stopId: number,
+    mutation: DeliveryExceptionMutation,
+) => Promise<DeliveryExceptionSubmitResult>;
+
+type DeliveryActionResult =
+    | { status: 'saved' }
+    | {
+          status: 'failed';
+          code: string | null;
+          statusCode: number | null;
+          message: string;
+      };
+
 function DriverDashboardWithPickupSync({
     dashboard,
     trackingState,
@@ -198,6 +218,7 @@ function DriverDashboardWithPickupSync({
     onRetry,
     onArrive,
     onDeliver,
+    onException,
     onPickupError,
     onPickupAcknowledged,
 }: {
@@ -222,6 +243,7 @@ function DriverDashboardWithPickupSync({
         expectedRouteRevision: number,
         notes?: string,
     ) => void;
+    onException: DeliveryExceptionAction;
     onPickupError: (error: unknown) => void;
     onPickupAcknowledged: () => void | Promise<void>;
 }) {
@@ -237,6 +259,7 @@ function DriverDashboardWithPickupSync({
                 onRetry={onRetry}
                 onArrive={onArrive}
                 onDeliver={onDeliver}
+                onException={onException}
                 pickupQueue={null}
                 onPickupScan={() => undefined}
                 onPickupItemState={() => undefined}
@@ -258,6 +281,7 @@ function DriverDashboardWithPickupSync({
             onRetry={onRetry}
             onArrive={onArrive}
             onDeliver={onDeliver}
+            onException={onException}
             onPickupError={onPickupError}
             onPickupAcknowledged={onPickupAcknowledged}
         />
@@ -274,6 +298,7 @@ function ActiveDriverDashboardWithPickupSync({
     onRetry,
     onArrive,
     onDeliver,
+    onException,
     onPickupError,
     onPickupAcknowledged,
 }: {
@@ -299,6 +324,7 @@ function ActiveDriverDashboardWithPickupSync({
         expectedRouteRevision: number,
         notes?: string,
     ) => void;
+    onException: DeliveryExceptionAction;
     onPickupError: (error: unknown) => void;
     onPickupAcknowledged: () => void | Promise<void>;
 }) {
@@ -325,6 +351,7 @@ function ActiveDriverDashboardWithPickupSync({
             onRetry={onRetry}
             onArrive={onArrive}
             onDeliver={onDeliver}
+            onException={onException}
             pickupQueue={pickupSync.snapshot}
             onPickupScan={(pickupNodeId, scanValue) =>
                 report(pickupSync.enqueueScan(pickupNodeId, scanValue))
@@ -355,6 +382,9 @@ function ActiveDriverDashboardWithPickupSync({
 export function DeliveryDashboard() {
     const [pendingAction, setPendingAction] = useState<string | null>(null);
     const [actionError, setActionError] = useState<string | null>(null);
+    const [actionConfirmation, setActionConfirmation] = useState<string | null>(
+        null,
+    );
     const query = useQuery({
         queryKey: ['delivery-dashboard'],
         queryFn: readDashboard,
@@ -386,24 +416,34 @@ export function DeliveryDashboard() {
         previousDriverUserIdRef.current = currentDriverUserId;
     }, [currentDriverUserId]);
 
-    const perform = async (key: string, path: string, body?: object) => {
+    const perform = async (
+        key: string,
+        path: string,
+        body?: object,
+        confirmation?: string,
+    ): Promise<DeliveryActionResult> => {
         setPendingAction(key);
         setActionError(null);
+        setActionConfirmation(null);
         try {
             await postAction(path, body);
             await query.refetch();
+            setActionConfirmation(confirmation ?? null);
+            return { status: 'saved' };
         } catch (error) {
-            if (
-                error instanceof DeliveryActionError &&
-                error.code === 'route-revision-conflict'
-            ) {
+            const code =
+                error instanceof DeliveryActionError ? error.code : null;
+            const statusCode =
+                error instanceof DeliveryActionError ? error.status : null;
+            if (statusCode === 409 || code === 'route-revision-conflict') {
                 await query.refetch();
             }
-            setActionError(
+            const message =
                 error instanceof Error
                     ? error.message
-                    : 'Radnju nije moguće dovršiti.',
-            );
+                    : 'Radnju nije moguće dovršiti.';
+            setActionError(message);
+            return { status: 'failed', code, statusCode, message };
         } finally {
             setPendingAction(null);
         }
@@ -412,6 +452,7 @@ export function DeliveryDashboard() {
     const startRun = async (deliveryRequestIds: string[]) => {
         setPendingAction('start-route');
         setActionError(null);
+        setActionConfirmation(null);
         try {
             const createPreparation = async () => {
                 const data = await postAction('/api/driver/runs/preflight', {
@@ -519,12 +560,35 @@ export function DeliveryDashboard() {
                     </Alert>
                 </div>
             ) : null}
+            {actionConfirmation ? (
+                <div className="fixed inset-x-4 top-4 z-50 mx-auto max-w-xl">
+                    <Alert
+                        color="success"
+                        endDecorator={
+                            <Button
+                                aria-label="Zatvori potvrdu"
+                                color="success"
+                                size="sm"
+                                variant="plain"
+                                onClick={() => setActionConfirmation(null)}
+                            >
+                                U redu
+                            </Button>
+                        }
+                    >
+                        {actionConfirmation}
+                    </Alert>
+                </div>
+            ) : null}
             {dashboard.kind === 'driver' ? (
                 <DriverDashboardWithPickupSync
                     dashboard={dashboard}
                     trackingState={trackingState}
                     pendingAction={pendingAction}
-                    onSelectionChange={() => setActionError(null)}
+                    onSelectionChange={() => {
+                        setActionError(null);
+                        setActionConfirmation(null);
+                    }}
                     onStartRun={(deliveryRequestIds) =>
                         void startRun(deliveryRequestIds)
                     }
@@ -554,13 +618,37 @@ export function DeliveryDashboard() {
                             },
                         )
                     }
-                    onPickupError={(error) =>
+                    onException={async (runId, stopId, mutation) => {
+                        const result = await perform(
+                            `${stopId}:exception`,
+                            `/api/driver/runs/${runId}/exceptions`,
+                            mutation,
+                            deliveryExceptionConfirmation(mutation),
+                        );
+                        if (result.status === 'saved') {
+                            return result;
+                        }
+                        if (result.statusCode === 409) {
+                            return {
+                                status: 'review-required',
+                                message:
+                                    'Ruta ili odabrani urodi promijenili su se. Provjeri osvježeni odabir i ponovno potvrdi spremanje.',
+                            };
+                        }
+                        return {
+                            status: 'retryable',
+                            message:
+                                'Promjena možda nije potvrđena. Provjeri vezu i pokušaj ponovno bez izmjene odabira.',
+                        };
+                    }}
+                    onPickupError={(error) => {
+                        setActionConfirmation(null);
                         setActionError(
                             error instanceof Error
                                 ? error.message
                                 : 'Promjenu preuzimanja nije moguće spremiti.',
-                        )
-                    }
+                        );
+                    }}
                     onPickupAcknowledged={async () => {
                         await query.refetch();
                     }}

--- a/apps/delivery/components/DeliveryExceptionSheet.tsx
+++ b/apps/delivery/components/DeliveryExceptionSheet.tsx
@@ -1,0 +1,516 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Checkbox } from '@gredice/ui/Checkbox';
+import { Chip } from '@gredice/ui/Chip';
+import { Mail, Mobile, Reset, Warning } from '@gredice/ui/icons';
+import { Modal } from '@gredice/ui/Modal';
+import { Typography } from '@gredice/ui/Typography';
+import { type FormEvent, useState } from 'react';
+import type {
+    DeliveryExceptionOutcome,
+    DeliveryExceptionReason,
+    DeliveryStopSummary,
+} from '../lib/deliveryDashboardTypes';
+import {
+    actionableDeliveryExceptionItems,
+    buildDeliveryExceptionMutation,
+    type DeliveryExceptionMutation,
+    type DeliveryExceptionSubmitResult,
+    deliveryDispatchContactHref,
+    deliveryExceptionItemIdentityLabels,
+    deliveryExceptionOutcomeOptions,
+    deliveryExceptionReasonOptions,
+} from '../lib/deliveryExceptionPresentation';
+
+export function DeliveryExceptionSheet({
+    runId,
+    routeRevision,
+    stop,
+    disabled,
+    onSubmit,
+}: {
+    runId: string;
+    routeRevision: number;
+    stop: DeliveryStopSummary;
+    disabled: boolean;
+    onSubmit: (
+        mutation: DeliveryExceptionMutation,
+    ) => Promise<DeliveryExceptionSubmitResult>;
+}) {
+    const actionableDeliveries = actionableDeliveryExceptionItems(
+        stop.deliveries,
+    );
+    const deliveryIdentityLabels =
+        deliveryExceptionItemIdentityLabels(actionableDeliveries);
+    const [open, setOpen] = useState(false);
+    const [reason, setReason] = useState<DeliveryExceptionReason>(
+        'customer-unavailable',
+    );
+    const [outcome, setOutcome] =
+        useState<Exclude<DeliveryExceptionOutcome, 'cancelled'>>('deferred');
+    const [selectedRequestIds, setSelectedRequestIds] = useState<string[]>([]);
+    const [note, setNote] = useState('');
+    const [pendingMutation, setPendingMutation] =
+        useState<DeliveryExceptionMutation | null>(null);
+    const [terminalConfirmed, setTerminalConfirmed] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const [validationMessage, setValidationMessage] = useState<string | null>(
+        null,
+    );
+    const mutationPending = disabled || submitting;
+    const effectiveOutcome: DeliveryExceptionOutcome =
+        reason === 'cancellation' ? 'cancelled' : outcome;
+    const selectedDeliveries = actionableDeliveries.filter((delivery) =>
+        selectedRequestIds.includes(delivery.requestId),
+    );
+    const terminalOutcome = effectiveOutcome !== 'deferred';
+
+    function resetDraft() {
+        setReason('customer-unavailable');
+        setOutcome('deferred');
+        setSelectedRequestIds(
+            actionableDeliveries.length === 1
+                ? actionableDeliveries.map((delivery) => delivery.requestId)
+                : [],
+        );
+        setNote('');
+        setPendingMutation(null);
+        setTerminalConfirmed(false);
+        setValidationMessage(null);
+    }
+
+    function handleOpenChange(nextOpen: boolean) {
+        if (mutationPending) return;
+        if (nextOpen) resetDraft();
+        setOpen(nextOpen);
+    }
+
+    function invalidatePendingOperation() {
+        setPendingMutation(null);
+        setTerminalConfirmed(false);
+        setValidationMessage(null);
+    }
+
+    function toggleDelivery(requestId: string, checked: boolean) {
+        invalidatePendingOperation();
+        setSelectedRequestIds((current) =>
+            checked
+                ? Array.from(new Set([...current, requestId]))
+                : current.filter((candidate) => candidate !== requestId),
+        );
+    }
+
+    async function submitException(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (mutationPending) return;
+
+        let mutation = pendingMutation;
+        if (!mutation) {
+            const result = buildDeliveryExceptionMutation({
+                deliveries: actionableDeliveries,
+                selectedRequestIds,
+                outcome,
+                reason,
+                note,
+                expectedRouteRevision: routeRevision,
+                clientOperationId: crypto.randomUUID(),
+                occurredAt: new Date().toISOString(),
+            });
+            if (result.status === 'invalid') {
+                setValidationMessage(result.message);
+                return;
+            }
+            if (terminalOutcome && !terminalConfirmed) {
+                setValidationMessage(
+                    'Potvrdi završni ishod za točno navedene urode prije spremanja.',
+                );
+                return;
+            }
+            mutation = result.mutation;
+            setPendingMutation(mutation);
+        }
+
+        setSubmitting(true);
+        setValidationMessage(null);
+        try {
+            const result = await onSubmit(mutation);
+            if (result.status === 'saved') {
+                setOpen(false);
+                resetDraft();
+                return;
+            }
+            if (result.status === 'review-required') {
+                setPendingMutation(null);
+                setTerminalConfirmed(false);
+            }
+            setValidationMessage(result.message);
+        } catch {
+            setValidationMessage(
+                'Promjena je možda spremljena. Provjeri vezu i pokušaj ponovno bez izmjene odabira.',
+            );
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <Modal
+            open={open}
+            onOpenChange={handleOpenChange}
+            title="Prijavi problem s dostavom"
+            description="Odaberi pogođene urode, zabilježi razlog i jasno odredi hoće li se dostava pokušati ponovno."
+            dismissible={!mutationPending}
+            className="md:max-w-2xl"
+            trigger={
+                <Button
+                    color="warning"
+                    variant="outlined"
+                    disabled={disabled || actionableDeliveries.length === 0}
+                    startDecorator={<Warning className="size-4" />}
+                >
+                    Prijavi problem
+                </Button>
+            }
+        >
+            <form className="space-y-5" onSubmit={submitException}>
+                <div className="pr-8">
+                    <Typography level="h3" semiBold>
+                        Problem na trenutačnoj stanici
+                    </Typography>
+                    <Typography
+                        level="body3"
+                        className="mt-1 text-muted-foreground"
+                    >
+                        Odaberi samo urode na koje se problem odnosi. Ostali
+                        urodi na skupnoj stanici ostaju spremni za predaju.
+                    </Typography>
+                </div>
+
+                <fieldset className="space-y-2" disabled={mutationPending}>
+                    <legend className="text-sm font-semibold">
+                        Pogođeni urodi
+                    </legend>
+                    {actionableDeliveries.length > 1 ? (
+                        <div className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-muted/60 px-3 py-2">
+                            <Typography level="body3">
+                                Skupna stanica · odabrano{' '}
+                                {selectedDeliveries.length} od{' '}
+                                {actionableDeliveries.length}
+                            </Typography>
+                            <div className="flex gap-2">
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="plain"
+                                    onClick={() => {
+                                        invalidatePendingOperation();
+                                        setSelectedRequestIds(
+                                            actionableDeliveries.map(
+                                                (delivery) =>
+                                                    delivery.requestId,
+                                            ),
+                                        );
+                                    }}
+                                >
+                                    Odaberi sve
+                                </Button>
+                                {selectedRequestIds.length > 0 ? (
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant="plain"
+                                        onClick={() => {
+                                            invalidatePendingOperation();
+                                            setSelectedRequestIds([]);
+                                        }}
+                                    >
+                                        Poništi odabir
+                                    </Button>
+                                ) : null}
+                            </div>
+                        </div>
+                    ) : null}
+                    <ul
+                        className="space-y-2"
+                        aria-label="Urodi obuhvaćeni problemom"
+                    >
+                        {actionableDeliveries.map((delivery) => {
+                            const checked = selectedRequestIds.includes(
+                                delivery.requestId,
+                            );
+                            const identityLabel =
+                                deliveryIdentityLabels.get(
+                                    delivery.requestId,
+                                ) ?? delivery.harvest.plantName;
+                            return (
+                                <li
+                                    key={delivery.requestId}
+                                    className="flex min-h-12 flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                                >
+                                    <Checkbox
+                                        checked={checked}
+                                        disabled={mutationPending}
+                                        label={
+                                            <span className="block min-w-0">
+                                                <span className="block font-semibold break-words">
+                                                    {identityLabel}
+                                                </span>
+                                            </span>
+                                        }
+                                        onCheckedChange={(value) =>
+                                            toggleDelivery(
+                                                delivery.requestId,
+                                                value === true,
+                                            )
+                                        }
+                                    />
+                                    {delivery.phone ? (
+                                        <Button
+                                            href={`tel:${delivery.phone}`}
+                                            size="sm"
+                                            variant="plain"
+                                            aria-label={`Nazovi kontakt za ${identityLabel}`}
+                                            startDecorator={
+                                                <Mobile className="size-4" />
+                                            }
+                                        >
+                                            Nazovi
+                                        </Button>
+                                    ) : null}
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </fieldset>
+
+                <fieldset className="space-y-2" disabled={mutationPending}>
+                    <legend className="text-sm font-semibold">
+                        Što se dogodilo?
+                    </legend>
+                    <div className="grid gap-2 sm:grid-cols-2">
+                        {deliveryExceptionReasonOptions.map((option) => (
+                            <label
+                                key={option.value}
+                                className={`flex min-h-16 cursor-pointer flex-col justify-center rounded-lg border px-3 py-2 transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 ${
+                                    reason === option.value
+                                        ? 'border-primary bg-primary/10 ring-1 ring-primary/30'
+                                        : 'bg-background hover:bg-muted/60'
+                                }`}
+                            >
+                                <input
+                                    className="sr-only"
+                                    type="radio"
+                                    name="delivery-exception-reason"
+                                    value={option.value}
+                                    checked={reason === option.value}
+                                    onChange={() => {
+                                        invalidatePendingOperation();
+                                        setReason(option.value);
+                                    }}
+                                />
+                                <span className="text-sm font-semibold">
+                                    {option.label}
+                                </span>
+                                <span className="text-xs text-muted-foreground">
+                                    {option.description}
+                                </span>
+                            </label>
+                        ))}
+                    </div>
+                </fieldset>
+
+                {reason === 'cancellation' ? (
+                    <Alert
+                        color="danger"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        Otkazivanje je terminalno. Odabrani urodi uklanjaju se
+                        iz aktivne dostave i neće dobiti ponovni pokušaj.
+                    </Alert>
+                ) : (
+                    <fieldset className="space-y-2" disabled={mutationPending}>
+                        <legend className="text-sm font-semibold">
+                            Što slijedi?
+                        </legend>
+                        <div className="grid gap-2 sm:grid-cols-2">
+                            {deliveryExceptionOutcomeOptions.map((option) => (
+                                <label
+                                    key={option.value}
+                                    className={`flex min-h-20 cursor-pointer flex-col justify-center rounded-lg border px-3 py-2 transition-colors focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 ${
+                                        outcome === option.value
+                                            ? option.terminal
+                                                ? 'border-red-400 bg-red-50 ring-1 ring-red-300 dark:bg-red-950'
+                                                : 'border-amber-400 bg-amber-50 ring-1 ring-amber-300 dark:bg-amber-950'
+                                            : 'bg-background hover:bg-muted/60'
+                                    }`}
+                                >
+                                    <input
+                                        className="sr-only"
+                                        type="radio"
+                                        name="delivery-exception-outcome"
+                                        value={option.value}
+                                        checked={outcome === option.value}
+                                        onChange={() => {
+                                            invalidatePendingOperation();
+                                            setOutcome(option.value);
+                                        }}
+                                    />
+                                    <span className="flex items-center gap-2 text-sm font-semibold">
+                                        {option.value === 'deferred' ? (
+                                            <Reset className="size-4" />
+                                        ) : (
+                                            <Warning className="size-4" />
+                                        )}
+                                        {option.label}
+                                        <Chip
+                                            color={
+                                                option.terminal
+                                                    ? 'error'
+                                                    : 'warning'
+                                            }
+                                            size="sm"
+                                        >
+                                            {option.terminal
+                                                ? 'Terminalno'
+                                                : 'Ponovni pokušaj'}
+                                        </Chip>
+                                    </span>
+                                    <span className="mt-1 text-xs text-muted-foreground">
+                                        {option.description}
+                                    </span>
+                                </label>
+                            ))}
+                        </div>
+                    </fieldset>
+                )}
+
+                <div className="space-y-1">
+                    <label
+                        className="block text-sm font-semibold"
+                        htmlFor={`delivery-exception-note-${stop.id ?? stop.requestId}`}
+                    >
+                        Operativna napomena
+                        {reason === 'operational-other'
+                            ? ' (obavezno)'
+                            : ' (opcionalno)'}
+                    </label>
+                    <textarea
+                        id={`delivery-exception-note-${stop.id ?? stop.requestId}`}
+                        value={note}
+                        onChange={(event) => {
+                            invalidatePendingOperation();
+                            setNote(event.currentTarget.value);
+                        }}
+                        rows={3}
+                        maxLength={1_000}
+                        disabled={mutationPending}
+                        aria-describedby={`delivery-exception-note-help-${stop.id ?? stop.requestId}`}
+                        className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+                        placeholder="Informacije korisne dispečeru (ne prikazuju se korisniku)"
+                    />
+                    <Typography
+                        id={`delivery-exception-note-help-${stop.id ?? stop.requestId}`}
+                        level="body3"
+                        className="text-muted-foreground"
+                    >
+                        Napomena je interna i korisnik je neće vidjeti.{' '}
+                        {note.length}
+                        /1000
+                    </Typography>
+                </div>
+
+                {effectiveOutcome === 'failed' ? (
+                    <Alert
+                        color="danger"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        Ovo je završni ishod za odabrane urode. Provjeri odabir
+                        prije spremanja.
+                    </Alert>
+                ) : null}
+
+                {terminalOutcome && selectedDeliveries.length > 0 ? (
+                    <div className="space-y-3 rounded-lg border border-red-300 bg-red-50 p-3 text-red-950 dark:border-red-800 dark:bg-red-950 dark:text-red-100">
+                        <div>
+                            <Typography level="body2" semiBold>
+                                Potvrdi završni ishod za{' '}
+                                {selectedDeliveries.length}{' '}
+                                {selectedDeliveries.length === 1
+                                    ? 'urod'
+                                    : 'uroda'}
+                            </Typography>
+                            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
+                                {selectedDeliveries.map((delivery) => (
+                                    <li key={delivery.requestId}>
+                                        {deliveryIdentityLabels.get(
+                                            delivery.requestId,
+                                        ) ?? delivery.harvest.plantName}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                        <Checkbox
+                            checked={terminalConfirmed}
+                            disabled={mutationPending}
+                            label="Potvrđujem da samo navedeni urodi dobivaju završni ishod."
+                            onCheckedChange={(value) => {
+                                setPendingMutation(null);
+                                setValidationMessage(null);
+                                setTerminalConfirmed(value === true);
+                            }}
+                        />
+                    </div>
+                ) : null}
+
+                {validationMessage ? (
+                    <Alert
+                        color="warning"
+                        aria-live="assertive"
+                        startDecorator={<Warning className="size-5" />}
+                    >
+                        {validationMessage}
+                    </Alert>
+                ) : null}
+
+                <div className="flex flex-col-reverse gap-2 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+                    <Button
+                        href={deliveryDispatchContactHref({
+                            runId,
+                            stopId: stop.id,
+                        })}
+                        variant="plain"
+                        startDecorator={<Mail className="size-4" />}
+                    >
+                        Javi se dispečeru
+                    </Button>
+                    <div className="flex flex-col-reverse gap-2 sm:flex-row">
+                        <Button
+                            type="button"
+                            variant="plain"
+                            disabled={mutationPending}
+                            onClick={() => handleOpenChange(false)}
+                        >
+                            Odustani
+                        </Button>
+                        <Button
+                            type="submit"
+                            color={
+                                effectiveOutcome === 'deferred'
+                                    ? 'warning'
+                                    : 'danger'
+                            }
+                            loading={submitting}
+                            disabled={mutationPending}
+                        >
+                            {effectiveOutcome === 'deferred'
+                                ? 'Spremi i nastavi rutu'
+                                : 'Potvrdi završni ishod'}
+                        </Button>
+                    </div>
+                </div>
+            </form>
+        </Modal>
+    );
+}

--- a/apps/delivery/components/DeliveryStopCard.tsx
+++ b/apps/delivery/components/DeliveryStopCard.tsx
@@ -22,11 +22,20 @@ import { Typography } from '@gredice/ui/Typography';
 import { useState } from 'react';
 import type { DeliveryStopSummary } from '../lib/deliveryDashboardTypes';
 import {
+    actionableDeliveryExceptionItems,
+    type DeliveryExceptionMutation,
+    type DeliveryExceptionSubmitResult,
+    deliveryExceptionOutcomeLabel,
+    deliveryExceptionReasonLabel,
+} from '../lib/deliveryExceptionPresentation';
+import {
     formatDeliveryDateTime,
     formatDeliveryTime,
     formatDistance,
     formatTravelDuration,
 } from '../lib/deliveryFormatting';
+import { DeliveryCustomerRecovery } from './DeliveryCustomerRecovery';
+import { DeliveryExceptionSheet } from './DeliveryExceptionSheet';
 import { DeliveryHarvestVerification } from './DeliveryHarvestVerification';
 
 function statusColor(
@@ -34,7 +43,14 @@ function statusColor(
 ): 'success' | 'info' | 'error' | 'warning' | 'neutral' {
     if (status === 'Dostavljeno') return 'success';
     if (status === 'Vozač je stigao') return 'info';
-    if (status === 'Otkazano') return 'error';
+    if (
+        status === 'Otkazano' ||
+        status === 'Dostava je otkazana' ||
+        status === 'Dostava nije uspjela'
+    ) {
+        return 'error';
+    }
+    if (status === 'Dostava je odgođena') return 'warning';
     if (status === 'Vozač stiže' || status === 'U dostavi') {
         return 'warning';
     }
@@ -45,16 +61,22 @@ export function DeliveryStopCard({
     stop,
     mode,
     pendingAction,
+    routeRevision,
     onRetry,
     onArrive,
     onDeliver,
+    onException,
 }: {
     stop: DeliveryStopSummary;
     mode: 'driver' | 'customer';
-    pendingAction?: 'retry' | 'arrive' | 'deliver' | null;
+    pendingAction?: 'retry' | 'arrive' | 'deliver' | 'exception' | null;
+    routeRevision?: number;
     onRetry?: () => void;
     onArrive?: () => void;
     onDeliver?: (notes?: string) => void;
+    onException?: (
+        mutation: DeliveryExceptionMutation,
+    ) => Promise<DeliveryExceptionSubmitResult>;
 }) {
     const [notes, setNotes] = useState('');
     const navigationUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(stop.address)}`;
@@ -64,11 +86,33 @@ export function DeliveryStopCard({
         stop.actionState ??
         (delivered ? 'completed' : stop.isCurrent ? 'current' : 'upcoming');
     const customerActionAvailable = driverActionState === 'current';
+    const actionableDeliveries = actionableDeliveryExceptionItems(
+        stop.deliveries,
+    );
+    const currentDeliveryCount =
+        stop.stopState === 'deferred'
+            ? stop.deliveryCount
+            : actionableDeliveries.length;
+    const displayedDeliveryCount =
+        driverMode && customerActionAvailable && !delivered
+            ? currentDeliveryCount
+            : stop.deliveryCount;
+    const groupedDelivery = stop.deliveries.length > 1;
     const estimatedOutsideWindow = Boolean(
         stop.estimatedArrivalAt &&
             stop.slotEndAt &&
             new Date(stop.estimatedArrivalAt) > new Date(stop.slotEndAt),
     );
+    const completedDriverException =
+        driverMode &&
+        driverActionState === 'completed' &&
+        (stop.stopState === 'failed' || stop.stopState === 'cancelled');
+    const showRouteEstimates =
+        Boolean(stop.estimatedArrivalAt || stop.estimatedTravelSeconds) &&
+        !completedDriverException &&
+        (driverMode ||
+            !stop.recovery ||
+            stop.recovery.kind === 'retry-planned');
 
     return (
         <Card
@@ -97,8 +141,8 @@ export function DeliveryStopCard({
                                 className="truncate"
                             >
                                 {driverMode
-                                    ? stop.deliveryCount > 1
-                                        ? `${stop.deliveryCount} uroda · skupna dostava`
+                                    ? groupedDelivery
+                                        ? `${displayedDeliveryCount} ${displayedDeliveryCount === 1 ? 'urod' : 'uroda'} · skupna dostava`
                                         : stop.contactName
                                     : stop.harvest.plantName}
                             </Typography>
@@ -107,7 +151,7 @@ export function DeliveryStopCard({
                                 className="mt-0.5 text-muted-foreground"
                             >
                                 {driverMode
-                                    ? stop.deliveryCount > 1
+                                    ? groupedDelivery
                                         ? 'Ista adresa i termin'
                                         : stop.harvest.plantName
                                     : formatDeliveryDateTime(stop.slotStartAt)}
@@ -119,7 +163,7 @@ export function DeliveryStopCard({
                     </Chip>
                 </div>
 
-                {stop.estimatedArrivalAt || stop.estimatedTravelSeconds ? (
+                {showRouteEstimates ? (
                     <div className="grid grid-cols-3 gap-2 rounded-lg bg-muted/70 p-3 text-center">
                         <div>
                             <Typography
@@ -159,6 +203,10 @@ export function DeliveryStopCard({
                     </div>
                 ) : null}
 
+                {!driverMode && stop.recovery ? (
+                    <DeliveryCustomerRecovery recovery={stop.recovery} />
+                ) : null}
+
                 {driverMode ? (
                     <div className="space-y-2 text-sm">
                         {stop.slotStartAt && stop.slotEndAt ? (
@@ -175,7 +223,9 @@ export function DeliveryStopCard({
                             <MapPin className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
                             <span>{stop.address}</span>
                         </div>
-                        {estimatedOutsideWindow && !delivered ? (
+                        {showRouteEstimates &&
+                        estimatedOutsideWindow &&
+                        !delivered ? (
                             <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
                                 <Warning className="mt-0.5 size-4 shrink-0" />
                                 <span>
@@ -220,18 +270,31 @@ export function DeliveryStopCard({
                 !delivered &&
                 stop.stopState !== 'deferred' ? (
                     <div className="space-y-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
-                        <Button
-                            href={navigationUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            variant="outlined"
-                            startDecorator={<Navigate className="size-4" />}
-                        >
-                            Navigacija
-                        </Button>
+                        <div className="flex flex-wrap gap-2">
+                            <Button
+                                href={navigationUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                variant="outlined"
+                                startDecorator={<Navigate className="size-4" />}
+                            >
+                                Navigacija
+                            </Button>
+                            {stop.runId &&
+                            routeRevision !== undefined &&
+                            onException ? (
+                                <DeliveryExceptionSheet
+                                    runId={stop.runId}
+                                    routeRevision={routeRevision}
+                                    stop={stop}
+                                    disabled={Boolean(pendingAction)}
+                                    onSubmit={onException}
+                                />
+                            ) : null}
+                        </div>
                         {stop.stopState === 'arrived' ? (
                             <DeliveryHarvestVerification
-                                deliveries={stop.deliveries}
+                                deliveries={actionableDeliveries}
                                 disabled={Boolean(pendingAction)}
                             />
                         ) : (
@@ -247,7 +310,7 @@ export function DeliveryStopCard({
                             className="block text-sm font-medium"
                             htmlFor={`notes-${stop.id}`}
                         >
-                            {stop.deliveryCount > 1
+                            {groupedDelivery
                                 ? 'Napomena za skupnu dostavu'
                                 : 'Napomena o dostavi'}
                         </label>
@@ -280,12 +343,15 @@ export function DeliveryStopCard({
                             <Button
                                 color="success"
                                 loading={pendingAction === 'deliver'}
-                                disabled={Boolean(pendingAction)}
+                                disabled={
+                                    Boolean(pendingAction) ||
+                                    actionableDeliveries.length === 0
+                                }
                                 onClick={() => onDeliver?.(notes || undefined)}
                                 startDecorator={<Approved className="size-4" />}
                             >
-                                {stop.deliveryCount > 1
-                                    ? `Dostavi ${stop.deliveryCount} uroda · dalje`
+                                {groupedDelivery
+                                    ? `Dostavi ${actionableDeliveries.length} ${actionableDeliveries.length === 1 ? 'urod' : 'uroda'} · dalje`
                                     : 'Dostavljeno · dalje'}
                             </Button>
                         </div>
@@ -329,37 +395,53 @@ export function DeliveryStopCard({
                                                 .join(' · ')}
                                         </span>
                                     </div>
+                                    {delivery.exception ? (
+                                        <div className="space-y-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <Chip
+                                                    color={
+                                                        delivery.exception
+                                                            .outcome ===
+                                                        'deferred'
+                                                            ? 'warning'
+                                                            : 'error'
+                                                    }
+                                                    size="sm"
+                                                >
+                                                    {deliveryExceptionOutcomeLabel(
+                                                        delivery.exception
+                                                            .outcome,
+                                                    )}
+                                                </Chip>
+                                                <span className="font-medium">
+                                                    {deliveryExceptionReasonLabel(
+                                                        delivery.exception
+                                                            .reason,
+                                                    )}
+                                                </span>
+                                            </div>
+                                            {delivery.exception.note ? (
+                                                <Typography level="body3">
+                                                    Interna napomena:{' '}
+                                                    {delivery.exception.note}
+                                                </Typography>
+                                            ) : null}
+                                            <Typography
+                                                level="body3"
+                                                className="text-current/70"
+                                            >
+                                                Zabilježeno{' '}
+                                                {formatDeliveryDateTime(
+                                                    delivery.exception
+                                                        .occurredAt,
+                                                )}
+                                            </Typography>
+                                        </div>
+                                    ) : null}
                                     {delivery.requestNotes ? (
                                         <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
                                             <strong>Napomena:</strong>{' '}
                                             {delivery.requestNotes}
-                                        </div>
-                                    ) : null}
-                                    {delivery.accountContacts.length > 0 ? (
-                                        <div className="border-t pt-2">
-                                            <Typography
-                                                level="body3"
-                                                semiBold
-                                                className="mb-1"
-                                            >
-                                                Korisnici računa
-                                            </Typography>
-                                            {delivery.accountContacts.map(
-                                                (contact) => (
-                                                    <div
-                                                        key={contact.id}
-                                                        className="text-sm"
-                                                    >
-                                                        {contact.displayName} ·{' '}
-                                                        <a
-                                                            href={`mailto:${contact.email}`}
-                                                            className="text-primary hover:underline"
-                                                        >
-                                                            {contact.email}
-                                                        </a>
-                                                    </div>
-                                                ),
-                                            )}
                                         </div>
                                     ) : null}
                                     {delivery.harvest.tracePath ? (
@@ -400,12 +482,16 @@ export function DeliveryStopCard({
                             ) : null}
                         </>
                     )}
-                    {!driverMode && estimatedOutsideWindow && !delivered ? (
+                    {!driverMode &&
+                    showRouteEstimates &&
+                    estimatedOutsideWindow &&
+                    !delivered ? (
                         <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
                             <Warning className="mt-0.5 size-4 shrink-0" />
                             <span>
                                 Trenutačna procjena dolaska je nakon završetka
-                                termina. Obavijesti korisnika o kašnjenju.
+                                termina. Prikaz će se ažurirati kada vozač
+                                nastavi rutu.
                             </span>
                         </div>
                     ) : null}

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -23,6 +23,10 @@ import type {
     DeliveryRouteOrderSummary,
     DriverDeliveryDashboard,
 } from '../lib/deliveryDashboardTypes';
+import type {
+    DeliveryExceptionMutation,
+    DeliveryExceptionSubmitResult,
+} from '../lib/deliveryExceptionPresentation';
 import {
     formatDeliveryDateTime,
     formatDistance,
@@ -257,6 +261,7 @@ export function DriverDashboard({
     onRetry,
     onArrive,
     onDeliver,
+    onException,
     pickupQueue,
     onPickupScan,
     onPickupItemState,
@@ -285,6 +290,11 @@ export function DriverDashboard({
         expectedRouteRevision: number,
         notes?: string,
     ) => void;
+    onException: (
+        runId: string,
+        stopId: number,
+        mutation: DeliveryExceptionMutation,
+    ) => Promise<DeliveryExceptionSubmitResult>;
     pickupQueue: PickupManifestQueueSnapshot | null;
     onPickupScan: (pickupNodeId: string, scanValue: string) => void;
     onPickupItemState: (
@@ -858,6 +868,9 @@ export function DriverDashboard({
                                             <DeliveryStopCard
                                                 stop={stop}
                                                 mode="driver"
+                                                routeRevision={
+                                                    run.routeRevision
+                                                }
                                                 pendingAction={
                                                     pendingAction?.startsWith(
                                                         `${stop.id}:`,
@@ -870,7 +883,11 @@ export function DriverDashboard({
                                                                     ':arrive',
                                                                 )
                                                               ? 'arrive'
-                                                              : 'deliver'
+                                                              : pendingAction.endsWith(
+                                                                      ':exception',
+                                                                  )
+                                                                ? 'exception'
+                                                                : 'deliver'
                                                         : null
                                                 }
                                                 onRetry={() =>
@@ -897,6 +914,19 @@ export function DriverDashboard({
                                                         run.routeRevision,
                                                         notes,
                                                     )
+                                                }
+                                                onException={(mutation) =>
+                                                    stop.id
+                                                        ? onException(
+                                                              run.id,
+                                                              stop.id,
+                                                              mutation,
+                                                          )
+                                                        : Promise.resolve({
+                                                              status: 'review-required',
+                                                              message:
+                                                                  'Stanica više nije dostupna. Osvježi rutu i provjeri odabir.',
+                                                          })
                                                 }
                                             />
                                         </div>

--- a/apps/delivery/lib/deliveryDashboard.node.spec.ts
+++ b/apps/delivery/lib/deliveryDashboard.node.spec.ts
@@ -8,6 +8,7 @@ import {
     expandLegacyCurrentDeliveryStopIds,
     pickupManifestTracePath,
     recordedExceptionNeedsReroute,
+    visibleDeliveryNotes,
     visibleDeliveryRunTotals,
     visibleDeliveryStopEstimates,
 } from './deliveryDashboard';
@@ -378,6 +379,24 @@ test('pending reroutes suppress stale customer arrival and travel estimates', ()
             estimatedDistanceMeters: 4_000,
         },
     );
+});
+
+test('customer dashboard serialization excludes driver delivery notes', () => {
+    const sentinel = 'PRIVATE DRIVER DELIVERY NOTE';
+    const customerProjection = {
+        deliveryNotes: visibleDeliveryNotes('customer', sentinel),
+        deliveries: [
+            {
+                deliveryNotes: visibleDeliveryNotes('customer', sentinel),
+                exception: null,
+            },
+        ],
+    };
+
+    assert.equal(customerProjection.deliveryNotes, null);
+    assert.equal(customerProjection.deliveries[0]?.deliveryNotes, null);
+    assert.equal(JSON.stringify(customerProjection).includes(sentinel), false);
+    assert.equal(visibleDeliveryNotes('driver', sentinel), sentinel);
 });
 
 test('exception receipt replay returns current revision without rerouting a stale receipt', () => {

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -10,7 +10,6 @@ import {
     fulfillDeliveryRunStops,
     getActiveDeliveryRunForDriver,
     getActiveDeliveryRunStopsForRequestIds,
-    getDeliveryAccountContacts,
     getDeliveryRequest,
     getDeliveryRequestsWithEvents,
     getDeliveryRun,
@@ -31,7 +30,6 @@ import {
 import 'server-only';
 import type {
     ActiveDeliveryRunSummary,
-    DeliveryContactSummary,
     DeliveryDashboard,
     DeliveryHarvestSummary,
     DeliveryPickupManifestItemState,
@@ -44,6 +42,11 @@ import type {
     DeliveryTrackingLocation,
 } from './deliveryDashboardTypes';
 import {
+    customerDeliveryRecoverySummary,
+    driverDeliveryExceptionSummary,
+} from './deliveryExceptionPresentation';
+import {
+    configuredDeliveryHqAddress,
     DeliveryRoutePlanningError,
     formatDeliveryDestinationAddress,
     maximumDeliveryRouteStops,
@@ -76,9 +79,6 @@ export type DeliveryRun = NonNullable<
 type DeliveryRunStop = DeliveryRun['stops'][number];
 type DeliveryRunExecutionStep = Awaited<
     ReturnType<typeof getDeliveryRunExecutionProgress>
->[number];
-type DeliveryAccountContact = Awaited<
-    ReturnType<typeof getDeliveryAccountContacts>
 >[number];
 
 const driverRoles = new Set(['driver', 'admin']);
@@ -124,24 +124,6 @@ function trackingLocation(run: {
     };
 }
 
-function accountContacts(
-    accountId: string | undefined,
-    contacts: DeliveryAccountContact[],
-): DeliveryContactSummary[] {
-    if (!accountId) {
-        return [];
-    }
-
-    return contacts
-        .filter((contact) => contact.accountId === accountId)
-        .map((contact) => ({
-            id: contact.id,
-            email: contact.userName,
-            displayName: contact.displayName ?? contact.userName,
-            avatarUrl: contact.avatarUrl,
-        }));
-}
-
 function plantName(request: DeliveryRequest) {
     return (
         request.plantSort?.information?.name ??
@@ -149,6 +131,13 @@ function plantName(request: DeliveryRequest) {
         request.operationData?.information?.label ??
         'Urod'
     );
+}
+
+export function visibleDeliveryNotes(
+    audience: 'driver' | 'customer',
+    notes: string | null | undefined,
+) {
+    return audience === 'driver' ? (notes ?? null) : null;
 }
 
 function raisedBedName(request: DeliveryRequest) {
@@ -369,11 +358,13 @@ export function visibleDeliveryRunTotals({
 
 function deliverySummaryItem(
     request: DeliveryRequest,
-    contacts: DeliveryAccountContact[],
-    stop?: DeliveryRunStop | null,
+    stop: DeliveryRunStop | null | undefined,
+    audience: 'driver' | 'customer',
 ): DeliveryStopDeliverySummary {
     const address = request.address;
     return {
+        stopId: stop?.id ?? null,
+        stopState: stop?.state ?? null,
         requestId: request.id,
         requestState: request.state,
         contactName:
@@ -383,9 +374,17 @@ function deliverySummaryItem(
         phone: stop?.deliveryPhone ?? address?.phone ?? null,
         addressLabel: stop?.deliveryAddressLabel ?? address?.label ?? null,
         requestNotes: request.requestNotes ?? null,
-        deliveryNotes: request.deliveryNotes ?? null,
+        deliveryNotes: visibleDeliveryNotes(audience, request.deliveryNotes),
         harvest: harvestSummary(request),
-        accountContacts: accountContacts(request.accountId, contacts),
+        exception:
+            audience === 'driver' && stop
+                ? driverDeliveryExceptionSummary({
+                      state: stop.state,
+                      reason: stop.exceptionReason,
+                      note: stop.exceptionNote,
+                      occurredAt: stop.exceptionOccurredAt,
+                  })
+                : null,
     };
 }
 
@@ -393,7 +392,8 @@ function deliveryStopSummary({
     items,
     run,
     isCurrent,
-    contacts,
+    audience,
+    now,
     includeTracking,
     sequence,
     actionState,
@@ -402,7 +402,8 @@ function deliveryStopSummary({
     items: { request: DeliveryRequest; stop?: DeliveryRunStop | null }[];
     run?: DeliveryRunSnapshot | null;
     isCurrent: boolean;
-    contacts: DeliveryAccountContact[];
+    audience: 'driver' | 'customer';
+    now: Date;
     includeTracking: boolean;
     sequence?: number | null;
     actionState?: DeliveryStopSummary['actionState'];
@@ -482,7 +483,7 @@ function deliveryStopSummary({
         addressLabel:
             representativeStop?.deliveryAddressLabel ?? address?.label ?? null,
         requestNotes: request.requestNotes ?? null,
-        deliveryNotes: request.deliveryNotes ?? null,
+        deliveryNotes: visibleDeliveryNotes(audience, request.deliveryNotes),
         slotStartAt: iso(runSlot?.windowStartAt ?? request.slot?.startAt),
         slotEndAt: iso(runSlot?.windowEndAt ?? request.slot?.endAt),
         ...estimates,
@@ -490,12 +491,23 @@ function deliveryStopSummary({
         arrivedAt: iso(stops.find((stop) => stop.arrivedAt)?.arrivedAt),
         deliveredAt: iso(stops.find((stop) => stop.deliveredAt)?.deliveredAt),
         harvest: harvestSummary(request),
-        accountContacts: accountContacts(request.accountId, contacts),
+        recovery:
+            audience === 'customer'
+                ? customerDeliveryRecoverySummary({
+                      requestState: request.state,
+                      stopState,
+                      exceptionReason: representativeStop?.exceptionReason,
+                      exceptionRecordedAt:
+                          request.deliveryException?.recordedAt,
+                      hqAddress: configuredDeliveryHqAddress(),
+                      now,
+                  })
+                : null,
         tracking: includeTracking ? runLocation : null,
         runId: run?.id ?? null,
         deliveryCount: items.length,
         deliveries: items.map((item) =>
-            deliverySummaryItem(item.request, contacts, item.stop),
+            deliverySummaryItem(item.request, item.stop, audience),
         ),
         ...(actionState
             ? { actionState, lockedReason: lockedReason ?? null }
@@ -672,17 +684,7 @@ async function activeRunSummary(
     const requestsById = new Map(
         requests.map((request) => [request.id, request]),
     );
-    const accountIds = Array.from(
-        new Set(
-            requests
-                .map((request) => request?.accountId)
-                .filter((accountId): accountId is string => Boolean(accountId)),
-        ),
-    );
-    const [contacts, executionSteps] = await Promise.all([
-        getDeliveryAccountContacts(accountIds),
-        getDeliveryRunExecutionProgress(run.id),
-    ]);
+    const executionSteps = await getDeliveryRunExecutionProgress(run.id);
     const groupsByStopId = new Map<number, ResolvedDeliveryRunStopGroup>();
     for (const group of groups) {
         for (const { stop } of group.items) {
@@ -762,7 +764,8 @@ async function activeRunSummary(
             items,
             run,
             isCurrent: actionState === 'current',
-            contacts,
+            audience: 'driver',
+            now: new Date(),
             includeTracking: true,
             sequence: Number.isFinite(itinerarySequence)
                 ? itinerarySequence
@@ -962,7 +965,6 @@ async function customerDashboard({
     const rowsByRequestId = new Map(
         runRows.map((row) => [row.stop.deliveryRequestId, row]),
     );
-    const contacts = await getDeliveryAccountContacts([accountId]);
     const activeRunIds = Array.from(
         new Set(
             runRows.flatMap(({ run }) =>
@@ -990,6 +992,7 @@ async function customerDashboard({
         );
     }
 
+    const projectedAt = new Date();
     const deliveries = requests
         .map((request) => {
             const historicalRow = rowsByRequestId.get(request.id);
@@ -1006,7 +1009,8 @@ async function customerDashboard({
                 items: [{ request, stop: row?.stop }],
                 run: row?.run,
                 isCurrent,
-                contacts,
+                audience: 'customer',
+                now: projectedAt,
                 includeTracking:
                     row?.run.state === DeliveryRunStates.ACTIVE &&
                     isDeliveryRunStopActionable(row.stop.state) &&

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -1,4 +1,8 @@
-import type { DeliveryRunEstimateSource } from '@gredice/storage';
+import type {
+    DeliveryRunEstimateSource,
+    DeliveryRunExceptionOutcome,
+    DeliveryRunExceptionReason,
+} from '@gredice/storage';
 
 export type DeliveryTrackingLocation = {
     latitude: number;
@@ -17,14 +21,32 @@ export type DeliveryHarvestSummary = {
     tracePath: string | null;
 };
 
-export type DeliveryContactSummary = {
-    id: string;
-    email: string;
-    displayName: string;
-    avatarUrl: string | null;
+export type DeliveryExceptionOutcome = DeliveryRunExceptionOutcome;
+
+export type DeliveryExceptionReason = DeliveryRunExceptionReason;
+
+export type DriverDeliveryExceptionSummary = {
+    outcome: DeliveryExceptionOutcome;
+    reason: DeliveryExceptionReason;
+    note: string | null;
+    occurredAt: string;
 };
 
+export type CustomerDeliveryRecoverySummary =
+    | { kind: 'retry-planned' }
+    | {
+          kind: 'hq-pickup';
+          pickupAddress: string;
+          pickupDeadlineAt: string;
+          pickupWindowHours: 72;
+      }
+    | { kind: 'hq-pickup-expired' }
+    | { kind: 'support' }
+    | { kind: 'cancelled' };
+
 export type DeliveryStopDeliverySummary = {
+    stopId: number | null;
+    stopState: string | null;
     requestId: string;
     requestState: string;
     contactName: string;
@@ -33,7 +55,7 @@ export type DeliveryStopDeliverySummary = {
     requestNotes: string | null;
     deliveryNotes: string | null;
     harvest: DeliveryHarvestSummary;
-    accountContacts: DeliveryContactSummary[];
+    exception: DriverDeliveryExceptionSummary | null;
 };
 
 export type DeliveryStopSummary = {
@@ -59,7 +81,7 @@ export type DeliveryStopSummary = {
     arrivedAt: string | null;
     deliveredAt: string | null;
     harvest: DeliveryHarvestSummary;
-    accountContacts: DeliveryContactSummary[];
+    recovery: CustomerDeliveryRecoverySummary | null;
     tracking: DeliveryTrackingLocation | null;
     runId: string | null;
     deliveryCount: number;

--- a/apps/delivery/lib/deliveryExceptionPresentation.node.spec.ts
+++ b/apps/delivery/lib/deliveryExceptionPresentation.node.spec.ts
@@ -1,0 +1,540 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type {
+    DeliveryExceptionOutcome,
+    DeliveryExceptionReason,
+    DeliveryStopDeliverySummary,
+} from './deliveryDashboardTypes';
+import {
+    actionableDeliveryExceptionItems,
+    buildDeliveryExceptionMutation,
+    customerDeliveryRecoverySummary,
+    type DeliveryExceptionMutation,
+    deliveryDispatchContactHref,
+    deliveryExceptionConfirmation,
+    deliveryExceptionItemIdentityLabels,
+    deliveryExceptionOutcomeIsTerminal,
+    deliveryExceptionOutcomeLabel,
+    deliveryExceptionReasonLabel,
+    deliveryExceptionReasonOptions,
+    driverDeliveryExceptionSummary,
+} from './deliveryExceptionPresentation';
+
+const allReasons: DeliveryExceptionReason[] = [
+    'customer-unavailable',
+    'address-inaccessible',
+    'address-wrong',
+    'harvest-damaged',
+    'harvest-missing',
+    'cancellation',
+    'operational-other',
+];
+
+function delivery({
+    requestId,
+    stopId,
+    stopState = 'pending',
+}: {
+    requestId: string;
+    stopId: number | null;
+    stopState?: string;
+}): DeliveryStopDeliverySummary {
+    return {
+        stopId,
+        stopState,
+        requestId,
+        requestState: 'in_delivery',
+        contactName: `Kontakt ${requestId}`,
+        phone: null,
+        addressLabel: null,
+        requestNotes: null,
+        deliveryNotes: null,
+        harvest: {
+            plantName: `Biljka ${requestId}`,
+            operationName: null,
+            raisedBedName: null,
+            fieldName: null,
+            tracePath: null,
+        },
+        exception: null,
+    };
+}
+
+function validMutation(overrides?: {
+    deliveries?: DeliveryStopDeliverySummary[];
+    selectedRequestIds?: string[];
+    outcome?: Exclude<DeliveryExceptionOutcome, 'cancelled'>;
+    reason?: DeliveryExceptionReason;
+    note?: string;
+}) {
+    return buildDeliveryExceptionMutation({
+        deliveries: overrides?.deliveries ?? [
+            delivery({ requestId: 'request-one', stopId: 11 }),
+        ],
+        selectedRequestIds: overrides?.selectedRequestIds ?? ['request-one'],
+        outcome: overrides?.outcome ?? 'deferred',
+        reason: overrides?.reason ?? 'customer-unavailable',
+        note: overrides?.note ?? '',
+        expectedRouteRevision: 7,
+        clientOperationId: ' operation-123 ',
+        occurredAt: '2026-07-15T10:30:00+02:00',
+    });
+}
+
+function mutationWithOutcome(
+    outcome: DeliveryExceptionOutcome,
+    count: number,
+): DeliveryExceptionMutation {
+    const reason: DeliveryExceptionReason =
+        outcome === 'cancelled' ? 'cancellation' : 'customer-unavailable';
+    return {
+        expectedRouteRevision: 1,
+        clientOperationId: 'confirmation-test',
+        occurredAt: '2026-07-15T08:30:00.000Z',
+        exceptions: Array.from({ length: count }, (_, index) => ({
+            stopId: index + 1,
+            outcome,
+            reason,
+        })),
+    };
+}
+
+test('presents every supported exception reason exactly once', () => {
+    assert.deepEqual(
+        deliveryExceptionReasonOptions.map((option) => option.value),
+        allReasons,
+    );
+    assert.equal(
+        new Set(deliveryExceptionReasonOptions.map((option) => option.value))
+            .size,
+        allReasons.length,
+    );
+    for (const reason of allReasons) {
+        assert.notEqual(deliveryExceptionReasonLabel(reason), reason);
+    }
+    for (const option of deliveryExceptionReasonOptions) {
+        assert.notEqual(option.label.trim(), '');
+        assert.notEqual(option.description.trim(), '');
+    }
+});
+
+test('filters actionable children and builds a deterministic bulk subset', () => {
+    const deliveries = [
+        delivery({ requestId: 'third', stopId: 30 }),
+        delivery({
+            requestId: 'delivered',
+            stopId: 10,
+            stopState: 'delivered',
+        }),
+        delivery({ requestId: 'first', stopId: 12, stopState: 'arrived' }),
+        delivery({ requestId: 'failed', stopId: 11, stopState: 'failed' }),
+        delivery({ requestId: 'missing-stop', stopId: null }),
+        delivery({ requestId: 'second', stopId: 20 }),
+    ];
+
+    assert.deepEqual(
+        actionableDeliveryExceptionItems(deliveries).map(
+            (item) => item.requestId,
+        ),
+        ['third', 'first', 'second'],
+    );
+
+    const result = validMutation({
+        deliveries,
+        selectedRequestIds: [
+            'third',
+            'delivered',
+            'first',
+            'failed',
+            'missing-stop',
+        ],
+        outcome: 'failed',
+        reason: 'address-inaccessible',
+        note: '  Prilaz je privremeno zatvoren.  ',
+    });
+
+    assert.equal(result.status, 'valid');
+    if (result.status !== 'valid') return;
+    assert.deepEqual(result.mutation, {
+        expectedRouteRevision: 7,
+        clientOperationId: 'operation-123',
+        occurredAt: '2026-07-15T08:30:00.000Z',
+        exceptions: [
+            {
+                stopId: 12,
+                outcome: 'failed',
+                reason: 'address-inaccessible',
+                note: 'Prilaz je privremeno zatvoren.',
+            },
+            {
+                stopId: 30,
+                outcome: 'failed',
+                reason: 'address-inaccessible',
+                note: 'Prilaz je privremeno zatvoren.',
+            },
+        ],
+    });
+});
+
+test('makes colliding driver item identities unique with stable full-token fallback', () => {
+    const first = delivery({ requestId: 'request-collision-one', stopId: 41 });
+    const second = delivery({ requestId: 'request-collision-two', stopId: 42 });
+    const duplicateHarvest = {
+        plantName: 'Rajčica Roma',
+        operationName: 'Berba',
+        raisedBedName: 'Gredica Z',
+        fieldName: null,
+    };
+    const identities = deliveryExceptionItemIdentityLabels([
+        {
+            ...first,
+            contactName: 'Iva Ista',
+            harvest: {
+                ...duplicateHarvest,
+                tracePath: '/trag/shared-prefix-one-0001',
+            },
+        },
+        {
+            ...second,
+            contactName: 'Iva Ista',
+            harvest: {
+                ...duplicateHarvest,
+                tracePath: '/trag/shared-prefix-two-0001',
+            },
+        },
+    ]);
+
+    assert.equal(
+        identities.get(first.requestId),
+        'Rajčica Roma · Gredica Z · Iva Ista · trag shared-prefix-one-0001',
+    );
+    assert.equal(
+        identities.get(second.requestId),
+        'Rajčica Roma · Gredica Z · Iva Ista · trag shared-prefix-two-0001',
+    );
+    assert.notEqual(
+        identities.get(first.requestId),
+        identities.get(second.requestId),
+    );
+});
+
+test('preserves deferred and failed semantics and pairs cancellation with cancelled', () => {
+    const deferred = validMutation({ outcome: 'deferred' });
+    assert.equal(deferred.status, 'valid');
+    if (deferred.status === 'valid') {
+        assert.equal(deferred.mutation.exceptions[0]?.outcome, 'deferred');
+    }
+
+    const failed = validMutation({
+        outcome: 'failed',
+        reason: 'address-wrong',
+    });
+    assert.equal(failed.status, 'valid');
+    if (failed.status === 'valid') {
+        assert.equal(failed.mutation.exceptions[0]?.outcome, 'failed');
+    }
+
+    const cancelled = validMutation({
+        outcome: 'deferred',
+        reason: 'cancellation',
+    });
+    assert.equal(cancelled.status, 'valid');
+    if (cancelled.status === 'valid') {
+        assert.deepEqual(cancelled.mutation.exceptions[0], {
+            stopId: 11,
+            outcome: 'cancelled',
+            reason: 'cancellation',
+        });
+    }
+});
+
+test('requires an operational-other note and rejects an empty actionable selection', () => {
+    const missingNote = validMutation({
+        reason: 'operational-other',
+        note: '   ',
+    });
+    assert.deepEqual(missingNote, {
+        status: 'invalid',
+        message: 'Ukratko opiši operativni problem.',
+    });
+
+    const describedOther = validMutation({
+        reason: 'operational-other',
+        note: '  Parkirna rampa se ne otvara. ',
+    });
+    assert.equal(describedOther.status, 'valid');
+    if (describedOther.status === 'valid') {
+        assert.equal(
+            describedOther.mutation.exceptions[0]?.note,
+            'Parkirna rampa se ne otvara.',
+        );
+    }
+
+    const noSelection = validMutation({ selectedRequestIds: [] });
+    assert.deepEqual(noSelection, {
+        status: 'invalid',
+        message: 'Odaberi barem jedan urod na koji se problem odnosi.',
+    });
+
+    const onlyTerminalChildren = validMutation({
+        deliveries: [
+            delivery({
+                requestId: 'already-failed',
+                stopId: 8,
+                stopState: 'failed',
+            }),
+        ],
+        selectedRequestIds: ['already-failed'],
+    });
+    assert.equal(onlyTerminalChildren.status, 'invalid');
+});
+
+test('provides distinct confirmation copy and outcome metadata', () => {
+    const expectations: Array<{
+        outcome: DeliveryExceptionOutcome;
+        singular: string;
+        plural: string;
+        label: string;
+        terminal: boolean;
+    }> = [
+        {
+            outcome: 'deferred',
+            singular: 'Ponovni pokušaj je dodan na kraj rute za odabrani urod.',
+            plural: 'Ponovni pokušaj je dodan na kraj rute za 2 odabrana uroda.',
+            label: 'Ponovni pokušaj',
+            terminal: false,
+        },
+        {
+            outcome: 'failed',
+            singular:
+                'Neuspjela dostava je zabilježena za odabrani urod. Ruta se može nastaviti.',
+            plural: 'Neuspjela dostava je zabilježena za 2 odabrana uroda. Ruta se može nastaviti.',
+            label: 'Neuspjela dostava',
+            terminal: true,
+        },
+        {
+            outcome: 'cancelled',
+            singular:
+                'Otkazivanje je zabilježeno za odabrani urod. Ruta se može nastaviti.',
+            plural: 'Otkazivanje je zabilježeno za 2 odabrana uroda. Ruta se može nastaviti.',
+            label: 'Otkazano',
+            terminal: true,
+        },
+    ];
+
+    for (const expectation of expectations) {
+        assert.equal(
+            deliveryExceptionConfirmation(
+                mutationWithOutcome(expectation.outcome, 1),
+            ),
+            expectation.singular,
+        );
+        assert.equal(
+            deliveryExceptionConfirmation(
+                mutationWithOutcome(expectation.outcome, 2),
+            ),
+            expectation.plural,
+        );
+        assert.equal(
+            deliveryExceptionOutcomeLabel(expectation.outcome),
+            expectation.label,
+        );
+        assert.equal(
+            deliveryExceptionOutcomeIsTerminal(expectation.outcome),
+            expectation.terminal,
+        );
+    }
+});
+
+test('projects a bounded driver exception summary and rejects unknown values', () => {
+    const summary = driverDeliveryExceptionSummary({
+        state: 'failed',
+        reason: 'address-wrong',
+        note: '  Nazovi dispečera prije nastavka.  ',
+        occurredAt: new Date('2026-07-15T08:30:00.000Z'),
+    });
+
+    assert.deepEqual(summary, {
+        outcome: 'failed',
+        reason: 'address-wrong',
+        note: 'Nazovi dispečera prije nastavka.',
+        occurredAt: '2026-07-15T08:30:00.000Z',
+    });
+    assert.deepEqual(Object.keys(summary ?? {}).sort(), [
+        'note',
+        'occurredAt',
+        'outcome',
+        'reason',
+    ]);
+    assert.equal(
+        driverDeliveryExceptionSummary({
+            state: 'failed',
+            reason: 'private-legacy-reason',
+            note: 'private note',
+            occurredAt: new Date('2026-07-15T08:30:00.000Z'),
+        }),
+        null,
+    );
+    assert.equal(
+        driverDeliveryExceptionSummary({
+            state: 'pending',
+            reason: 'address-wrong',
+            note: null,
+            occurredAt: new Date('2026-07-15T08:30:00.000Z'),
+        }),
+        null,
+    );
+});
+
+test('projects retry, cancellation, and a configured 72-hour HQ pickup window', () => {
+    const configuredHqAddress = 'Konfigurirani HQ, Testna 42, Zagreb';
+    const exceptionRecordedAt = new Date('2026-07-15T08:30:00.000Z');
+    const now = new Date('2026-07-15T09:00:00.000Z');
+
+    assert.deepEqual(
+        customerDeliveryRecoverySummary({
+            requestState: 'in_delivery',
+            stopState: 'deferred',
+            exceptionReason: 'customer-unavailable',
+            hqAddress: configuredHqAddress,
+        }),
+        { kind: 'retry-planned' },
+    );
+    assert.deepEqual(
+        customerDeliveryRecoverySummary({
+            requestState: 'in_delivery',
+            stopState: 'cancelled',
+            exceptionReason: 'cancellation',
+            hqAddress: configuredHqAddress,
+        }),
+        { kind: 'cancelled' },
+    );
+    assert.deepEqual(
+        customerDeliveryRecoverySummary({
+            requestState: 'in_delivery',
+            stopState: 'failed',
+            exceptionReason: 'customer-unavailable',
+            exceptionRecordedAt,
+            hqAddress: configuredHqAddress,
+            now,
+        }),
+        {
+            kind: 'hq-pickup',
+            pickupAddress: configuredHqAddress,
+            pickupDeadlineAt: '2026-07-18T08:30:00.000Z',
+            pickupWindowHours: 72,
+        },
+    );
+    assert.deepEqual(
+        customerDeliveryRecoverySummary({
+            requestState: 'failed',
+            stopState: null,
+            exceptionReason: 'address-wrong',
+            exceptionRecordedAt,
+            hqAddress: configuredHqAddress,
+            now,
+        }),
+        {
+            kind: 'hq-pickup',
+            pickupAddress: configuredHqAddress,
+            pickupDeadlineAt: '2026-07-18T08:30:00.000Z',
+            pickupWindowHours: 72,
+        },
+    );
+
+    const customerRecovery = customerDeliveryRecoverySummary({
+        requestState: 'failed',
+        stopState: 'failed',
+        exceptionReason: 'customer-unavailable',
+        exceptionRecordedAt,
+        hqAddress: configuredHqAddress,
+        now,
+    });
+    const serializedRecovery = JSON.stringify(customerRecovery);
+    for (const privateValue of [
+        'customer-unavailable',
+        'INTERNAL DRIVER NOTE',
+        'account-owner@example.com',
+    ]) {
+        assert.equal(serializedRecovery.includes(privateValue), false);
+    }
+});
+
+test('expires HQ pickup after 72 hours and falls back safely without a reliable occurrence time', () => {
+    const input = {
+        requestState: 'failed',
+        stopState: 'failed',
+        exceptionReason: 'customer-unavailable',
+        hqAddress: 'Konfigurirani HQ, Testna 42, Zagreb',
+    };
+
+    assert.deepEqual(
+        customerDeliveryRecoverySummary({
+            ...input,
+            exceptionRecordedAt: new Date('2026-07-15T08:30:00.000Z'),
+            now: new Date('2026-07-18T08:30:00.000Z'),
+        }),
+        { kind: 'hq-pickup-expired' },
+    );
+    assert.deepEqual(
+        customerDeliveryRecoverySummary({
+            ...input,
+            exceptionRecordedAt: null,
+            now: new Date('2026-07-15T09:00:00.000Z'),
+        }),
+        { kind: 'support' },
+    );
+});
+
+test('keeps damaged, missing, other, and unknown failed recovery support-only', () => {
+    const configuredHqAddress = 'PRIVATE HQ ADDRESS MUST NOT LEAK';
+    for (const exceptionReason of [
+        'harvest-damaged',
+        'harvest-missing',
+        'operational-other',
+        'unknown-private-reason',
+    ]) {
+        const recovery = customerDeliveryRecoverySummary({
+            requestState: 'failed',
+            stopState: 'failed',
+            exceptionReason,
+            hqAddress: configuredHqAddress,
+        });
+        assert.deepEqual(recovery, { kind: 'support' });
+        assert.doesNotMatch(
+            JSON.stringify(recovery),
+            /PRIVATE|harvest|unknown-private-reason/,
+        );
+    }
+
+    assert.equal(
+        customerDeliveryRecoverySummary({
+            requestState: 'in_delivery',
+            stopState: 'pending',
+            exceptionReason: null,
+            hqAddress: configuredHqAddress,
+        }),
+        null,
+    );
+});
+
+test('creates a dispatch href with operational identifiers and no customer PII', () => {
+    const href = deliveryDispatchContactHref({
+        runId: 'run-safe-123',
+        stopId: 45,
+    });
+    const decodedHref = decodeURIComponent(href);
+
+    assert.equal(
+        decodedHref,
+        'mailto:kontakt@gredice.com?subject=Pomoć dispečera · ruta run-safe-123 · stanica 45',
+    );
+    for (const privateValue of [
+        'customer@example.com',
+        '+385991234567',
+        'Privatna 1, Zagreb',
+        'Ime Kupca',
+    ]) {
+        assert.equal(decodedHref.includes(privateValue), false);
+    }
+});

--- a/apps/delivery/lib/deliveryExceptionPresentation.ts
+++ b/apps/delivery/lib/deliveryExceptionPresentation.ts
@@ -1,0 +1,442 @@
+import type {
+    CustomerDeliveryRecoverySummary,
+    DeliveryExceptionOutcome,
+    DeliveryExceptionReason,
+    DeliveryStopDeliverySummary,
+    DriverDeliveryExceptionSummary,
+} from './deliveryDashboardTypes';
+
+// Matches the published failed-delivery pickup policy on the public delivery page.
+export const failedDeliveryHqPickupWindowHours = 72;
+
+export const deliveryExceptionReasonOptions: ReadonlyArray<{
+    value: DeliveryExceptionReason;
+    label: string;
+    description: string;
+}> = [
+    {
+        value: 'customer-unavailable',
+        label: 'Korisnik nije dostupan',
+        description: 'Nitko ne može preuzeti dostavu na adresi.',
+    },
+    {
+        value: 'address-inaccessible',
+        label: 'Adresi se ne može prići',
+        description: 'Ulaz ili prilaz trenutačno nije dostupan.',
+    },
+    {
+        value: 'address-wrong',
+        label: 'Adresa je pogrešna',
+        description: 'Dostavu nije moguće pronaći na navedenoj adresi.',
+    },
+    {
+        value: 'harvest-damaged',
+        label: 'Urod je oštećen',
+        description: 'Odabrani urod nije prikladan za predaju.',
+    },
+    {
+        value: 'harvest-missing',
+        label: 'Urod nedostaje',
+        description: 'Odabrani urod nije pronađen u vozilu.',
+    },
+    {
+        value: 'cancellation',
+        label: 'Dostava je otkazana',
+        description: 'Otkazivanje je potvrđeno s korisnikom ili dispečerom.',
+    },
+    {
+        value: 'operational-other',
+        label: 'Drugi operativni problem',
+        description: 'Problem nije obuhvaćen ponuđenim razlozima.',
+    },
+];
+
+export const deliveryExceptionOutcomeOptions: ReadonlyArray<{
+    value: Exclude<DeliveryExceptionOutcome, 'cancelled'>;
+    label: string;
+    description: string;
+    terminal: boolean;
+}> = [
+    {
+        value: 'deferred',
+        label: 'Pokušaj ponovno kasnije',
+        description:
+            'Urodi ostaju u ruti i dobivaju jasan redoslijed povratka.',
+        terminal: false,
+    },
+    {
+        value: 'failed',
+        label: 'Završi bez dostave',
+        description: 'Odabrani urodi neće se ponovno dostavljati na ovoj ruti.',
+        terminal: true,
+    },
+];
+
+export function deliveryExceptionReasonLabel(reason: DeliveryExceptionReason) {
+    return (
+        deliveryExceptionReasonOptions.find((option) => option.value === reason)
+            ?.label ?? reason
+    );
+}
+
+export function deliveryExceptionOutcomeLabel(
+    outcome: DeliveryExceptionOutcome,
+) {
+    switch (outcome) {
+        case 'deferred':
+            return 'Ponovni pokušaj';
+        case 'failed':
+            return 'Neuspjela dostava';
+        case 'cancelled':
+            return 'Otkazano';
+    }
+}
+
+export function deliveryExceptionOutcomeIsTerminal(
+    outcome: DeliveryExceptionOutcome,
+) {
+    return outcome === 'failed' || outcome === 'cancelled';
+}
+
+export type DeliveryExceptionMutation = {
+    expectedRouteRevision: number;
+    clientOperationId: string;
+    occurredAt: string;
+    exceptions: Array<{
+        stopId: number;
+        outcome: DeliveryExceptionOutcome;
+        reason: DeliveryExceptionReason;
+        note?: string;
+    }>;
+};
+
+export type DeliveryExceptionSubmitResult =
+    | { status: 'saved' }
+    | { status: 'retryable'; message: string }
+    | { status: 'review-required'; message: string };
+
+export type DeliveryExceptionMutationBuildResult =
+    | { status: 'valid'; mutation: DeliveryExceptionMutation }
+    | { status: 'invalid'; message: string };
+
+export function actionableDeliveryExceptionItems(
+    deliveries: readonly DeliveryStopDeliverySummary[],
+) {
+    return deliveries.filter(
+        (delivery) =>
+            delivery.stopId !== null &&
+            (delivery.stopState === 'pending' ||
+                delivery.stopState === 'arrived'),
+    );
+}
+
+function deliveryExceptionBaseIdentity(delivery: DeliveryStopDeliverySummary) {
+    return [
+        delivery.harvest.plantName,
+        delivery.harvest.raisedBedName,
+        delivery.harvest.fieldName,
+        delivery.contactName,
+    ]
+        .filter(Boolean)
+        .join(' · ');
+}
+
+function deliveryTraceToken(tracePath: string | null) {
+    const pathWithoutQuery = tracePath?.split(/[?#]/)[0];
+    return pathWithoutQuery?.split('/').filter(Boolean).at(-1)?.trim() || null;
+}
+
+function shortStableIdentifier(value: string) {
+    return value.length <= 12
+        ? value
+        : `${value.slice(0, 6)}…${value.slice(-4)}`;
+}
+
+/**
+ * Produces driver-only item identities. Location is always included when it is
+ * available; colliding labels receive a trace-derived suffix, or a request ID
+ * fallback when trace provenance cannot distinguish them.
+ */
+export function deliveryExceptionItemIdentityLabels(
+    deliveries: readonly DeliveryStopDeliverySummary[],
+) {
+    const groups = new Map<string, DeliveryStopDeliverySummary[]>();
+    for (const delivery of deliveries) {
+        const base = deliveryExceptionBaseIdentity(delivery);
+        groups.set(base, [...(groups.get(base) ?? []), delivery]);
+    }
+
+    const identities = new Map<string, string>();
+    for (const [base, group] of groups) {
+        if (group.length === 1) {
+            const onlyDelivery = group[0];
+            if (onlyDelivery) identities.set(onlyDelivery.requestId, base);
+            continue;
+        }
+
+        const traceTokenCounts = new Map<string, number>();
+        for (const delivery of group) {
+            const token = deliveryTraceToken(delivery.harvest.tracePath);
+            if (token) {
+                traceTokenCounts.set(
+                    token,
+                    (traceTokenCounts.get(token) ?? 0) + 1,
+                );
+            }
+        }
+        const candidates = group.map((delivery) => {
+            const traceToken = deliveryTraceToken(delivery.harvest.tracePath);
+            return traceToken && traceTokenCounts.get(traceToken) === 1
+                ? {
+                      delivery,
+                      kind: 'trag',
+                      value: traceToken,
+                  }
+                : {
+                      delivery,
+                      kind: 'zahtjev',
+                      value: delivery.requestId,
+                  };
+        });
+        const shortSuffixCounts = new Map<string, number>();
+        for (const candidate of candidates) {
+            const suffix = `${candidate.kind} ${shortStableIdentifier(candidate.value)}`;
+            shortSuffixCounts.set(
+                suffix,
+                (shortSuffixCounts.get(suffix) ?? 0) + 1,
+            );
+        }
+        for (const candidate of candidates) {
+            const shortSuffix = `${candidate.kind} ${shortStableIdentifier(candidate.value)}`;
+            const suffix =
+                shortSuffixCounts.get(shortSuffix) === 1
+                    ? shortSuffix
+                    : `${candidate.kind} ${candidate.value}`;
+            identities.set(candidate.delivery.requestId, `${base} · ${suffix}`);
+        }
+    }
+    return identities;
+}
+
+export function buildDeliveryExceptionMutation({
+    deliveries,
+    selectedRequestIds,
+    outcome,
+    reason,
+    note,
+    expectedRouteRevision,
+    clientOperationId,
+    occurredAt,
+}: {
+    deliveries: readonly DeliveryStopDeliverySummary[];
+    selectedRequestIds: readonly string[];
+    outcome: Exclude<DeliveryExceptionOutcome, 'cancelled'>;
+    reason: DeliveryExceptionReason;
+    note: string;
+    expectedRouteRevision: number;
+    clientOperationId: string;
+    occurredAt: string;
+}): DeliveryExceptionMutationBuildResult {
+    const selectedRequestIdSet = new Set(selectedRequestIds);
+    const selectedDeliveries = actionableDeliveryExceptionItems(deliveries)
+        .filter((delivery) => selectedRequestIdSet.has(delivery.requestId))
+        .sort((first, second) => (first.stopId ?? 0) - (second.stopId ?? 0));
+    if (selectedDeliveries.length === 0) {
+        return {
+            status: 'invalid',
+            message: 'Odaberi barem jedan urod na koji se problem odnosi.',
+        };
+    }
+
+    const normalizedNote = note.trim();
+    if (normalizedNote.length > 1_000) {
+        return {
+            status: 'invalid',
+            message: 'Napomena smije imati najviše 1000 znakova.',
+        };
+    }
+    if (reason === 'operational-other' && normalizedNote.length === 0) {
+        return {
+            status: 'invalid',
+            message: 'Ukratko opiši operativni problem.',
+        };
+    }
+
+    const effectiveOutcome: DeliveryExceptionOutcome =
+        reason === 'cancellation' ? 'cancelled' : outcome;
+    const parsedOccurredAt = new Date(occurredAt);
+    if (
+        !Number.isInteger(expectedRouteRevision) ||
+        expectedRouteRevision < 0 ||
+        clientOperationId.trim().length === 0 ||
+        !Number.isFinite(parsedOccurredAt.getTime())
+    ) {
+        return {
+            status: 'invalid',
+            message:
+                'Promjena dostave nije valjana. Osvježi rutu i pokušaj ponovno.',
+        };
+    }
+
+    return {
+        status: 'valid',
+        mutation: {
+            expectedRouteRevision,
+            clientOperationId: clientOperationId.trim(),
+            occurredAt: parsedOccurredAt.toISOString(),
+            exceptions: selectedDeliveries.flatMap((delivery) =>
+                delivery.stopId === null
+                    ? []
+                    : [
+                          {
+                              stopId: delivery.stopId,
+                              outcome: effectiveOutcome,
+                              reason,
+                              ...(normalizedNote
+                                  ? { note: normalizedNote }
+                                  : {}),
+                          },
+                      ],
+            ),
+        },
+    };
+}
+
+export function deliveryExceptionConfirmation(
+    mutation: DeliveryExceptionMutation,
+) {
+    const count = mutation.exceptions.length;
+    const outcome = mutation.exceptions[0]?.outcome;
+    if (outcome === 'deferred') {
+        return count === 1
+            ? 'Ponovni pokušaj je dodan na kraj rute za odabrani urod.'
+            : `Ponovni pokušaj je dodan na kraj rute za ${count} odabrana uroda.`;
+    }
+    if (outcome === 'cancelled') {
+        return count === 1
+            ? 'Otkazivanje je zabilježeno za odabrani urod. Ruta se može nastaviti.'
+            : `Otkazivanje je zabilježeno za ${count} odabrana uroda. Ruta se može nastaviti.`;
+    }
+    return count === 1
+        ? 'Neuspjela dostava je zabilježena za odabrani urod. Ruta se može nastaviti.'
+        : `Neuspjela dostava je zabilježena za ${count} odabrana uroda. Ruta se može nastaviti.`;
+}
+
+function isDeliveryExceptionReason(
+    value: string | null | undefined,
+): value is DeliveryExceptionReason {
+    switch (value) {
+        case 'customer-unavailable':
+        case 'address-inaccessible':
+        case 'address-wrong':
+        case 'harvest-damaged':
+        case 'harvest-missing':
+        case 'cancellation':
+        case 'operational-other':
+            return true;
+        default:
+            return false;
+    }
+}
+
+function isDeliveryExceptionOutcome(
+    value: string | null | undefined,
+): value is DeliveryExceptionOutcome {
+    return value === 'deferred' || value === 'failed' || value === 'cancelled';
+}
+
+export function driverDeliveryExceptionSummary({
+    state,
+    reason,
+    note,
+    occurredAt,
+}: {
+    state: string | null | undefined;
+    reason: string | null | undefined;
+    note: string | null | undefined;
+    occurredAt: Date | null | undefined;
+}): DriverDeliveryExceptionSummary | null {
+    if (
+        !isDeliveryExceptionOutcome(state) ||
+        !isDeliveryExceptionReason(reason) ||
+        !occurredAt
+    ) {
+        return null;
+    }
+    return {
+        outcome: state,
+        reason,
+        note: note?.trim() || null,
+        occurredAt: occurredAt.toISOString(),
+    };
+}
+
+export function customerDeliveryRecoverySummary({
+    requestState,
+    stopState,
+    exceptionReason,
+    exceptionRecordedAt,
+    hqAddress,
+    now = new Date(),
+}: {
+    requestState: string;
+    stopState: string | null | undefined;
+    exceptionReason: string | null | undefined;
+    exceptionRecordedAt?: Date | null;
+    hqAddress: string;
+    now?: Date;
+}): CustomerDeliveryRecoverySummary | null {
+    const effectiveState = stopState ?? requestState;
+    if (effectiveState === 'deferred') {
+        return { kind: 'retry-planned' };
+    }
+    if (effectiveState === 'cancelled') {
+        return { kind: 'cancelled' };
+    }
+    if (effectiveState !== 'failed') {
+        return null;
+    }
+    if (
+        exceptionReason !== 'customer-unavailable' &&
+        exceptionReason !== 'address-inaccessible' &&
+        exceptionReason !== 'address-wrong'
+    ) {
+        return { kind: 'support' };
+    }
+
+    if (
+        !exceptionRecordedAt ||
+        !Number.isFinite(exceptionRecordedAt.getTime()) ||
+        !Number.isFinite(now.getTime())
+    ) {
+        return { kind: 'support' };
+    }
+
+    const pickupDeadline = new Date(
+        exceptionRecordedAt.getTime() +
+            failedDeliveryHqPickupWindowHours * 60 * 60 * 1000,
+    );
+    if (pickupDeadline.getTime() <= now.getTime()) {
+        return { kind: 'hq-pickup-expired' };
+    }
+
+    return {
+        kind: 'hq-pickup',
+        pickupAddress: hqAddress,
+        pickupDeadlineAt: pickupDeadline.toISOString(),
+        pickupWindowHours: failedDeliveryHqPickupWindowHours,
+    };
+}
+
+export function deliveryDispatchContactHref({
+    runId,
+    stopId,
+}: {
+    runId: string;
+    stopId: number | null;
+}) {
+    const subject = stopId
+        ? `Pomoć dispečera · ruta ${runId} · stanica ${stopId}`
+        : `Pomoć dispečera · ruta ${runId}`;
+    return `mailto:kontakt@gredice.com?subject=${encodeURIComponent(subject)}`;
+}

--- a/apps/delivery/lib/deliveryRouting.ts
+++ b/apps/delivery/lib/deliveryRouting.ts
@@ -49,6 +49,10 @@ export const maximumDeliveryRouteStops = 26;
 export const maximumDeliveryRouteWindowHours = 24;
 const defaultHqAddress = 'Ulica Julija Knifera 3, 10000 Zagreb, Hrvatska';
 
+export function configuredDeliveryHqAddress() {
+    return process.env.GREDICE_DELIVERY_HQ_ADDRESS?.trim() || defaultHqAddress;
+}
+
 export class DeliveryRoutePlanningError extends Error {
     override name = 'DeliveryRoutePlanningError';
 
@@ -737,8 +741,7 @@ export async function planDeliveryRoute({
         );
     }
 
-    const hqAddress =
-        process.env.GREDICE_DELIVERY_HQ_ADDRESS?.trim() || defaultHqAddress;
+    const hqAddress = configuredDeliveryHqAddress();
     const [origin, geocodedStops] = await Promise.all([
         geocodeAddress({ formattedAddress: hqAddress }),
         Promise.all(

--- a/apps/delivery/lib/deliveryRunExecutionError.ts
+++ b/apps/delivery/lib/deliveryRunExecutionError.ts
@@ -33,6 +33,18 @@ export function deliveryRunExecutionErrorDetails(
                 message:
                     'Ruta je u međuvremenu promijenjena. Osvježi podatke i pokušaj ponovno.',
             };
+        case 'exception-operation-conflict':
+            return {
+                code: error.code,
+                message:
+                    'Ova prijava problema već je korištena s drugim podacima. Provjeri osvježenu rutu i ponovno potvrdi odabir.',
+            };
+        case 'exception-transition-invalid':
+            return {
+                code: error.code,
+                message:
+                    'Stanje odabranog uroda promijenilo se. Provjeri osvježenu rutu i ponovno potvrdi odabir.',
+            };
         default:
             return {
                 code: error.code,

--- a/apps/delivery/lib/harvestTraceScan.node.spec.ts
+++ b/apps/delivery/lib/harvestTraceScan.node.spec.ts
@@ -57,6 +57,8 @@ function delivery({
     token: string | null;
 }): DeliveryStopDeliverySummary {
     return {
+        stopId: 1,
+        stopState: 'pending',
         requestId,
         requestState: 'in_delivery',
         contactName: `Kontakt ${requestId}`,
@@ -71,7 +73,7 @@ function delivery({
             fieldName: null,
             tracePath: token ? `/trag/${token}` : null,
         },
-        accountContacts: [],
+        exception: null,
     };
 }
 

--- a/apps/delivery/package.json
+++ b/apps/delivery/package.json
@@ -11,7 +11,12 @@
         "dev": "node ../../scripts/run-app-command.mjs dev",
         "build": "next build",
         "start": "node ../../scripts/run-app-command.mjs start",
-        "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test lib/*.node.spec.ts"
+        "test": "pnpm run test:run",
+        "test:unit": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=react-server\" node --import tsx --test lib/*.node.spec.ts",
+        "test:component": "playwright test --project=chromium",
+        "test:run": "pnpm run test:unit && pnpm run test:component",
+        "test-ui": "playwright test --project=chromium --ui",
+        "test:local": "pnpm run test:run"
     },
     "dependencies": {
         "next": "16.2.10",
@@ -26,6 +31,8 @@
         "@gredice/notifications": "workspace:*",
         "@gredice/storage": "workspace:*",
         "@gredice/ui": "workspace:*",
+        "@playwright/experimental-ct-react": "1.61.1",
+        "@playwright/test": "1.61.1",
         "@tailwindcss/postcss": "4.3.2",
         "@tailwindcss/typography": "0.5.20",
         "@tanstack/react-query": "5.101.2",

--- a/apps/delivery/playwright.config.ts
+++ b/apps/delivery/playwright.config.ts
@@ -1,0 +1,43 @@
+import {
+    defineConfig,
+    devices,
+    type PlaywrightTestConfig,
+} from '@playwright/experimental-ct-react';
+import {
+    getAppByName,
+    getComponentTestPort,
+} from '../../scripts/app-registry.ts';
+
+const app = getAppByName('delivery');
+const reporter: PlaywrightTestConfig['reporter'] = [
+    ['list'],
+    ['html', { open: 'never' }],
+];
+
+export const config: PlaywrightTestConfig = {
+    testDir: './tests',
+    snapshotDir: './__snapshots__',
+    timeout: 10 * 1000,
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter,
+    use: {
+        trace: 'on-first-retry',
+        ctPort: getComponentTestPort(app),
+        ctViteConfig: {
+            resolve: {
+                dedupe: ['react', 'react-dom'],
+            },
+        },
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+};
+
+export default defineConfig(config);

--- a/apps/delivery/playwright/index.html
+++ b/apps/delivery/playwright/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="hr" translate="no">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Delivery component test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/apps/delivery/playwright/index.tsx
+++ b/apps/delivery/playwright/index.tsx
@@ -1,0 +1,1 @@
+// Component specs import app/globals.css so every mounted journey uses the delivery theme.

--- a/apps/delivery/tests/DeliveryExceptionSheetStory.tsx
+++ b/apps/delivery/tests/DeliveryExceptionSheetStory.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { DeliveryExceptionSheet } from '../components/DeliveryExceptionSheet';
+import type { DeliveryStopSummary } from '../lib/deliveryDashboardTypes';
+import type {
+    DeliveryExceptionMutation,
+    DeliveryExceptionSubmitResult,
+} from '../lib/deliveryExceptionPresentation';
+import { bulkExceptionStop } from './deliveryRecoveryFixtures';
+
+type ResponseStatus = DeliveryExceptionSubmitResult['status'];
+
+function responseFor(status: ResponseStatus): DeliveryExceptionSubmitResult {
+    if (status === 'saved') return { status };
+    if (status === 'review-required') {
+        return {
+            status,
+            message:
+                'Ruta se promijenila. Pregledaj odabir prije ponovnog slanja.',
+        };
+    }
+    return {
+        status,
+        message: 'Veza s poslužiteljem je prekinuta. Pokušaj ponovno.',
+    };
+}
+
+export function DeliveryExceptionSheetStory({
+    routeRevision = 8,
+    responseStatuses = ['saved'],
+    stop = bulkExceptionStop,
+}: {
+    routeRevision?: number;
+    responseStatuses?: readonly ResponseStatus[];
+    stop?: DeliveryStopSummary;
+}) {
+    const nextSubmissionRef = useRef(0);
+    const [submissions, setSubmissions] = useState<
+        Array<{ sequence: number; body: string }>
+    >([]);
+
+    async function submitException(
+        mutation: DeliveryExceptionMutation,
+    ): Promise<DeliveryExceptionSubmitResult> {
+        const sequence = nextSubmissionRef.current;
+        nextSubmissionRef.current += 1;
+        setSubmissions((current) => [
+            ...current,
+            { sequence, body: JSON.stringify(mutation) },
+        ]);
+
+        const fallbackStatus = responseStatuses.at(-1) ?? 'saved';
+        return responseFor(responseStatuses[sequence] ?? fallbackStatus);
+    }
+
+    return (
+        <div className="space-y-4 p-4">
+            <DeliveryExceptionSheet
+                runId="run-component-4127"
+                routeRevision={routeRevision}
+                stop={stop}
+                disabled={false}
+                onSubmit={submitException}
+            />
+            <output data-testid="delivery-exception-route-revision">
+                {routeRevision}
+            </output>
+            <ol aria-label="Poslane promjene dostave">
+                {submissions.map((submission) => (
+                    <li key={submission.sequence}>
+                        <output
+                            data-testid={`delivery-exception-submission-${submission.sequence}`}
+                        >
+                            {submission.body}
+                        </output>
+                    </li>
+                ))}
+            </ol>
+        </div>
+    );
+}

--- a/apps/delivery/tests/DeliveryStopCardStory.tsx
+++ b/apps/delivery/tests/DeliveryStopCardStory.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { DeliveryStopCard } from '../components/DeliveryStopCard';
+import {
+    customerFailedStop,
+    deferredRetryStop,
+    driverFailedStop,
+    mixedStatusStop,
+} from './deliveryRecoveryFixtures';
+
+export function DeliveryStopCardStory() {
+    return (
+        <div className="max-w-2xl space-y-4 p-4">
+            <DeliveryStopCard
+                stop={mixedStatusStop}
+                mode="driver"
+                routeRevision={12}
+                pendingAction={null}
+                onArrive={() => undefined}
+                onDeliver={() => undefined}
+                onException={async () => ({ status: 'saved' })}
+            />
+            <DeliveryStopCard
+                stop={deferredRetryStop}
+                mode="driver"
+                routeRevision={13}
+                pendingAction={null}
+                onRetry={() => undefined}
+                onArrive={() => undefined}
+                onDeliver={() => undefined}
+                onException={async () => ({ status: 'saved' })}
+            />
+        </div>
+    );
+}
+
+export function DeliveryCustomerStopCardStory() {
+    return (
+        <div className="max-w-2xl p-4">
+            <DeliveryStopCard stop={customerFailedStop} mode="customer" />
+        </div>
+    );
+}
+
+export function DeliveryDriverTerminalStopCardStory() {
+    return (
+        <div className="max-w-2xl p-4">
+            <DeliveryStopCard stop={driverFailedStop} mode="driver" />
+        </div>
+    );
+}

--- a/apps/delivery/tests/delivery-recovery.spec.tsx
+++ b/apps/delivery/tests/delivery-recovery.spec.tsx
@@ -1,0 +1,479 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
+import { DeliveryCustomerRecovery } from '../components/DeliveryCustomerRecovery';
+import { DeliveryExceptionSheetStory } from './DeliveryExceptionSheetStory';
+import {
+    DeliveryCustomerStopCardStory,
+    DeliveryDriverTerminalStopCardStory,
+    DeliveryStopCardStory,
+} from './DeliveryStopCardStory';
+import { duplicateIdentityStop } from './deliveryRecoveryFixtures';
+import '../app/globals.css';
+
+const reasonLabels = [
+    'Korisnik nije dostupan',
+    'Adresi se ne može prići',
+    'Adresa je pogrešna',
+    'Urod je oštećen',
+    'Urod nedostaje',
+    'Dostava je otkazana',
+    'Drugi operativni problem',
+];
+
+async function openExceptionDialog(page: Page) {
+    await page.getByRole('button', { name: 'Prijavi problem' }).click();
+    const dialog = page.getByRole('dialog', {
+        name: 'Prijavi problem s dostavom',
+    });
+    await expect(dialog).toBeVisible();
+    return dialog;
+}
+
+async function submissionBody(page: Page, index: number) {
+    const body = await page
+        .getByTestId(`delivery-exception-submission-${index}`)
+        .textContent();
+    if (!body) throw new Error(`Missing exception submission ${index}.`);
+    return body;
+}
+
+test.describe('mobile bulk exception entry', () => {
+    test.use({
+        viewport: { width: 390, height: 844 },
+        hasTouch: true,
+        isMobile: true,
+    });
+
+    test('requires a deliberate bulk selection and records a deferred subset', async ({
+        mount,
+        page,
+    }) => {
+        await mount(<DeliveryExceptionSheetStory />);
+        const dialog = await openExceptionDialog(page);
+        const harvests = dialog.getByRole('checkbox', {
+            name: /Rajčica Roma|Bosiljak Genovese|Salata puterica/,
+        });
+
+        await expect(harvests).toHaveCount(3);
+        for (let index = 0; index < 3; index += 1) {
+            await expect(harvests.nth(index)).not.toBeChecked();
+        }
+        for (const label of reasonLabels) {
+            await expect(
+                dialog.getByRole('radio', { name: new RegExp(label) }),
+            ).toBeVisible();
+        }
+
+        await dialog.getByRole('button', { name: 'Odaberi sve' }).tap();
+        for (let index = 0; index < 3; index += 1) {
+            await expect(harvests.nth(index)).toBeChecked();
+        }
+        await dialog.getByRole('button', { name: 'Poništi odabir' }).tap();
+        await dialog.getByRole('checkbox', { name: /Rajčica Roma/ }).tap();
+        await expect(
+            dialog.getByRole('checkbox', { name: /Rajčica Roma/ }),
+        ).toBeChecked();
+
+        await dialog
+            .getByRole('button', { name: 'Spremi i nastavi rutu' })
+            .tap();
+        const mutation = JSON.parse(await submissionBody(page, 0));
+        expect(mutation).toMatchObject({
+            expectedRouteRevision: 8,
+            exceptions: [
+                {
+                    stopId: 101,
+                    outcome: 'deferred',
+                    reason: 'customer-unavailable',
+                },
+            ],
+        });
+        expect(mutation.clientOperationId).toEqual(expect.any(String));
+        expect(mutation.occurredAt).toEqual(expect.any(String));
+        await expect(dialog).toHaveCount(0);
+    });
+});
+
+test('confirms the exact harvests before recording a failed bulk subset', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryExceptionSheetStory />);
+    const dialog = await openExceptionDialog(page);
+    await dialog.getByRole('checkbox', { name: /Rajčica Roma/ }).click();
+    await dialog.getByRole('checkbox', { name: /Bosiljak Genovese/ }).click();
+    await dialog
+        .locator('label')
+        .filter({ hasText: 'Završi bez dostave' })
+        .click();
+
+    const terminalSummary = dialog
+        .getByText('Potvrdi završni ishod za 2 uroda')
+        .locator('..');
+    await expect(terminalSummary).toContainText(
+        'Rajčica Roma · Gredica A · Ana Anić',
+    );
+    await expect(terminalSummary).toContainText(
+        'Bosiljak Genovese · Gredica B · Borna Babić',
+    );
+
+    const confirmation = dialog.getByRole('checkbox', {
+        name: 'Potvrđujem da samo navedeni urodi dobivaju završni ishod.',
+    });
+    await expect(confirmation).not.toBeChecked();
+    await dialog.getByRole('button', { name: 'Potvrdi završni ishod' }).click();
+    await expect(
+        dialog.getByRole('alert').filter({
+            hasText: 'Potvrdi završni ishod za točno navedene urode',
+        }),
+    ).toBeVisible();
+
+    await confirmation.click();
+    await dialog.getByRole('button', { name: 'Potvrdi završni ishod' }).click();
+    expect(JSON.parse(await submissionBody(page, 0))).toMatchObject({
+        exceptions: [
+            { stopId: 101, outcome: 'failed' },
+            { stopId: 102, outcome: 'failed' },
+        ],
+    });
+});
+
+test('distinguishes duplicate harvest identities and targets exactly one stop', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryExceptionSheetStory stop={duplicateIdentityStop} />);
+    const dialog = await openExceptionDialog(page);
+    const firstIdentity =
+        'Rajčica duplikat · Gredica Z · Iva Ista · trag duplicate-harvest-one-0001';
+    const secondIdentity =
+        'Rajčica duplikat · Gredica Z · Iva Ista · trag duplicate-harvest-two-0001';
+    const firstHarvest = dialog.getByRole('checkbox', {
+        name: firstIdentity,
+        exact: true,
+    });
+
+    await expect(firstHarvest).toBeVisible();
+    await expect(
+        dialog.getByRole('checkbox', {
+            name: secondIdentity,
+            exact: true,
+        }),
+    ).toBeVisible();
+    await expect(
+        dialog.getByRole('link', {
+            name: `Nazovi kontakt za ${firstIdentity}`,
+            exact: true,
+        }),
+    ).toBeVisible();
+    await expect(
+        dialog.getByRole('link', {
+            name: `Nazovi kontakt za ${secondIdentity}`,
+            exact: true,
+        }),
+    ).toBeVisible();
+
+    await firstHarvest.click();
+    await dialog
+        .locator('label')
+        .filter({ hasText: 'Završi bez dostave' })
+        .click();
+    const confirmation = dialog
+        .getByText('Potvrdi završni ishod za 1 urod')
+        .locator('..');
+    await expect(confirmation).toContainText(firstIdentity);
+    await expect(confirmation).not.toContainText(secondIdentity);
+    await dialog
+        .getByRole('checkbox', {
+            name: 'Potvrđujem da samo navedeni urodi dobivaju završni ishod.',
+        })
+        .click();
+    await dialog.getByRole('button', { name: 'Potvrdi završni ishod' }).click();
+
+    expect(JSON.parse(await submissionBody(page, 0))).toMatchObject({
+        exceptions: [{ stopId: 601, outcome: 'failed' }],
+    });
+});
+
+test('pairs cancellation with a terminal cancelled outcome', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryExceptionSheetStory />);
+    const dialog = await openExceptionDialog(page);
+    await dialog.getByRole('checkbox', { name: /Salata puterica/ }).click();
+    await dialog.getByText('Dostava je otkazana', { exact: true }).click();
+    await expect(
+        dialog.getByText('Otkazivanje je terminalno.', { exact: false }),
+    ).toBeVisible();
+    await dialog
+        .getByRole('checkbox', {
+            name: 'Potvrđujem da samo navedeni urodi dobivaju završni ishod.',
+        })
+        .click();
+    await dialog.getByRole('button', { name: 'Potvrdi završni ishod' }).click();
+
+    expect(JSON.parse(await submissionBody(page, 0))).toMatchObject({
+        exceptions: [
+            {
+                stopId: 103,
+                outcome: 'cancelled',
+                reason: 'cancellation',
+            },
+        ],
+    });
+});
+
+test('retries an uncertain response with the exact immutable mutation', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <DeliveryExceptionSheetStory
+            responseStatuses={['retryable', 'saved']}
+        />,
+    );
+    const dialog = await openExceptionDialog(page);
+    await dialog.getByRole('checkbox', { name: /Rajčica Roma/ }).click();
+    await dialog
+        .getByPlaceholder(
+            'Informacije korisne dispečeru (ne prikazuju se korisniku)',
+        )
+        .fill('Portafon nije odgovorio.');
+
+    const submit = dialog.getByRole('button', {
+        name: 'Spremi i nastavi rutu',
+    });
+    await submit.click();
+    await expect(
+        dialog.getByRole('alert').filter({
+            hasText: 'Veza s poslužiteljem je prekinuta',
+        }),
+    ).toBeVisible();
+    const firstBody = await submissionBody(page, 0);
+
+    await submit.click();
+    const secondBody = await submissionBody(page, 1);
+    expect(secondBody).toBe(firstBody);
+    await expect(dialog).toHaveCount(0);
+});
+
+test('keeps the draft but requires a new operation after a route conflict', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(
+        <DeliveryExceptionSheetStory
+            routeRevision={8}
+            responseStatuses={['review-required', 'saved']}
+        />,
+    );
+    const dialog = await openExceptionDialog(page);
+    await dialog.getByRole('checkbox', { name: /Rajčica Roma/ }).click();
+    await dialog
+        .locator('label')
+        .filter({ hasText: 'Završi bez dostave' })
+        .click();
+    const note = dialog.getByPlaceholder(
+        'Informacije korisne dispečeru (ne prikazuju se korisniku)',
+    );
+    await note.fill('Adresa se promijenila.');
+    const confirmation = dialog.getByRole('checkbox', {
+        name: 'Potvrđujem da samo navedeni urodi dobivaju završni ishod.',
+    });
+    await confirmation.click();
+    await dialog.getByRole('button', { name: 'Potvrdi završni ishod' }).click();
+    await expect(
+        dialog.getByRole('alert').filter({
+            hasText: 'Ruta se promijenila. Pregledaj odabir',
+        }),
+    ).toBeVisible();
+
+    await component.update(
+        <DeliveryExceptionSheetStory
+            routeRevision={9}
+            responseStatuses={['review-required', 'saved']}
+        />,
+    );
+    await expect(
+        dialog.getByRole('checkbox', { name: /Rajčica Roma/ }),
+    ).toBeChecked();
+    await expect(
+        dialog.getByRole('radio', { name: /Završi bez dostave/ }),
+    ).toBeChecked();
+    await expect(note).toHaveValue('Adresa se promijenila.');
+    await expect(confirmation).not.toBeChecked();
+    await expect(
+        page.getByTestId('delivery-exception-route-revision'),
+    ).toHaveText('9');
+
+    await confirmation.click();
+    await dialog.getByRole('button', { name: 'Potvrdi završni ishod' }).click();
+    const firstMutation = JSON.parse(await submissionBody(page, 0));
+    const secondMutation = JSON.parse(await submissionBody(page, 1));
+    expect(firstMutation.expectedRouteRevision).toBe(8);
+    expect(secondMutation.expectedRouteRevision).toBe(9);
+    expect(secondMutation.clientOperationId).not.toBe(
+        firstMutation.clientOperationId,
+    );
+});
+
+test('provides keyboard focus management and screen-reader form semantics', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryExceptionSheetStory />);
+    const trigger = page.getByRole('button', { name: 'Prijavi problem' });
+    await trigger.focus();
+    await page.keyboard.press('Enter');
+    const dialog = page.getByRole('dialog', {
+        name: 'Prijavi problem s dostavom',
+    });
+    await expect(dialog).toBeVisible();
+    await expect(
+        dialog.getByRole('radio', { name: /Korisnik nije dostupan/ }),
+    ).toBeChecked();
+    await expect(
+        dialog.getByRole('radio', { name: /Pokušaj ponovno kasnije/ }),
+    ).toBeChecked();
+
+    for (let index = 0; index < 5; index += 1) {
+        await expect
+            .poll(() =>
+                page.evaluate(() =>
+                    Boolean(document.activeElement?.closest('[role="dialog"]')),
+                ),
+            )
+            .toBe(true);
+        await page.keyboard.press('Tab');
+    }
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toHaveCount(0);
+    await expect(trigger).toBeFocused();
+});
+
+test('renders every customer recovery state with only customer-safe actions', async ({
+    mount,
+    page,
+}) => {
+    const component = await mount(
+        <DeliveryCustomerRecovery recovery={{ kind: 'retry-planned' }} />,
+    );
+    await expect(page.getByText('Ponovni pokušaj je planiran')).toBeVisible();
+    await expect(page.getByText(/vratit će se kasnije/)).toBeVisible();
+
+    await component.update(
+        <DeliveryCustomerRecovery
+            recovery={{
+                kind: 'hq-pickup',
+                pickupAddress: 'Konfigurirani HQ, Testna 42, Zagreb',
+                pickupDeadlineAt: '2026-07-18T08:30:00.000Z',
+                pickupWindowHours: 72,
+            }}
+        />,
+    );
+    await expect(page.getByText('Osobno preuzimanje u HQ-u')).toBeVisible();
+    await expect(page.getByText(/rok od 72 sata/)).toBeVisible();
+    await expect(
+        page.getByText('Konfigurirani HQ, Testna 42, Zagreb'),
+    ).toBeVisible();
+    await expect(page.getByText(/najkasnije/)).toBeVisible();
+    await expect(
+        page.getByRole('link', { name: 'Potvrdi preuzimanje' }),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('link', { name: 'Otvori lokaciju HQ' }),
+    ).toHaveAttribute('href', /google\.com\/maps\/dir/);
+
+    await component.update(
+        <DeliveryCustomerRecovery recovery={{ kind: 'support' }} />,
+    );
+    await expect(
+        page.getByText('Podrška će dogovoriti sljedeći korak'),
+    ).toBeVisible();
+    await expect(
+        page.getByRole('link', { name: 'Kontaktiraj podršku' }),
+    ).toBeVisible();
+    await expect(
+        page.getByText(/harvest-missing|operational-other/),
+    ).toHaveCount(0);
+
+    await component.update(
+        <DeliveryCustomerRecovery recovery={{ kind: 'hq-pickup-expired' }} />,
+    );
+    await expect(
+        page.getByText('Rok za osobno preuzimanje je istekao'),
+    ).toBeVisible();
+    await expect(page.getByText(/više nije aktivan/)).toBeVisible();
+    await expect(
+        page.getByRole('link', { name: 'Kontaktiraj podršku' }),
+    ).toBeVisible();
+
+    await component.update(
+        <DeliveryCustomerRecovery recovery={{ kind: 'cancelled' }} />,
+    );
+    await expect(page.getByText('Dostava je otkazana')).toBeVisible();
+    await expect(page.getByText(/otkazivanje nisi očekivao/)).toBeVisible();
+});
+
+test('keeps terminal siblings as history but excludes them from current delivery work', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryStopCardStory />);
+
+    await expect(page.getByText('1 urod · skupna dostava')).toBeVisible();
+    await expect(
+        page.getByRole('button', { name: 'Dostavi 1 urod · dalje' }),
+    ).toBeVisible();
+    await expect(page.getByText('Provjereno 0 od 1.')).toBeVisible();
+    const verificationList = page.getByRole('list', {
+        name: 'Urodi na ovoj stanici',
+    });
+    await expect(verificationList).toContainText('Rajčica za predaju');
+    await expect(verificationList).not.toContainText('Blitva s iznimkom');
+
+    await expect(page.getByText('Blitva s iznimkom')).toBeVisible();
+    await expect(page.getByText('Neuspjela dostava')).toBeVisible();
+    await expect(page.getByText('Urod nedostaje')).toBeVisible();
+    await expect(
+        page.getByText('Sanduk nije pronađen u vozilu.'),
+    ).toBeVisible();
+
+    await expect(page.getByText('2 uroda · skupna dostava')).toBeVisible();
+    await expect(page.getByText('0 uroda · skupna dostava')).toHaveCount(0);
+    await expect(page.getByText('Ponovni pokušaj je na redu')).toBeVisible();
+});
+
+test('hides stale route estimates after a customer delivery reaches terminal recovery', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryCustomerStopCardStory />);
+
+    await expect(page.getByText('Dostava nije uspjela')).toBeVisible();
+    await expect(page.getByText('Osobno preuzimanje u HQ-u')).toBeVisible();
+    await expect(page.getByText('Dolazak')).toHaveCount(0);
+    await expect(page.getByText('Vožnja')).toHaveCount(0);
+    await expect(page.getByText('Udaljenost')).toHaveCount(0);
+    await expect(
+        page.getByText(/Prikaz će se ažurirati kada vozač nastavi rutu/),
+    ).toHaveCount(0);
+});
+
+test('hides stale route guidance on completed driver exception history', async ({
+    mount,
+    page,
+}) => {
+    await mount(<DeliveryDriverTerminalStopCardStory />);
+
+    await expect(
+        page.getByText('Tikvica iz završene dostave', { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText('Prilaz je zatvoren.')).toBeVisible();
+    await expect(page.getByText('Dolazak')).toHaveCount(0);
+    await expect(
+        page.getByText(/Obavijesti korisnika o kašnjenju/),
+    ).toHaveCount(0);
+});

--- a/apps/delivery/tests/deliveryRecoveryFixtures.ts
+++ b/apps/delivery/tests/deliveryRecoveryFixtures.ts
@@ -1,0 +1,253 @@
+import type {
+    DeliveryStopDeliverySummary,
+    DeliveryStopSummary,
+    DriverDeliveryExceptionSummary,
+} from '../lib/deliveryDashboardTypes';
+
+function delivery({
+    requestId,
+    stopId,
+    stopState,
+    contactName,
+    plantName,
+    raisedBedName,
+    tracePath,
+    exception = null,
+}: {
+    requestId: string;
+    stopId: number;
+    stopState: string;
+    contactName: string;
+    plantName: string;
+    raisedBedName: string;
+    tracePath: string;
+    exception?: DriverDeliveryExceptionSummary | null;
+}): DeliveryStopDeliverySummary {
+    return {
+        stopId,
+        stopState,
+        requestId,
+        requestState: 'in_delivery',
+        contactName,
+        phone: '+385 91 555 0101',
+        addressLabel: null,
+        requestNotes: null,
+        deliveryNotes: null,
+        harvest: {
+            plantName,
+            operationName: 'Berba',
+            raisedBedName,
+            fieldName: null,
+            tracePath,
+        },
+        exception,
+    };
+}
+
+function stop(
+    deliveries: DeliveryStopDeliverySummary[],
+    overrides: Partial<DeliveryStopSummary> = {},
+): DeliveryStopSummary {
+    const primaryDelivery = deliveries[0];
+    if (!primaryDelivery) {
+        throw new Error('A delivery recovery fixture needs at least one item.');
+    }
+
+    return {
+        id: 41,
+        requestId: primaryDelivery.requestId,
+        sequence: 2,
+        stopState: 'arrived',
+        requestState: 'in_delivery',
+        statusLabel: 'Vozač je stigao',
+        isCurrent: true,
+        contactName: primaryDelivery.contactName,
+        phone: primaryDelivery.phone,
+        address: 'Ilica 42, Zagreb',
+        addressLabel: 'Ulaz iz dvorišta',
+        requestNotes: null,
+        deliveryNotes: null,
+        slotStartAt: '2026-07-15T08:00:00.000Z',
+        slotEndAt: '2026-07-15T10:00:00.000Z',
+        estimatedArrivalAt: '2026-07-15T08:30:00.000Z',
+        estimatedTravelSeconds: 720,
+        estimatedDistanceMeters: 4_200,
+        reroutePending: false,
+        arrivedAt: '2026-07-15T08:29:00.000Z',
+        deliveredAt: null,
+        harvest: primaryDelivery.harvest,
+        recovery: null,
+        tracking: null,
+        runId: 'run-component-4127',
+        deliveryCount: deliveries.length,
+        deliveries,
+        actionState: 'current',
+        lockedReason: null,
+        ...overrides,
+    };
+}
+
+export const bulkExceptionStop = stop([
+    delivery({
+        requestId: 'request-tomato',
+        stopId: 101,
+        stopState: 'arrived',
+        contactName: 'Ana Anić',
+        plantName: 'Rajčica Roma',
+        raisedBedName: 'Gredica A',
+        tracePath: '/trag/tomato-trace-0001',
+    }),
+    delivery({
+        requestId: 'request-basil',
+        stopId: 102,
+        stopState: 'pending',
+        contactName: 'Borna Babić',
+        plantName: 'Bosiljak Genovese',
+        raisedBedName: 'Gredica B',
+        tracePath: '/trag/basil-trace-000002',
+    }),
+    delivery({
+        requestId: 'request-lettuce',
+        stopId: 103,
+        stopState: 'pending',
+        contactName: 'Cvita Cvetko',
+        plantName: 'Salata puterica',
+        raisedBedName: 'Gredica C',
+        tracePath: '/trag/lettuce-trace-0003',
+    }),
+]);
+
+export const duplicateIdentityStop = stop([
+    delivery({
+        requestId: 'request-duplicate-one',
+        stopId: 601,
+        stopState: 'arrived',
+        contactName: 'Iva Ista',
+        plantName: 'Rajčica duplikat',
+        raisedBedName: 'Gredica Z',
+        tracePath: '/trag/duplicate-harvest-one-0001',
+    }),
+    delivery({
+        requestId: 'request-duplicate-two',
+        stopId: 602,
+        stopState: 'arrived',
+        contactName: 'Iva Ista',
+        plantName: 'Rajčica duplikat',
+        raisedBedName: 'Gredica Z',
+        tracePath: '/trag/duplicate-harvest-two-0001',
+    }),
+]);
+
+export const mixedStatusStop = stop([
+    delivery({
+        requestId: 'request-active-tomato',
+        stopId: 201,
+        stopState: 'arrived',
+        contactName: 'Dora Dostavić',
+        plantName: 'Rajčica za predaju',
+        raisedBedName: 'Gredica D',
+        tracePath: '/trag/active-tomato-trace-0001',
+    }),
+    delivery({
+        requestId: 'request-failed-chard',
+        stopId: 202,
+        stopState: 'failed',
+        contactName: 'Dora Dostavić',
+        plantName: 'Blitva s iznimkom',
+        raisedBedName: 'Gredica E',
+        tracePath: '/trag/failed-chard-trace-0001',
+        exception: {
+            outcome: 'failed',
+            reason: 'harvest-missing',
+            note: 'Sanduk nije pronađen u vozilu.',
+            occurredAt: '2026-07-15T08:25:00.000Z',
+        },
+    }),
+]);
+
+export const deferredRetryStop = stop(
+    [
+        delivery({
+            requestId: 'request-deferred-tomato',
+            stopId: 301,
+            stopState: 'deferred',
+            contactName: 'Ena Ekološka',
+            plantName: 'Rajčica za ponovni pokušaj',
+            raisedBedName: 'Gredica F',
+            tracePath: '/trag/deferred-tomato-trace-0001',
+        }),
+        delivery({
+            requestId: 'request-deferred-pepper',
+            stopId: 302,
+            stopState: 'deferred',
+            contactName: 'Ena Ekološka',
+            plantName: 'Paprika za ponovni pokušaj',
+            raisedBedName: 'Gredica G',
+            tracePath: '/trag/deferred-pepper-trace-0001',
+        }),
+    ],
+    {
+        id: 301,
+        stopState: 'deferred',
+        statusLabel: 'Dostava je odgođena',
+        arrivedAt: null,
+    },
+);
+
+export const customerFailedStop = stop(
+    [
+        delivery({
+            requestId: 'request-customer-failed',
+            stopId: 401,
+            stopState: 'failed',
+            contactName: 'Korisnik Kupac',
+            plantName: 'Mrkva za preuzimanje',
+            raisedBedName: 'Gredica H',
+            tracePath: '/trag/customer-carrot-trace-0001',
+        }),
+    ],
+    {
+        id: 401,
+        stopState: 'failed',
+        requestState: 'failed',
+        statusLabel: 'Dostava nije uspjela',
+        isCurrent: false,
+        actionState: 'completed',
+        estimatedArrivalAt: '2026-07-15T10:30:00.000Z',
+        recovery: {
+            kind: 'hq-pickup',
+            pickupAddress: 'Konfigurirani HQ, Testna 42, Zagreb',
+            pickupDeadlineAt: '2026-07-18T08:30:00.000Z',
+            pickupWindowHours: 72,
+        },
+    },
+);
+
+export const driverFailedStop = stop(
+    [
+        delivery({
+            requestId: 'request-driver-failed',
+            stopId: 501,
+            stopState: 'failed',
+            contactName: 'Franjo Finalni',
+            plantName: 'Tikvica iz završene dostave',
+            raisedBedName: 'Gredica I',
+            tracePath: '/trag/driver-zucchini-trace-0001',
+            exception: {
+                outcome: 'failed',
+                reason: 'address-inaccessible',
+                note: 'Prilaz je zatvoren.',
+                occurredAt: '2026-07-15T10:20:00.000Z',
+            },
+        }),
+    ],
+    {
+        id: 501,
+        stopState: 'failed',
+        requestState: 'failed',
+        statusLabel: 'Dostava nije uspjela',
+        isCurrent: false,
+        actionState: 'completed',
+        estimatedArrivalAt: '2026-07-15T10:30:00.000Z',
+    },
+);

--- a/packages/storage/src/repositories/deliveryRequestsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRequestsRepo.ts
@@ -210,6 +210,7 @@ interface DeliveryRequestStateProjection {
     deliveryException?: {
         outcome: 'deferred' | 'failed' | 'cancelled';
         retryable: boolean;
+        recordedAt: Date;
     };
 }
 
@@ -291,6 +292,7 @@ function reconstructDeliveryRequestState(
         | {
               outcome: 'deferred' | 'failed' | 'cancelled';
               retryable: boolean;
+              recordedAt: Date;
           }
         | undefined;
 
@@ -360,6 +362,10 @@ function reconstructDeliveryRequestState(
                 retryable:
                     data.exceptionOutcome === 'deferred' &&
                     data.exceptionRetryable === true,
+                // Use the server-created audit timestamp. The event payload's
+                // occurredAt value originates on the driver's device and must
+                // not define public pickup policy deadlines.
+                recordedAt: event.createdAt,
             };
         } else if (
             event.type === knownEventTypes.delivery.requestExceptionRecovered &&

--- a/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRequestsRepo.node.spec.ts
@@ -701,6 +701,7 @@ test('delivery exception events project safe retry outcomes and invalidate dispa
         const expectedException = {
             outcome: exception.outcome,
             retryable: exception.retryable,
+            recordedAt: exceptionEvent.createdAt,
         };
 
         assert.equal(request?.state, exception.outcome);
@@ -709,6 +710,7 @@ test('delivery exception events project safe retry outcomes and invalidate dispa
         assert.deepEqual(listedRequest?.deliveryException, expectedException);
         assert.deepEqual(Object.keys(request?.deliveryException ?? {}).sort(), [
             'outcome',
+            'recordedAt',
             'retryable',
         ]);
         const publicProjection = JSON.stringify([request, listedRequest]);

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -2905,10 +2905,12 @@ test('delivery exceptions persist item outcomes, replay safely, and keep custome
         firstStop.deliveryRequestId,
     );
     assert.equal(customerRequest?.state, DeliveryRunStopStates.DEFERRED);
-    assert.deepEqual(customerRequest?.deliveryException, {
-        outcome: DeliveryRunExceptionOutcomes.DEFERRED,
-        retryable: true,
-    });
+    assert.equal(
+        customerRequest?.deliveryException?.outcome,
+        DeliveryRunExceptionOutcomes.DEFERRED,
+    );
+    assert.equal(customerRequest?.deliveryException?.retryable, true);
+    assert.ok(customerRequest?.deliveryException?.recordedAt instanceof Date);
     assert.ok(!JSON.stringify(customerRequest).includes(privateNote));
     assert.ok(
         !JSON.stringify(customerRequest).includes(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,12 @@ importers:
       '@gredice/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@playwright/experimental-ct-react':
+        specifier: 1.61.1
+        version: 1.61.1(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.101.0)(supports-color@8.1.1)(tsx@4.23.0)(vite@8.1.4(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))(yaml@2.9.0)
+      '@playwright/test':
+        specifier: 1.61.1
+        version: 1.61.1
       '@tailwindcss/postcss':
         specifier: 4.3.2
         version: 4.3.2

--- a/scripts/app-registry.ts
+++ b/scripts/app-registry.ts
@@ -76,7 +76,7 @@ export const appRegistry: AppRegistryEntry[] = [
         devPort: 3008,
         startPort: 3008,
         testPort: 3008,
-        componentTestPort: null,
+        componentTestPort: 3104,
         vercelProjectName: 'delivery',
         startsInDefaultDev: true,
     },


### PR DESCRIPTION
## Summary

- adds a current-stop exception sheet with deliberate bulk harvest selection, explicit retry versus terminal outcomes, confirmation, dispatch/contact actions, and immutable idempotent retries
- keeps deferred and terminal outcomes visible in the driver timeline while excluding terminal siblings from active delivery work
- gives customers privacy-safe retry, HQ pickup, expiry, support, and cancellation guidance without driver notes or unrelated account data
- derives HQ pickup deadlines from the server-created exception audit timestamp
- adds collision-safe harvest identities and Playwright component journeys for every outcome and recovery state

## Validation

- pnpm --filter delivery test (145 unit tests and 11 Chromium component journeys)
- pnpm test:node -- deliveryRequestsRepo.node.spec.ts deliveryRunsRepo.node.spec.ts (72 focused storage tests)
- pnpm --filter delivery typecheck
- pnpm --filter delivery build
- pnpm --filter delivery exec biome check .
- pnpm --filter @gredice/storage exec biome check src/repositories/deliveryRequestsRepo.ts tests/deliveryRequestsRepo.node.spec.ts tests/deliveryRunsRepo.node.spec.ts
- pnpm install --lockfile-only --frozen-lockfile
- git diff --check
- two independent final audits found no actionable P1/P2 issues

Closes #4127