### PR TITLE
feat(farm): preserve OAuth return paths

### DIFF
--- a/apps/api/app/api/[...route]/authRoutes.ts
+++ b/apps/api/app/api/[...route]/authRoutes.ts
@@ -39,6 +39,15 @@ import {
     generateAuthUrl,
 } from '../../../lib/auth/oauth';
 import {
+    createOAuthCallbackErrorRedirect,
+    type OAuthCallbackProvider,
+    oauthRedirectCookieName,
+    oauthStateCookieName,
+    oauthTimeZoneCookieName,
+    resolveOAuthCallback,
+    sanitizeOAuthCallbackUrl,
+} from '../../../lib/auth/oauthCallbackContract';
+import {
     clearRefreshCookie,
     setRefreshCookie,
 } from '../../../lib/auth/refreshCookies';
@@ -197,63 +206,12 @@ async function createOAuthStateFromSession(context: Context): Promise<string> {
     return randomUUID().toString().replace('-', '');
 }
 
-const defaultWebAppOrigin = 'https://vrt.gredice.com';
-const oauthRedirectCookieName = 'oauth_redirect';
-const oauthTimeZoneCookieName = 'oauth_timezone';
-const allowedDesktopRedirectProtocols = new Set([
-    'gredice-admin:',
-    'gredice-farm:',
-    'gredice-garden:',
-]);
-const allowedLocalRedirectHosts = new Set([
-    'localhost',
-    '127.0.0.1',
-    'app.gredice.test',
-    'vrt.gredice.test',
-    'farma.gredice.test',
-    'dostava.gredice.test',
-    'www.gredice.test',
-]);
-
-function sanitizeRedirectUrl(redirectUrl?: string) {
-    if (!redirectUrl) {
-        return undefined;
-    }
-
-    try {
-        const parsed = new URL(redirectUrl);
-        if (
-            allowedDesktopRedirectProtocols.has(parsed.protocol) &&
-            parsed.hostname === 'auth-callback'
-        ) {
-            return parsed.toString();
-        }
-
-        const hostname = parsed.hostname.toLowerCase();
-        const isSecureProtocol =
-            parsed.protocol === 'https:' ||
-            (parsed.protocol === 'http:' &&
-                allowedLocalRedirectHosts.has(hostname));
-        if (!isSecureProtocol) {
-            return undefined;
-        }
-
-        if (
-            hostname === 'gredice.com' ||
-            hostname.endsWith('.gredice.com') ||
-            allowedLocalRedirectHosts.has(hostname)
-        ) {
-            return parsed.toString();
-        }
-    } catch {
-        return undefined;
-    }
-
-    return undefined;
-}
-
-function storeRedirectCookie(context: Context, redirectUrl?: string) {
-    const sanitized = sanitizeRedirectUrl(redirectUrl);
+function storeRedirectCookie(
+    context: Context,
+    provider: OAuthCallbackProvider,
+    redirectUrl?: string,
+) {
+    const sanitized = sanitizeOAuthCallbackUrl(provider, redirectUrl);
     if (!sanitized) {
         deleteContextCookie(context, oauthRedirectCookieName);
         return;
@@ -285,30 +243,26 @@ function storeTimeZoneCookie(context: Context, timeZone?: string) {
     });
 }
 
-function getTimeZoneCookie(context: Context): string | undefined {
+function prepareOAuthCallback(
+    context: Context,
+    provider: OAuthCallbackProvider,
+) {
     const timeZone = getCookie(context, oauthTimeZoneCookieName);
-    deleteContextCookie(context, oauthTimeZoneCookieName);
-    return timeZone;
-}
+    const decision = resolveOAuthCallback({
+        provider,
+        code: context.req.query('code'),
+        state: context.req.query('state'),
+        storedState: getCookie(context, oauthStateCookieName),
+        storedRedirect: getCookie(context, oauthRedirectCookieName),
+        providerError: context.req.query('error'),
+        providerErrorReason: context.req.query('error_reason'),
+    });
 
-function resolveRedirectUrl(context: Context, fallbackPath: string) {
-    const fallbackUrl = new URL(fallbackPath, defaultWebAppOrigin);
-    const stored = getCookie(context, oauthRedirectCookieName);
-    if (!stored) {
-        return fallbackUrl;
+    for (const cookieName of decision.clearCookieNames) {
+        deleteContextCookie(context, cookieName);
     }
 
-    deleteContextCookie(context, oauthRedirectCookieName);
-    const sanitized = sanitizeRedirectUrl(stored);
-    if (!sanitized) {
-        return fallbackUrl;
-    }
-
-    try {
-        return new URL(sanitized);
-    } catch {
-        return fallbackUrl;
-    }
+    return { decision, timeZone };
 }
 
 type AuthProvider = 'password' | 'google' | 'facebook';
@@ -564,12 +518,12 @@ const app = new Hono()
         async (context) => {
             const query = context.req.valid('query');
             const state = await createOAuthStateFromSession(context);
-            storeRedirectCookie(context, query?.redirect);
+            storeRedirectCookie(context, 'google', query?.redirect);
             storeTimeZoneCookie(context, query?.timeZone);
             const authUrl = generateAuthUrl('google', state);
 
             // Store state in cookie for verification
-            setContextCookie(context, 'oauth_state', state, {
+            setContextCookie(context, oauthStateCookieName, state, {
                 httpOnly: true,
                 secure: true,
                 sameSite: 'Lax',
@@ -585,27 +539,24 @@ const app = new Hono()
             description: 'Google OAuth callback',
         }),
         async (context) => {
-            try {
-                const code = context.req.query('code');
-                const state = context.req.query('state');
-                if (!code || !state) {
-                    return context.json(
-                        { message: 'Missing code or state' },
-                        400,
-                    );
-                }
+            const { decision, timeZone } = prepareOAuthCallback(
+                context,
+                'google',
+            );
+            if (decision.kind === 'redirect') {
+                return context.redirect(decision.redirectUrl);
+            }
 
+            try {
                 let currentUserId: string | undefined;
                 try {
-                    const { result, error } = await verifyJwt(state);
+                    const { result, error } = await verifyJwt(decision.state);
                     if (error || !result?.payload.sub) {
                         throw new Error('Invalid state token');
                     }
                     currentUserId = result.payload.sub;
                     console.debug(
-                        'User authenticated',
-                        currentUserId,
-                        'proceeding with OAuth flow and existing user assignment',
+                        'Authenticated user is adding an OAuth login method.',
                     );
                 } catch {
                     // Note: this means user is not authenticated, and we can proceed with
@@ -615,12 +566,14 @@ const app = new Hono()
                     );
                 }
 
-                const tokenData = await exchangeCodeForToken('google', code);
+                const tokenData = await exchangeCodeForToken(
+                    'google',
+                    decision.code,
+                );
                 const userInfo = await fetchUserInfo(
                     'google',
                     tokenData.access_token,
                 );
-                const timeZone = getTimeZoneCookie(context);
                 const { userId, loginId, isNewUser } =
                     await createOrUpdateUserWithOauth(
                         {
@@ -676,27 +629,23 @@ const app = new Hono()
                     });
                 }
 
-                const redirectUrl = resolveRedirectUrl(
-                    context,
-                    '/prijava/google-prijava/povratak',
-                );
+                const redirectUrl = new URL(decision.callbackUrl);
                 // Pass tokens to frontend via URL fragment (hash) so they don't appear in logs/referrer
                 redirectUrl.hash = `token=${encodeURIComponent(accessToken)}&refreshToken=${encodeURIComponent(refreshToken)}`;
 
                 return context.redirect(redirectUrl.toString());
-            } catch (error) {
+            } catch {
                 console.error('Google OAuth callback failed', {
-                    error,
-                    hasCode: Boolean(context.req.query('code')),
-                    hasState: Boolean(context.req.query('state')),
+                    provider: 'google',
+                    reason: 'callback_error',
                 });
-                const redirectUrl = resolveRedirectUrl(
-                    context,
-                    '/prijava/google-prijava/povratak',
+                const redirectUrl = createOAuthCallbackErrorRedirect(
+                    'google',
+                    decision.callbackUrl,
+                    'callback_error',
                 );
-                redirectUrl.searchParams.set('error', 'oauth_error');
 
-                return context.redirect(redirectUrl.toString());
+                return context.redirect(redirectUrl);
             }
         },
     )
@@ -718,9 +667,9 @@ const app = new Hono()
             const authUrl = generateAuthUrl('facebook', state);
 
             // Store state in cookie for verification
-            storeRedirectCookie(context, query?.redirect);
+            storeRedirectCookie(context, 'facebook', query?.redirect);
             storeTimeZoneCookie(context, query?.timeZone);
-            setContextCookie(context, 'oauth_state', state, {
+            setContextCookie(context, oauthStateCookieName, state, {
                 httpOnly: true,
                 secure: true,
                 sameSite: 'Lax',
@@ -736,27 +685,24 @@ const app = new Hono()
             description: 'Facebook OAuth callback',
         }),
         async (context) => {
-            try {
-                const code = context.req.query('code');
-                const state = context.req.query('state');
-                if (!code || !state) {
-                    return context.json(
-                        { message: 'Missing code or state' },
-                        400,
-                    );
-                }
+            const { decision, timeZone } = prepareOAuthCallback(
+                context,
+                'facebook',
+            );
+            if (decision.kind === 'redirect') {
+                return context.redirect(decision.redirectUrl);
+            }
 
+            try {
                 let currentUserId: string | undefined;
                 try {
-                    const { result, error } = await verifyJwt(state);
+                    const { result, error } = await verifyJwt(decision.state);
                     if (error || !result?.payload.sub) {
                         throw new Error('Invalid state token');
                     }
                     currentUserId = result.payload.sub;
                     console.debug(
-                        'User authenticated',
-                        currentUserId,
-                        'proceeding with OAuth flow and existing user assignment',
+                        'Authenticated user is adding an OAuth login method.',
                     );
                 } catch {
                     // Note: this means user is not authenticated, and we can proceed with
@@ -766,12 +712,14 @@ const app = new Hono()
                     );
                 }
 
-                const tokenData = await exchangeCodeForToken('facebook', code);
+                const tokenData = await exchangeCodeForToken(
+                    'facebook',
+                    decision.code,
+                );
                 const userInfo = await fetchUserInfo(
                     'facebook',
                     tokenData.access_token,
                 );
-                const timeZone = getTimeZoneCookie(context);
                 const { userId, loginId, isNewUser } =
                     await createOrUpdateUserWithOauth(
                         {
@@ -827,27 +775,23 @@ const app = new Hono()
                     });
                 }
 
-                const redirectUrl = resolveRedirectUrl(
-                    context,
-                    '/prijava/facebook-prijava/povratak',
-                );
+                const redirectUrl = new URL(decision.callbackUrl);
                 // Pass tokens to frontend via URL fragment (hash) so they don't appear in logs/referrer
                 redirectUrl.hash = `token=${encodeURIComponent(accessToken)}&refreshToken=${encodeURIComponent(refreshToken)}`;
 
                 return context.redirect(redirectUrl.toString());
-            } catch (error) {
+            } catch {
                 console.error('Facebook OAuth callback failed', {
-                    error,
-                    hasCode: Boolean(context.req.query('code')),
-                    hasState: Boolean(context.req.query('state')),
+                    provider: 'facebook',
+                    reason: 'callback_error',
                 });
-                const redirectUrl = resolveRedirectUrl(
-                    context,
-                    '/prijava/facebook-prijava/povratak',
+                const redirectUrl = createOAuthCallbackErrorRedirect(
+                    'facebook',
+                    decision.callbackUrl,
+                    'callback_error',
                 );
-                redirectUrl.searchParams.set('error', 'oauth_error');
 
-                return context.redirect(redirectUrl.toString());
+                return context.redirect(redirectUrl);
             }
         },
     )

--- a/apps/api/lib/auth/oauthCallbackContract.node.spec.ts
+++ b/apps/api/lib/auth/oauthCallbackContract.node.spec.ts
@@ -166,6 +166,51 @@ test('accepts only provider-matched desktop callback targets', () => {
         ),
         undefined,
     );
+    assert.equal(
+        sanitizeOAuthCallbackUrl(
+            'google',
+            'gredice-farm://auth-callback/google?returnTo=%2Fnotifications%3Ffilter%3Dunread%23latest',
+        ),
+        'gredice-farm://auth-callback/google?returnTo=%2Fnotifications%3Ffilter%3Dunread%23latest',
+    );
+    assert.equal(
+        sanitizeOAuthCallbackUrl(
+            'google',
+            'gredice-farm://auth-callback/google?returnTo=%2Fnotifications&returnTo=%2Fschedule',
+        ),
+        undefined,
+    );
+});
+
+test('preserves a desktop return path through success and bounded errors', () => {
+    const callbackUrl =
+        'gredice-farm://auth-callback/google?returnTo=%2Fnotifications%3Ffilter%3Dunread%23latest';
+    const success = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        storedRedirect: callbackUrl,
+        ...matchingState,
+    });
+    assert.equal(success.kind, 'continue');
+    if (success.kind === 'continue') {
+        assert.equal(success.callbackUrl, callbackUrl);
+    }
+
+    const canceled = resolveOAuthCallback({
+        provider: 'google',
+        providerError: 'access_denied',
+        storedRedirect: callbackUrl,
+        ...matchingState,
+    });
+    assert.equal(canceled.kind, 'redirect');
+    if (canceled.kind === 'redirect') {
+        const redirectUrl = new URL(canceled.redirectUrl);
+        assert.equal(
+            redirectUrl.searchParams.get('returnTo'),
+            '/notifications?filter=unread#latest',
+        );
+        assert.equal(redirectUrl.searchParams.get('error'), 'canceled');
+    }
 });
 
 test('uses callback_error without replacing a validated return path', () => {

--- a/apps/api/lib/auth/oauthCallbackContract.node.spec.ts
+++ b/apps/api/lib/auth/oauthCallbackContract.node.spec.ts
@@ -1,0 +1,221 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createOAuthCallbackErrorRedirect,
+    oauthCallbackCookieNames,
+    resolveOAuthCallback,
+    sanitizeOAuthCallbackUrl,
+} from './oauthCallbackContract';
+
+const matchingState = {
+    state: 'signed-oauth-state',
+    storedState: 'signed-oauth-state',
+};
+
+test('continues a valid callback and preserves its encoded internal return path', () => {
+    const callbackUrl = new URL(
+        '/prijava/google-prijava/povratak',
+        'https://farma.gredice.com',
+    );
+    callbackUrl.searchParams.set(
+        'returnTo',
+        '/operations/42?tab=dokazi#fotografije',
+    );
+
+    const result = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        storedRedirect: callbackUrl.toString(),
+        ...matchingState,
+    });
+
+    assert.equal(result.kind, 'continue');
+    if (result.kind !== 'continue') {
+        return;
+    }
+    assert.equal(result.code, 'authorization-code');
+    assert.equal(result.state, matchingState.state);
+    assert.equal(result.callbackUrl, callbackUrl.toString());
+    assert.deepEqual(result.clearCookieNames, oauthCallbackCookieNames);
+});
+
+test('rejects missing or mismatched callback state before using an authorization code', () => {
+    const missingCookie = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        state: matchingState.state,
+    });
+    const missingState = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        storedState: matchingState.storedState,
+    });
+    const mismatch = resolveOAuthCallback({
+        provider: 'facebook',
+        code: 'authorization-code',
+        state: 'returned-state',
+        storedState: 'different-cookie-state',
+    });
+
+    for (const result of [missingCookie, missingState, mismatch]) {
+        assert.equal(result.kind, 'redirect');
+        if (result.kind !== 'redirect') {
+            continue;
+        }
+        assert.equal(result.error, 'state_invalid');
+        assert.equal(
+            new URL(result.redirectUrl).searchParams.get('error'),
+            'state_invalid',
+        );
+        assert.deepEqual(result.clearCookieNames, oauthCallbackCookieNames);
+    }
+});
+
+test('maps provider cancellation to a bounded callback error', () => {
+    const results = [
+        resolveOAuthCallback({
+            provider: 'google',
+            providerError: 'access_denied',
+            ...matchingState,
+        }),
+        resolveOAuthCallback({
+            provider: 'facebook',
+            providerError: 'access_denied',
+            providerErrorReason: 'user_denied',
+            ...matchingState,
+        }),
+    ];
+
+    for (const result of results) {
+        assert.equal(result.kind, 'redirect');
+        if (result.kind !== 'redirect') {
+            continue;
+        }
+        assert.equal(result.error, 'canceled');
+        assert.equal(
+            new URL(result.redirectUrl).searchParams.get('error'),
+            'canceled',
+        );
+        assert.equal(result.redirectUrl.includes('access_denied'), false);
+        assert.equal(result.redirectUrl.includes('user_denied'), false);
+    }
+});
+
+test('maps other provider failures to a bounded provider error', () => {
+    const result = resolveOAuthCallback({
+        provider: 'facebook',
+        providerError: 'temporarily_unavailable',
+        providerErrorReason: 'upstream detail that must not be forwarded',
+        ...matchingState,
+    });
+
+    assert.equal(result.kind, 'redirect');
+    if (result.kind !== 'redirect') {
+        return;
+    }
+    assert.equal(result.error, 'provider_error');
+    assert.equal(
+        new URL(result.redirectUrl).searchParams.get('error'),
+        'provider_error',
+    );
+    assert.equal(result.redirectUrl.includes('temporarily_unavailable'), false);
+    assert.equal(result.redirectUrl.includes('upstream'), false);
+});
+
+test('falls back when a callback target has an unsafe origin or path', () => {
+    const unsafeTargets = [
+        'https://attacker.example/prijava/google-prijava/povratak',
+        'https://farm-attacker-gredice.vercel.app/prijava/google-prijava/povratak',
+        'https://farma.gredice.com/operations/42',
+        'https://farma.gredice.com/prijava/facebook-prijava/povratak',
+        'https://farma.gredice.com/prijava/google-prijava/povratak?token=raw',
+        '//farma.gredice.com/prijava/google-prijava/povratak',
+    ];
+
+    for (const storedRedirect of unsafeTargets) {
+        const result = resolveOAuthCallback({
+            provider: 'google',
+            code: 'authorization-code',
+            storedRedirect,
+            ...matchingState,
+        });
+
+        assert.equal(result.kind, 'continue');
+        if (result.kind !== 'continue') {
+            continue;
+        }
+        assert.equal(
+            result.callbackUrl,
+            'https://vrt.gredice.com/prijava/google-prijava/povratak',
+        );
+    }
+});
+
+test('accepts only provider-matched desktop callback targets', () => {
+    assert.equal(
+        sanitizeOAuthCallbackUrl(
+            'google',
+            'gredice-farm://auth-callback/google',
+        ),
+        'gredice-farm://auth-callback/google',
+    );
+    assert.equal(
+        sanitizeOAuthCallbackUrl(
+            'google',
+            'gredice-farm://auth-callback/facebook',
+        ),
+        undefined,
+    );
+});
+
+test('uses callback_error without replacing a validated return path', () => {
+    const callbackUrl =
+        'https://farma.gredice.com/prijava/google-prijava/povratak?returnTo=%2Fnotifications%2F17';
+    const redirectUrl = createOAuthCallbackErrorRedirect(
+        'google',
+        callbackUrl,
+        'callback_error',
+    );
+    const parsed = new URL(redirectUrl);
+
+    assert.equal(parsed.searchParams.get('returnTo'), '/notifications/17');
+    assert.equal(parsed.searchParams.get('error'), 'callback_error');
+});
+
+test('uses callback_error when a state-valid callback has no code', () => {
+    const result = resolveOAuthCallback({
+        provider: 'google',
+        ...matchingState,
+    });
+
+    assert.equal(result.kind, 'redirect');
+    if (result.kind !== 'redirect') {
+        return;
+    }
+    assert.equal(result.error, 'callback_error');
+    assert.equal(
+        new URL(result.redirectUrl).searchParams.get('error'),
+        'callback_error',
+    );
+});
+
+test('declares state, redirect and timezone cleanup for every callback outcome', () => {
+    const success = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        ...matchingState,
+    });
+    const failure = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        state: 'wrong-state',
+        storedState: matchingState.storedState,
+    });
+
+    assert.deepEqual(success.clearCookieNames, [
+        'oauth_state',
+        'oauth_redirect',
+        'oauth_timezone',
+    ]);
+    assert.deepEqual(failure.clearCookieNames, success.clearCookieNames);
+});

