### PR TITLE
feat(delivery): retry GPS uploads truthfully

### DIFF
--- a/apps/delivery/app/api/driver/runs/[runId]/location/route.ts
+++ b/apps/delivery/app/api/driver/runs/[runId]/location/route.ts
@@ -1,10 +1,10 @@
-import {
-    DeliveryRunExecutionError,
-    DeliveryRunExecutionErrorCodes,
-} from '@gredice/storage';
+import { DeliveryRunExecutionError } from '@gredice/storage';
 import { withAuth } from '../../../../../../lib/auth/auth';
 import { recordDriverLocation } from '../../../../../../lib/deliveryDashboard';
-import { deliveryLocationCaptureTimeIsAcceptable } from '../../../../../../lib/deliveryTracking';
+import {
+    deliveryLocationCaptureTimeIsAcceptable,
+    deliveryLocationErrorStatus,
+} from '../../../../../../lib/deliveryTracking';
 
 function requiredNumber(value: unknown) {
     return typeof value === 'number' && Number.isFinite(value)
@@ -87,6 +87,7 @@ export async function POST(
                 {
                     status: result.status,
                     acceptedAt: result.acceptedAt.toISOString(),
+                    refreshedAt: new Date().toISOString(),
                     replayed: result.replayed,
                 },
                 { headers: noStoreHeaders },
@@ -108,12 +109,7 @@ export async function POST(
                         : {}),
                 },
                 {
-                    status:
-                        error instanceof DeliveryRunExecutionError &&
-                        error.code ===
-                            DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND
-                            ? 404
-                            : 409,
+                    status: deliveryLocationErrorStatus(error),
                     headers: noStoreHeaders,
                 },
             );

--- a/apps/delivery/components/DeliveryDashboard.tsx
+++ b/apps/delivery/components/DeliveryDashboard.tsx
@@ -390,11 +390,21 @@ export function DeliveryDashboard() {
         queryFn: readDashboard,
         refetchInterval: 10_000,
     });
-    const activeRunId =
-        query.data?.kind === 'driver'
-            ? (query.data.activeRun?.id ?? null)
+    const dashboardData = query.data;
+    const activeRun =
+        dashboardData && 'activeRun' in dashboardData
+            ? dashboardData.activeRun
             : null;
-    const trackingState = useDriverTracking(activeRunId);
+    const activeRunId = activeRun?.id ?? null;
+    const trackingState = useDriverTracking({
+        runId: activeRunId,
+        serverTracking: activeRun?.tracking ?? null,
+        dashboardRefreshedAt:
+            dashboardData?.kind === 'driver' ? dashboardData.refreshedAt : null,
+        onDashboardRefresh: async () => {
+            await query.refetch();
+        },
+    });
     const driverWithoutActiveRun =
         query.data?.kind === 'driver' && !query.data.activeRun
             ? query.data.user.id

