### PR TITLE
feat(delivery): enforce tracking freshness and privacy

### DIFF
--- a/apps/api/app/api/internal/cron/delivery-tracking-retention/route.ts
+++ b/apps/api/app/api/internal/cron/delivery-tracking-retention/route.ts
@@ -1,0 +1,61 @@
+import { clearExpiredDeliveryRunLocations } from '@gredice/storage';
+import type { NextRequest } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const noStoreHeaders = { 'Cache-Control': 'private, no-store' };
+
+function boundedErrorCode(error: unknown) {
+    if (
+        typeof error !== 'object' ||
+        error === null ||
+        !('code' in error) ||
+        typeof error.code !== 'string'
+    ) {
+        return undefined;
+    }
+
+    return error.code.slice(0, 64);
+}
+
+export async function GET(request: NextRequest) {
+    const cronSecret = process.env.CRON_SECRET?.trim();
+    if (
+        !cronSecret ||
+        request.headers.get('authorization') !== `Bearer ${cronSecret}`
+    ) {
+        return new Response('Unauthorized', {
+            status: 401,
+            headers: noStoreHeaders,
+        });
+    }
+
+    try {
+        const cleared = await clearExpiredDeliveryRunLocations();
+        if (cleared.length > 0) {
+            console.warn('Expired stale delivery tracking coordinates', {
+                clearedCount: cleared.length,
+            });
+        }
+        return Response.json(
+            {
+                success: true,
+                clearedCount: cleared.length,
+                timestamp: new Date().toISOString(),
+            },
+            { headers: noStoreHeaders },
+        );
+    } catch (error) {
+        console.error('Failed to expire stale delivery tracking coordinates', {
+            errorName: error instanceof Error ? error.name : 'Unknown',
+            errorCode: boundedErrorCode(error),
+        });
+        return Response.json(
+            {
+                success: false,
+                timestamp: new Date().toISOString(),
+            },
+            { status: 500, headers: noStoreHeaders },
+        );
+    }
+}

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -27,6 +27,10 @@
             "schedule": "*/5 * * * *"
         },
         {
+            "path": "/api/internal/cron/delivery-tracking-retention",
+            "schedule": "* * * * *"
+        },
+        {
             "path": "/api/internal/cron/update-farm-weather",
             "schedule": "0 * * * *"
         },

--- a/apps/delivery/app/api/driver/runs/[runId]/location/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/location/route.ts
@@ -1,11 +1,23 @@
+import {
+    DeliveryRunExecutionError,
+    DeliveryRunExecutionErrorCodes,
+} from '@gredice/storage';
 import { withAuth } from '../../../../../../lib/auth/auth';
 import { recordDriverLocation } from '../../../../../../lib/deliveryDashboard';
+import { deliveryLocationCaptureTimeIsAcceptable } from '../../../../../../lib/deliveryTracking';
 
