### PR TITLE
feat(farm): make email login recoverable

### DIFF
--- a/apps/api/app/api/[...route]/authRoutes.ts
+++ b/apps/api/app/api/[...route]/authRoutes.ts
@@ -39,6 +39,15 @@ import {
     generateAuthUrl,
 } from '../../../lib/auth/oauth';
 import {
+    createOAuthCallbackErrorRedirect,
+    type OAuthCallbackProvider,
+    oauthRedirectCookieName,
+    oauthStateCookieName,
+    oauthTimeZoneCookieName,
+    resolveOAuthCallback,
+    sanitizeOAuthCallbackUrl,
+} from '../../../lib/auth/oauthCallbackContract';
+import {
     clearRefreshCookie,
     setRefreshCookie,
 } from '../../../lib/auth/refreshCookies';
@@ -197,63 +206,12 @@ async function createOAuthStateFromSession(context: Context): Promise<string> {
     return randomUUID().toString().replace('-', '');
 }
 
-const defaultWebAppOrigin = 'https://vrt.gredice.com';
-const oauthRedirectCookieName = 'oauth_redirect';
-const oauthTimeZoneCookieName = 'oauth_timezone';
-const allowedDesktopRedirectProtocols = new Set([
-    'gredice-admin:',
-    'gredice-farm:',
-    'gredice-garden:',
-]);
-const allowedLocalRedirectHosts = new Set([
-    'localhost',
-    '127.0.0.1',
-    'app.gredice.test',
-    'vrt.gredice.test',
-    'farma.gredice.test',
-    'dostava.gredice.test',
-    'www.gredice.test',
-]);
-
-function sanitizeRedirectUrl(redirectUrl?: string) {
-    if (!redirectUrl) {
-        return undefined;
-    }
-
-    try {
-        const parsed = new URL(redirectUrl);
-        if (
-            allowedDesktopRedirectProtocols.has(parsed.protocol) &&
-            parsed.hostname === 'auth-callback'
-        ) {
-            return parsed.toString();
-        }
-
-        const hostname = parsed.hostname.toLowerCase();
-        const isSecureProtocol =
-            parsed.protocol === 'https:' ||
-            (parsed.protocol === 'http:' &&
-                allowedLocalRedirectHosts.has(hostname));
-        if (!isSecureProtocol) {
-            return undefined;
-        }
-
-        if (
-            hostname === 'gredice.com' ||
-            hostname.endsWith('.gredice.com') ||
-            allowedLocalRedirectHosts.has(hostname)
-        ) {
-            return parsed.toString();
-        }
-    } catch {
-        return undefined;
-    }
-
-    return undefined;
-}
-
-function storeRedirectCookie(context: Context, redirectUrl?: string) {
-    const sanitized = sanitizeRedirectUrl(redirectUrl);
+function storeRedirectCookie(
+    context: Context,
+    provider: OAuthCallbackProvider,
+    redirectUrl?: string,
+) {
+    const sanitized = sanitizeOAuthCallbackUrl(provider, redirectUrl);
     if (!sanitized) {
         deleteContextCookie(context, oauthRedirectCookieName);
         return;
@@ -285,30 +243,26 @@ function storeTimeZoneCookie(context: Context, timeZone?: string) {
     });
 }
 
-function getTimeZoneCookie(context: Context): string | undefined {
+function prepareOAuthCallback(
+    context: Context,
+    provider: OAuthCallbackProvider,
+) {
     const timeZone = getCookie(context, oauthTimeZoneCookieName);
-    deleteContextCookie(context, oauthTimeZoneCookieName);
-    return timeZone;
-}
+    const decision = resolveOAuthCallback({
+        provider,
+        code: context.req.query('code'),
+        state: context.req.query('state'),
+        storedState: getCookie(context, oauthStateCookieName),
+        storedRedirect: getCookie(context, oauthRedirectCookieName),
+        providerError: context.req.query('error'),
+        providerErrorReason: context.req.query('error_reason'),
+    });
 
-function resolveRedirectUrl(context: Context, fallbackPath: string) {
-    const fallbackUrl = new URL(fallbackPath, defaultWebAppOrigin);
-    const stored = getCookie(context, oauthRedirectCookieName);
-    if (!stored) {
-        return fallbackUrl;
+    for (const cookieName of decision.clearCookieNames) {
+        deleteContextCookie(context, cookieName);
     }
 
-    deleteContextCookie(context, oauthRedirectCookieName);
-    const sanitized = sanitizeRedirectUrl(stored);
-    if (!sanitized) {
-        return fallbackUrl;
-    }
-
-    try {
-        return new URL(sanitized);
-    } catch {
-        return fallbackUrl;
-    }
+    return { decision, timeZone };
 }
 
 type AuthProvider = 'password' | 'google' | 'facebook';
@@ -564,12 +518,12 @@ const app = new Hono()
         async (context) => {
             const query = context.req.valid('query');
             const state = await createOAuthStateFromSession(context);
-            storeRedirectCookie(context, query?.redirect);
+            storeRedirectCookie(context, 'google', query?.redirect);
             storeTimeZoneCookie(context, query?.timeZone);
             const authUrl = generateAuthUrl('google', state);
 
             // Store state in cookie for verification
-            setContextCookie(context, 'oauth_state', state, {
+            setContextCookie(context, oauthStateCookieName, state, {
                 httpOnly: true,
                 secure: true,
                 sameSite: 'Lax',
@@ -585,27 +539,24 @@ const app = new Hono()
             description: 'Google OAuth callback',
         }),
         async (context) => {
-            try {
-                const code = context.req.query('code');
-                const state = context.req.query('state');
-                if (!code || !state) {
-                    return context.json(
-                        { message: 'Missing code or state' },
-                        400,
-                    );
-                }
+            const { decision, timeZone } = prepareOAuthCallback(
+                context,
+                'google',
+            );
+            if (decision.kind === 'redirect') {
+                return context.redirect(decision.redirectUrl);
+            }
 
+            try {
                 let currentUserId: string | undefined;
                 try {
-                    const { result, error } = await verifyJwt(state);
+                    const { result, error } = await verifyJwt(decision.state);
                     if (error || !result?.payload.sub) {
                         throw new Error('Invalid state token');
                     }
                     currentUserId = result.payload.sub;
                     console.debug(
-                        'User authenticated',
-                        currentUserId,
-                        'proceeding with OAuth flow and existing user assignment',
+                        'Authenticated user is adding an OAuth login method.',
                     );
                 } catch {
                     // Note: this means user is not authenticated, and we can proceed with
@@ -615,12 +566,14 @@ const app = new Hono()
                     );
                 }
 
-                const tokenData = await exchangeCodeForToken('google', code);
+                const tokenData = await exchangeCodeForToken(
+                    'google',
+                    decision.code,
+                );
                 const userInfo = await fetchUserInfo(
                     'google',
                     tokenData.access_token,
                 );
-                const timeZone = getTimeZoneCookie(context);
                 const { userId, loginId, isNewUser } =
                     await createOrUpdateUserWithOauth(
                         {
@@ -676,27 +629,23 @@ const app = new Hono()
                     });
                 }
 
-                const redirectUrl = resolveRedirectUrl(
-                    context,
-                    '/prijava/google-prijava/povratak',
-                );
+                const redirectUrl = new URL(decision.callbackUrl);
                 // Pass tokens to frontend via URL fragment (hash) so they don't appear in logs/referrer
                 redirectUrl.hash = `token=${encodeURIComponent(accessToken)}&refreshToken=${encodeURIComponent(refreshToken)}`;
 
                 return context.redirect(redirectUrl.toString());
-            } catch (error) {
+            } catch {
                 console.error('Google OAuth callback failed', {
-                    error,
-                    hasCode: Boolean(context.req.query('code')),
-                    hasState: Boolean(context.req.query('state')),
+                    provider: 'google',
+                    reason: 'callback_error',
                 });
-                const redirectUrl = resolveRedirectUrl(
-                    context,
-                    '/prijava/google-prijava/povratak',
+                const redirectUrl = createOAuthCallbackErrorRedirect(
+                    'google',
+                    decision.callbackUrl,
+                    'callback_error',
                 );
-                redirectUrl.searchParams.set('error', 'oauth_error');
 
-                return context.redirect(redirectUrl.toString());
+                return context.redirect(redirectUrl);
             }
         },
     )
@@ -718,9 +667,9 @@ const app = new Hono()
             const authUrl = generateAuthUrl('facebook', state);
 
             // Store state in cookie for verification
-            storeRedirectCookie(context, query?.redirect);
+            storeRedirectCookie(context, 'facebook', query?.redirect);
             storeTimeZoneCookie(context, query?.timeZone);
-            setContextCookie(context, 'oauth_state', state, {
+            setContextCookie(context, oauthStateCookieName, state, {
                 httpOnly: true,
                 secure: true,
                 sameSite: 'Lax',
@@ -736,27 +685,24 @@ const app = new Hono()
             description: 'Facebook OAuth callback',
         }),
         async (context) => {
-            try {
-                const code = context.req.query('code');
-                const state = context.req.query('state');
-                if (!code || !state) {
-                    return context.json(
-                        { message: 'Missing code or state' },
-                        400,
-                    );
-                }
+            const { decision, timeZone } = prepareOAuthCallback(
+                context,
+                'facebook',
+            );
+            if (decision.kind === 'redirect') {
+                return context.redirect(decision.redirectUrl);
+            }
 
+            try {
                 let currentUserId: string | undefined;
                 try {
-                    const { result, error } = await verifyJwt(state);
+                    const { result, error } = await verifyJwt(decision.state);
                     if (error || !result?.payload.sub) {
                         throw new Error('Invalid state token');
                     }
                     currentUserId = result.payload.sub;
                     console.debug(
-                        'User authenticated',
-                        currentUserId,
-                        'proceeding with OAuth flow and existing user assignment',
+                        'Authenticated user is adding an OAuth login method.',
                     );
                 } catch {
                     // Note: this means user is not authenticated, and we can proceed with
@@ -766,12 +712,14 @@ const app = new Hono()
                     );
                 }
 
-                const tokenData = await exchangeCodeForToken('facebook', code);
+                const tokenData = await exchangeCodeForToken(
+                    'facebook',
+                    decision.code,
+                );
                 const userInfo = await fetchUserInfo(
                     'facebook',
                     tokenData.access_token,
                 );
-                const timeZone = getTimeZoneCookie(context);
                 const { userId, loginId, isNewUser } =
                     await createOrUpdateUserWithOauth(
                         {
@@ -827,27 +775,23 @@ const app = new Hono()
                     });
                 }
 
-                const redirectUrl = resolveRedirectUrl(
-                    context,
-                    '/prijava/facebook-prijava/povratak',
-                );
+                const redirectUrl = new URL(decision.callbackUrl);
                 // Pass tokens to frontend via URL fragment (hash) so they don't appear in logs/referrer
                 redirectUrl.hash = `token=${encodeURIComponent(accessToken)}&refreshToken=${encodeURIComponent(refreshToken)}`;
 
                 return context.redirect(redirectUrl.toString());
-            } catch (error) {
+            } catch {
                 console.error('Facebook OAuth callback failed', {
-                    error,
-                    hasCode: Boolean(context.req.query('code')),
-                    hasState: Boolean(context.req.query('state')),
+                    provider: 'facebook',
+                    reason: 'callback_error',
                 });
-                const redirectUrl = resolveRedirectUrl(
-                    context,
-                    '/prijava/facebook-prijava/povratak',
+                const redirectUrl = createOAuthCallbackErrorRedirect(
+                    'facebook',
+                    decision.callbackUrl,
+                    'callback_error',
                 );
-                redirectUrl.searchParams.set('error', 'oauth_error');
 
-                return context.redirect(redirectUrl.toString());
+                return context.redirect(redirectUrl);
             }
         },
     )

--- a/apps/api/lib/auth/oauthCallbackContract.node.spec.ts
+++ b/apps/api/lib/auth/oauthCallbackContract.node.spec.ts
@@ -166,6 +166,51 @@ test('accepts only provider-matched desktop callback targets', () => {
         ),
         undefined,
     );
+    assert.equal(
+        sanitizeOAuthCallbackUrl(
+            'google',
+            'gredice-farm://auth-callback/google?returnTo=%2Fnotifications%3Ffilter%3Dunread%23latest',
+        ),
+        'gredice-farm://auth-callback/google?returnTo=%2Fnotifications%3Ffilter%3Dunread%23latest',
+    );
+    assert.equal(
+        sanitizeOAuthCallbackUrl(
+            'google',
+            'gredice-farm://auth-callback/google?returnTo=%2Fnotifications&returnTo=%2Fschedule',
+        ),
+        undefined,
+    );
+});
+
+test('preserves a desktop return path through success and bounded errors', () => {
+    const callbackUrl =
+        'gredice-farm://auth-callback/google?returnTo=%2Fnotifications%3Ffilter%3Dunread%23latest';
+    const success = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        storedRedirect: callbackUrl,
+        ...matchingState,
+    });
+    assert.equal(success.kind, 'continue');
+    if (success.kind === 'continue') {
+        assert.equal(success.callbackUrl, callbackUrl);
+    }
+
+    const canceled = resolveOAuthCallback({
+        provider: 'google',
+        providerError: 'access_denied',
+        storedRedirect: callbackUrl,
+        ...matchingState,
+    });
+    assert.equal(canceled.kind, 'redirect');
+    if (canceled.kind === 'redirect') {
+        const redirectUrl = new URL(canceled.redirectUrl);
+        assert.equal(
+            redirectUrl.searchParams.get('returnTo'),
+            '/notifications?filter=unread#latest',
+        );
+        assert.equal(redirectUrl.searchParams.get('error'), 'canceled');
+    }
 });
 
 test('uses callback_error without replacing a validated return path', () => {

--- a/apps/api/lib/auth/oauthCallbackContract.node.spec.ts
+++ b/apps/api/lib/auth/oauthCallbackContract.node.spec.ts
@@ -1,0 +1,221 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createOAuthCallbackErrorRedirect,
+    oauthCallbackCookieNames,
+    resolveOAuthCallback,
+    sanitizeOAuthCallbackUrl,
+} from './oauthCallbackContract';
+
+const matchingState = {
+    state: 'signed-oauth-state',
+    storedState: 'signed-oauth-state',
+};
+
+test('continues a valid callback and preserves its encoded internal return path', () => {
+    const callbackUrl = new URL(
+        '/prijava/google-prijava/povratak',
+        'https://farma.gredice.com',
+    );
+    callbackUrl.searchParams.set(
+        'returnTo',
+        '/operations/42?tab=dokazi#fotografije',
+    );
+
+    const result = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        storedRedirect: callbackUrl.toString(),
+        ...matchingState,
+    });
+
+    assert.equal(result.kind, 'continue');
+    if (result.kind !== 'continue') {
+        return;
+    }
+    assert.equal(result.code, 'authorization-code');
+    assert.equal(result.state, matchingState.state);
+    assert.equal(result.callbackUrl, callbackUrl.toString());
+    assert.deepEqual(result.clearCookieNames, oauthCallbackCookieNames);
+});
+
+test('rejects missing or mismatched callback state before using an authorization code', () => {
+    const missingCookie = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        state: matchingState.state,
+    });
+    const missingState = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        storedState: matchingState.storedState,
+    });
+    const mismatch = resolveOAuthCallback({
+        provider: 'facebook',
+        code: 'authorization-code',
+        state: 'returned-state',
+        storedState: 'different-cookie-state',
+    });
+
+    for (const result of [missingCookie, missingState, mismatch]) {
+        assert.equal(result.kind, 'redirect');
+        if (result.kind !== 'redirect') {
+            continue;
+        }
+        assert.equal(result.error, 'state_invalid');
+        assert.equal(
+            new URL(result.redirectUrl).searchParams.get('error'),
+            'state_invalid',
+        );
+        assert.deepEqual(result.clearCookieNames, oauthCallbackCookieNames);
+    }
+});
+
+test('maps provider cancellation to a bounded callback error', () => {
+    const results = [
+        resolveOAuthCallback({
+            provider: 'google',
+            providerError: 'access_denied',
+            ...matchingState,
+        }),
+        resolveOAuthCallback({
+            provider: 'facebook',
+            providerError: 'access_denied',
+            providerErrorReason: 'user_denied',
+            ...matchingState,
+        }),
+    ];
+
+    for (const result of results) {
+        assert.equal(result.kind, 'redirect');
+        if (result.kind !== 'redirect') {
+            continue;
+        }
+        assert.equal(result.error, 'canceled');
+        assert.equal(
+            new URL(result.redirectUrl).searchParams.get('error'),
+            'canceled',
+        );
+        assert.equal(result.redirectUrl.includes('access_denied'), false);
+        assert.equal(result.redirectUrl.includes('user_denied'), false);
+    }
+});
+
+test('maps other provider failures to a bounded provider error', () => {
+    const result = resolveOAuthCallback({
+        provider: 'facebook',
+        providerError: 'temporarily_unavailable',
+        providerErrorReason: 'upstream detail that must not be forwarded',
+        ...matchingState,
+    });
+
+    assert.equal(result.kind, 'redirect');
+    if (result.kind !== 'redirect') {
+        return;
+    }
+    assert.equal(result.error, 'provider_error');
+    assert.equal(
+        new URL(result.redirectUrl).searchParams.get('error'),
+        'provider_error',
+    );
+    assert.equal(result.redirectUrl.includes('temporarily_unavailable'), false);
+    assert.equal(result.redirectUrl.includes('upstream'), false);
+});
+
+test('falls back when a callback target has an unsafe origin or path', () => {
+    const unsafeTargets = [
+        'https://attacker.example/prijava/google-prijava/povratak',
+        'https://farm-attacker-gredice.vercel.app/prijava/google-prijava/povratak',
+        'https://farma.gredice.com/operations/42',
+        'https://farma.gredice.com/prijava/facebook-prijava/povratak',
+        'https://farma.gredice.com/prijava/google-prijava/povratak?token=raw',
+        '//farma.gredice.com/prijava/google-prijava/povratak',
+    ];
+
+    for (const storedRedirect of unsafeTargets) {
+        const result = resolveOAuthCallback({
+            provider: 'google',
+            code: 'authorization-code',
+            storedRedirect,
+            ...matchingState,
+        });
+
+        assert.equal(result.kind, 'continue');
+        if (result.kind !== 'continue') {
+            continue;
+        }
+        assert.equal(
+            result.callbackUrl,
+            'https://vrt.gredice.com/prijava/google-prijava/povratak',
+        );
+    }
+});
+
+test('accepts only provider-matched desktop callback targets', () => {
+    assert.equal(
+        sanitizeOAuthCallbackUrl(
+            'google',
+            'gredice-farm://auth-callback/google',
+        ),
+        'gredice-farm://auth-callback/google',
+    );
+    assert.equal(
+        sanitizeOAuthCallbackUrl(
+            'google',
+            'gredice-farm://auth-callback/facebook',
+        ),
+        undefined,
+    );
+});
+
+test('uses callback_error without replacing a validated return path', () => {
+    const callbackUrl =
+        'https://farma.gredice.com/prijava/google-prijava/povratak?returnTo=%2Fnotifications%2F17';
+    const redirectUrl = createOAuthCallbackErrorRedirect(
+        'google',
+        callbackUrl,
+        'callback_error',
+    );
+    const parsed = new URL(redirectUrl);
+
+    assert.equal(parsed.searchParams.get('returnTo'), '/notifications/17');
+    assert.equal(parsed.searchParams.get('error'), 'callback_error');
+});
+
+test('uses callback_error when a state-valid callback has no code', () => {
+    const result = resolveOAuthCallback({
+        provider: 'google',
+        ...matchingState,
+    });
+
+    assert.equal(result.kind, 'redirect');
+    if (result.kind !== 'redirect') {
+        return;
+    }
+    assert.equal(result.error, 'callback_error');
+    assert.equal(
+        new URL(result.redirectUrl).searchParams.get('error'),
+        'callback_error',
+    );
+});
+
+test('declares state, redirect and timezone cleanup for every callback outcome', () => {
+    const success = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        ...matchingState,
+    });
+    const failure = resolveOAuthCallback({
+        provider: 'google',
+        code: 'authorization-code',
+        state: 'wrong-state',
+        storedState: matchingState.storedState,
+    });
+
+    assert.deepEqual(success.clearCookieNames, [
+        'oauth_state',
+        'oauth_redirect',
+        'oauth_timezone',
+    ]);
+    assert.deepEqual(failure.clearCookieNames, success.clearCookieNames);
+});