--- a/apps/api/lib/auth/oauthCallbackContract.ts
+++ b/apps/api/lib/auth/oauthCallbackContract.ts
@@ -1,0 +1,237 @@
+export type OAuthCallbackProvider = 'facebook' | 'google';
+
+export type OAuthCallbackErrorCode =
+    | 'canceled'
+    | 'state_invalid'
+    | 'provider_error'
+    | 'callback_error';
+
+export type OAuthCallbackCookieName =
+    | 'oauth_state'
+    | 'oauth_redirect'
+    | 'oauth_timezone';
+
+export const oauthStateCookieName: OAuthCallbackCookieName = 'oauth_state';
+export const oauthRedirectCookieName: OAuthCallbackCookieName =
+    'oauth_redirect';
+export const oauthTimeZoneCookieName: OAuthCallbackCookieName =
+    'oauth_timezone';
+export const oauthCallbackCookieNames: ReadonlyArray<OAuthCallbackCookieName> =
+    Object.freeze([
+        oauthStateCookieName,
+        oauthRedirectCookieName,
+        oauthTimeZoneCookieName,
+    ]);
+
+const defaultWebAppOrigin = 'https://vrt.gredice.com';
+const maximumCallbackUrlLength = 2_048;
+const maximumAuthorizationValueLength = 4_096;
+
+const allowedProductionCallbackOrigins = new Set([
+    'https://app.gredice.com',
+    'https://dostava.gredice.com',
+    'https://farma.gredice.com',
+    'https://gredice.com',
+    'https://vrt.gredice.com',
+    'https://www.gredice.com',
+]);
+
+const allowedLocalCallbackHosts = new Set([
+    '127.0.0.1',
+    '[::1]',
+    'app.gredice.test',
+    'dostava.gredice.test',
+    'farma.gredice.test',
+    'localhost',
+    'vrt.gredice.test',
+    'www.gredice.test',
+]);
+
+const allowedDesktopRedirectProtocols = new Set([
+    'gredice-admin:',
+    'gredice-farm:',
+    'gredice-garden:',
+]);
+
+export type OAuthCallbackDecision =
+    | {
+          kind: 'continue';
+          callbackUrl: string;
+          code: string;
+          state: string;
+          clearCookieNames: ReadonlyArray<OAuthCallbackCookieName>;
+      }
+    | {
+          kind: 'redirect';
+          error: OAuthCallbackErrorCode;
+          redirectUrl: string;
+          clearCookieNames: ReadonlyArray<OAuthCallbackCookieName>;
+      };
+
+type ResolveOAuthCallbackInput = {
+    provider: OAuthCallbackProvider;
+    code?: string;
+    state?: string;
+    storedState?: string;
+    storedRedirect?: string;
+    providerError?: string;
+    providerErrorReason?: string;
+};
+
+function callbackPath(provider: OAuthCallbackProvider) {
+    return `/prijava/${provider}-prijava/povratak`;
+}
+
+function isAllowedWebCallbackOrigin(url: URL) {
+    if (url.username || url.password) {
+        return false;
+    }
+
+    if (allowedProductionCallbackOrigins.has(url.origin)) {
+        return true;
+    }
+
+    const hostname = url.hostname.toLowerCase();
+    if (
+        allowedLocalCallbackHosts.has(hostname) &&
+        (url.protocol === 'http:' || url.protocol === 'https:')
+    ) {
+        return true;
+    }
+
+    return false;
+}
+
+function hasOnlySupportedCallbackQuery(url: URL) {
+    for (const key of url.searchParams.keys()) {
+        if (key !== 'returnTo') {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Restricts the browser hand-off to a known Gredice callback surface. The
+ * internal route carried in `returnTo` is deliberately left encoded for the
+ * receiving app to validate against its own route allowlist.
+ */
+export function sanitizeOAuthCallbackUrl(
+    provider: OAuthCallbackProvider,
+    redirectUrl?: string,
+) {
+    if (!redirectUrl || redirectUrl.length > maximumCallbackUrlLength) {
+        return undefined;
+    }
+
+    try {
+        const parsed = new URL(redirectUrl);
+        if (parsed.hash || !hasOnlySupportedCallbackQuery(parsed)) {
+            return undefined;
+        }
+
+        if (allowedDesktopRedirectProtocols.has(parsed.protocol)) {
+            if (
+                parsed.hostname === 'auth-callback' &&
+                parsed.pathname === `/${provider}` &&
+                !parsed.username &&
+                !parsed.password &&
+                !parsed.port
+            ) {
+                return parsed.toString();
+            }
+            return undefined;
+        }
+
+        if (
+            isAllowedWebCallbackOrigin(parsed) &&
+            parsed.pathname === callbackPath(provider)
+        ) {
+            return parsed.toString();
+        }
+    } catch {
+        return undefined;
+    }
+
+    return undefined;
+}
+
+export function resolveOAuthCallbackUrl(
+    provider: OAuthCallbackProvider,
+    storedRedirect?: string,
+) {
+    const sanitized = sanitizeOAuthCallbackUrl(provider, storedRedirect);
+    if (sanitized) {
+        return sanitized;
+    }
+
+    return new URL(callbackPath(provider), defaultWebAppOrigin).toString();
+}
+
+function errorRedirect(callbackUrl: string, error: OAuthCallbackErrorCode) {
+    const redirectUrl = new URL(callbackUrl);
+    redirectUrl.searchParams.set('error', error);
+    return redirectUrl.toString();
+}
+
+export function createOAuthCallbackErrorRedirect(
+    provider: OAuthCallbackProvider,
+    callbackUrl: string,
+    error: OAuthCallbackErrorCode,
+) {
+    const sanitized = resolveOAuthCallbackUrl(provider, callbackUrl);
+    return errorRedirect(sanitized, error);
+}
+
+function redirectDecision(
+    callbackUrl: string,
+    error: OAuthCallbackErrorCode,
+): OAuthCallbackDecision {
+    return {
+        kind: 'redirect',
+        error,
+        redirectUrl: errorRedirect(callbackUrl, error),
+        clearCookieNames: oauthCallbackCookieNames,
+    };
+}
+
+export function resolveOAuthCallback(
+    input: ResolveOAuthCallbackInput,
+): OAuthCallbackDecision {
+    const callbackUrl = resolveOAuthCallbackUrl(
+        input.provider,
+        input.storedRedirect,
+    );
+
+    if (
+        !input.state ||
+        !input.storedState ||
+        input.state.length > maximumAuthorizationValueLength ||
+        input.storedState.length > maximumAuthorizationValueLength ||
+        input.state !== input.storedState
+    ) {
+        return redirectDecision(callbackUrl, 'state_invalid');
+    }
+
+    if (input.providerError || input.providerErrorReason) {
+        const canceled =
+            input.providerError === 'access_denied' ||
+            input.providerErrorReason === 'user_denied';
+        return redirectDecision(
+            callbackUrl,
+            canceled ? 'canceled' : 'provider_error',
+        );
+    }
+
+    if (!input.code || input.code.length > maximumAuthorizationValueLength) {
+        return redirectDecision(callbackUrl, 'callback_error');
+    }
+
+    return {
+        kind: 'continue',
+        callbackUrl,
+        code: input.code,
+        state: input.state,
+        clearCookieNames: oauthCallbackCookieNames,
+    };
+}

--- a/apps/api/lib/auth/oauthCallbackContract.ts
+++ b/apps/api/lib/auth/oauthCallbackContract.ts
@@ -103,6 +103,10 @@ function isAllowedWebCallbackOrigin(url: URL) {
 }
 
 function hasOnlySupportedCallbackQuery(url: URL) {
+    if (url.searchParams.getAll('returnTo').length > 1) {
+        return false;
+    }
+
     for (const key of url.searchParams.keys()) {
         if (key !== 'returnTo') {
             return false;

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1,6 +1,9 @@
 const { app, BrowserWindow, Menu, shell, session } = require('electron');
 const fs = require('node:fs');
 const path = require('node:path');
+const {
+    createDesktopOAuthCallbackRedirectUrl,
+} = require('./oauth-redirect.cjs');
 
 const allowedPermissionNames = new Set([
     'clipboard-read',
@@ -384,12 +387,13 @@ function isTrustedAuthOrigin(parsedUrl) {
     );
 }
 
-function desktopAuthCallbackRedirectUrl(provider) {
-    if (!runtimeConfig.protocol) {
-        return null;
-    }
-
-    return `${runtimeConfig.protocol}://auth-callback/${provider}`;
+function desktopAuthCallbackRedirectUrl(provider, sourceAuthUrl) {
+    return createDesktopOAuthCallbackRedirectUrl({
+        protocol: runtimeConfig.protocol,
+        provider,
+        sourceAuthUrl,
+        trustedNavigationOrigins,
+    });
 }
 
 function openExternalOAuthLogin(targetUrl) {
@@ -400,7 +404,7 @@ function openExternalOAuthLogin(targetUrl) {
             return false;
         }
 
-        const redirectUrl = desktopAuthCallbackRedirectUrl(provider);
+        const redirectUrl = desktopAuthCallbackRedirectUrl(provider, parsedUrl);
         if (!redirectUrl) {
             return false;
         }

--- a/apps/desktop/electron/oauth-redirect.cjs
+++ b/apps/desktop/electron/oauth-redirect.cjs
@@ -1,0 +1,68 @@
+const maximumCallbackUrlLength = 2_048;
+const oauthProviders = new Set(['facebook', 'google']);
+
+function callbackPath(provider) {
+    return `/prijava/${provider}-prijava/povratak`;
+}
+
+function createDesktopOAuthCallbackRedirectUrl({
+    protocol,
+    provider,
+    sourceAuthUrl,
+    trustedNavigationOrigins,
+}) {
+    if (
+        typeof protocol !== 'string' ||
+        !/^gredice-[a-z0-9-]+$/.test(protocol) ||
+        !oauthProviders.has(provider)
+    ) {
+        return null;
+    }
+
+    const callbackUrl = new URL(`${protocol}://auth-callback/${provider}`);
+
+    try {
+        const authUrl = new URL(sourceAuthUrl);
+        const redirectValues = authUrl.searchParams.getAll('redirect');
+        if (redirectValues.length !== 1) {
+            return callbackUrl.toString();
+        }
+
+        const [redirectValue] = redirectValues;
+        if (!redirectValue || redirectValue.length > maximumCallbackUrlLength) {
+            return callbackUrl.toString();
+        }
+
+        const nestedCallbackUrl = new URL(redirectValue);
+        const trustedOrigins = new Set(trustedNavigationOrigins);
+        const returnToValues =
+            nestedCallbackUrl.searchParams.getAll('returnTo');
+        if (
+            nestedCallbackUrl.username ||
+            nestedCallbackUrl.password ||
+            nestedCallbackUrl.hash ||
+            !trustedOrigins.has(nestedCallbackUrl.origin) ||
+            nestedCallbackUrl.pathname !== callbackPath(provider) ||
+            returnToValues.length > 1 ||
+            Array.from(nestedCallbackUrl.searchParams.keys()).some(
+                (key) => key !== 'returnTo',
+            )
+        ) {
+            return callbackUrl.toString();
+        }
+
+        const [returnTo] = returnToValues;
+        if (returnTo) {
+            callbackUrl.searchParams.set('returnTo', returnTo);
+            if (callbackUrl.toString().length > maximumCallbackUrlLength) {
+                callbackUrl.searchParams.delete('returnTo');
+            }
+        }
+    } catch (_error) {
+        return callbackUrl.toString();
+    }
+
+    return callbackUrl.toString();
+}
+
+module.exports = { createDesktopOAuthCallbackRedirectUrl };

--- a/apps/desktop/scripts/check-desktop-sources.mjs
+++ b/apps/desktop/scripts/check-desktop-sources.mjs
@@ -8,6 +8,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(scriptDir, '..');
 const sourceFiles = [
     'electron/main.cjs',
+    'electron/oauth-redirect.cjs',
     'electron/preload.cjs',
     'scripts/check-desktop-sources.mjs',
     'scripts/desktop-apps.mjs',

--- a/apps/desktop/scripts/package-desktop-app.mjs
+++ b/apps/desktop/scripts/package-desktop-app.mjs
@@ -98,6 +98,10 @@ async function copyDesktopShellFiles(stageDir, desktopApp) {
         resolve(stageDir, 'main.cjs'),
     );
     await fs.copyFile(
+        resolve(desktopRoot, 'electron/oauth-redirect.cjs'),
+        resolve(stageDir, 'oauth-redirect.cjs'),
+    );
+    await fs.copyFile(
         resolve(desktopRoot, 'electron/preload.cjs'),
         resolve(stageDir, 'preload.cjs'),
     );
@@ -184,6 +188,7 @@ async function writeBuilderConfig(stageDir, desktopApp, electronVersion) {
             'favicon.ico',
             'icon.png',
             'main.cjs',
+            'oauth-redirect.cjs',
             'package.json',
             'preload.cjs',
         ],

--- a/apps/desktop/tests/desktop-apps.test.mjs
+++ b/apps/desktop/tests/desktop-apps.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -11,6 +12,36 @@ import {
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(testDir, '../../..');
+const require = createRequire(import.meta.url);
+const {
+    createDesktopOAuthCallbackRedirectUrl,
+} = require('../electron/oauth-redirect.cjs');
+
+const farmOrigin = 'https://farma.gredice.com';
+
+function desktopOAuthCallback({
+    nestedRedirect,
+    provider = 'google',
+    redirectValues,
+} = {}) {
+    const authUrl = new URL(`/api/gredice/api/auth/${provider}`, farmOrigin);
+    for (const redirectValue of redirectValues ?? [nestedRedirect]) {
+        if (redirectValue !== undefined) {
+            authUrl.searchParams.append('redirect', redirectValue);
+        }
+    }
+
+    return createDesktopOAuthCallbackRedirectUrl({
+        protocol: 'gredice-farm',
+        provider,
+        sourceAuthUrl: authUrl,
+        trustedNavigationOrigins: new Set([farmOrigin]),
+    });
+}
+
+function webOAuthCallback(provider = 'google') {
+    return new URL(`/prijava/${provider}-prijava/povratak`, farmOrigin);
+}
 
 test('desktop release configs use production HTTPS app origins', () => {
     assert.deepEqual(desktopAppNames, ['garden', 'farm', 'app']);
@@ -104,6 +135,7 @@ test('desktop shell hands OAuth login to the system browser', () => {
     assert.match(mainSource, /openExternalOAuthLogin/);
     assert.match(mainSource, /GREDICE_DESKTOP_EXTERNAL_AUTH_BASE_URL/);
     assert.match(mainSource, /desktopAuthCallbackRedirectUrl/);
+    assert.match(mainSource, /createDesktopOAuthCallbackRedirectUrl/);
     assert.match(mainSource, /api\\\/gredice\\\/api\\\/auth/);
     assert.match(mainSource, /setAsDefaultProtocolClient/);
     assert.match(mainSource, /auth-callback/);
@@ -117,6 +149,91 @@ test('desktop shell hands OAuth login to the system browser', () => {
     assert.match(packageSource, /uninstallerIcon: 'favicon\.ico'/);
     assert.match(packageSource, /icon: 'favicon\.ico'/);
     assert.match(packageSource, /schemes: \[desktopApp\.protocol\]/);
+    assert.match(packageSource, /oauth-redirect\.cjs/);
+});
+
+test('desktop OAuth preserves the nested Farm return path for each provider', () => {
+    for (const provider of ['google', 'facebook']) {
+        const nestedCallback = webOAuthCallback(provider);
+        nestedCallback.searchParams.set(
+            'returnTo',
+            '/notifications?filter=unread#latest',
+        );
+
+        const result = desktopOAuthCallback({
+            nestedRedirect: nestedCallback.toString(),
+            provider,
+        });
+        const callback = new URL(result);
+
+        assert.equal(callback.protocol, 'gredice-farm:');
+        assert.equal(callback.hostname, 'auth-callback');
+        assert.equal(callback.pathname, `/${provider}`);
+        assert.equal(
+            callback.searchParams.get('returnTo'),
+            '/notifications?filter=unread#latest',
+        );
+    }
+});
+
+test('desktop OAuth keeps a bare callback when no return path is present', () => {
+    assert.equal(
+        desktopOAuthCallback({
+            nestedRedirect: webOAuthCallback().toString(),
+        }),
+        'gredice-farm://auth-callback/google',
+    );
+    assert.equal(
+        desktopOAuthCallback({ redirectValues: [] }),
+        'gredice-farm://auth-callback/google',
+    );
+});
+
+test('desktop OAuth omits return paths from untrusted nested callbacks', () => {
+    const wrongOrigin = new URL(
+        '/prijava/google-prijava/povratak?returnTo=%2Fnotifications',
+        'https://attacker.example',
+    );
+    const wrongPath = new URL(
+        '/prijava/facebook-prijava/povratak?returnTo=%2Fnotifications',
+        farmOrigin,
+    );
+    const withHash = webOAuthCallback();
+    withHash.searchParams.set('returnTo', '/notifications');
+    withHash.hash = 'unexpected';
+    const withExtraQuery = webOAuthCallback();
+    withExtraQuery.searchParams.set('returnTo', '/notifications');
+    withExtraQuery.searchParams.set('token', 'raw');
+    const withCredentials = new URL(webOAuthCallback());
+    withCredentials.username = 'user';
+    const withDuplicateReturnTo = webOAuthCallback();
+    withDuplicateReturnTo.searchParams.append('returnTo', '/notifications');
+    withDuplicateReturnTo.searchParams.append('returnTo', '/schedule');
+    const oversizedReturnTo = webOAuthCallback();
+    oversizedReturnTo.searchParams.set('returnTo', `/${'a'.repeat(2_048)}`);
+
+    for (const nestedRedirect of [
+        wrongOrigin,
+        wrongPath,
+        withHash,
+        withExtraQuery,
+        withCredentials,
+        withDuplicateReturnTo,
+        oversizedReturnTo,
+    ]) {
+        assert.equal(
+            desktopOAuthCallback({ nestedRedirect: nestedRedirect.toString() }),
+            'gredice-farm://auth-callback/google',
+        );
+    }
+
+    const validCallback = webOAuthCallback().toString();
+    assert.equal(
+        desktopOAuthCallback({
+            redirectValues: [validCallback, validCallback],
+        }),
+        'gredice-farm://auth-callback/google',
+    );
 });
 
 test('desktop release workflows can sign macOS artifacts when credentials exist', () => {

--- a/apps/farm/app/prijava/OAuthCallbackPanel.tsx
+++ b/apps/farm/app/prijava/OAuthCallbackPanel.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Spinner } from '@gredice/ui/Spinner';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useEffect, useRef } from 'react';
+import { FarmSignInShell } from '../../components/auth/FarmSignInShell';
+import type { FarmOAuthProvider } from '../../lib/auth/safeFarmReturnPath';
+
+export type OAuthCallbackErrorCode =
+    | 'callback_error'
+    | 'canceled'
+    | 'exchange_error'
+    | 'missing_token'
+    | 'network_error'
+    | 'provider_error'
+    | 'state_invalid';
+
+export type OAuthCallbackViewState =
+    | { status: 'error'; code: OAuthCallbackErrorCode }
+    | { status: 'processing' };
+
+const ERROR_CONTENT: Record<
+    OAuthCallbackErrorCode,
+    { message: string; title: string }
+> = {
+    callback_error: {
+        title: 'Prijava nije završena',
+        message:
+            'Prijavu trenutno nije moguće završiti. Pokušaj ponovno ili se vrati na prijavu.',
+    },
+    canceled: {
+        title: 'Prijava je otkazana',
+        message:
+            'Nisi dovršio prijavu kod odabranog pružatelja. Tvoj račun nije promijenjen.',
+    },
+    exchange_error: {
+        title: 'Prijava nije spremljena',
+        message:
+            'Podaci za prijavu nisu mogli biti sigurno spremljeni. Pokreni prijavu ponovno.',
+    },
+    missing_token: {
+        title: 'Nedostaju podaci za prijavu',
+        message:
+            'Povratak s prijave nije sadržavao potrebne podatke. Pokreni prijavu ponovno.',
+    },
+    network_error: {
+        title: 'Veza je prekinuta',
+        message:
+            'Provjeri internetsku vezu i pokreni prijavu ponovno. Podaci za prijavu nisu spremljeni.',
+    },
+    provider_error: {
+        title: 'Pružatelj prijave nije dostupan',
+        message:
+            'Google ili Facebook nije uspio dovršiti prijavu. Pokušaj ponovno za nekoliko trenutaka.',
+    },
+    state_invalid: {
+        title: 'Prijavu treba ponoviti',
+        message:
+            'Sigurnosna provjera prijave nije uspjela. Pokreni novu prijavu iz Gredice Farme.',
+    },
+};
+
+function getProviderLabel(provider: FarmOAuthProvider) {
+    return provider === 'google' ? 'Google' : 'Facebook';
+}
+
+interface OAuthCallbackPanelProps {
+    onBack?: () => void;
+    onRetry?: () => void;
+    provider: FarmOAuthProvider;
+    state: OAuthCallbackViewState;
+}
+
+export function OAuthCallbackPanel({
+    onBack,
+    onRetry,
+    provider,
+    state,
+}: OAuthCallbackPanelProps) {
+    const errorRef = useRef<HTMLDivElement>(null);
+    const providerLabel = getProviderLabel(provider);
+
+    useEffect(() => {
+        if (state.status === 'error') {
+            errorRef.current?.focus();
+        }
+    }, [state.status]);
+
+    return (
+        <FarmSignInShell>
+            <Stack spacing={6}>
+                <Stack spacing={2}>
+                    <Typography className="text-xl" level="h2" semiBold>
+                        {providerLabel} prijava
+                    </Typography>
+                    {state.status === 'processing' ? (
+                        <Typography className="text-muted-foreground">
+                            Sigurno završavamo tvoju prijavu.
+                        </Typography>
+                    ) : null}
+                </Stack>
+
+                {state.status === 'processing' ? (
+                    <div
+                        aria-live="polite"
+                        className="flex min-h-11 items-center gap-3 rounded-lg border bg-muted/40 px-4 py-3"
+                        role="status"
+                    >
+                        <Spinner
+                            className="size-5 shrink-0"
+                            loading
+                            loadingLabel="Prijava u tijeku"
+                        />
+                        <Typography level="body2">Prijava u tijeku…</Typography>
+                    </div>
+                ) : (
+                    <Stack spacing={4}>
+                        <div ref={errorRef} tabIndex={-1}>
+                            <Alert color="danger" role="alert">
+                                <Stack spacing={1}>
+                                    <Typography level="body2" semiBold>
+                                        {ERROR_CONTENT[state.code].title}
+                                    </Typography>
+                                    <Typography level="body2">
+                                        {ERROR_CONTENT[state.code].message}
+                                    </Typography>
+                                </Stack>
+                            </Alert>
+                        </div>
+                        <Stack spacing={2}>
+                            <Button
+                                fullWidth
+                                onClick={onRetry}
+                                size="lg"
+                                type="button"
+                                variant="solid"
+                            >
+                                Pokušaj ponovno
+                            </Button>
+                            <Button
+                                color="neutral"
+                                fullWidth
+                                onClick={onBack}
+                                size="lg"
+                                type="button"
+                                variant="outlined"
+                            >
+                                Natrag na prijavu
+                            </Button>
+                        </Stack>
+                    </Stack>
+                )}
+            </Stack>
+        </FarmSignInShell>
+    );
+}

--- a/apps/farm/app/prijava/UrlAuthForward.spec.tsx
+++ b/apps/farm/app/prijava/UrlAuthForward.spec.tsx
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { OAuthCallbackStrictModeHarness } from '../../playwright/OAuthCallbackStrictModeHarness';
+
+test('retains OAuth credentials through Strict Mode effect replay', async ({
+    mount,
+    page,
+}) => {
+    const exchangeBodies: Array<string | null> = [];
+    await page.route('**/api/oauth-callback', async (route) => {
+        exchangeBodies.push(route.request().postData());
+        await route.fulfill({ status: 500 });
+    });
+    await page.evaluate(() => {
+        window.history.replaceState(
+            null,
+            '',
+            `${window.location.pathname}#token=strict-token&refreshToken=strict-refresh`,
+        );
+    });
+
+    const component = await mount(<OAuthCallbackStrictModeHarness />);
+
+    await expect(
+        component.locator('[data-farm-sign-in-panel]').getByRole('alert'),
+    ).toContainText('Prijava nije spremljena');
+    expect(exchangeBodies.length).toBeGreaterThan(0);
+    expect(
+        exchangeBodies.every(
+            (body) =>
+                body ===
+                JSON.stringify({
+                    token: 'strict-token',
+                    refreshToken: 'strict-refresh',
+                }),
+        ),
+    ).toBe(true);
+    expect(await page.evaluate(() => window.location.hash)).toBe('');
+});

--- a/apps/farm/app/prijava/UrlAuthForward.tsx
+++ b/apps/farm/app/prijava/UrlAuthForward.tsx
@@ -1,72 +1,189 @@
 'use client';
 
+import { getBrowserGrediceAppOrigin } from '@gredice/client';
 import { authCurrentUserQueryKeys } from '@gredice/ui/auth';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import {
+    type FarmOAuthProvider,
+    getFarmOAuthStartUrl,
+    getSafeFarmReturnPath,
+} from '../../lib/auth/safeFarmReturnPath';
+import {
+    type OAuthCallbackErrorCode,
+    OAuthCallbackPanel,
+    type OAuthCallbackViewState,
+} from './OAuthCallbackPanel';
 
-export function UrlAuthForward() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
+const OAUTH_CALLBACK_TIMEOUT_MS = 10_000;
+
+function getServerCallbackErrorCode(
+    value: string | null,
+): OAuthCallbackErrorCode | null {
+    switch (value) {
+        case null:
+            return null;
+        case 'callback_error':
+        case 'canceled':
+        case 'provider_error':
+        case 'state_invalid':
+            return value;
+        default:
+            return 'callback_error';
+    }
+}
+
+type OAuthCallbackForwarderProps = {
+    provider: FarmOAuthProvider;
+    returnTo: string;
+    serverErrorCode: OAuthCallbackErrorCode | null;
+};
+
+type OAuthFragment = {
+    refreshToken: string | null;
+    token: string | null;
+};
+
+export function OAuthCallbackForwarder({
+    provider,
+    returnTo,
+    serverErrorCode,
+}: OAuthCallbackForwarderProps) {
     const queryClient = useQueryClient();
+    const [viewState, setViewState] = useState<OAuthCallbackViewState>({
+        status: 'processing',
+    });
+    const oauthFragmentRef = useRef<OAuthFragment | undefined>(undefined);
 
     useEffect(() => {
+        const abortController = new AbortController();
+        let active = true;
+        let timeoutId: number | undefined;
+
         const forwardAuthSession = async () => {
-            const error = searchParams.get('error');
-            if (error) {
-                console.error('Authentication error:', error);
-                router.replace('/');
+            if (oauthFragmentRef.current === undefined) {
+                const hash = window.location.hash.slice(1);
+                const hashParams = new URLSearchParams(hash);
+                oauthFragmentRef.current = {
+                    refreshToken: hashParams.get('refreshToken'),
+                    token: hashParams.get('token'),
+                };
+
+                if (hash) {
+                    window.history.replaceState(
+                        null,
+                        '',
+                        window.location.pathname + window.location.search,
+                    );
+                }
+            }
+            const { refreshToken, token } = oauthFragmentRef.current;
+
+            if (serverErrorCode) {
+                setViewState({ status: 'error', code: serverErrorCode });
                 return;
             }
 
-            // Read tokens from URL fragment (hash) to avoid server logs/referrer leakage
-            const hash = window.location.hash.substring(1);
-            const params = new URLSearchParams(hash);
-            const token = params.get('token');
-            const refreshToken = params.get('refreshToken');
-
-            // Clear tokens from URL immediately to minimize exposure
-            if (hash) {
-                window.history.replaceState(
-                    null,
-                    '',
-                    window.location.pathname + window.location.search,
-                );
+            if (!token) {
+                setViewState({ status: 'error', code: 'missing_token' });
+                return;
             }
 
-            if (token) {
-                // Exchange tokens for httpOnly cookies via local route handler
-                try {
-                    const response = await fetch('/api/oauth-callback', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ token, refreshToken }),
-                    });
+            timeoutId = window.setTimeout(
+                () => abortController.abort(),
+                OAUTH_CALLBACK_TIMEOUT_MS,
+            );
 
-                    if (!response.ok) {
-                        console.error(
-                            'OAuth callback failed:',
-                            response.status,
-                            response.statusText,
-                        );
-                        router.replace('/');
-                        return;
+            try {
+                const response = await fetch('/api/oauth-callback', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ token, refreshToken }),
+                    signal: abortController.signal,
+                });
+
+                if (!response.ok) {
+                    console.error(
+                        'OAuth callback cookie exchange failed',
+                        response.status,
+                    );
+                    if (active) {
+                        setViewState({
+                            status: 'error',
+                            code: 'exchange_error',
+                        });
                     }
-                } catch (fetchError) {
-                    console.error('OAuth callback request error:', fetchError);
-                    router.replace('/');
                     return;
+                }
+            } catch (cause) {
+                console.error(
+                    'OAuth callback request failed',
+                    cause instanceof Error ? cause.name : 'unknown',
+                );
+                if (active) {
+                    setViewState({ status: 'error', code: 'network_error' });
+                }
+                return;
+            } finally {
+                if (timeoutId !== undefined) {
+                    window.clearTimeout(timeoutId);
                 }
             }
 
-            await queryClient.invalidateQueries({
-                queryKey: authCurrentUserQueryKeys,
-            });
-            router.replace('/');
+            if (!active) {
+                return;
+            }
+            await queryClient
+                .invalidateQueries({ queryKey: authCurrentUserQueryKeys })
+                .catch(() => undefined);
+            window.location.replace(returnTo);
         };
 
         void forwardAuthSession();
-    }, [queryClient, router, searchParams]);
 
-    return null;
+        return () => {
+            active = false;
+            abortController.abort();
+            if (timeoutId !== undefined) {
+                window.clearTimeout(timeoutId);
+            }
+        };
+    }, [queryClient, returnTo, serverErrorCode]);
+
+    const handleRetry = () => {
+        window.location.assign(
+            getFarmOAuthStartUrl({
+                apiOrigin: getBrowserGrediceAppOrigin('api'),
+                farmOrigin: window.location.origin,
+                provider,
+                returnTo,
+            }),
+        );
+    };
+
+    return (
+        <OAuthCallbackPanel
+            onBack={() => window.location.replace(returnTo)}
+            onRetry={handleRetry}
+            provider={provider}
+            state={viewState}
+        />
+    );
+}
+
+export function UrlAuthForward({ provider }: { provider: FarmOAuthProvider }) {
+    const searchParams = useSearchParams();
+    const returnTo = getSafeFarmReturnPath(searchParams.get('returnTo'));
+    const serverErrorCode = getServerCallbackErrorCode(
+        searchParams.get('error'),
+    );
+
+    return (
+        <OAuthCallbackForwarder
+            provider={provider}
+            returnTo={returnTo}
+            serverErrorCode={serverErrorCode}
+        />
+    );
 }

--- a/apps/farm/app/prijava/facebook-prijava/povratak/page.tsx
+++ b/apps/farm/app/prijava/facebook-prijava/povratak/page.tsx
@@ -1,50 +1,18 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
-import { Row } from '@gredice/ui/Row';
-import { Spinner } from '@gredice/ui/Spinner';
-import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
 import { Suspense } from 'react';
+import { OAuthCallbackPanel } from '../../OAuthCallbackPanel';
 import { UrlAuthForward } from '../../UrlAuthForward';
 
 export default function FacebookCallbackPage() {
     return (
-        <div className="min-h-[100dvh] flex items-center justify-center bg-background p-4">
-            <Card className="w-full max-w-[350px] p-6 sm:p-12">
-                <CardHeader>
-                    <svg
-                        className="mx-auto size-12 text-[#1877F2] mb-4"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                    >
-                        <title>Facebook</title>
-                        <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
-                    </svg>
-                    <CardTitle className="text-center">
-                        Facebook prijava
-                    </CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <Stack spacing={6}>
-                        <Row spacing={4} justifyContent="center">
-                            <Spinner
-                                loading
-                                className="size-5"
-                                loadingLabel="Prijava u tijeku..."
-                            />
-                            <Typography level="body2">
-                                Prijava u tijeku...
-                            </Typography>
-                        </Row>
-                        <Typography level="body3" center>
-                            Pričekaj dok završimo tvoju Facebook prijavu.
-                        </Typography>
-                    </Stack>
-                </CardContent>
-            </Card>
-            <Suspense>
-                <UrlAuthForward />
-            </Suspense>
-        </div>
+        <Suspense
+            fallback={
+                <OAuthCallbackPanel
+                    provider="facebook"
+                    state={{ status: 'processing' }}
+                />
+            }
+        >
+            <UrlAuthForward provider="facebook" />
+        </Suspense>
     );
 }

--- a/apps/farm/app/prijava/google-prijava/povratak/page.tsx
+++ b/apps/farm/app/prijava/google-prijava/povratak/page.tsx
@@ -1,65 +1,18 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
-import { Row } from '@gredice/ui/Row';
-import { Spinner } from '@gredice/ui/Spinner';
-import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
 import { Suspense } from 'react';
+import { OAuthCallbackPanel } from '../../OAuthCallbackPanel';
 import { UrlAuthForward } from '../../UrlAuthForward';
 
 export default function GoogleCallbackPage() {
     return (
-        <div className="min-h-[100dvh] flex items-center justify-center bg-background p-4">
-            <Card className="w-full max-w-[350px] p-6 sm:p-12">
-                <CardHeader>
-                    <svg
-                        className="mx-auto size-12 mb-4"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                    >
-                        <title>Google</title>
-                        <path
-                            fill="#4285F4"
-                            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                        />
-                        <path
-                            fill="#34A853"
-                            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                        />
-                        <path
-                            fill="#FBBC05"
-                            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                        />
-                        <path
-                            fill="#EA4335"
-                            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                        />
-                    </svg>
-                    <CardTitle className="text-center">
-                        Google prijava
-                    </CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <Stack spacing={6}>
-                        <Row spacing={4} justifyContent="center">
-                            <Spinner
-                                loading
-                                className="size-5"
-                                loadingLabel="Prijava u tijeku..."
-                            />
-                            <Typography level="body2">
-                                Prijava u tijeku...
-                            </Typography>
-                        </Row>
-                        <Typography level="body3" center>
-                            Pričekaj dok završimo tvoju Google prijavu.
-                        </Typography>
-                    </Stack>
-                </CardContent>
-            </Card>
-            <Suspense>
-                <UrlAuthForward />
-            </Suspense>
-        </div>
+        <Suspense
+            fallback={
+                <OAuthCallbackPanel
+                    provider="google"
+                    state={{ status: 'processing' }}
+                />
+            }
+        >
+            <UrlAuthForward provider="google" />
+        </Suspense>
     );
 }

--- a/apps/farm/components/auth/FarmSignInShell.tsx
+++ b/apps/farm/components/auth/FarmSignInShell.tsx
@@ -1,0 +1,55 @@
+import Image from 'next/image';
+import type { ReactNode } from 'react';
+
+interface FarmSignInShellProps {
+    children: ReactNode;
+}
+
+export function FarmSignInShell({ children }: FarmSignInShellProps) {
+    return (
+        <main
+            className="relative isolate flex min-h-[100dvh] w-full min-w-0 items-center justify-center overflow-hidden [padding-bottom:calc(var(--farm-safe-area-bottom,0px)+1rem)] [padding-left:calc(var(--farm-safe-area-left,0px)+1rem)] [padding-right:calc(var(--farm-safe-area-right,0px)+1rem)] [padding-top:calc(var(--farm-safe-area-top,0px)+1rem)] sm:[padding-bottom:calc(var(--farm-safe-area-bottom,0px)+1.5rem)] sm:[padding-left:calc(var(--farm-safe-area-left,0px)+1.5rem)] sm:[padding-right:calc(var(--farm-safe-area-right,0px)+1.5rem)] sm:[padding-top:calc(var(--farm-safe-area-top,0px)+1.5rem)]"
+            data-farm-sign-in-shell
+        >
+            <div aria-hidden="true" className="absolute inset-0 -z-20">
+                <Image
+                    alt=""
+                    className="object-cover"
+                    fill
+                    priority
+                    quality={90}
+                    sizes="100vw"
+                    src="/login-bg.webp"
+                />
+            </div>
+            <div
+                aria-hidden="true"
+                className="absolute inset-0 -z-10 bg-background/78 backdrop-blur-[2px] dark:bg-background/88"
+            />
+
+            <section
+                aria-labelledby="farm-sign-in-heading"
+                className="relative w-full max-w-md rounded-2xl border border-border/80 bg-background/95 p-5 shadow-xl shadow-black/10 backdrop-blur sm:p-7"
+                data-farm-sign-in-panel
+            >
+                <header className="mb-7 space-y-2">
+                    <p className="text-xs font-semibold uppercase tracking-[0.16em] text-primary">
+                        Prijava za farmere
+                    </p>
+                    <h1
+                        className="text-3xl font-semibold tracking-tight text-foreground"
+                        id="farm-sign-in-heading"
+                    >
+                        Gredice Farm
+                    </h1>
+                    <p className="max-w-sm text-sm leading-6 text-muted-foreground">
+                        Dnevni zadaci, gredice i evidencija rada na jednom
+                        mjestu.
+                    </p>
+                </header>
+
+                {children}
+            </section>
+        </main>
+    );
+}

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -10,14 +10,13 @@ import {
 import { Button } from '@gredice/ui/Button';
 import { Input } from '@gredice/ui/Input';
 import { Mail, Warning } from '@gredice/ui/icons';
-import { Modal } from '@gredice/ui/Modal';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { usePostHog } from '@posthog/next';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useActionState, useCallback, useState } from 'react';
 import { queryClient } from '../providers/ClientAppProvider';
+import { FarmSignInShell } from './FarmSignInShell';
 
 type OAuthProvider = 'google' | 'facebook';
 
@@ -117,107 +116,130 @@ export function LoginDialog() {
     };
 
     return (
-        <div className="min-h-[100dvh] flex items-center justify-center bg-gradient-to-br from-primary/10 via-transparent to-success/10 p-4">
-            <Image
-                src="/login-bg.webp"
-                alt="Pozadina"
-                fill
-                className="object-cover"
-                quality={100}
-                priority
-            />
-            <Modal
-                open
-                dismissible={false}
-                title="Prijava u Gredice farmu"
-                className="md:max-w-md"
-            >
-                <Stack spacing={8}>
-                    <Stack spacing={2}>
-                        <Typography level="h3" className="text-2xl" semiBold>
-                            Dobrodošli
-                        </Typography>
-                        <Typography className="text-muted-foreground">
-                            Prijavi se s Gredice računom kako bi upravljao
-                            svojom farmom.
-                        </Typography>
-                    </Stack>
-                    {!emailExpanded ? (
-                        <Stack spacing={2}>
-                            <GoogleLoginButton
-                                onClick={() => handleOAuthLogin('google')}
-                                lastUsed={lastLoginProvider === 'google'}
-                            >
-                                Google prijava
-                            </GoogleLoginButton>
-                            <FacebookLoginButton
-                                onClick={() => handleOAuthLogin('facebook')}
-                                lastUsed={lastLoginProvider === 'facebook'}
-                            >
-                                Facebook prijava
-                            </FacebookLoginButton>
-                            <Button
-                                type="button"
-                                variant="outlined"
-                                color="neutral"
-                                fullWidth
-                                startDecorator={
-                                    <Mail className="h-4 w-4 shrink-0" />
-                                }
-                                onClick={() => setEmailExpanded(true)}
-                            >
-                                Email prijava
-                            </Button>
-                        </Stack>
-                    ) : (
-                        <form
-                            action={submitAction}
-                            className="w-full space-y-4"
-                        >
-                            <Stack spacing={6}>
-                                <Stack spacing={2}>
-                                    <Input
-                                        name="email"
-                                        label="Email"
-                                        placeholder="ime@primjer.com"
-                                        type="email"
-                                        autoComplete="email"
-                                        fullWidth
-                                        required
-                                    />
-                                    <Input
-                                        name="password"
-                                        label="Zaporka"
-                                        type="password"
-                                        autoComplete="current-password"
-                                        fullWidth
-                                        required
-                                    />
-                                </Stack>
-                                <Button
-                                    type="submit"
-                                    loading={isPending}
-                                    variant="solid"
-                                    fullWidth
-                                >
-                                    Prijavi se
-                                </Button>
-                                {error && (
-                                    <Alert
-                                        color="danger"
-                                        startDecorator={
-                                            <Warning className="size-5" />
-                                        }
-                                    >
-                                        {error}
-                                    </Alert>
-                                )}
-                            </Stack>
-                        </form>
-                    )}
+        <FarmSignInShell>
+            <Stack spacing={7}>
+                <Stack spacing={2}>
+                    <Typography level="h2" className="text-xl" semiBold>
+                        Dobrodošli
+                    </Typography>
+                    <Typography className="text-muted-foreground">
+                        Prijavi se s Gredice računom kako bi upravljao svojom
+                        farmom.
+                    </Typography>
                 </Stack>
-            </Modal>
-        </div>
+                {!emailExpanded ? (
+                    <Stack spacing={2}>
+                        <GoogleLoginButton
+                            aria-describedby={
+                                lastLoginProvider === 'google'
+                                    ? 'farm-google-last-used'
+                                    : undefined
+                            }
+                            lastUsed={lastLoginProvider === 'google'}
+                            onClick={() => handleOAuthLogin('google')}
+                            size="lg"
+                        >
+                            Google prijava
+                        </GoogleLoginButton>
+                        {lastLoginProvider === 'google' ? (
+                            <Typography
+                                className="text-center text-xs text-muted-foreground sm:sr-only"
+                                id="farm-google-last-used"
+                                level="body3"
+                            >
+                                Zadnje korišteno
+                            </Typography>
+                        ) : null}
+                        <FacebookLoginButton
+                            aria-describedby={
+                                lastLoginProvider === 'facebook'
+                                    ? 'farm-facebook-last-used'
+                                    : undefined
+                            }
+                            lastUsed={lastLoginProvider === 'facebook'}
+                            onClick={() => handleOAuthLogin('facebook')}
+                            size="lg"
+                        >
+                            Facebook prijava
+                        </FacebookLoginButton>
+                        {lastLoginProvider === 'facebook' ? (
+                            <Typography
+                                className="text-center text-xs text-muted-foreground sm:sr-only"
+                                id="farm-facebook-last-used"
+                                level="body3"
+                            >
+                                Zadnje korišteno
+                            </Typography>
+                        ) : null}
+                        <Button
+                            color="neutral"
+                            fullWidth
+                            onClick={() => setEmailExpanded(true)}
+                            size="lg"
+                            startDecorator={
+                                <Mail
+                                    aria-hidden="true"
+                                    className="h-4 w-4 shrink-0"
+                                />
+                            }
+                            type="button"
+                            variant="outlined"
+                        >
+                            Email prijava
+                        </Button>
+                    </Stack>
+                ) : (
+                    <form action={submitAction} className="w-full space-y-4">
+                        <Stack spacing={6}>
+                            <Stack spacing={2}>
+                                <Input
+                                    autoComplete="email"
+                                    className="h-11 [&>input]:h-full"
+                                    fullWidth
+                                    label="Email"
+                                    name="email"
+                                    placeholder="ime@primjer.com"
+                                    required
+                                    type="email"
+                                />
+                                <Input
+                                    autoComplete="current-password"
+                                    className="h-11 [&>input]:h-full"
+                                    fullWidth
+                                    label="Zaporka"
+                                    name="password"
+                                    required
+                                    type="password"
+                                />
+                            </Stack>
+                            <Button
+                                fullWidth
+                                loading={isPending}
+                                size="lg"
+                                type="submit"
+                                variant="solid"
+                            >
+                                Prijavi se
+                            </Button>
+                            {error && (
+                                <Alert
+                                    color="danger"
+                                    role="alert"
+                                    startDecorator={
+                                        <Warning
+                                            aria-hidden="true"
+                                            className="size-5"
+                                        />
+                                    }
+                                >
+                                    {error}
+                                </Alert>
+                            )}
+                        </Stack>
+                    </form>
+                )}
+            </Stack>
+        </FarmSignInShell>
     );
 }
 

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getBrowserGrediceAppOrigin } from '@gredice/client';
 import { Alert } from '@gredice/ui/Alert';
 import {
     authCurrentUserQueryKeys,
@@ -15,10 +16,12 @@ import { Typography } from '@gredice/ui/Typography';
 import { usePostHog } from '@posthog/next';
 import { useRouter } from 'next/navigation';
 import { useActionState, useCallback, useState } from 'react';
+import {
+    type FarmOAuthProvider,
+    getFarmOAuthStartUrl,
+} from '../../lib/auth/safeFarmReturnPath';
 import { queryClient } from '../providers/ClientAppProvider';
 import { FarmSignInShell } from './FarmSignInShell';
-
-type OAuthProvider = 'google' | 'facebook';
 
 export function LoginDialog() {
     const posthog = usePostHog();
@@ -96,23 +99,17 @@ export function LoginDialog() {
             return 'Dogodila se neočekivana greška. Pokušaj ponovno kasnije.';
         }
     }, null);
-    const handleOAuthLogin = (provider: OAuthProvider) => {
+    const handleOAuthLogin = (provider: FarmOAuthProvider) => {
         posthog?.capture('user_oauth_started', {
             provider,
             surface: 'farm',
         });
-        const callbackPath =
-            provider === 'google'
-                ? '/prijava/google-prijava/povratak'
-                : '/prijava/facebook-prijava/povratak';
-        const redirectUrl = `${window.location.origin}${callbackPath}`;
-        // Use proxy path instead of direct API URL
-        const authUrl = new URL(
-            `/api/gredice/api/auth/${provider}`,
-            window.location.origin,
-        );
-        authUrl.searchParams.set('redirect', redirectUrl);
-        window.location.href = authUrl.toString();
+        window.location.href = getFarmOAuthStartUrl({
+            apiOrigin: getBrowserGrediceAppOrigin('api'),
+            farmOrigin: window.location.origin,
+            provider,
+            returnTo: `${window.location.pathname}${window.location.search}${window.location.hash}`,
+        });
     };
 
     return (

--- a/apps/farm/lib/auth/safeFarmReturnPath.spec.ts
+++ b/apps/farm/lib/auth/safeFarmReturnPath.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+import {
+    getFarmOAuthStartUrl,
+    getSafeFarmReturnPath,
+} from './safeFarmReturnPath';
+
+test('keeps supported Farm routes with their query and hash intact', () => {
+    for (const returnTo of [
+        '/',
+        '/schedule?date=2026-07-15&view=day#task-18',
+        '/notifications?filter=unread',
+        '/raised-beds/42#operations',
+        '/operations/7?source=notification',
+        '/plants/337',
+        '/greenhouse',
+        '/more',
+        '/payouts',
+        '/settings',
+    ]) {
+        expect(getSafeFarmReturnPath(returnTo)).toBe(returnTo);
+    }
+});
+
+test('falls back for external, malformed, private, and unsupported targets', () => {
+    for (const returnTo of [
+        null,
+        '',
+        ' /schedule',
+        '/schedule ',
+        'https://example.com/schedule',
+        '//example.com/schedule',
+        String.raw`\\example.com\schedule`,
+        '/schedule\\details',
+        '/schedule/%5c/example.com',
+        '/schedule/%2f/example.com',
+        '/schedule/%',
+        '/schedule/../notifications',
+        '/schedule/%2e%2e/notifications',
+        '/api/users/current',
+        '/prijava/google-prijava/povratak',
+        '/debug',
+        '/debug/labels',
+        '/unknown',
+        '/operations/0',
+        '/operations/-1',
+        '/operations/not-a-number',
+        `/schedule?value=${'x'.repeat(2048)}`,
+    ]) {
+        expect(getSafeFarmReturnPath(returnTo)).toBe('/');
+    }
+});
+
+test('builds a provider URL with only a validated internal callback target', () => {
+    const authUrl = new URL(
+        getFarmOAuthStartUrl({
+            apiOrigin: 'https://api.gredice.com',
+            farmOrigin: 'https://farma.gredice.com',
+            provider: 'google',
+            returnTo: '/notifications?filter=unread#notification-7',
+        }),
+    );
+    const callbackUrl = new URL(authUrl.searchParams.get('redirect') ?? '');
+
+    expect(authUrl.origin).toBe('https://api.gredice.com');
+    expect(authUrl.pathname).toBe('/api/auth/google');
+    expect(callbackUrl.origin).toBe('https://farma.gredice.com');
+    expect(callbackUrl.pathname).toBe('/prijava/google-prijava/povratak');
+    expect(callbackUrl.searchParams.get('returnTo')).toBe(
+        '/notifications?filter=unread#notification-7',
+    );
+
+    const unsafeCallbackUrl = new URL(
+        new URL(
+            getFarmOAuthStartUrl({
+                apiOrigin: 'https://api.gredice.com',
+                farmOrigin: 'https://farma.gredice.com',
+                provider: 'facebook',
+                returnTo: 'https://example.com/steal',
+            }),
+        ).searchParams.get('redirect') ?? '',
+    );
+    expect(unsafeCallbackUrl.pathname).toBe(
+        '/prijava/facebook-prijava/povratak',
+    );
+    expect(unsafeCallbackUrl.searchParams.get('returnTo')).toBe('/');
+});

--- a/apps/farm/lib/auth/safeFarmReturnPath.ts
+++ b/apps/farm/lib/auth/safeFarmReturnPath.ts
@@ -1,0 +1,107 @@
+const MAX_FARM_RETURN_PATH_LENGTH = 2048;
+
+const FARM_RETURN_EXACT_PATHS = new Set([
+    '/',
+    '/greenhouse',
+    '/more',
+    '/notifications',
+    '/operations',
+    '/payouts',
+    '/plants',
+    '/raised-beds',
+    '/schedule',
+    '/settings',
+]);
+
+const FARM_RETURN_DETAIL_PATH =
+    /^\/(?:operations|plants|raised-beds)\/[1-9]\d*$/;
+const ENCODED_PATH_SEPARATOR = /%(?:2f|5c)/i;
+
+function containsControlCharacter(value: string) {
+    return Array.from(value).some((character) => {
+        const code = character.charCodeAt(0);
+        return code <= 31 || code === 127;
+    });
+}
+
+function isSupportedFarmPath(pathname: string) {
+    return (
+        FARM_RETURN_EXACT_PATHS.has(pathname) ||
+        FARM_RETURN_DETAIL_PATH.test(pathname)
+    );
+}
+
+export function getSafeFarmReturnPath(
+    candidate: string | null | undefined,
+): string {
+    if (
+        !candidate ||
+        candidate !== candidate.trim() ||
+        candidate.length > MAX_FARM_RETURN_PATH_LENGTH ||
+        containsControlCharacter(candidate) ||
+        !candidate.startsWith('/') ||
+        candidate.startsWith('//')
+    ) {
+        return '/';
+    }
+
+    const suffixIndex = candidate.search(/[?#]/);
+    const rawPathname =
+        suffixIndex === -1 ? candidate : candidate.slice(0, suffixIndex);
+    if (
+        rawPathname.includes('\\') ||
+        ENCODED_PATH_SEPARATOR.test(rawPathname)
+    ) {
+        return '/';
+    }
+
+    let decodedPathname: string;
+    let parsedUrl: URL;
+    try {
+        decodedPathname = decodeURIComponent(rawPathname);
+        parsedUrl = new URL(candidate, 'https://farm.gredice.invalid');
+    } catch {
+        return '/';
+    }
+
+    if (
+        decodedPathname.includes('\\') ||
+        decodedPathname.includes('//') ||
+        containsControlCharacter(decodedPathname) ||
+        decodedPathname
+            .split('/')
+            .some((segment) => segment === '.' || segment === '..') ||
+        parsedUrl.origin !== 'https://farm.gredice.invalid' ||
+        !isSupportedFarmPath(decodedPathname)
+    ) {
+        return '/';
+    }
+
+    return candidate;
+}
+
+export type FarmOAuthProvider = 'facebook' | 'google';
+
+export function getFarmOAuthStartUrl({
+    apiOrigin,
+    farmOrigin,
+    provider,
+    returnTo,
+}: {
+    apiOrigin: string;
+    farmOrigin: string;
+    provider: FarmOAuthProvider;
+    returnTo: string | null | undefined;
+}) {
+    const safeReturnTo = getSafeFarmReturnPath(returnTo);
+    const callbackPath =
+        provider === 'google'
+            ? '/prijava/google-prijava/povratak'
+            : '/prijava/facebook-prijava/povratak';
+    const callbackUrl = new URL(callbackPath, farmOrigin);
+    callbackUrl.searchParams.set('returnTo', safeReturnTo);
+
+    const authUrl = new URL(`/api/auth/${provider}`, apiOrigin);
+    authUrl.searchParams.set('redirect', callbackUrl.toString());
+    return authUrl.toString();
+}

--- a/apps/farm/package.json
+++ b/apps/farm/package.json
@@ -34,6 +34,7 @@
         "server-only": "0.0.1"
     },
     "devDependencies": {
+        "@axe-core/playwright": "4.12.1",
         "@biomejs/biome": "2.5.3",
         "@gredice/auth": "workspace:*",
         "@gredice/client": "workspace:*",

--- a/apps/farm/playwright/OAuthCallbackStrictModeHarness.tsx
+++ b/apps/farm/playwright/OAuthCallbackStrictModeHarness.tsx
@@ -1,0 +1,19 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { StrictMode, useState } from 'react';
+import { OAuthCallbackForwarder } from '../app/prijava/UrlAuthForward';
+
+export function OAuthCallbackStrictModeHarness() {
+    const [queryClient] = useState(() => new QueryClient());
+
+    return (
+        <StrictMode>
+            <QueryClientProvider client={queryClient}>
+                <OAuthCallbackForwarder
+                    provider="google"
+                    returnTo="/notifications"
+                    serverErrorCode={null}
+                />
+            </QueryClientProvider>
+        </StrictMode>
+    );
+}

--- a/apps/farm/tests/auth.spec.ts
+++ b/apps/farm/tests/auth.spec.ts
@@ -1,37 +1,190 @@
+import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
+const signInViewports = [
+    { name: '320px phone', width: 320, height: 568 },
+    { name: '375px phone', width: 375, height: 667 },
+    { name: '390px phone', width: 390, height: 844 },
+    { name: '430px phone', width: 430, height: 932 },
+    { name: 'desktop', width: 1280, height: 800 },
+] as const;
+
+async function expectContainedInViewport(
+    locator: import('@playwright/test').Locator,
+    viewport: { height: number; width: number },
+) {
+    const box = await locator.boundingBox();
+    expect(box).not.toBeNull();
+
+    if (!box) {
+        return;
+    }
+
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.y).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);
+    expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
+}
+
+async function expectMinimumTouchTarget(
+    locator: import('@playwright/test').Locator,
+) {
+    const box = await locator.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box?.height).toBeGreaterThanOrEqual(44);
+    expect(box?.width).toBeGreaterThanOrEqual(44);
+}
+
 test.describe('Authentication Flow', () => {
-    test.describe('Login Dialog', () => {
-        test('should show login dialog with social login options', async ({
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/gredice/api/auth/last-login', (route) =>
+            route.fulfill({ status: 200, json: { provider: null } }),
+        );
+    });
+
+    test.describe('Login shell', () => {
+        for (const viewport of signInViewports) {
+            test(`keeps the ${viewport.name} sign-in shell visible and unclipped`, async ({
+                page,
+            }) => {
+                await page.setViewportSize(viewport);
+                await page.goto('/');
+
+                const shell = page.locator('[data-farm-sign-in-shell]');
+                const panel = page.locator('[data-farm-sign-in-panel]');
+
+                await expect(page.getByRole('main')).toBeVisible();
+                await expect(
+                    page.getByRole('heading', {
+                        exact: true,
+                        level: 1,
+                        name: 'Gredice Farm',
+                    }),
+                ).toBeVisible();
+                await expect(page.getByRole('dialog')).toHaveCount(0);
+                await expect(shell).toBeVisible();
+                await expect(panel).toBeVisible();
+                await expect(page.locator('img[alt=""]')).toHaveCount(1);
+                await expectContainedInViewport(shell, viewport);
+                await expectContainedInViewport(panel, viewport);
+
+                const pageWidths = await page.evaluate(() => ({
+                    clientWidth: document.documentElement.clientWidth,
+                    scrollWidth: document.documentElement.scrollWidth,
+                }));
+                expect(pageWidths.scrollWidth).toBeLessThanOrEqual(
+                    pageWidths.clientWidth,
+                );
+
+                for (const name of [
+                    'Google prijava',
+                    'Facebook prijava',
+                    'Email prijava',
+                ]) {
+                    await expectMinimumTouchTarget(
+                        page.getByRole('button', { name }),
+                    );
+                }
+            });
+        }
+
+        for (const viewport of [
+            { width: 320, height: 568 },
+            { width: 390, height: 844 },
+        ]) {
+            test(`keeps the last-used provider visible at ${viewport.width}px`, async ({
+                page,
+            }) => {
+                await page.unroute('**/api/gredice/api/auth/last-login');
+                await page.route(
+                    '**/api/gredice/api/auth/last-login',
+                    (route) =>
+                        route.fulfill({
+                            status: 200,
+                            json: { provider: 'google' },
+                        }),
+                );
+                await page.setViewportSize(viewport);
+                await page.goto('/');
+
+                const googleButton = page.getByRole('button', {
+                    name: 'Google prijava',
+                });
+                const lastUsed = page.locator('#farm-google-last-used');
+
+                await expect(lastUsed).toBeVisible();
+                await expect(lastUsed).toHaveText('Zadnje korišteno');
+                await expect(googleButton).toHaveAttribute(
+                    'aria-describedby',
+                    'farm-google-last-used',
+                );
+            });
+        }
+
+        test('follows a predictable keyboard order through sign-in choices', async ({
             page,
         }) => {
+            await page.setViewportSize({ width: 390, height: 844 });
             await page.goto('/');
 
-            // Check for login dialog presence - look for Google login button
             const googleButton = page.getByRole('button', {
-                name: /Google/i,
+                name: 'Google prijava',
             });
-            await expect(googleButton).toBeVisible();
-        });
-
-        test('should have Google login button', async ({ page }) => {
-            await page.goto('/');
-
-            // Look for Google login option (it's a button, not a link)
-            const googleButton = page.getByRole('button', {
-                name: /Google/i,
-            });
-            await expect(googleButton).toBeVisible();
-        });
-
-        test('should have Facebook login button', async ({ page }) => {
-            await page.goto('/');
-
-            // Look for Facebook login option (it's a button, not a link)
             const facebookButton = page.getByRole('button', {
-                name: /Facebook/i,
+                name: 'Facebook prijava',
             });
-            await expect(facebookButton).toBeVisible();
+            const emailButton = page.getByRole('button', {
+                name: 'Email prijava',
+            });
+
+            await page.locator('body').click({ position: { x: 1, y: 1 } });
+            await page.keyboard.press('Tab');
+            await expect(googleButton).toBeFocused();
+            await page.keyboard.press('Tab');
+            await expect(facebookButton).toBeFocused();
+            await page.keyboard.press('Tab');
+            await expect(emailButton).toBeFocused();
+        });
+
+        test('keeps the email form and submit action reachable at reduced height', async ({
+            page,
+        }) => {
+            const viewport = { width: 390, height: 480 };
+            await page.setViewportSize(viewport);
+            await page.goto('/');
+            await page.getByRole('button', { name: 'Email prijava' }).click();
+
+            await expect(page.getByLabel('Email')).toBeVisible();
+            await expect(page.getByLabel('Zaporka')).toBeVisible();
+
+            const submitButton = page.getByRole('button', {
+                name: 'Prijavi se',
+            });
+            await submitButton.scrollIntoViewIfNeeded();
+            await expect(submitButton).toBeVisible();
+            await expectContainedInViewport(submitButton, viewport);
+            await expectMinimumTouchTarget(submitButton);
+        });
+
+        test('has no serious or critical automated accessibility violations', async ({
+            page,
+        }) => {
+            await page.setViewportSize({ width: 390, height: 844 });
+            await page.goto('/');
+
+            const results = await new AxeBuilder({ page })
+                .withTags(['wcag2a', 'wcag2aa'])
+                .analyze();
+            const seriousViolations = results.violations.filter(
+                (violation) =>
+                    violation.impact === 'serious' ||
+                    violation.impact === 'critical',
+            );
+
+            expect(
+                seriousViolations,
+                JSON.stringify(seriousViolations, null, 2),
+            ).toEqual([]);
         });
     });
 

--- a/apps/farm/tests/auth.spec.ts
+++ b/apps/farm/tests/auth.spec.ts
@@ -316,10 +316,39 @@ test.describe('Authentication Flow', () => {
     });
 
     test.describe('OAuth Callback Flow', () => {
-        test('should POST tokens to /api/oauth-callback endpoint', async ({
+        test('starts OAuth on the API origin with the current internal route', async ({
             page,
         }) => {
-            // Track requests to the oauth-callback endpoint
+            await page.route('**/api/auth/google**', (route) =>
+                route.fulfill({ status: 204 }),
+            );
+            await page.goto('/notifications?filter=unread');
+            const farmOrigin = new URL(page.url()).origin;
+            const providerRequestPromise = page.waitForRequest((request) => {
+                const requestUrl = new URL(request.url());
+                return requestUrl.pathname === '/api/auth/google';
+            });
+
+            await page.getByRole('button', { name: 'Google prijava' }).click();
+            const providerRequest = await providerRequestPromise;
+            const authUrl = new URL(providerRequest.url());
+            const callbackUrl = new URL(
+                authUrl.searchParams.get('redirect') ?? '',
+            );
+
+            expect(authUrl.origin).not.toBe(farmOrigin);
+            expect(callbackUrl.origin).toBe(farmOrigin);
+            expect(callbackUrl.pathname).toBe(
+                '/prijava/google-prijava/povratak',
+            );
+            expect(callbackUrl.searchParams.get('returnTo')).toBe(
+                '/notifications?filter=unread',
+            );
+        });
+
+        test('posts tokens and returns to the intended internal route', async ({
+            page,
+        }) => {
             const callbackRequests: Array<{
                 method: string;
                 body: { token?: string; refreshToken?: string };
@@ -340,19 +369,24 @@ test.describe('Authentication Flow', () => {
                 });
             });
 
-            // Navigate to callback page with tokens in hash
-            // Wait for the response (not just the request) to ensure route handler has completed
             const responsePromise = page.waitForResponse(
                 (response) =>
                     response.url().includes('/api/oauth-callback') &&
                     response.request().method() === 'POST',
             );
+            const returnTo = '/notifications?filter=unread#notification-7';
             await page.goto(
-                '/prijava/google-prijava/povratak#token=test-access-token&refreshToken=test-refresh-token',
+                `/prijava/google-prijava/povratak?returnTo=${encodeURIComponent(returnTo)}#token=test-access-token&refreshToken=test-refresh-token`,
             );
             await responsePromise;
+            await page.waitForURL((url) => {
+                return (
+                    url.pathname === '/notifications' &&
+                    url.searchParams.get('filter') === 'unread' &&
+                    url.hash === '#notification-7'
+                );
+            });
 
-            // Verify that the POST request was made with correct data
             const callbackRequest = callbackRequests[0];
             expect(callbackRequest).toBeDefined();
             if (!callbackRequest) {
@@ -366,63 +400,190 @@ test.describe('Authentication Flow', () => {
             expect(callbackRequest.headers['content-type']).toContain(
                 'application/json',
             );
+            expect(page.url()).not.toContain('test-access-token');
+            expect(page.url()).not.toContain('test-refresh-token');
         });
 
-        test('should clear tokens from URL after processing', async ({
+        test('clears token fragments before the cookie exchange completes', async ({
             page,
         }) => {
-            // Navigate to callback page with tokens in hash and wait for redirect
+            let releaseExchange: (() => void) | undefined;
+            let markExchangeStarted: (() => void) | undefined;
+            const exchangeStarted = new Promise<void>((resolve) => {
+                markExchangeStarted = resolve;
+            });
+            const exchangeGate = new Promise<void>((resolve) => {
+                releaseExchange = resolve;
+            });
+            await page.route('**/api/oauth-callback', async (route) => {
+                markExchangeStarted?.();
+                await exchangeGate;
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ success: true }),
+                });
+            });
+
             await page.goto(
                 '/prijava/google-prijava/povratak#token=test-token&refreshToken=test-refresh',
             );
+            await exchangeStarted;
 
-            // Wait for URL to change (redirect to home)
-            await page.waitForURL((url) => !url.hash && url.pathname === '/');
+            expect(new URL(page.url()).hash).toBe('');
+            expect(page.url()).not.toContain('test-token');
+            await expect(
+                page.getByText('Prijava u tijeku…', { exact: true }),
+            ).toBeVisible();
 
-            // Verify URL no longer contains the tokens in hash
-            const currentUrl = page.url();
-            expect(currentUrl).not.toContain('token=');
-            expect(currentUrl).not.toContain('refreshToken=');
-            expect(currentUrl).not.toContain('#');
-        });
-
-        test('should handle missing token gracefully', async ({ page }) => {
-            // Navigate to callback page without tokens and wait for redirect
-            await page.goto('/prijava/google-prijava/povratak');
+            releaseExchange?.();
             await page.waitForURL((url) => url.pathname === '/');
-
-            // Should redirect to home without errors
-            const currentUrl = page.url();
-            expect(currentUrl).toContain('/');
-            expect(currentUrl).not.toContain('/prijava/');
         });
 
-        test('should handle callback endpoint errors', async ({ page }) => {
-            // Mock the callback endpoint to return an error
-            await page.route('/api/oauth-callback', (route) => {
+        test('shows a recoverable error when the token is missing', async ({
+            page,
+        }) => {
+            await page.setViewportSize({ width: 320, height: 568 });
+            await page.goto(
+                `/prijava/google-prijava/povratak?returnTo=${encodeURIComponent('/notifications')}`,
+            );
+
+            await expect(
+                page.locator('[data-farm-sign-in-panel]').getByRole('alert'),
+            ).toContainText('Nedostaju podaci za prijavu');
+            const retryButton = page.getByRole('button', {
+                name: 'Pokušaj ponovno',
+            });
+            await expectMinimumTouchTarget(retryButton);
+            const backButton = page.getByRole('button', {
+                name: 'Natrag na prijavu',
+            });
+            await expectMinimumTouchTarget(backButton);
+            expect(
+                await page.evaluate(
+                    () =>
+                        document.documentElement.scrollWidth <=
+                        document.documentElement.clientWidth,
+                ),
+            ).toBe(true);
+            await backButton.click();
+            await page.waitForURL((url) => url.pathname === '/notifications');
+        });
+
+        for (const callbackError of [
+            { code: 'canceled', title: 'Prijava je otkazana' },
+            { code: 'state_invalid', title: 'Prijavu treba ponoviti' },
+            {
+                code: 'provider_error',
+                title: 'Pružatelj prijave nije dostupan',
+            },
+            { code: 'callback_error', title: 'Prijava nije završena' },
+        ]) {
+            test(`shows bounded ${callbackError.code} recovery`, async ({
+                page,
+            }) => {
+                await page.goto(
+                    `/prijava/facebook-prijava/povratak?error=${callbackError.code}&returnTo=${encodeURIComponent('/schedule?date=2026-07-15')}`,
+                );
+
+                await expect(
+                    page
+                        .locator('[data-farm-sign-in-panel]')
+                        .getByRole('alert'),
+                ).toContainText(callbackError.title);
+                await expect(
+                    page.getByRole('button', { name: 'Pokušaj ponovno' }),
+                ).toBeVisible();
+                await expect(
+                    page.getByRole('button', { name: 'Natrag na prijavu' }),
+                ).toBeVisible();
+                expect(new URL(page.url()).pathname).toBe(
+                    '/prijava/facebook-prijava/povratak',
+                );
+            });
+        }
+
+        test('retries cancellation with the same safe internal return path', async ({
+            page,
+        }) => {
+            await page.route('**/api/auth/facebook**', (route) =>
+                route.fulfill({ status: 204 }),
+            );
+            await page.goto(
+                `/prijava/facebook-prijava/povratak?error=canceled&returnTo=${encodeURIComponent('/schedule?date=2026-07-15')}`,
+            );
+            const providerRequestPromise = page.waitForRequest((request) => {
+                return new URL(request.url()).pathname === '/api/auth/facebook';
+            });
+
+            await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+            const providerRequest = await providerRequestPromise;
+            const callbackUrl = new URL(
+                new URL(providerRequest.url()).searchParams.get('redirect') ??
+                    '',
+            );
+            expect(callbackUrl.searchParams.get('returnTo')).toBe(
+                '/schedule?date=2026-07-15',
+            );
+        });
+
+        test('shows cookie exchange failures without retaining token fragments', async ({
+            page,
+        }) => {
+            await page.route('**/api/oauth-callback', (route) => {
                 route.fulfill({
                     status: 500,
                     body: JSON.stringify({ error: 'Internal server error' }),
                 });
             });
 
-            // Navigate to callback page with tokens and wait for redirect
             await page.goto(
                 '/prijava/google-prijava/povratak#token=test-token&refreshToken=test-refresh',
             );
-            await page.waitForURL((url) => url.pathname === '/');
 
-            // Should redirect to home despite error
-            const currentUrl = page.url();
-            expect(currentUrl).toContain('/');
-            expect(currentUrl).not.toContain('/prijava/');
-
-            // Cookie should either not exist or not have the test token value
+            await expect(
+                page.locator('[data-farm-sign-in-panel]').getByRole('alert'),
+            ).toContainText('Prijava nije spremljena');
+            expect(new URL(page.url()).hash).toBe('');
             const cookies = await page.context().cookies();
             const sessionCookie = cookies.find(
                 (c) => c.name === 'gredice_session',
             );
             expect(sessionCookie?.value).not.toBe('test-token');
+        });
+
+        test('falls back to Farm home for a malicious return target', async ({
+            page,
+        }) => {
+            await page.route('**/api/oauth-callback', (route) =>
+                route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ success: true }),
+                }),
+            );
+            await page.goto(
+                `/prijava/google-prijava/povratak?returnTo=${encodeURIComponent('https://example.com/steal')}#token=test-token`,
+            );
+
+            await page.waitForURL((url) => url.pathname === '/');
+            expect(new URL(page.url()).origin).not.toBe('https://example.com');
+        });
+
+        test('maps unknown provider errors to the bounded callback failure', async ({
+            page,
+        }) => {
+            await page.goto(
+                '/prijava/google-prijava/povratak?error=raw_provider_detail',
+            );
+
+            const callbackAlert = page
+                .locator('[data-farm-sign-in-panel]')
+                .getByRole('alert');
+            await expect(callbackAlert).toContainText('Prijava nije završena');
+            await expect(callbackAlert).not.toContainText(
+                'raw_provider_detail',
+            );
         });
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,9 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.12.1
+        version: 4.12.1(playwright-core@1.61.1)
       '@biomejs/biome':
         specifier: 2.5.3
         version: 2.5.3


### PR DESCRIPTION
## Summary

- preserve validated internal Farm return paths through Google and Facebook authentication
- show bounded, mobile-friendly callback loading and recovery states with retry and back actions
- validate callback state and exact owned origins before token exchange, clear OAuth cookies on every outcome, and reject public preview-host patterns
- clear token fragments immediately while retaining credentials safely through React Strict Mode effect replay

## Validation

- API node tests: 224 passed
- Farm Playwright and component tests: 264 passed
- API and Farm production builds
- Farm TypeScript check
- Biome and git diff check
- independent security re-review of callback origins and Strict Mode behavior

Closes #4162