-function optionalNumber(value: unknown) {
+function requiredNumber(value: unknown) {
     return typeof value === 'number' && Number.isFinite(value)
         ? value
         : undefined;
 }
+
+function nullableNumber(value: unknown) {
+    if (value === null || value === undefined) return null;
+    return requiredNumber(value);
+}
+
+const noStoreHeaders = { 'Cache-Control': 'private, no-store' };
 
 export async function POST(
     request: Request,
@@ -17,60 +29,93 @@ export async function POST(
         if (typeof body !== 'object' || body === null) {
             return Response.json(
                 { error: 'Neispravna lokacija.' },
-                { status: 400 },
+                { status: 400, headers: noStoreHeaders },
             );
         }
         const latitude =
-            'latitude' in body ? optionalNumber(body.latitude) : undefined;
+            'latitude' in body ? requiredNumber(body.latitude) : undefined;
         const longitude =
-            'longitude' in body ? optionalNumber(body.longitude) : undefined;
+            'longitude' in body ? requiredNumber(body.longitude) : undefined;
         if (latitude === undefined || longitude === undefined) {
             return Response.json(
                 { error: 'Neispravna lokacija.' },
-                { status: 400 },
+                { status: 400, headers: noStoreHeaders },
             );
         }
-        const recordedAtValue =
+        const recordedAt =
             'recordedAt' in body && typeof body.recordedAt === 'string'
                 ? new Date(body.recordedAt)
-                : new Date();
-        const recordedAt = Number.isNaN(recordedAtValue.getTime())
-            ? new Date()
-            : recordedAtValue;
-        if (recordedAt.getTime() > Date.now() + 5 * 60 * 1000) {
+                : new Date(Number.NaN);
+        const receivedAt = new Date();
+        if (!deliveryLocationCaptureTimeIsAcceptable(recordedAt, receivedAt)) {
             return Response.json(
                 { error: 'Neispravno vrijeme lokacije.' },
-                { status: 400 },
+                { status: 400, headers: noStoreHeaders },
+            );
+        }
+
+        const accuracy =
+            'accuracy' in body ? nullableNumber(body.accuracy) : null;
+        const heading = 'heading' in body ? nullableNumber(body.heading) : null;
+        const speed = 'speed' in body ? nullableNumber(body.speed) : null;
+        if (
+            accuracy === undefined ||
+            (accuracy !== null && accuracy < 0) ||
+            heading === undefined ||
+            (heading !== null && (heading < 0 || heading > 360)) ||
+            speed === undefined ||
+            (speed !== null && speed < 0)
+        ) {
+            return Response.json(
+                { error: 'Neispravni podaci lokacije.' },
+                { status: 400, headers: noStoreHeaders },
             );
         }
 
         try {
-            await recordDriverLocation({
+            const result = await recordDriverLocation({
                 driverUserId: userId,
                 runId,
                 latitude,
                 longitude,
-                accuracy:
-                    'accuracy' in body
-                        ? optionalNumber(body.accuracy)
-                        : undefined,
-                heading:
-                    'heading' in body
-                        ? optionalNumber(body.heading)
-                        : undefined,
-                speed: 'speed' in body ? optionalNumber(body.speed) : undefined,
+                accuracy,
+                heading,
+                speed,
                 recordedAt,
             });
-            return new Response(null, { status: 204 });
+            return Response.json(
+                {
+                    status: result.status,
+                    acceptedAt: result.acceptedAt.toISOString(),
+                    replayed: result.replayed,
+                },
+                { headers: noStoreHeaders },
+            );
         } catch (error) {
             console.error('Failed to record driver location', {
-                error,
                 runId,
-                userId,
+                errorName: error instanceof Error ? error.name : 'Unknown',
+                errorCode:
+                    error instanceof DeliveryRunExecutionError
+                        ? error.code
+                        : undefined,
             });
             return Response.json(
-                { error: 'Lokaciju nije moguće spremiti.' },
-                { status: 409 },
+                {
+                    error: 'Lokaciju nije moguće spremiti.',
+                    ...(error instanceof DeliveryRunExecutionError
+                        ? { code: error.code }
+                        : {}),
+                },
+                {
+                    status:
+                        error instanceof DeliveryRunExecutionError &&
+                        error.code ===
+                            DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND
+                            ? 404
+                            : 409,
+                    headers: noStoreHeaders,
+                },
             );
         }
     });

--- a/apps/delivery/app/api/map/[runId]/route.ts
+++ b/apps/delivery/app/api/map/[runId]/route.ts
@@ -4,17 +4,20 @@ import {
     accountCanTrackDeliveryRun,
     resolveDeliveryRunStopGroups,
 } from '../../../../lib/deliveryDashboard';
+import { driverDeliveryTrackingLocation } from '../../../../lib/deliveryTracking';
 import {
     buildGoogleStaticMapUrl,
     unavailableMapSvg,
 } from '../../../../lib/googleStaticMap';
+
+const noStoreHeaders = { 'Cache-Control': 'private, no-store' };
 
 function unavailableMapResponse() {
     return new Response(unavailableMapSvg(), {
         status: 200,
         headers: {
             'Content-Type': 'image/svg+xml; charset=utf-8',
-            'Cache-Control': 'no-store',
+            ...noStoreHeaders,
         },
     });
 }
@@ -28,7 +31,12 @@ export async function GET(
         async ({ accountId, userId, user }) => {
             const { runId } = await params;
             const run = await getDeliveryRun(runId);
-            if (!run) return new Response(null, { status: 404 });
+            if (!run) {
+                return new Response(null, {
+                    status: 404,
+                    headers: noStoreHeaders,
+                });
+            }
 
             const driverView =
                 (user.role === 'driver' || user.role === 'admin') &&
@@ -38,9 +46,14 @@ export async function GET(
                 customerView &&
                 !(await accountCanTrackDeliveryRun({ accountId, runId }))
             ) {
-                return new Response(null, { status: 403 });
+                return new Response(null, {
+                    status: 403,
+                    headers: noStoreHeaders,
+                });
             }
 
+            const projectedAt = new Date();
+            const location = driverDeliveryTrackingLocation(run, projectedAt);
             const groups = await resolveDeliveryRunStopGroups(run);
             const stops = groups.flatMap((group, index) => {
                 const customerOwnsStop = group.items.some(
@@ -66,14 +79,12 @@ export async function GET(
                 ];
             });
             const url = buildGoogleStaticMapUrl({
-                driverLocation:
-                    run.currentLatitude !== null &&
-                    run.currentLongitude !== null
-                        ? {
-                              latitude: run.currentLatitude,
-                              longitude: run.currentLongitude,
-                          }
-                        : null,
+                driverLocation: location
+                    ? {
+                          latitude: location.latitude,
+                          longitude: location.longitude,
+                      }
+                    : null,
                 pickupNodes: driverView
                     ? run.pickupNodes.flatMap((pickupNode) =>
                           pickupNode.latitude !== null &&
@@ -101,11 +112,14 @@ export async function GET(
                     headers: {
                         'Content-Type':
                             response.headers.get('content-type') ?? 'image/png',
-                        'Cache-Control': 'no-store',
+                        ...noStoreHeaders,
                     },
                 });
             } catch (error) {
-                console.error('Failed to load delivery map', { error, runId });
+                console.error('Failed to load delivery map', {
+                    runId,
+                    errorName: error instanceof Error ? error.name : 'Unknown',
+                });
                 return unavailableMapResponse();
             }
         },

--- a/apps/delivery/components/CustomerDashboard.tsx
+++ b/apps/delivery/components/CustomerDashboard.tsx
@@ -1,11 +1,9 @@
-import { Alert } from '@gredice/ui/Alert';
 import { Card, CardContent } from '@gredice/ui/Card';
-import { MyLocation, ShoppingCart, Truck } from '@gredice/ui/icons';
+import { ShoppingCart, Truck } from '@gredice/ui/icons';
 import { Typography } from '@gredice/ui/Typography';
 import type { CustomerDeliveryDashboard } from '../lib/deliveryDashboardTypes';
-import { formatDeliveryDateTime } from '../lib/deliveryFormatting';
+import { CustomerDeliveryTracking } from './CustomerDeliveryTracking';
 import { DeliveryAppHeader } from './DeliveryAppHeader';
-import { DeliveryMap } from './DeliveryMap';
 import { DeliveryStopCard } from './DeliveryStopCard';
 
 export function CustomerDashboard({
@@ -13,7 +11,7 @@ export function CustomerDashboard({
 }: {
     dashboard: CustomerDeliveryDashboard;
 }) {
-    const liveDelivery = dashboard.deliveries.find(
+    const trackedDelivery = dashboard.deliveries.find(
         (delivery) =>
             delivery.runId &&
             delivery.tracking &&
@@ -37,23 +35,11 @@ export function CustomerDashboard({
                     </Typography>
                 </div>
 
-                {liveDelivery?.runId && liveDelivery.tracking ? (
-                    <section className="space-y-3">
-                        <Alert
-                            color="info"
-                            startDecorator={<MyLocation className="size-5" />}
-                        >
-                            Vozač je na putu. Zadnja lokacija:{' '}
-                            {formatDeliveryDateTime(
-                                liveDelivery.tracking.recordedAt,
-                            )}
-                        </Alert>
-                        <DeliveryMap
-                            mapUrl={`/api/map/${liveDelivery.runId}`}
-                            version={liveDelivery.tracking.recordedAt}
-                            title="Trenutna lokacija vozača i moja dostava"
-                        />
-                    </section>
+                {trackedDelivery?.runId && trackedDelivery.tracking ? (
+                    <CustomerDeliveryTracking
+                        runId={trackedDelivery.runId}
+                        tracking={trackedDelivery.tracking}
+                    />
                 ) : null}
 
                 {dashboard.deliveries.length > 0 ? (

--- a/apps/delivery/components/CustomerDeliveryTracking.tsx
+++ b/apps/delivery/components/CustomerDeliveryTracking.tsx
@@ -1,0 +1,74 @@
+import { Alert } from '@gredice/ui/Alert';
+import { MyLocation, Timer, Warning } from '@gredice/ui/icons';
+import type { CustomerDeliveryTrackingSummary } from '../lib/deliveryDashboardTypes';
+import { formatDeliveryDateTime } from '../lib/deliveryFormatting';
+import { deliveryTrackingMapVersion } from '../lib/deliveryTrackingPresentation';
+import { DeliveryMap } from './DeliveryMap';
+
+function trackingMessage(tracking: CustomerDeliveryTrackingSummary) {
+    const lastUpdate = tracking.lastAcceptedAt
+        ? formatDeliveryDateTime(tracking.lastAcceptedAt)
+        : null;
+    switch (tracking.status) {
+        case 'live':
+            return lastUpdate
+                ? `Lokacija vozača je uživo. Zadnje ažuriranje: ${lastUpdate}.`
+                : 'Lokacija vozača je uživo.';
+        case 'delayed':
+            return lastUpdate
+                ? `Lokacija vozača kasni. Zadnje potvrđeno ažuriranje: ${lastUpdate}.`
+                : 'Lokacija vozača kasni.';
+        case 'offline':
+            return lastUpdate
+                ? `Praćenje je trenutačno izvan mreže. Zadnje potvrđeno ažuriranje: ${lastUpdate}.`
+                : 'Praćenje je trenutačno izvan mreže.';
+        case 'unavailable':
+            return 'Lokacija vozača još nije dostupna. Status dostave i procjena dolaska i dalje će se ažurirati.';
+    }
+}
+
+export function CustomerDeliveryTracking({
+    runId,
+    tracking,
+}: {
+    runId: string;
+    tracking: CustomerDeliveryTrackingSummary;
+}) {
+    const showMap =
+        tracking.mapAvailable &&
+        (tracking.status === 'live' || tracking.status === 'delayed');
+    const delayed = tracking.status === 'delayed';
+    const offline = tracking.status === 'offline';
+
+    return (
+        <section className="space-y-3">
+            <Alert
+                role="status"
+                aria-live="polite"
+                color={delayed || offline ? 'warning' : 'info'}
+                startDecorator={
+                    offline ? (
+                        <Warning className="size-5" />
+                    ) : delayed ? (
+                        <Timer className="size-5" />
+                    ) : (
+                        <MyLocation className="size-5" />
+                    )
+                }
+            >
+                {trackingMessage(tracking)}
+            </Alert>
+            {showMap ? (
+                <DeliveryMap
+                    mapUrl={`/api/map/${runId}`}
+                    version={deliveryTrackingMapVersion(tracking)}
+                    title={
+                        tracking.status === 'live'
+                            ? 'Trenutna lokacija vozača i moja dostava'
+                            : 'Posljednja potvrđena lokacija vozača i moja dostava'
+                    }
+                />
+            ) : null}
+        </section>
+    );
+}

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -38,6 +38,7 @@ import {
     inspectDeliveryRouteSelection,
 } from '../lib/deliveryRouteSelection';
 import { groupByDeliveryStop } from '../lib/deliveryStopGrouping';
+import { deliveryTrackingMapVersion } from '../lib/deliveryTrackingPresentation';
 import {
     normalizeHarvestTraceScanValue,
     selectDeliveryStopFromHarvestTrace,
@@ -574,10 +575,10 @@ export function DriverDashboard({
                         <div className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(19rem,0.8fr)]">
                             <DeliveryMap
                                 mapUrl={run.mapUrl}
-                                version={
-                                    run.location?.recordedAt ??
-                                    run.estimatesUpdatedAt
-                                }
+                                version={deliveryTrackingMapVersion(
+                                    run.tracking,
+                                    run.estimatesUpdatedAt,
+                                )}
                                 title="Karta aktivne dostavne rute"
                             />
                             <Card>

--- a/apps/delivery/lib/deliveryDashboard.ts
+++ b/apps/delivery/lib/deliveryDashboard.ts
@@ -39,7 +39,6 @@ import type {
     DeliveryRouteStepSummary,
     DeliveryStopDeliverySummary,
     DeliveryStopSummary,
-    DeliveryTrackingLocation,
 } from './deliveryDashboardTypes';
 import {
     customerDeliveryRecoverySummary,
@@ -66,6 +65,12 @@ import {
 } from './deliveryRunRerouting';
 import { resolveDeliveryRunStart } from './deliveryRunStart';
 import { buildDeliveryStopKey } from './deliveryStopGrouping';
+import {
+    customerDeliveryTrackingSummary,
+    deliveryTrackingRecoveryTransition,
+    deliveryTrackingStatus,
+    driverDeliveryTrackingLocation,
+} from './deliveryTracking';
 
 type ListedDeliveryRequest = Awaited<
     ReturnType<typeof getDeliveryRequestsWithEvents>
@@ -96,32 +101,6 @@ const etaRefreshIntervalMs = 2 * 60 * 1000;
 
 function iso(value?: Date | null) {
     return value?.toISOString() ?? null;
-}
-
-function trackingLocation(run: {
-    currentLatitude: number | null;
-    currentLongitude: number | null;
-    currentLocationAccuracy: number | null;
-    currentLocationHeading: number | null;
-    currentLocationSpeed: number | null;
-    currentLocationRecordedAt: Date | null;
-}): DeliveryTrackingLocation | null {
-    if (
-        run.currentLatitude === null ||
-        run.currentLongitude === null ||
-        !run.currentLocationRecordedAt
-    ) {
-        return null;
-    }
-
-    return {
-        latitude: run.currentLatitude,
-        longitude: run.currentLongitude,
-        accuracy: run.currentLocationAccuracy,
-        heading: run.currentLocationHeading,
-        speed: run.currentLocationSpeed,
-        recordedAt: run.currentLocationRecordedAt.toISOString(),
-    };
 }
 
 function plantName(request: DeliveryRequest) {
@@ -312,6 +291,7 @@ type DeliveryRunSnapshot = Pick<
     | 'currentLocationHeading'
     | 'currentLocationSpeed'
     | 'currentLocationRecordedAt'
+    | 'currentLocationReceivedAt'
     | 'rerouteRequiredAt'
 >;
 
@@ -450,7 +430,6 @@ function deliveryStopSummary({
             ? formatDeliveryDestinationAddress(address)
             : 'Adresa nije dostupna');
     const runSlot = representativeStop?.runSlot;
-    const runLocation = run ? trackingLocation(run) : null;
     const reroutePending = Boolean(
         run?.state === DeliveryRunStates.ACTIVE && run.rerouteRequiredAt,
     );
@@ -503,7 +482,10 @@ function deliveryStopSummary({
                       now,
                   })
                 : null,
-        tracking: includeTracking ? runLocation : null,
+        tracking:
+            includeTracking && run
+                ? customerDeliveryTrackingSummary(run, now)
+                : null,
         runId: run?.id ?? null,
         deliveryCount: items.length,
         deliveries: items.map((item) =>
@@ -676,6 +658,7 @@ function pickupStepSummary({
 
 async function activeRunSummary(
     run: DeliveryRun,
+    now: Date,
 ): Promise<ActiveDeliveryRunSummary> {
     const groups = await resolveDeliveryRunStopGroups(run);
     const requests = groups.flatMap((group) =>
@@ -765,8 +748,8 @@ async function activeRunSummary(
             run,
             isCurrent: actionState === 'current',
             audience: 'driver',
-            now: new Date(),
-            includeTracking: true,
+            now,
+            includeTracking: false,
             sequence: Number.isFinite(itinerarySequence)
                 ? itinerarySequence
                 : stops.length + 1,
@@ -805,7 +788,8 @@ async function activeRunSummary(
         routeRevision: run.routeRevision,
         reroutePending,
         estimateSource: run.estimateSource,
-        location: trackingLocation(run),
+        tracking: customerDeliveryTrackingSummary(run, now),
+        location: driverDeliveryTrackingLocation(run, now),
         estimatesUpdatedAt: iso(run.estimatesUpdatedAt),
         mapUrl: `/api/map/${run.id}`,
         deliveryCount: stops.reduce(
@@ -832,13 +816,15 @@ async function driverDashboard({
     if (!user) {
         throw new Error('Korisnik nije pronađen.');
     }
+    const projectedAt = new Date();
     let activeRun = initialActiveRun;
     if (
         activeRun?.rerouteRequiredAt &&
-        deliveryRerouteLocationIsFresh(activeRun) &&
+        deliveryRerouteLocationIsFresh(activeRun, projectedAt) &&
         deliveryRerouteRetryIsDue(
             activeRun.rerouteRequiredAt,
             activeRun.rerouteAttemptedAt,
+            projectedAt,
         )
     ) {
         await reconcileDeliveryRunReroute({
@@ -849,7 +835,7 @@ async function driverDashboard({
         activeRun = await getActiveDeliveryRunForDriver(userId);
     }
 
-    const now = Date.now();
+    const now = projectedAt.getTime();
     const candidateRequests = requests.filter(
         (request) =>
             request.mode === 'delivery' &&
@@ -920,7 +906,9 @@ async function driverDashboard({
             displayName: user.displayName ?? user.userName,
             role,
         },
-        activeRun: activeRun ? await activeRunSummary(activeRun) : null,
+        activeRun: activeRun
+            ? await activeRunSummary(activeRun, projectedAt)
+            : null,
         batches: Array.from(batchesBySlot, ([slotId, batch]) => ({
             slotId,
             startAt: batch.startAt.toISOString(),
@@ -938,7 +926,7 @@ async function driverDashboard({
         ),
         maximumRouteStops: maximumDeliveryRouteStops,
         maximumRouteWindowHours: maximumDeliveryRouteWindowHours,
-        refreshedAt: new Date().toISOString(),
+        refreshedAt: projectedAt.toISOString(),
     };
 }
 
@@ -1031,7 +1019,7 @@ async function customerDashboard({
             role,
         },
         deliveries,
-        refreshedAt: new Date().toISOString(),
+        refreshedAt: projectedAt.toISOString(),
     };
 }
 
@@ -1482,49 +1470,44 @@ export function accountCanTrackCurrentDeliveryGroup({
     );
 }
 
-export async function recordDriverLocation({
+async function refreshDeliveryRunAfterLocation({
+    run,
+    previousRun,
     driverUserId,
     runId,
-    latitude,
-    longitude,
-    accuracy,
-    heading,
-    speed,
-    recordedAt,
+    expectedLocationRecordedAt,
+    expectedLocationReceivedAt,
+    now,
 }: {
+    run: DeliveryRun | null;
+    previousRun: DeliveryRun | null;
     driverUserId: string;
     runId: string;
-    latitude: number;
-    longitude: number;
-    accuracy?: number;
-    heading?: number;
-    speed?: number;
-    recordedAt: Date;
+    expectedLocationRecordedAt: Date;
+    expectedLocationReceivedAt: Date;
+    now: Date;
 }) {
-    const previousRun = await getDeliveryRun(runId);
-    await updateDeliveryRunLocation({
-        runId,
-        driverUserId,
-        latitude,
-        longitude,
-        accuracy,
-        heading,
-        speed,
-        recordedAt,
-    });
-
-    const run = await getDeliveryRun(runId);
-    if (!run || run.driverUserId !== driverUserId) {
+    if (
+        !run ||
+        run.driverUserId !== driverUserId ||
+        run.currentLocationRecordedAt?.getTime() !==
+            expectedLocationRecordedAt.getTime() ||
+        run.currentLocationReceivedAt?.getTime() !==
+            expectedLocationReceivedAt.getTime()
+    ) {
         return;
     }
+    const location = driverDeliveryTrackingLocation(run, now);
+    if (!location) return;
     if (
         run.rerouteRequiredAt &&
-        deliveryRerouteLocationIsFresh(run) &&
+        deliveryRerouteLocationIsFresh(run, now) &&
         (!previousRun ||
-            !deliveryRerouteLocationIsFresh(previousRun) ||
+            !deliveryRerouteLocationIsFresh(previousRun, now) ||
             deliveryRerouteRetryIsDue(
                 run.rerouteRequiredAt,
                 run.rerouteAttemptedAt,
+                now,
             ))
     ) {
         await reconcileDeliveryRunReroute({
@@ -1536,7 +1519,7 @@ export async function recordDriverLocation({
     }
     const estimatesAreFresh =
         run.estimatesUpdatedAt &&
-        Date.now() - run.estimatesUpdatedAt.getTime() < etaRefreshIntervalMs;
+        now.getTime() - run.estimatesUpdatedAt.getTime() < etaRefreshIntervalMs;
     if (estimatesAreFresh) {
         return;
     }
@@ -1580,7 +1563,10 @@ export async function recordDriverLocation({
         ];
     });
     const plan = await recalculateDeliveryRoute({
-        origin: { latitude, longitude },
+        origin: {
+            latitude: location.latitude,
+            longitude: location.longitude,
+        },
         stops: routeStops,
     });
     const estimates = plan.stops.flatMap((estimate) => {
@@ -1596,11 +1582,95 @@ export async function recordDriverLocation({
     });
     await updateDeliveryRunEstimates({
         runId,
+        driverUserId,
+        expectedRouteRevision: run.routeRevision,
+        expectedLocationRecordedAt,
+        expectedLocationReceivedAt,
         encodedPolyline: plan.encodedPolyline,
         totalDistanceMeters: plan.totalDistanceMeters,
         totalDurationSeconds: plan.totalDurationSeconds,
         estimates,
     });
+}
+
+export async function recordDriverLocation({
+    driverUserId,
+    runId,
+    latitude,
+    longitude,
+    accuracy,
+    heading,
+    speed,
+    recordedAt,
+}: {
+    driverUserId: string;
+    runId: string;
+    latitude: number;
+    longitude: number;
+    accuracy?: number | null;
+    heading?: number | null;
+    speed?: number | null;
+    recordedAt: Date;
+}) {
+    const previousRun = (await getDeliveryRun(runId)) ?? null;
+    const acknowledgement = await updateDeliveryRunLocation({
+        runId,
+        driverUserId,
+        latitude,
+        longitude,
+        accuracy,
+        heading,
+        speed,
+        recordedAt,
+    });
+    const processedAt = new Date();
+    const acknowledgedRun = (await getDeliveryRun(runId)) ?? null;
+    const status = acknowledgedRun
+        ? customerDeliveryTrackingSummary(acknowledgedRun, processedAt).status
+        : 'unavailable';
+    const previousStatus = previousRun
+        ? deliveryTrackingStatus(
+              {
+                  ...previousRun,
+                  currentLocationReceivedAt: acknowledgement.previousAcceptedAt,
+              },
+              processedAt,
+          )
+        : 'unavailable';
+
+    if (
+        !acknowledgement.replayed &&
+        deliveryTrackingRecoveryTransition(previousStatus, status)
+    ) {
+        console.info('Delivery tracking freshness recovered', {
+            runId,
+            previousStatus,
+            newStatus: status,
+        });
+    }
+
+    try {
+        await refreshDeliveryRunAfterLocation({
+            run: acknowledgedRun,
+            previousRun,
+            driverUserId,
+            runId,
+            expectedLocationRecordedAt: recordedAt,
+            expectedLocationReceivedAt: acknowledgement.acceptedAt,
+            now: processedAt,
+        });
+    } catch (error) {
+        console.warn('Driver location saved but route refresh failed', {
+            runId,
+            errorName: error instanceof Error ? error.name : 'Unknown',
+        });
+    }
+
+    return {
+        status,
+        acceptedAt: acknowledgement.acceptedAt,
+        replayed: acknowledgement.replayed,
+    };
 }
 
 export function deliveryRunStartErrorMessage(error: unknown) {

--- a/apps/delivery/lib/deliveryDashboardTypes.ts
+++ b/apps/delivery/lib/deliveryDashboardTypes.ts
@@ -4,14 +4,29 @@ import type {
     DeliveryRunExceptionReason,
 } from '@gredice/storage';
 
-export type DeliveryTrackingLocation = {
+export type DeliveryTrackingStatus =
+    | 'live'
+    | 'delayed'
+    | 'offline'
+    | 'unavailable';
+
+export type DeliveryTrackingFreshnessSummary = {
+    status: DeliveryTrackingStatus;
+    lastAcceptedAt: string | null;
+    mapAvailable: boolean;
+};
+
+export type DriverDeliveryTrackingLocation = {
     latitude: number;
     longitude: number;
     accuracy: number | null;
     heading: number | null;
     speed: number | null;
-    recordedAt: string;
+    capturedAt: string;
+    acceptedAt: string;
 };
+
+export type CustomerDeliveryTrackingSummary = DeliveryTrackingFreshnessSummary;
 
 export type DeliveryHarvestSummary = {
     plantName: string;
@@ -82,7 +97,7 @@ export type DeliveryStopSummary = {
     deliveredAt: string | null;
     harvest: DeliveryHarvestSummary;
     recovery: CustomerDeliveryRecoverySummary | null;
-    tracking: DeliveryTrackingLocation | null;
+    tracking: CustomerDeliveryTrackingSummary | null;
     runId: string | null;
     deliveryCount: number;
     deliveries: DeliveryStopDeliverySummary[];
@@ -195,7 +210,8 @@ export type ActiveDeliveryRunSummary = {
     routeRevision: number;
     reroutePending: boolean;
     estimateSource: DeliveryRunEstimateSource;
-    location: DeliveryTrackingLocation | null;
+    tracking: DeliveryTrackingFreshnessSummary;
+    location: DriverDeliveryTrackingLocation | null;
     estimatesUpdatedAt: string | null;
     mapUrl: string;
     deliveryCount: number;

--- a/apps/delivery/lib/deliveryRunRerouting.node.spec.ts
+++ b/apps/delivery/lib/deliveryRunRerouting.node.spec.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { deliveryRunRerouteLeaseMs } from '@gredice/storage';
+import {
+    deliveryRunExactLocationTtlMs,
+    deliveryRunRerouteLeaseMs,
+} from '@gredice/storage';
 import {
     deliveryRerouteLocationIsFresh,
     deliveryRerouteRetryIntervalMs,
@@ -10,6 +13,7 @@ import {
 
 test('reroute freshness uses the server-received GPS timestamp', () => {
     const rerouteRequiredAt = new Date('2026-07-15T10:00:00.000Z');
+    const now = new Date(rerouteRequiredAt);
     const location = {
         currentLatitude: 45.81,
         currentLongitude: 15.97,
@@ -17,27 +21,61 @@ test('reroute freshness uses the server-received GPS timestamp', () => {
     };
 
     assert.equal(
-        deliveryRerouteLocationIsFresh({
-            ...location,
-            currentLocationReceivedAt: new Date(
-                rerouteRequiredAt.getTime() - 1,
-            ),
-        }),
+        deliveryRerouteLocationIsFresh(
+            {
+                ...location,
+                currentLocationReceivedAt: new Date(
+                    rerouteRequiredAt.getTime() - 1,
+                ),
+            },
+            now,
+        ),
         false,
     );
     assert.equal(
-        deliveryRerouteLocationIsFresh({
-            ...location,
-            currentLocationReceivedAt: new Date(rerouteRequiredAt),
-        }),
+        deliveryRerouteLocationIsFresh(
+            {
+                ...location,
+                currentLocationReceivedAt: new Date(rerouteRequiredAt),
+            },
+            now,
+        ),
         true,
     );
     assert.equal(
-        deliveryRerouteLocationIsFresh({
-            ...location,
-            currentLatitude: null,
-            currentLocationReceivedAt: new Date(rerouteRequiredAt),
-        }),
+        deliveryRerouteLocationIsFresh(
+            {
+                ...location,
+                currentLatitude: null,
+                currentLocationReceivedAt: new Date(rerouteRequiredAt),
+            },
+            now,
+        ),
+        false,
+    );
+});
+
+test('reroute origin expires at the absolute exact-location TTL', () => {
+    const receivedAt = new Date('2026-07-15T10:00:00.000Z');
+    const location = {
+        currentLatitude: 45.81,
+        currentLongitude: 15.97,
+        currentLocationReceivedAt: receivedAt,
+        rerouteRequiredAt: new Date(receivedAt.getTime() - 1_000),
+    };
+
+    assert.equal(
+        deliveryRerouteLocationIsFresh(
+            location,
+            new Date(receivedAt.getTime() + deliveryRunExactLocationTtlMs),
+        ),
+        true,
+    );
+    assert.equal(
+        deliveryRerouteLocationIsFresh(
+            location,
+            new Date(receivedAt.getTime() + deliveryRunExactLocationTtlMs + 1),
+        ),
         false,
     );
 });

--- a/apps/delivery/lib/deliveryRunRerouting.ts
+++ b/apps/delivery/lib/deliveryRunRerouting.ts
@@ -7,6 +7,7 @@ import {
     DeliveryRunManifestStates,
     DeliveryRunStates,
     DeliveryRunStopStates,
+    deliveryRunExactLocationTtlMs,
     deliveryRunRerouteLeaseMs,
     getDeliveryRun,
     getDeliveryRunExecutionProgress,
@@ -49,6 +50,7 @@ type DeliveryRerouteLocation = {
 
 export function deliveryRerouteLocationIsFresh(
     location: DeliveryRerouteLocation,
+    now = new Date(),
 ): location is DeliveryRerouteLocation & {
     currentLatitude: number;
     currentLongitude: number;
@@ -61,7 +63,9 @@ export function deliveryRerouteLocationIsFresh(
             location.currentLocationReceivedAt &&
             location.rerouteRequiredAt &&
             location.currentLocationReceivedAt.getTime() >=
-                location.rerouteRequiredAt.getTime(),
+                location.rerouteRequiredAt.getTime() &&
+            now.getTime() - location.currentLocationReceivedAt.getTime() <=
+                deliveryRunExactLocationTtlMs,
     );
 }
 

--- a/apps/delivery/lib/deliveryTracking.node.spec.ts
+++ b/apps/delivery/lib/deliveryTracking.node.spec.ts
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    deliveryRunExactLocationTtlMs,
+    deliveryRunTrackingLiveThresholdMs,
+} from '@gredice/storage';
+import {
+    customerDeliveryTrackingSummary,
+    type DeliveryTrackingSnapshot,
+    deliveryLocationCaptureTimeIsAcceptable,
+    deliveryTrackingRecoveryTransition,
+    deliveryTrackingStatus,
+    driverDeliveryTrackingLocation,
+} from './deliveryTracking';
+import { deliveryTrackingMapVersion } from './deliveryTrackingPresentation';
+
+const acceptedAt = new Date('2026-07-15T10:00:00.000Z');
+
+function snapshot(
+    overrides: Partial<DeliveryTrackingSnapshot> = {},
+): DeliveryTrackingSnapshot {
+    return {
+        state: 'active',
+        currentLatitude: 45.812_345,
+        currentLongitude: 15.912_345,
+        currentLocationAccuracy: 7,
+        currentLocationHeading: 135,
+        currentLocationSpeed: 8.5,
+        currentLocationRecordedAt: new Date(acceptedAt.getTime() - 1_000),
+        currentLocationReceivedAt: acceptedAt,
+        ...overrides,
+    };
+}
+
+test('tracking freshness uses server receipt time at exact boundaries', () => {
+    assert.equal(
+        deliveryTrackingStatus(
+            snapshot(),
+            new Date(acceptedAt.getTime() + deliveryRunTrackingLiveThresholdMs),
+        ),
+        'live',
+    );
+    assert.equal(
+        deliveryTrackingStatus(
+            snapshot(),
+            new Date(
+                acceptedAt.getTime() + deliveryRunTrackingLiveThresholdMs + 1,
+            ),
+        ),
+        'delayed',
+    );
+    assert.equal(
+        deliveryTrackingStatus(
+            snapshot(),
+            new Date(acceptedAt.getTime() + deliveryRunExactLocationTtlMs),
+        ),
+        'delayed',
+    );
+    assert.equal(
+        deliveryTrackingStatus(
+            snapshot(),
+            new Date(acceptedAt.getTime() + deliveryRunExactLocationTtlMs + 1),
+        ),
+        'offline',
+    );
+});
+
+test('tracking is unavailable without a server receipt or after a terminal state', () => {
+    assert.equal(
+        deliveryTrackingStatus(
+            snapshot({ currentLocationReceivedAt: null }),
+            acceptedAt,
+        ),
+        'unavailable',
+    );
+    assert.equal(
+        deliveryTrackingStatus(snapshot({ state: 'completed' }), acceptedAt),
+        'unavailable',
+    );
+    assert.equal(
+        driverDeliveryTrackingLocation(
+            snapshot({ state: 'cancelled' }),
+            acceptedAt,
+        ),
+        null,
+    );
+});
+
+test('only offline or unavailable tracking recovery is a logged transition', () => {
+    assert.equal(deliveryTrackingRecoveryTransition('offline', 'live'), true);
+    assert.equal(
+        deliveryTrackingRecoveryTransition('unavailable', 'delayed'),
+        true,
+    );
+    assert.equal(deliveryTrackingRecoveryTransition('delayed', 'live'), false);
+    assert.equal(deliveryTrackingRecoveryTransition('live', 'live'), false);
+    assert.equal(
+        deliveryTrackingRecoveryTransition('offline', 'offline'),
+        false,
+    );
+});
+
+test('exact driver telemetry disappears after TTL while customer freshness stays data-minimized', () => {
+    const afterTtl = new Date(
+        acceptedAt.getTime() + deliveryRunExactLocationTtlMs + 1,
+    );
+    assert.equal(driverDeliveryTrackingLocation(snapshot(), afterTtl), null);
+
+    const customer = customerDeliveryTrackingSummary(snapshot(), afterTtl);
+    assert.deepEqual(customer, {
+        status: 'offline',
+        lastAcceptedAt: acceptedAt.toISOString(),
+        mapAvailable: false,
+    });
+    assert.deepEqual(Object.keys(customer).sort(), [
+        'lastAcceptedAt',
+        'mapAvailable',
+        'status',
+    ]);
+    const serialized = JSON.stringify(customer);
+    for (const privateValue of ['45.812345', '15.912345', '135', '8.5']) {
+        assert.equal(serialized.includes(privateValue), false);
+    }
+});
+
+test('customer map remains available only while exact telemetry is within TTL', () => {
+    assert.equal(
+        customerDeliveryTrackingSummary(snapshot(), acceptedAt).mapAvailable,
+        true,
+    );
+    assert.equal(
+        customerDeliveryTrackingSummary(
+            snapshot({ currentLatitude: null }),
+            acceptedAt,
+        ).mapAvailable,
+        false,
+    );
+});
+
+test('map version changes when freshness crosses a status boundary', () => {
+    const tracking = customerDeliveryTrackingSummary(snapshot(), acceptedAt);
+    const liveVersion = deliveryTrackingMapVersion(tracking);
+    const delayedVersion = deliveryTrackingMapVersion({
+        ...tracking,
+        status: 'delayed',
+    });
+    const offlineVersion = deliveryTrackingMapVersion({
+        ...tracking,
+        status: 'offline',
+        mapAvailable: false,
+    });
+
+    assert.notEqual(delayedVersion, liveVersion);
+    assert.notEqual(offlineVersion, delayedVersion);
+    assert.match(offlineVersion, /^offline:/);
+});
+
+test('capture time validation rejects already-expired and excessive future samples', () => {
+    assert.equal(
+        deliveryLocationCaptureTimeIsAcceptable(
+            new Date(acceptedAt.getTime() - deliveryRunExactLocationTtlMs),
+            acceptedAt,
+        ),
+        true,
+    );
+    assert.equal(
+        deliveryLocationCaptureTimeIsAcceptable(
+            new Date(acceptedAt.getTime() - deliveryRunExactLocationTtlMs - 1),
+            acceptedAt,
+        ),
+        false,
+    );
+    assert.equal(
+        deliveryLocationCaptureTimeIsAcceptable(
+            new Date(acceptedAt.getTime() + 5 * 60 * 1000),
+            acceptedAt,
+        ),
+        true,
+    );
+    assert.equal(
+        deliveryLocationCaptureTimeIsAcceptable(
+            new Date(acceptedAt.getTime() + 5 * 60 * 1000 + 1),
+            acceptedAt,
+        ),
+        false,
+    );
+    assert.equal(
+        deliveryLocationCaptureTimeIsAcceptable(new Date(Number.NaN)),
+        false,
+    );
+});

--- a/apps/delivery/lib/deliveryTracking.ts
+++ b/apps/delivery/lib/deliveryTracking.ts
@@ -1,0 +1,113 @@
+import {
+    DeliveryRunStates,
+    deliveryRunExactLocationTtlMs,
+    deliveryRunTrackingLiveThresholdMs,
+} from '@gredice/storage';
+import type {
+    CustomerDeliveryTrackingSummary,
+    DeliveryTrackingStatus,
+    DriverDeliveryTrackingLocation,
+} from './deliveryDashboardTypes';
+
+const maximumLocationClockSkewMs = 5 * 60 * 1000;
+
+export type DeliveryTrackingSnapshot = {
+    state: string;
+    currentLatitude: number | null;
+    currentLongitude: number | null;
+    currentLocationAccuracy: number | null;
+    currentLocationHeading: number | null;
+    currentLocationSpeed: number | null;
+    currentLocationRecordedAt: Date | null;
+    currentLocationReceivedAt: Date | null;
+};
+
+function acceptedLocationAgeMs(snapshot: DeliveryTrackingSnapshot, now: Date) {
+    if (
+        snapshot.state !== DeliveryRunStates.ACTIVE ||
+        !snapshot.currentLocationReceivedAt
+    ) {
+        return null;
+    }
+    return Math.max(
+        0,
+        now.getTime() - snapshot.currentLocationReceivedAt.getTime(),
+    );
+}
+
+export function deliveryTrackingStatus(
+    snapshot: DeliveryTrackingSnapshot,
+    now = new Date(),
+): DeliveryTrackingStatus {
+    const ageMs = acceptedLocationAgeMs(snapshot, now);
+    if (ageMs === null) return 'unavailable';
+    if (ageMs <= deliveryRunTrackingLiveThresholdMs) return 'live';
+    if (ageMs <= deliveryRunExactLocationTtlMs) return 'delayed';
+    return 'offline';
+}
+
+export function deliveryTrackingRecoveryTransition(
+    previousStatus: DeliveryTrackingStatus,
+    newStatus: DeliveryTrackingStatus,
+) {
+    return (
+        (previousStatus === 'offline' || previousStatus === 'unavailable') &&
+        (newStatus === 'live' || newStatus === 'delayed')
+    );
+}
+
+export function driverDeliveryTrackingLocation(
+    snapshot: DeliveryTrackingSnapshot,
+    now = new Date(),
+): DriverDeliveryTrackingLocation | null {
+    const ageMs = acceptedLocationAgeMs(snapshot, now);
+    if (
+        ageMs === null ||
+        ageMs > deliveryRunExactLocationTtlMs ||
+        snapshot.currentLatitude === null ||
+        snapshot.currentLongitude === null ||
+        !snapshot.currentLocationRecordedAt ||
+        !snapshot.currentLocationReceivedAt
+    ) {
+        return null;
+    }
+    return {
+        latitude: snapshot.currentLatitude,
+        longitude: snapshot.currentLongitude,
+        accuracy: snapshot.currentLocationAccuracy,
+        heading: snapshot.currentLocationHeading,
+        speed: snapshot.currentLocationSpeed,
+        capturedAt: snapshot.currentLocationRecordedAt.toISOString(),
+        acceptedAt: snapshot.currentLocationReceivedAt.toISOString(),
+    };
+}
+
+export function customerDeliveryTrackingSummary(
+    snapshot: DeliveryTrackingSnapshot,
+    now = new Date(),
+): CustomerDeliveryTrackingSummary {
+    const status = deliveryTrackingStatus(snapshot, now);
+    return {
+        status,
+        lastAcceptedAt:
+            snapshot.state === DeliveryRunStates.ACTIVE
+                ? (snapshot.currentLocationReceivedAt?.toISOString() ?? null)
+                : null,
+        mapAvailable:
+            driverDeliveryTrackingLocation(snapshot, now) !== null &&
+            (status === 'live' || status === 'delayed'),
+    };
+}
+
+export function deliveryLocationCaptureTimeIsAcceptable(
+    capturedAt: Date,
+    receivedAt = new Date(),
+) {
+    const capturedTime = capturedAt.getTime();
+    if (!Number.isFinite(capturedTime)) return false;
+    const ageMs = receivedAt.getTime() - capturedTime;
+    return (
+        ageMs <= deliveryRunExactLocationTtlMs &&
+        ageMs >= -maximumLocationClockSkewMs
+    );
+}

--- a/apps/delivery/lib/deliveryTrackingPresentation.ts
+++ b/apps/delivery/lib/deliveryTrackingPresentation.ts
@@ -1,0 +1,8 @@
+import type { DeliveryTrackingFreshnessSummary } from './deliveryDashboardTypes';
+
+export function deliveryTrackingMapVersion(
+    tracking: DeliveryTrackingFreshnessSummary,
+    fallback: string | null = null,
+) {
+    return `${tracking.status}:${tracking.lastAcceptedAt ?? fallback ?? 'initial'}`;
+}

--- a/apps/delivery/tests/delivery-tracking.spec.tsx
+++ b/apps/delivery/tests/delivery-tracking.spec.tsx
@@ -1,0 +1,95 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { CustomerDeliveryTracking } from '../components/CustomerDeliveryTracking';
+import '../app/globals.css';
+
+const lastAcceptedAt = '2026-07-15T10:00:00.000Z';
+
+test('customer sees a live server-acknowledged location and map', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <CustomerDeliveryTracking
+            runId="run-live"
+            tracking={{
+                status: 'live',
+                lastAcceptedAt,
+                mapAvailable: true,
+            }}
+        />,
+    );
+
+    await expect(page.getByRole('status')).toHaveCount(1);
+    await expect(page.getByRole('alert')).toHaveCount(0);
+    await expect(page.getByText(/Lokacija vozača je uživo/)).toBeVisible();
+    await expect(
+        page.getByRole('img', {
+            name: 'Trenutna lokacija vozača i moja dostava',
+        }),
+    ).toBeVisible();
+});
+
+test('customer sees delayed copy while the last exact location remains available', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <CustomerDeliveryTracking
+            runId="run-delayed"
+            tracking={{
+                status: 'delayed',
+                lastAcceptedAt,
+                mapAvailable: true,
+            }}
+        />,
+    );
+
+    await expect(page.getByText(/Lokacija vozača kasni/)).toBeVisible();
+    await expect(
+        page.getByRole('img', {
+            name: 'Posljednja potvrđena lokacija vozača i moja dostava',
+        }),
+    ).toBeVisible();
+});
+
+test('customer sees offline state without a stale exact-location map', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <CustomerDeliveryTracking
+            runId="run-offline"
+            tracking={{
+                status: 'offline',
+                lastAcceptedAt,
+                mapAvailable: false,
+            }}
+        />,
+    );
+
+    await expect(
+        page.getByText(/Praćenje je trenutačno izvan mreže/),
+    ).toBeVisible();
+    await expect(page.getByRole('img')).toHaveCount(0);
+});
+
+test('customer sees unavailable state before the first accepted location', async ({
+    mount,
+    page,
+}) => {
+    await mount(
+        <CustomerDeliveryTracking
+            runId="run-unavailable"
+            tracking={{
+                status: 'unavailable',
+                lastAcceptedAt: null,
+                mapAvailable: false,
+            }}
+        />,
+    );
+
+    await expect(
+        page.getByText(/Lokacija vozača još nije dostupna/),
+    ).toBeVisible();
+    await expect(page.getByRole('img')).toHaveCount(0);
+});

--- a/packages/storage/src/repositories/deliveryRunsRepo.ts
+++ b/packages/storage/src/repositories/deliveryRunsRepo.ts
@@ -12,6 +12,7 @@ import {
     inArray,
     isNotNull,
     isNull,
+    lt,
     lte,
     notInArray,
     or,
@@ -283,6 +284,8 @@ export const DeliveryRunExecutionErrorCodes = {
     EXCEPTION_TRANSITION_INVALID: 'exception-transition-invalid',
     RUN_DRIVER_CONFLICT: 'run-driver-conflict',
     RUN_MUTATION_INVALID: 'run-mutation-invalid',
+    LOCATION_CONFLICT: 'location-conflict',
+    LOCATION_STALE: 'location-stale',
 } as const;
 
 export type DeliveryRunExecutionErrorCode =
@@ -298,6 +301,9 @@ export class DeliveryRunExecutionError extends Error {
         super(message);
     }
 }
+
+export const deliveryRunTrackingLiveThresholdMs = 30 * 1000;
+export const deliveryRunExactLocationTtlMs = 2 * 60 * 1000;
 
 export type DeliveryRunExecutionStep =
     | {
@@ -4418,57 +4424,158 @@ export async function updateDeliveryRunLocation({
     driverUserId: string;
     latitude: number;
     longitude: number;
-    accuracy?: number;
-    heading?: number;
-    speed?: number;
+    accuracy?: number | null;
+    heading?: number | null;
+    speed?: number | null;
     recordedAt: Date;
 }) {
     ensureCoordinates(latitude, longitude);
 
-    const rows = await storage()
-        .update(deliveryRuns)
-        .set({
-            currentLatitude: latitude,
-            currentLongitude: longitude,
-            currentLocationAccuracy: accuracy,
-            currentLocationHeading: heading,
-            currentLocationSpeed: speed,
-            currentLocationRecordedAt: recordedAt,
-            currentLocationReceivedAt: new Date(),
-        })
-        .where(
-            and(
+    const normalizedAccuracy = accuracy ?? null;
+    const normalizedHeading = heading ?? null;
+    const normalizedSpeed = speed ?? null;
+
+    return await storage().transaction(async (tx) => {
+        await tx.execute(
+            sql`select ${deliveryRuns.id} from ${deliveryRuns} where ${deliveryRuns.id} = ${runId} for update`,
+        );
+        const current = await tx.query.deliveryRuns.findFirst({
+            where: and(
                 eq(deliveryRuns.id, runId),
                 eq(deliveryRuns.driverUserId, driverUserId),
                 eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+            ),
+        });
+        if (!current) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+                'Active delivery run not found',
+            );
+        }
+
+        const currentRecordedTime =
+            current.currentLocationRecordedAt?.getTime() ?? null;
+        if (
+            currentRecordedTime !== null &&
+            currentRecordedTime > recordedAt.getTime()
+        ) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.LOCATION_STALE,
+                'A newer delivery location is already stored',
+            );
+        }
+        if (currentRecordedTime === recordedAt.getTime()) {
+            const identicalReplay =
+                current.currentLatitude === latitude &&
+                current.currentLongitude === longitude &&
+                current.currentLocationAccuracy === normalizedAccuracy &&
+                current.currentLocationHeading === normalizedHeading &&
+                current.currentLocationSpeed === normalizedSpeed;
+            if (identicalReplay && current.currentLocationReceivedAt) {
+                return {
+                    acceptedAt: current.currentLocationReceivedAt,
+                    previousAcceptedAt: current.currentLocationReceivedAt,
+                    replayed: true,
+                };
+            }
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.LOCATION_CONFLICT,
+                'Delivery location timestamp conflicts with stored telemetry',
+            );
+        }
+
+        const acceptedAt = new Date();
+        const [updated] = await tx
+            .update(deliveryRuns)
+            .set({
+                currentLatitude: latitude,
+                currentLongitude: longitude,
+                currentLocationAccuracy: normalizedAccuracy,
+                currentLocationHeading: normalizedHeading,
+                currentLocationSpeed: normalizedSpeed,
+                currentLocationRecordedAt: recordedAt,
+                currentLocationReceivedAt: acceptedAt,
+            })
+            .where(
+                and(
+                    eq(deliveryRuns.id, runId),
+                    eq(deliveryRuns.driverUserId, driverUserId),
+                    eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                ),
+            )
+            .returning({ acceptedAt: deliveryRuns.currentLocationReceivedAt });
+        if (!updated?.acceptedAt) {
+            throw new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+                'Active delivery run not found',
+            );
+        }
+        return {
+            acceptedAt: updated.acceptedAt,
+            previousAcceptedAt: current.currentLocationReceivedAt,
+            replayed: false,
+        };
+    });
+}
+
+export async function clearExpiredDeliveryRunLocations(now = new Date()) {
+    const cutoff = new Date(now.getTime() - deliveryRunExactLocationTtlMs);
+    return await storage()
+        .update(deliveryRuns)
+        .set({
+            currentLatitude: null,
+            currentLongitude: null,
+            currentLocationAccuracy: null,
+            currentLocationHeading: null,
+            currentLocationSpeed: null,
+            currentLocationRecordedAt: null,
+        })
+        .where(
+            and(
+                eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
                 or(
-                    isNull(deliveryRuns.currentLocationRecordedAt),
-                    lte(deliveryRuns.currentLocationRecordedAt, recordedAt),
+                    isNull(deliveryRuns.currentLocationReceivedAt),
+                    lt(deliveryRuns.currentLocationReceivedAt, cutoff),
+                ),
+                or(
+                    isNotNull(deliveryRuns.currentLatitude),
+                    isNotNull(deliveryRuns.currentLongitude),
+                    isNotNull(deliveryRuns.currentLocationAccuracy),
+                    isNotNull(deliveryRuns.currentLocationHeading),
+                    isNotNull(deliveryRuns.currentLocationSpeed),
+                    isNotNull(deliveryRuns.currentLocationRecordedAt),
                 ),
             ),
         )
-        .returning({ id: deliveryRuns.id });
-
-    if (!rows[0]) {
-        throw new Error('Active delivery run not found');
-    }
+        .returning({
+            runId: deliveryRuns.id,
+            lastAcceptedAt: deliveryRuns.currentLocationReceivedAt,
+        });
 }
 
 export async function updateDeliveryRunEstimates({
     runId,
+    driverUserId,
+    expectedRouteRevision,
+    expectedLocationRecordedAt,
+    expectedLocationReceivedAt,
     encodedPolyline,
     totalDistanceMeters,
     totalDurationSeconds,
     estimates,
 }: {
     runId: string;
+    driverUserId: string;
+    expectedRouteRevision: number;
+    expectedLocationRecordedAt: Date;
+    expectedLocationReceivedAt: Date;
     encodedPolyline?: string;
     totalDistanceMeters: number;
     totalDurationSeconds: number;
     estimates: DeliveryRunStopEstimate[];
 }) {
-    await storage().transaction(async (tx) => {
-        await tx
+    return await storage().transaction(async (tx) => {
+        const [updatedRun] = await tx
             .update(deliveryRuns)
             .set({
                 encodedPolyline,
@@ -4479,9 +4586,21 @@ export async function updateDeliveryRunEstimates({
             .where(
                 and(
                     eq(deliveryRuns.id, runId),
+                    eq(deliveryRuns.driverUserId, driverUserId),
                     eq(deliveryRuns.state, DeliveryRunStates.ACTIVE),
+                    eq(deliveryRuns.routeRevision, expectedRouteRevision),
+                    eq(
+                        deliveryRuns.currentLocationRecordedAt,
+                        expectedLocationRecordedAt,
+                    ),
+                    eq(
+                        deliveryRuns.currentLocationReceivedAt,
+                        expectedLocationReceivedAt,
+                    ),
                 ),
-            );
+            )
+            .returning({ id: deliveryRuns.id });
+        if (!updatedRun) return false;
 
         for (const estimate of estimates) {
             await tx
@@ -4505,6 +4624,7 @@ export async function updateDeliveryRunEstimates({
                     ),
                 );
         }
+        return true;
     });
 }
 

--- a/packages/storage/tests/deliveryRunsRepo.node.spec.ts
+++ b/packages/storage/tests/deliveryRunsRepo.node.spec.ts
@@ -10,6 +10,7 @@ import {
     cancelDeliveryRequest,
     changeDeliveryRequestSlot,
     claimDeliveryRunReroute,
+    clearExpiredDeliveryRunLocations,
     consumeDeliveryRunPreparation,
     createDeliveryAddress,
     createDeliveryRun,
@@ -35,6 +36,7 @@ import {
     DeliveryRunStopStates,
     deleteDeliveryAddress,
     deliveryRequests,
+    deliveryRunExactLocationTtlMs,
     deliveryRunExceptionOperations,
     deliveryRunPickupNodes,
     deliveryRunPickupOperations,
@@ -75,6 +77,7 @@ import {
     timeSlots,
     uncancelDeliveryRequest,
     updateDeliveryAddress,
+    updateDeliveryRunEstimates,
     updateDeliveryRunLocation,
     updatePickupLocation,
     updateTimeSlot,
@@ -932,6 +935,7 @@ test('delivery run fulfills a current bulk stop atomically and preserves route o
     assert.equal(completedRun.currentLocationHeading, null);
     assert.equal(completedRun.currentLocationSpeed, null);
     assert.equal(completedRun.currentLocationRecordedAt, null);
+    assert.equal(completedRun.currentLocationReceivedAt, null);
     assert.equal(
         await accountCanTrackDeliveryRun({ accountId, runId: run.id }),
         false,
@@ -1086,7 +1090,7 @@ test('concurrent cross-driver assignment permits one run and rolls back the lose
     );
 });
 
-test('an older GPS sample is rejected without overwriting the latest telemetry', async () => {
+test('GPS acknowledgement replays identically without extending freshness and rejects conflicts', async () => {
     const fixture = await createDeliveryRunFixture();
     const [driverUserId] = fixture.driverUserIds;
     const [requestId] = fixture.requestIds;
@@ -1099,7 +1103,7 @@ test('an older GPS sample is rejected without overwriting the latest telemetry',
         requestIds: [requestId],
     });
     const latestRecordedAt = new Date('2026-07-13T08:10:00.000Z');
-    await updateDeliveryRunLocation({
+    const accepted = await updateDeliveryRunLocation({
         runId: run.id,
         driverUserId,
         latitude: 45.812,
@@ -1109,8 +1113,39 @@ test('an older GPS sample is rejected without overwriting the latest telemetry',
         speed: 9.25,
         recordedAt: latestRecordedAt,
     });
+    assert.equal(accepted.replayed, false);
+    assert.ok(accepted.acceptedAt instanceof Date);
+    assert.equal(accepted.previousAcceptedAt, null);
 
-    await assert.rejects(
+    const replayed = await updateDeliveryRunLocation({
+        runId: run.id,
+        driverUserId,
+        latitude: 45.812,
+        longitude: 15.982,
+        accuracy: 5,
+        heading: 135,
+        speed: 9.25,
+        recordedAt: latestRecordedAt,
+    });
+    assert.equal(replayed.replayed, true);
+    assert.deepEqual(replayed.acceptedAt, accepted.acceptedAt);
+    assert.deepEqual(replayed.previousAcceptedAt, accepted.acceptedAt);
+
+    await assertExecutionError(
+        updateDeliveryRunLocation({
+            runId: run.id,
+            driverUserId,
+            latitude: 45.7,
+            longitude: 15.8,
+            accuracy: 99,
+            heading: 5,
+            speed: 1,
+            recordedAt: latestRecordedAt,
+        }),
+        DeliveryRunExecutionErrorCodes.LOCATION_CONFLICT,
+    );
+
+    await assertExecutionError(
         updateDeliveryRunLocation({
             runId: run.id,
             driverUserId,
@@ -1121,7 +1156,7 @@ test('an older GPS sample is rejected without overwriting the latest telemetry',
             speed: 1,
             recordedAt: new Date('2026-07-13T08:09:59.000Z'),
         }),
-        /Active delivery run not found/,
+        DeliveryRunExecutionErrorCodes.LOCATION_STALE,
     );
 
     const persistedRun = await getDeliveryRun(run.id);
@@ -1133,6 +1168,271 @@ test('an older GPS sample is rejected without overwriting the latest telemetry',
     assert.equal(
         persistedRun?.currentLocationRecordedAt?.toISOString(),
         latestRecordedAt.toISOString(),
+    );
+    assert.deepEqual(
+        persistedRun?.currentLocationReceivedAt,
+        accepted.acceptedAt,
+    );
+});
+
+test('tracking retention clears exact active telemetry after TTL and is idempotent', async () => {
+    const fixture = await createDeliveryRunFixture({
+        accountIndexes: [0, 1],
+        driverCount: 2,
+    });
+    const [firstDriverUserId, secondDriverUserId] = fixture.driverUserIds;
+    const [firstRequestId, secondRequestId] = fixture.requestIds;
+    assert.ok(firstDriverUserId);
+    assert.ok(secondDriverUserId);
+    assert.ok(firstRequestId);
+    assert.ok(secondRequestId);
+
+    const firstRun = await createRun({
+        fixture,
+        driverUserId: firstDriverUserId,
+        requestIds: [firstRequestId],
+    });
+    const secondRun = await createRun({
+        fixture,
+        driverUserId: secondDriverUserId,
+        requestIds: [secondRequestId],
+    });
+    const now = new Date('2026-07-15T10:05:00.000Z');
+    const exactBoundary = new Date(
+        now.getTime() - deliveryRunExactLocationTtlMs,
+    );
+    await storage()
+        .update(deliveryRuns)
+        .set({
+            currentLatitude: 45.812,
+            currentLongitude: 15.982,
+            currentLocationAccuracy: 5,
+            currentLocationHeading: 135,
+            currentLocationSpeed: 9.25,
+            currentLocationRecordedAt: new Date(
+                exactBoundary.getTime() - 1_000,
+            ),
+            currentLocationReceivedAt: exactBoundary,
+        })
+        .where(eq(deliveryRuns.id, firstRun.id));
+    await storage()
+        .update(deliveryRuns)
+        .set({
+            currentLatitude: 45.7,
+            currentLongitude: 15.8,
+            currentLocationAccuracy: 9,
+            currentLocationHeading: 90,
+            currentLocationSpeed: 4,
+            currentLocationRecordedAt: new Date('2026-07-15T10:00:00.000Z'),
+            currentLocationReceivedAt: null,
+        })
+        .where(eq(deliveryRuns.id, secondRun.id));
+
+    const boundaryCleanup = await clearExpiredDeliveryRunLocations(now);
+    assert.deepEqual(
+        boundaryCleanup.map((row) => row.runId),
+        [secondRun.id],
+    );
+    assert.equal((await getDeliveryRun(firstRun.id))?.currentLatitude, 45.812);
+
+    const expired = await clearExpiredDeliveryRunLocations(
+        new Date(now.getTime() + 1),
+    );
+    assert.deepEqual(
+        expired.map((row) => row.runId),
+        [firstRun.id],
+    );
+    const persisted = await getDeliveryRun(firstRun.id);
+    assert.equal(persisted?.currentLatitude, null);
+    assert.equal(persisted?.currentLongitude, null);
+    assert.equal(persisted?.currentLocationAccuracy, null);
+    assert.equal(persisted?.currentLocationHeading, null);
+    assert.equal(persisted?.currentLocationSpeed, null);
+    assert.equal(persisted?.currentLocationRecordedAt, null);
+    assert.deepEqual(persisted?.currentLocationReceivedAt, exactBoundary);
+    assert.deepEqual(
+        await clearExpiredDeliveryRunLocations(new Date(now.getTime() + 2)),
+        [],
+    );
+});
+
+test('concurrent identical GPS submissions share one authoritative receipt', async () => {
+    const fixture = await createDeliveryRunFixture();
+    const [driverUserId] = fixture.driverUserIds;
+    const [requestId] = fixture.requestIds;
+    assert.ok(driverUserId);
+    assert.ok(requestId);
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [requestId],
+    });
+    const payload = {
+        runId: run.id,
+        driverUserId,
+        latitude: 45.812,
+        longitude: 15.982,
+        accuracy: 5,
+        heading: 135,
+        speed: 9.25,
+        recordedAt: new Date('2026-07-13T08:10:00.000Z'),
+    };
+
+    const results = await Promise.all([
+        updateDeliveryRunLocation(payload),
+        updateDeliveryRunLocation(payload),
+    ]);
+    assert.deepEqual(results.map((result) => result.replayed).sort(), [
+        false,
+        true,
+    ]);
+    assert.deepEqual(results[0]?.acceptedAt, results[1]?.acceptedAt);
+});
+
+test('a slower estimate calculation cannot overwrite the route for a newer accepted GPS sample', async () => {
+    const fixture = await createDeliveryRunFixture();
+    const [driverUserId] = fixture.driverUserIds;
+    const [requestId] = fixture.requestIds;
+    assert.ok(driverUserId);
+    assert.ok(requestId);
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [requestId],
+    });
+    const olderRecordedAt = new Date('2026-07-13T08:10:00.000Z');
+    const olderAcknowledgement = await updateDeliveryRunLocation({
+        runId: run.id,
+        driverUserId,
+        latitude: 45.81,
+        longitude: 15.97,
+        recordedAt: olderRecordedAt,
+    });
+    const slowerOlderEstimate = {
+        runId: run.id,
+        driverUserId,
+        expectedRouteRevision: run.routeRevision,
+        expectedLocationRecordedAt: olderRecordedAt,
+        expectedLocationReceivedAt: olderAcknowledgement.acceptedAt,
+        encodedPolyline: 'older-route',
+        totalDistanceMeters: 9_000,
+        totalDurationSeconds: 1_800,
+        estimates: [
+            {
+                deliveryRequestId: requestId,
+                estimatedArrivalAt: new Date('2026-07-13T08:40:00.000Z'),
+                estimatedTravelSeconds: 1_800,
+                estimatedDistanceMeters: 9_000,
+            },
+        ],
+    };
+
+    const newerRecordedAt = new Date('2026-07-13T08:10:10.000Z');
+    const newerAcknowledgement = await updateDeliveryRunLocation({
+        runId: run.id,
+        driverUserId,
+        latitude: 45.82,
+        longitude: 15.98,
+        recordedAt: newerRecordedAt,
+    });
+    const newerArrivalAt = new Date('2026-07-13T08:20:00.000Z');
+    assert.equal(
+        await updateDeliveryRunEstimates({
+            runId: run.id,
+            driverUserId,
+            expectedRouteRevision: run.routeRevision,
+            expectedLocationRecordedAt: newerRecordedAt,
+            expectedLocationReceivedAt: newerAcknowledgement.acceptedAt,
+            encodedPolyline: 'newer-route',
+            totalDistanceMeters: 3_000,
+            totalDurationSeconds: 600,
+            estimates: [
+                {
+                    deliveryRequestId: requestId,
+                    estimatedArrivalAt: newerArrivalAt,
+                    estimatedTravelSeconds: 600,
+                    estimatedDistanceMeters: 3_000,
+                },
+            ],
+        }),
+        true,
+    );
+
+    assert.equal(await updateDeliveryRunEstimates(slowerOlderEstimate), false);
+    const persisted = await getDeliveryRun(run.id);
+    assert.equal(persisted?.encodedPolyline, 'newer-route');
+    assert.equal(persisted?.totalDistanceMeters, 3_000);
+    assert.equal(persisted?.totalDurationSeconds, 600);
+    assert.equal(persisted?.stops[0]?.estimatedTravelSeconds, 600);
+    assert.equal(persisted?.stops[0]?.estimatedDistanceMeters, 3_000);
+    assert.deepEqual(persisted?.stops[0]?.estimatedArrivalAt, newerArrivalAt);
+});
+
+test('an estimate calculation cannot overwrite a route whose revision advanced at arrival', async () => {
+    const fixture = await createDeliveryRunFixture();
+    const [driverUserId] = fixture.driverUserIds;
+    const [requestId] = fixture.requestIds;
+    assert.ok(driverUserId);
+    assert.ok(requestId);
+    const run = await createRun({
+        fixture,
+        driverUserId,
+        requestIds: [requestId],
+    });
+    const [stop] = run.stops;
+    assert.ok(stop);
+    const recordedAt = new Date('2026-07-13T08:10:00.000Z');
+    const acknowledgement = await updateDeliveryRunLocation({
+        runId: run.id,
+        driverUserId,
+        latitude: 45.81,
+        longitude: 15.97,
+        recordedAt,
+    });
+
+    await markDeliveryRunStopArrived({
+        driverUserId,
+        runId: run.id,
+        stopId: stop.id,
+        expectedRouteRevision: run.routeRevision,
+    });
+    assert.equal(
+        await updateDeliveryRunEstimates({
+            runId: run.id,
+            driverUserId,
+            expectedRouteRevision: run.routeRevision,
+            expectedLocationRecordedAt: recordedAt,
+            expectedLocationReceivedAt: acknowledgement.acceptedAt,
+            encodedPolyline: 'stale-route',
+            totalDistanceMeters: 9_000,
+            totalDurationSeconds: 1_800,
+            estimates: [
+                {
+                    deliveryRequestId: requestId,
+                    estimatedArrivalAt: new Date('2026-07-13T08:40:00.000Z'),
+                    estimatedTravelSeconds: 1_800,
+                    estimatedDistanceMeters: 9_000,
+                },
+            ],
+        }),
+        false,
+    );
+
+    const persisted = await getDeliveryRun(run.id);
+    assert.equal(persisted?.routeRevision, run.routeRevision + 1);
+    assert.equal(persisted?.totalDistanceMeters, run.totalDistanceMeters);
+    assert.equal(persisted?.totalDurationSeconds, run.totalDurationSeconds);
+    assert.equal(
+        persisted?.stops[0]?.estimatedTravelSeconds,
+        stop.estimatedTravelSeconds,
+    );
+    assert.equal(
+        persisted?.stops[0]?.estimatedDistanceMeters,
+        stop.estimatedDistanceMeters,
+    );
+    assert.deepEqual(
+        persisted?.stops[0]?.estimatedArrivalAt,
+        stop.estimatedArrivalAt,
     );
 });
 
@@ -3104,6 +3404,16 @@ test('cancelled and fulfilled request projections are absorbing for late excepti
     });
     const [stop] = run.stops;
     assert.ok(stop);
+    await updateDeliveryRunLocation({
+        runId: run.id,
+        driverUserId,
+        latitude: 45.8,
+        longitude: 15.97,
+        accuracy: 6,
+        heading: 120,
+        speed: 7,
+        recordedAt: new Date('2026-07-13T08:59:00.000Z'),
+    });
     await cancelDeliveryRequest(requestId, 'admin', 'Otkazano tijekom dostave');
 
     await assertExecutionError(
@@ -3122,10 +3432,19 @@ test('cancelled and fulfilled request projections are absorbing for late excepti
         }),
         DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
     );
+    const cancelledRun = await getDeliveryRun(run.id);
+    assert.equal(cancelledRun?.state, DeliveryRunStates.COMPLETED);
     assert.equal(
-        (await getDeliveryRun(run.id))?.stops[0]?.state,
+        cancelledRun?.stops[0]?.state,
         DeliveryRunStopStates.CANCELLED,
     );
+    assert.equal(cancelledRun?.currentLatitude, null);
+    assert.equal(cancelledRun?.currentLongitude, null);
+    assert.equal(cancelledRun?.currentLocationAccuracy, null);
+    assert.equal(cancelledRun?.currentLocationHeading, null);
+    assert.equal(cancelledRun?.currentLocationSpeed, null);
+    assert.equal(cancelledRun?.currentLocationRecordedAt, null);
+    assert.equal(cancelledRun?.currentLocationReceivedAt, null);
     assert.equal(
         (
             await storage()
@@ -4219,6 +4538,9 @@ test('whole-run reassignment clears stale GPS and requires the current route rev
         driverUserId,
         latitude: 45.8,
         longitude: 15.97,
+        accuracy: 4,
+        heading: 180,
+        speed: 8,
         recordedAt: new Date('2026-07-13T12:00:00.000Z'),
     });
     await markDeliveryRunStopsArrived({
@@ -4249,6 +4571,9 @@ test('whole-run reassignment clears stale GPS and requires the current route rev
     assert.equal(persisted?.driverUserId, nextDriverUserId);
     assert.equal(persisted?.currentLatitude, null);
     assert.equal(persisted?.currentLongitude, null);
+    assert.equal(persisted?.currentLocationAccuracy, null);
+    assert.equal(persisted?.currentLocationHeading, null);
+    assert.equal(persisted?.currentLocationSpeed, null);
     assert.equal(persisted?.currentLocationRecordedAt, null);
     assert.equal(persisted?.currentLocationReceivedAt, null);
     assert.ok(
@@ -4276,6 +4601,16 @@ test('route abandonment releases requests but preserves a failed stop audit outc
     const [failedStop, pendingStop] = run.stops;
     assert.ok(failedStop);
     assert.ok(pendingStop);
+    await updateDeliveryRunLocation({
+        runId: run.id,
+        driverUserId,
+        latitude: 45.8,
+        longitude: 15.97,
+        accuracy: 4,
+        heading: 180,
+        speed: 8,
+        recordedAt: new Date('2026-07-13T12:09:00.000Z'),
+    });
     const failure = await recordDeliveryRunStopExceptions({
         driverUserId,
         runId: run.id,
@@ -4305,6 +4640,13 @@ test('route abandonment releases requests but preserves a failed stop audit outc
 
     const persisted = await getDeliveryRun(run.id);
     assert.equal(persisted?.state, DeliveryRunStates.CANCELLED);
+    assert.equal(persisted?.currentLatitude, null);
+    assert.equal(persisted?.currentLongitude, null);
+    assert.equal(persisted?.currentLocationAccuracy, null);
+    assert.equal(persisted?.currentLocationHeading, null);
+    assert.equal(persisted?.currentLocationSpeed, null);
+    assert.equal(persisted?.currentLocationRecordedAt, null);
+    assert.equal(persisted?.currentLocationReceivedAt, null);
     const persistedFailed = persisted?.stops.find(
         (stop) => stop.id === failedStop.id,
     );


### PR DESCRIPTION
## Summary

- derive live, delayed, offline, and unavailable tracking from server-accepted GPS timestamps
- suppress and expire exact telemetry after the TTL or terminal run transitions while preserving customer-safe freshness summaries
- acknowledge and replay GPS uploads safely, and CAS legacy ETA writes against the exact GPS and route revision
- preserve current-stop map authorization and add accessible customer tracking states

## Validation

- `corepack pnpm --filter @gredice/storage test:node -- deliveryRunsRepo.node.spec.ts` (56/56)
- `corepack pnpm --filter delivery test` (153 unit + 15 Chromium component)
- `corepack pnpm --filter delivery typecheck`
- `corepack pnpm --filter delivery build`
- `corepack pnpm --filter api build`
- focused Biome checks for API, delivery, and storage
- `git diff --check`

Closes #4128