--- a/apps/delivery/components/DriverDashboard.tsx
+++ b/apps/delivery/components/DriverDashboard.tsx
@@ -7,7 +7,6 @@ import { Chip } from '@gredice/ui/Chip';
 import {
     Map as MapIcon,
     MapPin,
-    MyLocation,
     Play,
     Reset,
     Timer,
@@ -55,24 +54,8 @@ import {
     type PickupManifestSyncSummary,
 } from './DeliveryPickupCard';
 import { DeliveryStopCard } from './DeliveryStopCard';
+import { DriverTrackingStatus } from './DriverTrackingStatus';
 import { HarvestTraceScanner } from './HarvestTraceScanner';
-
-function trackingMessage(state: DriverTrackingState) {
-    switch (state) {
-        case 'active':
-            return 'GPS praćenje je aktivno. Lokaciju vidi samo korisnik trenutačne dostavne stanice kada je ona na redu.';
-        case 'requesting':
-            return 'Čeka se dopuštenje za GPS lokaciju…';
-        case 'denied':
-            return 'Dopusti pristup lokaciji u pregledniku kako bi korisnici mogli pratiti dostavu.';
-        case 'unavailable':
-            return 'Ovaj uređaj ne podržava GPS praćenje u pregledniku.';
-        case 'error':
-            return 'Lokaciju trenutačno nije moguće poslati. Provjeri vezu i GPS postavke.';
-        default:
-            return null;
-    }
-}
 
 function routeEstimateSourceLabel(
     source: ActiveDeliveryRunSummary['estimateSource'],
@@ -312,7 +295,6 @@ export function DriverDashboard({
     onDiscardPickupSync: (operationId: string) => void | Promise<void>;
 }) {
     const run = dashboard.activeRun;
-    const locationMessage = trackingMessage(trackingState);
     const [selectedRequestIds, setSelectedRequestIdsState] = useState<string[]>(
         [],
     );
@@ -543,26 +525,7 @@ export function DriverDashboard({
 
                 {run ? (
                     <>
-                        {locationMessage ? (
-                            <Alert
-                                color={
-                                    trackingState === 'active'
-                                        ? 'success'
-                                        : trackingState === 'requesting'
-                                          ? 'info'
-                                          : 'warning'
-                                }
-                                startDecorator={
-                                    trackingState === 'active' ? (
-                                        <MyLocation className="size-5" />
-                                    ) : (
-                                        <Warning className="size-5" />
-                                    )
-                                }
-                            >
-                                {locationMessage}
-                            </Alert>
-                        ) : null}
+                        <DriverTrackingStatus tracking={trackingState} />
                         {run.reroutePending ? (
                             <Alert
                                 color="warning"

--- a/apps/delivery/components/DriverTrackingStatus.tsx
+++ b/apps/delivery/components/DriverTrackingStatus.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { MyLocation, Reset, Warning } from '@gredice/ui/icons';
+import { Typography } from '@gredice/ui/Typography';
+import type { DriverTrackingState } from '../hooks/useDriverTracking';
+import { formatDeliveryDateTime } from '../lib/deliveryFormatting';
+
+function lastConfirmationLabel(lastAcceptedAt: string | null) {
+    return lastAcceptedAt
+        ? ` Posljednja potvrda: ${formatDeliveryDateTime(lastAcceptedAt)}.`
+        : '';
+}
+
+type TrackingStatusContent = {
+    color: 'info' | 'success' | 'warning';
+    message: string;
+    action: 'retry' | 'permission' | 'refresh' | null;
+};
+
+function trackingStatusContent(
+    tracking: DriverTrackingState,
+): TrackingStatusContent | null {
+    const lastConfirmation = lastConfirmationLabel(tracking.lastAcceptedAt);
+    switch (tracking.status) {
+        case 'requesting':
+            return {
+                color: 'info',
+                message:
+                    'Čeka se GPS lokacija i dopuštenje preglednika. Praćenje još nije potvrđeno.',
+                action: null,
+            };
+        case 'sending':
+            return {
+                color: 'info',
+                message: tracking.lastAcceptedAt
+                    ? `Šalje se nova lokacija. Status će se osvježiti nakon potvrde poslužitelja.${lastConfirmation}`
+                    : 'Lokacija se šalje. Praćenje još nije potvrđeno.',
+                action: null,
+            };
+        case 'active':
+            return {
+                color: 'success',
+                message: `GPS praćenje je aktivno. Lokaciju vidi samo korisnik trenutačne dostavne stanice kada je ona na redu.${lastConfirmation}`,
+                action: null,
+            };
+        case 'delayed':
+            return {
+                color: 'warning',
+                message: `Posljednja potvrda lokacije kasni. Slanje se nastavlja dok je stranica vidljiva i aktivna; preglednik ga može pauzirati kada je skriven ili je zaslon zaključan.${lastConfirmation}`,
+                action: 'retry',
+            };
+        case 'retrying':
+            return {
+                color: 'warning',
+                message:
+                    tracking.reason === 'offline'
+                        ? tracking.sampleQueued
+                            ? `Nema internetske veze. Najnovija lokacija čeka slanje i uklonit će se ako zastari.${lastConfirmation}`
+                            : `Nema internetske veze. Slanje će se nastaviti nakon povratka veze i nove GPS lokacije.${lastConfirmation}`
+                        : `Slanje lokacije nije potvrđeno. Aplikacija će pokušati ponovno u sigurnim razmacima.${lastConfirmation}`,
+                action: tracking.reason === 'offline' ? null : 'retry',
+            };
+        case 'denied':
+            return {
+                color: 'warning',
+                message: `Pristup lokaciji je odbijen. Dopusti lokaciju u postavkama preglednika pa ponovno provjeri dopuštenje.${lastConfirmation}`,
+                action: 'permission',
+            };
+        case 'unavailable':
+            return {
+                color: 'warning',
+                message:
+                    tracking.reason === 'tracking-unsupported'
+                        ? `Ovaj uređaj ili preglednik ne podržava GPS praćenje.${lastConfirmation}`
+                        : tracking.reason === 'server-rejected'
+                          ? `Aktivna ruta ili prijava više ne prihvaća GPS lokaciju. Osvježi dostave i provjeri trenutačnu rutu.${lastConfirmation}`
+                          : tracking.reason === 'sample-expired'
+                            ? `Lokacija je istekla prije potvrde. Čeka se nova GPS lokacija.${lastConfirmation}`
+                            : tracking.reason === 'upload-rejected'
+                              ? `Poslužitelj nije prihvatio GPS zapis. Čeka se nova lokacija prije sljedećeg pokušaja.${lastConfirmation}`
+                              : `GPS lokacija trenutačno nije dostupna. Provjeri GPS postavke i pokušaj ponovno.${lastConfirmation}`,
+                action:
+                    tracking.reason === 'tracking-unsupported'
+                        ? null
+                        : tracking.reason === 'server-rejected'
+                          ? 'refresh'
+                          : 'retry',
+            };
+        case 'inactive':
+            return null;
+    }
+}
+
+export function DriverTrackingStatus({
+    tracking,
+}: {
+    tracking: DriverTrackingState;
+}) {
+    const content = trackingStatusContent(tracking);
+    if (!content) return null;
+    const announcement =
+        tracking.status === 'active'
+            ? 'GPS praćenje je potvrđeno i aktivno.'
+            : tracking.status === 'sending'
+              ? 'GPS lokacija se šalje i čeka potvrdu.'
+              : tracking.status === 'retrying'
+                ? 'Slanje GPS lokacije nije potvrđeno. Pokušaj će se ponoviti.'
+                : tracking.status === 'delayed'
+                  ? 'Potvrda GPS lokacije kasni.'
+                  : tracking.status === 'denied'
+                    ? 'Pristup GPS lokaciji je odbijen.'
+                    : tracking.status === 'unavailable'
+                      ? 'GPS praćenje trenutačno nije dostupno.'
+                      : 'Čeka se GPS lokacija.';
+
+    return (
+        <div>
+            <span className="sr-only" aria-live="polite" role="status">
+                {announcement}
+            </span>
+            <Alert
+                aria-label="Status GPS praćenja"
+                color={content.color}
+                role="group"
+                startDecorator={
+                    tracking.status === 'active' ? (
+                        <MyLocation className="size-5" />
+                    ) : (
+                        <Warning className="size-5" />
+                    )
+                }
+            >
+                <div className="flex w-full flex-wrap items-center justify-between gap-3">
+                    <Typography level="body2">{content.message}</Typography>
+                    {content.action ? (
+                        <Button
+                            color={content.color}
+                            size="sm"
+                            startDecorator={<Reset className="size-4" />}
+                            variant="soft"
+                            onClick={
+                                content.action === 'permission'
+                                    ? tracking.recheckPermission
+                                    : tracking.retryNow
+                            }
+                        >
+                            {content.action === 'permission'
+                                ? 'Ponovno provjeri dopuštenje'
+                                : content.action === 'refresh'
+                                  ? 'Osvježi dostave'
+                                  : 'Pokušaj sada'}
+                        </Button>
+                    ) : null}
+                </div>
+            </Alert>
+        </div>
+    );
+}

--- a/apps/delivery/hooks/useDriverTracking.ts
+++ b/apps/delivery/hooks/useDriverTracking.ts
@@ -1,83 +1,817 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { DeliveryTrackingFreshnessSummary } from '../lib/deliveryDashboardTypes';
+import {
+    classifyDriverLocationResponse,
+    type DriverLocationAcknowledgement,
+    type DriverLocationSample,
+    DriverTrackingController,
+    type DriverTrackingServerSeed,
+    type DriverTrackingViewState,
+    driverTrackingLiveThresholdMs,
+    driverTrackingSampleTtlMs,
+    driverTrackingUploadTimeoutMs,
+    initialDriverTrackingViewState,
+} from '../lib/driverTracking';
 
-export type DriverTrackingState =
-    | 'inactive'
-    | 'requesting'
-    | 'active'
-    | 'denied'
-    | 'unavailable'
-    | 'error';
+type UseDriverTrackingOptions = {
+    runId: string | null;
+    serverTracking: DeliveryTrackingFreshnessSummary | null;
+    dashboardRefreshedAt: string | null;
+    onDashboardRefresh?: () => void | Promise<void>;
+};
 
-const minimumUploadIntervalMs = 10_000;
+type TrackingControls = {
+    runId: string;
+    reconcileServerSeed: (seed: DriverTrackingServerSeed) => void;
+    recheckPermission: () => void;
+    retryNow: () => void;
+};
 
-export function useDriverTracking(runId: string | null) {
-    const [state, setState] = useState<DriverTrackingState>('inactive');
-    const lastUploadAt = useRef(0);
+export type DriverTrackingState = DriverTrackingViewState & {
+    retryNow: () => void;
+    recheckPermission: () => void;
+};
+
+function createLocationSample(
+    position: GeolocationPosition,
+    nowMonotonicMs: number,
+): DriverLocationSample | null {
+    const { latitude, longitude, accuracy, heading, speed } = position.coords;
+    if (
+        !Number.isFinite(latitude) ||
+        latitude < -90 ||
+        latitude > 90 ||
+        !Number.isFinite(longitude) ||
+        longitude < -180 ||
+        longitude > 180 ||
+        !Number.isFinite(position.timestamp)
+    ) {
+        return null;
+    }
+    const observedAtWallMs = Date.now();
+    const initialAgeMs = Math.max(0, observedAtWallMs - position.timestamp);
+    const remainingTtlMs = Math.max(
+        0,
+        driverTrackingSampleTtlMs - initialAgeMs,
+    );
+    return {
+        latitude,
+        longitude,
+        accuracy: Number.isFinite(accuracy) && accuracy >= 0 ? accuracy : null,
+        heading:
+            heading !== null &&
+            Number.isFinite(heading) &&
+            heading >= 0 &&
+            heading <= 360
+                ? heading
+                : null,
+        speed:
+            speed !== null && Number.isFinite(speed) && speed >= 0
+                ? speed
+                : null,
+        recordedAt: new Date(position.timestamp).toISOString(),
+        recordedAtMs: position.timestamp,
+        observedAtMonotonicMs: nowMonotonicMs,
+        expiresAtMonotonicMs: nowMonotonicMs + remainingTtlMs,
+        observedAtWallMs,
+        expiresAtWallMs: observedAtWallMs + remainingTtlMs,
+    };
+}
+
+export function useDriverTracking({
+    runId,
+    serverTracking,
+    dashboardRefreshedAt,
+    onDashboardRefresh,
+}: UseDriverTrackingOptions): DriverTrackingState {
+    const [viewState, setViewState] = useState<DriverTrackingViewState>(
+        initialDriverTrackingViewState,
+    );
+    const controlsRef = useRef<TrackingControls | null>(null);
+    const refreshDashboardRef = useRef(onDashboardRefresh);
+    const serverSeedRef = useRef<DriverTrackingServerSeed | null>(null);
+    refreshDashboardRef.current = onDashboardRefresh;
+    serverSeedRef.current =
+        serverTracking && dashboardRefreshedAt
+            ? { tracking: serverTracking, refreshedAt: dashboardRefreshedAt }
+            : null;
+
+    const retryNow = useCallback(() => {
+        controlsRef.current?.retryNow();
+    }, []);
+    const recheckPermission = useCallback(() => {
+        controlsRef.current?.recheckPermission();
+    }, []);
 
     useEffect(() => {
         if (!runId) {
-            setState('inactive');
-            return;
-        }
-        if (!('geolocation' in navigator)) {
-            setState('unavailable');
+            controlsRef.current = null;
+            setViewState(initialDriverTrackingViewState);
             return;
         }
 
-        setState('requesting');
-        lastUploadAt.current = 0;
+        const controller = new DriverTrackingController();
         let disposed = false;
-        const watchId = navigator.geolocation.watchPosition(
-            (position) => {
-                if (disposed) return;
-                setState('active');
-                const now = Date.now();
-                if (now - lastUploadAt.current < minimumUploadIntervalMs) {
+        let watchId: number | null = null;
+        let permissionStatus: PermissionStatus | null = null;
+        let timerId: ReturnType<typeof setTimeout> | null = null;
+        let timerTargetMonotonicMs: number | null = null;
+        let requestController: AbortController | null = null;
+        let requestGeneration = 0;
+        let networkOnline = navigator.onLine;
+        let permissionAllowsUpload = true;
+        let pendingPositionError:
+            | 'position-timeout'
+            | 'position-unavailable'
+            | null = null;
+        let state: DriverTrackingViewState = {
+            ...initialDriverTrackingViewState,
+            status: 'requesting',
+        };
+        setViewState(state);
+
+        const publish = (patch: Partial<DriverTrackingViewState>) => {
+            if (disposed) return;
+            state = { ...state, ...patch };
+            setViewState(state);
+        };
+
+        const requestDashboardRefresh = () => {
+            try {
+                const result = refreshDashboardRef.current?.();
+                if (result) void result.catch(() => undefined);
+            } catch {
+                // The regular dashboard poll remains the fallback.
+            }
+        };
+
+        const clearTimer = () => {
+            if (timerId !== null) clearTimeout(timerId);
+            timerId = null;
+            timerTargetMonotonicMs = null;
+        };
+
+        const currentAcknowledgementStatus = () =>
+            controller.acknowledgementStatus(performance.now(), Date.now()) ??
+            'requesting';
+
+        const refreshAcknowledgementFreshness = () => {
+            if (state.status !== 'active' && state.status !== 'delayed') return;
+            const status = currentAcknowledgementStatus();
+            if (status === 'delayed' && pendingPositionError) {
+                publish({
+                    status: 'unavailable',
+                    reason: pendingPositionError,
+                });
+                return;
+            }
+            if (status !== state.status) publish({ status });
+        };
+
+        const hasVisibleUnconfirmedFailure = () =>
+            state.status === 'retrying' ||
+            (state.status === 'unavailable' &&
+                (state.reason === 'upload-rejected' ||
+                    state.reason === 'server-rejected' ||
+                    state.reason === 'sample-expired'));
+
+        const scheduleTimerAt = (targetMonotonicMs: number) => {
+            if (
+                disposed ||
+                (timerTargetMonotonicMs !== null &&
+                    timerTargetMonotonicMs <= targetMonotonicMs)
+            ) {
+                return;
+            }
+            clearTimer();
+            timerTargetMonotonicMs = targetMonotonicMs;
+            timerId = setTimeout(
+                () => {
+                    timerId = null;
+                    timerTargetMonotonicMs = null;
+                    tick();
+                },
+                Math.max(0, targetMonotonicMs - performance.now()),
+            );
+        };
+
+        const scheduleFreshnessCheck = () => {
+            const acknowledgedAt = controller.acknowledgementMonotonicMs;
+            if (acknowledgedAt === null || state.status !== 'active') return;
+            scheduleTimerAt(acknowledgedAt + driverTrackingLiveThresholdMs + 1);
+        };
+
+        const publishExpiredSample = () => {
+            if (state.status === 'denied') {
+                publish({ nextRetryAt: null, sampleQueued: false });
+                return;
+            }
+            publish({
+                status: 'unavailable',
+                nextRetryAt: null,
+                sampleQueued: false,
+                reason: 'sample-expired',
+            });
+        };
+
+        const scheduleAttempt = (advance = false) => {
+            if (disposed || !controller.hasPendingSample) return;
+            if (controller.dropExpiredPending(performance.now(), Date.now())) {
+                publishExpiredSample();
+                return;
+            }
+            if (!permissionAllowsUpload) {
+                const expiresAt = controller.pendingExpiresAtMonotonicMs;
+                if (expiresAt !== null) scheduleTimerAt(expiresAt + 1);
+                return;
+            }
+            if (!networkOnline) {
+                clearTimer();
+                publish({
+                    status: 'retrying',
+                    reason: 'offline',
+                    nextRetryAt: null,
+                    sampleQueued: controller.hasPendingSample,
+                });
+                const expiresAt = controller.pendingExpiresAtMonotonicMs;
+                if (expiresAt !== null) scheduleTimerAt(expiresAt + 1);
+                return;
+            }
+            const now = performance.now();
+            const target = advance
+                ? controller.advanceRetry(now)
+                : controller.nextAttemptAt(now);
+            if (target === null) return;
+            scheduleTimerAt(target);
+            const expiresAt = controller.pendingExpiresAtMonotonicMs;
+            if (expiresAt !== null) scheduleTimerAt(expiresAt + 1);
+            scheduleFreshnessCheck();
+            publish({
+                nextRetryAt: new Date(
+                    Date.now() + Math.max(0, target - performance.now()),
+                ).toISOString(),
+                sampleQueued: controller.hasPendingSample,
+            });
+        };
+
+        const abortCurrentRequest = () => {
+            requestGeneration += 1;
+            requestController?.abort();
+            requestController = null;
+        };
+
+        const acknowledge = (
+            acknowledgement: DriverLocationAcknowledgement,
+            minimumInitialAgeMs: number,
+        ) => {
+            controller.acknowledge(
+                acknowledgement,
+                performance.now(),
+                Date.now(),
+                minimumInitialAgeMs,
+            );
+            publish({
+                status: currentAcknowledgementStatus(),
+                lastAcceptedAt: controller.lastAcceptedAt,
+                nextRetryAt: null,
+                retryAttempt: 0,
+                sampleQueued: controller.hasPendingSample,
+                reason: null,
+            });
+        };
+
+        const attemptUpload = async () => {
+            if (disposed || !networkOnline || !permissionAllowsUpload) return;
+            const attemptStartedAtMonotonicMs = performance.now();
+            const attemptStartedAtWallMs = Date.now();
+            const attempt = controller.beginAttempt(
+                attemptStartedAtMonotonicMs,
+                attemptStartedAtWallMs,
+            );
+            if (attempt.kind === 'expired') {
+                publishExpiredSample();
+                return;
+            }
+            if (attempt.kind === 'wait') {
+                scheduleTimerAt(attempt.eligibleAtMonotonicMs);
+                scheduleFreshnessCheck();
+                return;
+            }
+            if (attempt.kind !== 'send') {
+                scheduleFreshnessCheck();
+                return;
+            }
+
+            const retrying = controller.retryAttempt > 0;
+            const visibleFailure = hasVisibleUnconfirmedFailure();
+            const request = new AbortController();
+            requestController = request;
+            const currentRequestGeneration = ++requestGeneration;
+            publish({
+                status: visibleFailure
+                    ? state.status
+                    : retrying
+                      ? 'retrying'
+                      : controller.lastAcceptedAt
+                        ? currentAcknowledgementStatus()
+                        : 'sending',
+                lastAttemptAt: new Date().toISOString(),
+                nextRetryAt: null,
+                sampleQueued: controller.hasPendingSample,
+                reason: visibleFailure || retrying ? state.reason : null,
+            });
+            scheduleFreshnessCheck();
+
+            let result: ReturnType<typeof classifyDriverLocationResponse>;
+            const uploadTimeoutId = setTimeout(
+                () => request.abort(),
+                driverTrackingUploadTimeoutMs,
+            );
+            try {
+                const response = await fetch(
+                    `/api/driver/runs/${runId}/location`,
+                    {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            latitude: attempt.sample.latitude,
+                            longitude: attempt.sample.longitude,
+                            accuracy: attempt.sample.accuracy,
+                            heading: attempt.sample.heading,
+                            speed: attempt.sample.speed,
+                            recordedAt: attempt.sample.recordedAt,
+                        }),
+                        signal: request.signal,
+                    },
+                );
+                const body: unknown = await response.json().catch(() => null);
+                result = classifyDriverLocationResponse({
+                    status: response.status,
+                    body,
+                    retryAfter: response.headers.get('Retry-After'),
+                });
+            } catch {
+                result = { kind: 'retry', retryAfterMs: null };
+            } finally {
+                clearTimeout(uploadTimeoutId);
+            }
+
+            if (disposed || currentRequestGeneration !== requestGeneration) {
+                return;
+            }
+            requestController = null;
+
+            if (result.kind === 'acknowledged') {
+                acknowledge(
+                    result.acknowledgement,
+                    Math.max(
+                        0,
+                        performance.now() - attemptStartedAtMonotonicMs,
+                        Date.now() - attemptStartedAtWallMs,
+                    ),
+                );
+                if (
+                    result.acknowledgement.status === 'offline' ||
+                    result.acknowledgement.status === 'unavailable'
+                ) {
+                    requestDashboardRefresh();
+                }
+                if (controller.hasPendingSample) scheduleAttempt();
+                else scheduleFreshnessCheck();
+                return;
+            }
+            if (result.kind === 'retry') {
+                const retry = controller.retryInFlight({
+                    nowMonotonicMs: performance.now(),
+                    retryAfterMs: result.retryAfterMs,
+                    randomValue: Math.random(),
+                });
+                if (!retry) return;
+                publish({
+                    status: 'retrying',
+                    retryAttempt: retry.retryAttempt,
+                    sampleQueued: controller.hasPendingSample,
+                    reason: networkOnline ? 'upload-failed' : 'offline',
+                });
+                scheduleAttempt();
+                return;
+            }
+
+            if (result.kind === 'reconcile') {
+                controller.reconcileInFlight();
+                publish({
+                    status: 'unavailable',
+                    nextRetryAt: null,
+                    retryAttempt: 0,
+                    sampleQueued: controller.hasPendingSample,
+                    reason: 'upload-rejected',
+                });
+                requestDashboardRefresh();
+                if (controller.hasPendingSample) scheduleAttempt();
+                return;
+            }
+
+            controller.rejectInFlight({
+                acceptNewSample: result.acceptNewSample,
+            });
+            publish({
+                status: 'unavailable',
+                nextRetryAt: null,
+                retryAttempt: 0,
+                sampleQueued: controller.hasPendingSample,
+                reason:
+                    result.reason === 'server-rejected'
+                        ? 'server-rejected'
+                        : 'upload-rejected',
+            });
+            if (result.reason === 'server-rejected') {
+                pendingPositionError = null;
+                freshPositionGeneration += 1;
+                freshPositionPending = false;
+                stopWatch();
+                requestDashboardRefresh();
+            } else if (controller.hasPendingSample) {
+                scheduleAttempt();
+            }
+        };
+
+        function tick() {
+            if (disposed) return;
+            refreshAcknowledgementFreshness();
+            if (controller.dropExpiredPending(performance.now(), Date.now())) {
+                publishExpiredSample();
+                scheduleFreshnessCheck();
+                return;
+            }
+            if (controller.hasPendingSample) {
+                void attemptUpload();
+                return;
+            }
+            scheduleFreshnessCheck();
+        }
+
+        const stopWatch = () => {
+            if (watchId !== null) navigator.geolocation.clearWatch(watchId);
+            watchId = null;
+        };
+
+        const permissionDenied = () => {
+            permissionAllowsUpload = false;
+            pendingPositionError = null;
+            freshPositionGeneration += 1;
+            freshPositionPending = false;
+            stopWatch();
+            clearTimer();
+            abortCurrentRequest();
+            controller.blockAndDiscardExactSamples();
+            publish({
+                status: 'denied',
+                nextRetryAt: null,
+                retryAttempt: 0,
+                sampleQueued: false,
+                reason: 'permission-denied',
+            });
+        };
+
+        const handlePosition = (position: GeolocationPosition) => {
+            if (
+                disposed ||
+                !permissionAllowsUpload ||
+                state.reason === 'server-rejected'
+            ) {
+                return;
+            }
+            const sample = createLocationSample(position, performance.now());
+            if (!sample) {
+                if (
+                    state.status === 'retrying' ||
+                    controller.hasPendingSample ||
+                    controller.hasInFlightSample ||
+                    controller.acknowledgementMonotonicMs !== null
+                ) {
                     return;
                 }
-                lastUploadAt.current = now;
-                void fetch(`/api/driver/runs/${runId}/location`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        latitude: position.coords.latitude,
-                        longitude: position.coords.longitude,
-                        accuracy: position.coords.accuracy,
-                        heading: position.coords.heading,
-                        speed: position.coords.speed,
-                        recordedAt: new Date(position.timestamp).toISOString(),
-                    }),
-                })
-                    .then((response) => {
-                        if (!disposed && !response.ok) setState('error');
-                    })
-                    .catch(() => {
-                        if (!disposed) setState('error');
-                    });
+                publish({
+                    status: 'unavailable',
+                    reason: 'position-unavailable',
+                });
+                return;
+            }
+            pendingPositionError = null;
+            if (controller.queueSample(sample)) {
+                publish({ sampleQueued: true });
+                scheduleAttempt();
+            }
+        };
+
+        const handlePositionError = (error: GeolocationPositionError) => {
+            if (
+                disposed ||
+                !permissionAllowsUpload ||
+                state.reason === 'server-rejected'
+            ) {
+                return;
+            }
+            if (error.code === 1) {
+                permissionDenied();
+                return;
+            }
+            if (
+                (state.status === 'retrying' && state.reason !== 'offline') ||
+                controller.hasPendingSample ||
+                controller.hasInFlightSample
+            ) {
+                return;
+            }
+            pendingPositionError =
+                error.code === 3 ? 'position-timeout' : 'position-unavailable';
+            if (
+                controller.acknowledgementMonotonicMs !== null &&
+                currentAcknowledgementStatus() === 'active'
+            ) {
+                scheduleFreshnessCheck();
+                return;
+            }
+            publish({
+                status: 'unavailable',
+                nextRetryAt: null,
+                reason: pendingPositionError,
+            });
+        };
+
+        let freshPositionPending = false;
+        let freshPositionGeneration = 0;
+        const requestFreshPosition = () => {
+            if (
+                disposed ||
+                freshPositionPending ||
+                !permissionAllowsUpload ||
+                !('geolocation' in navigator)
+            ) {
+                return;
+            }
+            freshPositionPending = true;
+            const generation = ++freshPositionGeneration;
+            navigator.geolocation.getCurrentPosition(
+                (position) => {
+                    if (generation !== freshPositionGeneration) return;
+                    freshPositionPending = false;
+                    handlePosition(position);
+                },
+                (error) => {
+                    if (generation !== freshPositionGeneration) return;
+                    freshPositionPending = false;
+                    handlePositionError(error);
+                },
+                {
+                    enableHighAccuracy: true,
+                    maximumAge: 0,
+                    timeout: 20_000,
+                },
+            );
+        };
+
+        const startWatch = () => {
+            if (
+                disposed ||
+                watchId !== null ||
+                !permissionAllowsUpload ||
+                state.reason === 'server-rejected' ||
+                !('geolocation' in navigator)
+            ) {
+                return;
+            }
+            if (
+                networkOnline &&
+                controller.acknowledgementMonotonicMs === null
+            ) {
+                publish({ status: 'requesting', reason: null });
+            }
+            watchId = navigator.geolocation.watchPosition(
+                handlePosition,
+                handlePositionError,
+                {
+                    enableHighAccuracy: true,
+                    maximumAge: 5_000,
+                    timeout: 20_000,
+                },
+            );
+        };
+
+        const allowPermissionUploadsAndStartWatch = () => {
+            controller.allowPermissionUploads();
+            permissionAllowsUpload = true;
+            startWatch();
+        };
+
+        const handlePermissionChange = () => {
+            if (permissionStatus?.state === 'denied') {
+                permissionDenied();
+                return;
+            }
+            allowPermissionUploadsAndStartWatch();
+            if (controller.hasPendingSample) scheduleAttempt(true);
+        };
+
+        const queryPermission = async () => {
+            if (!navigator.permissions?.query) {
+                allowPermissionUploadsAndStartWatch();
+                return;
+            }
+            try {
+                const status = await navigator.permissions.query({
+                    name: 'geolocation',
+                });
+                if (disposed) return;
+                permissionStatus?.removeEventListener(
+                    'change',
+                    handlePermissionChange,
+                );
+                permissionStatus = status;
+                permissionStatus.addEventListener(
+                    'change',
+                    handlePermissionChange,
+                );
+                handlePermissionChange();
+            } catch {
+                allowPermissionUploadsAndStartWatch();
+            }
+        };
+
+        const reconcileServerSeed = (seed: DriverTrackingServerSeed) => {
+            const previousAcceptedAt = controller.lastAcceptedAt;
+            const parsed = controller.reconcileServerSeed(
+                seed,
+                performance.now(),
+                Date.now(),
+            );
+            if (!parsed) return;
+            const strictlyNewerAcknowledgement =
+                previousAcceptedAt === null ||
+                Date.parse(parsed.acceptedAt) > Date.parse(previousAcceptedAt);
+            const recoveringServerRejection =
+                state.reason === 'server-rejected' &&
+                strictlyNewerAcknowledgement;
+            const permissionOverridesFreshness =
+                state.status === 'denied' ||
+                (state.status === 'unavailable' &&
+                    state.reason === 'tracking-unsupported') ||
+                (hasVisibleUnconfirmedFailure() &&
+                    !strictlyNewerAcknowledgement);
+            publish({
+                ...(permissionOverridesFreshness
+                    ? {}
+                    : { status: parsed.status }),
+                lastAcceptedAt: parsed.acceptedAt,
+                ...(strictlyNewerAcknowledgement
+                    ? { nextRetryAt: null, retryAttempt: 0 }
+                    : {}),
+                reason: permissionOverridesFreshness ? state.reason : null,
+            });
+            if (
+                recoveringServerRejection &&
+                permissionAllowsUpload &&
+                'geolocation' in navigator
+            ) {
+                startWatch();
+                if (controller.hasPendingSample) scheduleAttempt();
+            }
+            scheduleFreshnessCheck();
+        };
+
+        const advanceRetry = () => {
+            if (disposed) return;
+            if (state.reason === 'server-rejected') {
+                requestDashboardRefresh();
+                return;
+            }
+            refreshAcknowledgementFreshness();
+            if (controller.hasPendingSample) scheduleAttempt(true);
+            else requestFreshPosition();
+        };
+        const handleOnline = () => {
+            networkOnline = true;
+            if (state.reason === 'offline') {
+                const queuedExactSample =
+                    controller.hasPendingSample || controller.hasInFlightSample;
+                publish({
+                    status: queuedExactSample
+                        ? 'retrying'
+                        : (controller.acknowledgementStatus(
+                              performance.now(),
+                              Date.now(),
+                          ) ?? 'requesting'),
+                    reason: queuedExactSample ? 'upload-failed' : null,
+                    nextRetryAt: null,
+                    sampleQueued: controller.hasPendingSample,
+                });
+            }
+            advanceRetry();
+        };
+        const handleOffline = () => {
+            networkOnline = false;
+            clearTimer();
+            if (
+                state.status === 'denied' ||
+                state.reason === 'tracking-unsupported' ||
+                state.reason === 'server-rejected'
+            ) {
+                return;
+            }
+            if (!controller.hasPendingSample && !controller.hasInFlightSample) {
+                publish({
+                    status: 'retrying',
+                    nextRetryAt: null,
+                    sampleQueued: false,
+                    reason: 'offline',
+                });
+                return;
+            }
+            publish({
+                status: 'retrying',
+                nextRetryAt: null,
+                sampleQueued: controller.hasPendingSample,
+                reason: 'offline',
+            });
+            scheduleAttempt();
+        };
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'visible') advanceRetry();
+        };
+
+        const initialSeed = serverSeedRef.current;
+        if (initialSeed) reconcileServerSeed(initialSeed);
+        controlsRef.current = {
+            runId,
+            reconcileServerSeed,
+            retryNow: advanceRetry,
+            recheckPermission: () => {
+                publish({ status: 'requesting', reason: null });
+                void queryPermission();
             },
-            (error) => {
-                if (!disposed) {
-                    setState(
-                        error.code === error.PERMISSION_DENIED
-                            ? 'denied'
-                            : 'error',
-                    );
+        };
+
+        if (!('geolocation' in navigator)) {
+            publish({
+                status: 'unavailable',
+                reason: 'tracking-unsupported',
+            });
+            return () => {
+                disposed = true;
+                if (controlsRef.current?.runId === runId) {
+                    controlsRef.current = null;
                 }
-            },
-            {
-                enableHighAccuracy: true,
-                maximumAge: 5_000,
-                timeout: 20_000,
-            },
-        );
+                controller.discard();
+            };
+        }
+
+        window.addEventListener('online', handleOnline);
+        window.addEventListener('offline', handleOffline);
+        window.addEventListener('pageshow', advanceRetry);
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        if (!networkOnline) handleOffline();
+        void queryPermission();
 
         return () => {
             disposed = true;
-            navigator.geolocation.clearWatch(watchId);
+            freshPositionGeneration += 1;
+            freshPositionPending = false;
+            if (controlsRef.current?.runId === runId) {
+                controlsRef.current = null;
+            }
+            stopWatch();
+            clearTimer();
+            permissionStatus?.removeEventListener(
+                'change',
+                handlePermissionChange,
+            );
+            window.removeEventListener('online', handleOnline);
+            window.removeEventListener('offline', handleOffline);
+            window.removeEventListener('pageshow', advanceRetry);
+            document.removeEventListener(
+                'visibilitychange',
+                handleVisibilityChange,
+            );
+            abortCurrentRequest();
+            controller.discard();
         };
     }, [runId]);
 
-    return state;
+    useEffect(() => {
+        if (!runId || !serverTracking || !dashboardRefreshedAt) return;
+        const controls = controlsRef.current;
+        if (controls?.runId !== runId) return;
+        controls.reconcileServerSeed({
+            tracking: serverTracking,
+            refreshedAt: dashboardRefreshedAt,
+        });
+    }, [dashboardRefreshedAt, runId, serverTracking]);
+
+    return {
+        ...viewState,
+        retryNow,
+        recheckPermission,
+    };
 }

--- a/apps/delivery/lib/deliveryTracking.node.spec.ts
+++ b/apps/delivery/lib/deliveryTracking.node.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    DeliveryRunExecutionError,
+    DeliveryRunExecutionErrorCodes,
     deliveryRunExactLocationTtlMs,
     deliveryRunTrackingLiveThresholdMs,
 } from '@gredice/storage';
@@ -8,6 +10,7 @@ import {
     customerDeliveryTrackingSummary,
     type DeliveryTrackingSnapshot,
     deliveryLocationCaptureTimeIsAcceptable,
+    deliveryLocationErrorStatus,
     deliveryTrackingRecoveryTransition,
     deliveryTrackingStatus,
     driverDeliveryTrackingLocation,
@@ -15,6 +18,39 @@ import {
 import { deliveryTrackingMapVersion } from './deliveryTrackingPresentation';
 
 const acceptedAt = new Date('2026-07-15T10:00:00.000Z');
+
+test('location endpoint retries unknown failures but preserves known domain statuses', () => {
+    assert.equal(deliveryLocationErrorStatus(new Error('storage down')), 500);
+    assert.equal(
+        deliveryLocationErrorStatus(
+            new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND,
+                'missing run',
+            ),
+        ),
+        404,
+    );
+    for (const code of [
+        DeliveryRunExecutionErrorCodes.LOCATION_STALE,
+        DeliveryRunExecutionErrorCodes.LOCATION_CONFLICT,
+    ]) {
+        assert.equal(
+            deliveryLocationErrorStatus(
+                new DeliveryRunExecutionError(code, 'location conflict'),
+            ),
+            409,
+        );
+    }
+    assert.equal(
+        deliveryLocationErrorStatus(
+            new DeliveryRunExecutionError(
+                DeliveryRunExecutionErrorCodes.ROUTE_ORDER,
+                'unexpected domain failure',
+            ),
+        ),
+        500,
+    );
+});
 
 function snapshot(
     overrides: Partial<DeliveryTrackingSnapshot> = {},

--- a/apps/delivery/lib/deliveryTracking.ts
+++ b/apps/delivery/lib/deliveryTracking.ts
@@ -1,4 +1,6 @@
 import {
+    DeliveryRunExecutionError,
+    DeliveryRunExecutionErrorCodes,
     DeliveryRunStates,
     deliveryRunExactLocationTtlMs,
     deliveryRunTrackingLiveThresholdMs,
@@ -10,6 +12,20 @@ import type {
 } from './deliveryDashboardTypes';
 
 const maximumLocationClockSkewMs = 5 * 60 * 1000;
+
+export function deliveryLocationErrorStatus(error: unknown) {
+    if (!(error instanceof DeliveryRunExecutionError)) return 500;
+    if (error.code === DeliveryRunExecutionErrorCodes.ACTIVE_RUN_NOT_FOUND) {
+        return 404;
+    }
+    if (
+        error.code === DeliveryRunExecutionErrorCodes.LOCATION_STALE ||
+        error.code === DeliveryRunExecutionErrorCodes.LOCATION_CONFLICT
+    ) {
+        return 409;
+    }
+    return 500;
+}
 
 export type DeliveryTrackingSnapshot = {
     state: string;

--- a/apps/delivery/lib/driverTracking.node.spec.ts
+++ b/apps/delivery/lib/driverTracking.node.spec.ts
@@ -1,0 +1,570 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    deliveryRunExactLocationTtlMs,
+    deliveryRunTrackingLiveThresholdMs,
+} from '@gredice/storage';
+import {
+    classifyDriverLocationResponse,
+    type DriverLocationSample,
+    DriverTrackingController,
+    driverLocationSampleIsExpired,
+    driverTrackingLiveThresholdMs,
+    driverTrackingMaximumRetryDelayMs,
+    driverTrackingMinimumAttemptIntervalMs,
+    driverTrackingNextAttemptAt,
+    driverTrackingRetryDelayMs,
+    driverTrackingSampleTtlMs,
+    driverTrackingServerSeedIsNewer,
+    driverTrackingStatusAfterElapsed,
+    driverTrackingUploadTimeoutMs,
+    initialDriverTrackingViewState,
+    parseDriverLocationAcknowledgement,
+    parseDriverTrackingServerSeed,
+    parseRetryAfterMs,
+    selectNewestDriverLocationSample,
+} from './driverTracking';
+
+function sample(
+    recordedAtMs: number,
+    overrides: Partial<DriverLocationSample> = {},
+): DriverLocationSample {
+    return {
+        latitude: 45.81,
+        longitude: 15.98,
+        accuracy: 8,
+        heading: 90,
+        speed: 6,
+        recordedAt: new Date(recordedAtMs).toISOString(),
+        recordedAtMs,
+        observedAtMonotonicMs: 1_000,
+        expiresAtMonotonicMs: 1_000 + driverTrackingSampleTtlMs,
+        observedAtWallMs: 1_000,
+        expiresAtWallMs: 1_000 + driverTrackingSampleTtlMs,
+        ...overrides,
+    };
+}
+
+test('client freshness and TTL thresholds stay aligned with the server contract', () => {
+    assert.equal(
+        driverTrackingLiveThresholdMs,
+        deliveryRunTrackingLiveThresholdMs,
+    );
+    assert.equal(driverTrackingSampleTtlMs, deliveryRunExactLocationTtlMs);
+});
+
+test('only a complete server acknowledgement can establish an accepted location', () => {
+    const acknowledged = parseDriverLocationAcknowledgement({
+        status: 'live',
+        acceptedAt: '2026-07-15T12:00:00.000Z',
+        refreshedAt: '2026-07-15T12:00:01.000Z',
+        replayed: false,
+    });
+    assert.deepEqual(acknowledged, {
+        status: 'live',
+        acceptedAt: '2026-07-15T12:00:00.000Z',
+        refreshedAt: '2026-07-15T12:00:01.000Z',
+        replayed: false,
+    });
+    assert.equal(
+        parseDriverLocationAcknowledgement({
+            status: 'live',
+            acceptedAt: 'not-a-date',
+            refreshedAt: '2026-07-15T12:00:01.000Z',
+            replayed: false,
+        }),
+        null,
+    );
+    assert.equal(
+        parseDriverLocationAcknowledgement({
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:00.000Z',
+            refreshedAt: '2026-07-15T12:00:01.000Z',
+        }),
+        null,
+    );
+    assert.equal(initialDriverTrackingViewState.status, 'inactive');
+    assert.equal(initialDriverTrackingViewState.lastAcceptedAt, null);
+});
+
+test('bursts retain only the newest unsent sample and equal timestamps preserve the original replay payload', () => {
+    const first = sample(1_000, { latitude: 45.1 });
+    const middle = sample(2_000, { latitude: 45.2 });
+    const latest = sample(3_000, { latitude: 45.3 });
+    const equalTimestampDifferentPayload = sample(3_000, { latitude: 46.3 });
+
+    assert.equal(selectNewestDriverLocationSample(first, middle), middle);
+    assert.equal(selectNewestDriverLocationSample(middle, latest), latest);
+    assert.equal(
+        selectNewestDriverLocationSample(
+            latest,
+            equalTimestampDifferentPayload,
+        ),
+        latest,
+    );
+    assert.equal(
+        selectNewestDriverLocationSample(latest, equalTimestampDifferentPayload)
+            .latitude,
+        45.3,
+    );
+});
+
+test('controller keeps one immutable in-flight sample and retries only the newest pending sample', () => {
+    const controller = new DriverTrackingController();
+    const first = sample(1_000, { latitude: 45.1 });
+    const middle = sample(2_000, { latitude: 45.2 });
+    const latest = sample(3_000, { latitude: 45.3 });
+    assert.equal(controller.queueSample(first), true);
+    const firstAttempt = controller.beginAttempt(1_000, 1_000);
+    assert.equal(firstAttempt.kind, 'send');
+    assert.equal(controller.beginAttempt(1_001, 1_001).kind, 'none');
+
+    assert.equal(controller.queueSample(middle), true);
+    assert.equal(controller.queueSample(latest), true);
+    const retry = controller.retryInFlight({
+        nowMonotonicMs: 2_000,
+        retryAfterMs: null,
+        randomValue: 0.5,
+    });
+    assert.equal(retry?.retryAttempt, 1);
+    assert.equal(retry?.eligibleAtMonotonicMs, 11_000);
+    assert.equal(controller.beginAttempt(10_999, 10_999).kind, 'wait');
+    const retried = controller.beginAttempt(11_000, 11_000);
+    assert.equal(retried.kind, 'send');
+    if (retried.kind === 'send') assert.equal(retried.sample, latest);
+});
+
+test('equal-timestamp callbacks cannot mutate an ambiguous replay payload', () => {
+    const controller = new DriverTrackingController();
+    const original = sample(1_000, { latitude: 45.1, heading: 10 });
+    const conflicting = sample(1_000, { latitude: 46.1, heading: 20 });
+    controller.queueSample(original);
+    assert.equal(controller.beginAttempt(1_000, 1_000).kind, 'send');
+    assert.equal(controller.queueSample(conflicting), false);
+    controller.retryInFlight({
+        nowMonotonicMs: 2_000,
+        retryAfterMs: null,
+        randomValue: 0.5,
+    });
+    const replay = controller.beginAttempt(11_000, 11_000);
+    assert.equal(replay.kind, 'send');
+    if (replay.kind === 'send') {
+        assert.equal(replay.sample, original);
+        assert.equal(replay.sample.latitude, 45.1);
+        assert.equal(replay.sample.heading, 10);
+    }
+    controller.acknowledge(
+        {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:00.000Z',
+            refreshedAt: '2026-07-15T12:00:01.000Z',
+            replayed: true,
+        },
+        12_000,
+        12_000,
+    );
+    assert.equal(controller.queueSample(conflicting), false);
+    assert.equal(controller.queueSample(sample(999)), false);
+    assert.equal(controller.queueSample(sample(2_000)), true);
+});
+
+test('new GPS callbacks do not reset retry backoff or hide the failure count', () => {
+    const controller = new DriverTrackingController();
+    controller.queueSample(sample(1_000));
+    controller.beginAttempt(1_000, 1_000);
+    const failed = controller.retryInFlight({
+        nowMonotonicMs: 2_000,
+        retryAfterMs: 40_000,
+        randomValue: 0.5,
+    });
+    assert.equal(failed?.eligibleAtMonotonicMs, 42_000);
+    controller.queueSample(sample(2_000));
+    assert.equal(controller.retryAttempt, 1);
+    assert.equal(controller.nextAttemptAt(3_000), 42_000);
+    assert.equal(controller.beginAttempt(41_999, 41_999).kind, 'wait');
+});
+
+test('acknowledgement resets retries while pending newer telemetry still respects throttle', () => {
+    const controller = new DriverTrackingController();
+    controller.queueSample(sample(1_000));
+    controller.beginAttempt(1_000, 1_000);
+    controller.queueSample(sample(2_000));
+    controller.retryInFlight({
+        nowMonotonicMs: 2_000,
+        retryAfterMs: null,
+        randomValue: 0.5,
+    });
+    controller.beginAttempt(11_000, 11_000);
+    controller.acknowledge(
+        {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:00.000Z',
+            refreshedAt: '2026-07-15T12:00:01.000Z',
+            replayed: false,
+        },
+        12_000,
+        Date.parse('2026-07-15T12:00:00.000Z'),
+    );
+    assert.equal(controller.retryAttempt, 0);
+    assert.equal(controller.lastAcceptedAt, '2026-07-15T12:00:00.000Z');
+
+    controller.queueSample(sample(3_000));
+    assert.equal(controller.beginAttempt(20_999, 20_999).kind, 'wait');
+    assert.equal(controller.beginAttempt(21_000, 21_000).kind, 'send');
+});
+
+test('permission revocation discards exact samples and resets retry bookkeeping', () => {
+    const controller = new DriverTrackingController();
+    controller.queueSample(sample(1_000));
+    controller.beginAttempt(1_000, 1_000);
+    controller.retryInFlight({
+        nowMonotonicMs: 2_000,
+        retryAfterMs: 40_000,
+        randomValue: 0.5,
+    });
+    assert.equal(controller.retryAttempt, 1);
+    controller.blockAndDiscardExactSamples();
+    assert.equal(controller.hasInFlightSample, false);
+    assert.equal(controller.hasPendingSample, false);
+    assert.equal(controller.retryAttempt, 0);
+    assert.equal(controller.beginAttempt(20_000, 20_000).kind, 'blocked');
+    controller.allowPermissionUploads();
+    controller.queueSample(sample(2_000));
+    assert.equal(controller.nextAttemptAt(20_000), 20_000);
+    controller.discard();
+    assert.equal(controller.hasPendingSample, false);
+    assert.equal(controller.beginAttempt(20_000, 20_000).kind, 'blocked');
+});
+
+test('permanent rejection drops newer pending telemetry while a sample rejection can continue with it', () => {
+    const blocked = new DriverTrackingController();
+    blocked.queueSample(sample(1_000));
+    blocked.beginAttempt(1_000, 1_000);
+    blocked.queueSample(sample(2_000));
+    blocked.rejectInFlight({ acceptNewSample: false });
+    assert.equal(blocked.hasPendingSample, false);
+    assert.equal(blocked.beginAttempt(20_000, 20_000).kind, 'blocked');
+    blocked.reconcileServerSeed(
+        {
+            tracking: {
+                status: 'live',
+                lastAcceptedAt: '2026-07-15T12:00:10.000Z',
+                mapAvailable: true,
+            },
+            refreshedAt: '2026-07-15T12:00:11.000Z',
+        },
+        20_000,
+        20_000,
+    );
+    assert.equal(blocked.retryAttempt, 0);
+    assert.equal(blocked.queueSample(sample(3_000)), true);
+    assert.equal(blocked.beginAttempt(20_000, 20_000).kind, 'send');
+
+    const recoverable = new DriverTrackingController();
+    recoverable.queueSample(sample(1_000));
+    recoverable.beginAttempt(1_000, 1_000);
+    recoverable.queueSample(sample(2_000));
+    recoverable.rejectInFlight({ acceptNewSample: true });
+    assert.equal(recoverable.hasPendingSample, true);
+    assert.equal(recoverable.beginAttempt(10_999, 10_999).kind, 'wait');
+    assert.equal(recoverable.beginAttempt(11_000, 11_000).kind, 'send');
+});
+
+test('late acknowledgements cannot regress a newer seed and equal seeds can age it conservatively', () => {
+    const controller = new DriverTrackingController();
+    const newerSeed = controller.reconcileServerSeed(
+        {
+            tracking: {
+                status: 'live',
+                lastAcceptedAt: '2026-07-15T12:00:10.000Z',
+                mapAvailable: true,
+            },
+            refreshedAt: '2026-07-15T12:00:11.000Z',
+        },
+        1_000,
+        100_000,
+    );
+    assert.equal(newerSeed?.status, 'active');
+    assert.equal(
+        controller.acknowledge(
+            {
+                status: 'live',
+                acceptedAt: '2026-07-15T12:00:05.000Z',
+                refreshedAt: '2026-07-15T12:00:06.000Z',
+                replayed: false,
+            },
+            2_000,
+            101_000,
+        ),
+        false,
+    );
+    assert.equal(controller.lastAcceptedAt, '2026-07-15T12:00:10.000Z');
+
+    const equalButOlder = controller.reconcileServerSeed(
+        {
+            tracking: {
+                status: 'delayed',
+                lastAcceptedAt: '2026-07-15T12:00:10.000Z',
+                mapAvailable: true,
+            },
+            refreshedAt: '2026-07-15T12:00:41.000Z',
+        },
+        2_000,
+        101_000,
+    );
+    assert.equal(equalButOlder?.status, 'delayed');
+    assert.equal(controller.acknowledgementStatus(2_000, 101_000), 'delayed');
+});
+
+test('wall elapsed time catches sleep even if the monotonic clock pauses', () => {
+    const controller = new DriverTrackingController();
+    controller.acknowledge(
+        {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:00.000Z',
+            refreshedAt: '2026-07-15T12:00:00.000Z',
+            replayed: false,
+        },
+        5_000,
+        100_000,
+    );
+    assert.equal(controller.acknowledgementStatus(5_000, 100_000), 'active');
+    assert.equal(controller.acknowledgementStatus(5_000, 130_001), 'delayed');
+    assert.equal(driverTrackingUploadTimeoutMs, 20_000);
+});
+
+test('acknowledgement freshness includes server processing age', () => {
+    const controller = new DriverTrackingController();
+    controller.acknowledge(
+        {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:00.000Z',
+            refreshedAt: '2026-07-15T12:00:15.000Z',
+            replayed: false,
+        },
+        50_000,
+        100_000,
+    );
+    assert.equal(controller.acknowledgementStatus(64_999, 114_999), 'active');
+    assert.equal(controller.acknowledgementStatus(65_001, 115_001), 'delayed');
+
+    const transitController = new DriverTrackingController();
+    transitController.acknowledge(
+        {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:00.000Z',
+            refreshedAt: '2026-07-15T12:00:00.000Z',
+            replayed: false,
+        },
+        50_000,
+        100_000,
+        19_000,
+    );
+    assert.equal(
+        transitController.acknowledgementStatus(61_000, 111_000),
+        'active',
+    );
+    assert.equal(
+        transitController.acknowledgementStatus(61_001, 111_001),
+        'delayed',
+    );
+});
+
+test('retry backoff grows within jitter bounds and remains capped', () => {
+    assert.equal(
+        driverTrackingRetryDelayMs({ retryAttempt: 1, randomValue: 0 }),
+        4_000,
+    );
+    assert.equal(
+        driverTrackingRetryDelayMs({ retryAttempt: 1, randomValue: 1 }),
+        6_000,
+    );
+    assert.equal(
+        driverTrackingRetryDelayMs({ retryAttempt: 2, randomValue: 0 }),
+        8_000,
+    );
+    assert.equal(
+        driverTrackingRetryDelayMs({ retryAttempt: 4, randomValue: 0.5 }),
+        40_000,
+    );
+    assert.equal(
+        driverTrackingRetryDelayMs({ retryAttempt: 12, randomValue: 1 }),
+        driverTrackingMaximumRetryDelayMs,
+    );
+    assert.equal(
+        driverTrackingRetryDelayMs({
+            retryAttempt: 2,
+            randomValue: 0,
+            retryAfterMs: 90_000,
+        }),
+        driverTrackingMaximumRetryDelayMs,
+    );
+});
+
+test('every attempt respects the minimum interval even when retry is advanced', () => {
+    assert.equal(
+        driverTrackingNextAttemptAt({
+            nowMonotonicMs: 12_000,
+            lastAttemptAtMonotonicMs: 10_000,
+            requestedDelayMs: 0,
+        }),
+        10_000 + driverTrackingMinimumAttemptIntervalMs,
+    );
+    assert.equal(
+        driverTrackingNextAttemptAt({
+            nowMonotonicMs: 12_000,
+            lastAttemptAtMonotonicMs: 10_000,
+            requestedDelayMs: 40_000,
+        }),
+        52_000,
+    );
+    assert.equal(
+        driverTrackingNextAttemptAt({
+            nowMonotonicMs: 12_000,
+            lastAttemptAtMonotonicMs: null,
+            requestedDelayMs: 0,
+        }),
+        12_000,
+    );
+});
+
+test('response classification retries ambiguous failures but reconciles poisoned timestamps', () => {
+    assert.equal(
+        classifyDriverLocationResponse({
+            status: 200,
+            body: { status: 'live' },
+            retryAfter: null,
+        }).kind,
+        'retry',
+    );
+    assert.deepEqual(
+        classifyDriverLocationResponse({
+            status: 503,
+            body: null,
+            retryAfter: '25',
+        }),
+        { kind: 'retry', retryAfterMs: 25_000 },
+    );
+    assert.deepEqual(
+        classifyDriverLocationResponse({
+            status: 409,
+            body: { code: 'location-stale' },
+            retryAfter: null,
+        }),
+        { kind: 'reconcile' },
+    );
+    assert.deepEqual(
+        classifyDriverLocationResponse({
+            status: 409,
+            body: { code: 'location-conflict' },
+            retryAfter: null,
+        }),
+        { kind: 'reconcile' },
+    );
+    assert.deepEqual(
+        classifyDriverLocationResponse({
+            status: 403,
+            body: null,
+            retryAfter: null,
+        }),
+        {
+            kind: 'reject',
+            acceptNewSample: false,
+            reason: 'server-rejected',
+        },
+    );
+    assert.deepEqual(
+        classifyDriverLocationResponse({
+            status: 400,
+            body: null,
+            retryAfter: null,
+        }),
+        {
+            kind: 'reject',
+            acceptNewSample: true,
+            reason: 'invalid-sample',
+        },
+    );
+});
+
+test('Retry-After supports seconds and dates without exceeding the cap', () => {
+    const nowMs = Date.parse('2026-07-15T12:00:00.000Z');
+    assert.equal(parseRetryAfterMs('12', nowMs), 12_000);
+    assert.equal(
+        parseRetryAfterMs('Wed, 15 Jul 2026 12:00:45 GMT', nowMs),
+        45_000,
+    );
+    assert.equal(
+        parseRetryAfterMs('Wed, 15 Jul 2026 12:02:00 GMT', nowMs),
+        driverTrackingMaximumRetryDelayMs,
+    );
+    assert.equal(parseRetryAfterMs('invalid', nowMs), null);
+});
+
+test('acknowledged tracking crosses to delayed only after the live threshold', () => {
+    assert.equal(driverTrackingStatusAfterElapsed(0), 'active');
+    assert.equal(
+        driverTrackingStatusAfterElapsed(driverTrackingLiveThresholdMs),
+        'active',
+    );
+    assert.equal(
+        driverTrackingStatusAfterElapsed(driverTrackingLiveThresholdMs + 1),
+        'delayed',
+    );
+});
+
+test('expired samples are discarded at the exact server TTL boundary', () => {
+    const pending = sample(1_000, { expiresAtMonotonicMs: 121_000 });
+    assert.equal(
+        driverLocationSampleIsExpired(pending, 121_000, 121_000),
+        false,
+    );
+    assert.equal(
+        driverLocationSampleIsExpired(pending, 121_001, 121_000),
+        true,
+    );
+    assert.equal(
+        driverLocationSampleIsExpired(pending, 121_000, 121_001),
+        true,
+    );
+});
+
+test('older dashboard polling cannot regress a newer local acknowledgement', () => {
+    const older = parseDriverTrackingServerSeed({
+        tracking: {
+            status: 'live',
+            lastAcceptedAt: '2026-07-15T12:00:00.000Z',
+            mapAvailable: true,
+        },
+        refreshedAt: '2026-07-15T12:00:05.000Z',
+    });
+    const newerAcceptedAt = Date.parse('2026-07-15T12:00:10.000Z');
+    assert.ok(older);
+    assert.equal(
+        driverTrackingServerSeedIsNewer(older, newerAcceptedAt),
+        false,
+    );
+    assert.equal(driverTrackingServerSeedIsNewer(older, null), true);
+});
+
+test('dashboard seed age uses server timestamps instead of the device clock', () => {
+    const live = parseDriverTrackingServerSeed({
+        tracking: {
+            status: 'live',
+            lastAcceptedAt: '2026-07-15T12:00:00.000Z',
+            mapAvailable: true,
+        },
+        refreshedAt: '2026-07-15T12:00:30.000Z',
+    });
+    const delayed = parseDriverTrackingServerSeed({
+        tracking: {
+            status: 'delayed',
+            lastAcceptedAt: '2026-07-15T12:00:00.000Z',
+            mapAvailable: true,
+        },
+        refreshedAt: '2026-07-15T12:00:31.000Z',
+    });
+    assert.equal(live?.status, 'active');
+    assert.equal(delayed?.status, 'delayed');
+    assert.equal(delayed?.ageAtRefreshMs, 31_000);
+});

--- a/apps/delivery/lib/driverTracking.ts
+++ b/apps/delivery/lib/driverTracking.ts
@@ -1,0 +1,619 @@
+import type {
+    DeliveryTrackingFreshnessSummary,
+    DeliveryTrackingStatus,
+} from './deliveryDashboardTypes';
+
+export const driverTrackingLiveThresholdMs = 30_000;
+export const driverTrackingSampleTtlMs = 120_000;
+export const driverTrackingMinimumAttemptIntervalMs = 10_000;
+export const driverTrackingMaximumRetryDelayMs = 60_000;
+export const driverTrackingUploadTimeoutMs = 20_000;
+
+const driverTrackingInitialRetryDelayMs = 5_000;
+const driverTrackingRetryJitterRatio = 0.2;
+
+export type DriverTrackingReason =
+    | 'offline'
+    | 'permission-denied'
+    | 'position-unavailable'
+    | 'position-timeout'
+    | 'tracking-unsupported'
+    | 'upload-failed'
+    | 'upload-rejected'
+    | 'server-rejected'
+    | 'sample-expired'
+    | null;
+
+export type DriverTrackingStatus =
+    | 'inactive'
+    | 'requesting'
+    | 'sending'
+    | 'active'
+    | 'delayed'
+    | 'retrying'
+    | 'denied'
+    | 'unavailable';
+
+export type DriverTrackingViewState = {
+    status: DriverTrackingStatus;
+    lastAttemptAt: string | null;
+    lastAcceptedAt: string | null;
+    nextRetryAt: string | null;
+    retryAttempt: number;
+    sampleQueued: boolean;
+    reason: DriverTrackingReason;
+};
+
+export type DriverLocationSample = {
+    latitude: number;
+    longitude: number;
+    accuracy: number | null;
+    heading: number | null;
+    speed: number | null;
+    recordedAt: string;
+    recordedAtMs: number;
+    observedAtMonotonicMs: number;
+    expiresAtMonotonicMs: number;
+    observedAtWallMs: number;
+    expiresAtWallMs: number;
+};
+
+export type DriverLocationAcknowledgement = {
+    status: DeliveryTrackingStatus;
+    acceptedAt: string;
+    refreshedAt: string;
+    replayed: boolean;
+};
+
+export type DriverLocationResponseResult =
+    | {
+          kind: 'acknowledged';
+          acknowledgement: DriverLocationAcknowledgement;
+      }
+    | {
+          kind: 'retry';
+          retryAfterMs: number | null;
+      }
+    | { kind: 'reconcile' }
+    | {
+          kind: 'reject';
+          acceptNewSample: boolean;
+          reason: 'invalid-sample' | 'server-rejected';
+      };
+
+export type DriverTrackingServerSeed = {
+    tracking: DeliveryTrackingFreshnessSummary;
+    refreshedAt: string;
+};
+
+export type ParsedDriverTrackingServerSeed = {
+    acceptedAt: string;
+    acceptedAtMs: number;
+    refreshedAtMs: number;
+    ageAtRefreshMs: number;
+    status: 'active' | 'delayed';
+};
+
+export type DriverTrackingAttemptResult =
+    | { kind: 'none' }
+    | { kind: 'blocked' }
+    | { kind: 'expired' }
+    | { kind: 'wait'; eligibleAtMonotonicMs: number }
+    | { kind: 'send'; sample: DriverLocationSample };
+
+export type DriverTrackingRetryResult = {
+    retryAttempt: number;
+    requestedDelayMs: number;
+    eligibleAtMonotonicMs: number;
+};
+
+export const initialDriverTrackingViewState: DriverTrackingViewState = {
+    status: 'inactive',
+    lastAttemptAt: null,
+    lastAcceptedAt: null,
+    nextRetryAt: null,
+    retryAttempt: 0,
+    sampleQueued: false,
+    reason: null,
+};
+
+function validDateMs(value: string) {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isDeliveryTrackingStatus(
+    value: unknown,
+): value is DeliveryTrackingStatus {
+    return (
+        value === 'live' ||
+        value === 'delayed' ||
+        value === 'offline' ||
+        value === 'unavailable'
+    );
+}
+
+function responseErrorCode(body: unknown) {
+    return typeof body === 'object' &&
+        body !== null &&
+        'code' in body &&
+        typeof body.code === 'string'
+        ? body.code
+        : null;
+}
+
+export function parseDriverLocationAcknowledgement(
+    value: unknown,
+): DriverLocationAcknowledgement | null {
+    if (
+        typeof value !== 'object' ||
+        value === null ||
+        !('status' in value) ||
+        !isDeliveryTrackingStatus(value.status) ||
+        !('acceptedAt' in value) ||
+        typeof value.acceptedAt !== 'string' ||
+        validDateMs(value.acceptedAt) === null ||
+        !('refreshedAt' in value) ||
+        typeof value.refreshedAt !== 'string' ||
+        validDateMs(value.refreshedAt) === null ||
+        Date.parse(value.refreshedAt) < Date.parse(value.acceptedAt) ||
+        !('replayed' in value) ||
+        typeof value.replayed !== 'boolean'
+    ) {
+        return null;
+    }
+    return {
+        status: value.status,
+        acceptedAt: value.acceptedAt,
+        refreshedAt: value.refreshedAt,
+        replayed: value.replayed,
+    };
+}
+
+export function parseRetryAfterMs(value: string | null, nowMs = Date.now()) {
+    if (!value) return null;
+    const seconds = Number(value);
+    const delayMs = Number.isFinite(seconds)
+        ? seconds * 1_000
+        : Date.parse(value) - nowMs;
+    if (!Number.isFinite(delayMs) || delayMs < 0) return null;
+    return Math.min(delayMs, driverTrackingMaximumRetryDelayMs);
+}
+
+export function classifyDriverLocationResponse({
+    status,
+    body,
+    retryAfter,
+    nowMs,
+}: {
+    status: number;
+    body: unknown;
+    retryAfter: string | null;
+    nowMs?: number;
+}): DriverLocationResponseResult {
+    if (status >= 200 && status < 300) {
+        const acknowledgement = parseDriverLocationAcknowledgement(body);
+        return acknowledgement
+            ? { kind: 'acknowledged', acknowledgement }
+            : {
+                  kind: 'retry',
+                  retryAfterMs: parseRetryAfterMs(retryAfter, nowMs),
+              };
+    }
+
+    const errorCode = responseErrorCode(body);
+    if (errorCode === 'location-stale' || errorCode === 'location-conflict') {
+        return { kind: 'reconcile' };
+    }
+    if (status === 408 || status === 425 || status === 429 || status >= 500) {
+        return {
+            kind: 'retry',
+            retryAfterMs: parseRetryAfterMs(retryAfter, nowMs),
+        };
+    }
+    return {
+        kind: 'reject',
+        acceptNewSample: status === 400 || status === 422,
+        reason:
+            status === 400 || status === 422
+                ? 'invalid-sample'
+                : 'server-rejected',
+    };
+}
+
+export function selectNewestDriverLocationSample(
+    current: DriverLocationSample | null,
+    candidate: DriverLocationSample,
+) {
+    if (!current || candidate.recordedAtMs > current.recordedAtMs) {
+        return candidate;
+    }
+    return current;
+}
+
+export function driverLocationSampleIsExpired(
+    sample: DriverLocationSample,
+    nowMonotonicMs: number,
+    nowWallMs: number,
+) {
+    return (
+        nowMonotonicMs > sample.expiresAtMonotonicMs ||
+        nowWallMs > sample.expiresAtWallMs
+    );
+}
+
+export function driverTrackingRetryDelayMs({
+    retryAttempt,
+    randomValue,
+    retryAfterMs,
+}: {
+    retryAttempt: number;
+    randomValue: number;
+    retryAfterMs?: number | null;
+}) {
+    if (retryAfterMs !== null && retryAfterMs !== undefined) {
+        return Math.min(
+            Math.max(0, retryAfterMs),
+            driverTrackingMaximumRetryDelayMs,
+        );
+    }
+    const boundedAttempt = Math.max(1, Math.floor(retryAttempt));
+    const baseDelay = Math.min(
+        driverTrackingInitialRetryDelayMs * 2 ** (boundedAttempt - 1),
+        driverTrackingMaximumRetryDelayMs,
+    );
+    const boundedRandom = Math.min(1, Math.max(0, randomValue));
+    const jitter = (boundedRandom * 2 - 1) * driverTrackingRetryJitterRatio;
+    return Math.min(
+        Math.round(baseDelay * (1 + jitter)),
+        driverTrackingMaximumRetryDelayMs,
+    );
+}
+
+export function driverTrackingNextAttemptAt({
+    nowMonotonicMs,
+    lastAttemptAtMonotonicMs,
+    requestedDelayMs,
+}: {
+    nowMonotonicMs: number;
+    lastAttemptAtMonotonicMs: number | null;
+    requestedDelayMs: number;
+}) {
+    return Math.max(
+        nowMonotonicMs + Math.max(0, requestedDelayMs),
+        lastAttemptAtMonotonicMs === null
+            ? nowMonotonicMs
+            : lastAttemptAtMonotonicMs + driverTrackingMinimumAttemptIntervalMs,
+    );
+}
+
+export function driverTrackingStatusFromAcknowledgement(
+    status: DeliveryTrackingStatus,
+): 'active' | 'delayed' {
+    return status === 'live' ? 'active' : 'delayed';
+}
+
+export function driverTrackingStatusAfterElapsed(
+    elapsedMs: number,
+): 'active' | 'delayed' {
+    return elapsedMs <= driverTrackingLiveThresholdMs ? 'active' : 'delayed';
+}
+
+export function parseDriverTrackingServerSeed({
+    tracking,
+    refreshedAt,
+}: DriverTrackingServerSeed): ParsedDriverTrackingServerSeed | null {
+    const acceptedAt = tracking.lastAcceptedAt;
+    const acceptedAtMs = acceptedAt ? validDateMs(acceptedAt) : null;
+    const refreshedAtMs = validDateMs(refreshedAt);
+    if (
+        acceptedAt === null ||
+        acceptedAtMs === null ||
+        refreshedAtMs === null
+    ) {
+        return null;
+    }
+    const ageAtRefreshMs = Math.max(0, refreshedAtMs - acceptedAtMs);
+    const status: ParsedDriverTrackingServerSeed['status'] =
+        tracking.status === 'live' &&
+        ageAtRefreshMs <= driverTrackingLiveThresholdMs
+            ? 'active'
+            : 'delayed';
+    return {
+        acceptedAt,
+        acceptedAtMs,
+        refreshedAtMs,
+        ageAtRefreshMs,
+        status,
+    };
+}
+
+export function driverTrackingServerSeedIsNewer(
+    seed: ParsedDriverTrackingServerSeed,
+    latestAcceptedAtMs: number | null,
+) {
+    return (
+        latestAcceptedAtMs === null || seed.acceptedAtMs > latestAcceptedAtMs
+    );
+}
+
+/**
+ * Memory-only queue and acknowledgement state for one active delivery run.
+ * Exact telemetry never leaves this controller except for the single sample
+ * returned to the upload boundary.
+ */
+export class DriverTrackingController {
+    private pending: DriverLocationSample | null = null;
+    private inFlight: DriverLocationSample | null = null;
+    private lastAttemptAtMonotonicMs: number | null = null;
+    private latestAcceptedAtMs: number | null = null;
+    private acknowledgedAtMonotonicMs: number | null = null;
+    private acknowledgedAtWallMs: number | null = null;
+    private acceptedAt: string | null = null;
+    private retryCount = 0;
+    private retryNotBeforeMonotonicMs: number | null = null;
+    private blockedReason: 'permission' | 'server' | null = null;
+    private highestObservedRecordedAtMs: number | null = null;
+
+    get hasPendingSample() {
+        return this.pending !== null;
+    }
+
+    get hasInFlightSample() {
+        return this.inFlight !== null;
+    }
+
+    get pendingExpiresAtMonotonicMs() {
+        return this.pending?.expiresAtMonotonicMs ?? null;
+    }
+
+    get retryAttempt() {
+        return this.retryCount;
+    }
+
+    get lastAcceptedAt() {
+        return this.acceptedAt;
+    }
+
+    get acknowledgementMonotonicMs() {
+        return this.acknowledgedAtMonotonicMs;
+    }
+
+    queueSample(sample: DriverLocationSample) {
+        if (this.blockedReason !== null) return false;
+        if (
+            this.highestObservedRecordedAtMs !== null &&
+            sample.recordedAtMs <= this.highestObservedRecordedAtMs
+        ) {
+            return false;
+        }
+        this.highestObservedRecordedAtMs = sample.recordedAtMs;
+        if (
+            this.inFlight &&
+            sample.recordedAtMs <= this.inFlight.recordedAtMs
+        ) {
+            return false;
+        }
+        const previous = this.pending;
+        this.pending = selectNewestDriverLocationSample(previous, sample);
+        return this.pending !== previous;
+    }
+
+    beginAttempt(
+        nowMonotonicMs: number,
+        nowWallMs: number,
+    ): DriverTrackingAttemptResult {
+        if (this.blockedReason !== null) return { kind: 'blocked' };
+        if (this.inFlight || !this.pending) return { kind: 'none' };
+        if (
+            driverLocationSampleIsExpired(
+                this.pending,
+                nowMonotonicMs,
+                nowWallMs,
+            )
+        ) {
+            this.pending = null;
+            return { kind: 'expired' };
+        }
+        const eligibleAtMonotonicMs = this.nextAttemptAt(nowMonotonicMs);
+        if (eligibleAtMonotonicMs === null) return { kind: 'blocked' };
+        if (eligibleAtMonotonicMs > nowMonotonicMs) {
+            return { kind: 'wait', eligibleAtMonotonicMs };
+        }
+        const sample = this.pending;
+        this.pending = null;
+        this.inFlight = sample;
+        this.lastAttemptAtMonotonicMs = nowMonotonicMs;
+        return { kind: 'send', sample };
+    }
+
+    retryInFlight({
+        nowMonotonicMs,
+        retryAfterMs,
+        randomValue,
+    }: {
+        nowMonotonicMs: number;
+        retryAfterMs: number | null;
+        randomValue: number;
+    }): DriverTrackingRetryResult | null {
+        if (!this.inFlight) return null;
+        this.pending = selectNewestDriverLocationSample(
+            this.inFlight,
+            this.pending ?? this.inFlight,
+        );
+        this.inFlight = null;
+        this.retryCount += 1;
+        const requestedDelayMs = driverTrackingRetryDelayMs({
+            retryAttempt: this.retryCount,
+            randomValue,
+            retryAfterMs,
+        });
+        this.retryNotBeforeMonotonicMs = nowMonotonicMs + requestedDelayMs;
+        return {
+            retryAttempt: this.retryCount,
+            requestedDelayMs,
+            eligibleAtMonotonicMs:
+                this.nextAttemptAt(nowMonotonicMs) ??
+                nowMonotonicMs + requestedDelayMs,
+        };
+    }
+
+    acknowledge(
+        acknowledgement: DriverLocationAcknowledgement,
+        nowMonotonicMs: number,
+        nowWallMs: number,
+        minimumInitialAgeMs = 0,
+    ) {
+        this.inFlight = null;
+        this.retryCount = 0;
+        this.retryNotBeforeMonotonicMs = null;
+        this.blockedReason = null;
+        const acceptedAtMs = Date.parse(acknowledgement.acceptedAt);
+        if (
+            this.latestAcceptedAtMs !== null &&
+            acceptedAtMs <= this.latestAcceptedAtMs
+        ) {
+            return false;
+        }
+        this.acceptedAt = acknowledgement.acceptedAt;
+        this.latestAcceptedAtMs = acceptedAtMs;
+        const serverAgeMs = Math.max(
+            0,
+            Date.parse(acknowledgement.refreshedAt) - acceptedAtMs,
+        );
+        const initialAgeMs = Math.max(
+            serverAgeMs,
+            Number.isFinite(minimumInitialAgeMs)
+                ? Math.max(0, minimumInitialAgeMs)
+                : 0,
+            acknowledgement.status === 'live'
+                ? 0
+                : driverTrackingLiveThresholdMs + 1,
+        );
+        this.acknowledgedAtMonotonicMs = nowMonotonicMs - initialAgeMs;
+        this.acknowledgedAtWallMs = nowWallMs - initialAgeMs;
+        return true;
+    }
+
+    rejectInFlight({ acceptNewSample }: { acceptNewSample: boolean }) {
+        this.inFlight = null;
+        this.retryCount = 0;
+        this.retryNotBeforeMonotonicMs = null;
+        this.blockedReason = acceptNewSample ? null : 'server';
+        if (this.blockedReason) this.pending = null;
+    }
+
+    reconcileInFlight() {
+        this.inFlight = null;
+        this.retryCount = 0;
+        this.retryNotBeforeMonotonicMs = null;
+    }
+
+    blockAndDiscardExactSamples() {
+        this.pending = null;
+        this.inFlight = null;
+        this.retryCount = 0;
+        this.retryNotBeforeMonotonicMs = null;
+        this.blockedReason = 'permission';
+    }
+
+    allowPermissionUploads() {
+        if (this.blockedReason === 'permission') this.blockedReason = null;
+    }
+
+    discard() {
+        this.pending = null;
+        this.inFlight = null;
+        this.retryCount = 0;
+        this.retryNotBeforeMonotonicMs = null;
+        this.blockedReason = 'server';
+    }
+
+    nextAttemptAt(nowMonotonicMs: number) {
+        if (!this.pending || this.blockedReason !== null) return null;
+        return Math.max(
+            driverTrackingNextAttemptAt({
+                nowMonotonicMs,
+                lastAttemptAtMonotonicMs: this.lastAttemptAtMonotonicMs,
+                requestedDelayMs: 0,
+            }),
+            this.retryNotBeforeMonotonicMs ?? nowMonotonicMs,
+        );
+    }
+
+    advanceRetry(nowMonotonicMs: number) {
+        if (this.retryCount > 0) {
+            this.retryNotBeforeMonotonicMs = nowMonotonicMs;
+        }
+        return this.nextAttemptAt(nowMonotonicMs);
+    }
+
+    dropExpiredPending(nowMonotonicMs: number, nowWallMs: number) {
+        if (
+            !this.pending ||
+            !driverLocationSampleIsExpired(
+                this.pending,
+                nowMonotonicMs,
+                nowWallMs,
+            )
+        ) {
+            return false;
+        }
+        this.pending = null;
+        return true;
+    }
+
+    acknowledgementStatus(nowMonotonicMs: number, nowWallMs: number) {
+        if (
+            this.acknowledgedAtMonotonicMs === null ||
+            this.acknowledgedAtWallMs === null
+        ) {
+            return null;
+        }
+        return driverTrackingStatusAfterElapsed(
+            Math.max(
+                nowMonotonicMs - this.acknowledgedAtMonotonicMs,
+                nowWallMs - this.acknowledgedAtWallMs,
+            ),
+        );
+    }
+
+    reconcileServerSeed(
+        seed: DriverTrackingServerSeed,
+        nowMonotonicMs: number,
+        nowWallMs: number,
+    ) {
+        const parsed = parseDriverTrackingServerSeed(seed);
+        if (!parsed) return null;
+        const strictlyNewer =
+            this.latestAcceptedAtMs === null ||
+            parsed.acceptedAtMs > this.latestAcceptedAtMs;
+        if (
+            this.latestAcceptedAtMs !== null &&
+            parsed.acceptedAtMs < this.latestAcceptedAtMs
+        ) {
+            return null;
+        }
+        if (
+            parsed.acceptedAtMs === this.latestAcceptedAtMs &&
+            this.acknowledgedAtMonotonicMs !== null &&
+            this.acknowledgedAtWallMs !== null
+        ) {
+            const currentAgeMs = Math.max(
+                nowMonotonicMs - this.acknowledgedAtMonotonicMs,
+                nowWallMs - this.acknowledgedAtWallMs,
+            );
+            if (parsed.ageAtRefreshMs <= currentAgeMs) return null;
+        }
+        this.latestAcceptedAtMs = parsed.acceptedAtMs;
+        this.acceptedAt = parsed.acceptedAt;
+        this.acknowledgedAtMonotonicMs = nowMonotonicMs - parsed.ageAtRefreshMs;
+        this.acknowledgedAtWallMs = nowWallMs - parsed.ageAtRefreshMs;
+        if (strictlyNewer) {
+            this.retryCount = 0;
+            this.retryNotBeforeMonotonicMs = null;
+            if (this.blockedReason === 'server') this.blockedReason = null;
+        }
+        return parsed;
+    }
+}

--- a/apps/delivery/tests/DriverTrackingStatusStory.tsx
+++ b/apps/delivery/tests/DriverTrackingStatusStory.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { DriverTrackingStatus } from '../components/DriverTrackingStatus';
+import type {
+    DriverTrackingReason,
+    DriverTrackingStatus as DriverTrackingStatusValue,
+} from '../lib/driverTracking';
+
+export function DriverTrackingStatusStory({
+    status,
+    reason = null,
+    sampleQueued,
+}: {
+    status: DriverTrackingStatusValue;
+    reason?: DriverTrackingReason;
+    sampleQueued?: boolean;
+}) {
+    return (
+        <DriverTrackingStatus
+            tracking={{
+                status,
+                reason,
+                lastAttemptAt: null,
+                lastAcceptedAt: '2026-07-15T12:00:00.000Z',
+                nextRetryAt: null,
+                retryAttempt: status === 'retrying' ? 2 : 0,
+                sampleQueued: sampleQueued ?? status === 'retrying',
+                retryNow: () => undefined,
+                recheckPermission: () => undefined,
+            }}
+        />
+    );
+}

--- a/apps/delivery/tests/DriverTrackingStory.tsx
+++ b/apps/delivery/tests/DriverTrackingStory.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { DriverTrackingStatus } from '../components/DriverTrackingStatus';
+import { useDriverTracking } from '../hooks/useDriverTracking';
+import type { DeliveryTrackingStatus } from '../lib/deliveryDashboardTypes';
+
+export function DriverTrackingStory({
+    runId = 'run-one',
+    serverStatus = 'unavailable',
+    lastAcceptedAt = null,
+    refreshedAt = '2026-07-15T12:00:00.000Z',
+}: {
+    runId?: string | null;
+    serverStatus?: DeliveryTrackingStatus;
+    lastAcceptedAt?: string | null;
+    refreshedAt?: string;
+}) {
+    const tracking = useDriverTracking({
+        runId,
+        serverTracking: {
+            status: serverStatus,
+            lastAcceptedAt,
+            mapAvailable: serverStatus === 'live' || serverStatus === 'delayed',
+        },
+        dashboardRefreshedAt: refreshedAt,
+        onDashboardRefresh: () => {
+            window.dispatchEvent(new Event('driver-dashboard-refresh'));
+        },
+    });
+
+    return (
+        <div
+            data-last-accepted-at={tracking.lastAcceptedAt ?? ''}
+            data-retry-attempt={tracking.retryAttempt}
+            data-sample-queued={tracking.sampleQueued ? 'true' : 'false'}
+            data-status={tracking.status}
+        >
+            <DriverTrackingStatus tracking={tracking} />
+        </div>
+    );
+}

--- a/apps/delivery/tests/driver-tracking.spec.tsx
+++ b/apps/delivery/tests/driver-tracking.spec.tsx
@@ -1,0 +1,974 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
+import { DriverTrackingStatusStory } from './DriverTrackingStatusStory';
+import { DriverTrackingStory } from './DriverTrackingStory';
+
+const clockStart = new Date('2026-07-15T12:00:00.000Z');
+
+type MockResponse = {
+    status: number;
+    body: object | null;
+    deferred?: boolean;
+};
+
+async function installTrackingBrowser(
+    page: Page,
+    options: {
+        permission?: PermissionState;
+        online?: boolean;
+        supported?: boolean;
+    } = {},
+) {
+    await page.evaluate(
+        ({ initialPermission, initialOnline, initialSupported }) => {
+            let permission = initialPermission;
+            let online = initialOnline;
+            let visibility: DocumentVisibilityState = 'visible';
+            let nextWatchId = 1;
+            let clearCount = 0;
+            let abortCount = 0;
+            let refreshCount = 0;
+            type Watcher = {
+                success: PositionCallback;
+                error: PositionErrorCallback | null;
+            };
+            const watchers = new Map<number, Watcher>();
+            const stoppedWatchers = new Set<Watcher>();
+            const oneShot = new Set<{
+                success: PositionCallback;
+                error: PositionErrorCallback | null;
+            }>();
+            const permissionListeners =
+                new Set<EventListenerOrEventListenerObject>();
+            const responses: Array<{
+                status: number;
+                body: object | null;
+                deferred: boolean;
+            }> = [];
+            const deferredResponses: Array<() => void> = [];
+            const requestBodies: unknown[] = [];
+            const root = document.documentElement;
+
+            const syncMetrics = () => {
+                root.dataset.trackingWatchCount = String(watchers.size);
+                root.dataset.trackingClearCount = String(clearCount);
+                root.dataset.trackingAbortCount = String(abortCount);
+                root.dataset.trackingRefreshCount = String(refreshCount);
+                root.dataset.trackingOneShotCount = String(oneShot.size);
+                root.dataset.trackingRequestCount = String(
+                    requestBodies.length,
+                );
+                root.dataset.trackingRequestBodies =
+                    JSON.stringify(requestBodies);
+            };
+
+            const permissionStatus = {
+                get state() {
+                    return permission;
+                },
+                onchange: null,
+                addEventListener(
+                    type: string,
+                    listener: EventListenerOrEventListenerObject,
+                ) {
+                    if (type === 'change') permissionListeners.add(listener);
+                },
+                removeEventListener(
+                    type: string,
+                    listener: EventListenerOrEventListenerObject,
+                ) {
+                    if (type === 'change') permissionListeners.delete(listener);
+                },
+                dispatchEvent() {
+                    return true;
+                },
+            };
+
+            Object.defineProperty(navigator, 'onLine', {
+                configurable: true,
+                get: () => online,
+            });
+            Object.defineProperty(document, 'visibilityState', {
+                configurable: true,
+                get: () => visibility,
+            });
+            Object.defineProperty(navigator, 'permissions', {
+                configurable: true,
+                value: {
+                    query: async () => permissionStatus,
+                },
+            });
+            if (initialSupported) {
+                Object.defineProperty(navigator, 'geolocation', {
+                    configurable: true,
+                    value: {
+                        watchPosition(
+                            success: PositionCallback,
+                            error: PositionErrorCallback | null,
+                        ) {
+                            const id = nextWatchId++;
+                            watchers.set(id, { success, error });
+                            syncMetrics();
+                            return id;
+                        },
+                        clearWatch(id: number) {
+                            const watcher = watchers.get(id);
+                            if (watcher) {
+                                stoppedWatchers.add(watcher);
+                                watchers.delete(id);
+                                clearCount += 1;
+                            }
+                            syncMetrics();
+                        },
+                        getCurrentPosition(
+                            success: PositionCallback,
+                            error: PositionErrorCallback | null,
+                        ) {
+                            oneShot.add({ success, error });
+                            syncMetrics();
+                        },
+                    },
+                });
+            } else {
+                Reflect.deleteProperty(navigator, 'geolocation');
+                const navigatorPrototype: object | null =
+                    Object.getPrototypeOf(navigator);
+                if (navigatorPrototype) {
+                    Reflect.deleteProperty(navigatorPrototype, 'geolocation');
+                }
+            }
+
+            window.addEventListener('tracking-test-position', (event) => {
+                if (!(event instanceof CustomEvent)) return;
+                const detail = event.detail;
+                if (typeof detail !== 'object' || detail === null) return;
+                const latitude = Reflect.get(detail, 'latitude');
+                const timestamp = Reflect.get(detail, 'timestamp');
+                const target = Reflect.get(detail, 'target');
+                if (
+                    typeof latitude !== 'number' ||
+                    typeof timestamp !== 'number'
+                ) {
+                    return;
+                }
+                const position = {
+                    coords: {
+                        latitude,
+                        longitude: 15.98,
+                        accuracy: 7,
+                        altitude: null,
+                        altitudeAccuracy: null,
+                        heading: 90,
+                        speed: 5,
+                        toJSON: () => ({}),
+                    },
+                    timestamp,
+                    toJSON: () => ({}),
+                };
+                if (target === 'stale-watch') {
+                    for (const watcher of stoppedWatchers) {
+                        watcher.success(position);
+                    }
+                } else if (target !== 'one-shot') {
+                    for (const watcher of watchers.values()) {
+                        watcher.success(position);
+                    }
+                }
+                if (target !== 'watch' && target !== 'stale-watch') {
+                    for (const request of oneShot) request.success(position);
+                    oneShot.clear();
+                    syncMetrics();
+                }
+            });
+            window.addEventListener('tracking-test-position-error', (event) => {
+                if (!(event instanceof CustomEvent)) return;
+                if (typeof event.detail !== 'number') return;
+                const error: GeolocationPositionError = {
+                    code: event.detail,
+                    message: 'Location unavailable',
+                    PERMISSION_DENIED: 1,
+                    POSITION_UNAVAILABLE: 2,
+                    TIMEOUT: 3,
+                };
+                for (const watcher of watchers.values()) {
+                    watcher.error?.(error);
+                }
+                for (const request of oneShot) request.error?.(error);
+                oneShot.clear();
+                syncMetrics();
+            });
+            window.addEventListener(
+                'tracking-test-stale-position-error',
+                () => {
+                    const error: GeolocationPositionError = {
+                        code: 3,
+                        message: 'Location unavailable',
+                        PERMISSION_DENIED: 1,
+                        POSITION_UNAVAILABLE: 2,
+                        TIMEOUT: 3,
+                    };
+                    for (const watcher of stoppedWatchers) {
+                        watcher.error?.(error);
+                    }
+                },
+            );
+            window.addEventListener('tracking-test-permission', (event) => {
+                if (!(event instanceof CustomEvent)) return;
+                if (
+                    event.detail !== 'granted' &&
+                    event.detail !== 'prompt' &&
+                    event.detail !== 'denied'
+                ) {
+                    return;
+                }
+                permission = event.detail;
+                const change = new Event('change');
+                for (const listener of permissionListeners) {
+                    if (typeof listener === 'function') listener(change);
+                    else listener.handleEvent(change);
+                }
+            });
+            window.addEventListener('tracking-test-network', (event) => {
+                if (!(event instanceof CustomEvent)) return;
+                online = event.detail === 'online';
+                window.dispatchEvent(new Event(online ? 'online' : 'offline'));
+            });
+            window.addEventListener('tracking-test-visibility', (event) => {
+                if (!(event instanceof CustomEvent)) return;
+                visibility = event.detail === 'hidden' ? 'hidden' : 'visible';
+                document.dispatchEvent(new Event('visibilitychange'));
+            });
+            window.addEventListener('tracking-test-response', (event) => {
+                if (!(event instanceof CustomEvent)) return;
+                const detail = event.detail;
+                if (typeof detail !== 'object' || detail === null) return;
+                const status = Reflect.get(detail, 'status');
+                const body = Reflect.get(detail, 'body');
+                const deferred = Reflect.get(detail, 'deferred');
+                if (typeof status !== 'number') return;
+                responses.push({
+                    status,
+                    body:
+                        typeof body === 'object' && body !== undefined
+                            ? body
+                            : null,
+                    deferred: deferred === true,
+                });
+            });
+            window.addEventListener('tracking-test-resolve', () => {
+                deferredResponses.shift()?.();
+            });
+            window.addEventListener('driver-dashboard-refresh', () => {
+                refreshCount += 1;
+                syncMetrics();
+            });
+
+            window.fetch = async (_input, init) => {
+                requestBodies.push(
+                    typeof init?.body === 'string'
+                        ? JSON.parse(init.body)
+                        : null,
+                );
+                syncMetrics();
+                const configured = responses.shift() ?? {
+                    status: 200,
+                    body: {
+                        status: 'live',
+                        acceptedAt: new Date().toISOString(),
+                        refreshedAt: new Date().toISOString(),
+                        replayed: false,
+                    },
+                    deferred: false,
+                };
+                const createResponse = () =>
+                    new Response(JSON.stringify(configured.body), {
+                        status: configured.status,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                if (!configured.deferred) return createResponse();
+                return await new Promise<Response>((resolve, reject) => {
+                    let settled = false;
+                    const finish = () => {
+                        if (settled) return;
+                        settled = true;
+                        resolve(createResponse());
+                    };
+                    deferredResponses.push(finish);
+                    init?.signal?.addEventListener(
+                        'abort',
+                        () => {
+                            if (settled) return;
+                            settled = true;
+                            abortCount += 1;
+                            syncMetrics();
+                            reject(new DOMException('Aborted', 'AbortError'));
+                        },
+                        { once: true },
+                    );
+                });
+            };
+            syncMetrics();
+        },
+        {
+            initialPermission: options.permission ?? 'granted',
+            initialOnline: options.online ?? true,
+            initialSupported: options.supported ?? true,
+        },
+    );
+}
+
+async function queueResponse(page: Page, response: MockResponse) {
+    await page.evaluate((detail) => {
+        window.dispatchEvent(
+            new CustomEvent('tracking-test-response', { detail }),
+        );
+    }, response);
+}
+
+async function emitPosition(
+    page: Page,
+    latitude: number,
+    timestamp: number,
+    target?: 'watch' | 'one-shot' | 'stale-watch',
+) {
+    await page.evaluate(
+        (detail) => {
+            window.dispatchEvent(
+                new CustomEvent('tracking-test-position', { detail }),
+            );
+        },
+        { latitude, timestamp, target },
+    );
+}
+
+async function setPermission(page: Page, permission: PermissionState) {
+    await page.evaluate((detail) => {
+        window.dispatchEvent(
+            new CustomEvent('tracking-test-permission', { detail }),
+        );
+    }, permission);
+}
+
+async function emitPositionError(page: Page, code: 1 | 2 | 3) {
+    await page.evaluate((detail) => {
+        window.dispatchEvent(
+            new CustomEvent('tracking-test-position-error', { detail }),
+        );
+    }, code);
+}
+
+async function emitStalePositionError(page: Page) {
+    await page.evaluate(() => {
+        window.dispatchEvent(new Event('tracking-test-stale-position-error'));
+    });
+}
+
+test('claims active tracking only after a complete acknowledgement', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    await queueResponse(page, {
+        status: 200,
+        deferred: true,
+        body: {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:01.000Z',
+            refreshedAt: '2026-07-15T12:00:01.000Z',
+            replayed: false,
+        },
+    });
+    const component = await mount(<DriverTrackingStory />);
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-watch-count',
+        '1',
+    );
+    await emitPosition(page, 45.81, clockStart.getTime());
+    await expect(component).toHaveAttribute('data-status', 'sending');
+    await expect(component).not.toHaveAttribute('data-status', 'active');
+
+    await page.evaluate(() => {
+        window.dispatchEvent(new Event('tracking-test-resolve'));
+    });
+    await expect(component).toHaveAttribute('data-status', 'active');
+    await expect(component).toHaveAttribute(
+        'data-last-accepted-at',
+        '2026-07-15T12:00:01.000Z',
+    );
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-refresh-count',
+        '0',
+    );
+});
+
+test('failure stays visible and retries only the newest coordinate after throttle', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    await queueResponse(page, { status: 500, body: null });
+    await queueResponse(page, {
+        status: 200,
+        body: {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:11.000Z',
+            refreshedAt: '2026-07-15T12:00:11.000Z',
+            replayed: false,
+        },
+    });
+    const component = await mount(<DriverTrackingStory />);
+    await emitPosition(page, 45.81, clockStart.getTime());
+    await expect(component).toHaveAttribute('data-status', 'retrying');
+    await emitPosition(page, 45.82, clockStart.getTime() + 1_000);
+    await emitPosition(page, 45.83, clockStart.getTime() + 2_000);
+    await page.clock.fastForward(9_000);
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-request-count',
+        '1',
+    );
+    await page.clock.fastForward(1_000);
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-request-count',
+        '2',
+    );
+    await expect(component).toHaveAttribute('data-status', 'active');
+    const bodies = await page
+        .locator('html')
+        .getAttribute('data-tracking-request-bodies');
+    expect(bodies).not.toBeNull();
+    expect(JSON.parse(bodies ?? '[]')).toMatchObject([
+        { latitude: 45.81 },
+        { latitude: 45.83 },
+    ]);
+});
+
+test('slow successful response keeps its server and client transit age', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    await queueResponse(page, {
+        status: 200,
+        deferred: true,
+        body: {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:00.000Z',
+            refreshedAt: '2026-07-15T12:00:00.000Z',
+            replayed: false,
+        },
+    });
+    const component = await mount(<DriverTrackingStory />);
+    await emitPosition(page, 45.81, clockStart.getTime());
+    await page.clock.fastForward(19_000);
+    await page.evaluate(() => {
+        window.dispatchEvent(new Event('tracking-test-resolve'));
+    });
+    await expect(component).toHaveAttribute('data-status', 'active');
+    await page.clock.fastForward(11_001);
+    await expect(component).toHaveAttribute('data-status', 'delayed');
+});
+
+test('permission changes restart accurately and revocation clears exact work', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page, { permission: 'denied' });
+    const component = await mount(<DriverTrackingStory />);
+    await expect(component).toHaveAttribute('data-status', 'denied');
+    await setPermission(page, 'granted');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-watch-count',
+        '1',
+    );
+    await emitPosition(page, 45.81, clockStart.getTime());
+    await expect(component).toHaveAttribute('data-status', 'active');
+    await setPermission(page, 'denied');
+    await expect(component).toHaveAttribute('data-status', 'denied');
+    await expect(component).toHaveAttribute('data-retry-attempt', '0');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-clear-count',
+        '1',
+    );
+    await emitPosition(
+        page,
+        45.82,
+        clockStart.getTime() + 1_000,
+        'stale-watch',
+    );
+    await emitStalePositionError(page);
+    await expect(component).toHaveAttribute('data-status', 'denied');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-request-count',
+        '1',
+    );
+});
+
+test('a server seed cannot start tracking on an unsupported browser', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page, { supported: false });
+    const component = await mount(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:00.000Z"
+            refreshedAt="2026-07-15T12:00:00.000Z"
+            serverStatus="live"
+        />,
+    );
+    await expect(component).toHaveAttribute('data-status', 'unavailable');
+    await expect(component).toContainText(
+        'Ovaj uređaj ili preglednik ne podržava GPS praćenje',
+    );
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-watch-count',
+        '0',
+    );
+});
+
+test('a newer server seed cannot bypass denied location permission', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page, { permission: 'denied' });
+    const component = await mount(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:00.000Z"
+            refreshedAt="2026-07-15T12:00:00.000Z"
+            serverStatus="live"
+        />,
+    );
+    await expect(component).toHaveAttribute('data-status', 'denied');
+    await component.update(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:10.000Z"
+            refreshedAt="2026-07-15T12:00:10.000Z"
+            serverStatus="live"
+        />,
+    );
+    await expect(component).toHaveAttribute('data-status', 'denied');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-watch-count',
+        '0',
+    );
+});
+
+test('visibility recovery advances a retry but never bypasses minimum interval', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    await queueResponse(page, { status: 503, body: null });
+    await queueResponse(page, {
+        status: 200,
+        body: {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:10.000Z',
+            refreshedAt: '2026-07-15T12:00:10.000Z',
+            replayed: false,
+        },
+    });
+    const component = await mount(<DriverTrackingStory />);
+    await emitPosition(page, 45.81, clockStart.getTime());
+    await expect(component).toHaveAttribute('data-status', 'retrying');
+    await page.clock.fastForward(9_000);
+    await page.evaluate(() => {
+        window.dispatchEvent(
+            new CustomEvent('tracking-test-visibility', {
+                detail: 'hidden',
+            }),
+        );
+        window.dispatchEvent(
+            new CustomEvent('tracking-test-visibility', {
+                detail: 'visible',
+            }),
+        );
+    });
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-request-count',
+        '1',
+    );
+    await page.clock.fastForward(1_000);
+    await expect(component).toHaveAttribute('data-status', 'active');
+});
+
+test('run switch aborts old work and unmount removes watchers and timers', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    await queueResponse(page, {
+        status: 200,
+        body: {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:01.000Z',
+            refreshedAt: '2026-07-15T12:00:01.000Z',
+            replayed: false,
+        },
+        deferred: true,
+    });
+    const component = await mount(<DriverTrackingStory runId="run-one" />);
+    await emitPosition(page, 45.81, clockStart.getTime());
+    await expect(component).toHaveAttribute('data-status', 'sending');
+    await component.update(<DriverTrackingStory runId="run-two" />);
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-abort-count',
+        '1',
+    );
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-clear-count',
+        '1',
+    );
+    await emitPosition(page, 45.82, clockStart.getTime() + 1_000);
+    await expect(component).toHaveAttribute('data-status', 'active');
+    await component.unmount();
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-clear-count',
+        '2',
+    );
+    await emitPosition(page, 45.83, clockStart.getTime() + 2_000);
+    await page.clock.fastForward(30_000);
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-request-count',
+        '2',
+    );
+});
+
+test('server seed crosses the live threshold and wall resume cannot keep it falsely active', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    const component = await mount(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:00.000Z"
+            refreshedAt="2026-07-15T12:00:00.000Z"
+            serverStatus="live"
+        />,
+    );
+    await expect(component).toHaveAttribute('data-status', 'active');
+    await page.clock.fastForward(30_001);
+    await expect(component).toHaveAttribute('data-status', 'delayed');
+});
+
+test('equal server freshness ages an acknowledgement without hiding a failed upload', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    await queueResponse(page, { status: 500, body: null });
+    const component = await mount(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:00.000Z"
+            refreshedAt="2026-07-15T12:00:00.000Z"
+            serverStatus="live"
+        />,
+    );
+    await emitPosition(page, 45.81, clockStart.getTime() + 1_000);
+    await expect(component).toHaveAttribute('data-status', 'retrying');
+    await component.update(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:00.000Z"
+            refreshedAt="2026-07-15T12:00:31.000Z"
+            serverStatus="delayed"
+        />,
+    );
+    await expect(component).toHaveAttribute('data-status', 'retrying');
+    await expect(component).toHaveAttribute('data-retry-attempt', '1');
+});
+
+test('permanent run rejection refreshes dashboard state and does not blame GPS settings', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    await queueResponse(page, { status: 403, body: null });
+    const component = await mount(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:00.000Z"
+            refreshedAt="2026-07-15T12:00:00.000Z"
+            serverStatus="live"
+        />,
+    );
+    await emitPosition(page, 45.81, clockStart.getTime() + 1_000);
+    await expect(component).toHaveAttribute('data-status', 'unavailable');
+    await expect(component).toContainText('ruta ili prijava');
+    await expect(
+        component.getByRole('button', { name: 'Osvježi dostave' }),
+    ).toBeVisible();
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-refresh-count',
+        '1',
+    );
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-watch-count',
+        '0',
+    );
+    await component.update(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:00.000Z"
+            refreshedAt="2026-07-15T12:00:31.000Z"
+            serverStatus="delayed"
+        />,
+    );
+    await expect(component).toHaveAttribute('data-status', 'unavailable');
+    await component.update(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:40.000Z"
+            refreshedAt="2026-07-15T12:00:41.000Z"
+            serverStatus="live"
+        />,
+    );
+    await expect(component).toHaveAttribute('data-status', 'active');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-watch-count',
+        '1',
+    );
+});
+
+test('permanent rejection ignores a late concurrent one-shot GPS callback', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    await queueResponse(page, { status: 403, body: null });
+    const component = await mount(<DriverTrackingStory />);
+    await page.evaluate(() => {
+        window.dispatchEvent(new PageTransitionEvent('pageshow'));
+    });
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-one-shot-count',
+        '1',
+    );
+    await emitPosition(page, 45.81, clockStart.getTime(), 'watch');
+    await expect(component).toHaveAttribute('data-status', 'unavailable');
+    await expect(component).toContainText('ruta ili prijava');
+    await emitPositionError(page, 3);
+    await emitPosition(
+        page,
+        45.82,
+        clockStart.getTime() + 1_000,
+        'stale-watch',
+    );
+    await emitStalePositionError(page);
+    await expect(component).toHaveAttribute('data-status', 'unavailable');
+    await expect(component).toContainText('ruta ili prijava');
+    await expect(
+        component.getByRole('button', { name: 'Osvježi dostave' }),
+    ).toBeVisible();
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-request-count',
+        '1',
+    );
+});
+
+test('offline exact telemetry expires in memory before a later reconnect', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page, { online: false });
+    const component = await mount(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:00.000Z"
+            refreshedAt="2026-07-15T12:00:00.000Z"
+            serverStatus="live"
+        />,
+    );
+    await expect(component).toHaveAttribute('data-status', 'retrying');
+    await expect(component).toHaveAttribute('data-sample-queued', 'false');
+    await expect(component).toContainText('Nema internetske veze');
+    await emitPosition(page, 45.81, clockStart.getTime());
+    await expect(component).toHaveAttribute('data-status', 'retrying');
+    await expect(component).toHaveAttribute('data-sample-queued', 'true');
+    await page.clock.fastForward(120_001);
+    await expect(component).toHaveAttribute('data-sample-queued', 'false');
+    await expect(component).toHaveAttribute('data-status', 'unavailable');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-request-count',
+        '0',
+    );
+    await page.evaluate(() => {
+        window.dispatchEvent(
+            new CustomEvent('tracking-test-network', { detail: 'online' }),
+        );
+    });
+    await page.clock.fastForward(10_000);
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-request-count',
+        '0',
+    );
+});
+
+test('reconnecting without a queued sample replaces stale offline copy with a GPS timeout', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    const component = await mount(<DriverTrackingStory />);
+    await page.evaluate(() => {
+        window.dispatchEvent(
+            new CustomEvent('tracking-test-network', { detail: 'offline' }),
+        );
+    });
+    await expect(component).toHaveAttribute('data-status', 'retrying');
+    await expect(component).toContainText('Nema internetske veze');
+    await page.evaluate(() => {
+        window.dispatchEvent(
+            new CustomEvent('tracking-test-network', { detail: 'online' }),
+        );
+    });
+    await expect(component).toHaveAttribute('data-status', 'requesting');
+    await emitPositionError(page, 3);
+    await expect(component).toHaveAttribute('data-status', 'unavailable');
+    await expect(component).toContainText(
+        'GPS lokacija trenutačno nije dostupna',
+    );
+    await expect(component).not.toContainText('Nema internetske veze');
+});
+
+test('online backoff wakes at sample expiry and discards exact telemetry first', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    await queueResponse(page, { status: 500, body: null });
+    const component = await mount(<DriverTrackingStory />);
+    await emitPosition(page, 45.81, clockStart.getTime() - 119_000);
+    await expect(component).toHaveAttribute('data-status', 'retrying');
+    await expect(component).toHaveAttribute('data-sample-queued', 'true');
+    await page.clock.fastForward(1_001);
+    await expect(component).toHaveAttribute('data-sample-queued', 'false');
+    await expect(component).toHaveAttribute('data-status', 'unavailable');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-request-count',
+        '1',
+    );
+});
+
+test('fresh acknowledgement survives a GPS timeout, then surfaces it when delayed', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    const component = await mount(
+        <DriverTrackingStory
+            lastAcceptedAt="2026-07-15T12:00:00.000Z"
+            refreshedAt="2026-07-15T12:00:00.000Z"
+            serverStatus="live"
+        />,
+    );
+    await emitPositionError(page, 3);
+    await expect(component).toHaveAttribute('data-status', 'active');
+    await page.clock.fastForward(30_001);
+    await expect(component).toHaveAttribute('data-status', 'unavailable');
+    await expect(component).toContainText(
+        'GPS lokacija trenutačno nije dostupna',
+    );
+    await emitPosition(page, 45.81, clockStart.getTime() + 31_000);
+    await expect(component).toHaveAttribute('data-status', 'active');
+});
+
+test('compatibility timeout aborts a hung upload and preserves retry state', async ({
+    mount,
+    page,
+}) => {
+    await page.clock.install({ time: clockStart });
+    await installTrackingBrowser(page);
+    await page.evaluate(() => {
+        Object.defineProperty(AbortSignal, 'any', {
+            configurable: true,
+            value: undefined,
+        });
+        Object.defineProperty(AbortSignal, 'timeout', {
+            configurable: true,
+            value: undefined,
+        });
+    });
+    await queueResponse(page, {
+        status: 200,
+        body: {
+            status: 'live',
+            acceptedAt: '2026-07-15T12:00:01.000Z',
+            refreshedAt: '2026-07-15T12:00:01.000Z',
+            replayed: false,
+        },
+        deferred: true,
+    });
+    const component = await mount(<DriverTrackingStory />);
+    await emitPosition(page, 45.81, clockStart.getTime());
+    await expect(component).toHaveAttribute('data-status', 'sending');
+    await page.clock.fastForward(20_000);
+    await expect(component).toHaveAttribute('data-status', 'retrying');
+    await expect(component).toHaveAttribute('data-sample-queued', 'true');
+    await expect(page.locator('html')).toHaveAttribute(
+        'data-tracking-abort-count',
+        '1',
+    );
+});
+
+test('Croatian states expose accessible recovery guidance without assertive churn', async ({
+    mount,
+}) => {
+    const component = await mount(
+        <DriverTrackingStatusStory status="sending" />,
+    );
+    await expect(component.getByRole('status')).toContainText(
+        'GPS lokacija se šalje',
+    );
+    await component.update(<DriverTrackingStatusStory status="delayed" />);
+    await expect(
+        component.getByRole('button', { name: 'Pokušaj sada' }),
+    ).toBeVisible();
+    await expect(component).toContainText('stranica vidljiva i aktivna');
+    await component.update(
+        <DriverTrackingStatusStory
+            reason="offline"
+            sampleQueued
+            status="retrying"
+        />,
+    );
+    await expect(component).toContainText('čeka slanje');
+    await expect(
+        component.getByRole('button', { name: 'Pokušaj sada' }),
+    ).toHaveCount(0);
+    await component.update(
+        <DriverTrackingStatusStory
+            reason="permission-denied"
+            status="denied"
+        />,
+    );
+    await expect(
+        component.getByRole('button', {
+            name: 'Ponovno provjeri dopuštenje',
+        }),
+    ).toBeVisible();
+    await component.update(
+        <DriverTrackingStatusStory
+            reason="server-rejected"
+            status="unavailable"
+        />,
+    );
+    await expect(
+        component.getByRole('button', { name: 'Osvježi dostave' }),
+    ).toBeVisible();
+    await expect(component.getByRole('group')).toHaveAttribute(
+        'aria-label',
+        'Status GPS praćenja',
+    );
+    await expect(component.getByRole('alert')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

- model driver tracking as requesting, sending, active, delayed, retrying, denied, or unavailable, with active shown only after a valid server acknowledgement
- keep one newest unsent location in memory and retry transient failures with bounded backoff, jitter, throttling, expiry, and lifecycle-safe cleanup
- expose truthful Croatian recovery guidance while preserving exact-coordinate privacy and returning retryable status codes for unknown server failures

## Validation

- `corepack pnpm --filter delivery test` (174 Node tests, 33 Chromium component tests)
- `corepack pnpm --filter delivery typecheck`
- `corepack pnpm --filter delivery build`
- focused Biome check across all 12 changed files
- `git diff --check`
- independent correctness and privacy/security reviews: no P1/P2 findings

Closes #4129