--- a/apps/api/lib/auth/oauthCallbackContract.ts
+++ b/apps/api/lib/auth/oauthCallbackContract.ts
@@ -1,0 +1,237 @@
+export type OAuthCallbackProvider = 'facebook' | 'google';
+
+export type OAuthCallbackErrorCode =
+    | 'canceled'
+    | 'state_invalid'
+    | 'provider_error'
+    | 'callback_error';
+
+export type OAuthCallbackCookieName =
+    | 'oauth_state'
+    | 'oauth_redirect'
+    | 'oauth_timezone';
+
+export const oauthStateCookieName: OAuthCallbackCookieName = 'oauth_state';
+export const oauthRedirectCookieName: OAuthCallbackCookieName =
+    'oauth_redirect';
+export const oauthTimeZoneCookieName: OAuthCallbackCookieName =
+    'oauth_timezone';
+export const oauthCallbackCookieNames: ReadonlyArray<OAuthCallbackCookieName> =
+    Object.freeze([
+        oauthStateCookieName,
+        oauthRedirectCookieName,
+        oauthTimeZoneCookieName,
+    ]);
+
+const defaultWebAppOrigin = 'https://vrt.gredice.com';
+const maximumCallbackUrlLength = 2_048;
+const maximumAuthorizationValueLength = 4_096;
+
+const allowedProductionCallbackOrigins = new Set([
+    'https://app.gredice.com',
+    'https://dostava.gredice.com',
+    'https://farma.gredice.com',
+    'https://gredice.com',
+    'https://vrt.gredice.com',
+    'https://www.gredice.com',
+]);
+
+const allowedLocalCallbackHosts = new Set([
+    '127.0.0.1',
+    '[::1]',
+    'app.gredice.test',
+    'dostava.gredice.test',
+    'farma.gredice.test',
+    'localhost',
+    'vrt.gredice.test',
+    'www.gredice.test',
+]);
+
+const allowedDesktopRedirectProtocols = new Set([
+    'gredice-admin:',
+    'gredice-farm:',
+    'gredice-garden:',
+]);
+
+export type OAuthCallbackDecision =
+    | {
+          kind: 'continue';
+          callbackUrl: string;
+          code: string;
+          state: string;
+          clearCookieNames: ReadonlyArray<OAuthCallbackCookieName>;
+      }
+    | {
+          kind: 'redirect';
+          error: OAuthCallbackErrorCode;
+          redirectUrl: string;
+          clearCookieNames: ReadonlyArray<OAuthCallbackCookieName>;
+      };
+
+type ResolveOAuthCallbackInput = {
+    provider: OAuthCallbackProvider;
+    code?: string;
+    state?: string;
+    storedState?: string;
+    storedRedirect?: string;
+    providerError?: string;
+    providerErrorReason?: string;
+};
+
+function callbackPath(provider: OAuthCallbackProvider) {
+    return `/prijava/${provider}-prijava/povratak`;
+}
+
+function isAllowedWebCallbackOrigin(url: URL) {
+    if (url.username || url.password) {
+        return false;
+    }
+
+    if (allowedProductionCallbackOrigins.has(url.origin)) {
+        return true;
+    }
+
+    const hostname = url.hostname.toLowerCase();
+    if (
+        allowedLocalCallbackHosts.has(hostname) &&
+        (url.protocol === 'http:' || url.protocol === 'https:')
+    ) {
+        return true;
+    }
+
+    return false;
+}
+
+function hasOnlySupportedCallbackQuery(url: URL) {
+    for (const key of url.searchParams.keys()) {
+        if (key !== 'returnTo') {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Restricts the browser hand-off to a known Gredice callback surface. The
+ * internal route carried in `returnTo` is deliberately left encoded for the
+ * receiving app to validate against its own route allowlist.
+ */
+export function sanitizeOAuthCallbackUrl(
+    provider: OAuthCallbackProvider,
+    redirectUrl?: string,
+) {
+    if (!redirectUrl || redirectUrl.length > maximumCallbackUrlLength) {
+        return undefined;
+    }
+
+    try {
+        const parsed = new URL(redirectUrl);
+        if (parsed.hash || !hasOnlySupportedCallbackQuery(parsed)) {
+            return undefined;
+        }
+
+        if (allowedDesktopRedirectProtocols.has(parsed.protocol)) {
+            if (
+                parsed.hostname === 'auth-callback' &&
+                parsed.pathname === `/${provider}` &&
+                !parsed.username &&
+                !parsed.password &&
+                !parsed.port
+            ) {
+                return parsed.toString();
+            }
+            return undefined;
+        }
+
+        if (
+            isAllowedWebCallbackOrigin(parsed) &&
+            parsed.pathname === callbackPath(provider)
+        ) {
+            return parsed.toString();
+        }
+    } catch {
+        return undefined;
+    }
+
+    return undefined;
+}
+
+export function resolveOAuthCallbackUrl(
+    provider: OAuthCallbackProvider,
+    storedRedirect?: string,
+) {
+    const sanitized = sanitizeOAuthCallbackUrl(provider, storedRedirect);
+    if (sanitized) {
+        return sanitized;
+    }
+
+    return new URL(callbackPath(provider), defaultWebAppOrigin).toString();
+}
+
+function errorRedirect(callbackUrl: string, error: OAuthCallbackErrorCode) {
+    const redirectUrl = new URL(callbackUrl);
+    redirectUrl.searchParams.set('error', error);
+    return redirectUrl.toString();
+}
+
+export function createOAuthCallbackErrorRedirect(
+    provider: OAuthCallbackProvider,
+    callbackUrl: string,
+    error: OAuthCallbackErrorCode,
+) {
+    const sanitized = resolveOAuthCallbackUrl(provider, callbackUrl);
+    return errorRedirect(sanitized, error);
+}
+
+function redirectDecision(
+    callbackUrl: string,
+    error: OAuthCallbackErrorCode,
+): OAuthCallbackDecision {
+    return {
+        kind: 'redirect',
+        error,
+        redirectUrl: errorRedirect(callbackUrl, error),
+        clearCookieNames: oauthCallbackCookieNames,
+    };
+}
+
+export function resolveOAuthCallback(
+    input: ResolveOAuthCallbackInput,
+): OAuthCallbackDecision {
+    const callbackUrl = resolveOAuthCallbackUrl(
+        input.provider,
+        input.storedRedirect,
+    );
+
+    if (
+        !input.state ||
+        !input.storedState ||
+        input.state.length > maximumAuthorizationValueLength ||
+        input.storedState.length > maximumAuthorizationValueLength ||
+        input.state !== input.storedState
+    ) {
+        return redirectDecision(callbackUrl, 'state_invalid');
+    }
+
+    if (input.providerError || input.providerErrorReason) {
+        const canceled =
+            input.providerError === 'access_denied' ||
+            input.providerErrorReason === 'user_denied';
+        return redirectDecision(
+            callbackUrl,
+            canceled ? 'canceled' : 'provider_error',
+        );
+    }
+
+    if (!input.code || input.code.length > maximumAuthorizationValueLength) {
+        return redirectDecision(callbackUrl, 'callback_error');
+    }
+
+    return {
+        kind: 'continue',
+        callbackUrl,
+        code: input.code,
+        state: input.state,
+        clearCookieNames: oauthCallbackCookieNames,
+    };
+}

--- a/apps/api/lib/auth/oauthCallbackContract.ts
+++ b/apps/api/lib/auth/oauthCallbackContract.ts
@@ -103,6 +103,10 @@ function isAllowedWebCallbackOrigin(url: URL) {
 }
 
 function hasOnlySupportedCallbackQuery(url: URL) {
+    if (url.searchParams.getAll('returnTo').length > 1) {
+        return false;
+    }
+
     for (const key of url.searchParams.keys()) {
         if (key !== 'returnTo') {
             return false;

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1,6 +1,9 @@
 const { app, BrowserWindow, Menu, shell, session } = require('electron');
 const fs = require('node:fs');
 const path = require('node:path');
+const {
+    createDesktopOAuthCallbackRedirectUrl,
+} = require('./oauth-redirect.cjs');
 
 const allowedPermissionNames = new Set([
     'clipboard-read',
@@ -384,12 +387,13 @@ function isTrustedAuthOrigin(parsedUrl) {
     );
 }
 
-function desktopAuthCallbackRedirectUrl(provider) {
-    if (!runtimeConfig.protocol) {
-        return null;
-    }
-
-    return `${runtimeConfig.protocol}://auth-callback/${provider}`;
+function desktopAuthCallbackRedirectUrl(provider, sourceAuthUrl) {
+    return createDesktopOAuthCallbackRedirectUrl({
+        protocol: runtimeConfig.protocol,
+        provider,
+        sourceAuthUrl,
+        trustedNavigationOrigins,
+    });
 }
 
 function openExternalOAuthLogin(targetUrl) {
@@ -400,7 +404,7 @@ function openExternalOAuthLogin(targetUrl) {
             return false;
         }
 
-        const redirectUrl = desktopAuthCallbackRedirectUrl(provider);
+        const redirectUrl = desktopAuthCallbackRedirectUrl(provider, parsedUrl);
         if (!redirectUrl) {
             return false;
         }

--- a/apps/desktop/electron/oauth-redirect.cjs
+++ b/apps/desktop/electron/oauth-redirect.cjs
@@ -1,0 +1,68 @@
+const maximumCallbackUrlLength = 2_048;
+const oauthProviders = new Set(['facebook', 'google']);
+
+function callbackPath(provider) {
+    return `/prijava/${provider}-prijava/povratak`;
+}
+
+function createDesktopOAuthCallbackRedirectUrl({
+    protocol,
+    provider,
+    sourceAuthUrl,
+    trustedNavigationOrigins,
+}) {
+    if (
+        typeof protocol !== 'string' ||
+        !/^gredice-[a-z0-9-]+$/.test(protocol) ||
+        !oauthProviders.has(provider)
+    ) {
+        return null;
+    }
+
+    const callbackUrl = new URL(`${protocol}://auth-callback/${provider}`);
+
+    try {
+        const authUrl = new URL(sourceAuthUrl);
+        const redirectValues = authUrl.searchParams.getAll('redirect');
+        if (redirectValues.length !== 1) {
+            return callbackUrl.toString();
+        }
+
+        const [redirectValue] = redirectValues;
+        if (!redirectValue || redirectValue.length > maximumCallbackUrlLength) {
+            return callbackUrl.toString();
+        }
+
+        const nestedCallbackUrl = new URL(redirectValue);
+        const trustedOrigins = new Set(trustedNavigationOrigins);
+        const returnToValues =
+            nestedCallbackUrl.searchParams.getAll('returnTo');
+        if (
+            nestedCallbackUrl.username ||
+            nestedCallbackUrl.password ||
+            nestedCallbackUrl.hash ||
+            !trustedOrigins.has(nestedCallbackUrl.origin) ||
+            nestedCallbackUrl.pathname !== callbackPath(provider) ||
+            returnToValues.length > 1 ||
+            Array.from(nestedCallbackUrl.searchParams.keys()).some(
+                (key) => key !== 'returnTo',
+            )
+        ) {
+            return callbackUrl.toString();
+        }
+
+        const [returnTo] = returnToValues;
+        if (returnTo) {
+            callbackUrl.searchParams.set('returnTo', returnTo);
+            if (callbackUrl.toString().length > maximumCallbackUrlLength) {
+                callbackUrl.searchParams.delete('returnTo');
+            }
+        }
+    } catch (_error) {
+        return callbackUrl.toString();
+    }
+
+    return callbackUrl.toString();
+}
+
+module.exports = { createDesktopOAuthCallbackRedirectUrl };

--- a/apps/desktop/scripts/check-desktop-sources.mjs
+++ b/apps/desktop/scripts/check-desktop-sources.mjs
@@ -8,6 +8,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(scriptDir, '..');
 const sourceFiles = [
     'electron/main.cjs',
+    'electron/oauth-redirect.cjs',
     'electron/preload.cjs',
     'scripts/check-desktop-sources.mjs',
     'scripts/desktop-apps.mjs',

--- a/apps/desktop/scripts/package-desktop-app.mjs
+++ b/apps/desktop/scripts/package-desktop-app.mjs
@@ -98,6 +98,10 @@ async function copyDesktopShellFiles(stageDir, desktopApp) {
         resolve(stageDir, 'main.cjs'),
     );
     await fs.copyFile(
+        resolve(desktopRoot, 'electron/oauth-redirect.cjs'),
+        resolve(stageDir, 'oauth-redirect.cjs'),
+    );
+    await fs.copyFile(
         resolve(desktopRoot, 'electron/preload.cjs'),
         resolve(stageDir, 'preload.cjs'),
     );
@@ -184,6 +188,7 @@ async function writeBuilderConfig(stageDir, desktopApp, electronVersion) {
             'favicon.ico',
             'icon.png',
             'main.cjs',
+            'oauth-redirect.cjs',
             'package.json',
             'preload.cjs',
         ],

--- a/apps/desktop/tests/desktop-apps.test.mjs
+++ b/apps/desktop/tests/desktop-apps.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -11,6 +12,36 @@ import {
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(testDir, '../../..');
+const require = createRequire(import.meta.url);
+const {
+    createDesktopOAuthCallbackRedirectUrl,
+} = require('../electron/oauth-redirect.cjs');
+
+const farmOrigin = 'https://farma.gredice.com';
+
+function desktopOAuthCallback({
+    nestedRedirect,
+    provider = 'google',
+    redirectValues,
+} = {}) {
+    const authUrl = new URL(`/api/gredice/api/auth/${provider}`, farmOrigin);
+    for (const redirectValue of redirectValues ?? [nestedRedirect]) {
+        if (redirectValue !== undefined) {
+            authUrl.searchParams.append('redirect', redirectValue);
+        }
+    }
+
+    return createDesktopOAuthCallbackRedirectUrl({
+        protocol: 'gredice-farm',
+        provider,
+        sourceAuthUrl: authUrl,
+        trustedNavigationOrigins: new Set([farmOrigin]),
+    });
+}
+
+function webOAuthCallback(provider = 'google') {
+    return new URL(`/prijava/${provider}-prijava/povratak`, farmOrigin);
+}
 
 test('desktop release configs use production HTTPS app origins', () => {
     assert.deepEqual(desktopAppNames, ['garden', 'farm', 'app']);
@@ -104,6 +135,7 @@ test('desktop shell hands OAuth login to the system browser', () => {
     assert.match(mainSource, /openExternalOAuthLogin/);
     assert.match(mainSource, /GREDICE_DESKTOP_EXTERNAL_AUTH_BASE_URL/);
     assert.match(mainSource, /desktopAuthCallbackRedirectUrl/);
+    assert.match(mainSource, /createDesktopOAuthCallbackRedirectUrl/);
     assert.match(mainSource, /api\\\/gredice\\\/api\\\/auth/);
     assert.match(mainSource, /setAsDefaultProtocolClient/);
     assert.match(mainSource, /auth-callback/);
@@ -117,6 +149,91 @@ test('desktop shell hands OAuth login to the system browser', () => {
     assert.match(packageSource, /uninstallerIcon: 'favicon\.ico'/);
     assert.match(packageSource, /icon: 'favicon\.ico'/);
     assert.match(packageSource, /schemes: \[desktopApp\.protocol\]/);
+    assert.match(packageSource, /oauth-redirect\.cjs/);
+});
+
+test('desktop OAuth preserves the nested Farm return path for each provider', () => {
+    for (const provider of ['google', 'facebook']) {
+        const nestedCallback = webOAuthCallback(provider);
+        nestedCallback.searchParams.set(
+            'returnTo',
+            '/notifications?filter=unread#latest',
+        );
+
+        const result = desktopOAuthCallback({
+            nestedRedirect: nestedCallback.toString(),
+            provider,
+        });
+        const callback = new URL(result);
+
+        assert.equal(callback.protocol, 'gredice-farm:');
+        assert.equal(callback.hostname, 'auth-callback');
+        assert.equal(callback.pathname, `/${provider}`);
+        assert.equal(
+            callback.searchParams.get('returnTo'),
+            '/notifications?filter=unread#latest',
+        );
+    }
+});
+
+test('desktop OAuth keeps a bare callback when no return path is present', () => {
+    assert.equal(
+        desktopOAuthCallback({
+            nestedRedirect: webOAuthCallback().toString(),
+        }),
+        'gredice-farm://auth-callback/google',
+    );
+    assert.equal(
+        desktopOAuthCallback({ redirectValues: [] }),
+        'gredice-farm://auth-callback/google',
+    );
+});
+
+test('desktop OAuth omits return paths from untrusted nested callbacks', () => {
+    const wrongOrigin = new URL(
+        '/prijava/google-prijava/povratak?returnTo=%2Fnotifications',
+        'https://attacker.example',
+    );
+    const wrongPath = new URL(
+        '/prijava/facebook-prijava/povratak?returnTo=%2Fnotifications',
+        farmOrigin,
+    );
+    const withHash = webOAuthCallback();
+    withHash.searchParams.set('returnTo', '/notifications');
+    withHash.hash = 'unexpected';
+    const withExtraQuery = webOAuthCallback();
+    withExtraQuery.searchParams.set('returnTo', '/notifications');
+    withExtraQuery.searchParams.set('token', 'raw');
+    const withCredentials = new URL(webOAuthCallback());
+    withCredentials.username = 'user';
+    const withDuplicateReturnTo = webOAuthCallback();
+    withDuplicateReturnTo.searchParams.append('returnTo', '/notifications');
+    withDuplicateReturnTo.searchParams.append('returnTo', '/schedule');
+    const oversizedReturnTo = webOAuthCallback();
+    oversizedReturnTo.searchParams.set('returnTo', `/${'a'.repeat(2_048)}`);
+
+    for (const nestedRedirect of [
+        wrongOrigin,
+        wrongPath,
+        withHash,
+        withExtraQuery,
+        withCredentials,
+        withDuplicateReturnTo,
+        oversizedReturnTo,
+    ]) {
+        assert.equal(
+            desktopOAuthCallback({ nestedRedirect: nestedRedirect.toString() }),
+            'gredice-farm://auth-callback/google',
+        );
+    }
+
+    const validCallback = webOAuthCallback().toString();
+    assert.equal(
+        desktopOAuthCallback({
+            redirectValues: [validCallback, validCallback],
+        }),
+        'gredice-farm://auth-callback/google',
+    );
 });
 
 test('desktop release workflows can sign macOS artifacts when credentials exist', () => {

--- a/apps/farm/app/api/login/route.ts
+++ b/apps/farm/app/api/login/route.ts
@@ -1,27 +1,53 @@
 import { getServerGrediceApiOrigin } from '@gredice/client';
-import { setCookie } from '../../../lib/auth/auth';
-import { setRefreshCookie } from '../../../lib/auth/refreshCookies';
+import {
+    getRefreshTokenUserId,
+    getUser,
+    revokeRefreshToken,
+} from '@gredice/storage';
+import { clearCookie, setCookie, verifyJwt } from '../../../lib/auth/auth';
+import {
+    establishFarmLoginSession,
+    type FarmLoginErrorCode,
+    getFarmLoginErrorStatus,
+    getIssuedRefreshToken,
+    mapTrustedLoginError,
+    parseFarmLoginCredentials,
+    parseFarmLoginTokens,
+} from '../../../lib/auth/farmLoginContract';
+import {
+    clearRefreshCookie,
+    setRefreshCookie,
+} from '../../../lib/auth/refreshCookies';
 
 const API_BASE_URL = getServerGrediceApiOrigin();
 
-function isLoginResponse(
-    data: unknown,
-): data is { token: string; refreshToken?: string } {
-    return (
-        typeof data === 'object' &&
-        data !== null &&
-        'token' in data &&
-        typeof data.token === 'string'
+function errorResponse(error: FarmLoginErrorCode) {
+    return Response.json(
+        { error },
+        {
+            status: getFarmLoginErrorStatus(error),
+            headers: { 'Cache-Control': 'no-store' },
+        },
     );
 }
 
+async function revokeIssuedSession(refreshToken: string) {
+    try {
+        await revokeRefreshToken(refreshToken);
+    } catch {
+        // Authentication still fails closed if cleanup is temporarily unavailable.
+    }
+}
+
+async function clearPartialSession() {
+    await Promise.allSettled([clearCookie(), clearRefreshCookie()]);
+}
+
 export async function POST(request: Request) {
-    const body = await request.json();
-    const { email, password } = body;
-    if (!email || !password) {
-        return new Response('User name and password are required', {
-            status: 400,
-        });
+    const body: unknown = await request.json().catch(() => null);
+    const credentials = parseFarmLoginCredentials(body);
+    if (!credentials) {
+        return errorResponse('invalid_request');
     }
 
     let response: Response;
@@ -29,32 +55,60 @@ export async function POST(request: Request) {
         response = await fetch(`${API_BASE_URL}/api/auth/login`, {
             method: 'POST',
             headers: {
+                Accept: 'application/json',
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ email, password }),
+            body: JSON.stringify(credentials),
+            cache: 'no-store',
         });
     } catch {
-        return Response.json({ error: 'api_unavailable' }, { status: 502 });
+        return errorResponse('service_unavailable');
     }
 
     const data: unknown = await response.json().catch(() => null);
     if (!response.ok) {
-        return Response.json(data ?? { error: 'login_failed' }, {
-            status: response.status,
-        });
+        const issuedRefreshToken = getIssuedRefreshToken(data);
+        if (issuedRefreshToken) {
+            await revokeIssuedSession(issuedRefreshToken);
+        }
+        return errorResponse(mapTrustedLoginError(data, response.status));
     }
 
-    if (!isLoginResponse(data)) {
-        return Response.json(
-            { error: 'invalid_login_response' },
-            { status: 502 },
-        );
+    const tokens = parseFarmLoginTokens(data);
+    if (!tokens) {
+        const issuedRefreshToken = getIssuedRefreshToken(data);
+        if (issuedRefreshToken) {
+            await revokeIssuedSession(issuedRefreshToken);
+        }
+        return errorResponse('service_unavailable');
     }
 
-    if (data?.refreshToken) {
-        await setRefreshCookie(data.refreshToken);
+    const sessionResult = await establishFarmLoginSession(tokens, {
+        clearSession: clearPartialSession,
+        loadRefreshTokenSubject: async (refreshToken) => {
+            const result = await getRefreshTokenUserId(refreshToken);
+            return result?.userId ?? null;
+        },
+        loadUser: getUser,
+        persistSession: async ({ token, refreshToken }) => {
+            await setRefreshCookie(refreshToken);
+            await setCookie(token);
+        },
+        revokeRefreshToken,
+        verifyAccessTokenSubject: async (token) => {
+            const { error, result } = await verifyJwt(token);
+            const subject = result?.payload.sub;
+            return !error && subject && subject.trim() === subject
+                ? subject
+                : null;
+        },
+    });
+    if ('error' in sessionResult) {
+        return errorResponse(sessionResult.error);
     }
-    await setCookie(data.token);
 
-    return Response.json(data);
+    return Response.json(
+        { ok: true },
+        { headers: { 'Cache-Control': 'no-store' } },
+    );
 }

--- a/apps/farm/app/prijava/OAuthCallbackPanel.tsx
+++ b/apps/farm/app/prijava/OAuthCallbackPanel.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Spinner } from '@gredice/ui/Spinner';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useEffect, useRef } from 'react';
+import { FarmSignInShell } from '../../components/auth/FarmSignInShell';
+import type { FarmOAuthProvider } from '../../lib/auth/safeFarmReturnPath';
+
+export type OAuthCallbackErrorCode =
+    | 'callback_error'
+    | 'canceled'
+    | 'exchange_error'
+    | 'missing_token'
+    | 'network_error'
+    | 'provider_error'
+    | 'state_invalid';
+
+export type OAuthCallbackViewState =
+    | { status: 'error'; code: OAuthCallbackErrorCode }
+    | { status: 'processing' };
+
+const ERROR_CONTENT: Record<
+    OAuthCallbackErrorCode,
+    { message: string; title: string }
+> = {
+    callback_error: {
+        title: 'Prijava nije završena',
+        message:
+            'Prijavu trenutno nije moguće završiti. Pokušaj ponovno ili se vrati na prijavu.',
+    },
+    canceled: {
+        title: 'Prijava je otkazana',
+        message:
+            'Nisi dovršio prijavu kod odabranog pružatelja. Tvoj račun nije promijenjen.',
+    },
+    exchange_error: {
+        title: 'Prijava nije spremljena',
+        message:
+            'Podaci za prijavu nisu mogli biti sigurno spremljeni. Pokreni prijavu ponovno.',
+    },
+    missing_token: {
+        title: 'Nedostaju podaci za prijavu',
+        message:
+            'Povratak s prijave nije sadržavao potrebne podatke. Pokreni prijavu ponovno.',
+    },
+    network_error: {
+        title: 'Veza je prekinuta',
+        message:
+            'Provjeri internetsku vezu i pokreni prijavu ponovno. Podaci za prijavu nisu spremljeni.',
+    },
+    provider_error: {
+        title: 'Pružatelj prijave nije dostupan',
+        message:
+            'Google ili Facebook nije uspio dovršiti prijavu. Pokušaj ponovno za nekoliko trenutaka.',
+    },
+    state_invalid: {
+        title: 'Prijavu treba ponoviti',
+        message:
+            'Sigurnosna provjera prijave nije uspjela. Pokreni novu prijavu iz Gredice Farme.',
+    },
+};
+
+function getProviderLabel(provider: FarmOAuthProvider) {
+    return provider === 'google' ? 'Google' : 'Facebook';
+}
+
+interface OAuthCallbackPanelProps {
+    onBack?: () => void;
+    onRetry?: () => void;
+    provider: FarmOAuthProvider;
+    state: OAuthCallbackViewState;
+}
+
+export function OAuthCallbackPanel({
+    onBack,
+    onRetry,
+    provider,
+    state,
+}: OAuthCallbackPanelProps) {
+    const errorRef = useRef<HTMLDivElement>(null);
+    const providerLabel = getProviderLabel(provider);
+
+    useEffect(() => {
+        if (state.status === 'error') {
+            errorRef.current?.focus();
+        }
+    }, [state.status]);
+
+    return (
+        <FarmSignInShell>
+            <Stack spacing={6}>
+                <Stack spacing={2}>
+                    <Typography className="text-xl" level="h2" semiBold>
+                        {providerLabel} prijava
+                    </Typography>
+                    {state.status === 'processing' ? (
+                        <Typography className="text-muted-foreground">
+                            Sigurno završavamo tvoju prijavu.
+                        </Typography>
+                    ) : null}
+                </Stack>
+
+                {state.status === 'processing' ? (
+                    <div
+                        aria-live="polite"
+                        className="flex min-h-11 items-center gap-3 rounded-lg border bg-muted/40 px-4 py-3"
+                        role="status"
+                    >
+                        <Spinner
+                            className="size-5 shrink-0"
+                            loading
+                            loadingLabel="Prijava u tijeku"
+                        />
+                        <Typography level="body2">Prijava u tijeku…</Typography>
+                    </div>
+                ) : (
+                    <Stack spacing={4}>
+                        <div ref={errorRef} tabIndex={-1}>
+                            <Alert color="danger" role="alert">
+                                <Stack spacing={1}>
+                                    <Typography level="body2" semiBold>
+                                        {ERROR_CONTENT[state.code].title}
+                                    </Typography>
+                                    <Typography level="body2">
+                                        {ERROR_CONTENT[state.code].message}
+                                    </Typography>
+                                </Stack>
+                            </Alert>
+                        </div>
+                        <Stack spacing={2}>
+                            <Button
+                                fullWidth
+                                onClick={onRetry}
+                                size="lg"
+                                type="button"
+                                variant="solid"
+                            >
+                                Pokušaj ponovno
+                            </Button>
+                            <Button
+                                color="neutral"
+                                fullWidth
+                                onClick={onBack}
+                                size="lg"
+                                type="button"
+                                variant="outlined"
+                            >
+                                Natrag na prijavu
+                            </Button>
+                        </Stack>
+                    </Stack>
+                )}
+            </Stack>
+        </FarmSignInShell>
+    );
+}

--- a/apps/farm/app/prijava/UrlAuthForward.spec.tsx
+++ b/apps/farm/app/prijava/UrlAuthForward.spec.tsx
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { OAuthCallbackStrictModeHarness } from '../../playwright/OAuthCallbackStrictModeHarness';
+
+test('retains OAuth credentials through Strict Mode effect replay', async ({
+    mount,
+    page,
+}) => {
+    const exchangeBodies: Array<string | null> = [];
+    await page.route('**/api/oauth-callback', async (route) => {
+        exchangeBodies.push(route.request().postData());
+        await route.fulfill({ status: 500 });
+    });
+    await page.evaluate(() => {
+        window.history.replaceState(
+            null,
+            '',
+            `${window.location.pathname}#token=strict-token&refreshToken=strict-refresh`,
+        );
+    });
+
+    const component = await mount(<OAuthCallbackStrictModeHarness />);
+
+    await expect(
+        component.locator('[data-farm-sign-in-panel]').getByRole('alert'),
+    ).toContainText('Prijava nije spremljena');
+    expect(exchangeBodies.length).toBeGreaterThan(0);
+    expect(
+        exchangeBodies.every(
+            (body) =>
+                body ===
+                JSON.stringify({
+                    token: 'strict-token',
+                    refreshToken: 'strict-refresh',
+                }),
+        ),
+    ).toBe(true);
+    expect(await page.evaluate(() => window.location.hash)).toBe('');
+});

--- a/apps/farm/app/prijava/UrlAuthForward.tsx
+++ b/apps/farm/app/prijava/UrlAuthForward.tsx
@@ -1,72 +1,189 @@
 'use client';
 
+import { getBrowserGrediceAppOrigin } from '@gredice/client';
 import { authCurrentUserQueryKeys } from '@gredice/ui/auth';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import {
+    type FarmOAuthProvider,
+    getFarmOAuthStartUrl,
+    getSafeFarmReturnPath,
+} from '../../lib/auth/safeFarmReturnPath';
+import {
+    type OAuthCallbackErrorCode,
+    OAuthCallbackPanel,
+    type OAuthCallbackViewState,
+} from './OAuthCallbackPanel';
 
-export function UrlAuthForward() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
+const OAUTH_CALLBACK_TIMEOUT_MS = 10_000;
+
+function getServerCallbackErrorCode(
+    value: string | null,
+): OAuthCallbackErrorCode | null {
+    switch (value) {
+        case null:
+            return null;
+        case 'callback_error':
+        case 'canceled':
+        case 'provider_error':
+        case 'state_invalid':
+            return value;
+        default:
+            return 'callback_error';
+    }
+}
+
+type OAuthCallbackForwarderProps = {
+    provider: FarmOAuthProvider;
+    returnTo: string;
+    serverErrorCode: OAuthCallbackErrorCode | null;
+};
+
+type OAuthFragment = {
+    refreshToken: string | null;
+    token: string | null;
+};
+
+export function OAuthCallbackForwarder({
+    provider,
+    returnTo,
+    serverErrorCode,
+}: OAuthCallbackForwarderProps) {
     const queryClient = useQueryClient();
+    const [viewState, setViewState] = useState<OAuthCallbackViewState>({
+        status: 'processing',
+    });
+    const oauthFragmentRef = useRef<OAuthFragment | undefined>(undefined);
 
     useEffect(() => {
+        const abortController = new AbortController();
+        let active = true;
+        let timeoutId: number | undefined;
+
         const forwardAuthSession = async () => {
-            const error = searchParams.get('error');
-            if (error) {
-                console.error('Authentication error:', error);
-                router.replace('/');
+            if (oauthFragmentRef.current === undefined) {
+                const hash = window.location.hash.slice(1);
+                const hashParams = new URLSearchParams(hash);
+                oauthFragmentRef.current = {
+                    refreshToken: hashParams.get('refreshToken'),
+                    token: hashParams.get('token'),
+                };
+
+                if (hash) {
+                    window.history.replaceState(
+                        null,
+                        '',
+                        window.location.pathname + window.location.search,
+                    );
+                }
+            }
+            const { refreshToken, token } = oauthFragmentRef.current;
+
+            if (serverErrorCode) {
+                setViewState({ status: 'error', code: serverErrorCode });
                 return;
             }
 
-            // Read tokens from URL fragment (hash) to avoid server logs/referrer leakage
-            const hash = window.location.hash.substring(1);
-            const params = new URLSearchParams(hash);
-            const token = params.get('token');
-            const refreshToken = params.get('refreshToken');
-
-            // Clear tokens from URL immediately to minimize exposure
-            if (hash) {
-                window.history.replaceState(
-                    null,
-                    '',
-                    window.location.pathname + window.location.search,
-                );
+            if (!token) {
+                setViewState({ status: 'error', code: 'missing_token' });
+                return;
             }
 
-            if (token) {
-                // Exchange tokens for httpOnly cookies via local route handler
-                try {
-                    const response = await fetch('/api/oauth-callback', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ token, refreshToken }),
-                    });
+            timeoutId = window.setTimeout(
+                () => abortController.abort(),
+                OAUTH_CALLBACK_TIMEOUT_MS,
+            );
 
-                    if (!response.ok) {
-                        console.error(
-                            'OAuth callback failed:',
-                            response.status,
-                            response.statusText,
-                        );
-                        router.replace('/');
-                        return;
+            try {
+                const response = await fetch('/api/oauth-callback', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ token, refreshToken }),
+                    signal: abortController.signal,
+                });
+
+                if (!response.ok) {
+                    console.error(
+                        'OAuth callback cookie exchange failed',
+                        response.status,
+                    );
+                    if (active) {
+                        setViewState({
+                            status: 'error',
+                            code: 'exchange_error',
+                        });
                     }
-                } catch (fetchError) {
-                    console.error('OAuth callback request error:', fetchError);
-                    router.replace('/');
                     return;
+                }
+            } catch (cause) {
+                console.error(
+                    'OAuth callback request failed',
+                    cause instanceof Error ? cause.name : 'unknown',
+                );
+                if (active) {
+                    setViewState({ status: 'error', code: 'network_error' });
+                }
+                return;
+            } finally {
+                if (timeoutId !== undefined) {
+                    window.clearTimeout(timeoutId);
                 }
             }
 
-            await queryClient.invalidateQueries({
-                queryKey: authCurrentUserQueryKeys,
-            });
-            router.replace('/');
+            if (!active) {
+                return;
+            }
+            await queryClient
+                .invalidateQueries({ queryKey: authCurrentUserQueryKeys })
+                .catch(() => undefined);
+            window.location.replace(returnTo);
         };
 
         void forwardAuthSession();
-    }, [queryClient, router, searchParams]);
 
-    return null;
+        return () => {
+            active = false;
+            abortController.abort();
+            if (timeoutId !== undefined) {
+                window.clearTimeout(timeoutId);
+            }
+        };
+    }, [queryClient, returnTo, serverErrorCode]);
+
+    const handleRetry = () => {
+        window.location.assign(
+            getFarmOAuthStartUrl({
+                apiOrigin: getBrowserGrediceAppOrigin('api'),
+                farmOrigin: window.location.origin,
+                provider,
+                returnTo,
+            }),
+        );
+    };
+
+    return (
+        <OAuthCallbackPanel
+            onBack={() => window.location.replace(returnTo)}
+            onRetry={handleRetry}
+            provider={provider}
+            state={viewState}
+        />
+    );
+}
+
+export function UrlAuthForward({ provider }: { provider: FarmOAuthProvider }) {
+    const searchParams = useSearchParams();
+    const returnTo = getSafeFarmReturnPath(searchParams.get('returnTo'));
+    const serverErrorCode = getServerCallbackErrorCode(
+        searchParams.get('error'),
+    );
+
+    return (
+        <OAuthCallbackForwarder
+            provider={provider}
+            returnTo={returnTo}
+            serverErrorCode={serverErrorCode}
+        />
+    );
 }

--- a/apps/farm/app/prijava/facebook-prijava/povratak/page.tsx
+++ b/apps/farm/app/prijava/facebook-prijava/povratak/page.tsx
@@ -1,50 +1,18 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
-import { Row } from '@gredice/ui/Row';
-import { Spinner } from '@gredice/ui/Spinner';
-import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
 import { Suspense } from 'react';
+import { OAuthCallbackPanel } from '../../OAuthCallbackPanel';
 import { UrlAuthForward } from '../../UrlAuthForward';
 
 export default function FacebookCallbackPage() {
     return (
-        <div className="min-h-[100dvh] flex items-center justify-center bg-background p-4">
-            <Card className="w-full max-w-[350px] p-6 sm:p-12">
-                <CardHeader>
-                    <svg
-                        className="mx-auto size-12 text-[#1877F2] mb-4"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                    >
-                        <title>Facebook</title>
-                        <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
-                    </svg>
-                    <CardTitle className="text-center">
-                        Facebook prijava
-                    </CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <Stack spacing={6}>
-                        <Row spacing={4} justifyContent="center">
-                            <Spinner
-                                loading
-                                className="size-5"
-                                loadingLabel="Prijava u tijeku..."
-                            />
-                            <Typography level="body2">
-                                Prijava u tijeku...
-                            </Typography>
-                        </Row>
-                        <Typography level="body3" center>
-                            Pričekaj dok završimo tvoju Facebook prijavu.
-                        </Typography>
-                    </Stack>
-                </CardContent>
-            </Card>
-            <Suspense>
-                <UrlAuthForward />
-            </Suspense>
-        </div>
+        <Suspense
+            fallback={
+                <OAuthCallbackPanel
+                    provider="facebook"
+                    state={{ status: 'processing' }}
+                />
+            }
+        >
+            <UrlAuthForward provider="facebook" />
+        </Suspense>
     );
 }

--- a/apps/farm/app/prijava/google-prijava/povratak/page.tsx
+++ b/apps/farm/app/prijava/google-prijava/povratak/page.tsx
@@ -1,65 +1,18 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@gredice/ui/Card';
-import { Row } from '@gredice/ui/Row';
-import { Spinner } from '@gredice/ui/Spinner';
-import { Stack } from '@gredice/ui/Stack';
-import { Typography } from '@gredice/ui/Typography';
 import { Suspense } from 'react';
+import { OAuthCallbackPanel } from '../../OAuthCallbackPanel';
 import { UrlAuthForward } from '../../UrlAuthForward';
 
 export default function GoogleCallbackPage() {
     return (
-        <div className="min-h-[100dvh] flex items-center justify-center bg-background p-4">
-            <Card className="w-full max-w-[350px] p-6 sm:p-12">
-                <CardHeader>
-                    <svg
-                        className="mx-auto size-12 mb-4"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                    >
-                        <title>Google</title>
-                        <path
-                            fill="#4285F4"
-                            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                        />
-                        <path
-                            fill="#34A853"
-                            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                        />
-                        <path
-                            fill="#FBBC05"
-                            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                        />
-                        <path
-                            fill="#EA4335"
-                            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                        />
-                    </svg>
-                    <CardTitle className="text-center">
-                        Google prijava
-                    </CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <Stack spacing={6}>
-                        <Row spacing={4} justifyContent="center">
-                            <Spinner
-                                loading
-                                className="size-5"
-                                loadingLabel="Prijava u tijeku..."
-                            />
-                            <Typography level="body2">
-                                Prijava u tijeku...
-                            </Typography>
-                        </Row>
-                        <Typography level="body3" center>
-                            Pričekaj dok završimo tvoju Google prijavu.
-                        </Typography>
-                    </Stack>
-                </CardContent>
-            </Card>
-            <Suspense>
-                <UrlAuthForward />
-            </Suspense>
-        </div>
+        <Suspense
+            fallback={
+                <OAuthCallbackPanel
+                    provider="google"
+                    state={{ status: 'processing' }}
+                />
+            }
+        >
+            <UrlAuthForward provider="google" />
+        </Suspense>
     );
 }

--- a/apps/farm/components/auth/EmailLoginForm.tsx
+++ b/apps/farm/components/auth/EmailLoginForm.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import { getBrowserGrediceAppOrigin } from '@gredice/client';
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Input } from '@gredice/ui/Input';
+import { ArrowLeft, Warning } from '@gredice/ui/icons';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { type FormEvent, useEffect, useRef, useState } from 'react';
+import type { FarmLoginErrorCode } from '../../lib/auth/farmLoginContract';
+
+const EMAIL_INPUT_ID = 'farm-email-login-email';
+
+const ERROR_CONTENT: Record<
+    FarmLoginErrorCode,
+    { message: string; title: string }
+> = {
+    email_verification_required: {
+        title: 'Potvrdi email prije prijave',
+        message:
+            'Otvori poruku za potvrdu računa ili zatraži novu poveznicu pa se ponovno prijavi.',
+    },
+    invalid_credentials: {
+        title: 'Email ili zaporka nisu ispravni',
+        message:
+            'Provjeri unesene podatke ili obnovi zaporku. Iz sigurnosnih razloga ne možemo navesti koji podatak nije ispravan.',
+    },
+    invalid_request: {
+        title: 'Provjeri unesene podatke',
+        message: 'Unesi valjanu email adresu i zaporku pa pokušaj ponovno.',
+    },
+    no_farm_access: {
+        title: 'Račun nema pristup Farmi',
+        message:
+            'Ovaj Gredice račun nije povezan s farmom koju možeš voditi. Podrška može provjeriti tvoj pristup.',
+    },
+    service_unavailable: {
+        title: 'Prijava trenutačno nije dostupna',
+        message:
+            'Provjeri internetsku vezu i pokušaj ponovno za nekoliko trenutaka. Uneseni podaci ostaju u obrascu.',
+    },
+    temporarily_locked: {
+        title: 'Prijava je privremeno zaključana',
+        message:
+            'Pričekaj prije novog pokušaja ili obnovi zaporku. Ne možemo prikazati sigurnosne pojedinosti zaključavanja.',
+    },
+};
+
+export type FarmLoginFailure = {
+    attempt: number;
+    code: FarmLoginErrorCode;
+};
+
+interface EmailLoginFormProps {
+    failure: FarmLoginFailure | null;
+    loading: boolean;
+    onBack: () => void;
+    onSubmit: (email: string, password: string) => Promise<void>;
+}
+
+function createRecoveryUrl(pathname: string, email: string) {
+    const url = new URL(pathname, getBrowserGrediceAppOrigin('garden'));
+    if (email) {
+        url.searchParams.set('email', email);
+    }
+    return url.toString();
+}
+
+export function EmailLoginForm({
+    failure,
+    loading,
+    onBack,
+    onSubmit,
+}: EmailLoginFormProps) {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [passwordVisible, setPasswordVisible] = useState(false);
+    const errorRef = useRef<HTMLDivElement>(null);
+    const passwordResetUrl = createRecoveryUrl(
+        '/prijava/zaboravljena-zaporka',
+        email,
+    );
+    const verificationUrl = createRecoveryUrl(
+        '/prijava/potvrda-emaila/posalji',
+        email,
+    );
+    const supportUrl = new URL(
+        '/kontakt',
+        getBrowserGrediceAppOrigin('www'),
+    ).toString();
+
+    useEffect(() => {
+        document.getElementById(EMAIL_INPUT_ID)?.focus();
+    }, []);
+
+    useEffect(() => {
+        if (failure) {
+            errorRef.current?.focus();
+        }
+    }, [failure]);
+
+    function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!loading) {
+            void onSubmit(email, password);
+        }
+    }
+
+    return (
+        <form
+            className="w-full min-w-0 space-y-5"
+            data-farm-email-login-form
+            onSubmit={handleSubmit}
+        >
+            <Button
+                color="neutral"
+                disabled={loading}
+                fullWidth
+                onClick={onBack}
+                size="lg"
+                startDecorator={
+                    <ArrowLeft aria-hidden="true" className="size-4" />
+                }
+                type="button"
+                variant="plain"
+            >
+                Natrag na druge načine prijave
+            </Button>
+
+            <Stack spacing={2}>
+                <Typography className="text-lg" level="h3" semiBold>
+                    Email prijava
+                </Typography>
+                <Typography className="text-muted-foreground" level="body2">
+                    Unesi podatke svog Gredice računa.
+                </Typography>
+            </Stack>
+
+            <Stack spacing={3}>
+                <Input
+                    autoCapitalize="none"
+                    autoComplete="email"
+                    className="h-11 [&>input]:h-full"
+                    disabled={loading}
+                    enterKeyHint="next"
+                    fullWidth
+                    id={EMAIL_INPUT_ID}
+                    inputMode="email"
+                    label="Email"
+                    name="email"
+                    onChange={(event) => setEmail(event.currentTarget.value)}
+                    placeholder="ime@primjer.com"
+                    required
+                    spellCheck={false}
+                    style={{ fontSize: '16px' }}
+                    type="email"
+                    value={email}
+                />
+                <Input
+                    autoComplete="current-password"
+                    className="h-11 [&>input]:h-full"
+                    disabled={loading}
+                    endDecorator={
+                        <button
+                            aria-label={
+                                passwordVisible
+                                    ? 'Sakrij zaporku'
+                                    : 'Prikaži zaporku'
+                            }
+                            aria-pressed={passwordVisible}
+                            className="min-h-11 min-w-11 shrink-0 rounded-r-md px-3 text-sm font-medium text-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                            disabled={loading}
+                            onClick={() =>
+                                setPasswordVisible((visible) => !visible)
+                            }
+                            type="button"
+                        >
+                            {passwordVisible ? 'Sakrij' : 'Prikaži'}
+                        </button>
+                    }
+                    enterKeyHint="go"
+                    fullWidth
+                    id="farm-email-login-password"
+                    label="Zaporka"
+                    name="password"
+                    onChange={(event) => setPassword(event.currentTarget.value)}
+                    required
+                    style={{ fontSize: '16px' }}
+                    type={passwordVisible ? 'text' : 'password'}
+                    value={password}
+                />
+            </Stack>
+
+            <Button
+                className="min-h-11 px-3"
+                color="neutral"
+                disabled={loading}
+                fullWidth
+                href={passwordResetUrl}
+                size="lg"
+                variant="link"
+            >
+                Zaboravljena zaporka?
+            </Button>
+
+            {failure ? (
+                <div
+                    className="rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                    data-farm-email-error
+                    ref={errorRef}
+                    tabIndex={-1}
+                >
+                    <Alert
+                        color="danger"
+                        role="alert"
+                        startDecorator={
+                            <Warning aria-hidden="true" className="size-5" />
+                        }
+                    >
+                        <Stack spacing={2}>
+                            <Stack spacing={1}>
+                                <Typography level="body2" semiBold>
+                                    {ERROR_CONTENT[failure.code].title}
+                                </Typography>
+                                <Typography level="body2">
+                                    {ERROR_CONTENT[failure.code].message}
+                                </Typography>
+                            </Stack>
+                            {failure.code === 'email_verification_required' ? (
+                                <Button
+                                    className="min-h-11 px-3"
+                                    color="danger"
+                                    disabled={loading}
+                                    fullWidth
+                                    href={verificationUrl}
+                                    size="lg"
+                                    variant="outlined"
+                                >
+                                    Pošalji novu potvrdu emaila
+                                </Button>
+                            ) : null}
+                        </Stack>
+                    </Alert>
+                </div>
+            ) : null}
+
+            <Button
+                fullWidth
+                loading={loading}
+                size="lg"
+                type="submit"
+                variant="solid"
+            >
+                Prijavi se
+            </Button>
+
+            <Button
+                className="min-h-11 px-3"
+                color="neutral"
+                disabled={loading}
+                fullWidth
+                href={supportUrl}
+                size="lg"
+                variant="link"
+            >
+                Trebaš pomoć? Kontaktiraj podršku
+            </Button>
+        </form>
+    );
+}

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { getBrowserGrediceAppOrigin } from '@gredice/client';
-import { Alert } from '@gredice/ui/Alert';
 import {
     authCurrentUserQueryKeys,
     FacebookLoginButton,
@@ -9,40 +8,60 @@ import {
     useLastLoginProvider,
 } from '@gredice/ui/auth';
 import { Button } from '@gredice/ui/Button';
-import { Input } from '@gredice/ui/Input';
-import { Mail, Warning } from '@gredice/ui/icons';
+import { Mail } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { usePostHog } from '@posthog/next';
 import { useRouter } from 'next/navigation';
-import { useActionState, useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getFarmLoginErrorCode } from '../../lib/auth/farmLoginContract';
 import {
     type FarmOAuthProvider,
     getFarmOAuthStartUrl,
 } from '../../lib/auth/safeFarmReturnPath';
 import { queryClient } from '../providers/ClientAppProvider';
+import { EmailLoginForm, type FarmLoginFailure } from './EmailLoginForm';
 import { FarmSignInShell } from './FarmSignInShell';
 
 export function LoginDialog() {
     const posthog = usePostHog();
     const router = useRouter();
     const [emailExpanded, setEmailExpanded] = useState(false);
+    const [emailFailure, setEmailFailure] = useState<FarmLoginFailure | null>(
+        null,
+    );
+    const [emailSubmitting, setEmailSubmitting] = useState(false);
+    const emailAttemptRef = useRef(0);
+    const restoreEmailTriggerFocusRef = useRef(false);
     const fetchLastLogin = useCallback(
         () => fetch('/api/gredice/api/auth/last-login'),
         [],
     );
     const lastLoginProvider = useLastLoginProvider(fetchLastLogin);
-    const [error, submitAction, isPending] = useActionState<
-        string | null,
-        FormData
-    >(async (_previousState, formData) => {
-        const email = formData.get('email');
-        const password = formData.get('password');
-
-        if (typeof email !== 'string' || typeof password !== 'string') {
-            return 'Unesi korisničko ime i zaporku.';
+    useEffect(() => {
+        if (!emailExpanded && restoreEmailTriggerFocusRef.current) {
+            restoreEmailTriggerFocusRef.current = false;
+            document.getElementById('farm-email-login-trigger')?.focus();
         }
+    }, [emailExpanded]);
 
+    const setBoundedEmailFailure = (
+        code: ReturnType<typeof getFarmLoginErrorCode>,
+        status?: number,
+    ) => {
+        emailAttemptRef.current += 1;
+        setEmailFailure({ attempt: emailAttemptRef.current, code });
+        posthog?.capture('user_login_failed', {
+            provider: 'password',
+            reason: code,
+            status,
+            surface: 'farm',
+        });
+    };
+
+    const handleEmailLogin = async (email: string, password: string) => {
+        setEmailSubmitting(true);
+        setEmailFailure(null);
         try {
             posthog?.capture('user_login_started', {
                 provider: 'password',
@@ -55,50 +74,38 @@ export function LoginDialog() {
                 },
                 body: JSON.stringify({ email, password }),
             });
+            const responseBody: unknown = await response
+                .json()
+                .catch(() => null);
 
             if (!response.ok) {
-                posthog?.capture('user_login_failed', {
-                    provider: 'password',
-                    reason: 'invalid_credentials_or_access',
+                const code = getFarmLoginErrorCode(responseBody);
+                console.warn('Farm email login rejected', {
+                    reason: code,
                     status: response.status,
-                    surface: 'farm',
                 });
-                console.error('Login failed with status', response.status);
-                return 'Prijava nije uspjela. Provjeri podatke i pokušaj ponovno.';
-            }
-
-            // Tokens are now in httpOnly cookies set by the API
-            // No need to store them in localStorage
-            await response.json();
-
-            const currentUserResponse = await fetch(
-                '/api/users/current-claims',
-            );
-            if (!currentUserResponse.ok) {
-                posthog?.capture('user_login_failed', {
-                    provider: 'password',
-                    reason: 'no_farm_access',
-                    status: currentUserResponse.status,
-                    surface: 'farm',
-                });
-                return 'Tvoj korisnički račun nema pristup Gredice farmi.';
+                setBoundedEmailFailure(code, response.status);
+                return;
             }
 
             await queryClient.invalidateQueries({
                 queryKey: authCurrentUserQueryKeys,
             });
             router.refresh();
-            return null;
-        } catch (cause) {
-            posthog?.capture('user_login_failed', {
-                provider: 'password',
-                reason: 'unexpected_error',
-                surface: 'farm',
-            });
-            console.error('Login request failed', cause);
-            return 'Dogodila se neočekivana greška. Pokušaj ponovno kasnije.';
+        } catch {
+            console.error('Farm email login request failed');
+            setBoundedEmailFailure('service_unavailable');
+        } finally {
+            setEmailSubmitting(false);
         }
-    }, null);
+    };
+
+    const handleEmailBack = () => {
+        restoreEmailTriggerFocusRef.current = true;
+        setEmailFailure(null);
+        setEmailExpanded(false);
+    };
+
     const handleOAuthLogin = (provider: FarmOAuthProvider) => {
         posthog?.capture('user_oauth_started', {
             provider,
@@ -171,7 +178,11 @@ export function LoginDialog() {
                         <Button
                             color="neutral"
                             fullWidth
-                            onClick={() => setEmailExpanded(true)}
+                            id="farm-email-login-trigger"
+                            onClick={() => {
+                                setEmailFailure(null);
+                                setEmailExpanded(true);
+                            }}
                             size="lg"
                             startDecorator={
                                 <Mail
@@ -186,54 +197,12 @@ export function LoginDialog() {
                         </Button>
                     </Stack>
                 ) : (
-                    <form action={submitAction} className="w-full space-y-4">
-                        <Stack spacing={6}>
-                            <Stack spacing={2}>
-                                <Input
-                                    autoComplete="email"
-                                    className="h-11 [&>input]:h-full"
-                                    fullWidth
-                                    label="Email"
-                                    name="email"
-                                    placeholder="ime@primjer.com"
-                                    required
-                                    type="email"
-                                />
-                                <Input
-                                    autoComplete="current-password"
-                                    className="h-11 [&>input]:h-full"
-                                    fullWidth
-                                    label="Zaporka"
-                                    name="password"
-                                    required
-                                    type="password"
-                                />
-                            </Stack>
-                            <Button
-                                fullWidth
-                                loading={isPending}
-                                size="lg"
-                                type="submit"
-                                variant="solid"
-                            >
-                                Prijavi se
-                            </Button>
-                            {error && (
-                                <Alert
-                                    color="danger"
-                                    role="alert"
-                                    startDecorator={
-                                        <Warning
-                                            aria-hidden="true"
-                                            className="size-5"
-                                        />
-                                    }
-                                >
-                                    {error}
-                                </Alert>
-                            )}
-                        </Stack>
-                    </form>
+                    <EmailLoginForm
+                        failure={emailFailure}
+                        loading={emailSubmitting}
+                        onBack={handleEmailBack}
+                        onSubmit={handleEmailLogin}
+                    />
                 )}
             </Stack>
         </FarmSignInShell>

--- a/apps/farm/components/auth/LoginDialog.tsx
+++ b/apps/farm/components/auth/LoginDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getBrowserGrediceAppOrigin } from '@gredice/client';
 import { Alert } from '@gredice/ui/Alert';
 import {
     authCurrentUserQueryKeys,
@@ -15,10 +16,12 @@ import { Typography } from '@gredice/ui/Typography';
 import { usePostHog } from '@posthog/next';
 import { useRouter } from 'next/navigation';
 import { useActionState, useCallback, useState } from 'react';
+import {
+    type FarmOAuthProvider,
+    getFarmOAuthStartUrl,
+} from '../../lib/auth/safeFarmReturnPath';
 import { queryClient } from '../providers/ClientAppProvider';
 import { FarmSignInShell } from './FarmSignInShell';
-
-type OAuthProvider = 'google' | 'facebook';
 
 export function LoginDialog() {
     const posthog = usePostHog();
@@ -96,23 +99,17 @@ export function LoginDialog() {
             return 'Dogodila se neočekivana greška. Pokušaj ponovno kasnije.';
         }
     }, null);
-    const handleOAuthLogin = (provider: OAuthProvider) => {
+    const handleOAuthLogin = (provider: FarmOAuthProvider) => {
         posthog?.capture('user_oauth_started', {
             provider,
             surface: 'farm',
         });
-        const callbackPath =
-            provider === 'google'
-                ? '/prijava/google-prijava/povratak'
-                : '/prijava/facebook-prijava/povratak';
-        const redirectUrl = `${window.location.origin}${callbackPath}`;
-        // Use proxy path instead of direct API URL
-        const authUrl = new URL(
-            `/api/gredice/api/auth/${provider}`,
-            window.location.origin,
-        );
-        authUrl.searchParams.set('redirect', redirectUrl);
-        window.location.href = authUrl.toString();
+        window.location.href = getFarmOAuthStartUrl({
+            apiOrigin: getBrowserGrediceAppOrigin('api'),
+            farmOrigin: window.location.origin,
+            provider,
+            returnTo: `${window.location.pathname}${window.location.search}${window.location.hash}`,
+        });
     };
 
     return (

--- a/apps/farm/lib/auth/farmLoginContract.spec.ts
+++ b/apps/farm/lib/auth/farmLoginContract.spec.ts
@@ -1,0 +1,326 @@
+import { expect, test } from '@playwright/test';
+import {
+    establishFarmLoginSession,
+    FARM_LOGIN_ERROR_CODES,
+    getFarmLoginErrorCode,
+    getFarmLoginErrorStatus,
+    getIssuedRefreshToken,
+    hasAuthorizedFarmLoginAccess,
+    mapTrustedLoginError,
+    parseFarmLoginCredentials,
+    parseFarmLoginTokens,
+} from './farmLoginContract';
+
+test('keeps the public login error taxonomy bounded', () => {
+    expect(FARM_LOGIN_ERROR_CODES).toEqual([
+        'invalid_request',
+        'invalid_credentials',
+        'temporarily_locked',
+        'email_verification_required',
+        'no_farm_access',
+        'service_unavailable',
+    ]);
+
+    for (const error of FARM_LOGIN_ERROR_CODES) {
+        expect(getFarmLoginErrorCode(error)).toBe(error);
+    }
+    for (const privateError of [
+        undefined,
+        null,
+        '',
+        'user_not_found',
+        'database_connection_failed',
+        { error: 'login_failed' },
+    ]) {
+        expect(getFarmLoginErrorCode(privateError)).toBe('service_unavailable');
+    }
+    expect(getFarmLoginErrorCode({ error: 'invalid_credentials' })).toBe(
+        'invalid_credentials',
+    );
+});
+
+test('normalizes the email without changing the password', () => {
+    expect(
+        parseFarmLoginCredentials({
+            email: '  farmer@example.com  ',
+            password: '  keep these spaces  ',
+        }),
+    ).toEqual({
+        email: 'farmer@example.com',
+        password: '  keep these spaces  ',
+    });
+});
+
+test('rejects malformed request bodies, emails, and passwords', () => {
+    for (const value of [
+        null,
+        [],
+        {},
+        { email: 'farmer@example.com' },
+        { email: 42, password: 'secret' },
+        { email: 'farmer@example.com', password: 42 },
+        { email: '', password: 'secret' },
+        { email: 'farmer', password: 'secret' },
+        { email: 'farmer @example.com', password: 'secret' },
+        { email: 'farmer@example.com\u0000', password: 'secret' },
+        { email: `${'a'.repeat(250)}@example.com`, password: 'secret' },
+        { email: 'farmer@example.com', password: '' },
+        { email: 'farmer@example.com', password: 'x'.repeat(4097) },
+    ]) {
+        expect(parseFarmLoginCredentials(value)).toBeNull();
+    }
+});
+
+test('requires both nonempty, unmodified session tokens', () => {
+    const tokens = {
+        token: 'access.token.signature',
+        refreshToken: 'refresh-token.secret',
+    };
+    expect(parseFarmLoginTokens(tokens)).toEqual(tokens);
+
+    for (const value of [
+        null,
+        {},
+        { token: tokens.token },
+        { refreshToken: tokens.refreshToken },
+        { token: '', refreshToken: tokens.refreshToken },
+        { token: tokens.token, refreshToken: '' },
+        { token: ` ${tokens.token}`, refreshToken: tokens.refreshToken },
+        { token: tokens.token, refreshToken: `${tokens.refreshToken}\n` },
+        { token: 'x'.repeat(16_385), refreshToken: tokens.refreshToken },
+    ]) {
+        expect(parseFarmLoginTokens(value)).toBeNull();
+    }
+});
+
+test('finds an issued refresh token even when the access token is invalid', () => {
+    expect(
+        getIssuedRefreshToken({ refreshToken: 'refresh-token.secret' }),
+    ).toBe('refresh-token.secret');
+    expect(getIssuedRefreshToken({ refreshToken: ' invalid' })).toBeNull();
+    expect(getIssuedRefreshToken({ refreshToken: '' })).toBeNull();
+    expect(getIssuedRefreshToken(null)).toBeNull();
+});
+
+test('maps only trusted upstream failures into public errors', () => {
+    const mappings = [
+        ['user_not_found', 'invalid_credentials'],
+        ['login_failed', 'invalid_credentials'],
+        ['invalid_credentials', 'invalid_credentials'],
+        ['user_blocked', 'temporarily_locked'],
+        ['temporarily_locked', 'temporarily_locked'],
+        ['verify_email', 'email_verification_required'],
+        ['email_verification_required', 'email_verification_required'],
+        ['invalid_request', 'invalid_request'],
+    ] as const;
+
+    for (const [upstreamCode, publicCode] of mappings) {
+        expect(mapTrustedLoginError({ errorCode: upstreamCode }, 500)).toBe(
+            publicCode,
+        );
+    }
+
+    expect(mapTrustedLoginError(null, 400)).toBe('invalid_request');
+    expect(mapTrustedLoginError(null, 422)).toBe('invalid_request');
+    expect(mapTrustedLoginError(null, 401)).toBe('invalid_credentials');
+    expect(mapTrustedLoginError(null, 404)).toBe('invalid_credentials');
+    expect(mapTrustedLoginError(null, 429)).toBe('temporarily_locked');
+    expect(mapTrustedLoginError({ errorCode: 'database_error' }, 500)).toBe(
+        'service_unavailable',
+    );
+    expect(mapTrustedLoginError({ error: 'private detail' }, 403)).toBe(
+        'service_unavailable',
+    );
+});
+
+test('assigns stable HTTP statuses to every public error', () => {
+    expect(getFarmLoginErrorStatus('invalid_request')).toBe(400);
+    expect(getFarmLoginErrorStatus('invalid_credentials')).toBe(401);
+    expect(getFarmLoginErrorStatus('temporarily_locked')).toBe(429);
+    expect(getFarmLoginErrorStatus('email_verification_required')).toBe(403);
+    expect(getFarmLoginErrorStatus('no_farm_access')).toBe(403);
+    expect(getFarmLoginErrorStatus('service_unavailable')).toBe(503);
+});
+
+test('allows only farmers and admins with an assigned account', () => {
+    expect(
+        hasAuthorizedFarmLoginAccess({ role: 'farmer', accounts: [{}] }),
+    ).toBe(true);
+    expect(
+        hasAuthorizedFarmLoginAccess({ role: 'admin', accounts: [{}] }),
+    ).toBe(true);
+
+    for (const value of [
+        null,
+        {},
+        { role: 'farmer' },
+        { role: 'farmer', accounts: [] },
+        { role: 'admin', accounts: [] },
+        { role: 'user', accounts: [{}] },
+        { role: 'owner', accounts: [{}] },
+        { role: 'farmer', accounts: null },
+    ]) {
+        expect(hasAuthorizedFarmLoginAccess(value)).toBe(false);
+    }
+});
+
+test('persists a verified authoritative Farm session without revoking it', async () => {
+    const events: string[] = [];
+    const result = await establishFarmLoginSession(
+        {
+            token: 'access.token.signature',
+            refreshToken: 'refresh-token.secret',
+        },
+        {
+            clearSession: async () => {
+                events.push('clear');
+            },
+            loadRefreshTokenSubject: async (refreshToken) => {
+                events.push(`refresh:${refreshToken}`);
+                return 'farmer-id';
+            },
+            loadUser: async (subject) => {
+                events.push(`load:${subject}`);
+                return { role: 'farmer', accounts: [{}] };
+            },
+            persistSession: async ({ token, refreshToken }) => {
+                events.push(`persist:${token}:${refreshToken}`);
+            },
+            revokeRefreshToken: async (refreshToken) => {
+                events.push(`revoke:${refreshToken}`);
+            },
+            verifyAccessTokenSubject: async (token) => {
+                events.push(`verify:${token}`);
+                return 'farmer-id';
+            },
+        },
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(events).toEqual([
+        'verify:access.token.signature',
+        'refresh:refresh-token.secret',
+        'load:farmer-id',
+        'persist:access.token.signature:refresh-token.secret',
+    ]);
+});
+
+test('revokes issued refresh tokens for every pre-cookie session rejection', async () => {
+    const tokens = {
+        token: 'access.token.signature',
+        refreshToken: 'refresh-token.secret',
+    };
+    const cases = [
+        {
+            expected: 'service_unavailable',
+            loadRefreshTokenSubject: async () => 'farmer-id',
+            loadUser: async () => ({ role: 'farmer', accounts: [{}] }),
+            verifyAccessTokenSubject: async () => null,
+        },
+        {
+            expected: 'service_unavailable',
+            loadRefreshTokenSubject: async () => 'farmer-id',
+            loadUser: async () => ({ role: 'farmer', accounts: [{}] }),
+            verifyAccessTokenSubject: async (): Promise<string> => {
+                throw new Error('verification failed');
+            },
+        },
+        {
+            expected: 'service_unavailable',
+            loadRefreshTokenSubject: async () => 'different-user-id',
+            loadUser: async () => ({ role: 'farmer', accounts: [{}] }),
+            verifyAccessTokenSubject: async () => 'farmer-id',
+        },
+        {
+            expected: 'service_unavailable',
+            loadRefreshTokenSubject: async () => null,
+            loadUser: async () => ({ role: 'farmer', accounts: [{}] }),
+            verifyAccessTokenSubject: async () => 'farmer-id',
+        },
+        {
+            expected: 'service_unavailable',
+            loadRefreshTokenSubject: async (): Promise<string> => {
+                throw new Error('refresh token lookup failed');
+            },
+            loadUser: async () => ({ role: 'farmer', accounts: [{}] }),
+            verifyAccessTokenSubject: async () => 'farmer-id',
+        },
+        {
+            expected: 'service_unavailable',
+            loadRefreshTokenSubject: async () => 'farmer-id',
+            loadUser: async (): Promise<unknown> => {
+                throw new Error('storage failed');
+            },
+            verifyAccessTokenSubject: async () => 'farmer-id',
+        },
+        {
+            expected: 'no_farm_access',
+            loadRefreshTokenSubject: async () => 'farmer-id',
+            loadUser: async () => null,
+            verifyAccessTokenSubject: async () => 'farmer-id',
+        },
+        {
+            expected: 'no_farm_access',
+            loadRefreshTokenSubject: async () => 'farmer-id',
+            loadUser: async () => ({ role: 'user', accounts: [{}] }),
+            verifyAccessTokenSubject: async () => 'farmer-id',
+        },
+        {
+            expected: 'no_farm_access',
+            loadRefreshTokenSubject: async () => 'farmer-id',
+            loadUser: async () => ({ role: 'farmer', accounts: [] }),
+            verifyAccessTokenSubject: async () => 'farmer-id',
+        },
+    ] as const;
+
+    for (const testCase of cases) {
+        const events: string[] = [];
+        const result = await establishFarmLoginSession(tokens, {
+            clearSession: async () => {
+                events.push('clear');
+            },
+            loadRefreshTokenSubject: testCase.loadRefreshTokenSubject,
+            loadUser: testCase.loadUser,
+            persistSession: async () => {
+                events.push('persist');
+            },
+            revokeRefreshToken: async (refreshToken) => {
+                events.push(`revoke:${refreshToken}`);
+            },
+            verifyAccessTokenSubject: testCase.verifyAccessTokenSubject,
+        });
+
+        expect(result).toEqual({ error: testCase.expected });
+        expect(events).not.toContain('persist');
+        expect(events).not.toContain('clear');
+        expect(events.at(-1)).toBe('revoke:refresh-token.secret');
+    }
+});
+
+test('clears partial cookies and revokes the refresh token when persistence fails', async () => {
+    const events: string[] = [];
+    const result = await establishFarmLoginSession(
+        {
+            token: 'access.token.signature',
+            refreshToken: 'refresh-token.secret',
+        },
+        {
+            clearSession: async () => {
+                events.push('clear');
+            },
+            loadRefreshTokenSubject: async () => 'admin-id',
+            loadUser: async () => ({ role: 'admin', accounts: [{}] }),
+            persistSession: async () => {
+                events.push('persist');
+                throw new Error('cookie failed');
+            },
+            revokeRefreshToken: async (refreshToken) => {
+                events.push(`revoke:${refreshToken}`);
+            },
+            verifyAccessTokenSubject: async () => 'admin-id',
+        },
+    );
+
+    expect(result).toEqual({ error: 'service_unavailable' });
+    expect(events).toEqual(['persist', 'clear', 'revoke:refresh-token.secret']);
+});

--- a/apps/farm/lib/auth/farmLoginContract.ts
+++ b/apps/farm/lib/auth/farmLoginContract.ts
@@ -1,0 +1,273 @@
+export const FARM_LOGIN_ERROR_CODES = [
+    'invalid_request',
+    'invalid_credentials',
+    'temporarily_locked',
+    'email_verification_required',
+    'no_farm_access',
+    'service_unavailable',
+] as const;
+
+export type FarmLoginErrorCode = (typeof FARM_LOGIN_ERROR_CODES)[number];
+
+export type FarmLoginCredentials = {
+    email: string;
+    password: string;
+};
+
+export type FarmLoginTokens = {
+    token: string;
+    refreshToken: string;
+};
+
+type FarmLoginSessionDependencies = {
+    clearSession: () => Promise<void>;
+    loadRefreshTokenSubject: (refreshToken: string) => Promise<string | null>;
+    loadUser: (subject: string) => Promise<unknown>;
+    persistSession: (tokens: FarmLoginTokens) => Promise<void>;
+    revokeRefreshToken: (refreshToken: string) => Promise<void>;
+    verifyAccessTokenSubject: (token: string) => Promise<string | null>;
+};
+
+export type FarmLoginSessionResult =
+    | { ok: true }
+    | { error: FarmLoginErrorCode };
+
+const MAX_EMAIL_LENGTH = 254;
+const MAX_PASSWORD_LENGTH = 4096;
+const MAX_TOKEN_LENGTH = 16_384;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function containsControlCharacter(value: string): boolean {
+    for (const character of value) {
+        const codePoint = character.codePointAt(0);
+        if (codePoint !== undefined && (codePoint <= 31 || codePoint === 127)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function isToken(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        value.length > 0 &&
+        value.length <= MAX_TOKEN_LENGTH &&
+        value.trim() === value &&
+        !/\s/u.test(value)
+    );
+}
+
+export function getFarmLoginErrorCode(value: unknown): FarmLoginErrorCode {
+    const candidate = isRecord(value) ? value.error : value;
+    if (typeof candidate === 'string') {
+        const error = FARM_LOGIN_ERROR_CODES.find(
+            (knownError) => knownError === candidate,
+        );
+        if (error) {
+            return error;
+        }
+    }
+
+    return 'service_unavailable';
+}
+
+export function parseFarmLoginCredentials(
+    value: unknown,
+): FarmLoginCredentials | null {
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    const { email: rawEmail, password } = value;
+    if (typeof rawEmail !== 'string' || typeof password !== 'string') {
+        return null;
+    }
+
+    const email = rawEmail.trim();
+    if (
+        email.length === 0 ||
+        email.length > MAX_EMAIL_LENGTH ||
+        containsControlCharacter(email) ||
+        !EMAIL_PATTERN.test(email) ||
+        password.length === 0 ||
+        password.length > MAX_PASSWORD_LENGTH
+    ) {
+        return null;
+    }
+
+    return { email, password };
+}
+
+export function parseFarmLoginTokens(value: unknown): FarmLoginTokens | null {
+    if (
+        !isRecord(value) ||
+        !isToken(value.token) ||
+        !isToken(value.refreshToken)
+    ) {
+        return null;
+    }
+
+    return {
+        token: value.token,
+        refreshToken: value.refreshToken,
+    };
+}
+
+export function getIssuedRefreshToken(value: unknown): string | null {
+    if (!isRecord(value) || !isToken(value.refreshToken)) {
+        return null;
+    }
+
+    return value.refreshToken;
+}
+
+export function mapTrustedLoginError(
+    value: unknown,
+    status: number,
+): FarmLoginErrorCode {
+    const upstreamCode = isRecord(value) ? value.errorCode : undefined;
+
+    switch (upstreamCode) {
+        case 'login_failed':
+        case 'user_not_found':
+        case 'invalid_credentials':
+            return 'invalid_credentials';
+        case 'user_blocked':
+        case 'temporarily_locked':
+            return 'temporarily_locked';
+        case 'verify_email':
+        case 'email_verification_required':
+            return 'email_verification_required';
+        case 'invalid_request':
+            return 'invalid_request';
+        default:
+            break;
+    }
+
+    if (status === 400 || status === 422) {
+        return 'invalid_request';
+    }
+    if (status === 401 || status === 404) {
+        return 'invalid_credentials';
+    }
+    if (status === 429) {
+        return 'temporarily_locked';
+    }
+
+    return 'service_unavailable';
+}
+
+export function getFarmLoginErrorStatus(error: FarmLoginErrorCode): number {
+    switch (error) {
+        case 'invalid_request':
+            return 400;
+        case 'invalid_credentials':
+            return 401;
+        case 'temporarily_locked':
+            return 429;
+        case 'email_verification_required':
+        case 'no_farm_access':
+            return 403;
+        case 'service_unavailable':
+            return 503;
+    }
+}
+
+export function hasAuthorizedFarmLoginAccess(value: unknown): boolean {
+    if (!isRecord(value) || !Array.isArray(value.accounts)) {
+        return false;
+    }
+
+    return (
+        (value.role === 'farmer' || value.role === 'admin') &&
+        value.accounts.length > 0
+    );
+}
+
+async function rejectIssuedSession(
+    error: FarmLoginErrorCode,
+    refreshToken: string,
+    revokeRefreshToken: FarmLoginSessionDependencies['revokeRefreshToken'],
+): Promise<FarmLoginSessionResult> {
+    try {
+        await revokeRefreshToken(refreshToken);
+    } catch {
+        // Authentication still fails closed if cleanup is temporarily unavailable.
+    }
+    return { error };
+}
+
+export async function establishFarmLoginSession(
+    tokens: FarmLoginTokens,
+    dependencies: FarmLoginSessionDependencies,
+): Promise<FarmLoginSessionResult> {
+    let subject: string | null;
+    try {
+        subject = await dependencies.verifyAccessTokenSubject(tokens.token);
+    } catch {
+        subject = null;
+    }
+    if (!subject) {
+        return rejectIssuedSession(
+            'service_unavailable',
+            tokens.refreshToken,
+            dependencies.revokeRefreshToken,
+        );
+    }
+
+    let refreshTokenSubject: string | null;
+    try {
+        refreshTokenSubject = await dependencies.loadRefreshTokenSubject(
+            tokens.refreshToken,
+        );
+    } catch {
+        refreshTokenSubject = null;
+    }
+    if (!refreshTokenSubject || refreshTokenSubject !== subject) {
+        return rejectIssuedSession(
+            'service_unavailable',
+            tokens.refreshToken,
+            dependencies.revokeRefreshToken,
+        );
+    }
+
+    let user: unknown;
+    try {
+        user = await dependencies.loadUser(subject);
+    } catch {
+        return rejectIssuedSession(
+            'service_unavailable',
+            tokens.refreshToken,
+            dependencies.revokeRefreshToken,
+        );
+    }
+    if (!hasAuthorizedFarmLoginAccess(user)) {
+        return rejectIssuedSession(
+            'no_farm_access',
+            tokens.refreshToken,
+            dependencies.revokeRefreshToken,
+        );
+    }
+
+    try {
+        await dependencies.persistSession(tokens);
+    } catch {
+        try {
+            await dependencies.clearSession();
+        } catch {
+            // Authentication still fails closed if partial cleanup fails.
+        }
+        return rejectIssuedSession(
+            'service_unavailable',
+            tokens.refreshToken,
+            dependencies.revokeRefreshToken,
+        );
+    }
+
+    return { ok: true };
+}

--- a/apps/farm/lib/auth/safeFarmReturnPath.spec.ts
+++ b/apps/farm/lib/auth/safeFarmReturnPath.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+import {
+    getFarmOAuthStartUrl,
+    getSafeFarmReturnPath,
+} from './safeFarmReturnPath';
+
+test('keeps supported Farm routes with their query and hash intact', () => {
+    for (const returnTo of [
+        '/',
+        '/schedule?date=2026-07-15&view=day#task-18',
+        '/notifications?filter=unread',
+        '/raised-beds/42#operations',
+        '/operations/7?source=notification',
+        '/plants/337',
+        '/greenhouse',
+        '/more',
+        '/payouts',
+        '/settings',
+    ]) {
+        expect(getSafeFarmReturnPath(returnTo)).toBe(returnTo);
+    }
+});
+
+test('falls back for external, malformed, private, and unsupported targets', () => {
+    for (const returnTo of [
+        null,
+        '',
+        ' /schedule',
+        '/schedule ',
+        'https://example.com/schedule',
+        '//example.com/schedule',
+        String.raw`\\example.com\schedule`,
+        '/schedule\\details',
+        '/schedule/%5c/example.com',
+        '/schedule/%2f/example.com',
+        '/schedule/%',
+        '/schedule/../notifications',
+        '/schedule/%2e%2e/notifications',
+        '/api/users/current',
+        '/prijava/google-prijava/povratak',
+        '/debug',
+        '/debug/labels',
+        '/unknown',
+        '/operations/0',
+        '/operations/-1',
+        '/operations/not-a-number',
+        `/schedule?value=${'x'.repeat(2048)}`,
+    ]) {
+        expect(getSafeFarmReturnPath(returnTo)).toBe('/');
+    }
+});
+
+test('builds a provider URL with only a validated internal callback target', () => {
+    const authUrl = new URL(
+        getFarmOAuthStartUrl({
+            apiOrigin: 'https://api.gredice.com',
+            farmOrigin: 'https://farma.gredice.com',
+            provider: 'google',
+            returnTo: '/notifications?filter=unread#notification-7',
+        }),
+    );
+    const callbackUrl = new URL(authUrl.searchParams.get('redirect') ?? '');
+
+    expect(authUrl.origin).toBe('https://api.gredice.com');
+    expect(authUrl.pathname).toBe('/api/auth/google');
+    expect(callbackUrl.origin).toBe('https://farma.gredice.com');
+    expect(callbackUrl.pathname).toBe('/prijava/google-prijava/povratak');
+    expect(callbackUrl.searchParams.get('returnTo')).toBe(
+        '/notifications?filter=unread#notification-7',
+    );
+
+    const unsafeCallbackUrl = new URL(
+        new URL(
+            getFarmOAuthStartUrl({
+                apiOrigin: 'https://api.gredice.com',
+                farmOrigin: 'https://farma.gredice.com',
+                provider: 'facebook',
+                returnTo: 'https://example.com/steal',
+            }),
+        ).searchParams.get('redirect') ?? '',
+    );
+    expect(unsafeCallbackUrl.pathname).toBe(
+        '/prijava/facebook-prijava/povratak',
+    );
+    expect(unsafeCallbackUrl.searchParams.get('returnTo')).toBe('/');
+});

--- a/apps/farm/lib/auth/safeFarmReturnPath.ts
+++ b/apps/farm/lib/auth/safeFarmReturnPath.ts
@@ -1,0 +1,107 @@
+const MAX_FARM_RETURN_PATH_LENGTH = 2048;
+
+const FARM_RETURN_EXACT_PATHS = new Set([
+    '/',
+    '/greenhouse',
+    '/more',
+    '/notifications',
+    '/operations',
+    '/payouts',
+    '/plants',
+    '/raised-beds',
+    '/schedule',
+    '/settings',
+]);
+
+const FARM_RETURN_DETAIL_PATH =
+    /^\/(?:operations|plants|raised-beds)\/[1-9]\d*$/;
+const ENCODED_PATH_SEPARATOR = /%(?:2f|5c)/i;
+
+function containsControlCharacter(value: string) {
+    return Array.from(value).some((character) => {
+        const code = character.charCodeAt(0);
+        return code <= 31 || code === 127;
+    });
+}
+
+function isSupportedFarmPath(pathname: string) {
+    return (
+        FARM_RETURN_EXACT_PATHS.has(pathname) ||
+        FARM_RETURN_DETAIL_PATH.test(pathname)
+    );
+}
+
+export function getSafeFarmReturnPath(
+    candidate: string | null | undefined,
+): string {
+    if (
+        !candidate ||
+        candidate !== candidate.trim() ||
+        candidate.length > MAX_FARM_RETURN_PATH_LENGTH ||
+        containsControlCharacter(candidate) ||
+        !candidate.startsWith('/') ||
+        candidate.startsWith('//')
+    ) {
+        return '/';
+    }
+
+    const suffixIndex = candidate.search(/[?#]/);
+    const rawPathname =
+        suffixIndex === -1 ? candidate : candidate.slice(0, suffixIndex);
+    if (
+        rawPathname.includes('\\') ||
+        ENCODED_PATH_SEPARATOR.test(rawPathname)
+    ) {
+        return '/';
+    }
+
+    let decodedPathname: string;
+    let parsedUrl: URL;
+    try {
+        decodedPathname = decodeURIComponent(rawPathname);
+        parsedUrl = new URL(candidate, 'https://farm.gredice.invalid');
+    } catch {
+        return '/';
+    }
+
+    if (
+        decodedPathname.includes('\\') ||
+        decodedPathname.includes('//') ||
+        containsControlCharacter(decodedPathname) ||
+        decodedPathname
+            .split('/')
+            .some((segment) => segment === '.' || segment === '..') ||
+        parsedUrl.origin !== 'https://farm.gredice.invalid' ||
+        !isSupportedFarmPath(decodedPathname)
+    ) {
+        return '/';
+    }
+
+    return candidate;
+}
+
+export type FarmOAuthProvider = 'facebook' | 'google';
+
+export function getFarmOAuthStartUrl({
+    apiOrigin,
+    farmOrigin,
+    provider,
+    returnTo,
+}: {
+    apiOrigin: string;
+    farmOrigin: string;
+    provider: FarmOAuthProvider;
+    returnTo: string | null | undefined;
+}) {
+    const safeReturnTo = getSafeFarmReturnPath(returnTo);
+    const callbackPath =
+        provider === 'google'
+            ? '/prijava/google-prijava/povratak'
+            : '/prijava/facebook-prijava/povratak';
+    const callbackUrl = new URL(callbackPath, farmOrigin);
+    callbackUrl.searchParams.set('returnTo', safeReturnTo);
+
+    const authUrl = new URL(`/api/auth/${provider}`, apiOrigin);
+    authUrl.searchParams.set('redirect', callbackUrl.toString());
+    return authUrl.toString();
+}

--- a/apps/farm/playwright/OAuthCallbackStrictModeHarness.tsx
+++ b/apps/farm/playwright/OAuthCallbackStrictModeHarness.tsx
@@ -1,0 +1,19 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { StrictMode, useState } from 'react';
+import { OAuthCallbackForwarder } from '../app/prijava/UrlAuthForward';
+
+export function OAuthCallbackStrictModeHarness() {
+    const [queryClient] = useState(() => new QueryClient());
+
+    return (
+        <StrictMode>
+            <QueryClientProvider client={queryClient}>
+                <OAuthCallbackForwarder
+                    provider="google"
+                    returnTo="/notifications"
+                    serverErrorCode={null}
+                />
+            </QueryClientProvider>
+        </StrictMode>
+    );
+}

--- a/apps/farm/tests/auth.spec.ts
+++ b/apps/farm/tests/auth.spec.ts
@@ -316,10 +316,39 @@ test.describe('Authentication Flow', () => {
     });
 
     test.describe('OAuth Callback Flow', () => {
-        test('should POST tokens to /api/oauth-callback endpoint', async ({
+        test('starts OAuth on the API origin with the current internal route', async ({
             page,
         }) => {
-            // Track requests to the oauth-callback endpoint
+            await page.route('**/api/auth/google**', (route) =>
+                route.fulfill({ status: 204 }),
+            );
+            await page.goto('/notifications?filter=unread');
+            const farmOrigin = new URL(page.url()).origin;
+            const providerRequestPromise = page.waitForRequest((request) => {
+                const requestUrl = new URL(request.url());
+                return requestUrl.pathname === '/api/auth/google';
+            });
+
+            await page.getByRole('button', { name: 'Google prijava' }).click();
+            const providerRequest = await providerRequestPromise;
+            const authUrl = new URL(providerRequest.url());
+            const callbackUrl = new URL(
+                authUrl.searchParams.get('redirect') ?? '',
+            );
+
+            expect(authUrl.origin).not.toBe(farmOrigin);
+            expect(callbackUrl.origin).toBe(farmOrigin);
+            expect(callbackUrl.pathname).toBe(
+                '/prijava/google-prijava/povratak',
+            );
+            expect(callbackUrl.searchParams.get('returnTo')).toBe(
+                '/notifications?filter=unread',
+            );
+        });
+
+        test('posts tokens and returns to the intended internal route', async ({
+            page,
+        }) => {
             const callbackRequests: Array<{
                 method: string;
                 body: { token?: string; refreshToken?: string };
@@ -340,19 +369,24 @@ test.describe('Authentication Flow', () => {
                 });
             });
 
-            // Navigate to callback page with tokens in hash
-            // Wait for the response (not just the request) to ensure route handler has completed
             const responsePromise = page.waitForResponse(
                 (response) =>
                     response.url().includes('/api/oauth-callback') &&
                     response.request().method() === 'POST',
             );
+            const returnTo = '/notifications?filter=unread#notification-7';
             await page.goto(
-                '/prijava/google-prijava/povratak#token=test-access-token&refreshToken=test-refresh-token',
+                `/prijava/google-prijava/povratak?returnTo=${encodeURIComponent(returnTo)}#token=test-access-token&refreshToken=test-refresh-token`,
             );
             await responsePromise;
+            await page.waitForURL((url) => {
+                return (
+                    url.pathname === '/notifications' &&
+                    url.searchParams.get('filter') === 'unread' &&
+                    url.hash === '#notification-7'
+                );
+            });
 
-            // Verify that the POST request was made with correct data
             const callbackRequest = callbackRequests[0];
             expect(callbackRequest).toBeDefined();
             if (!callbackRequest) {
@@ -366,63 +400,190 @@ test.describe('Authentication Flow', () => {
             expect(callbackRequest.headers['content-type']).toContain(
                 'application/json',
             );
+            expect(page.url()).not.toContain('test-access-token');
+            expect(page.url()).not.toContain('test-refresh-token');
         });
 
-        test('should clear tokens from URL after processing', async ({
+        test('clears token fragments before the cookie exchange completes', async ({
             page,
         }) => {
-            // Navigate to callback page with tokens in hash and wait for redirect
+            let releaseExchange: (() => void) | undefined;
+            let markExchangeStarted: (() => void) | undefined;
+            const exchangeStarted = new Promise<void>((resolve) => {
+                markExchangeStarted = resolve;
+            });
+            const exchangeGate = new Promise<void>((resolve) => {
+                releaseExchange = resolve;
+            });
+            await page.route('**/api/oauth-callback', async (route) => {
+                markExchangeStarted?.();
+                await exchangeGate;
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ success: true }),
+                });
+            });
+
             await page.goto(
                 '/prijava/google-prijava/povratak#token=test-token&refreshToken=test-refresh',
             );
+            await exchangeStarted;
 
-            // Wait for URL to change (redirect to home)
-            await page.waitForURL((url) => !url.hash && url.pathname === '/');
+            expect(new URL(page.url()).hash).toBe('');
+            expect(page.url()).not.toContain('test-token');
+            await expect(
+                page.getByText('Prijava u tijeku…', { exact: true }),
+            ).toBeVisible();
 
-            // Verify URL no longer contains the tokens in hash
-            const currentUrl = page.url();
-            expect(currentUrl).not.toContain('token=');
-            expect(currentUrl).not.toContain('refreshToken=');
-            expect(currentUrl).not.toContain('#');
-        });
-
-        test('should handle missing token gracefully', async ({ page }) => {
-            // Navigate to callback page without tokens and wait for redirect
-            await page.goto('/prijava/google-prijava/povratak');
+            releaseExchange?.();
             await page.waitForURL((url) => url.pathname === '/');
-
-            // Should redirect to home without errors
-            const currentUrl = page.url();
-            expect(currentUrl).toContain('/');
-            expect(currentUrl).not.toContain('/prijava/');
         });
 
-        test('should handle callback endpoint errors', async ({ page }) => {
-            // Mock the callback endpoint to return an error
-            await page.route('/api/oauth-callback', (route) => {
+        test('shows a recoverable error when the token is missing', async ({
+            page,
+        }) => {
+            await page.setViewportSize({ width: 320, height: 568 });
+            await page.goto(
+                `/prijava/google-prijava/povratak?returnTo=${encodeURIComponent('/notifications')}`,
+            );
+
+            await expect(
+                page.locator('[data-farm-sign-in-panel]').getByRole('alert'),
+            ).toContainText('Nedostaju podaci za prijavu');
+            const retryButton = page.getByRole('button', {
+                name: 'Pokušaj ponovno',
+            });
+            await expectMinimumTouchTarget(retryButton);
+            const backButton = page.getByRole('button', {
+                name: 'Natrag na prijavu',
+            });
+            await expectMinimumTouchTarget(backButton);
+            expect(
+                await page.evaluate(
+                    () =>
+                        document.documentElement.scrollWidth <=
+                        document.documentElement.clientWidth,
+                ),
+            ).toBe(true);
+            await backButton.click();
+            await page.waitForURL((url) => url.pathname === '/notifications');
+        });
+
+        for (const callbackError of [
+            { code: 'canceled', title: 'Prijava je otkazana' },
+            { code: 'state_invalid', title: 'Prijavu treba ponoviti' },
+            {
+                code: 'provider_error',
+                title: 'Pružatelj prijave nije dostupan',
+            },
+            { code: 'callback_error', title: 'Prijava nije završena' },
+        ]) {
+            test(`shows bounded ${callbackError.code} recovery`, async ({
+                page,
+            }) => {
+                await page.goto(
+                    `/prijava/facebook-prijava/povratak?error=${callbackError.code}&returnTo=${encodeURIComponent('/schedule?date=2026-07-15')}`,
+                );
+
+                await expect(
+                    page
+                        .locator('[data-farm-sign-in-panel]')
+                        .getByRole('alert'),
+                ).toContainText(callbackError.title);
+                await expect(
+                    page.getByRole('button', { name: 'Pokušaj ponovno' }),
+                ).toBeVisible();
+                await expect(
+                    page.getByRole('button', { name: 'Natrag na prijavu' }),
+                ).toBeVisible();
+                expect(new URL(page.url()).pathname).toBe(
+                    '/prijava/facebook-prijava/povratak',
+                );
+            });
+        }
+
+        test('retries cancellation with the same safe internal return path', async ({
+            page,
+        }) => {
+            await page.route('**/api/auth/facebook**', (route) =>
+                route.fulfill({ status: 204 }),
+            );
+            await page.goto(
+                `/prijava/facebook-prijava/povratak?error=canceled&returnTo=${encodeURIComponent('/schedule?date=2026-07-15')}`,
+            );
+            const providerRequestPromise = page.waitForRequest((request) => {
+                return new URL(request.url()).pathname === '/api/auth/facebook';
+            });
+
+            await page.getByRole('button', { name: 'Pokušaj ponovno' }).click();
+            const providerRequest = await providerRequestPromise;
+            const callbackUrl = new URL(
+                new URL(providerRequest.url()).searchParams.get('redirect') ??
+                    '',
+            );
+            expect(callbackUrl.searchParams.get('returnTo')).toBe(
+                '/schedule?date=2026-07-15',
+            );
+        });
+
+        test('shows cookie exchange failures without retaining token fragments', async ({
+            page,
+        }) => {
+            await page.route('**/api/oauth-callback', (route) => {
                 route.fulfill({
                     status: 500,
                     body: JSON.stringify({ error: 'Internal server error' }),
                 });
             });
 
-            // Navigate to callback page with tokens and wait for redirect
             await page.goto(
                 '/prijava/google-prijava/povratak#token=test-token&refreshToken=test-refresh',
             );
-            await page.waitForURL((url) => url.pathname === '/');
 
-            // Should redirect to home despite error
-            const currentUrl = page.url();
-            expect(currentUrl).toContain('/');
-            expect(currentUrl).not.toContain('/prijava/');
-
-            // Cookie should either not exist or not have the test token value
+            await expect(
+                page.locator('[data-farm-sign-in-panel]').getByRole('alert'),
+            ).toContainText('Prijava nije spremljena');
+            expect(new URL(page.url()).hash).toBe('');
             const cookies = await page.context().cookies();
             const sessionCookie = cookies.find(
                 (c) => c.name === 'gredice_session',
             );
             expect(sessionCookie?.value).not.toBe('test-token');
+        });
+
+        test('falls back to Farm home for a malicious return target', async ({
+            page,
+        }) => {
+            await page.route('**/api/oauth-callback', (route) =>
+                route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ success: true }),
+                }),
+            );
+            await page.goto(
+                `/prijava/google-prijava/povratak?returnTo=${encodeURIComponent('https://example.com/steal')}#token=test-token`,
+            );
+
+            await page.waitForURL((url) => url.pathname === '/');
+            expect(new URL(page.url()).origin).not.toBe('https://example.com');
+        });
+
+        test('maps unknown provider errors to the bounded callback failure', async ({
+            page,
+        }) => {
+            await page.goto(
+                '/prijava/google-prijava/povratak?error=raw_provider_detail',
+            );
+
+            const callbackAlert = page
+                .locator('[data-farm-sign-in-panel]')
+                .getByRole('alert');
+            await expect(callbackAlert).toContainText('Prijava nije završena');
+            await expect(callbackAlert).not.toContainText(
+                'raw_provider_detail',
+            );
         });
     });
 });

--- a/apps/farm/tests/auth.spec.ts
+++ b/apps/farm/tests/auth.spec.ts
@@ -9,6 +9,39 @@ const signInViewports = [
     { name: 'desktop', width: 1280, height: 800 },
 ] as const;
 
+const emailLoginErrors = [
+    {
+        code: 'invalid_request',
+        status: 400,
+        title: 'Provjeri unesene podatke',
+    },
+    {
+        code: 'invalid_credentials',
+        status: 401,
+        title: 'Email ili zaporka nisu ispravni',
+    },
+    {
+        code: 'temporarily_locked',
+        status: 423,
+        title: 'Prijava je privremeno zaključana',
+    },
+    {
+        code: 'email_verification_required',
+        status: 403,
+        title: 'Potvrdi email prije prijave',
+    },
+    {
+        code: 'no_farm_access',
+        status: 403,
+        title: 'Račun nema pristup Farmi',
+    },
+    {
+        code: 'service_unavailable',
+        status: 503,
+        title: 'Prijava trenutačno nije dostupna',
+    },
+] as const;
+
 async function expectContainedInViewport(
     locator: import('@playwright/test').Locator,
     viewport: { height: number; width: number },
@@ -181,6 +214,345 @@ test.describe('Authentication Flow', () => {
                     violation.impact === 'critical',
             );
 
+            expect(
+                seriousViolations,
+                JSON.stringify(seriousViolations, null, 2),
+            ).toEqual([]);
+        });
+    });
+
+    test.describe('Email login recovery', () => {
+        test('moves focus into email and restores it to the provider trigger on back', async ({
+            page,
+        }) => {
+            await page.setViewportSize({ width: 390, height: 844 });
+            await page.goto('/');
+
+            const emailTrigger = page.getByRole('button', {
+                name: 'Email prijava',
+            });
+            await emailTrigger.click();
+
+            await expect(page.getByLabel('Email')).toBeFocused();
+            const backButton = page.getByRole('button', {
+                name: 'Natrag na druge načine prijave',
+            });
+            await expectMinimumTouchTarget(backButton);
+            await backButton.click();
+
+            await expect(emailTrigger).toBeFocused();
+            await expect(
+                page.getByRole('button', { name: 'Google prijava' }),
+            ).toBeVisible();
+            await expect(
+                page.getByRole('button', { name: 'Facebook prijava' }),
+            ).toBeVisible();
+        });
+
+        test('supports mobile keyboard hints, password visibility, and real recovery links', async ({
+            page,
+        }) => {
+            await page.setViewportSize({ width: 390, height: 844 });
+            await page.goto('/');
+            await page.getByRole('button', { name: 'Email prijava' }).click();
+
+            const emailInput = page.getByLabel('Email');
+            const passwordInput = page.getByLabel('Zaporka');
+            await expect(emailInput).toHaveAttribute('autocomplete', 'email');
+            await expect(emailInput).toHaveAttribute('inputmode', 'email');
+            await expect(emailInput).toHaveAttribute('enterkeyhint', 'next');
+            await expect(passwordInput).toHaveAttribute(
+                'autocomplete',
+                'current-password',
+            );
+            await expect(passwordInput).toHaveAttribute('enterkeyhint', 'go');
+
+            await emailInput.fill('farmer@example.com');
+            await passwordInput.fill('secret-password');
+            const showPassword = page.getByRole('button', {
+                name: 'Prikaži zaporku',
+            });
+            await expectMinimumTouchTarget(showPassword);
+            await showPassword.click();
+            await expect(passwordInput).toHaveAttribute('type', 'text');
+            await expect(passwordInput).toHaveValue('secret-password');
+            await page.getByRole('button', { name: 'Sakrij zaporku' }).click();
+            await expect(passwordInput).toHaveAttribute('type', 'password');
+
+            const resetLink = page.getByRole('link', {
+                name: 'Zaboravljena zaporka?',
+            });
+            const supportLink = page.getByRole('link', {
+                name: 'Trebaš pomoć? Kontaktiraj podršku',
+            });
+            await expectMinimumTouchTarget(resetLink);
+            await expectMinimumTouchTarget(supportLink);
+            const resetUrl = new URL(
+                (await resetLink.getAttribute('href')) ?? '',
+            );
+            const supportUrl = new URL(
+                (await supportLink.getAttribute('href')) ?? '',
+            );
+            expect(resetUrl.origin).not.toBe(new URL(page.url()).origin);
+            expect(resetUrl.pathname).toBe('/prijava/zaboravljena-zaporka');
+            expect(resetUrl.searchParams.get('email')).toBe(
+                'farmer@example.com',
+            );
+            expect(supportUrl.origin).not.toBe(new URL(page.url()).origin);
+            expect(supportUrl.pathname).toBe('/kontakt');
+        });
+
+        test('keeps a predictable keyboard order without trapping page focus', async ({
+            page,
+        }) => {
+            await page.setViewportSize({ width: 390, height: 844 });
+            await page.goto('/');
+            await page.getByRole('button', { name: 'Email prijava' }).click();
+
+            const emailInput = page.getByLabel('Email');
+            await expect(emailInput).toBeFocused();
+            await page.keyboard.press('Shift+Tab');
+            await expect(
+                page.getByRole('button', {
+                    name: 'Natrag na druge načine prijave',
+                }),
+            ).toBeFocused();
+            await page.keyboard.press('Tab');
+            await expect(emailInput).toBeFocused();
+            await page.keyboard.press('Tab');
+            await expect(page.getByLabel('Zaporka')).toBeFocused();
+            await page.keyboard.press('Tab');
+            await expect(
+                page.getByRole('button', { name: 'Prikaži zaporku' }),
+            ).toBeFocused();
+            await page.keyboard.press('Tab');
+            await expect(
+                page.getByRole('link', { name: 'Zaboravljena zaporka?' }),
+            ).toBeFocused();
+            await page.keyboard.press('Tab');
+            await expect(
+                page.getByRole('button', { name: 'Prijavi se' }),
+            ).toBeFocused();
+            await page.keyboard.press('Tab');
+            await expect(
+                page.getByRole('link', {
+                    name: 'Trebaš pomoć? Kontaktiraj podršku',
+                }),
+            ).toBeFocused();
+        });
+
+        test('submits email credentials without exposing tokens and preserves the protected route', async ({
+            page,
+        }) => {
+            const loginBodies: Array<Record<string, unknown>> = [];
+            await page.route('**/api/login', async (route) => {
+                loginBodies.push(route.request().postDataJSON());
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ ok: true }),
+                });
+            });
+            await page.goto('/notifications?filter=unread');
+            await page.getByRole('button', { name: 'Email prijava' }).click();
+            await page.getByLabel('Email').fill('farmer@example.com');
+            await page.getByLabel('Zaporka').fill('secret-password');
+
+            await page.getByRole('button', { name: 'Prijavi se' }).click();
+            await expect.poll(() => loginBodies.length).toBe(1);
+
+            expect(loginBodies[0]).toEqual({
+                email: 'farmer@example.com',
+                password: 'secret-password',
+            });
+            await expect(page).toHaveURL(/\/notifications\?filter=unread/);
+        });
+
+        for (const loginError of emailLoginErrors) {
+            test(`shows bounded ${loginError.code} recovery and retains the form`, async ({
+                page,
+            }) => {
+                await page.route('**/api/login', (route) =>
+                    route.fulfill({
+                        status: loginError.status,
+                        contentType: 'application/json',
+                        body: JSON.stringify({
+                            error: loginError.code,
+                            rawDetail: 'PRIVATE_UPSTREAM_LOGIN_DETAIL',
+                        }),
+                    }),
+                );
+                await page.goto('/');
+                await page
+                    .getByRole('button', { name: 'Email prijava' })
+                    .click();
+                const emailInput = page.getByLabel('Email');
+                const passwordInput = page.getByLabel('Zaporka');
+                await emailInput.fill('farmer@example.com');
+                await passwordInput.fill('secret-password');
+
+                await page.getByRole('button', { name: 'Prijavi se' }).click();
+
+                const errorFocusTarget = page.locator(
+                    '[data-farm-email-error]',
+                );
+                await expect(errorFocusTarget).toBeFocused();
+                await expect
+                    .poll(() =>
+                        errorFocusTarget.evaluate(
+                            (element) => getComputedStyle(element).boxShadow,
+                        ),
+                    )
+                    .not.toBe('none');
+                await expect(
+                    page
+                        .locator('[data-farm-email-login-form]')
+                        .getByRole('alert'),
+                ).toContainText(loginError.title);
+                await expect(errorFocusTarget).not.toContainText(
+                    'PRIVATE_UPSTREAM_LOGIN_DETAIL',
+                );
+                await expect(emailInput).toHaveValue('farmer@example.com');
+                await expect(passwordInput).toHaveValue('secret-password');
+
+                if (loginError.code === 'email_verification_required') {
+                    const verificationLink = page.getByRole('link', {
+                        name: 'Pošalji novu potvrdu emaila',
+                    });
+                    const verificationUrl = new URL(
+                        (await verificationLink.getAttribute('href')) ?? '',
+                    );
+                    expect(verificationUrl.pathname).toBe(
+                        '/prijava/potvrda-emaila/posalji',
+                    );
+                    expect(verificationUrl.searchParams.get('email')).toBe(
+                        'farmer@example.com',
+                    );
+                    await expectMinimumTouchTarget(verificationLink);
+                }
+            });
+        }
+
+        test('focuses the error again after the same failed retry', async ({
+            page,
+        }) => {
+            let attempts = 0;
+            await page.route('**/api/login', async (route) => {
+                attempts += 1;
+                await route.fulfill({
+                    status: 401,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ error: 'invalid_credentials' }),
+                });
+            });
+            await page.goto('/');
+            await page.getByRole('button', { name: 'Email prijava' }).click();
+            await page.getByLabel('Email').fill('farmer@example.com');
+            await page.getByLabel('Zaporka').fill('secret-password');
+            const submit = page.getByRole('button', { name: 'Prijavi se' });
+
+            await submit.click();
+            await expect(page.locator('[data-farm-email-error]')).toBeFocused();
+            await page.getByLabel('Zaporka').focus();
+            await submit.click();
+            await expect.poll(() => attempts).toBe(2);
+            await expect(page.locator('[data-farm-email-error]')).toBeFocused();
+        });
+
+        for (const viewport of [
+            { width: 320, height: 568 },
+            { width: 390, height: 844 },
+            { width: 430, height: 932 },
+        ]) {
+            test(`keeps long recovery usable at ${viewport.width}px`, async ({
+                page,
+            }) => {
+                await page.route('**/api/login', (route) =>
+                    route.fulfill({
+                        status: 503,
+                        contentType: 'application/json',
+                        body: JSON.stringify({ error: 'service_unavailable' }),
+                    }),
+                );
+                await page.setViewportSize(viewport);
+                await page.goto('/');
+                await page
+                    .getByRole('button', { name: 'Email prijava' })
+                    .click();
+                await page.getByLabel('Email').fill('farmer@example.com');
+                await page.getByLabel('Zaporka').fill('secret-password');
+                await page.getByRole('button', { name: 'Prijavi se' }).click();
+
+                await expect(
+                    page
+                        .locator('[data-farm-email-login-form]')
+                        .getByRole('alert'),
+                ).toContainText('Prijava trenutačno nije dostupna');
+                for (const input of [
+                    page.getByLabel('Email'),
+                    page.getByLabel('Zaporka'),
+                ]) {
+                    expect(
+                        Number.parseFloat(
+                            await input.evaluate(
+                                (element) => getComputedStyle(element).fontSize,
+                            ),
+                        ),
+                    ).toBeGreaterThanOrEqual(16);
+                }
+                expect(
+                    await page.evaluate(
+                        () =>
+                            document.documentElement.scrollWidth <=
+                            document.documentElement.clientWidth,
+                    ),
+                ).toBe(true);
+
+                for (const control of [
+                    page.getByRole('button', {
+                        name: 'Natrag na druge načine prijave',
+                    }),
+                    page.getByRole('button', { name: 'Prikaži zaporku' }),
+                    page.getByRole('link', { name: 'Zaboravljena zaporka?' }),
+                    page.getByRole('button', { name: 'Prijavi se' }),
+                    page.getByRole('link', {
+                        name: 'Trebaš pomoć? Kontaktiraj podršku',
+                    }),
+                ]) {
+                    await control.scrollIntoViewIfNeeded();
+                    await expectMinimumTouchTarget(control);
+                }
+            });
+        }
+
+        test('has no serious or critical accessibility violations in a long error state', async ({
+            page,
+        }) => {
+            await page.route('**/api/login', (route) =>
+                route.fulfill({
+                    status: 403,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        error: 'email_verification_required',
+                    }),
+                }),
+            );
+            await page.setViewportSize({ width: 390, height: 844 });
+            await page.goto('/');
+            await page.getByRole('button', { name: 'Email prijava' }).click();
+            await page.getByLabel('Email').fill('farmer@example.com');
+            await page.getByLabel('Zaporka').fill('secret-password');
+            await page.getByRole('button', { name: 'Prijavi se' }).click();
+            await expect(page.locator('[data-farm-email-error]')).toBeFocused();
+
+            const results = await new AxeBuilder({ page })
+                .withTags(['wcag2a', 'wcag2aa'])
+                .analyze();
+            const seriousViolations = results.violations.filter(
+                (violation) =>
+                    violation.impact === 'serious' ||
+                    violation.impact === 'critical',
+            );
             expect(
                 seriousViolations,
                 JSON.stringify(seriousViolations, null, 2),

--- a/apps/garden/app/prijava/EmailSentCard.tsx
+++ b/apps/garden/app/prijava/EmailSentCard.tsx
@@ -4,9 +4,15 @@ import { Mail } from '@gredice/ui/icons';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 
-export function EmailSentCard() {
+export function EmailSentCard({
+    purpose = 'password-reset',
+}: {
+    purpose?: 'email-verification' | 'password-reset';
+}) {
+    const isEmailVerification = purpose === 'email-verification';
+
     return (
-        <Card className="w-[350px] p-12">
+        <Card className="w-full max-w-sm p-6 sm:p-10">
             <CardHeader>
                 <div className="flex items-center justify-center w-12 h-12 rounded-full bg-[#2f6e40] mx-auto mb-4">
                     <Mail className="w-6 h-6 text-white" />
@@ -16,14 +22,16 @@ export function EmailSentCard() {
             <CardContent>
                 <Stack spacing={6}>
                     <Typography center semiBold className="text-[#2f6e40]">
-                        Provjeri svoj email za nastavak promjene zaporke
+                        {isEmailVerification
+                            ? 'Provjeri svoj email za potvrdu email adrese'
+                            : 'Provjeri svoj email za nastavak promjene zaporke'}
                     </Typography>
                     <Typography level="body3" center>
-                        Poslali smo ti link za promjene zaporke na tvoju email
-                        adresu. Molimo te provjeri svoj inbox i slijedi upute za
-                        promjenu zaporke.
+                        {isEmailVerification
+                            ? 'Poslali smo ti poveznicu za potvrdu email adrese. Provjeri svoj inbox i slijedi upute za potvrdu.'
+                            : 'Poslali smo ti poveznicu za promjenu zaporke na tvoju email adresu. Provjeri svoj inbox i slijedi upute za promjenu zaporke.'}
                     </Typography>
-                    <Button href="/" fullWidth variant="soft">
+                    <Button href="/" fullWidth variant="soft" size="lg">
                         Povratak
                     </Button>
                 </Stack>

--- a/apps/garden/app/prijava/SendVerifyEmailButton.tsx
+++ b/apps/garden/app/prijava/SendVerifyEmailButton.tsx
@@ -20,21 +20,26 @@ export function SendVerifyEmailButton() {
         }
 
         setIsLoading(true);
-        const response = await clientPublic().api.auth[
-            'send-verify-email'
-        ].$post({
-            json: {
-                email,
-            },
-        });
+        try {
+            const response = await clientPublic().api.auth[
+                'send-verify-email'
+            ].$post({
+                json: {
+                    email,
+                },
+            });
 
-        if (response.status === 404 || response) {
-            setIsLoading(false);
+            if (response.ok) {
+                router.push('/prijava/potvrda-emaila/poslano');
+                return;
+            }
+
             showNotification(errorMessages.verificationEmail, 'error');
-            return;
+        } catch {
+            showNotification(errorMessages.verificationEmail, 'error');
+        } finally {
+            setIsLoading(false);
         }
-
-        router.push('/prijava/potvrda-emaila/poslano');
     };
 
     return (
@@ -45,6 +50,7 @@ export function SendVerifyEmailButton() {
                 onClick={handleSend}
                 disabled={!email}
                 loading={isLoading}
+                size="lg"
             >
                 Pošalji ponovno
             </Button>

--- a/apps/garden/app/prijava/potvrda-emaila/posalji/page.tsx
+++ b/apps/garden/app/prijava/potvrda-emaila/posalji/page.tsx
@@ -7,8 +7,8 @@ import { SendVerifyEmailButton } from '../../SendVerifyEmailButton';
 
 export default function EmailVerificationSendPage() {
     return (
-        <div className="flex items-center justify-center min-h-screen">
-            <Card className="w-[350px] p-12">
+        <div className="flex min-h-dvh items-center justify-center px-4 py-6">
+            <Card className="w-full max-w-sm p-6 sm:p-10">
                 <CardHeader>
                     <div className="flex items-center justify-center size-12 rounded-full bg-[#2f6e40] mx-auto mb-4">
                         <MailCheck className="w-6 h-6 text-white" />

--- a/apps/garden/app/prijava/potvrda-emaila/poslano/page.tsx
+++ b/apps/garden/app/prijava/potvrda-emaila/poslano/page.tsx
@@ -2,8 +2,8 @@ import { EmailSentCard } from '../../EmailSentCard';
 
 export default function VerifyEmailEmailSentPage() {
     return (
-        <div className="flex items-center justify-center min-h-screen">
-            <EmailSentCard />
+        <div className="flex min-h-dvh items-center justify-center px-4 py-6">
+            <EmailSentCard purpose="email-verification" />
         </div>
     );
 }

--- a/apps/garden/app/prijava/zaboravljena-zaporka/ForgotPasswordForm.tsx
+++ b/apps/garden/app/prijava/zaboravljena-zaporka/ForgotPasswordForm.tsx
@@ -14,26 +14,33 @@ export function ForgotPasswordForm() {
     const searchParams = useSearchParams();
     const [email, setEmail] = useState(searchParams.get('email') || '');
     const [error, setError] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
 
     const handleSubmit = async (e: FormEvent) => {
         e.preventDefault();
 
         setError('');
-        const response = await clientPublic().api.auth[
-            'send-change-password-email'
-        ].$post({
-            json: {
-                email,
-            },
-        });
+        setIsLoading(true);
+        try {
+            const response = await clientPublic().api.auth[
+                'send-change-password-email'
+            ].$post({
+                json: {
+                    email,
+                },
+            });
 
-        if (!response.ok) {
-            console.error(response.statusText);
+            if (response.ok) {
+                router.push('/prijava/zaboravljena-zaporka/poslano');
+                return;
+            }
+
             setError(errorMessages.forgotPasswordEmail);
-            return;
+        } catch {
+            setError(errorMessages.forgotPasswordEmail);
+        } finally {
+            setIsLoading(false);
         }
-
-        router.push('/prijava/zaboravljena-zaporka/poslano');
     };
 
     return (
@@ -48,14 +55,30 @@ export function ForgotPasswordForm() {
                     label="Email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
+                    autoComplete="email"
+                    className="h-11"
+                    fullWidth
+                    inputMode="email"
                     required
+                    style={{ fontSize: '16px' }}
                 />
                 {error && (
-                    <Typography level="body2" color="danger" semiBold>
+                    <Typography
+                        level="body2"
+                        color="danger"
+                        role="alert"
+                        semiBold
+                    >
                         {error}
                     </Typography>
                 )}
-                <Button type="submit" variant="soft" fullWidth>
+                <Button
+                    type="submit"
+                    variant="soft"
+                    fullWidth
+                    loading={isLoading}
+                    size="lg"
+                >
                     Pošalji email
                 </Button>
             </Stack>

--- a/apps/garden/app/prijava/zaboravljena-zaporka/page.tsx
+++ b/apps/garden/app/prijava/zaboravljena-zaporka/page.tsx
@@ -5,8 +5,8 @@ import { ForgotPasswordForm } from './ForgotPasswordForm';
 
 export default function ForgotPasswordPage() {
     return (
-        <div className="flex items-center justify-center min-h-screen">
-            <Card className="w-[350px] p-12">
+        <div className="flex min-h-dvh items-center justify-center px-4 py-6">
+            <Card className="w-full max-w-sm p-6 sm:p-10">
                 <CardHeader>
                     <div className="flex items-center justify-center size-12 rounded-full bg-[#2f6e40] mx-auto mb-4">
                         <Password className="w-6 h-6 text-white" />

--- a/apps/garden/app/prijava/zaboravljena-zaporka/poslano/page.tsx
+++ b/apps/garden/app/prijava/zaboravljena-zaporka/poslano/page.tsx
@@ -2,7 +2,7 @@ import { EmailSentCard } from '../../EmailSentCard';
 
 export default function ForgotPasswordEmailSentPage() {
     return (
-        <div className="flex items-center justify-center min-h-screen">
+        <div className="flex min-h-dvh items-center justify-center px-4 py-6">
             <EmailSentCard />
         </div>
     );

--- a/apps/garden/tests/account-recovery.spec.ts
+++ b/apps/garden/tests/account-recovery.spec.ts
@@ -1,0 +1,222 @@
+import { expect, type Locator, type Page, test } from '@playwright/test';
+import { errorMessages } from '../misc/errorMessages';
+
+const verificationEndpoint = '/api/auth/send-verify-email';
+const passwordResetEndpoint = '/api/auth/send-change-password-email';
+const rawUpstreamError = 'smtp-provider-secret-debug-detail';
+
+type RecoveryApiBehavior = {
+    abort?: boolean;
+    endpoint: string;
+    status: number;
+};
+
+async function mockRecoveryApi(page: Page, behavior: RecoveryApiBehavior) {
+    const requests: unknown[] = [];
+
+    await page.route('**/api/gredice/**', async (route) => {
+        const { pathname } = new URL(route.request().url());
+
+        if (pathname.endsWith('/api/auth/current-claims')) {
+            await route.fulfill({
+                body: JSON.stringify({ error: 'Unauthorized' }),
+                contentType: 'application/json',
+                status: 401,
+            });
+            return;
+        }
+
+        if (pathname.endsWith(behavior.endpoint)) {
+            requests.push(route.request().postDataJSON());
+            if (behavior.abort) {
+                await route.abort('failed');
+                return;
+            }
+
+            await route.fulfill({
+                body: JSON.stringify(
+                    behavior.status === 200
+                        ? { message: 'Email sent' }
+                        : { error: rawUpstreamError },
+                ),
+                contentType: 'application/json',
+                status: behavior.status,
+            });
+            return;
+        }
+
+        await route.fulfill({
+            body: JSON.stringify({ error: 'Not found' }),
+            contentType: 'application/json',
+            status: 404,
+        });
+    });
+
+    return requests;
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+    const viewport = await page.evaluate(() => ({
+        clientWidth: document.documentElement.clientWidth,
+        scrollWidth: document.documentElement.scrollWidth,
+    }));
+
+    expect(viewport.clientWidth).toBe(320);
+    expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth);
+}
+
+async function expectMinimumHeight(locator: Locator, minimum: number) {
+    const box = await locator.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box?.height).toBeGreaterThanOrEqual(minimum);
+}
+
+test.describe('Garden account recovery', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.setViewportSize({ width: 320, height: 640 });
+    });
+
+    test('resends verification email and shows the correct mobile confirmation', async ({
+        page,
+    }) => {
+        const requests = await mockRecoveryApi(page, {
+            endpoint: verificationEndpoint,
+            status: 200,
+        });
+
+        await page.goto(
+            '/prijava/potvrda-emaila/posalji?email=farmer%40example.com',
+        );
+
+        const resendButton = page.getByRole('button', {
+            name: 'Pošalji ponovno',
+        });
+        await expectMinimumHeight(resendButton, 44);
+        await expectNoHorizontalOverflow(page);
+        await resendButton.click();
+
+        await expect(page).toHaveURL('/prijava/potvrda-emaila/poslano');
+        await expect(
+            page.getByText('Provjeri svoj email za potvrdu email adrese'),
+        ).toBeVisible();
+        await expect(page.getByText(/promjene zaporke/u)).toHaveCount(0);
+        await expectMinimumHeight(
+            page.getByRole('link', { name: 'Povratak' }),
+            44,
+        );
+        await expectNoHorizontalOverflow(page);
+        expect(requests).toEqual([{ email: 'farmer@example.com' }]);
+    });
+
+    test('keeps verification failures bounded and retryable', async ({
+        page,
+    }) => {
+        await mockRecoveryApi(page, {
+            endpoint: verificationEndpoint,
+            status: 500,
+        });
+
+        await page.goto(
+            '/prijava/potvrda-emaila/posalji?email=farmer%40example.com',
+        );
+        const resendButton = page.getByRole('button', {
+            name: 'Pošalji ponovno',
+        });
+        await resendButton.click();
+
+        await expect(
+            page.getByText(errorMessages.verificationEmail),
+        ).toBeVisible();
+        await expect(page.getByText(rawUpstreamError)).toHaveCount(0);
+        await expect(page).toHaveURL(/\/prijava\/potvrda-emaila\/posalji/u);
+        await expect(resendButton).toBeEnabled();
+        await expectNoHorizontalOverflow(page);
+    });
+
+    test('turns verification transport failures into the same bounded error', async ({
+        page,
+    }) => {
+        await mockRecoveryApi(page, {
+            abort: true,
+            endpoint: verificationEndpoint,
+            status: 0,
+        });
+
+        await page.goto(
+            '/prijava/potvrda-emaila/posalji?email=farmer%40example.com',
+        );
+        const resendButton = page.getByRole('button', {
+            name: 'Pošalji ponovno',
+        });
+        await resendButton.click();
+
+        await expect(
+            page.getByText(errorMessages.verificationEmail),
+        ).toBeVisible();
+        await expect(resendButton).toBeEnabled();
+    });
+
+    test('submits password recovery with mobile-safe input and controls', async ({
+        page,
+    }) => {
+        const requests = await mockRecoveryApi(page, {
+            endpoint: passwordResetEndpoint,
+            status: 200,
+        });
+
+        await page.goto(
+            '/prijava/zaboravljena-zaporka?email=farmer%40example.com',
+        );
+
+        const emailInput = page.getByLabel('Email');
+        const submitButton = page.getByRole('button', {
+            name: 'Pošalji email',
+        });
+        const inputFontSize = await emailInput.evaluate((input) =>
+            Number.parseFloat(getComputedStyle(input).fontSize),
+        );
+        const inputControlHeight = await emailInput.evaluate(
+            (input) => input.parentElement?.getBoundingClientRect().height ?? 0,
+        );
+
+        expect(inputFontSize).toBeGreaterThanOrEqual(16);
+        expect(inputControlHeight).toBeGreaterThanOrEqual(44);
+        await expectMinimumHeight(submitButton, 44);
+        await expectNoHorizontalOverflow(page);
+        await submitButton.click();
+
+        await expect(page).toHaveURL('/prijava/zaboravljena-zaporka/poslano');
+        await expect(
+            page.getByText('Provjeri svoj email za nastavak promjene zaporke'),
+        ).toBeVisible();
+        await expectNoHorizontalOverflow(page);
+        expect(requests).toEqual([{ email: 'farmer@example.com' }]);
+    });
+
+    test('shows a bounded password recovery error without leaking response details', async ({
+        page,
+    }) => {
+        await mockRecoveryApi(page, {
+            endpoint: passwordResetEndpoint,
+            status: 404,
+        });
+
+        await page.goto(
+            '/prijava/zaboravljena-zaporka?email=farmer%40example.com',
+        );
+        const submitButton = page.getByRole('button', {
+            name: 'Pošalji email',
+        });
+        await submitButton.click();
+
+        await expect(
+            page.getByRole('alert').filter({
+                hasText: errorMessages.forgotPasswordEmail,
+            }),
+        ).toBeVisible();
+        await expect(page.getByText(rawUpstreamError)).toHaveCount(0);
+        await expect(page).toHaveURL(/\/prijava\/zaboravljena-zaporka/u);
+        await expect(submitButton).toBeEnabled();
+        await expectNoHorizontalOverflow(page);
+    });
+});


### PR DESCRIPTION
Closes #4163

## Summary
- harden Farm email login with bounded errors, exact access/refresh subject binding, server-side Farm authorization, and token-safe cookie persistence
- keep email recovery usable at 320-430px with explicit focus, 16px inputs, 44px controls, password visibility, and real reset/support actions
- repair the linked Garden password-reset and verification-email journeys, including correct confirmation copy and bounded HTTP/transport failures

## Validation
- Farm production build
- Farm Playwright: 290 passed
- Garden production build
- Garden account recovery Playwright: 5 passed at 320px
- Farm and Garden focused Biome checks
- Farm tsc --noEmit
- git diff --check
- independent security/mobile audit: no findings

## Known inherited check
- Garden full typecheck still reaches the pre-existing tests/garden-tab.spec.tsx import of Page from @playwright/experimental-ct-react; this slice does not touch that file, while the production Garden build is green.