### PR TITLE
feat(farm): add offline completion sync

### DIFF
--- a/apps/farm/app/api/logout/route.ts
+++ b/apps/farm/app/api/logout/route.ts
@@ -1,17 +1,48 @@
-import { revokeRefreshToken } from '@gredice/storage';
-import { clearCookie } from '../../../lib/auth/auth';
+import { getRefreshTokenUserId, revokeRefreshToken } from '@gredice/storage';
+import { cookies } from 'next/headers';
+import {
+    clearCookie,
+    createFarmSessionIncarnation,
+    verifyJwt,
+} from '../../../lib/auth/auth';
+import { collectFarmLoggedOutSessions } from '../../../lib/auth/logoutSessions';
 import {
     clearRefreshCookie,
     getRefreshTokenCookie,
 } from '../../../lib/auth/refreshCookies';
+import { sessionCookieName } from '../../../lib/auth/sessionConfig';
+
+async function getLoggedOutSessions(refreshToken: string | null) {
+    const accessToken = (await cookies()).get(sessionCookieName)?.value ?? null;
+    const accessTokenResult = accessToken ? await verifyJwt(accessToken) : null;
+    const accessUserId = accessTokenResult?.result?.payload.sub;
+    const refreshUser = refreshToken
+        ? await getRefreshTokenUserId(refreshToken)
+        : null;
+
+    return collectFarmLoggedOutSessions({
+        accessSessionIncarnation: accessToken
+            ? createFarmSessionIncarnation(accessToken)
+            : null,
+        accessUserId: typeof accessUserId === 'string' ? accessUserId : null,
+        refreshSessionIncarnation: refreshToken
+            ? createFarmSessionIncarnation(refreshToken)
+            : null,
+        refreshUserId: refreshUser?.userId ?? null,
+    });
+}
 
 export async function POST() {
     const refreshToken = await getRefreshTokenCookie();
+    const loggedOutSessions = await getLoggedOutSessions(refreshToken);
     if (refreshToken) {
         await revokeRefreshToken(refreshToken);
     }
     await clearCookie();
     await clearRefreshCookie();
 
-    return new Response(null, { status: 200 });
+    return Response.json(
+        { loggedOutSessions },
+        { headers: { 'Cache-Control': 'no-store' } },
+    );
 }

--- a/apps/farm/app/api/operations/images/upload/route.ts
+++ b/apps/farm/app/api/operations/images/upload/route.ts
@@ -1,6 +1,12 @@
 import { handleUpload } from '@vercel/blob/client';
 import { withAuth } from '../../../../../lib/auth/auth';
-import { getFarmOperationCompletionImagePathPrefix } from '../../../../schedule/operationCompletionProof';
+import {
+    FARM_OPERATION_COMPLETION_IDEMPOTENT_UPLOAD_CONSTRAINTS,
+    getFarmOperationCompletionImagePathPrefix,
+    isFarmOperationCompletionSubmissionImagePath,
+    parseFarmOperationCompletionAttachmentId,
+    parseFarmOperationCompletionSubmissionId,
+} from '../../../../schedule/operationCompletionProof';
 import { parseScheduleOperationCompletionRequirementsFingerprint } from '../../../../schedule/scheduleOperationRequirements';
 import {
     assertNonNegativeSafeInteger,
@@ -13,6 +19,13 @@ import {
 } from '../../../../schedule/scheduleTaskUploadValidation';
 
 const MAX_OPERATION_IMAGE_SIZE_BYTES = 25 * 1024 * 1024;
+
+function assertOperationUploadFileName(value: unknown) {
+    if (typeof value !== 'string') {
+        throw new Error('Invalid operation upload payload');
+    }
+    return value;
+}
 
 function getOperationTargetFromClientPayload(clientPayload: string | null) {
     if (!clientPayload) {
@@ -30,7 +43,24 @@ function getOperationTargetFromClientPayload(clientPayload: string | null) {
         throw new Error('Invalid operation upload payload');
     }
 
+    const rawSubmissionId = Reflect.get(parsedPayload, 'submissionId');
+    const rawAttachmentId = Reflect.get(parsedPayload, 'attachmentId');
+    const rawFileName = Reflect.get(parsedPayload, 'fileName');
+    const hasSubmissionIdentity =
+        rawSubmissionId !== undefined ||
+        rawAttachmentId !== undefined ||
+        rawFileName !== undefined;
+
     return {
+        ...(hasSubmissionIdentity
+            ? {
+                  attachmentId:
+                      parseFarmOperationCompletionAttachmentId(rawAttachmentId),
+                  fileName: assertOperationUploadFileName(rawFileName),
+                  submissionId:
+                      parseFarmOperationCompletionSubmissionId(rawSubmissionId),
+              }
+            : {}),
         expectedEntityId: assertPositiveSafeInteger(
             Reflect.get(parsedPayload, 'expectedEntityId'),
             'Invalid operation upload payload',
@@ -51,75 +81,96 @@ function getOperationTargetFromClientPayload(clientPayload: string | null) {
 }
 
 export async function POST(request: Request) {
-    return await withAuth(['farmer', 'admin'], async ({ user, userId }) => {
-        try {
-            const body = await request.json();
-            const json = await handleUpload({
-                request,
-                body,
-                onBeforeGenerateToken: async (pathname, clientPayload) => {
-                    const {
-                        expectedEntityId,
-                        expectedRequirementsFingerprint,
-                        expectedTaskVersionEventId,
-                        operationId,
-                    } = getOperationTargetFromClientPayload(clientPayload);
-                    assertScheduleTaskUploadTarget(
-                        await validateScheduleOperationUploadTarget({
-                            actor: { role: user.role, userId },
+    return await withAuth(
+        ['farmer', 'admin'],
+        async ({ accountId, user, userId }) => {
+            try {
+                const body = await request.json();
+                const json = await handleUpload({
+                    request,
+                    body,
+                    onBeforeGenerateToken: async (pathname, clientPayload) => {
+                        const target =
+                            getOperationTargetFromClientPayload(clientPayload);
+                        const {
                             expectedEntityId,
                             expectedRequirementsFingerprint,
                             expectedTaskVersionEventId,
                             operationId,
-                            purpose: 'completion',
-                        }),
-                    );
-
-                    if (
-                        !pathname.startsWith(
-                            getFarmOperationCompletionImagePathPrefix(
-                                operationId,
+                        } = target;
+                        assertScheduleTaskUploadTarget(
+                            await validateScheduleOperationUploadTarget({
+                                actor: { role: user.role, userId },
+                                expectedAccountId: accountId,
                                 expectedEntityId,
+                                expectedRequirementsFingerprint,
                                 expectedTaskVersionEventId,
-                            ),
-                        )
-                    ) {
-                        throw new Error('Invalid upload path');
-                    }
+                                operationId,
+                                purpose: 'completion',
+                            }),
+                        );
 
-                    return {
-                        allowedContentTypes: ['image/*'],
-                        maximumSizeInBytes: MAX_OPERATION_IMAGE_SIZE_BYTES,
-                        tokenPayload: clientPayload,
-                    };
-                },
-            });
+                        const validPath =
+                            target.submissionId !== undefined &&
+                            target.attachmentId !== undefined &&
+                            target.fileName !== undefined
+                                ? isFarmOperationCompletionSubmissionImagePath(
+                                      pathname,
+                                      operationId,
+                                      expectedEntityId,
+                                      expectedTaskVersionEventId,
+                                      target.submissionId,
+                                      target.attachmentId,
+                                      target.fileName,
+                                  )
+                                : pathname.startsWith(
+                                      getFarmOperationCompletionImagePathPrefix(
+                                          operationId,
+                                          expectedEntityId,
+                                          expectedTaskVersionEventId,
+                                      ),
+                                  );
+                        if (!validPath) {
+                            throw new Error('Invalid upload path');
+                        }
 
-            return Response.json(json);
-        } catch (error) {
-            if (error instanceof ScheduleTaskUploadTargetError) {
+                        return {
+                            ...(target.submissionId !== undefined
+                                ? FARM_OPERATION_COMPLETION_IDEMPOTENT_UPLOAD_CONSTRAINTS
+                                : {}),
+                            allowedContentTypes: ['image/*'],
+                            maximumSizeInBytes: MAX_OPERATION_IMAGE_SIZE_BYTES,
+                            tokenPayload: clientPayload,
+                        };
+                    },
+                });
+
+                return Response.json(json);
+            } catch (error) {
+                if (error instanceof ScheduleTaskUploadTargetError) {
+                    return Response.json(
+                        {
+                            canRetry: error.canRetry,
+                            code: error.code,
+                            error: error.message,
+                        },
+                        { status: 409 },
+                    );
+                }
+                const message =
+                    error instanceof Error
+                        ? error.message
+                        : 'Unable to prepare image upload';
+
                 return Response.json(
                     {
-                        canRetry: error.canRetry,
-                        code: error.code,
-                        error: error.message,
+                        canRetry: false,
+                        code: 'invalid_input',
+                        error: message,
                     },
-                    { status: 409 },
+                    { status: 400 },
                 );
             }
-            const message =
-                error instanceof Error
-                    ? error.message
-                    : 'Unable to prepare image upload';
-
-            return Response.json(
-                {
-                    canRetry: false,
-                    code: 'invalid_input',
-                    error: message,
-                },
-                { status: 400 },
-            );
-        }
-    });
+        },
+    );
 }

--- a/apps/farm/app/api/users/current-claims/route.ts
+++ b/apps/farm/app/api/users/current-claims/route.ts
@@ -1,12 +1,22 @@
 import { withAuth } from '../../../../lib/auth/auth';
+import { farmOperationCompletionSyncModeFlag } from '../../../flags';
 
 export async function GET() {
-    return await withAuth(['farmer', 'admin'], async ({ user }) => {
-        return Response.json({
-            id: user.id,
-            userName: user.userName,
-            role: user.role,
-            accounts: user.accountIds.map((accountId) => ({ accountId })),
-        });
-    });
+    return await withAuth(
+        ['farmer', 'admin'],
+        async ({ accountId, sessionIncarnation, user }) => {
+            const operationCompletionSyncMode =
+                await farmOperationCompletionSyncModeFlag();
+
+            return Response.json({
+                accountId,
+                id: user.id,
+                userName: user.userName,
+                role: user.role,
+                accounts: user.accountIds.map((accountId) => ({ accountId })),
+                operationCompletionSyncMode,
+                sessionIncarnation,
+            });
+        },
+    );
 }

--- a/apps/farm/app/flags.ts
+++ b/apps/farm/app/flags.ts
@@ -1,4 +1,5 @@
 import { flag } from 'flags/next';
+import type { FarmOperationCompletionSyncMode } from '../lib/offline/operationCompletionSyncMode';
 
 function isDevOrTestEnvironment() {
     return (
@@ -16,3 +17,16 @@ export const showUIFlag = flag<boolean>({
         { label: 'On', value: true },
     ],
 });
+
+export const farmOperationCompletionSyncModeFlag =
+    flag<FarmOperationCompletionSyncMode>({
+        key: 'farmOperationCompletionSyncMode',
+        description:
+            'Control local operation-completion queue creation and foreground draining.',
+        decide: () => (isDevOrTestEnvironment() ? 'enabled' : 'off'),
+        options: [
+            { label: 'Off', value: 'off' },
+            { label: 'Drain only', value: 'drain_only' },
+            { label: 'Enabled', value: 'enabled' },
+        ],
+    });

--- a/apps/farm/app/page.tsx
+++ b/apps/farm/app/page.tsx
@@ -22,9 +22,11 @@ async function getFarmAuth() {
 
 async function FarmTodayDashboard({
     fallbackDisplayName,
+    sessionIncarnation,
     userId,
 }: {
     fallbackDisplayName: string;
+    sessionIncarnation: string;
     userId: string;
 }) {
     const [data, dbUser] = await Promise.all([
@@ -59,7 +61,11 @@ async function FarmTodayDashboard({
                     >
                         <Settings aria-hidden className="size-4 shrink-0" />
                     </IconButton>
-                    <LogoutButton size="lg" />
+                    <LogoutButton
+                        sessionIncarnation={sessionIncarnation}
+                        size="lg"
+                        userId={userId}
+                    />
                 </>
             }
         />
@@ -75,6 +81,7 @@ export default async function Home() {
                 <Suspense fallback={<FarmTodayLoadingState />}>
                     <FarmTodayDashboard
                         fallbackDisplayName={authContext.user.userName}
+                        sessionIncarnation={authContext.sessionIncarnation}
                         userId={authContext.userId}
                     />
                 </Suspense>

--- a/apps/farm/app/schedule/CompleteOperationModal.spec.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.spec.tsx
@@ -4,6 +4,7 @@ import type { Page } from '@playwright/test';
 import {
     CompleteOperationModalAttemptStory,
     CompletePlantingModalAttemptStory,
+    OfflineQueueCompleteOperationModalStory,
     ScheduleTaskBlockerModalAttemptStory,
 } from '../../playwright/ScheduleTaskAttemptVersionStories';
 
@@ -42,6 +43,52 @@ async function settleResponsiveModal(page: Page) {
                     requestAnimationFrame(() => resolve()),
                 );
             }),
+    );
+}
+
+async function expireQueuedOperation(page: Page, operationId: number) {
+    await page.evaluate(
+        ({ databaseName, operationId: targetOperationId, queueStoreName }) =>
+            new Promise<void>((resolve, reject) => {
+                const openRequest = indexedDB.open(databaseName);
+                openRequest.onerror = () => reject(openRequest.error);
+                openRequest.onsuccess = () => {
+                    const database = openRequest.result;
+                    const transaction = database.transaction(
+                        queueStoreName,
+                        'readwrite',
+                    );
+                    const store = transaction.objectStore(queueStoreName);
+                    const getAllRequest = store.getAll();
+                    getAllRequest.onerror = () => reject(getAllRequest.error);
+                    getAllRequest.onsuccess = () => {
+                        const item = getAllRequest.result.find(
+                            (candidate: unknown) =>
+                                typeof candidate === 'object' &&
+                                candidate !== null &&
+                                'operationId' in candidate &&
+                                candidate.operationId === targetOperationId,
+                        );
+                        if (typeof item !== 'object' || item === null) {
+                            reject(new Error('Queued operation not found'));
+                            transaction.abort();
+                            return;
+                        }
+                        store.put({ ...item, expiresAt: Date.now() - 1 });
+                    };
+                    transaction.onabort = () => reject(transaction.error);
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        database.close();
+                        resolve();
+                    };
+                };
+            }),
+        {
+            databaseName: 'gredice-farm-offline',
+            operationId,
+            queueStoreName: 'operation-completion-queue',
+        },
     );
 }
 
@@ -2145,6 +2192,270 @@ test('offers a phone draft after refresh and removes it only after server confir
     await expect(
         dialog.getByPlaceholder('Upišite napomenu o završetku...'),
     ).toHaveValue('');
+});
+
+test('queues a phone completion before network work and restores the waiting gate after refresh', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState = {
+            blockerCalls: 0,
+            hold: false,
+            operationCalls: 0,
+            plantingCalls: 0,
+        };
+    });
+    await mount(
+        <OfflineQueueCompleteOperationModalStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Pregledaj navodnjavanje bez veze"
+            operationId={246}
+        />,
+    );
+    await settleResponsiveModal(page);
+    await page.context().setOffline(true);
+
+    let dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await dialog
+        .getByPlaceholder('Upišite napomenu o završetku...')
+        .fill('Završeno na udaljenom dijelu polja.');
+    await expect(dialog.locator('[data-operation-draft-status]')).toHaveText(
+        'Spremljeno samo na ovom uređaju — radnja još nije dovršena.',
+    );
+    await dialog.getByRole('button', { name: 'Potvrdi' }).click();
+    await expect(dialog.getByRole('status')).toContainText(
+        'sigurno je spremljena samo na ovom uređaju',
+    );
+    expect(
+        await page.evaluate(
+            () => window.__farmScheduleActionTestState?.operationCalls ?? -1,
+        ),
+    ).toBe(0);
+
+    const storedQueue = await page.evaluate(
+        () =>
+            new Promise<{
+                draftCount: number;
+                label: string | null;
+                notes: string | null;
+                state: string | null;
+                submissionId: string | null;
+            }>((resolve, reject) => {
+                const openRequest = indexedDB.open('gredice-farm-offline');
+                openRequest.onerror = () => reject(openRequest.error);
+                openRequest.onsuccess = () => {
+                    const database = openRequest.result;
+                    const transaction = database.transaction(
+                        [
+                            'operation-completion-drafts',
+                            'operation-completion-queue',
+                        ],
+                        'readonly',
+                    );
+                    const draftRequest = transaction
+                        .objectStore('operation-completion-drafts')
+                        .getAll();
+                    const queueRequest = transaction
+                        .objectStore('operation-completion-queue')
+                        .getAll();
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        const queueItem = queueRequest.result.find(
+                            (candidate) =>
+                                typeof candidate === 'object' &&
+                                candidate !== null &&
+                                'operationId' in candidate &&
+                                candidate.operationId === 246,
+                        );
+                        const item =
+                            typeof queueItem === 'object' && queueItem !== null
+                                ? queueItem
+                                : null;
+                        resolve({
+                            draftCount: draftRequest.result.filter(
+                                (candidate) =>
+                                    typeof candidate === 'object' &&
+                                    candidate !== null &&
+                                    'operationId' in candidate &&
+                                    candidate.operationId === 246,
+                            ).length,
+                            label:
+                                item &&
+                                'operationLabel' in item &&
+                                typeof item.operationLabel === 'string'
+                                    ? item.operationLabel
+                                    : null,
+                            notes:
+                                item &&
+                                'notes' in item &&
+                                typeof item.notes === 'string'
+                                    ? item.notes
+                                    : null,
+                            state:
+                                item &&
+                                'state' in item &&
+                                typeof item.state === 'string'
+                                    ? item.state
+                                    : null,
+                            submissionId:
+                                item &&
+                                'submissionId' in item &&
+                                typeof item.submissionId === 'string'
+                                    ? item.submissionId
+                                    : null,
+                        });
+                        database.close();
+                    };
+                };
+            }),
+    );
+    expect(storedQueue).toMatchObject({
+        draftCount: 0,
+        label: 'Pregledaj navodnjavanje bez veze',
+        notes: 'Završeno na udaljenom dijelu polja.',
+        state: 'queued',
+    });
+    expect(storedQueue.submissionId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu,
+    );
+
+    await dialog.getByRole('button', { name: 'U redu' }).click();
+    await expect(dialog).toBeHidden();
+    expect(
+        await page.evaluate(
+            () => window.__farmScheduleActionTestState?.refreshCalls ?? 0,
+        ),
+    ).toBe(0);
+
+    await page.context().setOffline(false);
+    await page.reload();
+    await mount(
+        <OfflineQueueCompleteOperationModalStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Pregledaj navodnjavanje bez veze"
+            operationId={246}
+        />,
+    );
+    await settleResponsiveModal(page);
+    dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await expect(
+        dialog.locator('[data-operation-completion-queue-gate]'),
+    ).toContainText('Radnja čeka slanje');
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toHaveCount(0);
+    const reviewButton = dialog.getByRole('link', {
+        name: 'Pregledaj slanje',
+    });
+    const bounds = await reviewButton.boundingBox();
+    expect(bounds?.height).toBeGreaterThanOrEqual(44);
+    expect(bounds?.x).toBeGreaterThanOrEqual(0);
+    expect((bounds?.x ?? 0) + (bounds?.width ?? 0)).toBeLessThanOrEqual(320);
+    const accessibilityResults = await new AxeBuilder({ page })
+        .include('[role="dialog"]')
+        .analyze();
+    expect(
+        accessibilityResults.violations.filter(
+            ({ impact }) => impact === 'serious' || impact === 'critical',
+        ),
+    ).toEqual([]);
+
+    await expireQueuedOperation(page, 246);
+    await page.reload();
+    await mount(
+        <OfflineQueueCompleteOperationModalStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Pregledaj navodnjavanje bez veze"
+            operationId={246}
+        />,
+    );
+    await settleResponsiveModal(page);
+    dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await expect(
+        dialog.locator('[data-operation-completion-queue-gate]'),
+    ).toContainText('Potrebna je tvoja radnja');
+    await expect(
+        dialog.locator('[data-operation-completion-queue-gate]'),
+    ).toContainText('sadržaj uklonjen s uređaja');
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toHaveCount(0);
+    await expect(dialog.getByText('Možeš započeti novu skicu.')).toHaveCount(0);
+});
+
+test('replaces the local-only success copy with a live server receipt', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    const story = (
+        items: NonNullable<
+            Parameters<
+                typeof OfflineQueueCompleteOperationModalStory
+            >[0]['syncContext']
+        >['items'] = [],
+    ) => (
+        <OfflineQueueCompleteOperationModalStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Pregledaj navodnjavanje"
+            operationId={247}
+            syncContext={{ items }}
+        />
+    );
+    const component = await mount(story());
+    await settleResponsiveModal(page);
+    const dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await dialog
+        .getByPlaceholder('Upišite napomenu o završetku...')
+        .fill('Navodnjavanje je pregledano.');
+    await expect(dialog.locator('[data-operation-draft-status]')).toHaveText(
+        'Spremljeno samo na ovom uređaju — radnja još nije dovršena.',
+    );
+    await dialog.getByRole('button', { name: 'Potvrdi' }).click();
+    await expect(dialog.getByRole('status')).toContainText(
+        'čeka potvrdu farme',
+    );
+
+    await component.update(
+        story([
+            {
+                createdAt: Date.now(),
+                failureMessage: null,
+                key: 'operation-receipt-247',
+                label: null,
+                operationId: 247,
+                retryable: false,
+                serverState: 'pendingVerification',
+                state: 'server_confirmed',
+            },
+        ]),
+    );
+
+    await expect(
+        dialog.locator('[data-operation-completion-server-receipt]'),
+    ).toContainText('Radnja je spremljena na farmi');
+    await expect(
+        dialog.locator('[data-operation-completion-server-receipt]'),
+    ).toContainText('radnja sada čeka provjeru');
+    await expect(dialog.getByText('čeka potvrdu farme')).toHaveCount(0);
 });
 
 test('does not resurrect a cleared note while its first local save is in flight', async ({

--- a/apps/farm/app/schedule/CompleteOperationModal.spec.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.spec.tsx
@@ -1,3 +1,4 @@
+import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/experimental-ct-react';
 import type { Page } from '@playwright/test';
 import {
@@ -5,6 +6,13 @@ import {
     CompletePlantingModalAttemptStory,
     ScheduleTaskBlockerModalAttemptStory,
 } from '../../playwright/ScheduleTaskAttemptVersionStories';
+
+declare global {
+    interface Window {
+        __restoreOperationDraftDeleteForTest?: () => void;
+        __restoreOperationDraftPutForTest?: () => void;
+    }
+}
 
 const expectedTaskVersionEventId = 81;
 const expectedPlantCycleVersionEventId = 802;
@@ -1980,4 +1988,510 @@ test('keeps one blocker request in flight under rapid phone input', async ({
     await expect(dialog.getByRole('status')).toContainText(
         'Status: Blokirano.',
     );
+});
+
+test('offers a phone draft after refresh and removes it only after server confirmation', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState = {
+            blockerCalls: 0,
+            hold: false,
+            operationCalls: 0,
+            plantingCalls: 0,
+        };
+    });
+    await mockOperationPhotoUpload(page, 0);
+    await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{
+                completionAttachImages: true,
+                completionAttachNotes: true,
+            }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Dokumentiraj završenu radnju"
+            operationId={142}
+        />,
+    );
+    await settleResponsiveModal(page);
+
+    let dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    const notes = dialog.getByPlaceholder('Upišite napomenu o završetku...');
+    await expect(notes).toBeVisible();
+    await notes.fill('Završeno nakon jutarnje provjere.');
+    await dialog.locator('input[capture="environment"]').setInputFiles({
+        buffer: Buffer.from('local completion draft proof'),
+        mimeType: 'image/jpeg',
+        name: 'lokalni-dokaz.jpg',
+    });
+    await expect(dialog.locator('[data-operation-draft-status]')).toHaveText(
+        'Spremljeno samo na ovom uređaju — radnja još nije dovršena.',
+    );
+
+    await page.reload();
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState = {
+            blockerCalls: 0,
+            hold: false,
+            operationCalls: 0,
+            plantingCalls: 0,
+        };
+    });
+    await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{
+                completionAttachImages: true,
+                completionAttachNotes: true,
+            }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Dokumentiraj završenu radnju"
+            operationId={142}
+        />,
+    );
+    await settleResponsiveModal(page);
+    dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+
+    await expect(dialog.getByText('Pronađena lokalna skica')).toBeVisible();
+    await expect(dialog.getByText('lokalni-dokaz.jpg')).toHaveCount(0);
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toHaveCount(0);
+    const resumeButton = dialog.getByRole('button', {
+        name: 'Nastavi uređivanje',
+    });
+    const discardButton = dialog.getByRole('button', {
+        name: 'Odbaci skicu',
+    });
+    const closeButton = dialog.getByRole('button', { name: 'Zatvori' });
+    for (const button of [resumeButton, discardButton, closeButton]) {
+        await button.scrollIntoViewIfNeeded();
+        const bounds = await button.boundingBox();
+        expect(bounds).not.toBeNull();
+        expect(bounds?.height).toBeGreaterThanOrEqual(44);
+        expect(bounds?.width).toBeGreaterThanOrEqual(44);
+        expect(bounds?.x).toBeGreaterThanOrEqual(0);
+        expect((bounds?.x ?? 0) + (bounds?.width ?? 0)).toBeLessThanOrEqual(
+            320,
+        );
+        expect(bounds?.y).toBeGreaterThanOrEqual(0);
+        expect((bounds?.y ?? 0) + (bounds?.height ?? 0)).toBeLessThanOrEqual(
+            568,
+        );
+    }
+    const accessibilityResults = await new AxeBuilder({ page })
+        .include('[role="dialog"]')
+        .analyze();
+    expect(
+        accessibilityResults.violations.filter(
+            ({ impact }) => impact === 'serious' || impact === 'critical',
+        ),
+    ).toEqual([]);
+    await closeButton.click();
+    await expect(dialog).toBeHidden();
+    await page
+        .getByRole('button', {
+            name: 'Dovrši radnju: Dokumentiraj završenu radnju',
+        })
+        .click();
+    await expect(dialog.getByText('Pronađena lokalna skica')).toBeVisible();
+    expect(
+        await page.evaluate(
+            () => window.__farmScheduleActionTestState?.operationCalls ?? -1,
+        ),
+    ).toBe(0);
+
+    await resumeButton.click();
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toHaveValue('Završeno nakon jutarnje provjere.');
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toBeFocused();
+    await expect(dialog.getByText('lokalni-dokaz.jpg')).toBeVisible();
+    await dialog.getByRole('button', { name: 'Potvrdi' }).click();
+    await expect(dialog.getByRole('status')).toContainText('čeka potvrdu');
+    expect(
+        await page.evaluate(
+            () => window.__farmScheduleActionTestState?.operationCalls ?? -1,
+        ),
+    ).toBe(1);
+
+    await page.reload();
+    await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{
+                completionAttachImages: true,
+                completionAttachNotes: true,
+            }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Dokumentiraj završenu radnju"
+            operationId={142}
+        />,
+    );
+    await settleResponsiveModal(page);
+    dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await expect(dialog.getByText('Pronađena lokalna skica')).toHaveCount(0);
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toHaveValue('');
+});
+
+test('does not resurrect a cleared note while its first local save is in flight', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.evaluate(() => {
+        const originalPut = Object.getOwnPropertyDescriptor(
+            IDBObjectStore.prototype,
+            'put',
+        );
+        const nativePut = IDBObjectStore.prototype.put;
+        let delayedFirstPut = false;
+
+        window.__restoreOperationDraftPutForTest = () => {
+            if (originalPut) {
+                Object.defineProperty(
+                    IDBObjectStore.prototype,
+                    'put',
+                    originalPut,
+                );
+            } else {
+                Reflect.deleteProperty(IDBObjectStore.prototype, 'put');
+            }
+            delete window.__restoreOperationDraftPutForTest;
+        };
+        Object.defineProperty(IDBObjectStore.prototype, 'put', {
+            configurable: true,
+            value: function delayedPut(
+                this: IDBObjectStore,
+                value: unknown,
+                key?: IDBValidKey,
+            ) {
+                const request =
+                    key === undefined
+                        ? nativePut.call(this, value)
+                        : nativePut.call(this, value, key);
+                const isTargetDraft =
+                    this.name === 'operation-completion-drafts' &&
+                    typeof value === 'object' &&
+                    value !== null &&
+                    'notes' in value &&
+                    value.notes === 'Ovu napomenu farmer odmah briše.';
+                if (delayedFirstPut || !isTargetDraft) {
+                    return request;
+                }
+                delayedFirstPut = true;
+                const nativeAddEventListener = request.addEventListener;
+                Object.defineProperty(request, 'addEventListener', {
+                    configurable: true,
+                    value: (
+                        type: string,
+                        listener: EventListenerOrEventListenerObject | null,
+                        options?: boolean | AddEventListenerOptions,
+                    ) => {
+                        if (type !== 'success' || listener === null) {
+                            return Reflect.apply(
+                                nativeAddEventListener,
+                                request,
+                                [type, listener, options],
+                            );
+                        }
+                        const delayedListener = (event: Event) => {
+                            window.setTimeout(() => {
+                                if (typeof listener === 'function') {
+                                    listener.call(request, event);
+                                } else {
+                                    listener.handleEvent(event);
+                                }
+                            }, 1_000);
+                        };
+                        return Reflect.apply(nativeAddEventListener, request, [
+                            type,
+                            delayedListener,
+                            options,
+                        ]);
+                    },
+                });
+                return request;
+            },
+        });
+    });
+
+    await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={702}
+            label="Očisti probnu napomenu"
+            operationId={143}
+        />,
+    );
+    await settleResponsiveModal(page);
+    let dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    const notes = dialog.getByPlaceholder('Upišite napomenu o završetku...');
+    await notes.fill('Ovu napomenu farmer odmah briše.');
+    await expect(dialog.locator('[data-operation-draft-status]')).toHaveText(
+        'Spremam lokalnu skicu…',
+    );
+    await notes.fill('');
+    await expect(dialog.locator('[data-operation-draft-status]')).toHaveText(
+        'Napomena i fotografije spremaju se samo na ovom uređaju. Radnja nije dovršena dok je ne potvrdiš.',
+        { timeout: 5_000 },
+    );
+    await page.evaluate(() => {
+        window.__restoreOperationDraftPutForTest?.();
+    });
+
+    await page.reload();
+    await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={702}
+            label="Očisti probnu napomenu"
+            operationId={143}
+        />,
+    );
+    await settleResponsiveModal(page);
+    dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await expect(dialog.getByText('Pronađena lokalna skica')).toHaveCount(0);
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toHaveValue('');
+});
+
+test('flushes the latest note when the phone app enters the background', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const component = await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Zapiši stanje tla"
+            operationId={143}
+        />,
+    );
+    await settleResponsiveModal(page);
+    let dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    const notes = dialog.getByPlaceholder('Upišite napomenu o završetku...');
+    await expect(notes).toBeVisible();
+    await notes.fill('Unos neposredno prije odlaska u pozadinu.');
+    await page.evaluate(() => {
+        Object.defineProperties(document, {
+            hidden: { configurable: true, value: true },
+            visibilityState: { configurable: true, value: 'hidden' },
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await expect(dialog.locator('[data-operation-draft-status]')).toHaveText(
+        'Spremljeno samo na ovom uređaju — radnja još nije dovršena.',
+    );
+    await component.unmount();
+    await page.evaluate(() => {
+        Reflect.deleteProperty(document, 'hidden');
+        Reflect.deleteProperty(document, 'visibilityState');
+        document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Zapiši stanje tla"
+            operationId={143}
+        />,
+    );
+    await settleResponsiveModal(page);
+    dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await expect(dialog.getByText('Pronađena lokalna skica')).toBeVisible();
+    await dialog.getByRole('button', { name: 'Nastavi uređivanje' }).click();
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toHaveValue('Unos neposredno prije odlaska u pozadinu.');
+});
+
+test('blocks a changed task draft until the farmer explicitly discards it', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 430, height: 932 });
+    let component = await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Pregledaj navodnjavanje"
+            operationId={144}
+        />,
+    );
+    await settleResponsiveModal(page);
+    let dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await dialog
+        .getByPlaceholder('Upišite napomenu o završetku...')
+        .fill('Skica za staru verziju zadatka.');
+    await expect(dialog.locator('[data-operation-draft-status]')).toHaveText(
+        'Spremljeno samo na ovom uređaju — radnja još nije dovršena.',
+    );
+    await component.unmount();
+
+    component = await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={702}
+            label="Pregledaj navodnjavanje"
+            operationId={144}
+        />,
+    );
+    await settleResponsiveModal(page);
+    dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await expect(dialog.getByText('Zadatak se promijenio')).toBeVisible();
+    await expect(
+        dialog.getByRole('button', { name: 'Nastavi uređivanje' }),
+    ).toHaveCount(0);
+    await expect(dialog.getByRole('button', { name: 'Potvrdi' })).toHaveCount(
+        0,
+    );
+    const discardButton = dialog.getByRole('button', {
+        name: 'Odbaci skicu',
+    });
+    const discardBounds = await discardButton.boundingBox();
+    expect(discardBounds?.height).toBeGreaterThanOrEqual(44);
+    expect(discardBounds?.x).toBeGreaterThanOrEqual(0);
+    expect(
+        (discardBounds?.x ?? 0) + (discardBounds?.width ?? 0),
+    ).toBeLessThanOrEqual(430);
+    await expect(dialog.getByRole('button', { name: 'Zatvori' })).toBeVisible();
+    await page.evaluate(() => {
+        const originalDelete = Object.getOwnPropertyDescriptor(
+            IDBObjectStore.prototype,
+            'delete',
+        );
+        window.__restoreOperationDraftDeleteForTest = () => {
+            if (originalDelete) {
+                Object.defineProperty(
+                    IDBObjectStore.prototype,
+                    'delete',
+                    originalDelete,
+                );
+            } else {
+                Reflect.deleteProperty(IDBObjectStore.prototype, 'delete');
+            }
+            delete window.__restoreOperationDraftDeleteForTest;
+        };
+        Object.defineProperty(IDBObjectStore.prototype, 'delete', {
+            configurable: true,
+            value: () => {
+                throw new DOMException(
+                    'Test delete failure',
+                    'InvalidStateError',
+                );
+            },
+        });
+    });
+    await discardButton.click();
+    await expect(
+        dialog.locator('[data-operation-draft-gate-error]'),
+    ).toContainText('Lokalnu skicu trenutačno nije moguće odbaciti.');
+    await page.evaluate(() => {
+        window.__restoreOperationDraftDeleteForTest?.();
+    });
+    await discardButton.click();
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toBeVisible();
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toBeFocused();
+    await component.unmount();
+
+    await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Pregledaj navodnjavanje"
+            operationId={144}
+        />,
+    );
+    await settleResponsiveModal(page);
+    dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await expect(dialog.getByText('Pronađena lokalna skica')).toHaveCount(0);
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toHaveValue('');
+});
+
+test('flushes the old scope before loading changed task props', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const component = await mount(
+        <CompleteOperationModalAttemptStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Pregledaj sustav"
+            operationId={145}
+        />,
+    );
+    await settleResponsiveModal(page);
+    const dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await dialog
+        .getByPlaceholder('Upišite napomenu o završetku...')
+        .fill('Neposredno prije promjene verzije zadatka.');
+
+    await component.update(
+        <CompleteOperationModalAttemptStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={702}
+            label="Pregledaj sustav"
+            operationId={145}
+        />,
+    );
+
+    await expect(dialog.getByText('Zadatak se promijenio')).toBeVisible();
+    await expect(dialog.locator('[data-operation-draft-status]')).toHaveCount(
+        0,
+    );
+    await dialog.getByRole('button', { name: 'Odbaci skicu' }).click();
+    const changedTaskNotes = dialog.getByPlaceholder(
+        'Upišite napomenu o završetku...',
+    );
+    await expect(changedTaskNotes).toHaveValue('');
+    await expect(changedTaskNotes).toBeFocused();
 });

--- a/apps/farm/app/schedule/CompleteOperationModal.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.tsx
@@ -8,7 +8,7 @@ import { Row } from '@gredice/ui/Row';
 import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { upload } from '@vercel/blob/client';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
     completeFarmOperation,
     completeFarmOperationWithImageUrls,
@@ -31,6 +31,10 @@ import {
     getScheduleTaskCompletionSuccessMessage,
     type ScheduleTaskSubmissionFailure,
 } from './scheduleTaskSubmissionResult';
+import {
+    type OperationCompletionDraftSaveState,
+    useOperationCompletionDraft,
+} from './useOperationCompletionDraft';
 
 type UploadItemStatus = 'pending' | 'uploading' | 'uploaded' | 'failed';
 
@@ -52,14 +56,38 @@ const MAX_UPLOAD_ATTEMPTS = 3;
 const MULTIPART_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024;
 const MAX_COMPLETION_NOTES_LENGTH = 2000;
 
-function createUploadItem(file: File): UploadItem {
+function createUploadItem(file: File, id = crypto.randomUUID()): UploadItem {
     return {
-        id: crypto.randomUUID(),
+        id,
         file,
         progress: 0,
         status: 'pending',
         attempts: 0,
     };
+}
+
+function getLocalDraftSaveErrorMessage(
+    reason: Extract<
+        OperationCompletionDraftSaveState,
+        { kind: 'error' }
+    >['reason'],
+) {
+    switch (reason) {
+        case 'draft_count_limit':
+            return 'Dosegnuto je ograničenje od 5 lokalnih skica. Otvori drugi zadatak sa skicom i odbaci je prije spremanja nove.';
+        case 'draft_size_limit':
+            return 'Lokalne skice koriste dopuštenih 100 MB. Ukloni fotografije ili odbaci drugu skicu.';
+        case 'draft_changed':
+            return 'Lokalna skica promijenila se u drugom prozoru. Pregledaj trenutnu skicu prije nastavka.';
+        case 'incompatible':
+            return 'Zadatak se promijenio pa se ova lokalna skica ne može spremiti. Osvježi raspored prije nastavka.';
+        case 'quota_exceeded':
+            return 'Uređaj nema dovoljno prostora za lokalnu skicu. Unos ostaje otvoren, ali možda neće preživjeti osvježavanje.';
+        case 'session_changed':
+            return 'Sesija je završila. Ovaj unos neće ostati spremljen na uređaju.';
+        default:
+            return 'Lokalna skica se ne može spremiti na ovom uređaju. Unos ostaje otvoren, ali možda neće preživjeti osvježavanje.';
+    }
 }
 
 function clampUploadProgress(progress: number) {
@@ -108,21 +136,27 @@ function getUploadItemProgressClassName(uploadItem: UploadItem) {
 }
 
 interface CompleteOperationModalProps {
+    accountId: string;
     expectedEntityId: number;
     expectedTaskVersionEventId: number;
     operationId: number;
+    sessionIncarnation: string;
     label: string;
     conditions?: EntityStandardized['conditions'];
     defaultOpen?: boolean;
+    userId: string;
 }
 
 export function CompleteOperationModal({
+    accountId,
     expectedEntityId,
     expectedTaskVersionEventId,
     operationId,
+    sessionIncarnation,
     label,
     conditions,
     defaultOpen = false,
+    userId,
 }: CompleteOperationModalProps) {
     const [isOpen, setIsOpen] = useState(defaultOpen);
     const [uploadItems, setUploadItems] = useState<UploadItem[]>([]);
@@ -134,16 +168,34 @@ export function CompleteOperationModal({
     const [imageSelectionMessage, setImageSelectionMessage] = useState<
         string | null
     >(null);
+    const [isResolvingLocalDraft, setIsResolvingLocalDraft] = useState(false);
+    const [localDraftCleanupWarning, setLocalDraftCleanupWarning] =
+        useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const cameraInputRef = useRef<HTMLInputElement>(null);
+    const notesInputRef = useRef<HTMLTextAreaElement>(null);
+    const sessionChangedFocusRef = useRef<HTMLDivElement>(null);
     const submissionInFlightRef = useRef(false);
     const errorRef = useRef<HTMLDivElement>(null);
+    const previousDraftScopeIdentityRef = useRef<string | null>(null);
 
     const requirements = getScheduleOperationCompletionRequirements({
         conditions,
     });
     const expectedRequirementsFingerprint =
         getScheduleOperationCompletionRequirementsFingerprint(requirements);
+    const localDraft = useOperationCompletionDraft({
+        accountId,
+        enabled: isOpen,
+        expectedEntityId,
+        expectedTaskVersionEventId,
+        notes,
+        operationId,
+        photos: uploadItems.map(({ file, id }) => ({ file, id })),
+        requirementsFingerprint: expectedRequirementsFingerprint,
+        sessionIncarnation,
+        userId,
+    });
     const attachImages = isScheduleOperationRequirementVisible(
         requirements.images,
     );
@@ -166,12 +218,99 @@ export function CompleteOperationModal({
     );
     const imageLimitReached =
         uploadItems.length >= MAX_FARM_OPERATION_COMPLETION_IMAGE_COUNT;
+    const localDraftBlocksEditing = localDraft.gate.kind !== 'none';
+    const draftScopeIdentity = JSON.stringify([
+        userId,
+        accountId,
+        operationId,
+        expectedEntityId,
+        expectedTaskVersionEventId,
+        expectedRequirementsFingerprint,
+        sessionIncarnation,
+    ]);
+
+    useEffect(() => {
+        const previousIdentity = previousDraftScopeIdentityRef.current;
+        previousDraftScopeIdentityRef.current = draftScopeIdentity;
+        if (
+            previousIdentity === null ||
+            previousIdentity === draftScopeIdentity
+        ) {
+            return;
+        }
+        setNotes('');
+        setUploadItems([]);
+        setErrorMessage(null);
+        setImageSelectionMessage(null);
+        setLocalDraftCleanupWarning(false);
+    }, [draftScopeIdentity]);
+
+    useEffect(() => {
+        if (localDraft.gate.kind !== 'session_changed') {
+            return;
+        }
+        setNotes('');
+        setUploadItems([]);
+        setErrorMessage(null);
+        setImageSelectionMessage(null);
+        setLocalDraftCleanupWarning(false);
+        if (fileInputRef.current) fileInputRef.current.value = '';
+        if (cameraInputRef.current) cameraInputRef.current.value = '';
+        requestAnimationFrame(() => sessionChangedFocusRef.current?.focus());
+    }, [localDraft.gate.kind]);
+
+    const focusCompletionForm = () => {
+        requestAnimationFrame(() => {
+            if (attachNotes) {
+                notesInputRef.current?.focus();
+                return;
+            }
+            document
+                .querySelector<HTMLButtonElement>(
+                    `[data-operation-draft-focus-target="${operationId.toString()}"]`,
+                )
+                ?.focus();
+        });
+    };
+
+    const resumeLocalDraft = () => {
+        const restoredDraft = localDraft.resume();
+        if (!restoredDraft) {
+            return;
+        }
+        setNotes(restoredDraft.notes);
+        setUploadItems(
+            restoredDraft.photos.map(({ file, id }) =>
+                createUploadItem(file, id),
+            ),
+        );
+        setErrorMessage(null);
+        setImageSelectionMessage(null);
+        focusCompletionForm();
+    };
+
+    const discardLocalDraft = async () => {
+        setIsResolvingLocalDraft(true);
+        try {
+            const discarded = await localDraft.discard();
+            if (discarded) {
+                setNotes('');
+                setUploadItems([]);
+                setErrorMessage(null);
+                setImageSelectionMessage(null);
+                focusCompletionForm();
+            }
+        } finally {
+            setIsResolvingLocalDraft(false);
+        }
+    };
 
     const resetCompletedDraft = () => {
         setSuccessMessage(null);
         setErrorMessage(null);
         setRequiresRefresh(false);
         setImageSelectionMessage(null);
+        setLocalDraftCleanupWarning(false);
         setUploadItems([]);
         setNotes('');
         if (fileInputRef.current) fileInputRef.current.value = '';
@@ -203,6 +342,7 @@ export function CompleteOperationModal({
 
         setIsOpen(open);
         if (!open && !requiresRefresh) {
+            void localDraft.flush();
             setErrorMessage(null);
             setImageSelectionMessage(null);
         }
@@ -239,7 +379,7 @@ export function CompleteOperationModal({
                     ...currentUploadItems,
                     ...acceptedFiles
                         .slice(0, remainingSlots)
-                        .map(createUploadItem),
+                        .map((file) => createUploadItem(file)),
                 ];
             });
             const selectionMessages = [
@@ -381,12 +521,8 @@ export function CompleteOperationModal({
                 }));
 
                 return { failure: null, url: uploadedImage.url };
-            } catch (error) {
-                console.error(
-                    'Error uploading image:',
-                    uploadItem.file.name,
-                    error,
-                );
+            } catch {
+                console.error('Error uploading completion image.');
                 lastErrorMessage =
                     'Spremanje fotografije nije uspjelo. Pokušaj ponovno.';
                 const currentTargetValidation =
@@ -419,7 +555,7 @@ export function CompleteOperationModal({
     };
 
     const handleConfirm = async () => {
-        if (submissionInFlightRef.current) {
+        if (submissionInFlightRef.current || localDraftBlocksEditing) {
             return;
         }
 
@@ -488,6 +624,9 @@ export function CompleteOperationModal({
                 requestAnimationFrame(() => errorRef.current?.focus());
                 return;
             }
+            const localConfirmationSucceeded =
+                await localDraft.discardAfterServerSuccess();
+            setLocalDraftCleanupWarning(!localConfirmationSucceeded);
             setSuccessMessage(
                 getScheduleTaskCompletionSuccessMessage({
                     kind: 'operation',
@@ -545,6 +684,13 @@ export function CompleteOperationModal({
                     <Alert color="success" role="status">
                         {successMessage}
                     </Alert>
+                    {localDraftCleanupWarning ? (
+                        <Alert color="warning" role="status">
+                            Radnja je spremljena na farmi, ali lokalnu skicu
+                            nije moguće očistiti. Osvježi raspored prije
+                            ponovnog otvaranja zadatka.
+                        </Alert>
+                    ) : null}
                     <Button
                         fullWidth
                         onClick={finishSuccess}
@@ -561,7 +707,185 @@ export function CompleteOperationModal({
                         Jeste li sigurni da želite označiti operaciju kao
                         završenu: <strong>{label}</strong>?
                     </Typography>
-                    {attachImages && (
+                    {localDraft.gate.kind === 'checking' ? (
+                        <Stack spacing={2}>
+                            <Alert color="info" role="status">
+                                Provjeravam postoji li lokalna skica na ovom
+                                uređaju…
+                            </Alert>
+                            <Button
+                                fullWidth
+                                onClick={() => handleOpenChange(false)}
+                                size="lg"
+                                type="button"
+                                variant="outlined"
+                            >
+                                Zatvori
+                            </Button>
+                        </Stack>
+                    ) : null}
+                    {localDraft.gate.kind === 'session_changed' ? (
+                        <Alert
+                            color="warning"
+                            data-operation-draft-gate
+                            role="alert"
+                        >
+                            <Stack spacing={3}>
+                                <div
+                                    data-operation-draft-session-focus
+                                    ref={sessionChangedFocusRef}
+                                    tabIndex={-1}
+                                >
+                                    <Typography level="body2" semiBold>
+                                        Sesija je završila
+                                    </Typography>
+                                    <Typography level="body2">
+                                        Ovaj unos nije spremljen i neće ostati
+                                        na ovom uređaju. Ponovno se prijavi
+                                        prije nastavka.
+                                    </Typography>
+                                </div>
+                                <Button
+                                    fullWidth
+                                    onClick={() => handleOpenChange(false)}
+                                    size="lg"
+                                    type="button"
+                                    variant="outlined"
+                                >
+                                    Zatvori
+                                </Button>
+                            </Stack>
+                        </Alert>
+                    ) : null}
+                    {localDraft.gate.kind === 'found' ? (
+                        <Alert color="info" data-operation-draft-gate>
+                            <Stack spacing={3}>
+                                <div>
+                                    <Typography level="body2" semiBold>
+                                        Pronađena lokalna skica
+                                    </Typography>
+                                    <Typography level="body2">
+                                        Skica je spremljena samo na ovom
+                                        uređaju. Radnja još nije dovršena.
+                                    </Typography>
+                                </div>
+                                <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                                    <Button
+                                        disabled={isResolvingLocalDraft}
+                                        fullWidth
+                                        onClick={resumeLocalDraft}
+                                        size="lg"
+                                        type="button"
+                                        variant="solid"
+                                    >
+                                        Nastavi uređivanje
+                                    </Button>
+                                    <Button
+                                        color="danger"
+                                        disabled={isResolvingLocalDraft}
+                                        fullWidth
+                                        loading={isResolvingLocalDraft}
+                                        onClick={() => void discardLocalDraft()}
+                                        size="lg"
+                                        type="button"
+                                        variant="outlined"
+                                    >
+                                        Odbaci skicu
+                                    </Button>
+                                    <Button
+                                        disabled={isResolvingLocalDraft}
+                                        fullWidth
+                                        onClick={() => handleOpenChange(false)}
+                                        size="lg"
+                                        type="button"
+                                        variant="plain"
+                                    >
+                                        Zatvori
+                                    </Button>
+                                </div>
+                                {localDraft.saveState.kind === 'error' ? (
+                                    <Typography
+                                        aria-live="assertive"
+                                        className="text-red-800 dark:text-red-200"
+                                        data-operation-draft-gate-error
+                                        level="body2"
+                                    >
+                                        {localDraft.saveState.reason ===
+                                        'draft_changed'
+                                            ? 'Skica se promijenila u drugom prozoru. Pregledaj trenutnu skicu prije odbacivanja.'
+                                            : 'Lokalnu skicu trenutačno nije moguće odbaciti. Zatvori prozor i pokušaj ponovno.'}
+                                    </Typography>
+                                ) : null}
+                            </Stack>
+                        </Alert>
+                    ) : null}
+                    {localDraft.gate.kind === 'stale' ? (
+                        <Alert color="warning" data-operation-draft-gate>
+                            <Stack spacing={3}>
+                                <div>
+                                    <Typography level="body2" semiBold>
+                                        Zadatak se promijenio
+                                    </Typography>
+                                    <Typography level="body2">
+                                        Spremljena skica pripada staroj verziji
+                                        zadatka i ne može se koristiti. Odbaci
+                                        je prije nastavka.
+                                    </Typography>
+                                </div>
+                                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                    <Button
+                                        color="danger"
+                                        disabled={isResolvingLocalDraft}
+                                        fullWidth
+                                        loading={isResolvingLocalDraft}
+                                        onClick={() => void discardLocalDraft()}
+                                        size="lg"
+                                        type="button"
+                                        variant="outlined"
+                                    >
+                                        Odbaci skicu
+                                    </Button>
+                                    <Button
+                                        disabled={isResolvingLocalDraft}
+                                        fullWidth
+                                        onClick={() => handleOpenChange(false)}
+                                        size="lg"
+                                        type="button"
+                                        variant="plain"
+                                    >
+                                        Zatvori
+                                    </Button>
+                                </div>
+                                {localDraft.saveState.kind === 'error' ? (
+                                    <Typography
+                                        aria-live="assertive"
+                                        className="text-red-800 dark:text-red-200"
+                                        data-operation-draft-gate-error
+                                        level="body2"
+                                    >
+                                        {localDraft.saveState.reason ===
+                                        'draft_changed'
+                                            ? 'Skica se promijenila u drugom prozoru. Pregledaj trenutnu skicu prije odbacivanja.'
+                                            : 'Lokalnu skicu trenutačno nije moguće odbaciti. Zatvori prozor i pokušaj ponovno.'}
+                                    </Typography>
+                                ) : null}
+                            </Stack>
+                        </Alert>
+                    ) : null}
+                    {localDraft.notice === 'expired' ? (
+                        <Alert color="warning" role="status">
+                            Lokalna skica istekla je nakon 7 dana i uklonjena
+                            je. Možeš započeti novu skicu.
+                        </Alert>
+                    ) : null}
+                    {localDraft.notice === 'storage_unavailable' ? (
+                        <Alert color="warning" role="status">
+                            Lokalna skica se ne može spremiti na ovom uređaju.
+                            Unos ostaje otvoren, ali možda neće preživjeti
+                            osvježavanje.
+                        </Alert>
+                    ) : null}
+                    {!localDraftBlocksEditing && attachImages && (
                         <Stack spacing={2}>
                             {imageRequirementText && (
                                 <Typography level="body2" className="italic">
@@ -585,6 +909,7 @@ export function CompleteOperationModal({
                                 onChange={handleFileChange}
                             />
                             <Button
+                                data-operation-draft-focus-target={operationId}
                                 variant="outlined"
                                 type="button"
                                 onClick={() => cameraInputRef.current?.click()}
@@ -722,7 +1047,7 @@ export function CompleteOperationModal({
                             )}
                         </Stack>
                     )}
-                    {attachNotes && (
+                    {!localDraftBlocksEditing && attachNotes && (
                         <Stack spacing={2}>
                             {notesRequirementText && (
                                 <label
@@ -733,6 +1058,7 @@ export function CompleteOperationModal({
                                 </label>
                             )}
                             <textarea
+                                ref={notesInputRef}
                                 aria-describedby={notesCounterId}
                                 aria-invalid={notesRequiredMissing || undefined}
                                 id={notesInputId}
@@ -757,7 +1083,7 @@ export function CompleteOperationModal({
                             </Typography>
                         </Stack>
                     )}
-                    {errorMessage && (
+                    {!localDraftBlocksEditing && errorMessage && (
                         <div
                             data-schedule-submission-error
                             ref={errorRef}
@@ -768,48 +1094,72 @@ export function CompleteOperationModal({
                             </Alert>
                         </div>
                     )}
-                    <Row
-                        spacing={2}
-                        justifyContent="end"
-                        className="flex-wrap gap-y-2"
-                    >
-                        <Button
-                            variant="outlined"
-                            onClick={() => handleOpenChange(false)}
-                            disabled={isSubmitting}
-                            size="lg"
-                        >
-                            Odustani
-                        </Button>
-                        <Button
-                            variant="solid"
-                            aria-busy={isSubmitting}
-                            onClick={
-                                requiresRefresh ? refreshTasks : handleConfirm
-                            }
-                            disabled={
-                                isSubmitting ||
-                                (attachImagesRequired &&
-                                    uploadItems.length === 0) ||
-                                notesRequiredMissing
-                            }
-                            loading={isSubmitting}
-                            size="lg"
-                        >
-                            {errorMessage && requiresRefresh
-                                ? 'Osvježi zadatke'
-                                : hasFailedUploads || errorMessage
-                                  ? 'Pokušaj ponovno'
-                                  : 'Potvrdi'}
-                        </Button>
-                    </Row>
-                    <Typography
-                        className="text-center text-muted-foreground"
-                        level="body3"
-                    >
-                        Odabrane fotografije i napomena ostaju sačuvane ako
-                        zatvoriš ovaj prozor prije slanja.
-                    </Typography>
+                    {!localDraftBlocksEditing ? (
+                        <>
+                            {localDraft.saveState.kind === 'error' ? (
+                                <Alert color="warning" role="status">
+                                    {getLocalDraftSaveErrorMessage(
+                                        localDraft.saveState.reason,
+                                    )}
+                                </Alert>
+                            ) : null}
+                            <Row
+                                spacing={2}
+                                justifyContent="end"
+                                className="flex-wrap gap-y-2"
+                            >
+                                <Button
+                                    variant="outlined"
+                                    onClick={() => handleOpenChange(false)}
+                                    disabled={isSubmitting}
+                                    size="lg"
+                                >
+                                    Odustani
+                                </Button>
+                                <Button
+                                    variant="solid"
+                                    aria-busy={isSubmitting}
+                                    onClick={
+                                        requiresRefresh
+                                            ? refreshTasks
+                                            : handleConfirm
+                                    }
+                                    disabled={
+                                        isSubmitting ||
+                                        (attachImagesRequired &&
+                                            uploadItems.length === 0) ||
+                                        notesRequiredMissing
+                                    }
+                                    loading={isSubmitting}
+                                    data-operation-draft-focus-target={
+                                        operationId
+                                    }
+                                    size="lg"
+                                >
+                                    {errorMessage && requiresRefresh
+                                        ? 'Osvježi zadatke'
+                                        : hasFailedUploads || errorMessage
+                                          ? 'Pokušaj ponovno'
+                                          : 'Potvrdi'}
+                                </Button>
+                            </Row>
+                            <Typography
+                                aria-live="polite"
+                                className="text-center text-muted-foreground"
+                                data-operation-draft-status
+                                level="body3"
+                            >
+                                {localDraft.saveState.kind === 'error' ||
+                                localDraft.notice === 'storage_unavailable'
+                                    ? 'Unos trenutačno nije spremljen na ovom uređaju. Radnja još nije dovršena.'
+                                    : localDraft.saveState.kind === 'saving'
+                                      ? 'Spremam lokalnu skicu…'
+                                      : localDraft.saveState.kind === 'saved'
+                                        ? 'Spremljeno samo na ovom uređaju — radnja još nije dovršena.'
+                                        : 'Napomena i fotografije spremaju se samo na ovom uređaju. Radnja nije dovršena dok je ne potvrdiš.'}
+                            </Typography>
+                        </>
+                    ) : null}
                 </Stack>
             )}
         </Modal>

--- a/apps/farm/app/schedule/CompleteOperationModal.tsx
+++ b/apps/farm/app/schedule/CompleteOperationModal.tsx
@@ -9,6 +9,8 @@ import { Stack } from '@gredice/ui/Stack';
 import { Typography } from '@gredice/ui/Typography';
 import { upload } from '@vercel/blob/client';
 import { useEffect, useRef, useState } from 'react';
+import { useOperationCompletionSync } from '../../components/offline/OperationCompletionSyncContext';
+import type { HandoffOperationCompletionDraftToQueueResult } from '../../lib/offline/operationCompletionQueueStore';
 import {
     completeFarmOperation,
     completeFarmOperationWithImageUrls,
@@ -90,6 +92,36 @@ function getLocalDraftSaveErrorMessage(
     }
 }
 
+function getQueueHandoffErrorMessage(
+    reason: Extract<
+        HandoffOperationCompletionDraftToQueueResult,
+        { status: 'error' }
+    >['reason'],
+) {
+    switch (reason) {
+        case 'draft_count_limit':
+            return 'Dosegnuto je ograničenje od 5 lokalnih unosa. Pregledaj spremljene radnje prije nastavka.';
+        case 'draft_size_limit':
+            return 'Lokalni unosi koriste dopuštenih 100 MB. Ukloni fotografije ili odbaci drugi unos.';
+        case 'quota_exceeded':
+            return 'Uređaj nema dovoljno prostora za sigurno spremanje radnje. Ukloni fotografije ili oslobodi prostor pa pokušaj ponovno.';
+        case 'draft_changed':
+            return 'Unos se promijenio u drugom prozoru. Zatvori i ponovno otvori zadatak prije nastavka.';
+        case 'incompatible':
+            return 'Zadatak se promijenio pa ovaj unos nije moguće poslati. Osvježi raspored.';
+        case 'queue_conflict':
+            return 'Za ovu radnju već postoji druga lokalna predaja. Ovaj unos nije zamijenio njezine napomene ili fotografije; pregledaj postojeće slanje.';
+        case 'server_confirmed':
+            return 'Ova radnja već je potvrđena na farmi. Osvježi raspored.';
+        case 'session_changed':
+            return 'Sesija je završila. Ponovno se prijavi prije spremanja radnje.';
+        case 'invalid_input':
+            return 'Lokalni unos nije ispravan. Pregledaj podatke i pokušaj ponovno.';
+        case 'storage_unavailable':
+            return 'Radnju nije moguće sigurno spremiti na ovom uređaju. Unos ostaje otvoren; provjeri prostor i pokušaj ponovno.';
+    }
+}
+
 function clampUploadProgress(progress: number) {
     return Math.max(0, Math.min(100, Math.round(progress)));
 }
@@ -158,6 +190,7 @@ export function CompleteOperationModal({
     defaultOpen = false,
     userId,
 }: CompleteOperationModalProps) {
+    const completionSync = useOperationCompletionSync();
     const [isOpen, setIsOpen] = useState(defaultOpen);
     const [uploadItems, setUploadItems] = useState<UploadItem[]>([]);
     const [notes, setNotes] = useState('');
@@ -165,6 +198,8 @@ export function CompleteOperationModal({
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [requiresRefresh, setRequiresRefresh] = useState(false);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    const [successNeedsScheduleRefresh, setSuccessNeedsScheduleRefresh] =
+        useState(false);
     const [imageSelectionMessage, setImageSelectionMessage] = useState<
         string | null
     >(null);
@@ -219,6 +254,27 @@ export function CompleteOperationModal({
     const imageLimitReached =
         uploadItems.length >= MAX_FARM_OPERATION_COMPLETION_IMAGE_COUNT;
     const localDraftBlocksEditing = localDraft.gate.kind !== 'none';
+    const currentQueueItem = completionSync?.items.find(
+        (item) => item.operationId === operationId,
+    );
+    const currentQueueState =
+        currentQueueItem?.state ??
+        (localDraft.gate.kind === 'queued' ||
+        localDraft.gate.kind === 'server_confirmed'
+            ? localDraft.gate.item.state
+            : null);
+    const currentQueueServerState =
+        currentQueueItem?.serverState ??
+        (localDraft.gate.kind === 'queued' ||
+        localDraft.gate.kind === 'server_confirmed'
+            ? localDraft.gate.item.serverState
+            : null);
+    const currentQueueFailureMessage =
+        currentQueueItem?.failureMessage ??
+        (localDraft.gate.kind === 'queued' &&
+        localDraft.gate.item.failureCode === 'expired'
+            ? 'Lokalni unos je istekao i njegov je sadržaj uklonjen s uređaja. Provjeri raspored pa odbaci ovaj zapis prije novog pokušaja.'
+            : null);
     const draftScopeIdentity = JSON.stringify([
         userId,
         accountId,
@@ -307,6 +363,7 @@ export function CompleteOperationModal({
 
     const resetCompletedDraft = () => {
         setSuccessMessage(null);
+        setSuccessNeedsScheduleRefresh(false);
         setErrorMessage(null);
         setRequiresRefresh(false);
         setImageSelectionMessage(null);
@@ -325,9 +382,12 @@ export function CompleteOperationModal({
     };
 
     const finishSuccess = () => {
+        const shouldRefreshSchedule = successNeedsScheduleRefresh;
         resetCompletedDraft();
         setIsOpen(false);
-        refreshAfterSuccess();
+        if (shouldRefreshSchedule) {
+            refreshAfterSuccess();
+        }
     };
 
     const handleOpenChange = (open: boolean) => {
@@ -570,6 +630,34 @@ export function CompleteOperationModal({
             submissionInFlightRef.current = true;
             setIsSubmitting(true);
             const completionNotes = attachNotes ? trimmedNotes : undefined;
+            if (completionSync?.mode === 'enabled') {
+                const handoff = await localDraft.handoffToQueue({
+                    operationLabel: label,
+                });
+                if (handoff.status === 'error') {
+                    setErrorMessage(
+                        getQueueHandoffErrorMessage(handoff.reason),
+                    );
+                    setRequiresRefresh(
+                        handoff.reason === 'server_confirmed' ||
+                            handoff.reason === 'incompatible' ||
+                            handoff.reason === 'queue_conflict' ||
+                            handoff.reason === 'draft_changed',
+                    );
+                    requestAnimationFrame(() => errorRef.current?.focus());
+                    return;
+                }
+                if (handoff.status === 'existing') {
+                    return;
+                }
+                setSuccessMessage(
+                    navigator.onLine
+                        ? `Radnja „${label}” sigurno je spremljena na ovom uređaju i čeka potvrdu farme.`
+                        : `Radnja „${label}” sigurno je spremljena samo na ovom uređaju. Poslat će se kada ponovno otvoriš aplikaciju uz internetsku vezu.`,
+                );
+                setSuccessNeedsScheduleRefresh(false);
+                return;
+            }
             let result: Awaited<ReturnType<typeof completeFarmOperation>>;
             if (attachImages && uploadItems.length > 0) {
                 const imageUrls: string[] = [];
@@ -634,6 +722,7 @@ export function CompleteOperationModal({
                     state: result.state,
                 }),
             );
+            setSuccessNeedsScheduleRefresh(true);
         } catch (error) {
             console.error('Error completing operation:', error);
             setErrorMessage(
@@ -678,7 +767,7 @@ export function CompleteOperationModal({
                 />
             }
         >
-            {successMessage ? (
+            {successMessage && currentQueueState !== 'server_confirmed' ? (
                 <Stack spacing={4}>
                     <h2 className="text-lg font-semibold">Radnja spremljena</h2>
                     <Alert color="success" role="status">
@@ -753,6 +842,89 @@ export function CompleteOperationModal({
                                     variant="outlined"
                                 >
                                     Zatvori
+                                </Button>
+                            </Stack>
+                        </Alert>
+                    ) : null}
+                    {localDraft.gate.kind === 'queued' &&
+                    currentQueueState !== 'server_confirmed' ? (
+                        <Alert
+                            color={
+                                currentQueueState === 'failed'
+                                    ? 'warning'
+                                    : 'info'
+                            }
+                            data-operation-completion-queue-gate
+                            role="status"
+                        >
+                            <Stack spacing={3}>
+                                <div>
+                                    <Typography level="body2" semiBold>
+                                        {currentQueueState === 'syncing'
+                                            ? 'Šaljem radnju farmi'
+                                            : currentQueueState === 'failed'
+                                              ? 'Potrebna je tvoja radnja'
+                                              : 'Radnja čeka slanje'}
+                                    </Typography>
+                                    <Typography level="body2">
+                                        {currentQueueState === 'syncing'
+                                            ? 'Ostani u aplikaciji dok se napomena i fotografije šalju.'
+                                            : currentQueueState === 'failed'
+                                              ? (currentQueueFailureMessage ??
+                                                'Pregledaj spremljeni unos prije ponovnog slanja ili odbacivanja.')
+                                              : 'Unos je sigurno spremljen samo na ovom uređaju. Poslat će se kada je aplikacija otvorena uz internetsku vezu.'}
+                                    </Typography>
+                                </div>
+                                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                    <Button
+                                        fullWidth
+                                        href="/settings#sinkronizacija-radnji"
+                                        size="lg"
+                                        type="button"
+                                        variant="solid"
+                                    >
+                                        Pregledaj slanje
+                                    </Button>
+                                    <Button
+                                        fullWidth
+                                        onClick={() => handleOpenChange(false)}
+                                        size="lg"
+                                        type="button"
+                                        variant="outlined"
+                                    >
+                                        Zatvori
+                                    </Button>
+                                </div>
+                            </Stack>
+                        </Alert>
+                    ) : null}
+                    {localDraft.gate.kind === 'server_confirmed' ||
+                    currentQueueState === 'server_confirmed' ? (
+                        <Alert
+                            color="success"
+                            data-operation-completion-server-receipt
+                            role="status"
+                        >
+                            <Stack spacing={3}>
+                                <div>
+                                    <Typography level="body2" semiBold>
+                                        Radnja je spremljena na farmi
+                                    </Typography>
+                                    <Typography level="body2">
+                                        {currentQueueServerState ===
+                                        'pendingVerification'
+                                            ? 'Poslužitelj je potvrdio primitak, a radnja sada čeka provjeru.'
+                                            : 'Poslužitelj je potvrdio dovršetak radnje.'}
+                                    </Typography>
+                                </div>
+                                <Button
+                                    fullWidth
+                                    onClick={refreshTasks}
+                                    size="lg"
+                                    type="button"
+                                    variant="solid"
+                                >
+                                    Osvježi raspored
                                 </Button>
                             </Stack>
                         </Alert>

--- a/apps/farm/app/schedule/FarmScheduleDay.tsx
+++ b/apps/farm/app/schedule/FarmScheduleDay.tsx
@@ -13,6 +13,7 @@ import type {
 import { getFarmScheduleRaisedBedPhotoPreviewsForDay } from './scheduleData';
 
 interface FarmScheduleDayProps {
+    accountId: string;
     dayDataPromise: Promise<FarmScheduleDayData>;
     operationsDayDataPromise: Promise<FarmScheduleOperationsDayData>;
     plantingsDayDataPromise: Promise<FarmSchedulePlantingsDayData>;
@@ -22,10 +23,12 @@ interface FarmScheduleDayProps {
     plantSortsPromise: ReturnType<typeof getFarmSchedulePlantSorts>;
     groupWateringOperations: boolean;
     selectedDateKey: string;
+    sessionIncarnation: string;
     userId: string;
 }
 
 export function FarmScheduleDay({
+    accountId,
     dayDataPromise,
     operationsDayDataPromise,
     operationsDataPromise,
@@ -33,6 +36,7 @@ export function FarmScheduleDay({
     plantSortsPromise,
     groupWateringOperations,
     selectedDateKey,
+    sessionIncarnation,
     userId,
 }: FarmScheduleDayProps) {
     const raisedBedPhotoPreviewByIdPromise =
@@ -46,6 +50,7 @@ export function FarmScheduleDay({
             {groupWateringOperations && (
                 <Suspense fallback={<FarmScheduleSectionSkeleton />}>
                     <FarmScheduleOperationsSectionContent
+                        accountId={accountId}
                         dayDataPromise={operationsDayDataPromise}
                         plantSortsPromise={plantSortsPromise}
                         operationsDataPromise={operationsDataPromise}
@@ -54,6 +59,7 @@ export function FarmScheduleDay({
                         }
                         mode="watering"
                         selectedDateKey={selectedDateKey}
+                        sessionIncarnation={sessionIncarnation}
                         userId={userId}
                     />
                 </Suspense>
@@ -71,6 +77,7 @@ export function FarmScheduleDay({
             </Suspense>
             <Suspense fallback={<FarmScheduleSectionSkeleton />}>
                 <FarmScheduleOperationsSectionContent
+                    accountId={accountId}
                     dayDataPromise={operationsDayDataPromise}
                     plantSortsPromise={plantSortsPromise}
                     operationsDataPromise={operationsDataPromise}
@@ -79,6 +86,7 @@ export function FarmScheduleDay({
                     }
                     mode={groupWateringOperations ? 'withoutWatering' : 'all'}
                     selectedDateKey={selectedDateKey}
+                    sessionIncarnation={sessionIncarnation}
                     userId={userId}
                 />
             </Suspense>

--- a/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSection.tsx
@@ -25,6 +25,7 @@ type FarmRaisedBed = FarmScheduleDayData['raisedBeds'][number];
 type FarmOperation = FarmScheduleDayData['scheduledOperations'][number];
 
 interface FarmScheduleOperationsSectionProps {
+    accountId: string;
     raisedBeds: FarmScheduleDayData['raisedBeds'];
     scheduledOperations: FarmScheduleDayData['scheduledOperations'];
     plantSorts: EntityStandardized[] | null | undefined;
@@ -34,6 +35,7 @@ interface FarmScheduleOperationsSectionProps {
     >;
     mode: FarmScheduleOperationsMode;
     selectedDateKey: string;
+    sessionIncarnation: string;
     userId: string;
 }
 
@@ -65,6 +67,7 @@ function buildOperationLabel(
 }
 
 export function FarmScheduleOperationsSection({
+    accountId,
     raisedBeds,
     scheduledOperations,
     plantSorts,
@@ -72,6 +75,7 @@ export function FarmScheduleOperationsSection({
     raisedBedPhotoPreviewByIdPromise,
     mode,
     selectedDateKey,
+    sessionIncarnation,
     userId,
 }: FarmScheduleOperationsSectionProps) {
     if (scheduledOperations.length === 0) {
@@ -213,12 +217,15 @@ export function FarmScheduleOperationsSection({
                             key={operation.id}
                             completionAction={
                                 <CompleteOperationModal
+                                    accountId={accountId}
                                     expectedEntityId={operation.entityId}
                                     expectedTaskVersionEventId={
                                         operation.taskVersionEventId
                                     }
                                     operationId={operation.id}
                                     label={operation.label}
+                                    sessionIncarnation={sessionIncarnation}
+                                    userId={userId}
                                     conditions={
                                         operationDataById.get(
                                             operation.entityId,
@@ -329,6 +336,7 @@ export function FarmScheduleOperationsSection({
                                         key={operation.id}
                                         completionAction={
                                             <CompleteOperationModal
+                                                accountId={accountId}
                                                 expectedEntityId={
                                                     operation.entityId
                                                 }
@@ -337,6 +345,10 @@ export function FarmScheduleOperationsSection({
                                                 }
                                                 operationId={operation.id}
                                                 label={operation.label}
+                                                sessionIncarnation={
+                                                    sessionIncarnation
+                                                }
+                                                userId={userId}
                                                 conditions={
                                                     operationDataById.get(
                                                         operation.entityId,
@@ -373,12 +385,15 @@ export function FarmScheduleOperationsSection({
                                 key={operation.id}
                                 completionAction={
                                     <CompleteOperationModal
+                                        accountId={accountId}
                                         expectedEntityId={operation.entityId}
                                         expectedTaskVersionEventId={
                                             operation.taskVersionEventId
                                         }
                                         operationId={operation.id}
                                         label={operation.label}
+                                        sessionIncarnation={sessionIncarnation}
+                                        userId={userId}
                                         conditions={
                                             operationDataById.get(
                                                 operation.entityId,

--- a/apps/farm/app/schedule/FarmScheduleOperationsSectionContent.tsx
+++ b/apps/farm/app/schedule/FarmScheduleOperationsSectionContent.tsx
@@ -3,6 +3,7 @@ import type { FarmScheduleOperationsDayData } from './scheduleData';
 import type { FarmScheduleOperationsMode } from './scheduleShared';
 
 interface FarmScheduleOperationsSectionContentProps {
+    accountId: string;
     dayDataPromise: Promise<FarmScheduleOperationsDayData>;
     plantSortsPromise: ReturnType<
         typeof import('./scheduleData').getFarmSchedulePlantSorts
@@ -15,16 +16,19 @@ interface FarmScheduleOperationsSectionContentProps {
     >;
     mode: FarmScheduleOperationsMode;
     selectedDateKey: string;
+    sessionIncarnation: string;
     userId: string;
 }
 
 export async function FarmScheduleOperationsSectionContent({
+    accountId,
     dayDataPromise,
     plantSortsPromise,
     operationsDataPromise,
     raisedBedPhotoPreviewByIdPromise,
     mode,
     selectedDateKey,
+    sessionIncarnation,
     userId,
 }: FarmScheduleOperationsSectionContentProps) {
     const { raisedBeds, scheduledOperations } = await dayDataPromise;
@@ -40,6 +44,7 @@ export async function FarmScheduleOperationsSectionContent({
 
     return (
         <FarmScheduleOperationsSection
+            accountId={accountId}
             raisedBeds={raisedBeds}
             scheduledOperations={scheduledOperations}
             plantSorts={plantSorts}
@@ -47,6 +52,7 @@ export async function FarmScheduleOperationsSectionContent({
             raisedBedPhotoPreviewByIdPromise={raisedBedPhotoPreviewByIdPromise}
             mode={mode}
             selectedDateKey={selectedDateKey}
+            sessionIncarnation={sessionIncarnation}
             userId={userId}
         />
     );

--- a/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
+++ b/apps/farm/app/schedule/FarmScheduleTaskCards.spec.tsx
@@ -263,6 +263,7 @@ for (const width of [320, 375, 390, 430]) {
             <FarmScheduleOperationTaskCard
                 completionAction={
                     <CompleteOperationModal
+                        accountId="account-test"
                         conditions={conditions}
                         expectedEntityId={operation.entityId}
                         expectedTaskVersionEventId={
@@ -270,6 +271,8 @@ for (const width of [320, 375, 390, 430]) {
                         }
                         label={operation.label}
                         operationId={operation.id}
+                        sessionIncarnation="session-test"
+                        userId="farmer-1"
                     />
                 }
                 operation={operation}

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -5,19 +5,24 @@ import {
     getEntitiesFormatted,
     getFarmUserPrintableHarvestTraceLinkIds,
     markHarvestTraceLinksPrinted,
+    resolveOperationTaskCompletionSubmission,
     ScheduleTaskSubmissionError,
     submitOperationTaskBlock,
     submitOperationTaskCompletion,
     submitPlantingTaskBlock,
     submitPlantingTaskCompletion,
 } from '@gredice/storage';
-import { head } from '@vercel/blob';
+import { BlobNotFoundError, head } from '@vercel/blob';
 import { revalidatePath } from 'next/cache';
 import { auth } from '../../lib/auth/auth';
 import {
     assertFarmOperationCompletionImagesStored,
+    FarmOperationCompletionImageMetadataUnavailableError,
     FarmOperationCompletionImagesValidationError,
+    getFarmOperationCompletionSubmissionImagePath,
     normalizeFarmOperationCompletionImageUrls,
+    parseFarmOperationCompletionAttachmentId,
+    parseFarmOperationCompletionSubmissionId,
 } from './operationCompletionProof';
 import {
     assertScheduleOperationCompletionProof,
@@ -130,6 +135,28 @@ function taskChangedFailure(message: string): ScheduleTaskSubmissionFailure {
     };
 }
 
+function invalidSubmissionFailure(
+    message: string,
+): ScheduleTaskSubmissionFailure {
+    return {
+        canRetry: false,
+        code: 'invalid_input',
+        message,
+        success: false,
+    };
+}
+
+function submissionConflictFailure(
+    message: string,
+): ScheduleTaskSubmissionFailure {
+    return {
+        canRetry: false,
+        code: 'submission_conflict',
+        message,
+        success: false,
+    };
+}
+
 function notAuthorizedFailure(): ScheduleTaskSubmissionFailure {
     return {
         canRetry: false,
@@ -185,6 +212,17 @@ function retryableProofFailure(
     };
 }
 
+async function loadFarmOperationCompletionImageMetadata(imageUrl: string) {
+    try {
+        return await head(imageUrl);
+    } catch (error) {
+        if (error instanceof BlobNotFoundError) {
+            throw error;
+        }
+        throw new FarmOperationCompletionImageMetadataUnavailableError();
+    }
+}
+
 export async function validateFarmOperationUploadTarget(
     operationId: number,
     expectedEntityId: number,
@@ -196,6 +234,7 @@ export async function validateFarmOperationUploadTarget(
         return authorization.failure;
     }
     const {
+        accountId,
         user: { role },
         userId,
     } = authorization.context;
@@ -230,9 +269,137 @@ export async function validateFarmOperationUploadTarget(
 
     return await validateScheduleOperationUploadTarget({
         actor: { role, userId },
+        expectedAccountId: accountId,
         ...target,
         purpose: 'completion',
     });
+}
+
+export async function recoverFarmOperationCompletionImage(
+    operationId: number,
+    expectedEntityId: number,
+    expectedTaskVersionEventId: number,
+    expectedRequirementsFingerprint: ScheduleOperationCompletionRequirementsFingerprint,
+    submissionId: string,
+    attachmentId: string,
+    fileName: string,
+) {
+    const authorization = await getScheduleTaskAuthContext();
+    if (authorization.failure) {
+        return authorization.failure;
+    }
+    const {
+        accountId,
+        user: { role },
+        userId,
+    } = authorization.context;
+
+    let target: {
+        attachmentId: string;
+        expectedEntityId: number;
+        expectedRequirementsFingerprint: ScheduleOperationCompletionRequirementsFingerprint;
+        expectedTaskVersionEventId: number;
+        fileName: string;
+        operationId: number;
+        submissionId: string;
+    };
+    try {
+        if (typeof fileName !== 'string') {
+            throw new Error('Invalid file name');
+        }
+        target = {
+            attachmentId:
+                parseFarmOperationCompletionAttachmentId(attachmentId),
+            expectedEntityId: assertPositiveSafeInteger(
+                expectedEntityId,
+                'ID vrste radnje nije ispravan.',
+            ),
+            expectedRequirementsFingerprint:
+                parseScheduleOperationCompletionRequirementsFingerprint(
+                    expectedRequirementsFingerprint,
+                ),
+            expectedTaskVersionEventId: assertNonNegativeSafeInteger(
+                expectedTaskVersionEventId,
+                'Verzija radnje nije ispravna.',
+            ),
+            fileName,
+            operationId: assertPositiveSafeInteger(
+                operationId,
+                'ID radnje nije ispravan.',
+            ),
+            submissionId:
+                parseFarmOperationCompletionSubmissionId(submissionId),
+        };
+    } catch {
+        return invalidSubmissionFailure(
+            'Podaci spremljene fotografije nisu ispravni. Odbaci pokušaj i ponovno odaberi fotografiju.',
+        );
+    }
+
+    const uploadTargetValidation = await validateScheduleOperationUploadTarget({
+        actor: { role, userId },
+        expectedAccountId: accountId,
+        expectedEntityId: target.expectedEntityId,
+        expectedRequirementsFingerprint: target.expectedRequirementsFingerprint,
+        expectedTaskVersionEventId: target.expectedTaskVersionEventId,
+        operationId: target.operationId,
+        purpose: 'completion',
+    });
+    if (!uploadTargetValidation.success) {
+        return uploadTargetValidation;
+    }
+
+    const pathname = getFarmOperationCompletionSubmissionImagePath(
+        target.operationId,
+        target.expectedEntityId,
+        target.expectedTaskVersionEventId,
+        target.submissionId,
+        target.attachmentId,
+        target.fileName,
+    );
+    let metadata: Awaited<ReturnType<typeof head>>;
+    try {
+        metadata = await head(pathname);
+    } catch (error) {
+        if (error instanceof BlobNotFoundError) {
+            return { imageUrl: null, success: true as const };
+        }
+        throw error;
+    }
+
+    if (metadata.pathname !== pathname) {
+        return submissionConflictFailure(
+            'Spremljena fotografija ne odgovara ovom pokušaju. Pregledaj pokušaj prije ponovnog slanja.',
+        );
+    }
+    try {
+        const normalizedImageUrls = normalizeFarmOperationCompletionImageUrls(
+            [metadata.url],
+            target.operationId,
+            target.expectedEntityId,
+            target.expectedTaskVersionEventId,
+            target.submissionId,
+        );
+        if (normalizedImageUrls?.length !== 1) {
+            return submissionConflictFailure(
+                'Spremljena fotografija nije valjana za ovaj pokušaj. Pregledaj pokušaj prije ponovnog slanja.',
+            );
+        }
+        await assertFarmOperationCompletionImagesStored(
+            normalizedImageUrls,
+            target.operationId,
+            target.expectedEntityId,
+            target.expectedTaskVersionEventId,
+            async () => metadata,
+            target.submissionId,
+        );
+    } catch {
+        return submissionConflictFailure(
+            'Spremljena fotografija nije valjana za ovaj pokušaj. Pregledaj pokušaj prije ponovnog slanja.',
+        );
+    }
+
+    return { imageUrl: metadata.url, success: true as const };
 }
 
 export async function validateFarmScheduleBlockerUploadTarget(
@@ -268,27 +435,100 @@ export async function completeFarmOperation(
     expectedRequirementsFingerprint: ScheduleOperationCompletionRequirementsFingerprint,
     imageUrls?: string[],
     notes?: string,
+    submissionId?: string,
 ) {
     const authorization = await getScheduleTaskAuthContext();
     if (authorization.failure) {
         return authorization.failure;
     }
     const {
+        accountId,
         user: { role },
         userId,
     } = authorization.context;
-    const validOperationId = assertPositiveSafeInteger(
-        operationId,
-        'ID radnje nije ispravan.',
-    );
-    const validExpectedEntityId = assertPositiveSafeInteger(
-        expectedEntityId,
-        'ID vrste radnje nije ispravan.',
-    );
-    const validExpectedTaskVersionEventId = assertNonNegativeSafeInteger(
-        expectedTaskVersionEventId,
-        'Verzija radnje nije ispravna.',
-    );
+    const keyedSubmission = submissionId !== undefined;
+    let validOperationId: number;
+    let validExpectedEntityId: number;
+    let validExpectedTaskVersionEventId: number;
+    try {
+        validOperationId = assertPositiveSafeInteger(
+            operationId,
+            'ID radnje nije ispravan.',
+        );
+        validExpectedEntityId = assertPositiveSafeInteger(
+            expectedEntityId,
+            'ID vrste radnje nije ispravan.',
+        );
+        validExpectedTaskVersionEventId = assertNonNegativeSafeInteger(
+            expectedTaskVersionEventId,
+            'Verzija radnje nije ispravna.',
+        );
+    } catch (error) {
+        if (!keyedSubmission) {
+            throw error;
+        }
+        return invalidSubmissionFailure(
+            'Spremljeni pokušaj više nema ispravan identitet zadatka. Odbaci ga i pokušaj ponovno.',
+        );
+    }
+    let validSubmissionId: string | undefined;
+    try {
+        validSubmissionId = keyedSubmission
+            ? parseFarmOperationCompletionSubmissionId(submissionId)
+            : undefined;
+    } catch {
+        return invalidSubmissionFailure(
+            'Spremljeni pokušaj slanja nije ispravan. Odbaci ga i pokušaj ponovno.',
+        );
+    }
+    let completionImageUrls: string[] | undefined;
+    let completionNotes: string | undefined;
+    try {
+        completionImageUrls = normalizeFarmOperationCompletionImageUrls(
+            imageUrls,
+            validOperationId,
+            validExpectedEntityId,
+            validExpectedTaskVersionEventId,
+            validSubmissionId,
+        );
+        completionNotes = normalizeCompletionNotes(notes);
+    } catch (error) {
+        if (!validSubmissionId) {
+            throw error;
+        }
+        return invalidSubmissionFailure(
+            'Spremljeni pokušaj sadrži neispravne podatke. Pregledaj ga ili ga odbaci prije ponovnog slanja.',
+        );
+    }
+    const actor = getTaskActor(userId, role);
+
+    if (validSubmissionId) {
+        try {
+            const replay = await resolveOperationTaskCompletionSubmission({
+                actor,
+                expectedAccountId: accountId,
+                expectedEntityId: validExpectedEntityId,
+                expectedTaskVersionEventId: validExpectedTaskVersionEventId,
+                imageUrls: completionImageUrls,
+                notes: completionNotes,
+                operationId: validOperationId,
+                submissionId: validSubmissionId,
+            });
+            if (replay) {
+                return actionResult(
+                    completionState(replay.status),
+                    replay.occurredAt,
+                );
+            }
+        } catch (error) {
+            const failure = submissionFailure(error);
+            if (failure) {
+                return failure;
+            }
+            throw error;
+        }
+    }
+
     let validExpectedRequirementsFingerprint: ScheduleOperationCompletionRequirementsFingerprint;
     try {
         validExpectedRequirementsFingerprint =
@@ -300,16 +540,10 @@ export async function completeFarmOperation(
             'Zahtjevi za dovršetak radnje promijenili su se. Osvježi zadatke.',
         );
     }
-    const completionImageUrls = normalizeFarmOperationCompletionImageUrls(
-        imageUrls,
-        validOperationId,
-        validExpectedEntityId,
-        validExpectedTaskVersionEventId,
-    );
-    const completionNotes = normalizeCompletionNotes(notes);
 
     const uploadTargetValidation = await validateScheduleOperationUploadTarget({
-        actor: { role, userId },
+        actor,
+        expectedAccountId: accountId,
         expectedEntityId: validExpectedEntityId,
         expectedRequirementsFingerprint: validExpectedRequirementsFingerprint,
         expectedTaskVersionEventId: validExpectedTaskVersionEventId,
@@ -347,13 +581,17 @@ export async function completeFarmOperation(
             notes: completionNotes,
         });
     } catch (error) {
+        const message =
+            error instanceof Error
+                ? error.message
+                : 'Dokaz dovršetka nije ispravan.';
+        if (validSubmissionId) {
+            return invalidSubmissionFailure(message);
+        }
         return {
             canRetry: true,
             code: 'invalid_input' as const,
-            message:
-                error instanceof Error
-                    ? error.message
-                    : 'Dokaz dovršetka nije ispravan.',
+            message,
             success: false as const,
         };
     }
@@ -363,10 +601,16 @@ export async function completeFarmOperation(
             validOperationId,
             validExpectedEntityId,
             validExpectedTaskVersionEventId,
-            head,
+            loadFarmOperationCompletionImageMetadata,
+            validSubmissionId,
         );
     } catch (error) {
         if (error instanceof FarmOperationCompletionImagesValidationError) {
+            if (validSubmissionId && error.reason === 'invalid') {
+                return submissionConflictFailure(
+                    'Spremljena fotografija ne odgovara ovom pokušaju i ne može se sigurno zamijeniti. Odbaci pokušaj i pošalji ga ponovno.',
+                );
+            }
             return retryableProofFailure(error);
         }
         throw error;
@@ -375,12 +619,14 @@ export async function completeFarmOperation(
     let result: Awaited<ReturnType<typeof submitOperationTaskCompletion>>;
     try {
         result = await submitOperationTaskCompletion({
-            actor: getTaskActor(userId, role),
+            actor,
+            expectedAccountId: accountId,
             expectedEntityId: validExpectedEntityId,
             expectedTaskVersionEventId: validExpectedTaskVersionEventId,
             imageUrls: completionImageUrls,
             notes: completionNotes,
             operationId: validOperationId,
+            submissionId: validSubmissionId,
         });
     } catch (error) {
         const failure = submissionFailure(error);
@@ -400,6 +646,7 @@ export async function completeFarmOperationWithImageUrls(
     expectedRequirementsFingerprint: ScheduleOperationCompletionRequirementsFingerprint,
     imageUrls: string[],
     notes?: string,
+    submissionId?: string,
 ) {
     return completeFarmOperation(
         operationId,
@@ -408,6 +655,7 @@ export async function completeFarmOperationWithImageUrls(
         expectedRequirementsFingerprint,
         imageUrls,
         notes,
+        submissionId,
     );
 }
 

--- a/apps/farm/app/schedule/actions.ts
+++ b/apps/farm/app/schedule/actions.ts
@@ -31,6 +31,7 @@ import {
     parseScheduleOperationCompletionRequirementsFingerprint,
     type ScheduleOperationCompletionRequirementsFingerprint,
 } from './scheduleOperationRequirements';
+import { getExpectedScheduleTaskAccountId } from './scheduleTaskAccountScope';
 import {
     getScheduleTaskBlockerReason,
     parseScheduleTaskBlockerTarget,
@@ -269,7 +270,7 @@ export async function validateFarmOperationUploadTarget(
 
     return await validateScheduleOperationUploadTarget({
         actor: { role, userId },
-        expectedAccountId: accountId,
+        expectedAccountId: getExpectedScheduleTaskAccountId(accountId, role),
         ...target,
         purpose: 'completion',
     });
@@ -338,7 +339,7 @@ export async function recoverFarmOperationCompletionImage(
 
     const uploadTargetValidation = await validateScheduleOperationUploadTarget({
         actor: { role, userId },
-        expectedAccountId: accountId,
+        expectedAccountId: getExpectedScheduleTaskAccountId(accountId, role),
         expectedEntityId: target.expectedEntityId,
         expectedRequirementsFingerprint: target.expectedRequirementsFingerprint,
         expectedTaskVersionEventId: target.expectedTaskVersionEventId,
@@ -501,12 +502,13 @@ export async function completeFarmOperation(
         );
     }
     const actor = getTaskActor(userId, role);
+    const expectedAccountId = getExpectedScheduleTaskAccountId(accountId, role);
 
     if (validSubmissionId) {
         try {
             const replay = await resolveOperationTaskCompletionSubmission({
                 actor,
-                expectedAccountId: accountId,
+                expectedAccountId,
                 expectedEntityId: validExpectedEntityId,
                 expectedTaskVersionEventId: validExpectedTaskVersionEventId,
                 imageUrls: completionImageUrls,
@@ -543,7 +545,7 @@ export async function completeFarmOperation(
 
     const uploadTargetValidation = await validateScheduleOperationUploadTarget({
         actor,
-        expectedAccountId: accountId,
+        expectedAccountId,
         expectedEntityId: validExpectedEntityId,
         expectedRequirementsFingerprint: validExpectedRequirementsFingerprint,
         expectedTaskVersionEventId: validExpectedTaskVersionEventId,
@@ -620,7 +622,7 @@ export async function completeFarmOperation(
     try {
         result = await submitOperationTaskCompletion({
             actor,
-            expectedAccountId: accountId,
+            expectedAccountId,
             expectedEntityId: validExpectedEntityId,
             expectedTaskVersionEventId: validExpectedTaskVersionEventId,
             imageUrls: completionImageUrls,

--- a/apps/farm/app/schedule/operationCompletionProof.spec.ts
+++ b/apps/farm/app/schedule/operationCompletionProof.spec.ts
@@ -1,9 +1,15 @@
 import { expect, test } from '@playwright/test';
 import {
     assertFarmOperationCompletionImagesStored,
+    FARM_OPERATION_COMPLETION_IDEMPOTENT_UPLOAD_CONSTRAINTS,
+    FarmOperationCompletionImageMetadataUnavailableError,
     FarmOperationCompletionImagesValidationError,
     getFarmOperationCompletionImageFileError,
+    getFarmOperationCompletionSubmissionImagePath,
+    isFarmOperationCompletionSubmissionImagePath,
     normalizeFarmOperationCompletionImageUrls,
+    parseFarmOperationCompletionAttachmentId,
+    parseFarmOperationCompletionSubmissionId,
 } from './operationCompletionProof';
 
 const trustedHost = 'myegtvromcktt2y7.public.blob.vercel-storage.com';
@@ -12,6 +18,10 @@ const expectedEntityId = 701;
 const expectedTaskVersionEventId = 81;
 const targetPath = `operations/${operationId}/entity-${expectedEntityId}/version-${expectedTaskVersionEventId}`;
 const trustedImageUrl = `https://${trustedHost}/${targetPath}/proof.jpg`;
+const submissionId = '11111111-1111-4111-8111-111111111111';
+const attachmentId = '2222222a-222b-4222-8222-22222222222c';
+const submissionPath = `${targetPath}/submissions/${submissionId}/attachments/${attachmentId}.jpg`;
+const trustedSubmissionImageUrl = `https://${trustedHost}/${submissionPath}`;
 
 test('rejects deterministic non-image and oversized phone files before upload', () => {
     expect(
@@ -34,6 +44,101 @@ test('rejects deterministic non-image and oversized phone files before upload', 
     ).toBeNull();
 });
 
+test('builds one canonical evidence pathname per submission attachment', () => {
+    expect(FARM_OPERATION_COMPLETION_IDEMPOTENT_UPLOAD_CONSTRAINTS).toEqual({
+        addRandomSuffix: false,
+        allowOverwrite: false,
+    });
+    expect(
+        getFarmOperationCompletionSubmissionImagePath(
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId.toUpperCase(),
+            attachmentId.toUpperCase(),
+            'Dokaz.JPEG',
+        ),
+    ).toBe(
+        `${targetPath}/submissions/${submissionId}/attachments/${attachmentId}.jpeg`,
+    );
+    expect(
+        getFarmOperationCompletionSubmissionImagePath(
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId,
+            attachmentId,
+            'dokaz.nepodrzani-nastavak',
+        ),
+    ).toBe(
+        `${targetPath}/submissions/${submissionId}/attachments/${attachmentId}`,
+    );
+});
+
+test('accepts only the exact deterministic submission attachment path', () => {
+    expect(
+        isFarmOperationCompletionSubmissionImagePath(
+            submissionPath,
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId,
+            attachmentId,
+            'proof.jpg',
+        ),
+    ).toBe(true);
+    expect(
+        isFarmOperationCompletionSubmissionImagePath(
+            `${targetPath}/submissions/${submissionId}/attachments/${attachmentId}-attempt-2.jpg`,
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId,
+            attachmentId,
+            'proof.jpg',
+        ),
+    ).toBe(false);
+    expect(
+        isFarmOperationCompletionSubmissionImagePath(
+            `${targetPath}/submissions/${submissionId}/attachments/33333333-3333-4333-8333-333333333333.jpg`,
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId,
+            attachmentId,
+            'proof.jpg',
+        ),
+    ).toBe(false);
+    expect(
+        isFarmOperationCompletionSubmissionImagePath(
+            `${targetPath}/submissions/${submissionId}/attachments/${attachmentId}.png`,
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId,
+            attachmentId,
+            'proof.jpg',
+        ),
+    ).toBe(false);
+});
+
+test('validates canonical submission and attachment UUIDs', () => {
+    expect(parseFarmOperationCompletionSubmissionId(submissionId)).toBe(
+        submissionId,
+    );
+    expect(parseFarmOperationCompletionAttachmentId(attachmentId)).toBe(
+        attachmentId,
+    );
+    expect(() =>
+        parseFarmOperationCompletionSubmissionId('not-a-uuid'),
+    ).toThrow('ID slanja');
+    expect(() =>
+        parseFarmOperationCompletionAttachmentId(
+            '22222222-2222-0222-8222-222222222222',
+        ),
+    ).toThrow('ID fotografije');
+});
+
 test('normalizes trusted proof URLs bound to the exact operation', () => {
     expect(
         normalizeFarmOperationCompletionImageUrls(
@@ -51,6 +156,84 @@ test('normalizes trusted proof URLs bound to the exact operation', () => {
             expectedTaskVersionEventId,
         ),
     ).toBeUndefined();
+});
+
+test('binds keyed proof URLs to the exact submission and attachment shape', () => {
+    expect(
+        normalizeFarmOperationCompletionImageUrls(
+            [trustedSubmissionImageUrl],
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId,
+        ),
+    ).toEqual([trustedSubmissionImageUrl]);
+    expect(() =>
+        normalizeFarmOperationCompletionImageUrls(
+            [trustedImageUrl],
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId,
+        ),
+    ).toThrow('učitane kroz ovu radnju');
+    expect(() =>
+        normalizeFarmOperationCompletionImageUrls(
+            [
+                `https://${trustedHost}/${targetPath}/submissions/${submissionId}/attachments/${attachmentId}-attempt-2.jpg`,
+            ],
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId,
+        ),
+    ).toThrow('učitane kroz ovu radnju');
+    expect(() =>
+        normalizeFarmOperationCompletionImageUrls(
+            [
+                trustedSubmissionImageUrl.replace(
+                    attachmentId,
+                    attachmentId.toUpperCase(),
+                ),
+            ],
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId,
+        ),
+    ).toThrow('učitane kroz ovu radnju');
+});
+
+test('accepts recovered metadata only from the exact keyed submission path', async () => {
+    await assertFarmOperationCompletionImagesStored(
+        [trustedSubmissionImageUrl],
+        operationId,
+        expectedEntityId,
+        expectedTaskVersionEventId,
+        async () => ({
+            contentType: 'image/jpeg',
+            pathname: submissionPath,
+            size: 128,
+            url: trustedSubmissionImageUrl,
+        }),
+        submissionId,
+    );
+
+    await expect(
+        assertFarmOperationCompletionImagesStored(
+            [trustedSubmissionImageUrl],
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            async () => ({
+                contentType: 'image/jpeg',
+                pathname: `${targetPath}/submissions/33333333-3333-4333-8333-333333333333/attachments/${attachmentId}.jpg`,
+                size: 128,
+                url: trustedSubmissionImageUrl,
+            }),
+            submissionId,
+        ),
+    ).rejects.toBeInstanceOf(FarmOperationCompletionImagesValidationError);
 });
 
 test('rejects malformed, untrusted, insecure, and cross-operation proof', () => {
@@ -174,11 +357,28 @@ test('identifies every stored proof URL that must be uploaded again', async () =
         FarmOperationCompletionImagesValidationError,
     );
     if (caughtError instanceof FarmOperationCompletionImagesValidationError) {
+        expect(caughtError.reason).toBe('missing');
         expect(caughtError.imageUrls).toEqual([
             trustedImageUrl,
             secondImageUrl,
         ]);
     }
+});
+
+test('does not misclassify a transient metadata outage as a missing upload', async () => {
+    const unavailable =
+        new FarmOperationCompletionImageMetadataUnavailableError();
+    await expect(
+        assertFarmOperationCompletionImagesStored(
+            [trustedImageUrl],
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            async () => {
+                throw unavailable;
+            },
+        ),
+    ).rejects.toBe(unavailable);
 });
 
 test('limits one completion record to twenty unique images', () => {

--- a/apps/farm/app/schedule/operationCompletionProof.ts
+++ b/apps/farm/app/schedule/operationCompletionProof.ts
@@ -2,14 +2,30 @@ import { validateHostedImageUrl } from '@gredice/js/urls';
 
 export const MAX_FARM_OPERATION_COMPLETION_IMAGE_COUNT = 20;
 export const MAX_FARM_OPERATION_COMPLETION_IMAGE_SIZE_BYTES = 25 * 1024 * 1024;
+export const FARM_OPERATION_COMPLETION_IDEMPOTENT_UPLOAD_CONSTRAINTS = {
+    addRandomSuffix: false,
+    allowOverwrite: false,
+} as const;
+
+const FARM_OPERATION_COMPLETION_UUID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const FARM_OPERATION_COMPLETION_IMAGE_EXTENSION_PATTERN = /^[a-z0-9]{1,10}$/;
 
 export class FarmOperationCompletionImagesValidationError extends Error {
     constructor(
         message: string,
         readonly imageUrls: string[],
+        readonly reason: 'invalid' | 'missing',
     ) {
         super(message);
         this.name = 'FarmOperationCompletionImagesValidationError';
+    }
+}
+
+export class FarmOperationCompletionImageMetadataUnavailableError extends Error {
+    constructor() {
+        super('Provjera spremljene fotografije trenutačno nije dostupna.');
+        this.name = 'FarmOperationCompletionImageMetadataUnavailableError';
     }
 }
 
@@ -38,20 +54,148 @@ export function getFarmOperationCompletionImagePathPrefix(
     return `operations/${operationId}/entity-${expectedEntityId}/version-${expectedTaskVersionEventId}/`;
 }
 
+function parseFarmOperationCompletionUuid(value: unknown, label: string) {
+    if (
+        typeof value !== 'string' ||
+        !FARM_OPERATION_COMPLETION_UUID_PATTERN.test(value)
+    ) {
+        throw new Error(`${label} nije ispravan.`);
+    }
+
+    return value.toLowerCase();
+}
+
+export function parseFarmOperationCompletionSubmissionId(value: unknown) {
+    return parseFarmOperationCompletionUuid(value, 'ID slanja');
+}
+
+export function parseFarmOperationCompletionAttachmentId(value: unknown) {
+    return parseFarmOperationCompletionUuid(value, 'ID fotografije');
+}
+
+export function getFarmOperationCompletionSubmissionImagePathPrefix(
+    operationId: number,
+    expectedEntityId: number,
+    expectedTaskVersionEventId: number,
+    submissionId: string,
+) {
+    const validSubmissionId =
+        parseFarmOperationCompletionSubmissionId(submissionId);
+
+    return `${getFarmOperationCompletionImagePathPrefix(operationId, expectedEntityId, expectedTaskVersionEventId)}submissions/${validSubmissionId}/attachments/`;
+}
+
+function getFarmOperationCompletionImageExtension(fileName: string) {
+    const lastDotIndex = fileName.lastIndexOf('.');
+    if (lastDotIndex < 0 || lastDotIndex === fileName.length - 1) {
+        return '';
+    }
+
+    const extension = fileName.slice(lastDotIndex + 1).toLowerCase();
+    return FARM_OPERATION_COMPLETION_IMAGE_EXTENSION_PATTERN.test(extension)
+        ? `.${extension}`
+        : '';
+}
+
+export function getFarmOperationCompletionSubmissionImagePath(
+    operationId: number,
+    expectedEntityId: number,
+    expectedTaskVersionEventId: number,
+    submissionId: string,
+    attachmentId: string,
+    fileName: string,
+) {
+    const validAttachmentId =
+        parseFarmOperationCompletionAttachmentId(attachmentId);
+
+    return `${getFarmOperationCompletionSubmissionImagePathPrefix(
+        operationId,
+        expectedEntityId,
+        expectedTaskVersionEventId,
+        submissionId,
+    )}${validAttachmentId}${getFarmOperationCompletionImageExtension(fileName)}`;
+}
+
+export function isFarmOperationCompletionSubmissionImagePath(
+    pathname: string,
+    operationId: number,
+    expectedEntityId: number,
+    expectedTaskVersionEventId: number,
+    submissionId: string,
+    attachmentId: string,
+    fileName: string,
+) {
+    return (
+        pathname ===
+        getFarmOperationCompletionSubmissionImagePath(
+            operationId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            submissionId,
+            attachmentId,
+            fileName,
+        )
+    );
+}
+
+function isSubmissionAttachmentPathname(
+    pathname: string,
+    expectedPathPrefix: string,
+) {
+    if (!pathname.startsWith(expectedPathPrefix)) {
+        return false;
+    }
+
+    const fileName = pathname.slice(expectedPathPrefix.length);
+    const dotIndex = fileName.indexOf('.');
+    const attachmentId = dotIndex < 0 ? fileName : fileName.slice(0, dotIndex);
+    try {
+        if (
+            parseFarmOperationCompletionAttachmentId(attachmentId) !==
+            attachmentId
+        ) {
+            return false;
+        }
+    } catch {
+        return false;
+    }
+
+    return (
+        dotIndex < 0 ||
+        FARM_OPERATION_COMPLETION_IMAGE_EXTENSION_PATTERN.test(
+            fileName.slice(dotIndex + 1),
+        )
+    );
+}
+
 function isOperationImageUrl(
     imageUrl: string,
     operationId: number,
     expectedEntityId: number,
     expectedTaskVersionEventId: number,
+    submissionId?: string,
 ) {
     const parsedImageUrl = new URL(imageUrl);
-    return (
-        !parsedImageUrl.search &&
-        !parsedImageUrl.hash &&
-        parsedImageUrl.pathname.startsWith(
-            `/${getFarmOperationCompletionImagePathPrefix(operationId, expectedEntityId, expectedTaskVersionEventId)}`,
-        )
-    );
+    const expectedPathPrefix = submissionId
+        ? getFarmOperationCompletionSubmissionImagePathPrefix(
+              operationId,
+              expectedEntityId,
+              expectedTaskVersionEventId,
+              submissionId,
+          )
+        : getFarmOperationCompletionImagePathPrefix(
+              operationId,
+              expectedEntityId,
+              expectedTaskVersionEventId,
+          );
+    if (parsedImageUrl.search || parsedImageUrl.hash) {
+        return false;
+    }
+
+    const pathname = parsedImageUrl.pathname.slice(1);
+    return submissionId
+        ? isSubmissionAttachmentPathname(pathname, expectedPathPrefix)
+        : pathname.startsWith(expectedPathPrefix);
 }
 
 export interface FarmOperationCompletionImageMetadata {
@@ -70,6 +214,7 @@ export function normalizeFarmOperationCompletionImageUrls(
     operationId: number,
     expectedEntityId: number,
     expectedTaskVersionEventId: number,
+    submissionId?: string,
 ) {
     if (value === undefined) {
         return undefined;
@@ -95,6 +240,7 @@ export function normalizeFarmOperationCompletionImageUrls(
                 operationId,
                 expectedEntityId,
                 expectedTaskVersionEventId,
+                submissionId,
             )
         ) {
             throw new Error(
@@ -120,26 +266,41 @@ export async function assertFarmOperationCompletionImagesStored(
     expectedEntityId: number,
     expectedTaskVersionEventId: number,
     loadMetadata: FarmOperationCompletionImageMetadataLoader,
+    submissionId?: string,
 ) {
     if (!imageUrls) {
         return;
     }
 
-    const expectedPathPrefix = getFarmOperationCompletionImagePathPrefix(
-        operationId,
-        expectedEntityId,
-        expectedTaskVersionEventId,
-    );
+    const expectedPathPrefix = submissionId
+        ? getFarmOperationCompletionSubmissionImagePathPrefix(
+              operationId,
+              expectedEntityId,
+              expectedTaskVersionEventId,
+              submissionId,
+          )
+        : getFarmOperationCompletionImagePathPrefix(
+              operationId,
+              expectedEntityId,
+              expectedTaskVersionEventId,
+          );
     const validationResults = await Promise.all(
         imageUrls.map(async (imageUrl) => {
             let metadata: FarmOperationCompletionImageMetadata;
             try {
                 metadata = await loadMetadata(imageUrl);
-            } catch {
+            } catch (error) {
+                if (
+                    error instanceof
+                    FarmOperationCompletionImageMetadataUnavailableError
+                ) {
+                    throw error;
+                }
                 return {
                     imageUrl,
                     message:
                         'Fotografija nije pronađena. Učitaj je ponovno prije završetka radnje.',
+                    reason: 'missing' as const,
                 };
             }
 
@@ -156,10 +317,11 @@ export async function assertFarmOperationCompletionImagesStored(
                     imageUrl,
                     message:
                         'Dokaz mora biti postojeća fotografija učitana kroz ovu radnju.',
+                    reason: 'invalid' as const,
                 };
             }
 
-            return { imageUrl, message: null };
+            return { imageUrl, message: null, reason: null };
         }),
     );
     const invalidResults = validationResults.filter(
@@ -170,6 +332,9 @@ export async function assertFarmOperationCompletionImagesStored(
             invalidResults[0]?.message ??
                 'Fotografija nije dostupna. Učitaj je ponovno.',
             invalidResults.map((result) => result.imageUrl),
+            invalidResults.some((result) => result.reason === 'invalid')
+                ? 'invalid'
+                : 'missing',
         );
     }
 }

--- a/apps/farm/app/schedule/page.tsx
+++ b/apps/farm/app/schedule/page.tsx
@@ -37,10 +37,14 @@ async function getFarmAuth() {
 }
 
 async function FarmScheduleContent({
+    accountId,
     selectedDateKey,
+    sessionIncarnation,
     userId,
 }: {
+    accountId: string;
     selectedDateKey: string;
+    sessionIncarnation: string;
     userId: string;
 }) {
     const userPromise = getUser(userId);
@@ -90,6 +94,7 @@ async function FarmScheduleContent({
         >
             <FarmScheduleDay
                 key={selectedDateKey}
+                accountId={accountId}
                 selectedDateKey={selectedDateKey}
                 dayDataPromise={dayDataPromise}
                 plantingsDayDataPromise={plantingsDayDataPromise}
@@ -99,6 +104,7 @@ async function FarmScheduleContent({
                 groupWateringOperations={
                     user?.farmScheduleGroupedWateringEnabled ?? true
                 }
+                sessionIncarnation={sessionIncarnation}
                 userId={userId}
             />
         </FarmScheduleNavigationFrame>
@@ -118,7 +124,9 @@ export default async function FarmSchedulePage({
         <div className="min-h-[100dvh] w-full bg-background">
             {authContext ? (
                 <FarmScheduleContent
+                    accountId={authContext.accountId}
                     selectedDateKey={selectedDateKey}
+                    sessionIncarnation={authContext.sessionIncarnation}
                     userId={authContext.userId}
                 />
             ) : (

--- a/apps/farm/app/schedule/scheduleTaskAccountScope.spec.ts
+++ b/apps/farm/app/schedule/scheduleTaskAccountScope.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+import { getExpectedScheduleTaskAccountId } from './scheduleTaskAccountScope';
+
+test('keeps admin task submissions inside the selected account', () => {
+    expect(getExpectedScheduleTaskAccountId('selected-account', 'admin')).toBe(
+        'selected-account',
+    );
+});
+
+test('lets farmer membership authorize tasks from every visible farm', () => {
+    expect(
+        getExpectedScheduleTaskAccountId('selected-account', 'farmer'),
+    ).toBeUndefined();
+});

--- a/apps/farm/app/schedule/scheduleTaskAccountScope.ts
+++ b/apps/farm/app/schedule/scheduleTaskAccountScope.ts
@@ -1,0 +1,6 @@
+export function getExpectedScheduleTaskAccountId(
+    accountId: string,
+    role: string,
+) {
+    return role === 'admin' ? accountId : undefined;
+}

--- a/apps/farm/app/schedule/scheduleTaskSubmissionResult.ts
+++ b/apps/farm/app/schedule/scheduleTaskSubmissionResult.ts
@@ -9,6 +9,7 @@ export type ScheduleTaskSubmissionFailureCode =
     | 'invalid_status'
     | 'not_authorized'
     | 'not_found'
+    | 'submission_conflict'
     | 'task_changed';
 
 export type ScheduleTaskSubmissionSuccess = {

--- a/apps/farm/app/schedule/scheduleTaskUploadValidation.ts
+++ b/apps/farm/app/schedule/scheduleTaskUploadValidation.ts
@@ -63,6 +63,7 @@ export function assertScheduleTaskUploadTarget(
 
 export async function validateScheduleOperationUploadTarget({
     actor,
+    expectedAccountId,
     expectedEntityId,
     expectedRequirementsFingerprint,
     expectedTaskVersionEventId,
@@ -70,6 +71,7 @@ export async function validateScheduleOperationUploadTarget({
     purpose,
 }: {
     actor: ScheduleTaskUploadActor;
+    expectedAccountId?: string;
     expectedEntityId: number;
     expectedRequirementsFingerprint?: ScheduleOperationCompletionRequirementsFingerprint;
     expectedTaskVersionEventId: number;
@@ -85,6 +87,15 @@ export async function validateScheduleOperationUploadTarget({
         return uploadTargetFailure(
             'not_authorized',
             'Više nemaš pristup ovom zadatku. Osvježi zadatke za aktualno stanje.',
+        );
+    }
+    if (
+        expectedAccountId !== undefined &&
+        operation.accountId !== expectedAccountId
+    ) {
+        return uploadTargetFailure(
+            'not_authorized',
+            'Ovaj zadatak više ne pripada odabranom računu. Osvježi zadatke za aktualno stanje.',
         );
     }
     if (operation.entityId !== expectedEntityId) {

--- a/apps/farm/app/schedule/useOperationCompletionDraft.spec.tsx
+++ b/apps/farm/app/schedule/useOperationCompletionDraft.spec.tsx
@@ -1,0 +1,295 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
+import {
+    FARM_OFFLINE_DATABASE_NAME,
+    FARM_OFFLINE_DATABASE_VERSION,
+    OPERATION_COMPLETION_DRAFT_STORE_NAME,
+    OPERATION_COMPLETION_QUEUE_STORE_NAME,
+} from '../../lib/offline/operationCompletionDraftStore';
+import { OperationCompletionDraftHookHarness } from '../../playwright/OperationCompletionDraftHookHarness';
+
+declare global {
+    interface Window {
+        __restoreOperationDraftPutForHookTest?: () => void;
+    }
+}
+
+const scope = {
+    accountId: 'account-hook',
+    expectedEntityId: 701,
+    expectedTaskVersionEventId: 801,
+    operationId: 901,
+    operationLabel: 'Zalij rajčice',
+    requirementsFingerprint: 'images:optional|notes:optional',
+    scheduleDateKey: '2026-07-15',
+    sessionIncarnation: 'session-hook',
+    userId: 'farmer-hook',
+} as const;
+
+async function readStoredCompletionRecords(page: Page) {
+    return page.evaluate(
+        async ({
+            databaseName,
+            databaseVersion,
+            draftStoreName,
+            queueStoreName,
+        }) => {
+            const database = await new Promise<IDBDatabase>(
+                (resolve, reject) => {
+                    const request = indexedDB.open(
+                        databaseName,
+                        databaseVersion,
+                    );
+                    request.addEventListener('success', () =>
+                        resolve(request.result),
+                    );
+                    request.addEventListener('error', () =>
+                        reject(
+                            request.error ?? new Error('Database open failed'),
+                        ),
+                    );
+                },
+            );
+            try {
+                const transaction = database.transaction(
+                    [draftStoreName, queueStoreName],
+                    'readonly',
+                );
+                const all = (storeName: string) =>
+                    new Promise<unknown[]>((resolve, reject) => {
+                        const request = transaction
+                            .objectStore(storeName)
+                            .getAll();
+                        request.addEventListener('success', () =>
+                            resolve(request.result),
+                        );
+                        request.addEventListener('error', () =>
+                            reject(
+                                request.error ??
+                                    new Error('Database read failed'),
+                            ),
+                        );
+                    });
+                const [drafts, queue] = await Promise.all([
+                    all(draftStoreName),
+                    all(queueStoreName),
+                ]);
+                return { drafts, queue };
+            } finally {
+                database.close();
+            }
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            databaseVersion: FARM_OFFLINE_DATABASE_VERSION,
+            draftStoreName: OPERATION_COMPLETION_DRAFT_STORE_NAME,
+            queueStoreName: OPERATION_COMPLETION_QUEUE_STORE_NAME,
+        },
+    );
+}
+
+test('hands the latest form to the queue before the debounce can recreate a draft', async ({
+    mount,
+    page,
+}) => {
+    let component = await mount(
+        <OperationCompletionDraftHookHarness {...scope} />,
+    );
+    await expect(page.getByTestId('operation-draft-gate')).toHaveText(
+        '{"kind":"none"}',
+    );
+
+    await page.getByLabel('Napomena').fill('Zaliveno prije večernje smjene.');
+    await page.getByRole('button', { name: 'Predaj u red' }).click();
+
+    await expect(
+        page.getByTestId('operation-draft-handoff-result'),
+    ).toContainText('"status":"enqueued"');
+    await expect(page.getByTestId('operation-draft-gate')).toContainText(
+        '"kind":"queued"',
+    );
+    await expect(page.getByTestId('operation-draft-gate')).toContainText(
+        '"scheduleDateKey":"2026-07-15"',
+    );
+    const firstGate = JSON.parse(
+        (await page.getByTestId('operation-draft-gate').textContent()) ?? '{}',
+    ) as { item?: { submissionId?: string } };
+    expect(firstGate.item?.submissionId).toMatch(/^[0-9a-f-]{36}$/u);
+
+    await component.unmount();
+    await page.waitForTimeout(400);
+    const stored = await readStoredCompletionRecords(page);
+    expect(
+        stored.drafts.filter(
+            (value) =>
+                typeof value === 'object' &&
+                value !== null &&
+                'operationId' in value,
+        ),
+    ).toHaveLength(0);
+    expect(stored.queue).toHaveLength(1);
+    expect(stored.queue[0]).toMatchObject({
+        notes: 'Zaliveno prije večernje smjene.',
+        operationLabel: 'Zalij rajčice',
+        scheduleDateKey: '2026-07-15',
+        submissionId: firstGate.item?.submissionId,
+    });
+
+    component = await mount(<OperationCompletionDraftHookHarness {...scope} />);
+    await expect(page.getByTestId('operation-draft-gate')).toContainText(
+        '"kind":"queued"',
+    );
+    await expect(page.getByTestId('operation-draft-gate')).toContainText(
+        firstGate.item?.submissionId ?? 'missing-submission-id',
+    );
+    await component.unmount();
+});
+
+test('serializes handoff after an in-flight draft save', async ({
+    mount,
+    page,
+}) => {
+    await mount(<OperationCompletionDraftHookHarness {...scope} />);
+    await expect(page.getByTestId('operation-draft-gate')).toHaveText(
+        '{"kind":"none"}',
+    );
+    await page.evaluate(() => {
+        const originalPut = Object.getOwnPropertyDescriptor(
+            IDBObjectStore.prototype,
+            'put',
+        );
+        const nativePut = IDBObjectStore.prototype.put;
+        window.__restoreOperationDraftPutForHookTest = () => {
+            if (originalPut) {
+                Object.defineProperty(
+                    IDBObjectStore.prototype,
+                    'put',
+                    originalPut,
+                );
+            } else {
+                Reflect.deleteProperty(IDBObjectStore.prototype, 'put');
+            }
+            delete window.__restoreOperationDraftPutForHookTest;
+        };
+        Object.defineProperty(IDBObjectStore.prototype, 'put', {
+            configurable: true,
+            value: function delayedDraftPut(
+                this: IDBObjectStore,
+                value: unknown,
+                key?: IDBValidKey,
+            ) {
+                const request =
+                    key === undefined
+                        ? nativePut.call(this, value)
+                        : nativePut.call(this, value, key);
+                const isTargetDraft =
+                    this.name === 'operation-completion-drafts' &&
+                    typeof value === 'object' &&
+                    value !== null &&
+                    'notes' in value &&
+                    value.notes === 'Pričekaj završetak prve lokalne pohrane.';
+                if (!isTargetDraft) return request;
+                const nativeAddEventListener = request.addEventListener;
+                Object.defineProperty(request, 'addEventListener', {
+                    configurable: true,
+                    value: (
+                        type: string,
+                        listener: EventListenerOrEventListenerObject | null,
+                        options?: boolean | AddEventListenerOptions,
+                    ) => {
+                        if (type !== 'success' || listener === null) {
+                            return Reflect.apply(
+                                nativeAddEventListener,
+                                request,
+                                [type, listener, options],
+                            );
+                        }
+                        const delayedListener = (event: Event) => {
+                            window.setTimeout(() => {
+                                if (typeof listener === 'function') {
+                                    listener.call(request, event);
+                                } else {
+                                    listener.handleEvent(event);
+                                }
+                            }, 500);
+                        };
+                        return Reflect.apply(nativeAddEventListener, request, [
+                            type,
+                            delayedListener,
+                            options,
+                        ]);
+                    },
+                });
+                return request;
+            },
+        });
+        window.addEventListener(
+            'pagehide',
+            () => {
+                window.__restoreOperationDraftPutForHookTest?.();
+            },
+            { once: true },
+        );
+    });
+
+    await page
+        .getByLabel('Napomena')
+        .fill('Pričekaj završetak prve lokalne pohrane.');
+    await expect(page.getByTestId('operation-draft-save-state')).toContainText(
+        '"kind":"saving"',
+    );
+    await page.getByRole('button', { name: 'Predaj u red' }).click();
+    await expect(
+        page.getByTestId('operation-draft-handoff-result'),
+    ).toContainText('"status":"enqueued"');
+
+    const stored = await readStoredCompletionRecords(page);
+    expect(
+        stored.drafts.filter(
+            (value) =>
+                typeof value === 'object' &&
+                value !== null &&
+                'operationId' in value,
+        ),
+    ).toHaveLength(0);
+    expect(stored.queue[0]).toMatchObject({
+        notes: 'Pričekaj završetak prve lokalne pohrane.',
+    });
+    await page.evaluate(() => {
+        window.__restoreOperationDraftPutForHookTest?.();
+    });
+});
+
+test('restores a server-confirmed queue tombstone as a blocking gate', async ({
+    mount,
+    page,
+}) => {
+    let component = await mount(
+        <OperationCompletionDraftHookHarness {...scope} />,
+    );
+    await expect(page.getByTestId('operation-draft-gate')).toHaveText(
+        '{"kind":"none"}',
+    );
+    await page.getByLabel('Napomena').fill('Potvrđeno na poslužitelju.');
+    await page.getByRole('button', { name: 'Predaj u red' }).click();
+    await expect(page.getByTestId('operation-draft-gate')).toContainText(
+        '"kind":"queued"',
+    );
+    await page.getByRole('button', { name: 'Označi potvrđeno' }).click();
+    await expect(
+        page.getByTestId('operation-draft-confirmation-result'),
+    ).toHaveText('{"status":"ok"}');
+    await expect(page.getByTestId('operation-draft-gate')).toContainText(
+        '"kind":"server_confirmed"',
+    );
+
+    await component.unmount();
+    component = await mount(<OperationCompletionDraftHookHarness {...scope} />);
+    await expect(page.getByTestId('operation-draft-gate')).toContainText(
+        '"kind":"server_confirmed"',
+    );
+    await expect(page.getByTestId('operation-draft-gate')).toContainText(
+        '"contentAvailable":false',
+    );
+    await component.unmount();
+});

--- a/apps/farm/app/schedule/useOperationCompletionDraft.ts
+++ b/apps/farm/app/schedule/useOperationCompletionDraft.ts
@@ -18,12 +18,22 @@ import {
     saveOperationCompletionDraft,
     subscribeToOperationCompletionDraftLogout,
 } from '../../lib/offline/operationCompletionDraftStore';
+import {
+    type HandoffOperationCompletionDraftToQueueResult,
+    handoffOperationCompletionDraftToQueue,
+    loadOperationCompletionQueueItem,
+    type OperationCompletionQueueSummary,
+    subscribeToOperationCompletionQueueChanges,
+    summarizeOperationCompletionQueueItem,
+} from '../../lib/offline/operationCompletionQueueStore';
 
 const NOTES_SAVE_DEBOUNCE_MS = 300;
 
 export type OperationCompletionDraftGate =
     | { kind: 'checking' }
     | { kind: 'found'; draft: OperationCompletionDraft }
+    | { kind: 'queued'; item: OperationCompletionQueueSummary }
+    | { kind: 'server_confirmed'; item: OperationCompletionQueueSummary }
     | { kind: 'none' }
     | { kind: 'session_changed' }
     | { kind: 'stale'; revisionId: string };
@@ -55,6 +65,11 @@ type UseOperationCompletionDraftInput = OperationCompletionDraftScope & {
 type RestoredOperationCompletionDraft = {
     notes: string;
     photos: OperationCompletionDraftPhotoInput[];
+};
+
+export type OperationCompletionDraftHandoffInput = {
+    operationLabel: string;
+    scheduleDateKey?: string;
 };
 
 function photoSignature(photos: OperationCompletionDraftPhotoInput[]) {
@@ -118,6 +133,7 @@ export function useOperationCompletionDraft({
     const [saveState, setSaveState] =
         useState<OperationCompletionDraftSaveState>({ kind: 'idle' });
     const activeRef = useRef(false);
+    const gateRef = useRef(gate);
     const generationRef = useRef(0);
     const leaseRef = useRef<OperationCompletionDraftLease | null>(null);
     const leasePromiseRef =
@@ -136,6 +152,7 @@ export function useOperationCompletionDraft({
     const writeQueueRef = useRef<Promise<void>>(Promise.resolve());
 
     latestFormRef.current = { notes, photos };
+    gateRef.current = gate;
 
     const updateSaveState = useCallback(
         (
@@ -147,6 +164,22 @@ export function useOperationCompletionDraft({
             }
         },
         [],
+    );
+
+    const showQueueGate = useCallback(
+        (item: OperationCompletionQueueSummary) => {
+            activeRef.current = false;
+            persistedRevisionByScopeRef.current.delete(scopeIdentity);
+            setGate({
+                item,
+                kind:
+                    item.state === 'server_confirmed'
+                        ? 'server_confirmed'
+                        : 'queued',
+            });
+            setNotice(null);
+        },
+        [scopeIdentity],
     );
 
     const markSessionChanged = useCallback(() => {
@@ -279,6 +312,180 @@ export function useOperationCompletionDraft({
         return enqueueCurrentDraftWrite();
     }, [enqueueCurrentDraftWrite]);
 
+    const handoffToQueue = useCallback(
+        async ({
+            operationLabel,
+            scheduleDateKey,
+        }: OperationCompletionDraftHandoffInput): Promise<HandoffOperationCompletionDraftToQueueResult> => {
+            const generation = generationRef.current;
+            const lease = leaseRef.current;
+            activeRef.current = false;
+            if (saveTimerRef.current) {
+                clearTimeout(saveTimerRef.current);
+                saveTimerRef.current = null;
+            }
+            if (!lease) {
+                markSessionChanged();
+                return { reason: 'session_changed', status: 'error' };
+            }
+
+            let handoffResult: HandoffOperationCompletionDraftToQueueResult = {
+                reason: 'storage_unavailable',
+                status: 'error',
+            };
+            writeQueueRef.current = writeQueueRef.current
+                .catch(() => undefined)
+                .then(async () => {
+                    if (generationRef.current !== generation) {
+                        handoffResult = {
+                            reason: 'session_changed',
+                            status: 'error',
+                        };
+                        return;
+                    }
+                    const currentForm = {
+                        notes: latestFormRef.current.notes,
+                        photos: [...latestFormRef.current.photos],
+                    };
+                    handoffResult =
+                        await handoffOperationCompletionDraftToQueue(
+                            {
+                                ...scope,
+                                notes: currentForm.notes,
+                                operationLabel,
+                                photos: currentForm.photos,
+                                ...(scheduleDateKey === undefined
+                                    ? {}
+                                    : { scheduleDateKey }),
+                            },
+                            {
+                                expectedDraftRevisionId:
+                                    persistedRevisionByScopeRef.current.get(
+                                        scopeIdentity,
+                                    ) ?? null,
+                                lease,
+                            },
+                        );
+                    if (generationRef.current !== generation) {
+                        handoffResult = {
+                            reason: 'session_changed',
+                            status: 'error',
+                        };
+                        return;
+                    }
+                    if (handoffResult.status !== 'error') {
+                        showQueueGate(handoffResult.item);
+                        setSaveState({ kind: 'idle' });
+                        return;
+                    }
+                    if (handoffResult.reason === 'session_changed') {
+                        markSessionChanged();
+                        return;
+                    }
+                    if (
+                        handoffResult.reason === 'server_confirmed' ||
+                        handoffResult.reason === 'draft_changed' ||
+                        handoffResult.reason === 'incompatible' ||
+                        handoffResult.reason === 'queue_conflict'
+                    ) {
+                        const queueResult =
+                            await loadOperationCompletionQueueItem(
+                                scope,
+                                lease,
+                            );
+                        if (generationRef.current !== generation) {
+                            handoffResult = {
+                                reason: 'session_changed',
+                                status: 'error',
+                            };
+                            return;
+                        }
+                        if (
+                            queueResult.status === 'found' ||
+                            queueResult.status === 'expired'
+                        ) {
+                            showQueueGate(
+                                summarizeOperationCompletionQueueItem(
+                                    queueResult.item,
+                                ),
+                            );
+                            return;
+                        }
+                        if (queueResult.status === 'session_changed') {
+                            handoffResult = {
+                                reason: 'session_changed',
+                                status: 'error',
+                            };
+                            markSessionChanged();
+                            return;
+                        }
+                        if (queueResult.status === 'unavailable') {
+                            setNotice('storage_unavailable');
+                            return;
+                        }
+                        const draftResult = await loadOperationCompletionDraft(
+                            scope,
+                            lease,
+                        );
+                        if (generationRef.current !== generation) {
+                            handoffResult = {
+                                reason: 'session_changed',
+                                status: 'error',
+                            };
+                            return;
+                        }
+                        if (draftResult.status === 'found') {
+                            persistedRevisionByScopeRef.current.set(
+                                scopeIdentity,
+                                draftResult.draft.revisionId,
+                            );
+                            setGate({
+                                draft: draftResult.draft,
+                                kind: 'found',
+                            });
+                            return;
+                        }
+                        if (
+                            draftResult.status === 'missing' &&
+                            draftResult.reason === 'incompatible'
+                        ) {
+                            persistedRevisionByScopeRef.current.set(
+                                scopeIdentity,
+                                draftResult.revisionId,
+                            );
+                            setGate({
+                                kind: 'stale',
+                                revisionId: draftResult.revisionId,
+                            });
+                            return;
+                        }
+                        if (draftResult.status === 'session_changed') {
+                            handoffResult = {
+                                reason: 'session_changed',
+                                status: 'error',
+                            };
+                            markSessionChanged();
+                            return;
+                        }
+                        if (draftResult.status === 'unavailable') {
+                            setNotice('storage_unavailable');
+                            return;
+                        }
+                        activeRef.current = true;
+                        setGate({ kind: 'none' });
+                        if (draftResult.status === 'expired') {
+                            setNotice('expired');
+                        }
+                        return;
+                    }
+                    activeRef.current = true;
+                });
+            await writeQueueRef.current;
+            return handoffResult;
+        },
+        [markSessionChanged, scope, scopeIdentity, showQueueGate],
+    );
+
     useEffect(() => {
         if (resetScopeIdentityRef.current === scopeIdentity) {
             return;
@@ -304,22 +511,60 @@ export function useOperationCompletionDraft({
         void writeQueueRef.current
             .catch(() => undefined)
             .then(() => leasePromiseRef.current)
-            .then((leaseResult) =>
-                leaseResult?.status === 'ready'
-                    ? loadOperationCompletionDraft(scope, leaseResult.lease)
-                    : Promise.resolve(
-                          leaseResult?.status === 'unavailable'
-                              ? ({
-                                    status: 'unavailable',
-                                } satisfies LoadOperationCompletionDraftResult)
-                              : sessionChangedLoadResult(),
-                      ),
-            )
-            .then((result) => {
+            .then(async (leaseResult) => {
+                if (leaseResult?.status !== 'ready') {
+                    return {
+                        kind: 'draft' as const,
+                        result:
+                            leaseResult?.status === 'unavailable'
+                                ? ({
+                                      status: 'unavailable',
+                                  } satisfies LoadOperationCompletionDraftResult)
+                                : sessionChangedLoadResult(),
+                    };
+                }
+                const queueResult = await loadOperationCompletionQueueItem(
+                    scope,
+                    leaseResult.lease,
+                );
+                if (queueResult.status !== 'missing') {
+                    return { kind: 'queue' as const, result: queueResult };
+                }
+                return {
+                    kind: 'draft' as const,
+                    result: await loadOperationCompletionDraft(
+                        scope,
+                        leaseResult.lease,
+                    ),
+                };
+            })
+            .then((loaded) => {
                 settled = true;
                 if (cancelled || generationRef.current !== generation) {
                     return;
                 }
+                if (loaded.kind === 'queue') {
+                    const result = loaded.result;
+                    if (
+                        result.status === 'found' ||
+                        result.status === 'expired'
+                    ) {
+                        showQueueGate(
+                            summarizeOperationCompletionQueueItem(result.item),
+                        );
+                        return;
+                    }
+                    if (result.status === 'session_changed') {
+                        markSessionChanged();
+                        return;
+                    }
+                    activeRef.current = false;
+                    persistedRevisionByScopeRef.current.delete(scopeIdentity);
+                    setGate({ kind: 'none' });
+                    setNotice('storage_unavailable');
+                    return;
+                }
+                const result = loaded.result;
                 if (result.status === 'found') {
                     persistedRevisionByScopeRef.current.set(
                         scopeIdentity,
@@ -364,7 +609,71 @@ export function useOperationCompletionDraft({
                 loadedScopeIdentityRef.current = null;
             }
         };
-    }, [enabled, markSessionChanged, scope, scopeIdentity]);
+    }, [enabled, markSessionChanged, scope, scopeIdentity, showQueueGate]);
+
+    useEffect(() => {
+        if (!enabled) {
+            return;
+        }
+        const generation = generationRef.current;
+        let cancelled = false;
+        let refreshSequence = 0;
+        const refreshQueueGate = () => {
+            const lease = leaseRef.current;
+            if (!lease || sessionChangedRef.current) {
+                return;
+            }
+            refreshSequence += 1;
+            const currentRefreshSequence = refreshSequence;
+            void loadOperationCompletionQueueItem(scope, lease).then(
+                (result) => {
+                    if (
+                        cancelled ||
+                        !mountedRef.current ||
+                        generationRef.current !== generation ||
+                        currentRefreshSequence !== refreshSequence
+                    ) {
+                        return;
+                    }
+                    if (
+                        result.status === 'found' ||
+                        result.status === 'expired'
+                    ) {
+                        showQueueGate(
+                            summarizeOperationCompletionQueueItem(result.item),
+                        );
+                        return;
+                    }
+                    if (result.status === 'session_changed') {
+                        markSessionChanged();
+                        return;
+                    }
+                    if (result.status === 'unavailable') {
+                        setNotice('storage_unavailable');
+                        return;
+                    }
+                    if (
+                        gateRef.current.kind !== 'queued' &&
+                        gateRef.current.kind !== 'server_confirmed'
+                    ) {
+                        return;
+                    }
+                    activeRef.current = result.status === 'missing';
+                    setGate({ kind: 'none' });
+                },
+            );
+        };
+        const unsubscribe = subscribeToOperationCompletionQueueChanges(
+            userId,
+            accountId,
+            refreshQueueGate,
+        );
+        return () => {
+            cancelled = true;
+            refreshSequence += 1;
+            unsubscribe();
+        };
+    }, [accountId, enabled, markSessionChanged, scope, showQueueGate, userId]);
 
     useEffect(() => {
         if (previousFormSignatureRef.current === currentFormSignature) {
@@ -571,6 +880,7 @@ export function useOperationCompletionDraft({
         discardAfterServerSuccess,
         flush,
         gate,
+        handoffToQueue,
         notice,
         resume,
         saveState,

--- a/apps/farm/app/schedule/useOperationCompletionDraft.ts
+++ b/apps/farm/app/schedule/useOperationCompletionDraft.ts
@@ -1,0 +1,578 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    type AcquireOperationCompletionDraftLeaseResult,
+    acquireOperationCompletionDraftLease,
+    captureOperationCompletionDraftLogoutNonce,
+    discardOperationCompletionDraft,
+    type LoadOperationCompletionDraftResult,
+    loadOperationCompletionDraft,
+    markOperationCompletionDraftServerConfirmed,
+    type OperationCompletionDraft,
+    type OperationCompletionDraftLease,
+    type OperationCompletionDraftPhotoInput,
+    type OperationCompletionDraftScope,
+    operationCompletionDraftPhotoToFile,
+    type SaveOperationCompletionDraftResult,
+    saveOperationCompletionDraft,
+    subscribeToOperationCompletionDraftLogout,
+} from '../../lib/offline/operationCompletionDraftStore';
+
+const NOTES_SAVE_DEBOUNCE_MS = 300;
+
+export type OperationCompletionDraftGate =
+    | { kind: 'checking' }
+    | { kind: 'found'; draft: OperationCompletionDraft }
+    | { kind: 'none' }
+    | { kind: 'session_changed' }
+    | { kind: 'stale'; revisionId: string };
+
+export type OperationCompletionDraftNotice =
+    | 'expired'
+    | 'storage_unavailable'
+    | null;
+
+export type OperationCompletionDraftSaveState =
+    | { kind: 'idle' }
+    | { kind: 'saved' }
+    | { kind: 'saving' }
+    | {
+          kind: 'error';
+          reason: Extract<
+              SaveOperationCompletionDraftResult,
+              { status: 'error' }
+          >['reason'];
+      };
+
+type UseOperationCompletionDraftInput = OperationCompletionDraftScope & {
+    enabled: boolean;
+    notes: string;
+    photos: OperationCompletionDraftPhotoInput[];
+    sessionIncarnation: string;
+};
+
+type RestoredOperationCompletionDraft = {
+    notes: string;
+    photos: OperationCompletionDraftPhotoInput[];
+};
+
+function photoSignature(photos: OperationCompletionDraftPhotoInput[]) {
+    return photos
+        .map(
+            ({ file, id }) =>
+                `${id}:${file.name}:${file.type}:${file.size.toString()}:${file.lastModified.toString()}`,
+        )
+        .join('|');
+}
+
+function sessionChangedLoadResult(): LoadOperationCompletionDraftResult {
+    return { status: 'session_changed' };
+}
+
+export function useOperationCompletionDraft({
+    accountId,
+    enabled,
+    expectedEntityId,
+    expectedTaskVersionEventId,
+    notes,
+    operationId,
+    photos,
+    requirementsFingerprint,
+    sessionIncarnation,
+    userId,
+}: UseOperationCompletionDraftInput) {
+    const scope = useMemo<OperationCompletionDraftScope>(
+        () => ({
+            accountId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            operationId,
+            requirementsFingerprint,
+            userId,
+        }),
+        [
+            accountId,
+            expectedEntityId,
+            expectedTaskVersionEventId,
+            operationId,
+            requirementsFingerprint,
+            userId,
+        ],
+    );
+    const currentPhotoSignature = photoSignature(photos);
+    const currentFormSignature = `${notes.length.toString()}:${notes}:${currentPhotoSignature}`;
+    const scopeIdentity = JSON.stringify([
+        userId,
+        accountId,
+        operationId,
+        expectedEntityId,
+        expectedTaskVersionEventId,
+        requirementsFingerprint,
+        sessionIncarnation,
+    ]);
+    const [gate, setGate] = useState<OperationCompletionDraftGate>({
+        kind: 'checking',
+    });
+    const [notice, setNotice] = useState<OperationCompletionDraftNotice>(null);
+    const [saveState, setSaveState] =
+        useState<OperationCompletionDraftSaveState>({ kind: 'idle' });
+    const activeRef = useRef(false);
+    const generationRef = useRef(0);
+    const leaseRef = useRef<OperationCompletionDraftLease | null>(null);
+    const leasePromiseRef =
+        useRef<Promise<AcquireOperationCompletionDraftLeaseResult> | null>(
+            null,
+        );
+    const mountedRef = useRef(true);
+    const persistedRevisionByScopeRef = useRef(new Map<string, string>());
+    const sessionChangedRef = useRef(false);
+    const loadedScopeIdentityRef = useRef<string | null>(null);
+    const resetScopeIdentityRef = useRef<string | null>(null);
+    const latestFormRef = useRef({ notes, photos });
+    const previousPhotoSignatureRef = useRef(currentPhotoSignature);
+    const previousFormSignatureRef = useRef(currentFormSignature);
+    const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const writeQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+    latestFormRef.current = { notes, photos };
+
+    const updateSaveState = useCallback(
+        (
+            nextState: OperationCompletionDraftSaveState,
+            generation = generationRef.current,
+        ) => {
+            if (mountedRef.current && generationRef.current === generation) {
+                setSaveState(nextState);
+            }
+        },
+        [],
+    );
+
+    const markSessionChanged = useCallback(() => {
+        if (sessionChangedRef.current) {
+            return;
+        }
+        sessionChangedRef.current = true;
+        generationRef.current += 1;
+        activeRef.current = false;
+        if (saveTimerRef.current) {
+            clearTimeout(saveTimerRef.current);
+            saveTimerRef.current = null;
+        }
+        persistedRevisionByScopeRef.current.clear();
+        setGate({ kind: 'session_changed' });
+        setNotice(null);
+        setSaveState({ kind: 'error', reason: 'session_changed' });
+    }, []);
+
+    useEffect(() => {
+        let cancelled = false;
+        sessionChangedRef.current = false;
+        leaseRef.current = null;
+        const capturedLogoutNonce =
+            captureOperationCompletionDraftLogoutNonce(userId);
+        const leasePromise = acquireOperationCompletionDraftLease(
+            userId,
+            capturedLogoutNonce,
+            sessionIncarnation,
+        );
+        leasePromiseRef.current = leasePromise;
+        void leasePromise.then((result) => {
+            if (cancelled || sessionChangedRef.current) {
+                return;
+            }
+            if (result.status === 'ready') {
+                leaseRef.current = result.lease;
+                return;
+            }
+            if (result.status === 'session_changed') {
+                markSessionChanged();
+                return;
+            }
+            activeRef.current = false;
+            setGate({ kind: 'none' });
+            setNotice('storage_unavailable');
+        });
+        const unsubscribe = subscribeToOperationCompletionDraftLogout(
+            userId,
+            sessionIncarnation,
+            markSessionChanged,
+        );
+
+        return () => {
+            cancelled = true;
+            unsubscribe();
+        };
+    }, [markSessionChanged, sessionIncarnation, userId]);
+
+    const enqueueCurrentDraftWrite = useCallback(() => {
+        if (!activeRef.current) {
+            return writeQueueRef.current;
+        }
+        const generation = generationRef.current;
+        const lease = leaseRef.current;
+        if (!lease) {
+            return writeQueueRef.current;
+        }
+        const currentForm = {
+            notes: latestFormRef.current.notes,
+            photos: [...latestFormRef.current.photos],
+        };
+        const writeScopeIdentity = scopeIdentity;
+
+        const write = async () => {
+            updateSaveState({ kind: 'saving' }, generation);
+            const expectedRevisionId =
+                persistedRevisionByScopeRef.current.get(writeScopeIdentity) ??
+                null;
+            const result = await saveOperationCompletionDraft(
+                {
+                    ...scope,
+                    notes: currentForm.notes,
+                    photos: currentForm.photos,
+                },
+                { expectedRevisionId, lease },
+            );
+            if (generationRef.current !== generation) {
+                return;
+            }
+            if (result.status === 'error') {
+                if (result.reason === 'session_changed') {
+                    markSessionChanged();
+                    return;
+                }
+                updateSaveState(
+                    { kind: 'error', reason: result.reason },
+                    generation,
+                );
+                return;
+            }
+
+            if (result.revisionId) {
+                persistedRevisionByScopeRef.current.set(
+                    writeScopeIdentity,
+                    result.revisionId,
+                );
+            } else {
+                persistedRevisionByScopeRef.current.delete(writeScopeIdentity);
+            }
+            updateSaveState(
+                result.action === 'saved'
+                    ? { kind: 'saved' }
+                    : { kind: 'idle' },
+                generation,
+            );
+        };
+
+        writeQueueRef.current = writeQueueRef.current
+            .catch(() => undefined)
+            .then(write);
+        return writeQueueRef.current;
+    }, [markSessionChanged, scope, scopeIdentity, updateSaveState]);
+
+    const flush = useCallback(() => {
+        if (saveTimerRef.current) {
+            clearTimeout(saveTimerRef.current);
+            saveTimerRef.current = null;
+        }
+        return enqueueCurrentDraftWrite();
+    }, [enqueueCurrentDraftWrite]);
+
+    useEffect(() => {
+        if (resetScopeIdentityRef.current === scopeIdentity) {
+            return;
+        }
+        resetScopeIdentityRef.current = scopeIdentity;
+        generationRef.current += 1;
+        loadedScopeIdentityRef.current = null;
+        activeRef.current = false;
+        setGate({ kind: 'checking' });
+        setNotice(null);
+        setSaveState({ kind: 'idle' });
+    }, [scopeIdentity]);
+
+    useEffect(() => {
+        if (!enabled || loadedScopeIdentityRef.current === scopeIdentity) {
+            return;
+        }
+        loadedScopeIdentityRef.current = scopeIdentity;
+        const generation = generationRef.current;
+        let cancelled = false;
+        let settled = false;
+
+        void writeQueueRef.current
+            .catch(() => undefined)
+            .then(() => leasePromiseRef.current)
+            .then((leaseResult) =>
+                leaseResult?.status === 'ready'
+                    ? loadOperationCompletionDraft(scope, leaseResult.lease)
+                    : Promise.resolve(
+                          leaseResult?.status === 'unavailable'
+                              ? ({
+                                    status: 'unavailable',
+                                } satisfies LoadOperationCompletionDraftResult)
+                              : sessionChangedLoadResult(),
+                      ),
+            )
+            .then((result) => {
+                settled = true;
+                if (cancelled || generationRef.current !== generation) {
+                    return;
+                }
+                if (result.status === 'found') {
+                    persistedRevisionByScopeRef.current.set(
+                        scopeIdentity,
+                        result.draft.revisionId,
+                    );
+                    setGate({ draft: result.draft, kind: 'found' });
+                    return;
+                }
+                if (
+                    result.status === 'missing' &&
+                    result.reason === 'incompatible'
+                ) {
+                    persistedRevisionByScopeRef.current.set(
+                        scopeIdentity,
+                        result.revisionId,
+                    );
+                    setGate({
+                        kind: 'stale',
+                        revisionId: result.revisionId,
+                    });
+                    return;
+                }
+
+                if (result.status === 'session_changed') {
+                    markSessionChanged();
+                    return;
+                }
+
+                activeRef.current = result.status !== 'unavailable';
+                persistedRevisionByScopeRef.current.delete(scopeIdentity);
+                setGate({ kind: 'none' });
+                if (result.status === 'expired') {
+                    setNotice('expired');
+                } else if (result.status === 'unavailable') {
+                    setNotice('storage_unavailable');
+                }
+            });
+
+        return () => {
+            cancelled = true;
+            if (!settled && loadedScopeIdentityRef.current === scopeIdentity) {
+                loadedScopeIdentityRef.current = null;
+            }
+        };
+    }, [enabled, markSessionChanged, scope, scopeIdentity]);
+
+    useEffect(() => {
+        if (previousFormSignatureRef.current === currentFormSignature) {
+            return;
+        }
+        previousFormSignatureRef.current = currentFormSignature;
+        const photosChanged =
+            previousPhotoSignatureRef.current !== currentPhotoSignature;
+        previousPhotoSignatureRef.current = currentPhotoSignature;
+        if (!activeRef.current || gate.kind !== 'none') {
+            return;
+        }
+        if (saveTimerRef.current) {
+            clearTimeout(saveTimerRef.current);
+        }
+        saveTimerRef.current = setTimeout(
+            () => {
+                saveTimerRef.current = null;
+                void enqueueCurrentDraftWrite();
+            },
+            photosChanged ? 0 : NOTES_SAVE_DEBOUNCE_MS,
+        );
+
+        return () => {
+            if (saveTimerRef.current) {
+                clearTimeout(saveTimerRef.current);
+                saveTimerRef.current = null;
+            }
+        };
+    }, [
+        currentFormSignature,
+        currentPhotoSignature,
+        enqueueCurrentDraftWrite,
+        gate.kind,
+    ]);
+
+    useEffect(() => {
+        const flushWhenHidden = () => {
+            if (document.visibilityState === 'hidden') {
+                void flush();
+            }
+        };
+        const flushBeforePageLeaves = () => {
+            void flush();
+        };
+
+        document.addEventListener('visibilitychange', flushWhenHidden);
+        window.addEventListener('pagehide', flushBeforePageLeaves);
+        return () => {
+            document.removeEventListener('visibilitychange', flushWhenHidden);
+            window.removeEventListener('pagehide', flushBeforePageLeaves);
+        };
+    }, [flush]);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    useEffect(
+        () => () => {
+            void flush();
+        },
+        [flush],
+    );
+
+    const resume = useCallback((): RestoredOperationCompletionDraft | null => {
+        if (gate.kind !== 'found') {
+            return null;
+        }
+        activeRef.current = true;
+        setGate({ kind: 'none' });
+        setNotice(null);
+        setSaveState({ kind: 'saved' });
+        return {
+            notes: gate.draft.notes,
+            photos: gate.draft.photos.map((photo) => ({
+                file: operationCompletionDraftPhotoToFile(photo),
+                id: photo.id,
+            })),
+        };
+    }, [gate]);
+
+    const discard = useCallback(async () => {
+        if (gate.kind !== 'found' && gate.kind !== 'stale') {
+            return true;
+        }
+        const generation = generationRef.current;
+        const lease = leaseRef.current;
+        if (!lease) {
+            markSessionChanged();
+            return false;
+        }
+        const expectedRevisionId =
+            gate.kind === 'found' ? gate.draft.revisionId : gate.revisionId;
+        const result = await discardOperationCompletionDraft(scope, {
+            expectedRevisionId,
+            lease,
+        });
+        if (generationRef.current !== generation) {
+            return false;
+        }
+        if (result.status === 'session_changed') {
+            markSessionChanged();
+            return false;
+        }
+        if (result.status === 'unavailable') {
+            setSaveState({
+                kind: 'error',
+                reason: 'storage_unavailable',
+            });
+            return false;
+        }
+        if (result.status === 'conflict') {
+            const latest = await loadOperationCompletionDraft(scope, lease);
+            if (generationRef.current !== generation) {
+                return false;
+            }
+            if (latest.status === 'session_changed') {
+                markSessionChanged();
+                return false;
+            }
+            if (latest.status === 'unavailable') {
+                setSaveState({
+                    kind: 'error',
+                    reason: 'storage_unavailable',
+                });
+                return false;
+            }
+            if (latest.status === 'found') {
+                persistedRevisionByScopeRef.current.set(
+                    scopeIdentity,
+                    latest.draft.revisionId,
+                );
+                setGate({ draft: latest.draft, kind: 'found' });
+                setSaveState({ kind: 'error', reason: 'draft_changed' });
+                return false;
+            }
+            if (
+                latest.status === 'missing' &&
+                latest.reason === 'incompatible'
+            ) {
+                persistedRevisionByScopeRef.current.set(
+                    scopeIdentity,
+                    latest.revisionId,
+                );
+                setGate({
+                    kind: 'stale',
+                    revisionId: latest.revisionId,
+                });
+                setSaveState({ kind: 'error', reason: 'draft_changed' });
+                return false;
+            }
+        }
+        persistedRevisionByScopeRef.current.delete(scopeIdentity);
+        activeRef.current = true;
+        setGate({ kind: 'none' });
+        setNotice(null);
+        setSaveState({ kind: 'idle' });
+        return true;
+    }, [gate, markSessionChanged, scope, scopeIdentity]);
+
+    const discardAfterServerSuccess = useCallback(async () => {
+        const generation = generationRef.current;
+        activeRef.current = false;
+        if (saveTimerRef.current) {
+            clearTimeout(saveTimerRef.current);
+            saveTimerRef.current = null;
+        }
+        let localConfirmationSucceeded = false;
+        const lease = leaseRef.current;
+        if (!lease) {
+            markSessionChanged();
+            return false;
+        }
+        writeQueueRef.current = writeQueueRef.current
+            .catch(() => undefined)
+            .then(async () => {
+                const result =
+                    await markOperationCompletionDraftServerConfirmed(
+                        scope,
+                        lease,
+                    );
+                if (result.status === 'session_changed') {
+                    markSessionChanged();
+                    return;
+                }
+                localConfirmationSucceeded = result.status === 'ok';
+                if (
+                    localConfirmationSucceeded &&
+                    generationRef.current === generation
+                ) {
+                    persistedRevisionByScopeRef.current.delete(scopeIdentity);
+                }
+            });
+        await writeQueueRef.current;
+        return localConfirmationSucceeded;
+    }, [markSessionChanged, scope, scopeIdentity]);
+
+    return {
+        discard,
+        discardAfterServerSuccess,
+        flush,
+        gate,
+        notice,
+        resume,
+        saveState,
+    };
+}

--- a/apps/farm/app/settings/_components/OperationCompletionSyncSettings.tsx
+++ b/apps/farm/app/settings/_components/OperationCompletionSyncSettings.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { Alert } from '@gredice/ui/Alert';
+import { Button } from '@gredice/ui/Button';
+import { Stack } from '@gredice/ui/Stack';
+import { Typography } from '@gredice/ui/Typography';
+import { useState } from 'react';
+import { useOperationCompletionSync } from '../../../components/offline/OperationCompletionSyncContext';
+
+function itemStatus(item: {
+    retryable: boolean;
+    state: 'queued' | 'syncing' | 'failed' | 'server_confirmed';
+}) {
+    if (item.state === 'server_confirmed') return 'Spremljeno na farmi';
+    if (item.state === 'syncing') return 'Šaljem farmi';
+    if (item.state === 'queued') return 'Čeka slanje';
+    return item.retryable ? 'Slanje nije uspjelo' : 'Potrebna je provjera';
+}
+
+export function OperationCompletionSyncSettings() {
+    const sync = useOperationCompletionSync();
+    const [discardKey, setDiscardKey] = useState<string | null>(null);
+    const [busyKey, setBusyKey] = useState<string | null>(null);
+    const activeItems =
+        sync?.items.filter((item) => item.state !== 'server_confirmed') ?? [];
+    const confirmedItems =
+        sync?.items.filter((item) => item.state === 'server_confirmed') ?? [];
+
+    if (
+        !sync ||
+        (sync.mode === 'off' &&
+            activeItems.length === 0 &&
+            confirmedItems.length === 0)
+    ) {
+        return null;
+    }
+
+    const runRetry = async (key: string) => {
+        setBusyKey(key);
+        try {
+            await sync.retry(key);
+        } finally {
+            setBusyKey(null);
+        }
+    };
+
+    const confirmDiscard = async (key: string) => {
+        setBusyKey(key);
+        try {
+            if (await sync.discard(key)) {
+                setDiscardKey(null);
+            }
+        } finally {
+            setBusyKey(null);
+        }
+    };
+
+    return (
+        <section
+            aria-labelledby="sinkronizacija-radnji-naslov"
+            className="scroll-mt-4 rounded-xl border bg-card p-4"
+            id="sinkronizacija-radnji"
+        >
+            <Stack spacing={3}>
+                <div>
+                    <Typography
+                        component="h2"
+                        id="sinkronizacija-radnji-naslov"
+                        level="h6"
+                        semiBold
+                    >
+                        Slanje dovršenih radnji
+                    </Typography>
+                    <Typography level="body2">
+                        Radnje se čuvaju na ovom uređaju dok ih poslužitelj ne
+                        potvrdi. Slanje se nastavlja kada ponovno otvoriš
+                        aplikaciju s internetskom vezom.
+                    </Typography>
+                </div>
+
+                {!sync.isStorageAvailable ? (
+                    <Alert color="warning" role="status">
+                        Lokalna pohrana trenutačno nije dostupna. Ne zatvaraj
+                        unos koji još nisi poslao.
+                    </Alert>
+                ) : null}
+
+                {sync.mode === 'off' && activeItems.length > 0 ? (
+                    <Alert color="warning" role="status">
+                        Automatsko slanje je pauzirano. Lokalni unosi ostaju na
+                        uređaju i vidljivi su za oporavak.
+                    </Alert>
+                ) : null}
+
+                {activeItems.length === 0 ? (
+                    <Alert color="success" role="status">
+                        {confirmedItems.length > 0
+                            ? confirmedItems.length === 1
+                                ? 'Poslužitelj je nedavno potvrdio jednu radnju.'
+                                : `Poslužitelj je nedavno potvrdio ${confirmedItems.length.toString()} radnji.`
+                            : 'Nema radnji koje čekaju slanje.'}
+                    </Alert>
+                ) : (
+                    <Stack spacing={2}>
+                        {activeItems.map((item) => (
+                            <article
+                                className="rounded-lg border p-3"
+                                data-operation-completion-sync-item={item.state}
+                                key={item.key}
+                            >
+                                <Stack spacing={2}>
+                                    <div>
+                                        <Typography level="body2" semiBold>
+                                            {item.label ?? 'Dovršena radnja'}
+                                        </Typography>
+                                        <Typography level="body3">
+                                            {itemStatus(item)}
+                                        </Typography>
+                                        {item.failureMessage ? (
+                                            <Typography
+                                                className="text-red-800 dark:text-red-200"
+                                                level="body3"
+                                            >
+                                                {item.failureMessage}
+                                            </Typography>
+                                        ) : null}
+                                    </div>
+
+                                    {discardKey === item.key ? (
+                                        <Alert color="warning" role="alert">
+                                            <Stack spacing={2}>
+                                                <Typography level="body2">
+                                                    Odbacivanjem se brišu
+                                                    lokalna napomena i
+                                                    fotografije. Ako je slanje
+                                                    već počelo, provjeri
+                                                    raspored jer ga ova radnja
+                                                    ne može poništiti na
+                                                    poslužitelju.
+                                                </Typography>
+                                                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                                    <Button
+                                                        className="min-h-11"
+                                                        color="danger"
+                                                        disabled={
+                                                            busyKey !== null
+                                                        }
+                                                        loading={
+                                                            busyKey === item.key
+                                                        }
+                                                        onClick={() =>
+                                                            void confirmDiscard(
+                                                                item.key,
+                                                            )
+                                                        }
+                                                        size="lg"
+                                                        variant="solid"
+                                                    >
+                                                        Odbaci lokalni unos
+                                                    </Button>
+                                                    <Button
+                                                        className="min-h-11"
+                                                        disabled={
+                                                            busyKey !== null
+                                                        }
+                                                        onClick={() =>
+                                                            setDiscardKey(null)
+                                                        }
+                                                        size="lg"
+                                                        variant="outlined"
+                                                    >
+                                                        Zadrži unos
+                                                    </Button>
+                                                </div>
+                                            </Stack>
+                                        </Alert>
+                                    ) : (
+                                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                            {item.state !== 'syncing' &&
+                                            item.retryable &&
+                                            sync.mode !== 'off' ? (
+                                                <Button
+                                                    className="min-h-11"
+                                                    disabled={busyKey !== null}
+                                                    loading={
+                                                        busyKey === item.key
+                                                    }
+                                                    onClick={() =>
+                                                        void runRetry(item.key)
+                                                    }
+                                                    size="lg"
+                                                    variant="solid"
+                                                >
+                                                    Pokušaj ponovno
+                                                </Button>
+                                            ) : null}
+                                            <Button
+                                                className="min-h-11"
+                                                disabled={
+                                                    busyKey !== null ||
+                                                    item.state === 'syncing'
+                                                }
+                                                onClick={() =>
+                                                    setDiscardKey(item.key)
+                                                }
+                                                size="lg"
+                                                variant="outlined"
+                                            >
+                                                Odbaci
+                                            </Button>
+                                        </div>
+                                    )}
+                                </Stack>
+                            </article>
+                        ))}
+                    </Stack>
+                )}
+
+                {confirmedItems.length > 0 ? (
+                    <Stack spacing={2}>
+                        <Typography level="body2" semiBold>
+                            Nedavne potvrde poslužitelja
+                        </Typography>
+                        {confirmedItems.map((item) => (
+                            <article
+                                className="rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-900 dark:bg-green-950/40"
+                                key={item.key}
+                            >
+                                <Stack spacing={2}>
+                                    <div>
+                                        <Typography level="body2" semiBold>
+                                            Radnja spremljena na farmi
+                                        </Typography>
+                                        <Typography level="body3">
+                                            {item.serverState === 'completed'
+                                                ? 'Dovršetak je potvrđen.'
+                                                : 'Predaja je potvrđena i čeka provjeru.'}
+                                        </Typography>
+                                    </div>
+                                    <Button
+                                        className="min-h-11"
+                                        disabled={busyKey !== null}
+                                        loading={busyKey === item.key}
+                                        onClick={() =>
+                                            void confirmDiscard(item.key)
+                                        }
+                                        size="lg"
+                                        variant="outlined"
+                                    >
+                                        Sakrij potvrdu
+                                    </Button>
+                                </Stack>
+                            </article>
+                        ))}
+                    </Stack>
+                ) : null}
+            </Stack>
+        </section>
+    );
+}

--- a/apps/farm/app/settings/page.tsx
+++ b/apps/farm/app/settings/page.tsx
@@ -5,6 +5,7 @@ import LoginDialog from '../../components/auth/LoginDialog';
 import { auth } from '../../lib/auth/auth';
 import { FarmSchedulePreferences } from './_components/FarmSchedulePreferences';
 import { NotificationSettings } from './_components/NotificationSettings';
+import { OperationCompletionSyncSettings } from './_components/OperationCompletionSyncSettings';
 
 export const dynamic = 'force-dynamic';
 
@@ -22,6 +23,7 @@ async function FarmSettingsContent() {
                     user?.farmScheduleGroupedWateringEnabled ?? true
                 }
             />
+            <OperationCompletionSyncSettings />
             <NotificationSettings />
         </div>
     );

--- a/apps/farm/components/analytics/FarmAnalyticsProvider.spec.tsx
+++ b/apps/farm/components/analytics/FarmAnalyticsProvider.spec.tsx
@@ -346,6 +346,47 @@ test('captures one first recognized action per Today mount without leaking priva
     }
 });
 
+test('captures only bounded completion synchronization properties', async ({
+    mount,
+    page,
+}) => {
+    const analyticsEvents = await captureFarmAnalyticsEvents(page);
+    const component = await mount(<FarmAnalyticsHarness />);
+
+    await component.getByTestId('completion-sync-analytics').click();
+    await expect
+        .poll(
+            () =>
+                eventsNamed(
+                    analyticsEvents,
+                    'farm_completion_sync_state_changed',
+                ).length,
+        )
+        .toBe(1);
+
+    const syncEvent = eventsNamed(
+        analyticsEvents,
+        'farm_completion_sync_state_changed',
+    )[0];
+    expect(syncEvent).toBeDefined();
+    if (!syncEvent) {
+        return;
+    }
+
+    expectExactProperties(syncEvent, {
+        age_bucket: 'under_1h',
+        attempt_bucket: 'two',
+        failure_code: 'network',
+        queue_size_bucket: 'two_to_five',
+        state: 'failed',
+        surface: 'farm',
+        trigger: 'online',
+    });
+    expect(JSON.stringify(syncEvent)).not.toContain(
+        'PRIVATE_SYNC_NOTE_SENTINEL',
+    );
+});
+
 test('marks actual Today focus, queue, and attention task links with safe analytics attributes', async ({
     mount,
 }) => {

--- a/apps/farm/components/analytics/FarmAnalyticsProvider.tsx
+++ b/apps/farm/components/analytics/FarmAnalyticsProvider.tsx
@@ -11,6 +11,7 @@ import {
 import {
     type FarmAnalyticsCapture,
     type FarmAnalyticsEvent,
+    type FarmCompletionSyncStateChangedProperties,
     type FarmNavigationSelectedProperties,
     type FarmTodayFirstActionProperties,
     type FarmTodayTaskOpenedProperties,
@@ -146,6 +147,16 @@ export function FarmAnalyticsProvider({
         [captureEvent],
     );
 
+    const captureCompletionSyncState = useCallback(
+        (properties: FarmCompletionSyncStateChangedProperties) => {
+            captureEvent({
+                name: 'farm_completion_sync_state_changed',
+                properties,
+            });
+        },
+        [captureEvent],
+    );
+
     const handleClickCapture = useCallback(
         (event: MouseEvent<HTMLDivElement>) => {
             const element = getAnalyticsElement(event);
@@ -219,8 +230,12 @@ export function FarmAnalyticsProvider({
     }, []);
 
     const contextValue = useMemo<FarmAnalyticsContextValue>(
-        () => ({ mountTodayView, unmountTodayView }),
-        [mountTodayView, unmountTodayView],
+        () => ({
+            captureCompletionSyncState,
+            mountTodayView,
+            unmountTodayView,
+        }),
+        [captureCompletionSyncState, mountTodayView, unmountTodayView],
     );
 
     return (

--- a/apps/farm/components/analytics/farmAnalytics.ts
+++ b/apps/farm/components/analytics/farmAnalytics.ts
@@ -34,6 +34,41 @@ export type FarmTodayViewedProperties = {
     work_state?: FarmTodayWorkState;
 };
 
+export type FarmCompletionSyncState =
+    | 'saved_local'
+    | 'queued'
+    | 'syncing'
+    | 'failed'
+    | 'server_confirmed';
+
+export type FarmCompletionSyncTrigger =
+    | 'auth_mount'
+    | 'created'
+    | 'manual'
+    | 'online'
+    | 'pageshow'
+    | 'retry_timer'
+    | 'visibility';
+
+export type FarmCompletionSyncFailureCode =
+    | 'auth_changed'
+    | 'expired'
+    | 'network'
+    | 'server_unavailable'
+    | 'storage_unavailable'
+    | 'submission_conflict'
+    | 'task_changed'
+    | 'upload_unavailable';
+
+export type FarmCompletionSyncStateChangedProperties = {
+    age_bucket: 'under_5m' | 'under_1h' | 'under_1d' | 'older';
+    attempt_bucket: 'none' | 'one' | 'two' | 'three_plus';
+    failure_code?: FarmCompletionSyncFailureCode;
+    queue_size_bucket: 'one' | 'two_to_five' | 'six_plus';
+    state: FarmCompletionSyncState;
+    trigger: FarmCompletionSyncTrigger;
+};
+
 export type FarmTodayTaskOpenedProperties = {
     assignment: FarmTodayTaskAssignment;
     overdue: boolean;
@@ -60,6 +95,10 @@ export type FarmTodayFirstActionProperties =
       };
 
 export type FarmAnalyticsEvent =
+    | {
+          name: 'farm_completion_sync_state_changed';
+          properties: FarmCompletionSyncStateChangedProperties;
+      }
     | {
           name: 'farm_navigation_selected';
           properties: FarmNavigationSelectedProperties;

--- a/apps/farm/components/analytics/farmAnalyticsContext.ts
+++ b/apps/farm/components/analytics/farmAnalyticsContext.ts
@@ -1,9 +1,15 @@
 'use client';
 
 import { createContext, useContext } from 'react';
-import type { FarmTodayViewedProperties } from './farmAnalytics';
+import type {
+    FarmCompletionSyncStateChangedProperties,
+    FarmTodayViewedProperties,
+} from './farmAnalytics';
 
 export type FarmAnalyticsContextValue = {
+    captureCompletionSyncState: (
+        properties: FarmCompletionSyncStateChangedProperties,
+    ) => void;
     mountTodayView: (
         properties: FarmTodayViewedProperties,
         captureView: boolean,

--- a/apps/farm/components/auth/LogoutButton.spec.tsx
+++ b/apps/farm/components/auth/LogoutButton.spec.tsx
@@ -1,0 +1,578 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
+import {
+    AppRouterContext,
+    type AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { CompleteOperationModal } from '../../app/schedule/CompleteOperationModal';
+import {
+    FARM_OFFLINE_DATABASE_NAME,
+    FARM_OFFLINE_DATABASE_VERSION,
+    OPERATION_COMPLETION_DRAFT_STORE_NAME,
+    type OperationCompletionDraftScope,
+} from '../../lib/offline/operationCompletionDraftStore';
+import {
+    LogoutWithLateModalMountStory,
+    StaleLogoutWithCurrentModalStory,
+} from '../../playwright/LogoutDraftStories';
+import { OperationCompletionDraftStoreHarness } from '../../playwright/OperationCompletionDraftStoreHarness';
+import { LogoutButton } from './LogoutButton';
+
+const nextNavigationRouter = {
+    back: () => undefined,
+    forward: () => undefined,
+    prefetch: () => undefined,
+    push: () => undefined,
+    refresh: () => undefined,
+    replace: () => undefined,
+} satisfies AppRouterInstance;
+
+const currentUserId = 'farmer-current';
+const otherUserId = 'farmer-other';
+const currentSessionIncarnation = 'session-current';
+const authoritativeUserId = 'farmer-authoritative';
+const authoritativeSessionIncarnation = 'session-authoritative';
+
+const draftScopes = [
+    {
+        accountId: 'account-a',
+        expectedEntityId: 701,
+        expectedTaskVersionEventId: 81,
+        operationId: 41,
+        requirementsFingerprint: 'none:optional',
+        userId: currentUserId,
+    },
+    {
+        accountId: 'account-b',
+        expectedEntityId: 702,
+        expectedTaskVersionEventId: 82,
+        operationId: 42,
+        requirementsFingerprint: 'none:optional',
+        userId: currentUserId,
+    },
+    {
+        accountId: 'account-c',
+        expectedEntityId: 703,
+        expectedTaskVersionEventId: 83,
+        operationId: 43,
+        requirementsFingerprint: 'none:optional',
+        userId: otherUserId,
+    },
+] satisfies OperationCompletionDraftScope[];
+
+function logoutButton(userId: string) {
+    return (
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <OperationCompletionDraftStoreHarness />
+            <LogoutButton
+                sessionIncarnation={currentSessionIncarnation}
+                userId={userId}
+            />
+        </AppRouterContext.Provider>
+    );
+}
+
+const logoutRaceScope = {
+    accountId: 'account-logout-race',
+    expectedEntityId: 801,
+    expectedTaskVersionEventId: 901,
+    operationId: 501,
+    requirementsFingerprint: 'none:optional',
+    userId: currentUserId,
+} satisfies OperationCompletionDraftScope;
+
+function logoutWithOpenDraft() {
+    return (
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <OperationCompletionDraftStoreHarness />
+            <CompleteOperationModal
+                accountId={logoutRaceScope.accountId}
+                conditions={{
+                    completionAttachImages: true,
+                    completionAttachNotes: true,
+                }}
+                defaultOpen
+                expectedEntityId={logoutRaceScope.expectedEntityId}
+                expectedTaskVersionEventId={
+                    logoutRaceScope.expectedTaskVersionEventId
+                }
+                label="Bilješka prije odjave"
+                operationId={logoutRaceScope.operationId}
+                sessionIncarnation={currentSessionIncarnation}
+                userId={logoutRaceScope.userId}
+            />
+            <LogoutButton
+                sessionIncarnation={currentSessionIncarnation}
+                userId={currentUserId}
+            />
+        </AppRouterContext.Provider>
+    );
+}
+
+async function seedDrafts(page: Page) {
+    await page.evaluate(
+        async ({ currentSessionIncarnation, currentUserId, scopes }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            const leases = new Map();
+            for (const [index, scope] of scopes.entries()) {
+                let lease = leases.get(scope.userId);
+                if (!lease) {
+                    const leaseResult = await api.acquireLease(
+                        scope.userId,
+                        api.captureLogoutNonce(scope.userId),
+                        scope.userId === currentUserId
+                            ? currentSessionIncarnation
+                            : `legacy:${scope.userId}`,
+                    );
+                    if (leaseResult.status !== 'ready') {
+                        throw new Error('Draft lease seed failed');
+                    }
+                    lease = leaseResult.lease;
+                    leases.set(scope.userId, lease);
+                }
+                const result = await api.save(
+                    {
+                        ...scope,
+                        notes: `Lokalna skica ${index + 1}`,
+                        photos: [],
+                    },
+                    { lease },
+                );
+                if (result.status !== 'ok' || result.action !== 'saved') {
+                    throw new Error('Draft seed failed');
+                }
+            }
+        },
+        { currentSessionIncarnation, currentUserId, scopes: draftScopes },
+    );
+}
+
+async function loadDraftStates(page: Page) {
+    return page.evaluate(
+        async ({ databaseName, databaseVersion, scopes, storeName }) => {
+            const database = await new Promise<IDBDatabase>(
+                (resolve, reject) => {
+                    const request = indexedDB.open(
+                        databaseName,
+                        databaseVersion,
+                    );
+                    request.onerror = () => reject(request.error);
+                    request.onsuccess = () => resolve(request.result);
+                },
+            );
+            try {
+                const transaction = database.transaction(storeName, 'readonly');
+                const store = transaction.objectStore(storeName);
+                return await Promise.all(
+                    scopes.map(
+                        (scope) =>
+                            new Promise<
+                                | { notes: string; status: 'found' }
+                                | { reason: 'not_found'; status: 'missing' }
+                            >((resolve, reject) => {
+                                const request = store.get(
+                                    JSON.stringify([
+                                        1,
+                                        scope.userId,
+                                        scope.accountId,
+                                        scope.operationId,
+                                    ]),
+                                );
+                                request.onerror = () => reject(request.error);
+                                request.onsuccess = () => {
+                                    const value: unknown = request.result;
+                                    if (
+                                        typeof value === 'object' &&
+                                        value !== null &&
+                                        'notes' in value &&
+                                        typeof value.notes === 'string'
+                                    ) {
+                                        resolve({
+                                            notes: value.notes,
+                                            status: 'found',
+                                        });
+                                        return;
+                                    }
+                                    resolve({
+                                        reason: 'not_found',
+                                        status: 'missing',
+                                    });
+                                };
+                            }),
+                    ),
+                );
+            } finally {
+                database.close();
+            }
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            databaseVersion: FARM_OFFLINE_DATABASE_VERSION,
+            scopes: draftScopes,
+            storeName: OPERATION_COMPLETION_DRAFT_STORE_NAME,
+        },
+    );
+}
+
+test('purges only the logged-out user drafts across accounts', async ({
+    mount,
+    page,
+}) => {
+    let logoutCalls = 0;
+    await page.route('**/api/logout', async (route) => {
+        logoutCalls += 1;
+        await route.fulfill({
+            json: {
+                loggedOutSessions: [
+                    {
+                        sessionIncarnation: currentSessionIncarnation,
+                        userId: currentUserId,
+                    },
+                ],
+            },
+            status: 200,
+        });
+    });
+    const component = await mount(logoutButton(currentUserId));
+    await expect(page.getByTestId('operation-draft-store-ready')).toHaveText(
+        'ready',
+    );
+    await seedDrafts(page);
+
+    await component.getByRole('button', { name: 'Odjavi se' }).click();
+
+    await expect.poll(() => logoutCalls).toBe(1);
+    await expect
+        .poll(() => loadDraftStates(page))
+        .toEqual([
+            { reason: 'not_found', status: 'missing' },
+            { reason: 'not_found', status: 'missing' },
+            { notes: 'Lokalna skica 3', status: 'found' },
+        ]);
+});
+
+test('unions the rendered session with every token identity returned by logout', async ({
+    mount,
+    page,
+}) => {
+    await page.route('**/api/logout', async (route) => {
+        await route.fulfill({
+            json: {
+                loggedOutSessions: [
+                    {
+                        sessionIncarnation: `legacy:${otherUserId}`,
+                        userId: otherUserId,
+                    },
+                ],
+            },
+            status: 200,
+        });
+    });
+    const component = await mount(logoutButton(currentUserId));
+    await expect(page.getByTestId('operation-draft-store-ready')).toHaveText(
+        'ready',
+    );
+    await seedDrafts(page);
+
+    await component.getByRole('button', { name: 'Odjavi se' }).click();
+
+    await expect
+        .poll(() => loadDraftStates(page))
+        .toEqual([
+            { reason: 'not_found', status: 'missing' },
+            { reason: 'not_found', status: 'missing' },
+            { reason: 'not_found', status: 'missing' },
+        ]);
+});
+
+test('retains every draft when logout is rejected', async ({ mount, page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (message) => {
+        if (message.type() === 'error') {
+            consoleErrors.push(message.text());
+        }
+    });
+    let logoutCalls = 0;
+    await page.route('**/api/logout', async (route) => {
+        logoutCalls += 1;
+        await route.fulfill({ json: { error: 'unavailable' }, status: 503 });
+    });
+    const component = await mount(logoutButton(currentUserId));
+    await expect(page.getByTestId('operation-draft-store-ready')).toHaveText(
+        'ready',
+    );
+    await seedDrafts(page);
+
+    await component.getByRole('button', { name: 'Odjavi se' }).click();
+
+    await expect.poll(() => logoutCalls).toBe(1);
+    await expect
+        .poll(() => consoleErrors)
+        .toContain('Logout failed with status 503');
+    await expect
+        .poll(() => loadDraftStates(page))
+        .toEqual([
+            { notes: 'Lokalna skica 1', status: 'found' },
+            { notes: 'Lokalna skica 2', status: 'found' },
+            { notes: 'Lokalna skica 3', status: 'found' },
+        ]);
+});
+
+test('fences a late pagehide flush and clears in-memory proof after logout', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.route('**/api/logout', async (route) => {
+        await route.fulfill({
+            json: {
+                loggedOutSessions: [
+                    {
+                        sessionIncarnation: currentSessionIncarnation,
+                        userId: currentUserId,
+                    },
+                ],
+            },
+            status: 200,
+        });
+    });
+    await mount(logoutWithOpenDraft());
+    await expect(page.getByTestId('operation-draft-store-ready')).toHaveText(
+        'ready',
+    );
+    const dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    const notes = dialog.getByPlaceholder('Upišite napomenu o završetku...');
+    await expect(notes).toBeVisible();
+    await notes.fill('Privatna bilješka neposredno prije odjave.');
+    const fileInputs = await dialog
+        .locator('input[type="file"]')
+        .elementHandles();
+    await dialog.locator('input[capture="environment"]').setInputFiles({
+        buffer: Buffer.from('private photo proof'),
+        mimeType: 'image/jpeg',
+        name: 'privatni-dokaz.jpg',
+    });
+    await expect(dialog.getByText('privatni-dokaz.jpg')).toBeVisible();
+    await expect(dialog.locator('[data-operation-upload-item]')).toHaveCount(1);
+
+    await page.locator('button[title="Odjavi se"]').evaluate((button) => {
+        if (button instanceof HTMLElement) button.click();
+    });
+    await expect(dialog.getByText('Sesija je završila')).toBeVisible();
+    await expect(
+        dialog.getByText(
+            'Ovaj unos nije spremljen i neće ostati na ovom uređaju. Ponovno se prijavi prije nastavka.',
+        ),
+    ).toBeVisible();
+    await expect(notes).toHaveCount(0);
+    await expect(dialog.getByText('privatni-dokaz.jpg')).toHaveCount(0);
+    await expect(dialog.locator('[data-operation-upload-item]')).toHaveCount(0);
+    for (const fileInput of fileInputs) {
+        expect(
+            await fileInput.evaluate((input) =>
+                input instanceof HTMLInputElement ? input.files?.length : null,
+            ),
+        ).toBe(0);
+    }
+    const closeButton = dialog.getByRole('button', { name: 'Zatvori' });
+    await expect(
+        dialog.locator('[data-operation-draft-session-focus]'),
+    ).toBeFocused();
+    await closeButton.scrollIntoViewIfNeeded();
+    const closeBox = await closeButton.boundingBox();
+    expect(closeBox).not.toBeNull();
+    expect(closeBox?.height).toBeGreaterThanOrEqual(44);
+    expect(closeBox?.x).toBeGreaterThanOrEqual(0);
+    expect(closeBox ? closeBox.x + closeBox.width : 321).toBeLessThanOrEqual(
+        320,
+    );
+    expect(closeBox?.y).toBeGreaterThanOrEqual(0);
+    expect(closeBox ? closeBox.y + closeBox.height : 569).toBeLessThanOrEqual(
+        568,
+    );
+    await page.evaluate(() => {
+        window.dispatchEvent(new PageTransitionEvent('pagehide'));
+        Object.defineProperties(document, {
+            hidden: { configurable: true, value: true },
+            visibilityState: { configurable: true, value: 'hidden' },
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await expect
+        .poll(() =>
+            page.evaluate(async (scope) => {
+                const api = window.__operationCompletionDraftStoreTestApi;
+                if (!api) {
+                    throw new Error('Draft store test API is unavailable');
+                }
+                return api.load(scope);
+            }, logoutRaceScope),
+        )
+        .toEqual({ reason: 'not_found', status: 'missing' });
+    await expect(dialog.getByText('Sesija je završila')).toBeVisible();
+});
+
+test('refuses a stale task modal that mounts only after logout', async ({
+    mount,
+    page,
+}) => {
+    await page.route('**/api/logout', async (route) => {
+        await route.fulfill({
+            json: {
+                loggedOutSessions: [
+                    {
+                        sessionIncarnation: currentSessionIncarnation,
+                        userId: currentUserId,
+                    },
+                ],
+            },
+            status: 200,
+        });
+    });
+    const component = await mount(
+        <LogoutWithLateModalMountStory
+            accountId={logoutRaceScope.accountId}
+            expectedEntityId={logoutRaceScope.expectedEntityId}
+            expectedTaskVersionEventId={
+                logoutRaceScope.expectedTaskVersionEventId
+            }
+            operationId={logoutRaceScope.operationId}
+            sessionIncarnation={currentSessionIncarnation}
+            userId={currentUserId}
+        />,
+    );
+    await expect(page.getByTestId('operation-draft-store-ready')).toHaveText(
+        'ready',
+    );
+
+    await component.getByRole('button', { name: 'Odjavi se' }).click();
+    await expect
+        .poll(() =>
+            page.evaluate(
+                ({ sessionIncarnation, userId }) =>
+                    localStorage.getItem(
+                        `gredice:farm:operation-completion-draft-logged-out-session:v1:${userId}:${sessionIncarnation}`,
+                    ) !== null,
+                {
+                    sessionIncarnation: currentSessionIncarnation,
+                    userId: currentUserId,
+                },
+            ),
+        )
+        .toBe(true);
+    await component
+        .getByRole('button', { name: 'Prikaži stari zadatak' })
+        .click();
+
+    const dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await expect(dialog.getByText('Sesija je završila')).toBeVisible();
+    await expect(
+        dialog.getByPlaceholder('Upišite napomenu o završetku...'),
+    ).toHaveCount(0);
+    await expect(
+        dialog.locator('[data-operation-draft-session-focus]'),
+    ).toBeFocused();
+});
+
+test('clears an open draft through the storage-event fallback', async ({
+    mount,
+    page,
+}) => {
+    await page.evaluate(() => {
+        Object.defineProperty(window, 'BroadcastChannel', {
+            configurable: true,
+            value: undefined,
+        });
+    });
+    await mount(logoutWithOpenDraft());
+    const dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    const notes = dialog.getByPlaceholder('Upišite napomenu o završetku...');
+    await expect(notes).toBeVisible();
+    await notes.fill('Privatna bilješka u drugoj kartici.');
+    await dialog.locator('input[capture="environment"]').setInputFiles({
+        buffer: Buffer.from('private cross-tab proof'),
+        mimeType: 'image/jpeg',
+        name: 'druga-kartica.jpg',
+    });
+    await expect(dialog.getByText('druga-kartica.jpg')).toBeVisible();
+
+    await page.evaluate(
+        ({ sessionIncarnation, userId }) => {
+            window.dispatchEvent(
+                new StorageEvent('storage', {
+                    key: `gredice:farm:operation-completion-draft-logged-out-session:v1:${userId}:${sessionIncarnation}`,
+                    newValue: (Date.now() + 60_000).toString(),
+                    oldValue: null,
+                    storageArea: localStorage,
+                }),
+            );
+        },
+        {
+            sessionIncarnation: currentSessionIncarnation,
+            userId: currentUserId,
+        },
+    );
+
+    await expect(dialog.getByText('Sesija je završila')).toBeVisible();
+    await expect(notes).toHaveCount(0);
+    await expect(dialog.getByText('druga-kartica.jpg')).toHaveCount(0);
+    await expect(
+        dialog.locator('[data-operation-draft-session-focus]'),
+    ).toBeFocused();
+});
+
+test('purges the session the server actually logged out from a stale tab', async ({
+    mount,
+    page,
+}) => {
+    await page.route('**/api/logout', async (route) => {
+        await route.fulfill({
+            json: {
+                loggedOutSessions: [
+                    {
+                        sessionIncarnation: authoritativeSessionIncarnation,
+                        userId: authoritativeUserId,
+                    },
+                ],
+            },
+            status: 200,
+        });
+    });
+    await mount(
+        <StaleLogoutWithCurrentModalStory
+            accountId="account-authoritative"
+            currentSessionIncarnation={authoritativeSessionIncarnation}
+            currentUserId={authoritativeUserId}
+            expectedEntityId={912}
+            expectedTaskVersionEventId={913}
+            operationId={914}
+            staleSessionIncarnation={currentSessionIncarnation}
+            staleUserId={currentUserId}
+        />,
+    );
+    const dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    const notes = dialog.getByPlaceholder('Upišite napomenu o završetku...');
+    await expect(notes).toBeVisible();
+    await notes.fill('Privatna bilješka trenutačno prijavljenog farmera.');
+
+    await page.locator('button[title="Odjavi se"]').evaluate((button) => {
+        if (button instanceof HTMLElement) button.click();
+    });
+
+    await expect(dialog.getByText('Sesija je završila')).toBeVisible();
+    await expect(notes).toHaveCount(0);
+    await expect(
+        dialog.locator('[data-operation-draft-session-focus]'),
+    ).toBeFocused();
+});

--- a/apps/farm/components/auth/LogoutButton.spec.tsx
+++ b/apps/farm/components/auth/LogoutButton.spec.tsx
@@ -20,6 +20,7 @@ import { LogoutButton } from './LogoutButton';
 
 const nextNavigationRouter = {
     back: () => undefined,
+    bfcacheId: 'farm-logout-test',
     forward: () => undefined,
     prefetch: () => undefined,
     push: () => undefined,

--- a/apps/farm/components/auth/LogoutButton.tsx
+++ b/apps/farm/components/auth/LogoutButton.tsx
@@ -6,12 +6,57 @@ import { LogOut } from '@gredice/ui/icons';
 import { usePostHog } from '@posthog/next';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import type { FarmLoggedOutSession } from '../../lib/auth/logoutSessions';
+import { purgeOperationCompletionDraftsForUser } from '../../lib/offline/operationCompletionDraftStore';
 import { queryClient } from '../providers/ClientAppProvider';
 
+function parseLoggedOutSessions(value: unknown) {
+    if (
+        typeof value !== 'object' ||
+        value === null ||
+        !('loggedOutSessions' in value) ||
+        !Array.isArray(value.loggedOutSessions)
+    ) {
+        return [];
+    }
+
+    const sessions: FarmLoggedOutSession[] = [];
+    for (const candidate of value.loggedOutSessions.slice(0, 3)) {
+        if (
+            typeof candidate !== 'object' ||
+            candidate === null ||
+            !('sessionIncarnation' in candidate) ||
+            !('userId' in candidate)
+        ) {
+            continue;
+        }
+        const { sessionIncarnation, userId } = candidate;
+        if (
+            typeof sessionIncarnation !== 'string' ||
+            sessionIncarnation.length === 0 ||
+            typeof userId !== 'string' ||
+            userId.length === 0 ||
+            sessions.some(
+                (session) =>
+                    session.sessionIncarnation === sessionIncarnation &&
+                    session.userId === userId,
+            )
+        ) {
+            continue;
+        }
+        sessions.push({ sessionIncarnation, userId });
+    }
+    return sessions;
+}
+
 export function LogoutButton({
+    sessionIncarnation,
     size = 'md',
+    userId,
 }: {
+    sessionIncarnation: string;
     size?: 'xs' | 'sm' | 'md' | 'lg';
+    userId: string;
 }) {
     const posthog = usePostHog();
     const router = useRouter();
@@ -26,6 +71,31 @@ export function LogoutButton({
                 return;
             }
 
+            const responseBody: unknown = await response
+                .json()
+                .catch(() => null);
+            const loggedOutSessions = parseLoggedOutSessions(responseBody);
+            const sessionsToPurge = [...loggedOutSessions];
+            if (
+                !sessionsToPurge.some(
+                    (session) =>
+                        session.sessionIncarnation === sessionIncarnation &&
+                        session.userId === userId,
+                )
+            ) {
+                sessionsToPurge.push({ sessionIncarnation, userId });
+            }
+            for (const loggedOutSession of sessionsToPurge) {
+                const purgeResult = await purgeOperationCompletionDraftsForUser(
+                    loggedOutSession.userId,
+                    loggedOutSession.sessionIncarnation,
+                );
+                if (purgeResult.status === 'unavailable') {
+                    console.error(
+                        'Local completion drafts could not be cleared after logout.',
+                    );
+                }
+            }
             await queryClient.invalidateQueries({
                 queryKey: authCurrentUserQueryKeys,
             });

--- a/apps/farm/components/navigation/FarmAuthenticatedShell.tsx
+++ b/apps/farm/components/navigation/FarmAuthenticatedShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { PropsWithChildren } from 'react';
+import { OperationCompletionSyncBanner } from '../offline/OperationCompletionSyncBanner';
 import { FarmAuthenticatedNavigation } from './FarmAuthenticatedNavigation';
 
 type FarmAuthenticatedShellProps = PropsWithChildren<{
@@ -23,6 +24,7 @@ export function FarmAuthenticatedShell({
                 }`}
                 data-farm-shell-content
             >
+                {authenticated ? <OperationCompletionSyncBanner /> : null}
                 {children}
             </div>
             {authenticated ? (

--- a/apps/farm/components/navigation/FarmPrimaryNavigation.spec.tsx
+++ b/apps/farm/components/navigation/FarmPrimaryNavigation.spec.tsx
@@ -471,7 +471,11 @@ test('does not remount or recount Today when authentication resolves', async ({
     await page.route('**/api/gredice/api/notifications**', async (route) => {
         await route.fulfill({ json: [], status: 200 });
     });
-    const component = await mount(<FarmShellAuthTransitionHarness />);
+    const component = await mount(
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <FarmShellAuthTransitionHarness />
+        </AppRouterContext.Provider>,
+    );
     const mountProbe = component.locator('[data-today-mount-marker]');
     const viewCount = component.locator('[data-today-view-count]');
 
@@ -480,6 +484,10 @@ test('does not remount or recount Today when authentication resolves', async ({
     const mountMarker = await mountProbe.getAttribute(
         'data-today-mount-marker',
     );
+    await page.waitForFunction(
+        () => typeof window.__resolveFarmShellAuth === 'function',
+    );
+    await page.evaluate(() => window.__resolveFarmShellAuth?.());
     await expect(visibleNavigation(component)).toBeVisible();
 
     await expect(mountProbe).toHaveAttribute(
@@ -495,9 +503,15 @@ test('keeps the farm shell hidden from signed-in users without a farm role', asy
 }) => {
     await page.setViewportSize(phoneViewports[0]);
     const component = await mount(
-        <FarmShellAuthTransitionHarness userRole="customer" />,
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <FarmShellAuthTransitionHarness userRole="customer" />
+        </AppRouterContext.Provider>,
     );
 
+    await page.waitForFunction(
+        () => typeof window.__resolveFarmShellAuth === 'function',
+    );
+    await page.evaluate(() => window.__resolveFarmShellAuth?.());
     await expect(component.locator('[data-auth-resolution]')).toHaveText(
         'resolved',
     );

--- a/apps/farm/components/navigation/FarmShellAuthGate.tsx
+++ b/apps/farm/components/navigation/FarmShellAuthGate.tsx
@@ -2,6 +2,7 @@
 
 import { useCurrentUser } from '@gredice/ui/auth';
 import type { PropsWithChildren } from 'react';
+import { OperationCompletionSyncProvider } from '../offline/OperationCompletionSyncProvider';
 import { isFarmCurrentUser } from '../providers/AuthAppProvider';
 import { FarmAuthenticatedShell } from './FarmAuthenticatedShell';
 
@@ -14,16 +15,30 @@ export function FarmShellAuthGate({
     pathname,
 }: FarmShellAuthGateProps) {
     const currentUser = useCurrentUser();
+    const user = isFarmCurrentUser(currentUser.data?.user)
+        ? currentUser.data.user
+        : null;
     const authenticated =
-        Boolean(currentUser.data?.isLogginedIn) &&
-        isFarmCurrentUser(currentUser.data?.user);
-
-    return (
+        Boolean(currentUser.data?.isLogginedIn) && user !== null;
+    const shell = (
         <FarmAuthenticatedShell
             authenticated={authenticated}
             pathname={pathname}
         >
             {children}
         </FarmAuthenticatedShell>
+    );
+
+    return user && authenticated ? (
+        <OperationCompletionSyncProvider
+            accountId={user.accountId}
+            mode={user.operationCompletionSyncMode}
+            sessionIncarnation={user.sessionIncarnation}
+            userId={user.id}
+        >
+            {shell}
+        </OperationCompletionSyncProvider>
+    ) : (
+        shell
     );
 }

--- a/apps/farm/components/navigation/FarmShellAuthGate.tsx
+++ b/apps/farm/components/navigation/FarmShellAuthGate.tsx
@@ -29,16 +29,15 @@ export function FarmShellAuthGate({
         </FarmAuthenticatedShell>
     );
 
-    return user && authenticated ? (
+    return (
         <OperationCompletionSyncProvider
-            accountId={user.accountId}
-            mode={user.operationCompletionSyncMode}
-            sessionIncarnation={user.sessionIncarnation}
-            userId={user.id}
+            accountId={user?.accountId ?? ''}
+            enabled={authenticated}
+            mode={user?.operationCompletionSyncMode ?? 'off'}
+            sessionIncarnation={user?.sessionIncarnation ?? ''}
+            userId={user?.id ?? ''}
         >
             {shell}
         </OperationCompletionSyncProvider>
-    ) : (
-        shell
     );
 }

--- a/apps/farm/components/offline/OperationCompletionSyncBanner.tsx
+++ b/apps/farm/components/offline/OperationCompletionSyncBanner.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { Button } from '@gredice/ui/Button';
+import { Typography } from '@gredice/ui/Typography';
+import { useMemo } from 'react';
+import { useOperationCompletionSync } from './OperationCompletionSyncContext';
+
+function bannerCopy({
+    failed,
+    paused,
+    queued,
+    syncing,
+}: {
+    failed: number;
+    paused: boolean;
+    queued: number;
+    syncing: number;
+}) {
+    if (paused) {
+        const total = failed + queued + syncing;
+        return {
+            description:
+                'Unos je sigurno ostao na ovom uređaju. Pregledaj ga prije ponovnog slanja ili odbacivanja.',
+            title: `${total.toString()} ${total === 1 ? 'radnja čeka dok je slanje pauzirano' : 'radnje čekaju dok je slanje pauzirano'}`,
+            tone: 'border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-800 dark:bg-amber-950/70 dark:text-amber-50',
+        };
+    }
+    if (failed > 0) {
+        return {
+            description:
+                'Unos je sigurno ostao na ovom uređaju. Pregledaj ga prije ponovnog slanja ili odbacivanja.',
+            title: `${failed.toString()} ${failed === 1 ? 'radnja traži' : 'radnje traže'} tvoju pažnju`,
+            tone: 'border-red-300 bg-red-50 text-red-950 dark:border-red-800 dark:bg-red-950/70 dark:text-red-50',
+        };
+    }
+    if (syncing > 0) {
+        return {
+            description:
+                'Ostani u aplikaciji dok se potvrda i fotografije šalju.',
+            title: `${syncing.toString()} ${syncing === 1 ? 'radnja se šalje' : 'radnje se šalju'}`,
+            tone: 'border-blue-300 bg-blue-50 text-blue-950 dark:border-blue-800 dark:bg-blue-950/70 dark:text-blue-50',
+        };
+    }
+    return {
+        description:
+            'Spremljeno je samo na ovom uređaju. Otvori aplikaciju uz internetsku vezu kako bi se poslalo farmi.',
+        title: `${queued.toString()} ${queued === 1 ? 'radnja čeka slanje' : 'radnje čekaju slanje'}`,
+        tone: 'border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-800 dark:bg-amber-950/70 dark:text-amber-50',
+    };
+}
+
+export function OperationCompletionSyncBanner() {
+    const sync = useOperationCompletionSync();
+    const queueState = useMemo(() => {
+        const activeItems =
+            sync?.items.filter((item) => item.state !== 'server_confirmed') ??
+            [];
+        return {
+            confirmedItems:
+                sync?.items.filter(
+                    (item) => item.state === 'server_confirmed',
+                ) ?? [],
+            counts: {
+                failed: activeItems.filter((item) => item.state === 'failed')
+                    .length,
+                queued: activeItems.filter((item) => item.state === 'queued')
+                    .length,
+                syncing: activeItems.filter((item) => item.state === 'syncing')
+                    .length,
+            },
+        };
+    }, [sync?.items]);
+    const { confirmedItems, counts } = queueState;
+    const total = counts.failed + counts.queued + counts.syncing;
+
+    if (!sync || (total === 0 && confirmedItems.length === 0)) {
+        return null;
+    }
+
+    const copy =
+        total > 0
+            ? bannerCopy({ ...counts, paused: sync.mode === 'off' })
+            : {
+                  description:
+                      confirmedItems.length === 1 &&
+                      confirmedItems[0]?.serverState === 'completed'
+                          ? 'Poslužitelj je potvrdio dovršetak radnje.'
+                          : 'Poslužitelj je potvrdio primitak. Status provjere vidiš u rasporedu.',
+                  title:
+                      confirmedItems.length === 1
+                          ? 'Radnja je spremljena na farmi'
+                          : `${confirmedItems.length.toString()} radnji spremljeno je na farmi`,
+                  tone: 'border-green-300 bg-green-50 text-green-950 dark:border-green-800 dark:bg-green-950/70 dark:text-green-50',
+              };
+
+    return (
+        <aside
+            aria-atomic="true"
+            aria-live="polite"
+            className={`sticky top-0 z-30 border-b px-3 py-3 shadow-sm sm:px-4 ${copy.tone}`}
+            data-operation-completion-sync-banner
+            role="status"
+        >
+            <div className="mx-auto flex w-full max-w-5xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                    <Typography className="text-current" level="body2" semiBold>
+                        {copy.title}
+                    </Typography>
+                    <Typography className="text-current" level="body3">
+                        {copy.description}
+                    </Typography>
+                </div>
+                {total > 0 ? (
+                    <Button
+                        className="min-h-11 shrink-0"
+                        href="/settings#sinkronizacija-radnji"
+                        size="lg"
+                        variant="outlined"
+                    >
+                        Pregledaj
+                    </Button>
+                ) : (
+                    <Button
+                        className="min-h-11 shrink-0"
+                        onClick={() =>
+                            void sync.discard(confirmedItems[0]?.key ?? '')
+                        }
+                        size="lg"
+                        variant="outlined"
+                    >
+                        U redu
+                    </Button>
+                )}
+            </div>
+        </aside>
+    );
+}

--- a/apps/farm/components/offline/OperationCompletionSyncContext.tsx
+++ b/apps/farm/components/offline/OperationCompletionSyncContext.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import type { FarmOperationCompletionSyncMode } from '../../lib/offline/operationCompletionSyncMode';
+
+export type OperationCompletionSyncPublicState =
+    | 'queued'
+    | 'syncing'
+    | 'failed'
+    | 'server_confirmed';
+
+export type OperationCompletionSyncPublicItem = {
+    createdAt: number;
+    failureMessage: string | null;
+    key: string;
+    label: string | null;
+    operationId: number;
+    retryable: boolean;
+    serverState: 'completed' | 'pendingVerification' | null;
+    state: OperationCompletionSyncPublicState;
+};
+
+export type OperationCompletionSyncContextValue = {
+    discard: (key: string) => Promise<boolean>;
+    isStorageAvailable: boolean;
+    items: OperationCompletionSyncPublicItem[];
+    mode: FarmOperationCompletionSyncMode;
+    retry: (key: string) => Promise<void>;
+    retryAll: () => Promise<void>;
+};
+
+export const OperationCompletionSyncContext =
+    createContext<OperationCompletionSyncContextValue | null>(null);
+
+export function useOperationCompletionSync() {
+    return useContext(OperationCompletionSyncContext);
+}

--- a/apps/farm/components/offline/OperationCompletionSyncProvider.spec.tsx
+++ b/apps/farm/components/offline/OperationCompletionSyncProvider.spec.tsx
@@ -309,3 +309,105 @@ test('keeps queued phone work visible without promising a send while rollback mo
         )
         .toBe(0);
 });
+
+test('hides queued private work immediately while auth is disabled and restores it only after the same session is authenticated again', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState = {
+            blockerCalls: 0,
+            hold: false,
+            operationCalls: 0,
+            plantingCalls: 0,
+        };
+    });
+    await seedQueuedCompletion({ mount, operationId: 348, page });
+
+    const component = await mount(
+        <OperationCompletionSyncProviderHarness mode="off" />,
+    );
+    const privateLabel = component.getByText(
+        'Privatna radnja za sinkronizaciju',
+    );
+    await expect(privateLabel).toBeVisible();
+
+    await component.update(
+        <OperationCompletionSyncProviderHarness enabled={false} mode="off" />,
+    );
+    await expect(privateLabel).toHaveCount(0);
+    await expect(
+        component.locator('[data-operation-completion-sync-banner]'),
+    ).toHaveCount(0);
+    await expect(component.locator('#sinkronizacija-radnji')).toHaveCount(0);
+
+    await component.update(
+        <OperationCompletionSyncProviderHarness mode="off" />,
+    );
+    await expect(privateLabel).toBeVisible();
+    await expect(
+        component.locator('[data-operation-completion-sync-banner]'),
+    ).toContainText('1 radnja čeka dok je slanje pauzirano');
+});
+
+test('prevents an old in-flight session from refreshing the next auth boundary', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState = {
+            blockerCalls: 0,
+            hold: false,
+            operationCalls: 0,
+            plantingCalls: 0,
+        };
+        window.__farmSyncRouterRefreshes = 0;
+    });
+    await seedQueuedCompletion({ mount, operationId: 349, page });
+    await page.evaluate(() => {
+        if (window.__farmScheduleActionTestState) {
+            window.__farmScheduleActionTestState.hold = true;
+        }
+    });
+
+    const component = await mount(<OperationCompletionSyncProviderHarness />);
+    await expect(
+        component.locator('[data-operation-completion-sync-banner]'),
+    ).toContainText('radnja se šalje');
+    await expect
+        .poll(() =>
+            page.evaluate(
+                () => window.__farmScheduleActionTestState?.operationCalls ?? 0,
+            ),
+        )
+        .toBe(1);
+
+    await component.update(
+        <OperationCompletionSyncProviderHarness enabled={false} />,
+    );
+    await expect(
+        component.getByText('Privatna radnja za sinkronizaciju'),
+    ).toHaveCount(0);
+    await component.update(<OperationCompletionSyncProviderHarness />);
+
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState?.release?.();
+    });
+    await expect
+        .poll(() =>
+            page.evaluate(
+                () =>
+                    window.__farmScheduleActionTestState
+                        ?.operationResolutions ?? 0,
+            ),
+        )
+        .toBe(1);
+    expect(
+        await page.evaluate(() => window.__farmSyncRouterRefreshes ?? 0),
+    ).toBe(0);
+    await expect(
+        component.getByText('Privatna radnja za sinkronizaciju'),
+    ).toBeVisible();
+});

--- a/apps/farm/components/offline/OperationCompletionSyncProvider.spec.tsx
+++ b/apps/farm/components/offline/OperationCompletionSyncProvider.spec.tsx
@@ -1,0 +1,311 @@
+import AxeBuilder from '@axe-core/playwright';
+import {
+    type ComponentFixtures,
+    expect,
+    test,
+} from '@playwright/experimental-ct-react';
+import type { Page } from '@playwright/test';
+import { OperationCompletionSyncProviderHarness } from '../../playwright/OperationCompletionSyncProviderHarness';
+import { OfflineQueueCompleteOperationModalStory } from '../../playwright/ScheduleTaskAttemptVersionStories';
+
+type AnalyticsEvent = {
+    eventName: string;
+    properties: Record<string, unknown>;
+};
+
+declare global {
+    interface Window {
+        recordFarmSyncAnalytics?: (event: unknown) => void;
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+async function captureAnalytics(page: Page) {
+    const events: AnalyticsEvent[] = [];
+    await page.exposeFunction('recordFarmSyncAnalytics', (event: unknown) => {
+        if (
+            isRecord(event) &&
+            typeof event.eventName === 'string' &&
+            isRecord(event.properties)
+        ) {
+            events.push({
+                eventName: event.eventName,
+                properties: event.properties,
+            });
+        }
+    });
+    await page.evaluate(() => {
+        window.addEventListener('gredice:farm-sync-analytics', (event) => {
+            if (event instanceof CustomEvent) {
+                window.recordFarmSyncAnalytics?.(event.detail);
+            }
+        });
+    });
+    return events;
+}
+
+async function seedQueuedCompletion({
+    mount,
+    operationId,
+    page,
+}: {
+    mount: ComponentFixtures['mount'];
+    operationId: number;
+    page: Page;
+}) {
+    const component = await mount(
+        <OfflineQueueCompleteOperationModalStory
+            conditions={{ completionAttachNotes: true }}
+            defaultOpen
+            expectedEntityId={701}
+            label="Privatna radnja za sinkronizaciju"
+            operationId={operationId}
+        />,
+    );
+    await page.context().setOffline(true);
+    const dialog = page.getByRole('dialog', {
+        name: 'Potvrda završetka radnje',
+    });
+    await dialog
+        .getByPlaceholder('Upišite napomenu o završetku...')
+        .fill('PRIVATNA_NAPOMENA_SINKRONIZACIJE');
+    await expect(dialog.locator('[data-operation-draft-status]')).toHaveText(
+        'Spremljeno samo na ovom uređaju — radnja još nije dovršena.',
+    );
+    await dialog.getByRole('button', { name: 'Potvrdi' }).click();
+    await expect(dialog.getByRole('status')).toContainText(
+        'sigurno je spremljena samo na ovom uređaju',
+    );
+    await component.unmount();
+    await page.context().setOffline(false);
+}
+
+test('drains one phone queue item to a content-free server receipt with private-safe analytics', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    const analyticsEvents = await captureAnalytics(page);
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState = {
+            blockerCalls: 0,
+            hold: false,
+            operationCalls: 0,
+            plantingCalls: 0,
+        };
+        window.__farmSyncRouterRefreshes = 0;
+    });
+    await seedQueuedCompletion({ mount, operationId: 346, page });
+    await page.evaluate(() => {
+        if (window.__farmScheduleActionTestState) {
+            window.__farmScheduleActionTestState.hold = true;
+        }
+    });
+
+    const component = await mount(<OperationCompletionSyncProviderHarness />);
+    const banner = component.locator('[data-operation-completion-sync-banner]');
+    await expect(banner).toContainText('radnja se šalje');
+    const reviewLink = banner.getByRole('link', { name: 'Pregledaj' });
+    const reviewBounds = await reviewLink.boundingBox();
+    expect(reviewBounds?.height).toBeGreaterThanOrEqual(44);
+    expect(reviewBounds?.x).toBeGreaterThanOrEqual(0);
+    expect(
+        (reviewBounds?.x ?? 0) + (reviewBounds?.width ?? 0),
+    ).toBeLessThanOrEqual(320);
+
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState?.release?.();
+    });
+    await expect
+        .poll(
+            () =>
+                page.evaluate(
+                    () =>
+                        window.__farmScheduleActionTestState?.operationCalls ??
+                        0,
+                ),
+            { timeout: 5_000 },
+        )
+        .toBe(1);
+    await expect(banner).toContainText('Radnja je spremljena na farmi');
+    await expect(
+        component.getByText('Predaja je potvrđena i čeka provjeru.'),
+    ).toBeVisible();
+    await expect
+        .poll(() => page.evaluate(() => window.__farmSyncRouterRefreshes ?? 0))
+        .toBe(1);
+
+    const storedReceipt = await page.evaluate(
+        () =>
+            new Promise<{
+                attachmentCount: number;
+                label: string | null;
+                notes: string | null;
+                scheduleDateKey: string | null;
+                state: string | null;
+            }>((resolve, reject) => {
+                const openRequest = indexedDB.open('gredice-farm-offline');
+                openRequest.onerror = () => reject(openRequest.error);
+                openRequest.onsuccess = () => {
+                    const database = openRequest.result;
+                    const transaction = database.transaction(
+                        'operation-completion-queue',
+                        'readonly',
+                    );
+                    const request = transaction
+                        .objectStore('operation-completion-queue')
+                        .getAll();
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        const candidate = request.result.find(
+                            (value) =>
+                                typeof value === 'object' &&
+                                value !== null &&
+                                'operationId' in value &&
+                                value.operationId === 346,
+                        );
+                        const value =
+                            typeof candidate === 'object' && candidate !== null
+                                ? candidate
+                                : null;
+                        resolve({
+                            attachmentCount:
+                                value &&
+                                'attachments' in value &&
+                                Array.isArray(value.attachments)
+                                    ? value.attachments.length
+                                    : -1,
+                            label:
+                                value &&
+                                'operationLabel' in value &&
+                                typeof value.operationLabel === 'string'
+                                    ? value.operationLabel
+                                    : null,
+                            notes:
+                                value &&
+                                'notes' in value &&
+                                typeof value.notes === 'string'
+                                    ? value.notes
+                                    : null,
+                            scheduleDateKey:
+                                value &&
+                                'scheduleDateKey' in value &&
+                                (value.scheduleDateKey === null ||
+                                    typeof value.scheduleDateKey === 'string')
+                                    ? value.scheduleDateKey
+                                    : null,
+                            state:
+                                value &&
+                                'state' in value &&
+                                typeof value.state === 'string'
+                                    ? value.state
+                                    : null,
+                        });
+                        database.close();
+                    };
+                };
+            }),
+    );
+    expect(storedReceipt).toEqual({
+        attachmentCount: 0,
+        label: '',
+        notes: '',
+        scheduleDateKey: null,
+        state: 'server_confirmed',
+    });
+
+    const acknowledgeReceipt = banner.getByRole('button', { name: 'U redu' });
+    const acknowledgeBounds = await acknowledgeReceipt.boundingBox();
+    expect(acknowledgeBounds?.height).toBeGreaterThanOrEqual(44);
+    expect(
+        (acknowledgeBounds?.x ?? 0) + (acknowledgeBounds?.width ?? 0),
+    ).toBeLessThanOrEqual(320);
+    await acknowledgeReceipt.click();
+    await expect(banner).toHaveCount(0);
+    await expect(
+        component.getByText('Nema radnji koje čekaju slanje.'),
+    ).toBeVisible();
+
+    await expect
+        .poll(
+            () =>
+                analyticsEvents.filter(
+                    (event) =>
+                        event.eventName ===
+                        'farm_completion_sync_state_changed',
+                ).length,
+        )
+        .toBeGreaterThanOrEqual(2);
+    const serializedAnalytics = JSON.stringify(analyticsEvents);
+    for (const privateValue of [
+        'PRIVATNA_NAPOMENA_SINKRONIZACIJE',
+        'Privatna radnja za sinkronizaciju',
+        'account-test',
+        'user-test',
+        'session-test',
+        '346',
+    ]) {
+        expect(serializedAnalytics).not.toContain(privateValue);
+    }
+    for (const event of analyticsEvents.filter(
+        ({ eventName }) => eventName === 'farm_completion_sync_state_changed',
+    )) {
+        expect(Object.keys(event.properties).sort()).toEqual(
+            expect.arrayContaining([
+                'age_bucket',
+                'attempt_bucket',
+                'queue_size_bucket',
+                'state',
+                'surface',
+                'trigger',
+            ]),
+        );
+    }
+
+    const accessibilityResults = await new AxeBuilder({ page }).analyze();
+    expect(
+        accessibilityResults.violations.filter(
+            ({ impact }) => impact === 'serious' || impact === 'critical',
+        ),
+    ).toEqual([]);
+});
+
+test('keeps queued phone work visible without promising a send while rollback mode is off', async ({
+    mount,
+    page,
+}) => {
+    await page.setViewportSize({ width: 320, height: 568 });
+    await page.evaluate(() => {
+        window.__farmScheduleActionTestState = {
+            blockerCalls: 0,
+            hold: false,
+            operationCalls: 0,
+            plantingCalls: 0,
+        };
+    });
+    await seedQueuedCompletion({ mount, operationId: 347, page });
+
+    const component = await mount(
+        <OperationCompletionSyncProviderHarness mode="off" />,
+    );
+    const banner = component.locator('[data-operation-completion-sync-banner]');
+    await expect(banner).toContainText('1 radnja čeka dok je slanje pauzirano');
+    await expect(banner).not.toContainText(
+        'Otvori aplikaciju uz internetsku vezu',
+    );
+    await expect(
+        component.getByText(
+            'Automatsko slanje je pauzirano. Lokalni unosi ostaju na uređaju i vidljivi su za oporavak.',
+        ),
+    ).toBeVisible();
+    await expect
+        .poll(() =>
+            page.evaluate(
+                () => window.__farmScheduleActionTestState?.operationCalls ?? 0,
+            ),
+        )
+        .toBe(0);
+});

--- a/apps/farm/components/offline/OperationCompletionSyncProvider.tsx
+++ b/apps/farm/components/offline/OperationCompletionSyncProvider.tsx
@@ -41,11 +41,25 @@ import {
 
 const QUEUE_LOCK_NAME_PREFIX = 'gredice:farm:operation-completion-queue:v1';
 const QUEUE_CLAIM_RENEW_INTERVAL_MS = 30_000;
+const EMPTY_QUEUE_ITEMS: OperationCompletionQueueSummary[] = [];
 
 type SyncItem = typeof syncClaimedOperationCompletionQueueItem;
+type DrainPromise = {
+    identityKey: string;
+    promise: Promise<void>;
+};
+type QueueSnapshot = {
+    identityKey: string;
+    items: OperationCompletionQueueSummary[];
+};
+type StorageSnapshot = {
+    available: boolean;
+    identityKey: string;
+};
 
 type OperationCompletionSyncProviderProps = PropsWithChildren<{
     accountId: string;
+    enabled?: boolean;
     mode: FarmOperationCompletionSyncMode;
     sessionIncarnation: string;
     syncItem?: SyncItem;
@@ -168,6 +182,7 @@ function canDrainInForeground(mode: FarmOperationCompletionSyncMode) {
 export function OperationCompletionSyncProvider({
     accountId,
     children,
+    enabled = true,
     mode,
     sessionIncarnation,
     syncItem = syncClaimedOperationCompletionQueueItem,
@@ -175,10 +190,35 @@ export function OperationCompletionSyncProvider({
 }: OperationCompletionSyncProviderProps) {
     const analytics = useFarmAnalytics();
     const router = useRouter();
-    const [items, setItems] = useState<OperationCompletionQueueSummary[]>([]);
-    const [isStorageAvailable, setIsStorageAvailable] = useState(true);
+    const durableIdentityKey = enabled
+        ? JSON.stringify([userId, accountId, sessionIncarnation])
+        : null;
+    const previousDurableIdentityKeyRef = useRef<string | null>(null);
+    const identityEpochRef = useRef(0);
+    if (previousDurableIdentityKeyRef.current !== durableIdentityKey) {
+        previousDurableIdentityKeyRef.current = durableIdentityKey;
+        identityEpochRef.current += 1;
+    }
+    const identityKey = durableIdentityKey
+        ? `${identityEpochRef.current.toString()}:${durableIdentityKey}`
+        : null;
+    const identityRef = useRef(identityKey);
+    identityRef.current = identityKey;
+    const [queueSnapshot, setQueueSnapshot] = useState<QueueSnapshot | null>(
+        null,
+    );
+    const [storageSnapshot, setStorageSnapshot] =
+        useState<StorageSnapshot | null>(null);
+    const items =
+        queueSnapshot?.identityKey === identityKey
+            ? queueSnapshot.items
+            : EMPTY_QUEUE_ITEMS;
+    const isStorageAvailable =
+        storageSnapshot?.identityKey === identityKey
+            ? storageSnapshot.available
+            : true;
     const activeRef = useRef(false);
-    const drainPromiseRef = useRef<Promise<void> | null>(null);
+    const drainPromiseRef = useRef<DrainPromise | null>(null);
     const pendingDrainTriggerRef = useRef<FarmCompletionSyncTrigger | null>(
         null,
     );
@@ -192,7 +232,29 @@ export function OperationCompletionSyncProvider({
         (trigger: FarmCompletionSyncTrigger) => Promise<void>
     >(async () => undefined);
 
-    modeRef.current = mode;
+    modeRef.current = enabled ? mode : 'off';
+
+    const deactivateCurrentIdentity = useCallback(() => {
+        if (!identityKey || identityRef.current !== identityKey) {
+            return;
+        }
+        activeRef.current = false;
+        leaseRef.current = null;
+        drainPromiseRef.current = null;
+        pendingDrainTriggerRef.current = null;
+        previousStatesRef.current.clear();
+        setQueueSnapshot(null);
+        setStorageSnapshot(null);
+    }, [identityKey]);
+
+    const setCurrentStorageAvailability = useCallback(
+        (available: boolean) => {
+            if (identityKey && identityRef.current === identityKey) {
+                setStorageSnapshot({ available, identityKey });
+            }
+        },
+        [identityKey],
+    );
 
     const captureChangedStates = useCallback(
         (
@@ -230,64 +292,82 @@ export function OperationCompletionSyncProvider({
     const refreshItems = useCallback(
         async (trigger: FarmCompletionSyncTrigger) => {
             const lease = leaseRef.current;
-            if (!lease || !activeRef.current) {
+            if (
+                !identityKey ||
+                identityRef.current !== identityKey ||
+                !lease ||
+                !activeRef.current
+            ) {
                 return;
             }
             const result = await listOperationCompletionQueueItems(
                 { accountId, userId },
                 lease,
             );
-            if (!activeRef.current) {
+            if (identityRef.current !== identityKey || !activeRef.current) {
                 return;
             }
             if (result.status === 'session_changed') {
-                activeRef.current = false;
-                leaseRef.current = null;
-                setItems([]);
+                deactivateCurrentIdentity();
                 return;
             }
             if (result.status === 'unavailable') {
-                setIsStorageAvailable(false);
+                setCurrentStorageAvailability(false);
                 return;
             }
-            setIsStorageAvailable(true);
-            setItems(result.items);
+            setCurrentStorageAvailability(true);
+            setQueueSnapshot({ identityKey, items: result.items });
             captureChangedStates(result.items, trigger);
         },
-        [accountId, captureChangedStates, userId],
+        [
+            accountId,
+            captureChangedStates,
+            deactivateCurrentIdentity,
+            identityKey,
+            setCurrentStorageAvailability,
+            userId,
+        ],
     );
     refreshItemsRef.current = refreshItems;
 
     const drainOwnedQueue = useCallback(
         async (trigger: FarmCompletionSyncTrigger) => {
             const lease = leaseRef.current;
-            if (
-                !lease ||
-                !activeRef.current ||
-                !canDrainInForeground(modeRef.current)
-            ) {
+            const providerIsActive = () =>
+                Boolean(identityKey) &&
+                identityRef.current === identityKey &&
+                activeRef.current &&
+                leaseRef.current === lease &&
+                leaseRef.current?.generation === lease?.generation &&
+                leaseRef.current?.sessionIncarnation === sessionIncarnation;
+            if (!lease || !providerIsActive()) {
+                return;
+            }
+            if (!canDrainInForeground(modeRef.current)) {
                 await refreshItemsRef.current(trigger);
                 return;
             }
 
-            while (activeRef.current && canDrainInForeground(modeRef.current)) {
+            while (
+                providerIsActive() &&
+                canDrainInForeground(modeRef.current)
+            ) {
                 const claim = await claimNextOperationCompletionQueueItem(
                     { accountId, userId },
                     { claimId: crypto.randomUUID(), lease },
                 );
-                if (!activeRef.current) {
+                if (!providerIsActive()) {
                     return;
                 }
                 if (claim.status !== 'claimed') {
                     if (claim.status === 'session_changed') {
-                        activeRef.current = false;
-                        leaseRef.current = null;
+                        deactivateCurrentIdentity();
                     } else if (claim.status === 'unavailable') {
-                        setIsStorageAvailable(false);
+                        setCurrentStorageAvailability(false);
                     }
                     break;
                 }
-                setIsStorageAvailable(true);
+                setCurrentStorageAvailability(true);
                 await refreshItemsRef.current(trigger);
                 const claimId = claim.item.claim?.claimId;
                 if (!claimId) {
@@ -295,10 +375,6 @@ export function OperationCompletionSyncProvider({
                 }
                 let claimIsOwned = true;
                 let renewalInFlight = false;
-                const providerIsActive = () =>
-                    activeRef.current &&
-                    leaseRef.current?.generation === lease.generation &&
-                    leaseRef.current.sessionIncarnation === sessionIncarnation;
                 const renewClaim = async () => {
                     if (
                         renewalInFlight ||
@@ -317,13 +393,16 @@ export function OperationCompletionSyncProvider({
                             },
                             lease,
                         );
+                        if (!providerIsActive()) {
+                            claimIsOwned = false;
+                            return;
+                        }
                         if (result.status !== 'ok') {
                             claimIsOwned = false;
                             if (result.status === 'session_changed') {
-                                activeRef.current = false;
-                                leaseRef.current = null;
+                                deactivateCurrentIdentity();
                             } else if (result.status === 'unavailable') {
-                                setIsStorageAvailable(false);
+                                setCurrentStorageAvailability(false);
                             }
                         }
                     } finally {
@@ -339,25 +418,44 @@ export function OperationCompletionSyncProvider({
                     lease,
                     () => claimIsOwned && providerIsActive(),
                 ).finally(() => window.clearInterval(heartbeat));
+                if (!providerIsActive()) {
+                    return;
+                }
                 if (outcome.status === 'confirmed') {
                     router.refresh();
-                }
-                if (outcome.status === 'abandoned' && !activeRef.current) {
-                    return;
                 }
                 await refreshItemsRef.current(trigger);
             }
         },
-        [accountId, router, sessionIncarnation, syncItem, userId],
+        [
+            accountId,
+            deactivateCurrentIdentity,
+            identityKey,
+            router,
+            sessionIncarnation,
+            setCurrentStorageAvailability,
+            syncItem,
+            userId,
+        ],
     );
 
     const requestDrain = useCallback(
         (trigger: FarmCompletionSyncTrigger): Promise<void> => {
-            if (drainPromiseRef.current) {
+            if (!identityKey || identityRef.current !== identityKey) {
+                return Promise.resolve();
+            }
+            if (drainPromiseRef.current?.identityKey === identityKey) {
                 pendingDrainTriggerRef.current = trigger;
-                return drainPromiseRef.current;
+                return drainPromiseRef.current.promise;
+            }
+            if (drainPromiseRef.current) {
+                drainPromiseRef.current = null;
+                pendingDrainTriggerRef.current = null;
             }
             const run = async () => {
+                if (identityRef.current !== identityKey) {
+                    return;
+                }
                 const locks = navigator.locks;
                 if (!locks) {
                     await drainOwnedQueue(trigger);
@@ -367,6 +465,9 @@ export function OperationCompletionSyncProvider({
                     `${QUEUE_LOCK_NAME_PREFIX}:${userId}:${accountId}`,
                     { ifAvailable: true },
                     async (lock) => {
+                        if (identityRef.current !== identityKey) {
+                            return;
+                        }
                         if (lock) {
                             await drainOwnedQueue(trigger);
                         } else {
@@ -375,29 +476,45 @@ export function OperationCompletionSyncProvider({
                     },
                 );
             };
+            let drain: DrainPromise;
             const promise = run().finally(() => {
-                if (drainPromiseRef.current === promise) {
+                if (drainPromiseRef.current === drain) {
                     drainPromiseRef.current = null;
                     const pendingTrigger = pendingDrainTriggerRef.current;
                     pendingDrainTriggerRef.current = null;
-                    if (pendingTrigger) {
+                    if (pendingTrigger && identityRef.current === identityKey) {
                         void requestDrainRef.current(pendingTrigger);
                     }
                 }
             });
-            drainPromiseRef.current = promise;
+            drain = { identityKey, promise };
+            drainPromiseRef.current = drain;
             return promise;
         },
-        [accountId, drainOwnedQueue, userId],
+        [accountId, drainOwnedQueue, identityKey, userId],
     );
     requestDrainRef.current = requestDrain;
 
     useEffect(() => {
+        if (!enabled || !identityKey) {
+            activeRef.current = false;
+            leaseRef.current = null;
+            drainPromiseRef.current = null;
+            pendingDrainTriggerRef.current = null;
+            previousStatesRef.current.clear();
+            setQueueSnapshot(null);
+            setStorageSnapshot(null);
+            return;
+        }
+
         let cancelled = false;
         activeRef.current = true;
         leaseRef.current = null;
+        drainPromiseRef.current = null;
+        pendingDrainTriggerRef.current = null;
         previousStatesRef.current.clear();
-        setItems([]);
+        setQueueSnapshot(null);
+        setStorageSnapshot(null);
         const capturedLogoutNonce =
             captureOperationCompletionDraftLogoutNonce(userId);
 
@@ -405,9 +522,7 @@ export function OperationCompletionSyncProvider({
             userId,
             sessionIncarnation,
             () => {
-                activeRef.current = false;
-                leaseRef.current = null;
-                setItems([]);
+                deactivateCurrentIdentity();
             },
         );
         const unsubscribeQueue = subscribeToOperationCompletionQueueChanges(
@@ -427,19 +542,23 @@ export function OperationCompletionSyncProvider({
             capturedLogoutNonce,
             sessionIncarnation,
         ).then((result) => {
-            if (cancelled || !activeRef.current) {
+            if (
+                cancelled ||
+                identityRef.current !== identityKey ||
+                !activeRef.current
+            ) {
                 return;
             }
             if (result.status !== 'ready') {
                 if (result.status === 'unavailable') {
-                    setIsStorageAvailable(false);
+                    setCurrentStorageAvailability(false);
                 } else {
-                    activeRef.current = false;
+                    deactivateCurrentIdentity();
                 }
                 return;
             }
             leaseRef.current = result.lease;
-            setIsStorageAvailable(true);
+            setCurrentStorageAvailability(true);
             void refreshItemsRef.current('auth_mount').then(() => {
                 if (modeRef.current !== 'off') {
                     void requestDrain('auth_mount');
@@ -451,11 +570,23 @@ export function OperationCompletionSyncProvider({
             cancelled = true;
             activeRef.current = false;
             leaseRef.current = null;
+            if (drainPromiseRef.current?.identityKey === identityKey) {
+                drainPromiseRef.current = null;
+            }
             pendingDrainTriggerRef.current = null;
             unsubscribeLogout();
             unsubscribeQueue();
         };
-    }, [accountId, requestDrain, sessionIncarnation, userId]);
+    }, [
+        accountId,
+        deactivateCurrentIdentity,
+        enabled,
+        identityKey,
+        requestDrain,
+        sessionIncarnation,
+        setCurrentStorageAvailability,
+        userId,
+    ]);
 
     useEffect(() => {
         const handleOnline = () => void requestDrain('online');
@@ -509,6 +640,10 @@ export function OperationCompletionSyncProvider({
             const lease = leaseRef.current;
             const item = items.find((candidate) => candidate.key === key);
             if (
+                !enabled ||
+                !identityKey ||
+                identityRef.current !== identityKey ||
+                !activeRef.current ||
                 !lease ||
                 !item ||
                 modeRef.current === 'off' ||
@@ -516,14 +651,25 @@ export function OperationCompletionSyncProvider({
             ) {
                 return;
             }
-            await retryOperationCompletionQueueItem(
+            const result = await retryOperationCompletionQueueItem(
                 { key: item.key, submissionId: item.submissionId },
                 lease,
             );
+            if (
+                identityRef.current !== identityKey ||
+                !activeRef.current ||
+                leaseRef.current !== lease
+            ) {
+                return;
+            }
+            if (result.status === 'session_changed') {
+                deactivateCurrentIdentity();
+                return;
+            }
             await refreshItemsRef.current('manual');
             await requestDrain('manual');
         },
-        [items, requestDrain],
+        [deactivateCurrentIdentity, enabled, identityKey, items, requestDrain],
     );
 
     const retryAll = useCallback(async () => {
@@ -541,17 +687,36 @@ export function OperationCompletionSyncProvider({
         async (key: string) => {
             const lease = leaseRef.current;
             const item = items.find((candidate) => candidate.key === key);
-            if (!lease || !item || item.state === 'syncing') {
+            if (
+                !enabled ||
+                !identityKey ||
+                identityRef.current !== identityKey ||
+                !activeRef.current ||
+                !lease ||
+                !item ||
+                item.state === 'syncing'
+            ) {
                 return false;
             }
             const result = await discardOperationCompletionQueueItem(
                 { key: item.key, submissionId: item.submissionId },
                 lease,
             );
+            if (
+                identityRef.current !== identityKey ||
+                !activeRef.current ||
+                leaseRef.current !== lease
+            ) {
+                return false;
+            }
+            if (result.status === 'session_changed') {
+                deactivateCurrentIdentity();
+                return false;
+            }
             await refreshItemsRef.current('manual');
             return result.status === 'ok';
         },
-        [items],
+        [deactivateCurrentIdentity, enabled, identityKey, items],
     );
 
     const value = useMemo<OperationCompletionSyncContextValue>(
@@ -559,11 +724,11 @@ export function OperationCompletionSyncProvider({
             discard,
             isStorageAvailable,
             items: items.map(publicItem),
-            mode,
+            mode: enabled ? mode : 'off',
             retry,
             retryAll,
         }),
-        [discard, isStorageAvailable, items, mode, retry, retryAll],
+        [discard, enabled, isStorageAvailable, items, mode, retry, retryAll],
     );
 
     return (

--- a/apps/farm/components/offline/OperationCompletionSyncProvider.tsx
+++ b/apps/farm/components/offline/OperationCompletionSyncProvider.tsx
@@ -1,0 +1,574 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import {
+    type PropsWithChildren,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import {
+    acquireOperationCompletionDraftLease,
+    captureOperationCompletionDraftLogoutNonce,
+    type OperationCompletionDraftLease,
+    subscribeToOperationCompletionDraftLogout,
+} from '../../lib/offline/operationCompletionDraftStore';
+import {
+    claimNextOperationCompletionQueueItem,
+    discardOperationCompletionQueueItem,
+    listOperationCompletionQueueItems,
+    type OperationCompletionQueueFailureCode,
+    type OperationCompletionQueueSummary,
+    renewOperationCompletionQueueClaim,
+    retryOperationCompletionQueueItem,
+    subscribeToOperationCompletionQueueChanges,
+} from '../../lib/offline/operationCompletionQueueStore';
+import { syncClaimedOperationCompletionQueueItem } from '../../lib/offline/operationCompletionQueueSync';
+import type { FarmOperationCompletionSyncMode } from '../../lib/offline/operationCompletionSyncMode';
+import type {
+    FarmCompletionSyncFailureCode,
+    FarmCompletionSyncState,
+    FarmCompletionSyncTrigger,
+} from '../analytics/farmAnalytics';
+import { useFarmAnalytics } from '../analytics/farmAnalyticsContext';
+import {
+    OperationCompletionSyncContext,
+    type OperationCompletionSyncContextValue,
+    type OperationCompletionSyncPublicItem,
+} from './OperationCompletionSyncContext';
+
+const QUEUE_LOCK_NAME_PREFIX = 'gredice:farm:operation-completion-queue:v1';
+const QUEUE_CLAIM_RENEW_INTERVAL_MS = 30_000;
+
+type SyncItem = typeof syncClaimedOperationCompletionQueueItem;
+
+type OperationCompletionSyncProviderProps = PropsWithChildren<{
+    accountId: string;
+    mode: FarmOperationCompletionSyncMode;
+    sessionIncarnation: string;
+    syncItem?: SyncItem;
+    userId: string;
+}>;
+
+function queueFailureMessage(code: OperationCompletionQueueFailureCode | null) {
+    switch (code) {
+        case 'network_unavailable':
+            return 'Nema internetske veze. Slanje će se nastaviti kada ponovno otvoriš aplikaciju uz vezu.';
+        case 'server_unavailable':
+            return 'Farma trenutačno nije dostupna. Pokušat ćemo ponovno.';
+        case 'upload_failed':
+            return 'Fotografije se nisu mogle poslati. Pokušaj ponovno uz stabilnu vezu.';
+        case 'expired':
+            return 'Lokalni unos je istekao. Sadržaj je uklonjen s uređaja; provjeri raspored prije nastavka.';
+        case 'not_authorized':
+            return 'Pristup zadatku se promijenio. Osvježi prijavu i provjeri raspored.';
+        case 'assignment_changed':
+            return 'Zaduženje se promijenilo. Provjeri zadatak prije odbacivanja lokalnog unosa.';
+        case 'idempotency_conflict':
+            return 'Poslužitelj je pronašao drugačiji pokušaj za ovu radnju. Provjeri raspored prije odbacivanja.';
+        case 'invalid_input':
+        case 'invalid_status':
+        case 'not_found':
+        case 'task_changed':
+            return 'Zadatak se promijenio. Provjeri trenutni raspored prije odbacivanja lokalnog unosa.';
+        case 'discarded':
+        case null:
+            return null;
+    }
+}
+
+function isRetryableFailure(code: OperationCompletionQueueFailureCode | null) {
+    return (
+        code === 'network_unavailable' ||
+        code === 'server_unavailable' ||
+        code === 'upload_failed'
+    );
+}
+
+function publicItem(
+    item: OperationCompletionQueueSummary,
+): OperationCompletionSyncPublicItem {
+    return {
+        createdAt: item.createdAt,
+        failureMessage: queueFailureMessage(item.failureCode),
+        key: item.key,
+        label: item.operationLabel || null,
+        operationId: item.operationId,
+        retryable: isRetryableFailure(item.failureCode),
+        serverState: item.serverState,
+        state: item.state,
+    };
+}
+
+function queueSizeBucket(size: number) {
+    if (size <= 1) return 'one' as const;
+    if (size <= 5) return 'two_to_five' as const;
+    return 'six_plus' as const;
+}
+
+function queueAgeBucket(createdAt: number) {
+    const age = Math.max(0, Date.now() - createdAt);
+    if (age < 5 * 60_000) return 'under_5m' as const;
+    if (age < 60 * 60_000) return 'under_1h' as const;
+    if (age < 24 * 60 * 60_000) return 'under_1d' as const;
+    return 'older' as const;
+}
+
+function queueAttemptBucket(attemptCount: number) {
+    if (attemptCount <= 0) return 'none' as const;
+    if (attemptCount === 1) return 'one' as const;
+    if (attemptCount === 2) return 'two' as const;
+    return 'three_plus' as const;
+}
+
+function analyticsFailureCode(
+    code: OperationCompletionQueueFailureCode | null,
+): FarmCompletionSyncFailureCode | undefined {
+    switch (code) {
+        case 'network_unavailable':
+            return 'network';
+        case 'server_unavailable':
+            return 'server_unavailable';
+        case 'upload_failed':
+            return 'upload_unavailable';
+        case 'expired':
+            return 'expired';
+        case 'not_authorized':
+            return 'auth_changed';
+        case 'idempotency_conflict':
+            return 'submission_conflict';
+        case 'assignment_changed':
+        case 'invalid_input':
+        case 'invalid_status':
+        case 'not_found':
+        case 'task_changed':
+            return 'task_changed';
+        case 'discarded':
+        case null:
+            return undefined;
+    }
+}
+
+function analyticsState(
+    state: OperationCompletionQueueSummary['state'],
+): Exclude<FarmCompletionSyncState, 'saved_local'> {
+    return state;
+}
+
+function canDrainInForeground(mode: FarmOperationCompletionSyncMode) {
+    return (
+        mode !== 'off' &&
+        navigator.onLine &&
+        document.visibilityState === 'visible'
+    );
+}
+
+export function OperationCompletionSyncProvider({
+    accountId,
+    children,
+    mode,
+    sessionIncarnation,
+    syncItem = syncClaimedOperationCompletionQueueItem,
+    userId,
+}: OperationCompletionSyncProviderProps) {
+    const analytics = useFarmAnalytics();
+    const router = useRouter();
+    const [items, setItems] = useState<OperationCompletionQueueSummary[]>([]);
+    const [isStorageAvailable, setIsStorageAvailable] = useState(true);
+    const activeRef = useRef(false);
+    const drainPromiseRef = useRef<Promise<void> | null>(null);
+    const pendingDrainTriggerRef = useRef<FarmCompletionSyncTrigger | null>(
+        null,
+    );
+    const requestDrainRef = useRef<
+        (trigger: FarmCompletionSyncTrigger) => Promise<void>
+    >(async () => undefined);
+    const leaseRef = useRef<OperationCompletionDraftLease | null>(null);
+    const modeRef = useRef(mode);
+    const previousStatesRef = useRef(new Map<string, string>());
+    const refreshItemsRef = useRef<
+        (trigger: FarmCompletionSyncTrigger) => Promise<void>
+    >(async () => undefined);
+
+    modeRef.current = mode;
+
+    const captureChangedStates = useCallback(
+        (
+            nextItems: OperationCompletionQueueSummary[],
+            trigger: FarmCompletionSyncTrigger,
+        ) => {
+            const previousStates = previousStatesRef.current;
+            const nextStates = new Map<string, string>();
+            for (const item of nextItems) {
+                nextStates.set(
+                    item.key,
+                    `${item.state}:${item.failureCode ?? ''}`,
+                );
+                if (
+                    previousStates.get(item.key) ===
+                    `${item.state}:${item.failureCode ?? ''}`
+                ) {
+                    continue;
+                }
+                const failureCode = analyticsFailureCode(item.failureCode);
+                analytics?.captureCompletionSyncState({
+                    age_bucket: queueAgeBucket(item.createdAt),
+                    attempt_bucket: queueAttemptBucket(item.attemptCount),
+                    ...(failureCode ? { failure_code: failureCode } : {}),
+                    queue_size_bucket: queueSizeBucket(nextItems.length),
+                    state: analyticsState(item.state),
+                    trigger,
+                });
+            }
+            previousStatesRef.current = nextStates;
+        },
+        [analytics],
+    );
+
+    const refreshItems = useCallback(
+        async (trigger: FarmCompletionSyncTrigger) => {
+            const lease = leaseRef.current;
+            if (!lease || !activeRef.current) {
+                return;
+            }
+            const result = await listOperationCompletionQueueItems(
+                { accountId, userId },
+                lease,
+            );
+            if (!activeRef.current) {
+                return;
+            }
+            if (result.status === 'session_changed') {
+                activeRef.current = false;
+                leaseRef.current = null;
+                setItems([]);
+                return;
+            }
+            if (result.status === 'unavailable') {
+                setIsStorageAvailable(false);
+                return;
+            }
+            setIsStorageAvailable(true);
+            setItems(result.items);
+            captureChangedStates(result.items, trigger);
+        },
+        [accountId, captureChangedStates, userId],
+    );
+    refreshItemsRef.current = refreshItems;
+
+    const drainOwnedQueue = useCallback(
+        async (trigger: FarmCompletionSyncTrigger) => {
+            const lease = leaseRef.current;
+            if (
+                !lease ||
+                !activeRef.current ||
+                !canDrainInForeground(modeRef.current)
+            ) {
+                await refreshItemsRef.current(trigger);
+                return;
+            }
+
+            while (activeRef.current && canDrainInForeground(modeRef.current)) {
+                const claim = await claimNextOperationCompletionQueueItem(
+                    { accountId, userId },
+                    { claimId: crypto.randomUUID(), lease },
+                );
+                if (!activeRef.current) {
+                    return;
+                }
+                if (claim.status !== 'claimed') {
+                    if (claim.status === 'session_changed') {
+                        activeRef.current = false;
+                        leaseRef.current = null;
+                    } else if (claim.status === 'unavailable') {
+                        setIsStorageAvailable(false);
+                    }
+                    break;
+                }
+                setIsStorageAvailable(true);
+                await refreshItemsRef.current(trigger);
+                const claimId = claim.item.claim?.claimId;
+                if (!claimId) {
+                    break;
+                }
+                let claimIsOwned = true;
+                let renewalInFlight = false;
+                const providerIsActive = () =>
+                    activeRef.current &&
+                    leaseRef.current?.generation === lease.generation &&
+                    leaseRef.current.sessionIncarnation === sessionIncarnation;
+                const renewClaim = async () => {
+                    if (
+                        renewalInFlight ||
+                        !claimIsOwned ||
+                        !providerIsActive()
+                    ) {
+                        return;
+                    }
+                    renewalInFlight = true;
+                    try {
+                        const result = await renewOperationCompletionQueueClaim(
+                            {
+                                claimId,
+                                key: claim.item.key,
+                                submissionId: claim.item.submissionId,
+                            },
+                            lease,
+                        );
+                        if (result.status !== 'ok') {
+                            claimIsOwned = false;
+                            if (result.status === 'session_changed') {
+                                activeRef.current = false;
+                                leaseRef.current = null;
+                            } else if (result.status === 'unavailable') {
+                                setIsStorageAvailable(false);
+                            }
+                        }
+                    } finally {
+                        renewalInFlight = false;
+                    }
+                };
+                const heartbeat = window.setInterval(
+                    () => void renewClaim(),
+                    QUEUE_CLAIM_RENEW_INTERVAL_MS,
+                );
+                const outcome = await syncItem(
+                    claim.item,
+                    lease,
+                    () => claimIsOwned && providerIsActive(),
+                ).finally(() => window.clearInterval(heartbeat));
+                if (outcome.status === 'confirmed') {
+                    router.refresh();
+                }
+                if (outcome.status === 'abandoned' && !activeRef.current) {
+                    return;
+                }
+                await refreshItemsRef.current(trigger);
+            }
+        },
+        [accountId, router, sessionIncarnation, syncItem, userId],
+    );
+
+    const requestDrain = useCallback(
+        (trigger: FarmCompletionSyncTrigger): Promise<void> => {
+            if (drainPromiseRef.current) {
+                pendingDrainTriggerRef.current = trigger;
+                return drainPromiseRef.current;
+            }
+            const run = async () => {
+                const locks = navigator.locks;
+                if (!locks) {
+                    await drainOwnedQueue(trigger);
+                    return;
+                }
+                await locks.request(
+                    `${QUEUE_LOCK_NAME_PREFIX}:${userId}:${accountId}`,
+                    { ifAvailable: true },
+                    async (lock) => {
+                        if (lock) {
+                            await drainOwnedQueue(trigger);
+                        } else {
+                            await refreshItemsRef.current(trigger);
+                        }
+                    },
+                );
+            };
+            const promise = run().finally(() => {
+                if (drainPromiseRef.current === promise) {
+                    drainPromiseRef.current = null;
+                    const pendingTrigger = pendingDrainTriggerRef.current;
+                    pendingDrainTriggerRef.current = null;
+                    if (pendingTrigger) {
+                        void requestDrainRef.current(pendingTrigger);
+                    }
+                }
+            });
+            drainPromiseRef.current = promise;
+            return promise;
+        },
+        [accountId, drainOwnedQueue, userId],
+    );
+    requestDrainRef.current = requestDrain;
+
+    useEffect(() => {
+        let cancelled = false;
+        activeRef.current = true;
+        leaseRef.current = null;
+        previousStatesRef.current.clear();
+        setItems([]);
+        const capturedLogoutNonce =
+            captureOperationCompletionDraftLogoutNonce(userId);
+
+        const unsubscribeLogout = subscribeToOperationCompletionDraftLogout(
+            userId,
+            sessionIncarnation,
+            () => {
+                activeRef.current = false;
+                leaseRef.current = null;
+                setItems([]);
+            },
+        );
+        const unsubscribeQueue = subscribeToOperationCompletionQueueChanges(
+            userId,
+            accountId,
+            () => {
+                void refreshItemsRef.current('created').then(() => {
+                    if (modeRef.current !== 'off') {
+                        void requestDrain('created');
+                    }
+                });
+            },
+        );
+
+        void acquireOperationCompletionDraftLease(
+            userId,
+            capturedLogoutNonce,
+            sessionIncarnation,
+        ).then((result) => {
+            if (cancelled || !activeRef.current) {
+                return;
+            }
+            if (result.status !== 'ready') {
+                if (result.status === 'unavailable') {
+                    setIsStorageAvailable(false);
+                } else {
+                    activeRef.current = false;
+                }
+                return;
+            }
+            leaseRef.current = result.lease;
+            setIsStorageAvailable(true);
+            void refreshItemsRef.current('auth_mount').then(() => {
+                if (modeRef.current !== 'off') {
+                    void requestDrain('auth_mount');
+                }
+            });
+        });
+
+        return () => {
+            cancelled = true;
+            activeRef.current = false;
+            leaseRef.current = null;
+            pendingDrainTriggerRef.current = null;
+            unsubscribeLogout();
+            unsubscribeQueue();
+        };
+    }, [accountId, requestDrain, sessionIncarnation, userId]);
+
+    useEffect(() => {
+        const handleOnline = () => void requestDrain('online');
+        const handlePageShow = () => void requestDrain('pageshow');
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'visible') {
+                void requestDrain('visibility');
+            }
+        };
+        window.addEventListener('online', handleOnline);
+        window.addEventListener('pageshow', handlePageShow);
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        return () => {
+            window.removeEventListener('online', handleOnline);
+            window.removeEventListener('pageshow', handlePageShow);
+            document.removeEventListener(
+                'visibilitychange',
+                handleVisibilityChange,
+            );
+        };
+    }, [requestDrain]);
+
+    useEffect(() => {
+        if (mode === 'off') {
+            return;
+        }
+        const nextRetryAt = items.reduce<number | null>((earliest, item) => {
+            if (
+                item.state !== 'queued' ||
+                item.nextAttemptAt === null ||
+                item.nextAttemptAt <= Date.now()
+            ) {
+                return earliest;
+            }
+            return earliest === null
+                ? item.nextAttemptAt
+                : Math.min(earliest, item.nextAttemptAt);
+        }, null);
+        if (nextRetryAt === null) {
+            return;
+        }
+        const timer = window.setTimeout(
+            () => void requestDrain('retry_timer'),
+            Math.max(0, nextRetryAt - Date.now()),
+        );
+        return () => window.clearTimeout(timer);
+    }, [items, mode, requestDrain]);
+
+    const retry = useCallback(
+        async (key: string) => {
+            const lease = leaseRef.current;
+            const item = items.find((candidate) => candidate.key === key);
+            if (
+                !lease ||
+                !item ||
+                modeRef.current === 'off' ||
+                !isRetryableFailure(item.failureCode)
+            ) {
+                return;
+            }
+            await retryOperationCompletionQueueItem(
+                { key: item.key, submissionId: item.submissionId },
+                lease,
+            );
+            await refreshItemsRef.current('manual');
+            await requestDrain('manual');
+        },
+        [items, requestDrain],
+    );
+
+    const retryAll = useCallback(async () => {
+        for (const item of items) {
+            if (
+                item.state === 'failed' &&
+                isRetryableFailure(item.failureCode)
+            ) {
+                await retry(item.key);
+            }
+        }
+    }, [items, retry]);
+
+    const discard = useCallback(
+        async (key: string) => {
+            const lease = leaseRef.current;
+            const item = items.find((candidate) => candidate.key === key);
+            if (!lease || !item || item.state === 'syncing') {
+                return false;
+            }
+            const result = await discardOperationCompletionQueueItem(
+                { key: item.key, submissionId: item.submissionId },
+                lease,
+            );
+            await refreshItemsRef.current('manual');
+            return result.status === 'ok';
+        },
+        [items],
+    );
+
+    const value = useMemo<OperationCompletionSyncContextValue>(
+        () => ({
+            discard,
+            isStorageAvailable,
+            items: items.map(publicItem),
+            mode,
+            retry,
+            retryAll,
+        }),
+        [discard, isStorageAvailable, items, mode, retry, retryAll],
+    );
+
+    return (
+        <OperationCompletionSyncContext.Provider value={value}>
+            {children}
+        </OperationCompletionSyncContext.Provider>
+    );
+}

--- a/apps/farm/components/providers/AuthAppProvider.tsx
+++ b/apps/farm/components/providers/AuthAppProvider.tsx
@@ -2,24 +2,50 @@
 
 import { AuthProvider } from '@gredice/ui/auth';
 import type { PropsWithChildren } from 'react';
+import {
+    type FarmOperationCompletionSyncMode,
+    isFarmOperationCompletionSyncMode,
+} from '../../lib/offline/operationCompletionSyncMode';
 
 export type User = {
+    accountId: string;
+    accounts: { accountId: string }[];
     id: string;
     userName: string;
     displayName?: string;
     avatarUrl?: string | null;
     role: 'admin' | 'farmer';
+    operationCompletionSyncMode: FarmOperationCompletionSyncMode;
+    sessionIncarnation: string;
     createdAt?: string;
 };
+
+function isAccount(value: unknown): value is { accountId: string } {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'accountId' in value &&
+        typeof value.accountId === 'string'
+    );
+}
 
 export function isFarmCurrentUser(value: unknown): value is User {
     return (
         typeof value === 'object' &&
         value !== null &&
+        'accountId' in value &&
+        typeof value.accountId === 'string' &&
+        'accounts' in value &&
+        Array.isArray(value.accounts) &&
+        value.accounts.every(isAccount) &&
         'id' in value &&
         typeof value.id === 'string' &&
+        'operationCompletionSyncMode' in value &&
+        isFarmOperationCompletionSyncMode(value.operationCompletionSyncMode) &&
         'role' in value &&
         (value.role === 'admin' || value.role === 'farmer') &&
+        'sessionIncarnation' in value &&
+        typeof value.sessionIncarnation === 'string' &&
         'userName' in value &&
         typeof value.userName === 'string'
     );

--- a/apps/farm/lib/auth/auth.ts
+++ b/apps/farm/lib/auth/auth.ts
@@ -1,7 +1,8 @@
 import 'server-only';
 
+import { createHash } from 'node:crypto';
 import { getUser as storageGetUser } from '@gredice/storage';
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import {
     baseAuth,
     baseWithAuth,
@@ -10,6 +11,7 @@ import {
     setCookie,
     verifyJwt,
 } from './baseAuth';
+import { getRefreshTokenCookie } from './refreshCookies';
 import { accountCookieName } from './sessionConfig';
 import { refreshSessionIfNeeded } from './sessionRefresh';
 
@@ -102,7 +104,29 @@ async function authFromToken(token: string, roles: string[]) {
         userId,
         user: authUser,
         accountId,
+        sessionIncarnation: await getSessionIncarnation(token),
     };
+}
+
+async function getSessionIncarnation(accessToken: string) {
+    const refreshToken = await getRefreshTokenCookie();
+    return createFarmSessionIncarnation(refreshToken ?? accessToken);
+}
+
+export function createFarmSessionIncarnation(sessionToken: string) {
+    return createHash('sha256').update(sessionToken).digest('base64url');
+}
+
+async function getRequestToken() {
+    const cookieToken = (await cookies()).get('gredice_session')?.value;
+    if (cookieToken) {
+        return cookieToken;
+    }
+    const authorization = (await headers()).get('Authorization');
+    if (authorization?.toLowerCase().startsWith('bearer ')) {
+        return authorization.substring(7);
+    }
+    throw new Error('Unauthorized: Missing authenticated session token');
 }
 
 export async function auth(...args: Parameters<typeof baseAuth>) {
@@ -115,7 +139,13 @@ export async function auth(...args: Parameters<typeof baseAuth>) {
         return await authFromToken(accessToken, roles);
     }
 
-    return await baseAuth(...args);
+    const context = await baseAuth(...args);
+    return {
+        ...context,
+        sessionIncarnation: await getSessionIncarnation(
+            await getRequestToken(),
+        ),
+    };
 }
 
 export async function withAuth(...args: Parameters<typeof baseWithAuth>) {

--- a/apps/farm/lib/auth/auth.ts
+++ b/apps/farm/lib/auth/auth.ts
@@ -148,8 +148,12 @@ export async function auth(...args: Parameters<typeof baseAuth>) {
     };
 }
 
-export async function withAuth(...args: Parameters<typeof baseWithAuth>) {
-    const [roles, handler] = args;
+type FarmAuthContext = Awaited<ReturnType<typeof authFromToken>>;
+
+export async function withAuth(
+    roles: string[],
+    handler: (context: FarmAuthContext) => Promise<Response> | Response,
+) {
     const accessToken = await refreshSessionIfNeeded();
     if (accessToken) {
         try {
@@ -160,5 +164,12 @@ export async function withAuth(...args: Parameters<typeof baseWithAuth>) {
         }
     }
 
-    return await baseWithAuth(...args);
+    return await baseWithAuth(roles, async (context) => {
+        return await handler({
+            ...context,
+            sessionIncarnation: await getSessionIncarnation(
+                await getRequestToken(),
+            ),
+        });
+    });
 }

--- a/apps/farm/lib/auth/logoutSessions.spec.tsx
+++ b/apps/farm/lib/auth/logoutSessions.spec.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { collectFarmLoggedOutSessions } from './logoutSessions';
+
+test('keeps access and refresh logout identities paired when cookies disagree', () => {
+    expect(
+        collectFarmLoggedOutSessions({
+            accessSessionIncarnation: 'access-a',
+            accessUserId: 'farmer-a',
+            refreshSessionIncarnation: 'refresh-b',
+            refreshUserId: 'farmer-b',
+        }),
+    ).toEqual([
+        {
+            sessionIncarnation: 'refresh-b',
+            userId: 'farmer-a',
+        },
+        {
+            sessionIncarnation: 'refresh-b',
+            userId: 'farmer-b',
+        },
+        {
+            sessionIncarnation: 'access-a',
+            userId: 'farmer-a',
+        },
+    ]);
+});
+
+test('deduplicates an aligned access and refresh identity', () => {
+    expect(
+        collectFarmLoggedOutSessions({
+            accessSessionIncarnation: 'access-a',
+            accessUserId: 'farmer-a',
+            refreshSessionIncarnation: 'refresh-a',
+            refreshUserId: 'farmer-a',
+        }),
+    ).toEqual([
+        {
+            sessionIncarnation: 'refresh-a',
+            userId: 'farmer-a',
+        },
+        {
+            sessionIncarnation: 'access-a',
+            userId: 'farmer-a',
+        },
+    ]);
+});

--- a/apps/farm/lib/auth/logoutSessions.ts
+++ b/apps/farm/lib/auth/logoutSessions.ts
@@ -1,0 +1,46 @@
+export type FarmLoggedOutSession = {
+    sessionIncarnation: string;
+    userId: string;
+};
+
+type FarmLogoutTokenIdentities = {
+    accessSessionIncarnation: string | null;
+    accessUserId: string | null;
+    refreshSessionIncarnation: string | null;
+    refreshUserId: string | null;
+};
+
+export function collectFarmLoggedOutSessions({
+    accessSessionIncarnation,
+    accessUserId,
+    refreshSessionIncarnation,
+    refreshUserId,
+}: FarmLogoutTokenIdentities): FarmLoggedOutSession[] {
+    const sessions: FarmLoggedOutSession[] = [];
+    const addSession = (
+        userId: string | null,
+        sessionIncarnation: string | null,
+    ) => {
+        if (!userId || !sessionIncarnation) {
+            return;
+        }
+        if (
+            sessions.some(
+                (session) =>
+                    session.userId === userId &&
+                    session.sessionIncarnation === sessionIncarnation,
+            )
+        ) {
+            return;
+        }
+        sessions.push({ sessionIncarnation, userId });
+    };
+
+    // Farm pages use the refresh token fingerprint while it is present, so
+    // include that rendered identity alongside each token's own paired identity.
+    addSession(accessUserId, refreshSessionIncarnation);
+    addSession(refreshUserId, refreshSessionIncarnation);
+    addSession(accessUserId, accessSessionIncarnation);
+
+    return sessions;
+}

--- a/apps/farm/lib/offline/operationCompletionDraftStore.spec.tsx
+++ b/apps/farm/lib/offline/operationCompletionDraftStore.spec.tsx
@@ -1,0 +1,1371 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { OperationCompletionDraftStoreHarness } from '../../playwright/OperationCompletionDraftStoreHarness';
+import {
+    FARM_OFFLINE_DATABASE_NAME,
+    FARM_OFFLINE_DATABASE_VERSION,
+    OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+    OPERATION_COMPLETION_DRAFT_MAX_BYTES,
+    OPERATION_COMPLETION_DRAFT_STORE_NAME,
+} from './operationCompletionDraftStore';
+
+const baseScope = {
+    accountId: 'account-a',
+    expectedEntityId: 101,
+    expectedTaskVersionEventId: 201,
+    operationId: 301,
+    requirementsFingerprint: 'required:optional',
+    userId: 'farmer-a',
+} as const;
+
+test.beforeEach(async ({ mount, page }) => {
+    await mount(<OperationCompletionDraftStoreHarness />);
+    await expect(page.getByTestId('operation-draft-store-ready')).toHaveText(
+        'ready',
+    );
+});
+
+test('round-trips Blob-backed photo evidence as the original File metadata', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const original = new File(['photo bytes'], 'harvest-proof.jpg', {
+            lastModified: 1_725_000_000_000,
+            type: 'image/jpeg',
+        });
+        const saveResult = await api.save({
+            ...scope,
+            notes: '  Sačuvaj razmake u napomeni.  ',
+            photos: [{ file: original, id: 'photo-a' }],
+        });
+        const loadResult = await api.load(scope);
+        if (loadResult.status !== 'found') {
+            return { loadResult, saveResult };
+        }
+
+        const storedPhoto = loadResult.draft.photos[0];
+        if (!storedPhoto) throw new Error('Expected one stored photo');
+        const restored = api.photoToFile(storedPhoto);
+
+        return {
+            draftId: loadResult.draft.draftId,
+            notes: loadResult.draft.notes,
+            photoId: storedPhoto.id,
+            restored: {
+                lastModified: restored.lastModified,
+                name: restored.name,
+                size: restored.size,
+                text: await restored.text(),
+                type: restored.type,
+            },
+            saveResult,
+            status: loadResult.status,
+        };
+    }, baseScope);
+
+    expect(result).toMatchObject({
+        notes: '  Sačuvaj razmake u napomeni.  ',
+        photoId: 'photo-a',
+        restored: {
+            lastModified: 1_725_000_000_000,
+            name: 'harvest-proof.jpg',
+            size: 11,
+            text: 'photo bytes',
+            type: 'image/jpeg',
+        },
+        saveResult: { action: 'saved', status: 'ok' },
+        status: 'found',
+    });
+    expect('draftId' in result && result.draftId).toMatch(/^[0-9a-f-]{36}$/u);
+});
+
+test('isolates drafts by user, account, and operation', async ({ page }) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        await api.save({ ...scope, notes: 'Moja napomena', photos: [] });
+
+        return {
+            otherAccount: await api.load({
+                ...scope,
+                accountId: 'account-b',
+            }),
+            otherOperation: await api.load({
+                ...scope,
+                operationId: scope.operationId + 1,
+            }),
+            otherUser: await api.load({ ...scope, userId: 'farmer-b' }),
+            owner: await api.load(scope),
+        };
+    }, baseScope);
+
+    expect(result.owner.status).toBe('found');
+    expect(result.otherUser).toEqual({
+        reason: 'not_found',
+        status: 'missing',
+    });
+    expect(result.otherAccount).toEqual({
+        reason: 'not_found',
+        status: 'missing',
+    });
+    expect(result.otherOperation).toEqual({
+        reason: 'not_found',
+        status: 'missing',
+    });
+});
+
+test('rejects stale entity, task version, and requirements fingerprints without exposing content', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        await api.save({ ...scope, notes: 'Privatna napomena', photos: [] });
+
+        return {
+            entity: await api.load({
+                ...scope,
+                expectedEntityId: scope.expectedEntityId + 1,
+            }),
+            fingerprint: await api.load({
+                ...scope,
+                requirementsFingerprint: 'optional:required',
+            }),
+            original: await api.load(scope),
+            version: await api.load({
+                ...scope,
+                expectedTaskVersionEventId:
+                    scope.expectedTaskVersionEventId + 1,
+            }),
+        };
+    }, baseScope);
+
+    expect(result.entity).toMatchObject({
+        reason: 'incompatible',
+        status: 'missing',
+    });
+    expect(result.version).toMatchObject({
+        reason: 'incompatible',
+        status: 'missing',
+    });
+    expect(result.fingerprint).toMatchObject({
+        reason: 'incompatible',
+        status: 'missing',
+    });
+    expect(
+        'revisionId' in result.entity ? result.entity.revisionId : null,
+    ).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(result.original.status).toBe('found');
+    expect(JSON.stringify(result.entity)).not.toContain('Privatna napomena');
+});
+
+test('uses per-write revisions so an old gate cannot delete or clear newer draft content', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const oldScope = scope;
+        const currentScope = {
+            ...scope,
+            expectedEntityId: scope.expectedEntityId + 1,
+            expectedTaskVersionEventId: scope.expectedTaskVersionEventId + 1,
+        };
+        const firstSave = await api.save({
+            ...oldScope,
+            notes: 'Stara skica A',
+            photos: [],
+        });
+        const staleLoad = await api.load(currentScope);
+        if (
+            firstSave.status !== 'ok' ||
+            firstSave.revisionId === null ||
+            staleLoad.status !== 'missing' ||
+            staleLoad.reason !== 'incompatible'
+        ) {
+            throw new Error('Expected the first stale revision');
+        }
+
+        const otherTabDiscard = await api.discard(currentScope, {
+            expectedRevisionId: staleLoad.revisionId,
+        });
+        const secondSave = await api.save({
+            ...currentScope,
+            notes: 'Nova skica B',
+            photos: [],
+        });
+        if (secondSave.status !== 'ok' || secondSave.revisionId === null) {
+            throw new Error('Expected the replacement revision');
+        }
+        const oldStaleDiscard = await api.discard(currentScope, {
+            expectedRevisionId: staleLoad.revisionId,
+        });
+        const retainedAfterStaleDiscard = await api.load(currentScope);
+        if (retainedAfterStaleDiscard.status !== 'found') {
+            throw new Error('Expected the replacement draft to survive');
+        }
+
+        const thirdSave = await api.save(
+            {
+                ...currentScope,
+                notes: 'Ažurirana skica C',
+                photos: [],
+            },
+            {
+                expectedRevisionId: retainedAfterStaleDiscard.draft.revisionId,
+            },
+        );
+        if (thirdSave.status !== 'ok' || thirdSave.revisionId === null) {
+            throw new Error('Expected the updated revision');
+        }
+        const oldFoundDiscard = await api.discard(currentScope, {
+            expectedRevisionId: retainedAfterStaleDiscard.draft.revisionId,
+        });
+        const oldQueuedClear = await api.save(
+            { ...currentScope, notes: '', photos: [] },
+            {
+                expectedRevisionId: retainedAfterStaleDiscard.draft.revisionId,
+            },
+        );
+        const finalDraft = await api.load(currentScope);
+
+        return {
+            finalDraft,
+            firstSave,
+            oldFoundDiscard,
+            oldQueuedClear,
+            oldStaleDiscard,
+            otherTabDiscard,
+            retainedRevision: retainedAfterStaleDiscard.draft.revisionId,
+            secondSave,
+            staleRevision: staleLoad.revisionId,
+            thirdSave,
+        };
+    }, baseScope);
+
+    expect(result.otherTabDiscard).toEqual({ status: 'ok' });
+    expect(result.oldStaleDiscard).toEqual({ status: 'conflict' });
+    expect(result.oldFoundDiscard).toEqual({ status: 'conflict' });
+    expect(result.oldQueuedClear).toEqual({
+        reason: 'draft_changed',
+        status: 'error',
+    });
+    expect(result.staleRevision).not.toBe(result.secondSave.revisionId);
+    expect(result.retainedRevision).toBe(result.secondSave.revisionId);
+    expect(result.thirdSave.revisionId).not.toBe(result.retainedRevision);
+    expect(result.finalDraft).toMatchObject({
+        draft: { notes: 'Ažurirana skica C' },
+        status: 'found',
+    });
+});
+
+test('reports an expired draft once, removes it, and prunes expired records before applying the count limit', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ databaseName, databaseVersion, scope, storeName }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            for (let index = 0; index < 5; index += 1) {
+                await api.save({
+                    ...scope,
+                    notes: `Napomena ${index.toString()}`,
+                    operationId: scope.operationId + index,
+                    photos: [],
+                });
+            }
+            const first = await api.load(scope);
+            if (first.status !== 'found') {
+                throw new Error('Expected the first draft before expiring it');
+            }
+
+            await new Promise<void>((resolve, reject) => {
+                const openRequest = indexedDB.open(
+                    databaseName,
+                    databaseVersion,
+                );
+                openRequest.onerror = () => reject(openRequest.error);
+                openRequest.onsuccess = () => {
+                    const database = openRequest.result;
+                    const transaction = database.transaction(
+                        storeName,
+                        'readwrite',
+                    );
+                    const store = transaction.objectStore(storeName);
+                    const getRequest = store.get(first.draft.key);
+                    getRequest.onerror = () => reject(getRequest.error);
+                    getRequest.onsuccess = () => {
+                        const record = getRequest.result;
+                        record.expiresAt = Date.now() - 1;
+                        store.put(record);
+                    };
+                    transaction.onabort = () => reject(transaction.error);
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        database.close();
+                        resolve();
+                    };
+                };
+            });
+
+            const expired = await api.load(scope);
+            const afterExpired = await api.load(scope);
+
+            await api.save({
+                ...scope,
+                notes: 'Ponovno istekni ovaj zapis',
+                photos: [],
+            });
+            const replacement = await api.load(scope);
+            if (replacement.status !== 'found') {
+                throw new Error('Expected the replacement draft');
+            }
+            await new Promise<void>((resolve, reject) => {
+                const openRequest = indexedDB.open(
+                    databaseName,
+                    databaseVersion,
+                );
+                openRequest.onerror = () => reject(openRequest.error);
+                openRequest.onsuccess = () => {
+                    const database = openRequest.result;
+                    const transaction = database.transaction(
+                        storeName,
+                        'readwrite',
+                    );
+                    const store = transaction.objectStore(storeName);
+                    const getRequest = store.get(replacement.draft.key);
+                    getRequest.onerror = () => reject(getRequest.error);
+                    getRequest.onsuccess = () => {
+                        const record = getRequest.result;
+                        record.expiresAt = Date.now() - 1;
+                        store.put(record);
+                    };
+                    transaction.onabort = () => reject(transaction.error);
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        database.close();
+                        resolve();
+                    };
+                };
+            });
+
+            const sixth = await api.save({
+                ...scope,
+                notes: 'Novi peti živi zapis',
+                operationId: scope.operationId + 5,
+                photos: [],
+            });
+
+            return { afterExpired, expired, sixth };
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            databaseVersion: FARM_OFFLINE_DATABASE_VERSION,
+            scope: baseScope,
+            storeName: OPERATION_COMPLETION_DRAFT_STORE_NAME,
+        },
+    );
+
+    expect(result.expired).toEqual({ status: 'expired' });
+    expect(result.afterExpired).toEqual({
+        reason: 'not_found',
+        status: 'missing',
+    });
+    expect(result.sixth).toMatchObject({ action: 'saved', status: 'ok' });
+});
+
+test('allows exactly five live drafts per user and account without evicting any of them', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const accepted = [];
+        for (let index = 0; index < 5; index += 1) {
+            accepted.push(
+                await api.save({
+                    ...scope,
+                    notes: `Draft ${index.toString()}`,
+                    operationId: scope.operationId + index,
+                    photos: [],
+                }),
+            );
+        }
+        const sixth = await api.save({
+            ...scope,
+            notes: 'Šesti zapis',
+            operationId: scope.operationId + 5,
+            photos: [],
+        });
+        const retained = await Promise.all(
+            Array.from({ length: 5 }, (_, index) =>
+                api.load({
+                    ...scope,
+                    operationId: scope.operationId + index,
+                }),
+            ),
+        );
+
+        return { accepted, retained, sixth };
+    }, baseScope);
+
+    expect(result.accepted).toHaveLength(5);
+    expect(
+        result.accepted.every(
+            (saveResult) =>
+                saveResult.status === 'ok' && saveResult.action === 'saved',
+        ),
+    ).toBe(true);
+    expect(result.sixth).toEqual({
+        reason: 'draft_count_limit',
+        status: 'error',
+    });
+    expect(
+        result.retained.every((loadResult) => loadResult.status === 'found'),
+    ).toBe(true);
+});
+
+test('enforces the 100 MiB boundary without allocating a 100 MiB payload', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ maxBytes, scope }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            function virtualFile(size: number) {
+                const file = new File([], 'virtual-proof.jpg', {
+                    lastModified: 1,
+                    type: 'image/jpeg',
+                });
+                Object.defineProperty(file, 'size', {
+                    configurable: true,
+                    value: size,
+                });
+                return file;
+            }
+
+            const atLimit = await api.save({
+                ...scope,
+                notes: '',
+                photos: [{ file: virtualFile(maxBytes), id: 'at-limit' }],
+            });
+            const aboveLimit = await api.save({
+                ...scope,
+                accountId: 'account-over-limit',
+                notes: '',
+                photos: [
+                    { file: virtualFile(maxBytes + 1), id: 'above-limit' },
+                ],
+            });
+
+            return { aboveLimit, atLimit };
+        },
+        { maxBytes: OPERATION_COMPLETION_DRAFT_MAX_BYTES, scope: baseScope },
+    );
+
+    expect(result.atLimit).toMatchObject({ action: 'saved', status: 'ok' });
+    expect(result.aboveLimit).toEqual({
+        reason: 'draft_size_limit',
+        status: 'error',
+    });
+});
+
+test('reports a browser quota failure without losing control of the form', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const leaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+        );
+        if (leaseResult.status !== 'ready') {
+            throw new Error('Expected a writer lease');
+        }
+
+        const originalPut = Object.getOwnPropertyDescriptor(
+            IDBObjectStore.prototype,
+            'put',
+        );
+        Object.defineProperty(IDBObjectStore.prototype, 'put', {
+            configurable: true,
+            value: () => {
+                throw new DOMException(
+                    'Test quota reached',
+                    'QuotaExceededError',
+                );
+            },
+        });
+        try {
+            return await api.save(
+                {
+                    ...scope,
+                    notes: 'Ostaje u obrascu',
+                    photos: [],
+                },
+                { lease: leaseResult.lease },
+            );
+        } finally {
+            if (originalPut) {
+                Object.defineProperty(
+                    IDBObjectStore.prototype,
+                    'put',
+                    originalPut,
+                );
+            } else {
+                Reflect.deleteProperty(IDBObjectStore.prototype, 'put');
+            }
+        }
+    }, baseScope);
+
+    expect(result).toEqual({
+        reason: 'quota_exceeded',
+        status: 'error',
+    });
+});
+
+test('keeps a scrubbed server-confirmed tombstone that fences late writers', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ databaseName, databaseVersion, maxAge, scope, storeName }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            await api.save({
+                ...scope,
+                notes: 'Privatna napomena ne smije ostati',
+                photos: [
+                    {
+                        file: new File(['private photo'], 'private.jpg', {
+                            type: 'image/jpeg',
+                        }),
+                        id: 'private-photo',
+                    },
+                ],
+            });
+            const confirmation = await api.markServerConfirmed(scope);
+            const reloadResult = await api.load(scope);
+            const lateWrite = await api.save({
+                ...scope,
+                notes: 'Kasni zapis iz drugog prozora',
+                photos: [],
+            });
+            const lateClear = await api.save({
+                ...scope,
+                notes: '',
+                photos: [],
+            });
+            const staleDiscard = await api.discard(scope);
+            const afterDiscardWrite = await api.save({
+                ...scope,
+                notes: 'Ni odbacivanje iz starog prozora ne otvara ogradu',
+                photos: [],
+            });
+
+            const emptyScope = {
+                ...scope,
+                operationId: scope.operationId + 1,
+            };
+            const emptyConfirmation = await api.markServerConfirmed(emptyScope);
+            const emptyLateWrite = await api.save({
+                ...emptyScope,
+                notes: 'Kasni zapis bez prethodne skice',
+                photos: [],
+            });
+
+            const records = await new Promise<unknown[]>((resolve, reject) => {
+                const openRequest = indexedDB.open(
+                    databaseName,
+                    databaseVersion,
+                );
+                openRequest.onerror = () => reject(openRequest.error);
+                openRequest.onsuccess = () => {
+                    const database = openRequest.result;
+                    const transaction = database.transaction(
+                        storeName,
+                        'readonly',
+                    );
+                    const getAllRequest = transaction
+                        .objectStore(storeName)
+                        .getAll();
+                    getAllRequest.onerror = () => reject(getAllRequest.error);
+                    getAllRequest.onsuccess = () =>
+                        resolve(getAllRequest.result);
+                    transaction.oncomplete = () => database.close();
+                };
+            });
+            const tombstones = records
+                .flatMap((record) => {
+                    if (
+                        typeof record !== 'object' ||
+                        record === null ||
+                        !('serverConfirmedAt' in record) ||
+                        typeof record.serverConfirmedAt !== 'number'
+                    ) {
+                        return [];
+                    }
+                    return [
+                        {
+                            age:
+                                'expiresAt' in record &&
+                                typeof record.expiresAt === 'number'
+                                    ? record.expiresAt -
+                                      record.serverConfirmedAt
+                                    : null,
+                            notes:
+                                'notes' in record &&
+                                typeof record.notes === 'string'
+                                    ? record.notes
+                                    : null,
+                            operationId:
+                                'operationId' in record &&
+                                typeof record.operationId === 'number'
+                                    ? record.operationId
+                                    : null,
+                            photoCount:
+                                'photos' in record &&
+                                Array.isArray(record.photos)
+                                    ? record.photos.length
+                                    : null,
+                        },
+                    ];
+                })
+                .sort(
+                    (left, right) =>
+                        (left.operationId ?? 0) - (right.operationId ?? 0),
+                );
+
+            return {
+                afterDiscardWrite,
+                confirmation,
+                emptyConfirmation,
+                emptyLateWrite,
+                lateClear,
+                lateWrite,
+                maxAge,
+                reloadResult,
+                staleDiscard,
+                tombstones,
+            };
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            databaseVersion: FARM_OFFLINE_DATABASE_VERSION,
+            maxAge: OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+            scope: baseScope,
+            storeName: OPERATION_COMPLETION_DRAFT_STORE_NAME,
+        },
+    );
+
+    expect(result.confirmation).toEqual({ status: 'ok' });
+    expect(result.reloadResult).toEqual({
+        reason: 'not_found',
+        status: 'missing',
+    });
+    expect(result.lateWrite).toEqual({
+        reason: 'incompatible',
+        status: 'error',
+    });
+    expect(result.lateClear).toEqual({
+        reason: 'incompatible',
+        status: 'error',
+    });
+    expect(result.staleDiscard).toEqual({ status: 'ok' });
+    expect(result.afterDiscardWrite).toEqual({
+        reason: 'incompatible',
+        status: 'error',
+    });
+    expect(result.emptyConfirmation).toEqual({ status: 'ok' });
+    expect(result.emptyLateWrite).toEqual({
+        reason: 'incompatible',
+        status: 'error',
+    });
+    expect(result.tombstones).toEqual([
+        {
+            age: result.maxAge,
+            notes: '',
+            operationId: baseScope.operationId,
+            photoCount: 0,
+        },
+        {
+            age: result.maxAge,
+            notes: '',
+            operationId: baseScope.operationId + 1,
+            photoCount: 0,
+        },
+    ]);
+});
+
+test('removes an expired server-confirmed tombstone before allowing a new draft', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ databaseName, databaseVersion, scope, storeName }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            await api.markServerConfirmed(scope);
+            await new Promise<void>((resolve, reject) => {
+                const openRequest = indexedDB.open(
+                    databaseName,
+                    databaseVersion,
+                );
+                openRequest.onerror = () => reject(openRequest.error);
+                openRequest.onsuccess = () => {
+                    const database = openRequest.result;
+                    const transaction = database.transaction(
+                        storeName,
+                        'readwrite',
+                    );
+                    const store = transaction.objectStore(storeName);
+                    const getAllRequest = store.getAll();
+                    getAllRequest.onerror = () => reject(getAllRequest.error);
+                    getAllRequest.onsuccess = () => {
+                        const record = getAllRequest.result.find(
+                            (value) =>
+                                typeof value === 'object' &&
+                                value !== null &&
+                                'serverConfirmedAt' in value &&
+                                typeof value.serverConfirmedAt === 'number',
+                        );
+                        if (!record) {
+                            reject(new Error('Expected a tombstone'));
+                            return;
+                        }
+                        record.expiresAt = Date.now() - 1;
+                        store.put(record);
+                    };
+                    transaction.onabort = () => reject(transaction.error);
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        database.close();
+                        resolve();
+                    };
+                };
+            });
+
+            const expiredLoad = await api.load(scope);
+            const saveAfterExpiry = await api.save({
+                ...scope,
+                notes: 'Nova skica nakon isteka ograde',
+                photos: [],
+            });
+            return {
+                expiredLoad,
+                reloaded: await api.load(scope),
+                saveAfterExpiry,
+            };
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            databaseVersion: FARM_OFFLINE_DATABASE_VERSION,
+            scope: baseScope,
+            storeName: OPERATION_COMPLETION_DRAFT_STORE_NAME,
+        },
+    );
+
+    expect(result.expiredLoad).toEqual({
+        reason: 'not_found',
+        status: 'missing',
+    });
+    expect(result.saveAfterExpiry).toMatchObject({
+        action: 'saved',
+        status: 'ok',
+    });
+    expect(result.reloaded.status).toBe('found');
+});
+
+test('removes malformed records on read and then reports them missing', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ databaseName, databaseVersion, scope, storeName }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            await api.save({ ...scope, notes: 'Valid first', photos: [] });
+            const valid = await api.load(scope);
+            if (valid.status !== 'found') {
+                throw new Error('Expected a valid draft before corruption');
+            }
+
+            await new Promise<void>((resolve, reject) => {
+                const openRequest = indexedDB.open(
+                    databaseName,
+                    databaseVersion,
+                );
+                openRequest.onerror = () => reject(openRequest.error);
+                openRequest.onsuccess = () => {
+                    const database = openRequest.result;
+                    const transaction = database.transaction(
+                        storeName,
+                        'readwrite',
+                    );
+                    transaction.objectStore(storeName).put({
+                        key: valid.draft.key,
+                        notes: 'must never escape',
+                        schemaVersion: 1,
+                        userId: scope.userId,
+                    });
+                    transaction.onabort = () => reject(transaction.error);
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        database.close();
+                        resolve();
+                    };
+                };
+            });
+
+            return {
+                first: await api.load(scope),
+                second: await api.load(scope),
+            };
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            databaseVersion: FARM_OFFLINE_DATABASE_VERSION,
+            scope: baseScope,
+            storeName: OPERATION_COMPLETION_DRAFT_STORE_NAME,
+        },
+    );
+
+    expect(result.first).toEqual({
+        reason: 'invalid_record',
+        status: 'missing',
+    });
+    expect(result.second).toEqual({
+        reason: 'not_found',
+        status: 'missing',
+    });
+    expect(JSON.stringify(result.first)).not.toContain('must never escape');
+});
+
+test('purges one user across accounts while preserving every other user', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const firstAccount = scope;
+        const secondAccount = { ...scope, accountId: 'account-b' };
+        const otherUser = { ...scope, userId: 'farmer-b' };
+        await api.save({ ...firstAccount, notes: 'A1', photos: [] });
+        await api.save({ ...secondAccount, notes: 'A2', photos: [] });
+        await api.save({ ...otherUser, notes: 'B1', photos: [] });
+
+        const purge = await api.purgeUser(scope.userId);
+        const newLeaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            'new-session-after-purge',
+        );
+        if (newLeaseResult.status !== 'ready') {
+            throw new Error('Expected a new login writer lease');
+        }
+
+        return {
+            firstAccount: await api.load(firstAccount, newLeaseResult.lease),
+            otherUser: await api.load(otherUser),
+            purge,
+            secondAccount: await api.load(secondAccount, newLeaseResult.lease),
+        };
+    }, baseScope);
+
+    expect(result.purge).toEqual({ deletedCount: 2, status: 'ok' });
+    expect(result.firstAccount).toEqual({
+        reason: 'not_found',
+        status: 'missing',
+    });
+    expect(result.secondAccount).toEqual({
+        reason: 'not_found',
+        status: 'missing',
+    });
+    expect(result.otherUser.status).toBe('found');
+});
+
+test('atomically fences every late mutation from the logged-out writer generation', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const oldLeaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+        );
+        if (oldLeaseResult.status !== 'ready') {
+            throw new Error('Expected the original writer lease');
+        }
+        const oldLease = oldLeaseResult.lease;
+        const initialSave = await api.save(
+            { ...scope, notes: 'Mora nestati pri odjavi', photos: [] },
+            { lease: oldLease },
+        );
+        if (initialSave.status !== 'ok' || initialSave.revisionId === null) {
+            throw new Error('Expected the original draft');
+        }
+
+        const otherScope = { ...scope, userId: 'farmer-other' };
+        await api.save({
+            ...otherScope,
+            notes: 'Drugi korisnik ostaje',
+            photos: [],
+        });
+        const purge = await api.purgeUser(scope.userId);
+        const lateLoad = await api.load(scope, oldLease);
+        const lateSave = await api.save(
+            { ...scope, notes: 'Kasni privatni unos', photos: [] },
+            {
+                expectedRevisionId: initialSave.revisionId,
+                lease: oldLease,
+            },
+        );
+        const lateClear = await api.save(
+            { ...scope, notes: '', photos: [] },
+            {
+                expectedRevisionId: initialSave.revisionId,
+                lease: oldLease,
+            },
+        );
+        const lateDiscard = await api.discard(scope, {
+            expectedRevisionId: initialSave.revisionId,
+            lease: oldLease,
+        });
+        const lateConfirmation = await api.markServerConfirmed(scope, oldLease);
+
+        const newLeaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            'new-session-after-logout',
+        );
+        if (newLeaseResult.status !== 'ready') {
+            throw new Error('Expected a new login writer lease');
+        }
+        const newSave = await api.save(
+            { ...scope, notes: 'Nova prijavljena sesija', photos: [] },
+            { lease: newLeaseResult.lease },
+        );
+
+        return {
+            generationChanged:
+                oldLease.generation !== newLeaseResult.lease.generation,
+            lateClear,
+            lateConfirmation,
+            lateDiscard,
+            lateLoad,
+            lateSave,
+            newDraft: await api.load(scope, newLeaseResult.lease),
+            newSave,
+            otherDraft: await api.load(otherScope),
+            purge,
+        };
+    }, baseScope);
+
+    expect(result.purge).toEqual({ deletedCount: 1, status: 'ok' });
+    expect(result.generationChanged).toBe(true);
+    expect(result.lateLoad).toEqual({ status: 'session_changed' });
+    expect(result.lateSave).toEqual({
+        reason: 'session_changed',
+        status: 'error',
+    });
+    expect(result.lateClear).toEqual({
+        reason: 'session_changed',
+        status: 'error',
+    });
+    expect(result.lateDiscard).toEqual({ status: 'session_changed' });
+    expect(result.lateConfirmation).toEqual({ status: 'session_changed' });
+    expect(result.newSave).toMatchObject({ action: 'saved', status: 'ok' });
+    expect(result.newDraft).toMatchObject({
+        draft: { notes: 'Nova prijavljena sesija' },
+        status: 'found',
+    });
+    expect(result.otherDraft).toMatchObject({
+        draft: { notes: 'Drugi korisnik ostaje' },
+        status: 'found',
+    });
+});
+
+test('retries a lease when only the logout nonce rotates during acquisition', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const capturedLogoutNonce = api.captureLogoutNonce(scope.userId);
+        const originalOpen = indexedDB.open.bind(indexedDB);
+        let intercepted = false;
+        Object.defineProperty(indexedDB, 'open', {
+            configurable: true,
+            value: (name: string, version?: number) => {
+                if (!intercepted) {
+                    intercepted = true;
+                    localStorage.setItem(
+                        `gredice:farm:operation-completion-draft-logout:v1:${scope.userId}`,
+                        'rotated-during-acquire',
+                    );
+                }
+                return version === undefined
+                    ? originalOpen(name)
+                    : originalOpen(name, version);
+            },
+        });
+        try {
+            return await api.acquireLease(scope.userId, capturedLogoutNonce);
+        } finally {
+            Object.defineProperty(indexedDB, 'open', {
+                configurable: true,
+                value: originalOpen,
+            });
+        }
+    }, baseScope);
+
+    expect(result).toMatchObject({
+        lease: { logoutNonce: 'rotated-during-acquire' },
+        status: 'ready',
+    });
+});
+
+test('lets a successor session queued behind an older purge acquire a lease', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ databaseName, databaseVersion, scope, storeName }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            const oldSession = 'queued-old-session';
+            const successorSession = 'queued-successor-session';
+            const oldLeaseResult = await api.acquireLease(
+                scope.userId,
+                api.captureLogoutNonce(scope.userId),
+                oldSession,
+            );
+            if (oldLeaseResult.status !== 'ready') {
+                throw new Error('Expected the older session lease');
+            }
+            await api.save(
+                { ...scope, notes: 'Stari unos', photos: [] },
+                { lease: oldLeaseResult.lease },
+            );
+
+            const database = await new Promise<IDBDatabase>(
+                (resolve, reject) => {
+                    const request = indexedDB.open(
+                        databaseName,
+                        databaseVersion,
+                    );
+                    request.onerror = () => reject(request.error);
+                    request.onsuccess = () => resolve(request.result);
+                },
+            );
+            let releaseBlocker = false;
+            let blockerStarted = false;
+            const blocker = database.transaction(storeName, 'readwrite');
+            const blockerStore = blocker.objectStore(storeName);
+            const blockerComplete = new Promise<void>((resolve, reject) => {
+                blocker.onabort = () => reject(blocker.error);
+                blocker.onerror = () => reject(blocker.error);
+                blocker.oncomplete = () => resolve();
+            });
+            const keepBlockerAlive = () => {
+                const request = blockerStore.get('queued-purge-blocker');
+                request.onsuccess = () => {
+                    blockerStarted = true;
+                    if (!releaseBlocker) keepBlockerAlive();
+                };
+            };
+            keepBlockerAlive();
+            while (!blockerStarted) {
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+
+            const originalTransaction = IDBDatabase.prototype.transaction;
+            let transactionCount = 0;
+            Object.defineProperty(IDBDatabase.prototype, 'transaction', {
+                configurable: true,
+                value: function (
+                    this: IDBDatabase,
+                    storeNames: string | string[],
+                    mode?: IDBTransactionMode,
+                    options?: IDBTransactionOptions,
+                ) {
+                    const transaction = options
+                        ? originalTransaction.call(
+                              this,
+                              storeNames,
+                              mode,
+                              options,
+                          )
+                        : originalTransaction.call(this, storeNames, mode);
+                    transactionCount += 1;
+                    return transaction;
+                },
+            });
+
+            try {
+                const capturedLogoutNonce = api.captureLogoutNonce(
+                    scope.userId,
+                );
+                const purgePromise = api.purgeUser(scope.userId, oldSession);
+                while (transactionCount < 1) {
+                    await new Promise((resolve) => setTimeout(resolve, 0));
+                }
+
+                const successorLeasePromise = api.acquireLease(
+                    scope.userId,
+                    capturedLogoutNonce,
+                    successorSession,
+                );
+                while (transactionCount < 2) {
+                    await new Promise((resolve) => setTimeout(resolve, 0));
+                }
+
+                releaseBlocker = true;
+                await blockerComplete;
+                const [purge, successorLeaseResult] = await Promise.all([
+                    purgePromise,
+                    successorLeasePromise,
+                ]);
+                if (successorLeaseResult.status !== 'ready') {
+                    throw new Error(
+                        `Expected successor lease, received ${successorLeaseResult.status}`,
+                    );
+                }
+                const successorSave = await api.save(
+                    {
+                        ...scope,
+                        notes: 'Novi unos nakon stare odjave',
+                        photos: [],
+                    },
+                    { lease: successorLeaseResult.lease },
+                );
+                return {
+                    oldLoad: await api.load(scope, oldLeaseResult.lease),
+                    purge,
+                    successorLeaseResult,
+                    successorSave,
+                    transactionCount,
+                };
+            } finally {
+                releaseBlocker = true;
+                await blockerComplete.catch(() => undefined);
+                Object.defineProperty(IDBDatabase.prototype, 'transaction', {
+                    configurable: true,
+                    value: originalTransaction,
+                });
+                database.close();
+            }
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            databaseVersion: FARM_OFFLINE_DATABASE_VERSION,
+            scope: baseScope,
+            storeName: OPERATION_COMPLETION_DRAFT_STORE_NAME,
+        },
+    );
+
+    expect(result.purge).toEqual({ deletedCount: 1, status: 'ok' });
+    expect(result.successorLeaseResult).toMatchObject({ status: 'ready' });
+    expect(result.successorSave).toMatchObject({
+        action: 'saved',
+        status: 'ok',
+    });
+    expect(result.oldLoad).toEqual({ status: 'session_changed' });
+    expect(result.transactionCount).toBeGreaterThanOrEqual(5);
+});
+
+test('retains every live session revocation across later logout cycles', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const acquire = async (sessionIncarnation: string) => {
+            const leaseResult = await api.acquireLease(
+                scope.userId,
+                api.captureLogoutNonce(scope.userId),
+                sessionIncarnation,
+            );
+            if (leaseResult.status !== 'ready') {
+                throw new Error(`Expected ${sessionIncarnation} to be ready`);
+            }
+            return leaseResult.lease;
+        };
+
+        await acquire('session-a');
+        await api.purgeUser(scope.userId, 'session-a');
+        await acquire('session-b');
+        await api.purgeUser(scope.userId, 'session-b');
+        const sessionC = await acquire('session-c');
+        const saveC = await api.save(
+            { ...scope, notes: 'Skica aktivne sesije C', photos: [] },
+            { lease: sessionC },
+        );
+
+        localStorage.removeItem(
+            `gredice:farm:operation-completion-draft-logged-out-session:v1:${scope.userId}:session-a`,
+        );
+        const lateSessionA = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            'session-a',
+        );
+
+        return {
+            lateSessionA,
+            sessionCDraft: await api.load(scope, sessionC),
+            saveC,
+        };
+    }, baseScope);
+
+    expect(result.lateSessionA).toEqual({ status: 'session_changed' });
+    expect(result.saveC).toMatchObject({ action: 'saved', status: 'ok' });
+    expect(result.sessionCDraft).toMatchObject({
+        draft: { notes: 'Skica aktivne sesije C' },
+        status: 'found',
+    });
+});
+
+test('rebroadcasts after durable revocation when localStorage is unavailable', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const sessionIncarnation = 'session-without-local-storage';
+        let logoutEvents = 0;
+        const handleLogout = () => {
+            logoutEvents += 1;
+        };
+        window.addEventListener(
+            'gredice:operation-completion-draft-logout:v1',
+            handleLogout,
+        );
+        const originalGetItem = Storage.prototype.getItem;
+        const originalSetItem = Storage.prototype.setItem;
+        Object.defineProperties(Storage.prototype, {
+            getItem: {
+                configurable: true,
+                value: () => {
+                    throw new DOMException('Storage unavailable');
+                },
+            },
+            setItem: {
+                configurable: true,
+                value: () => {
+                    throw new DOMException('Storage unavailable');
+                },
+            },
+        });
+        try {
+            const purge = await api.purgeUser(scope.userId, sessionIncarnation);
+            const lateAcquire = await api.acquireLease(
+                scope.userId,
+                null,
+                sessionIncarnation,
+            );
+            return { lateAcquire, logoutEvents, purge };
+        } finally {
+            Object.defineProperties(Storage.prototype, {
+                getItem: { configurable: true, value: originalGetItem },
+                setItem: { configurable: true, value: originalSetItem },
+            });
+            window.removeEventListener(
+                'gredice:operation-completion-draft-logout:v1',
+                handleLogout,
+            );
+        }
+    }, baseScope);
+
+    expect(result.purge.status).toBe('ok');
+    expect(result.logoutEvents).toBe(2);
+    expect(result.lateAcquire).toEqual({ status: 'session_changed' });
+});
+
+test('preserves a newer same-user session when an older logout response arrives late', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const oldSession = 'old-session-incarnation';
+        const oldLeaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            oldSession,
+        );
+        if (oldLeaseResult.status !== 'ready') {
+            throw new Error('Expected the original writer lease');
+        }
+        await api.save(
+            { ...scope, notes: 'Stara sesija', photos: [] },
+            { lease: oldLeaseResult.lease },
+        );
+
+        const newLeaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            'new-session-incarnation',
+        );
+        if (newLeaseResult.status !== 'ready') {
+            throw new Error('Expected the newer writer lease');
+        }
+        const initialNewSave = await api.save(
+            { ...scope, notes: 'Nova sesija prije stare odjave', photos: [] },
+            { lease: newLeaseResult.lease },
+        );
+        if (
+            initialNewSave.status !== 'ok' ||
+            initialNewSave.revisionId === null
+        ) {
+            throw new Error('Expected the newer session draft');
+        }
+
+        const purge = await api.purgeUser(scope.userId, oldSession);
+
+        return {
+            newDraft: await api.load(scope, newLeaseResult.lease),
+            oldDraft: await api.load(scope, oldLeaseResult.lease),
+            purge,
+            saveAfterPurge: await api.save(
+                {
+                    ...scope,
+                    notes: 'Nova sesija i nakon stare odjave',
+                    photos: [],
+                },
+                {
+                    expectedRevisionId: initialNewSave.revisionId,
+                    lease: newLeaseResult.lease,
+                },
+            ),
+        };
+    }, baseScope);
+
+    expect(result.purge).toEqual({ deletedCount: 0, status: 'ok' });
+    expect(result.oldDraft).toEqual({ status: 'session_changed' });
+    expect(result.newDraft).toMatchObject({
+        draft: { notes: 'Nova sesija prije stare odjave' },
+        status: 'found',
+    });
+    expect(result.saveAfterPurge).toMatchObject({
+        action: 'saved',
+        status: 'ok',
+    });
+});

--- a/apps/farm/lib/offline/operationCompletionDraftStore.ts
+++ b/apps/farm/lib/offline/operationCompletionDraftStore.ts
@@ -1,14 +1,17 @@
 'use client';
 
 export const FARM_OFFLINE_DATABASE_NAME = 'gredice-farm-offline';
-export const FARM_OFFLINE_DATABASE_VERSION = 1;
+export const FARM_OFFLINE_DATABASE_VERSION = 2;
 export const OPERATION_COMPLETION_DRAFT_STORE_NAME =
     'operation-completion-drafts';
+export const OPERATION_COMPLETION_QUEUE_STORE_NAME =
+    'operation-completion-queue';
 export const OPERATION_COMPLETION_DRAFT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 export const OPERATION_COMPLETION_DRAFT_MAX_COUNT = 5;
 export const OPERATION_COMPLETION_DRAFT_MAX_BYTES = 100 * 1024 * 1024;
 
 const OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION = 1;
+const OPERATION_COMPLETION_QUEUE_SCHEMA_VERSION = 1;
 const OPERATION_COMPLETION_DRAFT_GENERATION_KIND =
     'operation-completion-draft-generation';
 const OPERATION_COMPLETION_DRAFT_REVOCATION_KIND =
@@ -179,6 +182,23 @@ function operationCompletionDraftKey({
     ]);
 }
 
+export function operationCompletionQueueRecordKey({
+    accountId,
+    operationId,
+    userId,
+}: Pick<
+    OperationCompletionDraftScope,
+    'accountId' | 'operationId' | 'userId'
+>) {
+    return JSON.stringify([
+        'operation-completion-queue',
+        OPERATION_COMPLETION_QUEUE_SCHEMA_VERSION,
+        userId,
+        accountId,
+        operationId,
+    ]);
+}
+
 function operationCompletionDraftGenerationKey(userId: string) {
     return JSON.stringify([
         OPERATION_COMPLETION_DRAFT_GENERATION_KIND,
@@ -278,7 +298,7 @@ function isOperationCompletionDraftPhoto(
     );
 }
 
-function isOperationCompletionDraft(
+export function isOperationCompletionDraftRecord(
     value: unknown,
 ): value is OperationCompletionDraft {
     if (!isObject(value)) {
@@ -308,7 +328,7 @@ function isOperationCompletionDraft(
     );
 }
 
-function isCompatibleDraft(
+export function isCompatibleOperationCompletionDraft(
     draft: OperationCompletionDraft,
     scope: OperationCompletionDraftScope,
 ) {
@@ -320,6 +340,81 @@ function isCompatibleDraft(
         draft.expectedTaskVersionEventId === scope.expectedTaskVersionEventId &&
         draft.requirementsFingerprint === scope.requirementsFingerprint
     );
+}
+
+type OperationCompletionQueueRecordForDraftStore = {
+    accountId: string;
+    attachments: Array<{ blob: Blob; size: number }>;
+    contentDiscardedAt: number | null;
+    expiresAt: number;
+    key: string;
+    notes: string;
+    operationId: number;
+    schemaVersion: 1;
+    userId: string;
+    writerGeneration: string;
+};
+
+function isOperationCompletionQueueRecordForDraftStore(
+    value: unknown,
+): value is OperationCompletionQueueRecordForDraftStore {
+    if (!isObject(value)) {
+        return false;
+    }
+
+    return (
+        value.schemaVersion === OPERATION_COMPLETION_QUEUE_SCHEMA_VERSION &&
+        typeof value.accountId === 'string' &&
+        Array.isArray(value.attachments) &&
+        value.attachments.every(
+            (attachment) =>
+                isObject(attachment) &&
+                attachment.blob instanceof Blob &&
+                isFiniteNumber(attachment.size) &&
+                attachment.size === attachment.blob.size,
+        ) &&
+        (value.contentDiscardedAt === null ||
+            isFiniteNumber(value.contentDiscardedAt)) &&
+        isFiniteNumber(value.expiresAt) &&
+        typeof value.key === 'string' &&
+        typeof value.notes === 'string' &&
+        isFiniteNumber(value.operationId) &&
+        typeof value.userId === 'string' &&
+        typeof value.writerGeneration === 'string'
+    );
+}
+
+function operationCompletionQueueByteSizeForDraftStore(
+    item: OperationCompletionQueueRecordForDraftStore,
+) {
+    const notesBytes = new TextEncoder().encode(item.notes).byteLength;
+    return item.attachments.reduce(
+        (bytes, attachment) => bytes + attachment.blob.size,
+        notesBytes,
+    );
+}
+
+function scrubExpiredOperationCompletionQueueRecordForDraftStore(
+    item: OperationCompletionQueueRecordForDraftStore,
+    now: number,
+) {
+    return {
+        ...item,
+        attachments: [],
+        claim: null,
+        contentDiscardedAt: now,
+        expiresAt: now + OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+        failureCode: 'expired',
+        nextAttemptAt: null,
+        notes: '',
+        operationLabel: '',
+        revisionId: newDraftId(),
+        scheduleDateKey: null,
+        serverConfirmedAt: null,
+        serverState: null,
+        state: 'failed',
+        updatedAt: now,
+    };
 }
 
 function getIndexedDb() {
@@ -542,7 +637,18 @@ export function subscribeToOperationCompletionDraftLogout(
     };
 }
 
-function requestResult<Result>(request: IDBRequest<Result>) {
+export function operationCompletionDraftRecordKey(
+    scope: Pick<
+        OperationCompletionDraftScope,
+        'accountId' | 'operationId' | 'userId'
+    >,
+) {
+    return operationCompletionDraftKey(scope);
+}
+
+export function requestOperationCompletionStoreResult<Result>(
+    request: IDBRequest<Result>,
+) {
     return new Promise<Result>((resolve, reject) => {
         request.addEventListener('success', () => resolve(request.result), {
             once: true,
@@ -582,7 +688,7 @@ function transactionComplete(transaction: IDBTransaction) {
     });
 }
 
-function openFarmOfflineDatabase() {
+export function openFarmOfflineDatabase() {
     const indexedDb = getIndexedDb();
     if (!indexedDb) {
         return Promise.reject(new Error('IndexedDB unavailable'));
@@ -604,6 +710,16 @@ function openFarmOfflineDatabase() {
                 ) {
                     database.createObjectStore(
                         OPERATION_COMPLETION_DRAFT_STORE_NAME,
+                        { keyPath: 'key' },
+                    );
+                }
+                if (
+                    !database.objectStoreNames.contains(
+                        OPERATION_COMPLETION_QUEUE_STORE_NAME,
+                    )
+                ) {
+                    database.createObjectStore(
+                        OPERATION_COMPLETION_QUEUE_STORE_NAME,
                         { keyPath: 'key' },
                     );
                 }
@@ -657,7 +773,51 @@ async function withDraftStore<Result>(
     }
 }
 
-function draftByteSize(draft: OperationCompletionDraft) {
+export async function withOperationCompletionOfflineStores<Result>(
+    mode: IDBTransactionMode,
+    runWithStores: (stores: {
+        drafts: IDBObjectStore;
+        queue: IDBObjectStore;
+    }) => Promise<Result>,
+) {
+    const database = await openFarmOfflineDatabase();
+    try {
+        const transaction = database.transaction(
+            [
+                OPERATION_COMPLETION_DRAFT_STORE_NAME,
+                OPERATION_COMPLETION_QUEUE_STORE_NAME,
+            ],
+            mode,
+        );
+        const completion = transactionComplete(transaction);
+        try {
+            const result = await runWithStores({
+                drafts: transaction.objectStore(
+                    OPERATION_COMPLETION_DRAFT_STORE_NAME,
+                ),
+                queue: transaction.objectStore(
+                    OPERATION_COMPLETION_QUEUE_STORE_NAME,
+                ),
+            });
+            await completion;
+            return result;
+        } catch (error) {
+            try {
+                transaction.abort();
+            } catch {
+                // The transaction may already be complete or aborted.
+            }
+            await completion.catch(() => undefined);
+            throw error;
+        }
+    } finally {
+        database.close();
+    }
+}
+
+export function operationCompletionDraftByteSize(
+    draft: OperationCompletionDraft,
+) {
     const notesBytes = new TextEncoder().encode(draft.notes).byteLength;
     return draft.photos.reduce(
         (bytes, photo) => bytes + photo.blob.size,
@@ -684,22 +844,24 @@ async function operationCompletionDraftSessionIsRevoked(
         userId,
         sessionIncarnation,
     );
-    const storedValue: unknown = await requestResult(store.get(key));
+    const storedValue: unknown = await requestOperationCompletionStoreResult(
+        store.get(key),
+    );
     if (storedValue === undefined) {
         return false;
     }
     if (!isOperationCompletionDraftRevocation(storedValue)) {
-        await requestResult(store.delete(key));
+        await requestOperationCompletionStoreResult(store.delete(key));
         return false;
     }
     if (storedValue.expiresAt <= Date.now()) {
-        await requestResult(store.delete(key));
+        await requestOperationCompletionStoreResult(store.delete(key));
         return false;
     }
     return true;
 }
 
-async function operationCompletionDraftLeaseMatches(
+export async function operationCompletionDraftLeaseMatches(
     store: IDBObjectStore,
     lease: OperationCompletionDraftLease,
 ) {
@@ -715,7 +877,7 @@ async function operationCompletionDraftLeaseMatches(
     ) {
         return false;
     }
-    const storedValue: unknown = await requestResult(
+    const storedValue: unknown = await requestOperationCompletionStoreResult(
         store.get(operationCompletionDraftGenerationKey(lease.userId)),
     );
     return (
@@ -748,14 +910,15 @@ export async function acquireOperationCompletionDraftLease(
     try {
         for (let attempt = 0; attempt < 3; attempt++) {
             const result =
-                await withDraftStore<AcquireOperationCompletionDraftLeaseAttempt>(
+                await withOperationCompletionOfflineStores<AcquireOperationCompletionDraftLeaseAttempt>(
                     'readwrite',
-                    async (store) => {
+                    async ({ drafts, queue }) => {
                         const key =
                             operationCompletionDraftGenerationKey(userId);
-                        const storedValue: unknown = await requestResult(
-                            store.get(key),
-                        );
+                        const storedValue: unknown =
+                            await requestOperationCompletionStoreResult(
+                                drafts.get(key),
+                            );
                         const latestLogoutNonce =
                             readOperationCompletionDraftLogoutNonce(userId);
                         if (
@@ -770,7 +933,7 @@ export async function acquireOperationCompletionDraftLease(
                                 sessionIncarnation,
                             ) ||
                             (await operationCompletionDraftSessionIsRevoked(
-                                store,
+                                drafts,
                                 userId,
                                 sessionIncarnation,
                             ))
@@ -795,25 +958,39 @@ export async function acquireOperationCompletionDraftLease(
                         }
 
                         const generation = newDraftId();
-                        const storedValues: unknown[] = await requestResult(
-                            store.getAll(),
-                        );
-                        for (const value of storedValues) {
+                        const storedDraftValues: unknown[] =
+                            await requestOperationCompletionStoreResult(
+                                drafts.getAll(),
+                            );
+                        const storedQueueValues: unknown[] =
+                            await requestOperationCompletionStoreResult(
+                                queue.getAll(),
+                            );
+                        for (const value of storedDraftValues) {
                             if (isOperationCompletionDraftRevocation(value)) {
                                 if (value.expiresAt <= Date.now()) {
-                                    store.delete(value.key);
+                                    drafts.delete(value.key);
                                 }
                                 continue;
                             }
                             if (
-                                isOperationCompletionDraft(value) &&
+                                isOperationCompletionDraftRecord(value) &&
                                 value.userId === userId
                             ) {
-                                store.delete(value.key);
+                                drafts.delete(value.key);
                             }
                         }
-                        await requestResult(
-                            store.put({
+                        for (const value of storedQueueValues) {
+                            if (
+                                isObject(value) &&
+                                value.userId === userId &&
+                                typeof value.key === 'string'
+                            ) {
+                                queue.delete(value.key);
+                            }
+                        }
+                        await requestOperationCompletionStoreResult(
+                            drafts.put({
                                 generation,
                                 key,
                                 kind: OPERATION_COMPLETION_DRAFT_GENERATION_KIND,
@@ -896,50 +1073,65 @@ export async function loadOperationCompletionDraft(
         return { status: leaseResult.status };
     }
     try {
-        return await withDraftStore('readwrite', async (store) => {
-            if (
-                !(await operationCompletionDraftLeaseMatches(
-                    store,
-                    leaseResult.lease,
-                ))
-            ) {
-                return {
-                    status: 'session_changed',
-                } satisfies LoadOperationCompletionDraftResult;
-            }
-            const key = operationCompletionDraftKey(scope);
-            const storedValue: unknown = await requestResult(store.get(key));
-            if (storedValue === undefined) {
-                return { reason: 'not_found', status: 'missing' };
-            }
-            if (!isOperationCompletionDraft(storedValue)) {
-                await requestResult(store.delete(key));
-                return { reason: 'invalid_record', status: 'missing' };
-            }
-            if (storedValue.expiresAt <= Date.now()) {
-                await requestResult(store.delete(key));
+        return await withOperationCompletionOfflineStores(
+            'readwrite',
+            async ({ drafts }) => {
+                if (
+                    !(await operationCompletionDraftLeaseMatches(
+                        drafts,
+                        leaseResult.lease,
+                    ))
+                ) {
+                    return {
+                        status: 'session_changed',
+                    } satisfies LoadOperationCompletionDraftResult;
+                }
+                const key = operationCompletionDraftKey(scope);
+                const storedValue: unknown =
+                    await requestOperationCompletionStoreResult(
+                        drafts.get(key),
+                    );
+                if (storedValue === undefined) {
+                    return { reason: 'not_found', status: 'missing' };
+                }
+                if (!isOperationCompletionDraftRecord(storedValue)) {
+                    await requestOperationCompletionStoreResult(
+                        drafts.delete(key),
+                    );
+                    return { reason: 'invalid_record', status: 'missing' };
+                }
+                if (storedValue.expiresAt <= Date.now()) {
+                    await requestOperationCompletionStoreResult(
+                        drafts.delete(key),
+                    );
+                    if (storedValue.serverConfirmedAt !== null) {
+                        return { reason: 'not_found', status: 'missing' };
+                    }
+                    return { status: 'expired' };
+                }
+                if (
+                    storedValue.writerGeneration !==
+                    leaseResult.lease.generation
+                ) {
+                    await requestOperationCompletionStoreResult(
+                        drafts.delete(key),
+                    );
+                    return { reason: 'not_found', status: 'missing' };
+                }
                 if (storedValue.serverConfirmedAt !== null) {
                     return { reason: 'not_found', status: 'missing' };
                 }
-                return { status: 'expired' };
-            }
-            if (storedValue.writerGeneration !== leaseResult.lease.generation) {
-                await requestResult(store.delete(key));
-                return { reason: 'not_found', status: 'missing' };
-            }
-            if (storedValue.serverConfirmedAt !== null) {
-                return { reason: 'not_found', status: 'missing' };
-            }
-            if (!isCompatibleDraft(storedValue, scope)) {
-                return {
-                    reason: 'incompatible',
-                    revisionId: storedValue.revisionId,
-                    status: 'missing',
-                };
-            }
+                if (!isCompatibleOperationCompletionDraft(storedValue, scope)) {
+                    return {
+                        reason: 'incompatible',
+                        revisionId: storedValue.revisionId,
+                        status: 'missing',
+                    };
+                }
 
-            return { draft: storedValue, status: 'found' };
-        });
+                return { draft: storedValue, status: 'found' };
+            },
+        );
     } catch {
         return { status: 'unavailable' };
     }
@@ -963,35 +1155,119 @@ export async function saveOperationCompletionDraft(
         };
     }
     try {
-        return await withDraftStore('readwrite', async (store) => {
-            if (
-                !(await operationCompletionDraftLeaseMatches(
-                    store,
-                    leaseResult.lease,
-                ))
-            ) {
-                return { reason: 'session_changed', status: 'error' };
-            }
-            const now = Date.now();
-            const key = operationCompletionDraftKey(scope);
-
-            if (!notes.trim() && photos.length === 0) {
-                const storedValue: unknown = await requestResult(
-                    store.get(key),
-                );
-                if (storedValue === undefined) {
-                    return {
-                        action: 'discarded',
-                        draftId: null,
-                        revisionId: null,
-                        status: 'ok',
-                    };
+        return await withOperationCompletionOfflineStores(
+            'readwrite',
+            async ({ drafts: draftStore, queue: queueStore }) => {
+                if (
+                    !(await operationCompletionDraftLeaseMatches(
+                        draftStore,
+                        leaseResult.lease,
+                    ))
+                ) {
+                    return { reason: 'session_changed', status: 'error' };
                 }
-                if (!isOperationCompletionDraft(storedValue)) {
-                    if (expectedRevisionId !== undefined) {
+                const now = Date.now();
+                const key = operationCompletionDraftKey(scope);
+                const queuedValue: unknown =
+                    await requestOperationCompletionStoreResult(
+                        queueStore.get(
+                            operationCompletionQueueRecordKey(scope),
+                        ),
+                    );
+                if (queuedValue !== undefined) {
+                    if (
+                        !isOperationCompletionQueueRecordForDraftStore(
+                            queuedValue,
+                        )
+                    ) {
+                        return { reason: 'incompatible', status: 'error' };
+                    }
+                    if (
+                        queuedValue.writerGeneration !==
+                        leaseResult.lease.generation
+                    ) {
+                        await requestOperationCompletionStoreResult(
+                            queueStore.delete(queuedValue.key),
+                        );
+                    } else if (queuedValue.expiresAt <= now) {
+                        if (queuedValue.contentDiscardedAt !== null) {
+                            await requestOperationCompletionStoreResult(
+                                queueStore.delete(queuedValue.key),
+                            );
+                        } else {
+                            await requestOperationCompletionStoreResult(
+                                queueStore.put(
+                                    scrubExpiredOperationCompletionQueueRecordForDraftStore(
+                                        queuedValue,
+                                        now,
+                                    ),
+                                ),
+                            );
+                            return { reason: 'incompatible', status: 'error' };
+                        }
+                    } else {
+                        return { reason: 'incompatible', status: 'error' };
+                    }
+                }
+
+                if (!notes.trim() && photos.length === 0) {
+                    const storedValue: unknown =
+                        await requestOperationCompletionStoreResult(
+                            draftStore.get(key),
+                        );
+                    if (storedValue === undefined) {
+                        return {
+                            action: 'discarded',
+                            draftId: null,
+                            revisionId: null,
+                            status: 'ok',
+                        };
+                    }
+                    if (!isOperationCompletionDraftRecord(storedValue)) {
+                        if (expectedRevisionId !== undefined) {
+                            return { reason: 'draft_changed', status: 'error' };
+                        }
+                        await requestOperationCompletionStoreResult(
+                            draftStore.delete(key),
+                        );
+                        return {
+                            action: 'discarded',
+                            draftId: null,
+                            revisionId: null,
+                            status: 'ok',
+                        };
+                    }
+                    if (storedValue.expiresAt <= now) {
+                        await requestOperationCompletionStoreResult(
+                            draftStore.delete(key),
+                        );
+                        return {
+                            action: 'discarded',
+                            draftId: null,
+                            revisionId: null,
+                            status: 'ok',
+                        };
+                    }
+                    if (
+                        storedValue.serverConfirmedAt !== null ||
+                        storedValue.writerGeneration !==
+                            leaseResult.lease.generation ||
+                        !isCompatibleOperationCompletionDraft(
+                            storedValue,
+                            scope,
+                        )
+                    ) {
+                        return { reason: 'incompatible', status: 'error' };
+                    }
+                    if (
+                        expectedRevisionId !== undefined &&
+                        expectedRevisionId !== storedValue.revisionId
+                    ) {
                         return { reason: 'draft_changed', status: 'error' };
                     }
-                    await requestResult(store.delete(key));
+                    await requestOperationCompletionStoreResult(
+                        draftStore.delete(key),
+                    );
                     return {
                         action: 'discarded',
                         draftId: null,
@@ -999,149 +1275,181 @@ export async function saveOperationCompletionDraft(
                         status: 'ok',
                     };
                 }
-                if (storedValue.expiresAt <= now) {
-                    await requestResult(store.delete(key));
-                    return {
-                        action: 'discarded',
-                        draftId: null,
-                        revisionId: null,
-                        status: 'ok',
-                    };
+
+                const storedValues: unknown[] =
+                    await requestOperationCompletionStoreResult(
+                        draftStore.getAll(),
+                    );
+                const storedQueueValues: unknown[] =
+                    await requestOperationCompletionStoreResult(
+                        queueStore.getAll(),
+                    );
+                const drafts: OperationCompletionDraft[] = [];
+                const ownerQueueItems: OperationCompletionQueueRecordForDraftStore[] =
+                    [];
+                const serverConfirmedKeys = new Set<string>();
+
+                for (const storedValue of storedValues) {
+                    if (!isOperationCompletionDraftRecord(storedValue)) {
+                        if (isOperationCompletionDraftGeneration(storedValue)) {
+                            continue;
+                        }
+                        if (isOperationCompletionDraftRevocation(storedValue)) {
+                            if (storedValue.expiresAt <= now) {
+                                draftStore.delete(storedValue.key);
+                            }
+                            continue;
+                        }
+                        if (
+                            isObject(storedValue) &&
+                            typeof storedValue.key === 'string'
+                        ) {
+                            draftStore.delete(storedValue.key);
+                        }
+                        continue;
+                    }
+                    if (storedValue.expiresAt <= now) {
+                        draftStore.delete(storedValue.key);
+                        continue;
+                    }
+                    if (
+                        storedValue.userId === scope.userId &&
+                        storedValue.writerGeneration !==
+                            leaseResult.lease.generation
+                    ) {
+                        draftStore.delete(storedValue.key);
+                        continue;
+                    }
+                    if (storedValue.serverConfirmedAt !== null) {
+                        serverConfirmedKeys.add(storedValue.key);
+                        continue;
+                    }
+                    drafts.push(storedValue);
                 }
+
+                for (const storedValue of storedQueueValues) {
+                    if (
+                        !isOperationCompletionQueueRecordForDraftStore(
+                            storedValue,
+                        )
+                    ) {
+                        continue;
+                    }
+                    if (storedValue.expiresAt <= now) {
+                        if (storedValue.contentDiscardedAt !== null) {
+                            queueStore.delete(storedValue.key);
+                        } else {
+                            queueStore.put(
+                                scrubExpiredOperationCompletionQueueRecordForDraftStore(
+                                    storedValue,
+                                    now,
+                                ),
+                            );
+                        }
+                        continue;
+                    }
+                    if (
+                        storedValue.userId === scope.userId &&
+                        storedValue.writerGeneration !==
+                            leaseResult.lease.generation
+                    ) {
+                        queueStore.delete(storedValue.key);
+                        continue;
+                    }
+                    if (
+                        storedValue.userId === scope.userId &&
+                        storedValue.accountId === scope.accountId &&
+                        storedValue.contentDiscardedAt === null
+                    ) {
+                        ownerQueueItems.push(storedValue);
+                    }
+                }
+
+                if (serverConfirmedKeys.has(key)) {
+                    return { reason: 'incompatible', status: 'error' };
+                }
+                const existingDraft = drafts.find((draft) => draft.key === key);
                 if (
-                    storedValue.serverConfirmedAt !== null ||
-                    storedValue.writerGeneration !==
-                        leaseResult.lease.generation ||
-                    !isCompatibleDraft(storedValue, scope)
+                    existingDraft &&
+                    !isCompatibleOperationCompletionDraft(existingDraft, scope)
                 ) {
                     return { reason: 'incompatible', status: 'error' };
                 }
                 if (
                     expectedRevisionId !== undefined &&
-                    expectedRevisionId !== storedValue.revisionId
+                    (existingDraft?.revisionId ?? null) !== expectedRevisionId
                 ) {
                     return { reason: 'draft_changed', status: 'error' };
                 }
-                await requestResult(store.delete(key));
+
+                const ownerDrafts = drafts.filter(
+                    (draft) =>
+                        draft.userId === scope.userId &&
+                        draft.accountId === scope.accountId,
+                );
+                if (
+                    !existingDraft &&
+                    ownerDrafts.length + ownerQueueItems.length >=
+                        OPERATION_COMPLETION_DRAFT_MAX_COUNT
+                ) {
+                    return { reason: 'draft_count_limit', status: 'error' };
+                }
+
+                const draft: OperationCompletionDraft = {
+                    ...scope,
+                    createdAt: existingDraft?.createdAt ?? now,
+                    draftId: existingDraft?.draftId ?? newDraftId(),
+                    expiresAt: now + OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+                    key,
+                    notes,
+                    photos: photos.map(({ file, id }) => ({
+                        blob: file,
+                        id,
+                        lastModified: file.lastModified,
+                        name: file.name,
+                        size: file.size,
+                        type: file.type,
+                    })),
+                    revisionId: newDraftId(),
+                    schemaVersion: OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
+                    serverConfirmedAt: null,
+                    updatedAt: now,
+                    writerGeneration: leaseResult.lease.generation,
+                };
+                const otherOwnerBytes = ownerDrafts.reduce(
+                    (bytes, ownerDraft) =>
+                        ownerDraft.key === key
+                            ? bytes
+                            : bytes +
+                              operationCompletionDraftByteSize(ownerDraft),
+                    0,
+                );
+                const ownerQueueBytes = ownerQueueItems.reduce(
+                    (bytes, item) =>
+                        bytes +
+                        operationCompletionQueueByteSizeForDraftStore(item),
+                    0,
+                );
+                if (
+                    otherOwnerBytes +
+                        ownerQueueBytes +
+                        operationCompletionDraftByteSize(draft) >
+                    OPERATION_COMPLETION_DRAFT_MAX_BYTES
+                ) {
+                    return { reason: 'draft_size_limit', status: 'error' };
+                }
+
+                await requestOperationCompletionStoreResult(
+                    draftStore.put(draft),
+                );
                 return {
-                    action: 'discarded',
-                    draftId: null,
-                    revisionId: null,
+                    action: 'saved',
+                    draftId: draft.draftId,
+                    revisionId: draft.revisionId,
                     status: 'ok',
                 };
-            }
-
-            const storedValues: unknown[] = await requestResult(store.getAll());
-            const drafts: OperationCompletionDraft[] = [];
-            const serverConfirmedKeys = new Set<string>();
-
-            for (const storedValue of storedValues) {
-                if (!isOperationCompletionDraft(storedValue)) {
-                    if (isOperationCompletionDraftGeneration(storedValue)) {
-                        continue;
-                    }
-                    if (isOperationCompletionDraftRevocation(storedValue)) {
-                        if (storedValue.expiresAt <= now) {
-                            store.delete(storedValue.key);
-                        }
-                        continue;
-                    }
-                    if (
-                        isObject(storedValue) &&
-                        typeof storedValue.key === 'string'
-                    ) {
-                        store.delete(storedValue.key);
-                    }
-                    continue;
-                }
-                if (storedValue.expiresAt <= now) {
-                    store.delete(storedValue.key);
-                    continue;
-                }
-                if (
-                    storedValue.userId === scope.userId &&
-                    storedValue.writerGeneration !==
-                        leaseResult.lease.generation
-                ) {
-                    store.delete(storedValue.key);
-                    continue;
-                }
-                if (storedValue.serverConfirmedAt !== null) {
-                    serverConfirmedKeys.add(storedValue.key);
-                    continue;
-                }
-                drafts.push(storedValue);
-            }
-
-            if (serverConfirmedKeys.has(key)) {
-                return { reason: 'incompatible', status: 'error' };
-            }
-            const existingDraft = drafts.find((draft) => draft.key === key);
-            if (existingDraft && !isCompatibleDraft(existingDraft, scope)) {
-                return { reason: 'incompatible', status: 'error' };
-            }
-            if (
-                expectedRevisionId !== undefined &&
-                (existingDraft?.revisionId ?? null) !== expectedRevisionId
-            ) {
-                return { reason: 'draft_changed', status: 'error' };
-            }
-
-            const ownerDrafts = drafts.filter(
-                (draft) =>
-                    draft.userId === scope.userId &&
-                    draft.accountId === scope.accountId,
-            );
-            if (
-                !existingDraft &&
-                ownerDrafts.length >= OPERATION_COMPLETION_DRAFT_MAX_COUNT
-            ) {
-                return { reason: 'draft_count_limit', status: 'error' };
-            }
-
-            const draft: OperationCompletionDraft = {
-                ...scope,
-                createdAt: existingDraft?.createdAt ?? now,
-                draftId: existingDraft?.draftId ?? newDraftId(),
-                expiresAt: now + OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
-                key,
-                notes,
-                photos: photos.map(({ file, id }) => ({
-                    blob: file,
-                    id,
-                    lastModified: file.lastModified,
-                    name: file.name,
-                    size: file.size,
-                    type: file.type,
-                })),
-                revisionId: newDraftId(),
-                schemaVersion: OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
-                serverConfirmedAt: null,
-                updatedAt: now,
-                writerGeneration: leaseResult.lease.generation,
-            };
-            const otherOwnerBytes = ownerDrafts.reduce(
-                (bytes, ownerDraft) =>
-                    ownerDraft.key === key
-                        ? bytes
-                        : bytes + draftByteSize(ownerDraft),
-                0,
-            );
-            if (
-                otherOwnerBytes + draftByteSize(draft) >
-                OPERATION_COMPLETION_DRAFT_MAX_BYTES
-            ) {
-                return { reason: 'draft_size_limit', status: 'error' };
-            }
-
-            await requestResult(store.put(draft));
-            return {
-                action: 'saved',
-                draftId: draft.draftId,
-                revisionId: draft.revisionId,
-                status: 'ok',
-            };
-        });
+            },
+        );
     } catch (error) {
         return {
             reason: isQuotaExceeded(error)
@@ -1179,15 +1487,16 @@ export async function discardOperationCompletionDraft(
                 } satisfies OperationCompletionDraftMutationResult;
             }
             const key = operationCompletionDraftKey(scope);
-            const storedValue: unknown = await requestResult(store.get(key));
+            const storedValue: unknown =
+                await requestOperationCompletionStoreResult(store.get(key));
             if (storedValue === undefined) {
                 return;
             }
-            if (!isOperationCompletionDraft(storedValue)) {
+            if (!isOperationCompletionDraftRecord(storedValue)) {
                 if (expectedRevisionId !== undefined) {
                     throw new OperationCompletionDraftConflictError();
                 }
-                await requestResult(store.delete(key));
+                await requestOperationCompletionStoreResult(store.delete(key));
                 return;
             }
             if (storedValue.writerGeneration !== leaseResult.lease.generation) {
@@ -1205,7 +1514,7 @@ export async function discardOperationCompletionDraft(
             ) {
                 throw new OperationCompletionDraftConflictError();
             }
-            await requestResult(store.delete(key));
+            await requestOperationCompletionStoreResult(store.delete(key));
         });
         if (result?.status === 'session_changed') {
             return result;
@@ -1231,41 +1540,62 @@ export async function markOperationCompletionDraftServerConfirmed(
         return { status: leaseResult.status };
     }
     try {
-        const result = await withDraftStore('readwrite', async (store) => {
-            if (
-                !(await operationCompletionDraftLeaseMatches(
-                    store,
-                    leaseResult.lease,
-                ))
-            ) {
-                return {
-                    status: 'session_changed',
-                } satisfies OperationCompletionDraftMutationResult;
-            }
-            const key = operationCompletionDraftKey(scope);
-            const storedValue: unknown = await requestResult(store.get(key));
-            const now = Date.now();
-            const existingDraft = isOperationCompletionDraft(storedValue)
-                ? storedValue
-                : null;
-            await requestResult(
-                store.put({
-                    ...scope,
-                    createdAt: existingDraft?.createdAt ?? now,
-                    draftId: existingDraft?.draftId ?? newDraftId(),
-                    expiresAt: now + OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
-                    key,
-                    notes: '',
-                    photos: [],
-                    revisionId: newDraftId(),
-                    schemaVersion: OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
-                    serverConfirmedAt: now,
-                    updatedAt: now,
-                    writerGeneration: leaseResult.lease.generation,
-                }),
-            );
-        });
+        const result = await withOperationCompletionOfflineStores(
+            'readwrite',
+            async ({ drafts, queue }) => {
+                if (
+                    !(await operationCompletionDraftLeaseMatches(
+                        drafts,
+                        leaseResult.lease,
+                    ))
+                ) {
+                    return {
+                        status: 'session_changed',
+                    } satisfies OperationCompletionDraftMutationResult;
+                }
+                const queuedValue: unknown =
+                    await requestOperationCompletionStoreResult(
+                        queue.get(operationCompletionQueueRecordKey(scope)),
+                    );
+                if (queuedValue !== undefined) {
+                    return {
+                        status: 'conflict',
+                    } satisfies OperationCompletionDraftMutationResult;
+                }
+                const key = operationCompletionDraftKey(scope);
+                const storedValue: unknown =
+                    await requestOperationCompletionStoreResult(
+                        drafts.get(key),
+                    );
+                const now = Date.now();
+                const existingDraft = isOperationCompletionDraftRecord(
+                    storedValue,
+                )
+                    ? storedValue
+                    : null;
+                await requestOperationCompletionStoreResult(
+                    drafts.put({
+                        ...scope,
+                        createdAt: existingDraft?.createdAt ?? now,
+                        draftId: existingDraft?.draftId ?? newDraftId(),
+                        expiresAt: now + OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+                        key,
+                        notes: '',
+                        photos: [],
+                        revisionId: newDraftId(),
+                        schemaVersion:
+                            OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
+                        serverConfirmedAt: now,
+                        updatedAt: now,
+                        writerGeneration: leaseResult.lease.generation,
+                    }),
+                );
+            },
+        );
         if (result?.status === 'session_changed') {
+            return result;
+        }
+        if (result?.status === 'conflict') {
             return result;
         }
         return { status: 'ok' };
@@ -1283,14 +1613,17 @@ export async function purgeOperationCompletionDraftsForUser(
     recordOperationCompletionDraftLoggedOutSession(userId, sessionIncarnation);
     broadcastOperationCompletionDraftLogout(userId, sessionIncarnation);
     try {
-        const deletedCount = await withDraftStore(
+        const deletedCount = await withOperationCompletionOfflineStores(
             'readwrite',
-            async (store) => {
-                const storedValues: unknown[] = await requestResult(
-                    store.getAll(),
-                );
+            async ({ drafts, queue }) => {
+                const storedDraftValues: unknown[] =
+                    await requestOperationCompletionStoreResult(
+                        drafts.getAll(),
+                    );
+                const storedQueueValues: unknown[] =
+                    await requestOperationCompletionStoreResult(queue.getAll());
                 const now = Date.now();
-                const activeDifferentSession = storedValues.find(
+                const activeDifferentSession = storedDraftValues.find(
                     (
                         storedValue,
                     ): storedValue is OperationCompletionDraftGeneration =>
@@ -1301,7 +1634,7 @@ export async function purgeOperationCompletionDraftsForUser(
                 );
                 const currentGeneration =
                     activeDifferentSession &&
-                    !storedValues.some(
+                    !storedDraftValues.some(
                         (storedValue) =>
                             isOperationCompletionDraftRevocation(storedValue) &&
                             storedValue.userId === userId &&
@@ -1312,7 +1645,7 @@ export async function purgeOperationCompletionDraftsForUser(
                         ? activeDifferentSession
                         : null;
                 let count = 0;
-                for (const storedValue of storedValues) {
+                for (const storedValue of storedDraftValues) {
                     if (
                         isOperationCompletionDraftGeneration(storedValue) &&
                         storedValue.userId === userId
@@ -1321,7 +1654,7 @@ export async function purgeOperationCompletionDraftsForUser(
                     }
                     if (isOperationCompletionDraftRevocation(storedValue)) {
                         if (storedValue.expiresAt <= now) {
-                            store.delete(storedValue.key);
+                            drafts.delete(storedValue.key);
                         }
                         continue;
                     }
@@ -1332,18 +1665,36 @@ export async function purgeOperationCompletionDraftsForUser(
                     ) {
                         if (
                             currentGeneration &&
-                            isOperationCompletionDraft(storedValue) &&
+                            isOperationCompletionDraftRecord(storedValue) &&
                             storedValue.writerGeneration ===
                                 currentGeneration.generation
                         ) {
                             continue;
                         }
-                        store.delete(storedValue.key);
+                        drafts.delete(storedValue.key);
                         count += 1;
                     }
                 }
-                await requestResult(
-                    store.put({
+                for (const storedValue of storedQueueValues) {
+                    if (
+                        !isObject(storedValue) ||
+                        storedValue.userId !== userId ||
+                        typeof storedValue.key !== 'string'
+                    ) {
+                        continue;
+                    }
+                    if (
+                        currentGeneration &&
+                        storedValue.writerGeneration ===
+                            currentGeneration.generation
+                    ) {
+                        continue;
+                    }
+                    queue.delete(storedValue.key);
+                    count += 1;
+                }
+                await requestOperationCompletionStoreResult(
+                    drafts.put({
                         expiresAt:
                             now +
                             OPERATION_COMPLETION_DRAFT_REVOCATION_MAX_AGE_MS,
@@ -1362,8 +1713,8 @@ export async function purgeOperationCompletionDraftsForUser(
                 if (!currentGeneration) {
                     const logoutNonce =
                         rotateOperationCompletionDraftLogoutNonce(userId);
-                    await requestResult(
-                        store.put({
+                    await requestOperationCompletionStoreResult(
+                        drafts.put({
                             generation: newDraftId(),
                             key: operationCompletionDraftGenerationKey(userId),
                             kind: OPERATION_COMPLETION_DRAFT_GENERATION_KIND,

--- a/apps/farm/lib/offline/operationCompletionDraftStore.ts
+++ b/apps/farm/lib/offline/operationCompletionDraftStore.ts
@@ -1,0 +1,1396 @@
+'use client';
+
+export const FARM_OFFLINE_DATABASE_NAME = 'gredice-farm-offline';
+export const FARM_OFFLINE_DATABASE_VERSION = 1;
+export const OPERATION_COMPLETION_DRAFT_STORE_NAME =
+    'operation-completion-drafts';
+export const OPERATION_COMPLETION_DRAFT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const OPERATION_COMPLETION_DRAFT_MAX_COUNT = 5;
+export const OPERATION_COMPLETION_DRAFT_MAX_BYTES = 100 * 1024 * 1024;
+
+const OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION = 1;
+const OPERATION_COMPLETION_DRAFT_GENERATION_KIND =
+    'operation-completion-draft-generation';
+const OPERATION_COMPLETION_DRAFT_REVOCATION_KIND =
+    'operation-completion-draft-revocation';
+const OPERATION_COMPLETION_DRAFT_LOGOUT_EVENT =
+    'gredice:operation-completion-draft-logout:v1';
+const OPERATION_COMPLETION_DRAFT_LOGOUT_NONCE_PREFIX =
+    'gredice:farm:operation-completion-draft-logout:v1:';
+const OPERATION_COMPLETION_DRAFT_LOGGED_OUT_SESSION_PREFIX =
+    'gredice:farm:operation-completion-draft-logged-out-session:v1:';
+const OPERATION_COMPLETION_DRAFT_INITIAL_LOGOUT_NONCE = 'initial';
+const OPERATION_COMPLETION_DRAFT_REVOCATION_MAX_AGE_MS =
+    31 * 24 * 60 * 60 * 1000;
+
+export type OperationCompletionDraftScope = {
+    accountId: string;
+    expectedEntityId: number;
+    expectedTaskVersionEventId: number;
+    operationId: number;
+    requirementsFingerprint: string;
+    userId: string;
+};
+
+export type OperationCompletionDraftPhotoInput = {
+    file: File;
+    id: string;
+};
+
+export type OperationCompletionDraftPhoto = {
+    blob: Blob;
+    id: string;
+    lastModified: number;
+    name: string;
+    size: number;
+    type: string;
+};
+
+export type OperationCompletionDraftLease = {
+    generation: string;
+    logoutNonce: string;
+    sessionIncarnation: string;
+    userId: string;
+};
+
+export type OperationCompletionDraft = {
+    accountId: string;
+    createdAt: number;
+    draftId: string;
+    expectedEntityId: number;
+    expectedTaskVersionEventId: number;
+    expiresAt: number;
+    key: string;
+    notes: string;
+    operationId: number;
+    photos: OperationCompletionDraftPhoto[];
+    requirementsFingerprint: string;
+    revisionId: string;
+    schemaVersion: 1;
+    serverConfirmedAt: number | null;
+    updatedAt: number;
+    userId: string;
+    writerGeneration: string;
+};
+
+type OperationCompletionDraftGeneration = {
+    generation: string;
+    key: string;
+    kind: typeof OPERATION_COMPLETION_DRAFT_GENERATION_KIND;
+    logoutNonce: string;
+    schemaVersion: 1;
+    sessionIncarnation: string | null;
+    updatedAt: number;
+    userId: string;
+};
+
+type OperationCompletionDraftRevocation = {
+    expiresAt: number;
+    key: string;
+    kind: typeof OPERATION_COMPLETION_DRAFT_REVOCATION_KIND;
+    revokedAt: number;
+    schemaVersion: 1;
+    sessionIncarnation: string;
+    userId: string;
+};
+
+export type AcquireOperationCompletionDraftLeaseResult =
+    | { lease: OperationCompletionDraftLease; status: 'ready' }
+    | { status: 'session_changed' }
+    | { status: 'unavailable' };
+
+type AcquireOperationCompletionDraftLeaseAttempt =
+    | { lease: OperationCompletionDraftLease; status: 'ready' }
+    | { status: 'nonce_changed' }
+    | { status: 'session_changed' };
+
+export type LoadOperationCompletionDraftResult =
+    | { draft: OperationCompletionDraft; status: 'found' }
+    | {
+          reason: 'invalid_record' | 'not_found';
+          status: 'missing';
+      }
+    | {
+          reason: 'incompatible';
+          revisionId: string;
+          status: 'missing';
+      }
+    | { status: 'expired' }
+    | { status: 'session_changed' }
+    | { status: 'unavailable' };
+
+export type SaveOperationCompletionDraftResult =
+    | {
+          action: 'discarded' | 'saved';
+          draftId: string | null;
+          revisionId: string | null;
+          status: 'ok';
+      }
+    | {
+          reason:
+              | 'draft_count_limit'
+              | 'draft_changed'
+              | 'draft_size_limit'
+              | 'incompatible'
+              | 'quota_exceeded'
+              | 'session_changed'
+              | 'storage_unavailable';
+          status: 'error';
+      };
+
+export type OperationCompletionDraftMutationResult =
+    | { status: 'ok' }
+    | { status: 'conflict' }
+    | { status: 'session_changed' }
+    | { status: 'unavailable' };
+
+export type PurgeOperationCompletionDraftsResult =
+    | { deletedCount: number; status: 'ok' }
+    | { status: 'unavailable' };
+
+type SaveOperationCompletionDraftInput = OperationCompletionDraftScope & {
+    notes: string;
+    photos: OperationCompletionDraftPhotoInput[];
+};
+
+type SaveOperationCompletionDraftOptions = {
+    expectedRevisionId?: string | null;
+    lease?: OperationCompletionDraftLease;
+};
+
+type DiscardOperationCompletionDraftOptions = {
+    expectedRevisionId?: string;
+    lease?: OperationCompletionDraftLease;
+};
+
+function operationCompletionDraftKey({
+    accountId,
+    operationId,
+    userId,
+}: Pick<
+    OperationCompletionDraftScope,
+    'accountId' | 'operationId' | 'userId'
+>) {
+    return JSON.stringify([
+        OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
+        userId,
+        accountId,
+        operationId,
+    ]);
+}
+
+function operationCompletionDraftGenerationKey(userId: string) {
+    return JSON.stringify([
+        OPERATION_COMPLETION_DRAFT_GENERATION_KIND,
+        OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
+        userId,
+    ]);
+}
+
+function operationCompletionDraftRevocationKey(
+    userId: string,
+    sessionIncarnation: string,
+) {
+    return JSON.stringify([
+        OPERATION_COMPLETION_DRAFT_REVOCATION_KIND,
+        OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
+        userId,
+        sessionIncarnation,
+    ]);
+}
+
+function operationCompletionDraftLogoutNonceKey(userId: string) {
+    return `${OPERATION_COMPLETION_DRAFT_LOGOUT_NONCE_PREFIX}${userId}`;
+}
+
+function operationCompletionDraftLoggedOutSessionKey(
+    userId: string,
+    sessionIncarnation: string,
+) {
+    return `${OPERATION_COMPLETION_DRAFT_LOGGED_OUT_SESSION_PREFIX}${userId}:${sessionIncarnation}`;
+}
+
+function defaultOperationCompletionDraftSessionIncarnation(userId: string) {
+    return `legacy:${userId}`;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isOperationCompletionDraftGeneration(
+    value: unknown,
+): value is OperationCompletionDraftGeneration {
+    if (!isObject(value)) {
+        return false;
+    }
+
+    return (
+        value.kind === OPERATION_COMPLETION_DRAFT_GENERATION_KIND &&
+        value.schemaVersion === OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION &&
+        typeof value.generation === 'string' &&
+        typeof value.key === 'string' &&
+        typeof value.logoutNonce === 'string' &&
+        (value.sessionIncarnation === null ||
+            typeof value.sessionIncarnation === 'string') &&
+        isFiniteNumber(value.updatedAt) &&
+        typeof value.userId === 'string'
+    );
+}
+
+function isOperationCompletionDraftRevocation(
+    value: unknown,
+): value is OperationCompletionDraftRevocation {
+    if (!isObject(value)) {
+        return false;
+    }
+
+    return (
+        value.kind === OPERATION_COMPLETION_DRAFT_REVOCATION_KIND &&
+        value.schemaVersion === OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION &&
+        isFiniteNumber(value.expiresAt) &&
+        typeof value.key === 'string' &&
+        isFiniteNumber(value.revokedAt) &&
+        typeof value.sessionIncarnation === 'string' &&
+        typeof value.userId === 'string'
+    );
+}
+
+function isOperationCompletionDraftPhoto(
+    value: unknown,
+): value is OperationCompletionDraftPhoto {
+    if (!isObject(value)) {
+        return false;
+    }
+
+    return (
+        value.blob instanceof Blob &&
+        typeof value.id === 'string' &&
+        isFiniteNumber(value.lastModified) &&
+        typeof value.name === 'string' &&
+        isFiniteNumber(value.size) &&
+        value.size === value.blob.size &&
+        typeof value.type === 'string'
+    );
+}
+
+function isOperationCompletionDraft(
+    value: unknown,
+): value is OperationCompletionDraft {
+    if (!isObject(value)) {
+        return false;
+    }
+
+    return (
+        value.schemaVersion === OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION &&
+        typeof value.accountId === 'string' &&
+        isFiniteNumber(value.createdAt) &&
+        typeof value.draftId === 'string' &&
+        isFiniteNumber(value.expectedEntityId) &&
+        isFiniteNumber(value.expectedTaskVersionEventId) &&
+        isFiniteNumber(value.expiresAt) &&
+        typeof value.key === 'string' &&
+        typeof value.notes === 'string' &&
+        isFiniteNumber(value.operationId) &&
+        Array.isArray(value.photos) &&
+        value.photos.every(isOperationCompletionDraftPhoto) &&
+        typeof value.requirementsFingerprint === 'string' &&
+        typeof value.revisionId === 'string' &&
+        (value.serverConfirmedAt === null ||
+            isFiniteNumber(value.serverConfirmedAt)) &&
+        isFiniteNumber(value.updatedAt) &&
+        typeof value.userId === 'string' &&
+        typeof value.writerGeneration === 'string'
+    );
+}
+
+function isCompatibleDraft(
+    draft: OperationCompletionDraft,
+    scope: OperationCompletionDraftScope,
+) {
+    return (
+        draft.userId === scope.userId &&
+        draft.accountId === scope.accountId &&
+        draft.operationId === scope.operationId &&
+        draft.expectedEntityId === scope.expectedEntityId &&
+        draft.expectedTaskVersionEventId === scope.expectedTaskVersionEventId &&
+        draft.requirementsFingerprint === scope.requirementsFingerprint
+    );
+}
+
+function getIndexedDb() {
+    if (typeof window === 'undefined' || !window.indexedDB) {
+        return null;
+    }
+
+    return window.indexedDB;
+}
+
+function readOperationCompletionDraftLogoutNonce(userId: string) {
+    if (typeof window === 'undefined') {
+        return null;
+    }
+    try {
+        return (
+            window.localStorage.getItem(
+                operationCompletionDraftLogoutNonceKey(userId),
+            ) ?? OPERATION_COMPLETION_DRAFT_INITIAL_LOGOUT_NONCE
+        );
+    } catch {
+        return null;
+    }
+}
+
+export function captureOperationCompletionDraftLogoutNonce(userId: string) {
+    return readOperationCompletionDraftLogoutNonce(userId);
+}
+
+function readOperationCompletionDraftLoggedOutSession(
+    userId: string,
+    sessionIncarnation: string,
+) {
+    if (typeof window === 'undefined') {
+        return false;
+    }
+    try {
+        const key = operationCompletionDraftLoggedOutSessionKey(
+            userId,
+            sessionIncarnation,
+        );
+        const expiresAt = Number(window.localStorage.getItem(key));
+        if (!Number.isFinite(expiresAt)) {
+            return false;
+        }
+        if (expiresAt <= Date.now()) {
+            window.localStorage.removeItem(key);
+            return false;
+        }
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function recordOperationCompletionDraftLoggedOutSession(
+    userId: string,
+    sessionIncarnation: string,
+) {
+    if (typeof window === 'undefined') {
+        return;
+    }
+    try {
+        const now = Date.now();
+        const userPrefix = `${OPERATION_COMPLETION_DRAFT_LOGGED_OUT_SESSION_PREFIX}${userId}:`;
+        for (let index = window.localStorage.length - 1; index >= 0; index--) {
+            const key = window.localStorage.key(index);
+            if (!key?.startsWith(userPrefix)) {
+                continue;
+            }
+            const expiresAt = Number(window.localStorage.getItem(key));
+            if (!Number.isFinite(expiresAt) || expiresAt <= now) {
+                window.localStorage.removeItem(key);
+            }
+        }
+        window.localStorage.setItem(
+            operationCompletionDraftLoggedOutSessionKey(
+                userId,
+                sessionIncarnation,
+            ),
+            (now + OPERATION_COMPLETION_DRAFT_REVOCATION_MAX_AGE_MS).toString(),
+        );
+    } catch {
+        // The IndexedDB generation record remains the durable session fence.
+    }
+}
+
+function rotateOperationCompletionDraftLogoutNonce(userId: string) {
+    const logoutNonce = newDraftId();
+    if (typeof window !== 'undefined') {
+        try {
+            window.localStorage.setItem(
+                operationCompletionDraftLogoutNonceKey(userId),
+                logoutNonce,
+            );
+        } catch {
+            // IndexedDB generation rotation remains the durable fence.
+        }
+    }
+    return logoutNonce;
+}
+
+function isCurrentOperationCompletionDraftLogoutNonce(
+    lease: OperationCompletionDraftLease,
+) {
+    const currentLogoutNonce = readOperationCompletionDraftLogoutNonce(
+        lease.userId,
+    );
+    return (
+        (currentLogoutNonce === null ||
+            currentLogoutNonce === lease.logoutNonce) &&
+        !readOperationCompletionDraftLoggedOutSession(
+            lease.userId,
+            lease.sessionIncarnation,
+        )
+    );
+}
+
+function isOperationCompletionDraftLogoutMessage(
+    value: unknown,
+): value is { sessionIncarnation: string; userId: string } {
+    return (
+        isObject(value) &&
+        value.kind === 'logout' &&
+        typeof value.sessionIncarnation === 'string' &&
+        typeof value.userId === 'string'
+    );
+}
+
+function broadcastOperationCompletionDraftLogout(
+    userId: string,
+    sessionIncarnation: string,
+) {
+    if (typeof window === 'undefined') {
+        return;
+    }
+    const message = { kind: 'logout', sessionIncarnation, userId };
+    window.dispatchEvent(
+        new CustomEvent(OPERATION_COMPLETION_DRAFT_LOGOUT_EVENT, {
+            detail: message,
+        }),
+    );
+    if (!('BroadcastChannel' in window)) {
+        return;
+    }
+    try {
+        const channel = new BroadcastChannel(
+            OPERATION_COMPLETION_DRAFT_LOGOUT_EVENT,
+        );
+        channel.postMessage(message);
+        channel.close();
+    } catch {
+        // The IndexedDB generation fence does not depend on the channel.
+    }
+}
+
+export function subscribeToOperationCompletionDraftLogout(
+    userId: string,
+    sessionIncarnation: string,
+    listener: () => void,
+) {
+    if (typeof window === 'undefined') {
+        return () => undefined;
+    }
+    const handleWindowEvent = (event: Event) => {
+        if (
+            event instanceof CustomEvent &&
+            isOperationCompletionDraftLogoutMessage(event.detail) &&
+            event.detail.userId === userId &&
+            event.detail.sessionIncarnation === sessionIncarnation
+        ) {
+            listener();
+        }
+    };
+    const handleChannelMessage = (event: MessageEvent<unknown>) => {
+        if (
+            isOperationCompletionDraftLogoutMessage(event.data) &&
+            event.data.userId === userId &&
+            event.data.sessionIncarnation === sessionIncarnation
+        ) {
+            listener();
+        }
+    };
+    const handleStorage = (event: StorageEvent) => {
+        if (
+            event.key ===
+                operationCompletionDraftLoggedOutSessionKey(
+                    userId,
+                    sessionIncarnation,
+                ) &&
+            event.newValue !== null
+        ) {
+            listener();
+        }
+    };
+    window.addEventListener(
+        OPERATION_COMPLETION_DRAFT_LOGOUT_EVENT,
+        handleWindowEvent,
+    );
+    window.addEventListener('storage', handleStorage);
+    let channel: BroadcastChannel | null = null;
+    if ('BroadcastChannel' in window) {
+        try {
+            channel = new BroadcastChannel(
+                OPERATION_COMPLETION_DRAFT_LOGOUT_EVENT,
+            );
+            channel.addEventListener('message', handleChannelMessage);
+        } catch {
+            channel = null;
+        }
+    }
+    return () => {
+        window.removeEventListener(
+            OPERATION_COMPLETION_DRAFT_LOGOUT_EVENT,
+            handleWindowEvent,
+        );
+        window.removeEventListener('storage', handleStorage);
+        channel?.removeEventListener('message', handleChannelMessage);
+        channel?.close();
+    };
+}
+
+function requestResult<Result>(request: IDBRequest<Result>) {
+    return new Promise<Result>((resolve, reject) => {
+        request.addEventListener('success', () => resolve(request.result), {
+            once: true,
+        });
+        request.addEventListener(
+            'error',
+            () =>
+                reject(request.error ?? new Error('IndexedDB request failed')),
+            { once: true },
+        );
+    });
+}
+
+function transactionComplete(transaction: IDBTransaction) {
+    return new Promise<void>((resolve, reject) => {
+        transaction.addEventListener('complete', () => resolve(), {
+            once: true,
+        });
+        transaction.addEventListener(
+            'abort',
+            () =>
+                reject(
+                    transaction.error ??
+                        new Error('IndexedDB transaction aborted'),
+                ),
+            { once: true },
+        );
+        transaction.addEventListener(
+            'error',
+            () =>
+                reject(
+                    transaction.error ??
+                        new Error('IndexedDB transaction failed'),
+                ),
+            { once: true },
+        );
+    });
+}
+
+function openFarmOfflineDatabase() {
+    const indexedDb = getIndexedDb();
+    if (!indexedDb) {
+        return Promise.reject(new Error('IndexedDB unavailable'));
+    }
+
+    return new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDb.open(
+            FARM_OFFLINE_DATABASE_NAME,
+            FARM_OFFLINE_DATABASE_VERSION,
+        );
+        request.addEventListener(
+            'upgradeneeded',
+            () => {
+                const database = request.result;
+                if (
+                    !database.objectStoreNames.contains(
+                        OPERATION_COMPLETION_DRAFT_STORE_NAME,
+                    )
+                ) {
+                    database.createObjectStore(
+                        OPERATION_COMPLETION_DRAFT_STORE_NAME,
+                        { keyPath: 'key' },
+                    );
+                }
+            },
+            { once: true },
+        );
+        request.addEventListener('success', () => resolve(request.result), {
+            once: true,
+        });
+        request.addEventListener(
+            'blocked',
+            () => reject(new Error('IndexedDB upgrade blocked')),
+            { once: true },
+        );
+        request.addEventListener(
+            'error',
+            () => reject(request.error ?? new Error('IndexedDB open failed')),
+            { once: true },
+        );
+    });
+}
+
+async function withDraftStore<Result>(
+    mode: IDBTransactionMode,
+    runWithStore: (store: IDBObjectStore) => Promise<Result>,
+) {
+    const database = await openFarmOfflineDatabase();
+    try {
+        const transaction = database.transaction(
+            OPERATION_COMPLETION_DRAFT_STORE_NAME,
+            mode,
+        );
+        const completion = transactionComplete(transaction);
+        try {
+            const result = await runWithStore(
+                transaction.objectStore(OPERATION_COMPLETION_DRAFT_STORE_NAME),
+            );
+            await completion;
+            return result;
+        } catch (error) {
+            try {
+                transaction.abort();
+            } catch {
+                // The transaction may already be complete or aborted.
+            }
+            await completion.catch(() => undefined);
+            throw error;
+        }
+    } finally {
+        database.close();
+    }
+}
+
+function draftByteSize(draft: OperationCompletionDraft) {
+    const notesBytes = new TextEncoder().encode(draft.notes).byteLength;
+    return draft.photos.reduce(
+        (bytes, photo) => bytes + photo.blob.size,
+        notesBytes,
+    );
+}
+
+function isQuotaExceeded(error: unknown) {
+    return error instanceof DOMException && error.name === 'QuotaExceededError';
+}
+
+function newDraftId() {
+    return globalThis.crypto.randomUUID();
+}
+
+class OperationCompletionDraftConflictError extends Error {}
+
+async function operationCompletionDraftSessionIsRevoked(
+    store: IDBObjectStore,
+    userId: string,
+    sessionIncarnation: string,
+) {
+    const key = operationCompletionDraftRevocationKey(
+        userId,
+        sessionIncarnation,
+    );
+    const storedValue: unknown = await requestResult(store.get(key));
+    if (storedValue === undefined) {
+        return false;
+    }
+    if (!isOperationCompletionDraftRevocation(storedValue)) {
+        await requestResult(store.delete(key));
+        return false;
+    }
+    if (storedValue.expiresAt <= Date.now()) {
+        await requestResult(store.delete(key));
+        return false;
+    }
+    return true;
+}
+
+async function operationCompletionDraftLeaseMatches(
+    store: IDBObjectStore,
+    lease: OperationCompletionDraftLease,
+) {
+    if (!isCurrentOperationCompletionDraftLogoutNonce(lease)) {
+        return false;
+    }
+    if (
+        await operationCompletionDraftSessionIsRevoked(
+            store,
+            lease.userId,
+            lease.sessionIncarnation,
+        )
+    ) {
+        return false;
+    }
+    const storedValue: unknown = await requestResult(
+        store.get(operationCompletionDraftGenerationKey(lease.userId)),
+    );
+    return (
+        isOperationCompletionDraftGeneration(storedValue) &&
+        storedValue.generation === lease.generation &&
+        storedValue.logoutNonce === lease.logoutNonce &&
+        storedValue.sessionIncarnation === lease.sessionIncarnation &&
+        storedValue.userId === lease.userId
+    );
+}
+
+export async function acquireOperationCompletionDraftLease(
+    userId: string,
+    capturedLogoutNonce = captureOperationCompletionDraftLogoutNonce(userId),
+    sessionIncarnation = defaultOperationCompletionDraftSessionIncarnation(
+        userId,
+    ),
+): Promise<AcquireOperationCompletionDraftLeaseResult> {
+    const currentLogoutNonce = readOperationCompletionDraftLogoutNonce(userId);
+    if (
+        readOperationCompletionDraftLoggedOutSession(userId, sessionIncarnation)
+    ) {
+        return { status: 'session_changed' };
+    }
+    let logoutNonce =
+        currentLogoutNonce ??
+        capturedLogoutNonce ??
+        OPERATION_COMPLETION_DRAFT_INITIAL_LOGOUT_NONCE;
+
+    try {
+        for (let attempt = 0; attempt < 3; attempt++) {
+            const result =
+                await withDraftStore<AcquireOperationCompletionDraftLeaseAttempt>(
+                    'readwrite',
+                    async (store) => {
+                        const key =
+                            operationCompletionDraftGenerationKey(userId);
+                        const storedValue: unknown = await requestResult(
+                            store.get(key),
+                        );
+                        const latestLogoutNonce =
+                            readOperationCompletionDraftLogoutNonce(userId);
+                        if (
+                            latestLogoutNonce !== null &&
+                            latestLogoutNonce !== logoutNonce
+                        ) {
+                            return { status: 'nonce_changed' };
+                        }
+                        if (
+                            readOperationCompletionDraftLoggedOutSession(
+                                userId,
+                                sessionIncarnation,
+                            ) ||
+                            (await operationCompletionDraftSessionIsRevoked(
+                                store,
+                                userId,
+                                sessionIncarnation,
+                            ))
+                        ) {
+                            return { status: 'session_changed' };
+                        }
+                        if (
+                            isOperationCompletionDraftGeneration(storedValue) &&
+                            storedValue.logoutNonce === logoutNonce &&
+                            storedValue.sessionIncarnation ===
+                                sessionIncarnation
+                        ) {
+                            return {
+                                lease: {
+                                    generation: storedValue.generation,
+                                    logoutNonce: storedValue.logoutNonce,
+                                    sessionIncarnation,
+                                    userId,
+                                },
+                                status: 'ready',
+                            };
+                        }
+
+                        const generation = newDraftId();
+                        const storedValues: unknown[] = await requestResult(
+                            store.getAll(),
+                        );
+                        for (const value of storedValues) {
+                            if (isOperationCompletionDraftRevocation(value)) {
+                                if (value.expiresAt <= Date.now()) {
+                                    store.delete(value.key);
+                                }
+                                continue;
+                            }
+                            if (
+                                isOperationCompletionDraft(value) &&
+                                value.userId === userId
+                            ) {
+                                store.delete(value.key);
+                            }
+                        }
+                        await requestResult(
+                            store.put({
+                                generation,
+                                key,
+                                kind: OPERATION_COMPLETION_DRAFT_GENERATION_KIND,
+                                logoutNonce,
+                                schemaVersion:
+                                    OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
+                                sessionIncarnation,
+                                updatedAt: Date.now(),
+                                userId,
+                            }),
+                        );
+                        return {
+                            lease: {
+                                generation,
+                                logoutNonce,
+                                sessionIncarnation,
+                                userId,
+                            },
+                            status: 'ready',
+                        };
+                    },
+                );
+            if (result.status === 'session_changed') {
+                return result;
+            }
+            if (result.status === 'ready') {
+                if (
+                    isCurrentOperationCompletionDraftLogoutNonce(result.lease)
+                ) {
+                    return result;
+                }
+                if (
+                    readOperationCompletionDraftLoggedOutSession(
+                        userId,
+                        sessionIncarnation,
+                    )
+                ) {
+                    return { status: 'session_changed' };
+                }
+            }
+
+            const latestLogoutNonce =
+                readOperationCompletionDraftLogoutNonce(userId);
+            if (
+                latestLogoutNonce === null ||
+                latestLogoutNonce === logoutNonce
+            ) {
+                return { status: 'unavailable' };
+            }
+            logoutNonce = latestLogoutNonce;
+        }
+        return { status: 'unavailable' };
+    } catch {
+        return { status: 'unavailable' };
+    }
+}
+
+async function resolveOperationCompletionDraftLease(
+    userId: string,
+    lease?: OperationCompletionDraftLease,
+): Promise<AcquireOperationCompletionDraftLeaseResult> {
+    if (lease) {
+        if (lease.userId !== userId) {
+            return { status: 'session_changed' };
+        }
+        return { lease, status: 'ready' };
+    }
+    return acquireOperationCompletionDraftLease(userId);
+}
+
+export async function loadOperationCompletionDraft(
+    scope: OperationCompletionDraftScope,
+    lease?: OperationCompletionDraftLease,
+): Promise<LoadOperationCompletionDraftResult> {
+    const leaseResult = await resolveOperationCompletionDraftLease(
+        scope.userId,
+        lease,
+    );
+    if (leaseResult.status !== 'ready') {
+        return { status: leaseResult.status };
+    }
+    try {
+        return await withDraftStore('readwrite', async (store) => {
+            if (
+                !(await operationCompletionDraftLeaseMatches(
+                    store,
+                    leaseResult.lease,
+                ))
+            ) {
+                return {
+                    status: 'session_changed',
+                } satisfies LoadOperationCompletionDraftResult;
+            }
+            const key = operationCompletionDraftKey(scope);
+            const storedValue: unknown = await requestResult(store.get(key));
+            if (storedValue === undefined) {
+                return { reason: 'not_found', status: 'missing' };
+            }
+            if (!isOperationCompletionDraft(storedValue)) {
+                await requestResult(store.delete(key));
+                return { reason: 'invalid_record', status: 'missing' };
+            }
+            if (storedValue.expiresAt <= Date.now()) {
+                await requestResult(store.delete(key));
+                if (storedValue.serverConfirmedAt !== null) {
+                    return { reason: 'not_found', status: 'missing' };
+                }
+                return { status: 'expired' };
+            }
+            if (storedValue.writerGeneration !== leaseResult.lease.generation) {
+                await requestResult(store.delete(key));
+                return { reason: 'not_found', status: 'missing' };
+            }
+            if (storedValue.serverConfirmedAt !== null) {
+                return { reason: 'not_found', status: 'missing' };
+            }
+            if (!isCompatibleDraft(storedValue, scope)) {
+                return {
+                    reason: 'incompatible',
+                    revisionId: storedValue.revisionId,
+                    status: 'missing',
+                };
+            }
+
+            return { draft: storedValue, status: 'found' };
+        });
+    } catch {
+        return { status: 'unavailable' };
+    }
+}
+
+export async function saveOperationCompletionDraft(
+    { notes, photos, ...scope }: SaveOperationCompletionDraftInput,
+    { expectedRevisionId, lease }: SaveOperationCompletionDraftOptions = {},
+): Promise<SaveOperationCompletionDraftResult> {
+    const leaseResult = await resolveOperationCompletionDraftLease(
+        scope.userId,
+        lease,
+    );
+    if (leaseResult.status !== 'ready') {
+        return {
+            reason:
+                leaseResult.status === 'session_changed'
+                    ? 'session_changed'
+                    : 'storage_unavailable',
+            status: 'error',
+        };
+    }
+    try {
+        return await withDraftStore('readwrite', async (store) => {
+            if (
+                !(await operationCompletionDraftLeaseMatches(
+                    store,
+                    leaseResult.lease,
+                ))
+            ) {
+                return { reason: 'session_changed', status: 'error' };
+            }
+            const now = Date.now();
+            const key = operationCompletionDraftKey(scope);
+
+            if (!notes.trim() && photos.length === 0) {
+                const storedValue: unknown = await requestResult(
+                    store.get(key),
+                );
+                if (storedValue === undefined) {
+                    return {
+                        action: 'discarded',
+                        draftId: null,
+                        revisionId: null,
+                        status: 'ok',
+                    };
+                }
+                if (!isOperationCompletionDraft(storedValue)) {
+                    if (expectedRevisionId !== undefined) {
+                        return { reason: 'draft_changed', status: 'error' };
+                    }
+                    await requestResult(store.delete(key));
+                    return {
+                        action: 'discarded',
+                        draftId: null,
+                        revisionId: null,
+                        status: 'ok',
+                    };
+                }
+                if (storedValue.expiresAt <= now) {
+                    await requestResult(store.delete(key));
+                    return {
+                        action: 'discarded',
+                        draftId: null,
+                        revisionId: null,
+                        status: 'ok',
+                    };
+                }
+                if (
+                    storedValue.serverConfirmedAt !== null ||
+                    storedValue.writerGeneration !==
+                        leaseResult.lease.generation ||
+                    !isCompatibleDraft(storedValue, scope)
+                ) {
+                    return { reason: 'incompatible', status: 'error' };
+                }
+                if (
+                    expectedRevisionId !== undefined &&
+                    expectedRevisionId !== storedValue.revisionId
+                ) {
+                    return { reason: 'draft_changed', status: 'error' };
+                }
+                await requestResult(store.delete(key));
+                return {
+                    action: 'discarded',
+                    draftId: null,
+                    revisionId: null,
+                    status: 'ok',
+                };
+            }
+
+            const storedValues: unknown[] = await requestResult(store.getAll());
+            const drafts: OperationCompletionDraft[] = [];
+            const serverConfirmedKeys = new Set<string>();
+
+            for (const storedValue of storedValues) {
+                if (!isOperationCompletionDraft(storedValue)) {
+                    if (isOperationCompletionDraftGeneration(storedValue)) {
+                        continue;
+                    }
+                    if (isOperationCompletionDraftRevocation(storedValue)) {
+                        if (storedValue.expiresAt <= now) {
+                            store.delete(storedValue.key);
+                        }
+                        continue;
+                    }
+                    if (
+                        isObject(storedValue) &&
+                        typeof storedValue.key === 'string'
+                    ) {
+                        store.delete(storedValue.key);
+                    }
+                    continue;
+                }
+                if (storedValue.expiresAt <= now) {
+                    store.delete(storedValue.key);
+                    continue;
+                }
+                if (
+                    storedValue.userId === scope.userId &&
+                    storedValue.writerGeneration !==
+                        leaseResult.lease.generation
+                ) {
+                    store.delete(storedValue.key);
+                    continue;
+                }
+                if (storedValue.serverConfirmedAt !== null) {
+                    serverConfirmedKeys.add(storedValue.key);
+                    continue;
+                }
+                drafts.push(storedValue);
+            }
+
+            if (serverConfirmedKeys.has(key)) {
+                return { reason: 'incompatible', status: 'error' };
+            }
+            const existingDraft = drafts.find((draft) => draft.key === key);
+            if (existingDraft && !isCompatibleDraft(existingDraft, scope)) {
+                return { reason: 'incompatible', status: 'error' };
+            }
+            if (
+                expectedRevisionId !== undefined &&
+                (existingDraft?.revisionId ?? null) !== expectedRevisionId
+            ) {
+                return { reason: 'draft_changed', status: 'error' };
+            }
+
+            const ownerDrafts = drafts.filter(
+                (draft) =>
+                    draft.userId === scope.userId &&
+                    draft.accountId === scope.accountId,
+            );
+            if (
+                !existingDraft &&
+                ownerDrafts.length >= OPERATION_COMPLETION_DRAFT_MAX_COUNT
+            ) {
+                return { reason: 'draft_count_limit', status: 'error' };
+            }
+
+            const draft: OperationCompletionDraft = {
+                ...scope,
+                createdAt: existingDraft?.createdAt ?? now,
+                draftId: existingDraft?.draftId ?? newDraftId(),
+                expiresAt: now + OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+                key,
+                notes,
+                photos: photos.map(({ file, id }) => ({
+                    blob: file,
+                    id,
+                    lastModified: file.lastModified,
+                    name: file.name,
+                    size: file.size,
+                    type: file.type,
+                })),
+                revisionId: newDraftId(),
+                schemaVersion: OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
+                serverConfirmedAt: null,
+                updatedAt: now,
+                writerGeneration: leaseResult.lease.generation,
+            };
+            const otherOwnerBytes = ownerDrafts.reduce(
+                (bytes, ownerDraft) =>
+                    ownerDraft.key === key
+                        ? bytes
+                        : bytes + draftByteSize(ownerDraft),
+                0,
+            );
+            if (
+                otherOwnerBytes + draftByteSize(draft) >
+                OPERATION_COMPLETION_DRAFT_MAX_BYTES
+            ) {
+                return { reason: 'draft_size_limit', status: 'error' };
+            }
+
+            await requestResult(store.put(draft));
+            return {
+                action: 'saved',
+                draftId: draft.draftId,
+                revisionId: draft.revisionId,
+                status: 'ok',
+            };
+        });
+    } catch (error) {
+        return {
+            reason: isQuotaExceeded(error)
+                ? 'quota_exceeded'
+                : 'storage_unavailable',
+            status: 'error',
+        };
+    }
+}
+
+export async function discardOperationCompletionDraft(
+    scope: Pick<
+        OperationCompletionDraftScope,
+        'accountId' | 'operationId' | 'userId'
+    >,
+    { expectedRevisionId, lease }: DiscardOperationCompletionDraftOptions = {},
+): Promise<OperationCompletionDraftMutationResult> {
+    const leaseResult = await resolveOperationCompletionDraftLease(
+        scope.userId,
+        lease,
+    );
+    if (leaseResult.status !== 'ready') {
+        return { status: leaseResult.status };
+    }
+    try {
+        const result = await withDraftStore('readwrite', async (store) => {
+            if (
+                !(await operationCompletionDraftLeaseMatches(
+                    store,
+                    leaseResult.lease,
+                ))
+            ) {
+                return {
+                    status: 'session_changed',
+                } satisfies OperationCompletionDraftMutationResult;
+            }
+            const key = operationCompletionDraftKey(scope);
+            const storedValue: unknown = await requestResult(store.get(key));
+            if (storedValue === undefined) {
+                return;
+            }
+            if (!isOperationCompletionDraft(storedValue)) {
+                if (expectedRevisionId !== undefined) {
+                    throw new OperationCompletionDraftConflictError();
+                }
+                await requestResult(store.delete(key));
+                return;
+            }
+            if (storedValue.writerGeneration !== leaseResult.lease.generation) {
+                throw new OperationCompletionDraftConflictError();
+            }
+            if (
+                storedValue.serverConfirmedAt !== null &&
+                storedValue.expiresAt > Date.now()
+            ) {
+                return;
+            }
+            if (
+                expectedRevisionId !== undefined &&
+                storedValue.revisionId !== expectedRevisionId
+            ) {
+                throw new OperationCompletionDraftConflictError();
+            }
+            await requestResult(store.delete(key));
+        });
+        if (result?.status === 'session_changed') {
+            return result;
+        }
+        return { status: 'ok' };
+    } catch (error) {
+        if (error instanceof OperationCompletionDraftConflictError) {
+            return { status: 'conflict' };
+        }
+        return { status: 'unavailable' };
+    }
+}
+
+export async function markOperationCompletionDraftServerConfirmed(
+    scope: OperationCompletionDraftScope,
+    lease?: OperationCompletionDraftLease,
+): Promise<OperationCompletionDraftMutationResult> {
+    const leaseResult = await resolveOperationCompletionDraftLease(
+        scope.userId,
+        lease,
+    );
+    if (leaseResult.status !== 'ready') {
+        return { status: leaseResult.status };
+    }
+    try {
+        const result = await withDraftStore('readwrite', async (store) => {
+            if (
+                !(await operationCompletionDraftLeaseMatches(
+                    store,
+                    leaseResult.lease,
+                ))
+            ) {
+                return {
+                    status: 'session_changed',
+                } satisfies OperationCompletionDraftMutationResult;
+            }
+            const key = operationCompletionDraftKey(scope);
+            const storedValue: unknown = await requestResult(store.get(key));
+            const now = Date.now();
+            const existingDraft = isOperationCompletionDraft(storedValue)
+                ? storedValue
+                : null;
+            await requestResult(
+                store.put({
+                    ...scope,
+                    createdAt: existingDraft?.createdAt ?? now,
+                    draftId: existingDraft?.draftId ?? newDraftId(),
+                    expiresAt: now + OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+                    key,
+                    notes: '',
+                    photos: [],
+                    revisionId: newDraftId(),
+                    schemaVersion: OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
+                    serverConfirmedAt: now,
+                    updatedAt: now,
+                    writerGeneration: leaseResult.lease.generation,
+                }),
+            );
+        });
+        if (result?.status === 'session_changed') {
+            return result;
+        }
+        return { status: 'ok' };
+    } catch {
+        return { status: 'unavailable' };
+    }
+}
+
+export async function purgeOperationCompletionDraftsForUser(
+    userId: string,
+    sessionIncarnation = defaultOperationCompletionDraftSessionIncarnation(
+        userId,
+    ),
+): Promise<PurgeOperationCompletionDraftsResult> {
+    recordOperationCompletionDraftLoggedOutSession(userId, sessionIncarnation);
+    broadcastOperationCompletionDraftLogout(userId, sessionIncarnation);
+    try {
+        const deletedCount = await withDraftStore(
+            'readwrite',
+            async (store) => {
+                const storedValues: unknown[] = await requestResult(
+                    store.getAll(),
+                );
+                const now = Date.now();
+                const activeDifferentSession = storedValues.find(
+                    (
+                        storedValue,
+                    ): storedValue is OperationCompletionDraftGeneration =>
+                        isOperationCompletionDraftGeneration(storedValue) &&
+                        storedValue.userId === userId &&
+                        storedValue.sessionIncarnation !== null &&
+                        storedValue.sessionIncarnation !== sessionIncarnation,
+                );
+                const currentGeneration =
+                    activeDifferentSession &&
+                    !storedValues.some(
+                        (storedValue) =>
+                            isOperationCompletionDraftRevocation(storedValue) &&
+                            storedValue.userId === userId &&
+                            storedValue.sessionIncarnation ===
+                                activeDifferentSession.sessionIncarnation &&
+                            storedValue.expiresAt > now,
+                    )
+                        ? activeDifferentSession
+                        : null;
+                let count = 0;
+                for (const storedValue of storedValues) {
+                    if (
+                        isOperationCompletionDraftGeneration(storedValue) &&
+                        storedValue.userId === userId
+                    ) {
+                        continue;
+                    }
+                    if (isOperationCompletionDraftRevocation(storedValue)) {
+                        if (storedValue.expiresAt <= now) {
+                            store.delete(storedValue.key);
+                        }
+                        continue;
+                    }
+                    if (
+                        isObject(storedValue) &&
+                        storedValue.userId === userId &&
+                        typeof storedValue.key === 'string'
+                    ) {
+                        if (
+                            currentGeneration &&
+                            isOperationCompletionDraft(storedValue) &&
+                            storedValue.writerGeneration ===
+                                currentGeneration.generation
+                        ) {
+                            continue;
+                        }
+                        store.delete(storedValue.key);
+                        count += 1;
+                    }
+                }
+                await requestResult(
+                    store.put({
+                        expiresAt:
+                            now +
+                            OPERATION_COMPLETION_DRAFT_REVOCATION_MAX_AGE_MS,
+                        key: operationCompletionDraftRevocationKey(
+                            userId,
+                            sessionIncarnation,
+                        ),
+                        kind: OPERATION_COMPLETION_DRAFT_REVOCATION_KIND,
+                        revokedAt: now,
+                        schemaVersion:
+                            OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
+                        sessionIncarnation,
+                        userId,
+                    }),
+                );
+                if (!currentGeneration) {
+                    const logoutNonce =
+                        rotateOperationCompletionDraftLogoutNonce(userId);
+                    await requestResult(
+                        store.put({
+                            generation: newDraftId(),
+                            key: operationCompletionDraftGenerationKey(userId),
+                            kind: OPERATION_COMPLETION_DRAFT_GENERATION_KIND,
+                            logoutNonce,
+                            schemaVersion:
+                                OPERATION_COMPLETION_DRAFT_SCHEMA_VERSION,
+                            sessionIncarnation: null,
+                            updatedAt: Date.now(),
+                            userId,
+                        }),
+                    );
+                }
+                return count;
+            },
+        );
+        broadcastOperationCompletionDraftLogout(userId, sessionIncarnation);
+        return { deletedCount, status: 'ok' };
+    } catch {
+        return { status: 'unavailable' };
+    }
+}
+
+export function operationCompletionDraftPhotoToFile(
+    photo: OperationCompletionDraftPhoto,
+) {
+    return new File([photo.blob], photo.name, {
+        lastModified: photo.lastModified,
+        type: photo.type,
+    });
+}

--- a/apps/farm/lib/offline/operationCompletionQueueStore.spec.tsx
+++ b/apps/farm/lib/offline/operationCompletionQueueStore.spec.tsx
@@ -1,0 +1,1289 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { OperationCompletionDraftStoreHarness } from '../../playwright/OperationCompletionDraftStoreHarness';
+import {
+    FARM_OFFLINE_DATABASE_NAME,
+    FARM_OFFLINE_DATABASE_VERSION,
+    OPERATION_COMPLETION_DRAFT_MAX_COUNT,
+    OPERATION_COMPLETION_DRAFT_STORE_NAME,
+    OPERATION_COMPLETION_QUEUE_STORE_NAME,
+} from './operationCompletionDraftStore';
+
+const baseScope = {
+    accountId: 'account-a',
+    expectedEntityId: 101,
+    expectedTaskVersionEventId: 201,
+    operationId: 301,
+    requirementsFingerprint: 'required:optional',
+    userId: 'farmer-a',
+} as const;
+
+test.beforeEach(async ({ mount, page }) => {
+    await mount(<OperationCompletionDraftStoreHarness />);
+    await expect(page.getByTestId('operation-draft-store-ready')).toHaveText(
+        'ready',
+    );
+});
+
+test('upgrades a v1 draft database without data loss and rejects stale v1 clients', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ databaseName, draftStoreName, queueStoreName }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            await new Promise<void>((resolve, reject) => {
+                const request = indexedDB.deleteDatabase(databaseName);
+                request.onerror = () => reject(request.error);
+                request.onblocked = () =>
+                    reject(new Error('Database deletion was blocked'));
+                request.onsuccess = () => resolve();
+            });
+
+            await new Promise<void>((resolve, reject) => {
+                const request = indexedDB.open(databaseName, 1);
+                request.onerror = () => reject(request.error);
+                request.onupgradeneeded = () => {
+                    request.result.createObjectStore(draftStoreName, {
+                        keyPath: 'key',
+                    });
+                };
+                request.onsuccess = () => {
+                    const database = request.result;
+                    const transaction = database.transaction(
+                        draftStoreName,
+                        'readwrite',
+                    );
+                    transaction.objectStore(draftStoreName).put({
+                        key: 'legacy-draft-record',
+                        notes: 'legacy private draft',
+                        userId: 'legacy-farmer',
+                    });
+                    transaction.onabort = () => reject(transaction.error);
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        database.close();
+                        resolve();
+                    };
+                };
+            });
+
+            const lease = await api.acquireLease(
+                'upgrade-trigger-user',
+                api.captureLogoutNonce('upgrade-trigger-user'),
+                'upgrade-trigger-session',
+            );
+
+            const upgraded = await new Promise<{
+                legacyRecord: unknown;
+                stores: string[];
+                version: number;
+            }>((resolve, reject) => {
+                const request = indexedDB.open(databaseName);
+                request.onerror = () => reject(request.error);
+                request.onsuccess = () => {
+                    const database = request.result;
+                    const transaction = database.transaction(
+                        draftStoreName,
+                        'readonly',
+                    );
+                    const getRequest = transaction
+                        .objectStore(draftStoreName)
+                        .get('legacy-draft-record');
+                    getRequest.onerror = () => reject(getRequest.error);
+                    getRequest.onsuccess = () => {
+                        resolve({
+                            legacyRecord: getRequest.result,
+                            stores: Array.from(database.objectStoreNames),
+                            version: database.version,
+                        });
+                        database.close();
+                    };
+                };
+            });
+
+            const staleOpenError = await new Promise<string | null>(
+                (resolve) => {
+                    const request = indexedDB.open(databaseName, 1);
+                    request.onerror = () =>
+                        resolve(request.error?.name ?? 'UnknownError');
+                    request.onsuccess = () => {
+                        request.result.close();
+                        resolve(null);
+                    };
+                },
+            );
+
+            return {
+                leaseStatus: lease.status,
+                queueStorePresent: upgraded.stores.includes(queueStoreName),
+                staleOpenError,
+                upgraded,
+            };
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            draftStoreName: OPERATION_COMPLETION_DRAFT_STORE_NAME,
+            queueStoreName: OPERATION_COMPLETION_QUEUE_STORE_NAME,
+        },
+    );
+
+    expect(result).toMatchObject({
+        leaseStatus: 'ready',
+        queueStorePresent: true,
+        staleOpenError: 'VersionError',
+        upgraded: {
+            legacyRecord: {
+                key: 'legacy-draft-record',
+                notes: 'legacy private draft',
+                userId: 'legacy-farmer',
+            },
+            version: FARM_OFFLINE_DATABASE_VERSION,
+        },
+    });
+});
+
+test('atomically hands a draft to the queue, preserves File metadata, and fences late draft writes', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const leaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            'handoff-session',
+        );
+        if (leaseResult.status !== 'ready') {
+            throw new Error('Expected a writer lease');
+        }
+        const file = new File(['photo bytes'], 'berba.jpg', {
+            lastModified: 1_725_000_000_000,
+            type: 'image/jpeg',
+        });
+        const input = {
+            ...scope,
+            notes: 'Privatna napomena za berbu',
+            operationLabel: '  Berba rajčice  ',
+            photos: [{ file, id: 'photo-a' }],
+            scheduleDateKey: '2026-07-15',
+        };
+        const save = await api.save(input, { lease: leaseResult.lease });
+        if (save.status !== 'ok' || save.revisionId === null) {
+            throw new Error('Expected the source draft');
+        }
+
+        const handoff = await api.queue.handoff(input, {
+            expectedDraftRevisionId: save.revisionId,
+            lease: leaseResult.lease,
+        });
+        if (handoff.status !== 'enqueued') {
+            throw new Error('Expected an enqueued handoff');
+        }
+        const queued = await api.queue.load(scope, leaseResult.lease);
+        if (queued.status !== 'found') {
+            throw new Error('Expected the queued item');
+        }
+        const attachment = queued.item.attachments[0];
+        if (!attachment) throw new Error('Expected one attachment');
+
+        const repeated = await api.queue.handoff(input, {
+            expectedDraftRevisionId: save.revisionId,
+            lease: leaseResult.lease,
+        });
+        const conflicting = await api.queue.handoff(
+            {
+                ...input,
+                notes: 'Druga napomena iz drugog prozora',
+                photos: [{ file, id: 'photo-from-other-tab' }],
+            },
+            { lease: leaseResult.lease },
+        );
+        const lateSave = await api.save(
+            {
+                ...scope,
+                notes: 'Kasni upis koji ne smije uskrsnuti skicu',
+                photos: [],
+            },
+            { lease: leaseResult.lease },
+        );
+
+        return {
+            attachment: {
+                id: attachment.id,
+                lastModified: attachment.lastModified,
+                name: attachment.name,
+                size: attachment.size,
+                text: await attachment.blob.text(),
+                type: attachment.type,
+                uploadedUrl: attachment.uploadedUrl,
+            },
+            draftAfterHandoff: await api.load(scope, leaseResult.lease),
+            conflicting,
+            handoff,
+            lateSave,
+            queued: {
+                notes: queued.item.notes,
+                operationLabel: queued.item.operationLabel,
+                scheduleDateKey: queued.item.scheduleDateKey,
+                state: queued.item.state,
+                submissionId: queued.item.submissionId,
+            },
+            repeated,
+        };
+    }, baseScope);
+
+    expect(result.handoff).toMatchObject({
+        item: {
+            attachmentCount: 1,
+            contentAvailable: true,
+            operationLabel: 'Berba rajčice',
+            scheduleDateKey: '2026-07-15',
+            state: 'queued',
+        },
+        status: 'enqueued',
+    });
+    expect(result.attachment).toEqual({
+        id: 'photo-a',
+        lastModified: 1_725_000_000_000,
+        name: 'berba.jpg',
+        size: 11,
+        text: 'photo bytes',
+        type: 'image/jpeg',
+        uploadedUrl: null,
+    });
+    expect(result.queued).toMatchObject({
+        notes: 'Privatna napomena za berbu',
+        operationLabel: 'Berba rajčice',
+        scheduleDateKey: '2026-07-15',
+        state: 'queued',
+    });
+    expect(result.draftAfterHandoff).toEqual({
+        reason: 'not_found',
+        status: 'missing',
+    });
+    expect(result.repeated).toMatchObject({ status: 'existing' });
+    expect(
+        result.repeated.status === 'existing'
+            ? result.repeated.item.submissionId
+            : null,
+    ).toBe(result.queued.submissionId);
+    expect(result.conflicting).toEqual({
+        reason: 'queue_conflict',
+        status: 'error',
+    });
+    expect(result.lateSave).toEqual({
+        reason: 'incompatible',
+        status: 'error',
+    });
+});
+
+test('shares the five-item bound between drafts and queued completions', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ maxCount, scope }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            const leaseResult = await api.acquireLease(
+                scope.userId,
+                api.captureLogoutNonce(scope.userId),
+                'combined-bound-session',
+            );
+            if (leaseResult.status !== 'ready') {
+                throw new Error('Expected a writer lease');
+            }
+            const queued = await api.queue.handoff(
+                {
+                    ...scope,
+                    notes: 'Jedna stavka u redu',
+                    operationLabel: 'Zalijevanje',
+                    photos: [],
+                },
+                { lease: leaseResult.lease },
+            );
+            if (queued.status !== 'enqueued') {
+                throw new Error('Expected the first queue item');
+            }
+
+            const draftResults = [];
+            for (let offset = 1; offset < maxCount; offset += 1) {
+                draftResults.push(
+                    await api.save(
+                        {
+                            ...scope,
+                            notes: `Skica ${offset}`,
+                            operationId: scope.operationId + offset,
+                            photos: [],
+                        },
+                        { lease: leaseResult.lease },
+                    ),
+                );
+            }
+            const extraDraft = await api.save(
+                {
+                    ...scope,
+                    notes: 'Šesta stavka',
+                    operationId: scope.operationId + maxCount,
+                    photos: [],
+                },
+                { lease: leaseResult.lease },
+            );
+            const extraQueue = await api.queue.handoff(
+                {
+                    ...scope,
+                    notes: 'Također šesta stavka',
+                    operationId: scope.operationId + maxCount + 1,
+                    operationLabel: 'Plijevljenje',
+                    photos: [],
+                },
+                { lease: leaseResult.lease },
+            );
+
+            return {
+                draftResults,
+                extraDraft,
+                extraQueue,
+                listed: await api.queue.list(
+                    { accountId: scope.accountId, userId: scope.userId },
+                    leaseResult.lease,
+                ),
+            };
+        },
+        { maxCount: OPERATION_COMPLETION_DRAFT_MAX_COUNT, scope: baseScope },
+    );
+
+    expect(result.draftResults).toHaveLength(
+        OPERATION_COMPLETION_DRAFT_MAX_COUNT - 1,
+    );
+    expect(
+        result.draftResults.every(
+            (item) => item.status === 'ok' && item.action === 'saved',
+        ),
+    ).toBe(true);
+    expect(result.extraDraft).toEqual({
+        reason: 'draft_count_limit',
+        status: 'error',
+    });
+    expect(result.extraQueue).toEqual({
+        reason: 'draft_count_limit',
+        status: 'error',
+    });
+    expect(result.listed).toMatchObject({
+        items: [{ operationId: baseScope.operationId }],
+        status: 'ok',
+    });
+});
+
+test('serializes concurrent claims and recovers a stale claim with CAS fencing', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ databaseName, queueStoreName, scope }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            const leaseResult = await api.acquireLease(
+                scope.userId,
+                api.captureLogoutNonce(scope.userId),
+                'claim-session',
+            );
+            if (leaseResult.status !== 'ready') {
+                throw new Error('Expected a writer lease');
+            }
+            const handoff = await api.queue.handoff(
+                {
+                    ...scope,
+                    notes: 'Sadržaj za jedan zahtjev',
+                    operationLabel: 'Prihrana',
+                    photos: [
+                        {
+                            file: new File(['claim photo'], 'claim.jpg', {
+                                type: 'image/jpeg',
+                            }),
+                            id: 'claim-photo',
+                        },
+                    ],
+                },
+                { lease: leaseResult.lease },
+            );
+            if (handoff.status !== 'enqueued') {
+                throw new Error('Expected an enqueued item');
+            }
+            const owner = {
+                accountId: scope.accountId,
+                userId: scope.userId,
+            };
+            const claims = await Promise.all([
+                api.queue.claimNext(owner, {
+                    claimId: 'claim-a',
+                    lease: leaseResult.lease,
+                }),
+                api.queue.claimNext(owner, {
+                    claimId: 'claim-b',
+                    lease: leaseResult.lease,
+                }),
+            ]);
+            const winner = claims.find((claim) => claim.status === 'claimed');
+            if (winner?.status !== 'claimed' || !winner.item.claim) {
+                throw new Error('Expected exactly one winning claim');
+            }
+
+            await new Promise<void>((resolve, reject) => {
+                const request = indexedDB.open(databaseName);
+                request.onerror = () => reject(request.error);
+                request.onsuccess = () => {
+                    const database = request.result;
+                    const transaction = database.transaction(
+                        queueStoreName,
+                        'readwrite',
+                    );
+                    const store = transaction.objectStore(queueStoreName);
+                    const getRequest = store.get(handoff.item.key);
+                    getRequest.onerror = () => reject(getRequest.error);
+                    getRequest.onsuccess = () => {
+                        const item = getRequest.result;
+                        if (!item?.claim) {
+                            reject(new Error('Expected the stored claim'));
+                            return;
+                        }
+                        item.claim.expiresAt = Date.now() - 1;
+                        store.put(item);
+                    };
+                    transaction.onabort = () => reject(transaction.error);
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        database.close();
+                        resolve();
+                    };
+                };
+            });
+
+            const recovered = await api.queue.claimNext(owner, {
+                claimId: 'claim-recovered',
+                lease: leaseResult.lease,
+            });
+            const staleMutation = await api.queue.markAttachmentUploaded(
+                {
+                    attachmentId: 'claim-photo',
+                    claimId: winner.item.claim.claimId,
+                    key: handoff.item.key,
+                    submissionId: handoff.item.submissionId,
+                    uploadedUrl: 'https://example.com/stale.jpg',
+                },
+                leaseResult.lease,
+            );
+
+            return { claims, recovered, staleMutation };
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            queueStoreName: OPERATION_COMPLETION_QUEUE_STORE_NAME,
+            scope: baseScope,
+        },
+    );
+
+    expect(result.claims.map((claim) => claim.status).sort()).toEqual([
+        'claimed',
+        'empty',
+    ]);
+    expect(result.recovered).toMatchObject({
+        item: {
+            attemptCount: 2,
+            claim: { claimId: 'claim-recovered' },
+            state: 'syncing',
+        },
+        status: 'claimed',
+    });
+    expect(result.staleMutation).toEqual({ status: 'conflict' });
+});
+
+test('renews only the active claim and fences expired claims and logged-out sessions', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ databaseName, queueStoreName, scope }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            const session = 'claim-renewal-session';
+            const leaseResult = await api.acquireLease(
+                scope.userId,
+                api.captureLogoutNonce(scope.userId),
+                session,
+            );
+            if (leaseResult.status !== 'ready') {
+                throw new Error('Expected a writer lease');
+            }
+            const handoff = await api.queue.handoff(
+                {
+                    ...scope,
+                    notes: 'Fotografije se još prenose',
+                    operationLabel: 'Dugi prijenos fotografija',
+                    photos: [],
+                },
+                { lease: leaseResult.lease },
+            );
+            if (handoff.status !== 'enqueued') {
+                throw new Error('Expected an enqueued item');
+            }
+            const claim = await api.queue.claimNext(
+                { accountId: scope.accountId, userId: scope.userId },
+                { claimId: 'long-upload-claim', lease: leaseResult.lease },
+            );
+            if (claim.status !== 'claimed' || !claim.item.claim) {
+                throw new Error('Expected an active claim');
+            }
+            const target = {
+                claimId: 'long-upload-claim',
+                key: handoff.item.key,
+                submissionId: handoff.item.submissionId,
+            };
+            const initialExpiry = claim.item.claim.expiresAt;
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            const renewed = await api.queue.renewClaim(
+                target,
+                leaseResult.lease,
+            );
+            const afterRenewal = await api.queue.load(scope, leaseResult.lease);
+            const wrongClaim = await api.queue.renewClaim(
+                { ...target, claimId: 'wrong-claim' },
+                leaseResult.lease,
+            );
+
+            await new Promise<void>((resolve, reject) => {
+                const request = indexedDB.open(databaseName);
+                request.onerror = () => reject(request.error);
+                request.onsuccess = () => {
+                    const database = request.result;
+                    const transaction = database.transaction(
+                        queueStoreName,
+                        'readwrite',
+                    );
+                    const store = transaction.objectStore(queueStoreName);
+                    const getRequest = store.get(target.key);
+                    getRequest.onerror = () => reject(getRequest.error);
+                    getRequest.onsuccess = () => {
+                        const item = getRequest.result;
+                        if (!item?.claim) {
+                            reject(new Error('Expected a stored claim'));
+                            return;
+                        }
+                        item.claim.expiresAt = Date.now() - 1;
+                        store.put(item);
+                    };
+                    transaction.onabort = () => reject(transaction.error);
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        database.close();
+                        resolve();
+                    };
+                };
+            });
+
+            const expiredClaim = await api.queue.renewClaim(
+                target,
+                leaseResult.lease,
+            );
+            await api.purgeUser(scope.userId, session);
+            const loggedOutClaim = await api.queue.renewClaim(
+                target,
+                leaseResult.lease,
+            );
+
+            return {
+                afterRenewal:
+                    afterRenewal.status === 'found'
+                        ? afterRenewal.item.claim?.expiresAt
+                        : null,
+                expiredClaim,
+                initialExpiry,
+                loggedOutClaim,
+                renewed,
+                wrongClaim,
+            };
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            queueStoreName: OPERATION_COMPLETION_QUEUE_STORE_NAME,
+            scope: baseScope,
+        },
+    );
+
+    expect(result.renewed).toEqual({ status: 'ok' });
+    expect(result.afterRenewal).toBeGreaterThan(result.initialExpiry);
+    expect(result.wrongClaim).toEqual({ status: 'conflict' });
+    expect(result.expiredClaim).toEqual({ status: 'conflict' });
+    expect(result.loggedOutClaim).toEqual({ status: 'session_changed' });
+});
+
+test('supports upload, retry, failure, and confirmation transitions while scrubbing the tombstone', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const leaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            'transition-session',
+        );
+        if (leaseResult.status !== 'ready') {
+            throw new Error('Expected a writer lease');
+        }
+        const handoff = await api.queue.handoff(
+            {
+                ...scope,
+                notes: 'Vrlo privatna napomena',
+                operationLabel: 'Rezidba osjetljivog nasada',
+                photos: [
+                    {
+                        file: new File(['private photo bytes'], 'private.jpg', {
+                            type: 'image/jpeg',
+                        }),
+                        id: 'private-photo',
+                    },
+                ],
+                scheduleDateKey: '2026-07-15',
+            },
+            { lease: leaseResult.lease },
+        );
+        if (handoff.status !== 'enqueued') {
+            throw new Error('Expected an enqueued item');
+        }
+        const owner = {
+            accountId: scope.accountId,
+            userId: scope.userId,
+        };
+        const target = {
+            key: handoff.item.key,
+            submissionId: handoff.item.submissionId,
+        };
+
+        const firstClaim = await api.queue.claimNext(owner, {
+            claimId: 'transition-claim-1',
+            lease: leaseResult.lease,
+        });
+        if (firstClaim.status !== 'claimed') {
+            throw new Error('Expected the first claim');
+        }
+        const upload = await api.queue.markAttachmentUploaded(
+            {
+                ...target,
+                attachmentId: 'private-photo',
+                claimId: 'transition-claim-1',
+                uploadedUrl: 'https://uploads.example/private.jpg',
+            },
+            leaseResult.lease,
+        );
+        const afterUpload = await api.queue.load(scope, leaseResult.lease);
+        const release = await api.queue.releaseForRetry(
+            {
+                ...target,
+                claimId: 'transition-claim-1',
+                failureCode: 'network_unavailable',
+                nextAttemptAt: Date.now() - 1,
+            },
+            leaseResult.lease,
+        );
+        const secondClaim = await api.queue.claimNext(owner, {
+            claimId: 'transition-claim-2',
+            lease: leaseResult.lease,
+        });
+        const failed = await api.queue.markFailed(
+            {
+                ...target,
+                claimId: 'transition-claim-2',
+                failureCode: 'upload_failed',
+            },
+            leaseResult.lease,
+        );
+        const afterFailure = await api.queue.load(scope, leaseResult.lease);
+        const retry = await api.queue.retry(target, leaseResult.lease);
+        const thirdClaim = await api.queue.claimNext(owner, {
+            claimId: 'transition-claim-3',
+            lease: leaseResult.lease,
+        });
+        const confirmed = await api.queue.markServerConfirmed(
+            {
+                ...target,
+                claimId: 'transition-claim-3',
+                serverState: 'pendingVerification',
+            },
+            leaseResult.lease,
+        );
+        const tombstone = await api.queue.load(scope, leaseResult.lease);
+        const listed = await api.queue.list(owner, leaseResult.lease);
+
+        return {
+            afterFailure:
+                afterFailure.status === 'found'
+                    ? {
+                          attemptCount: afterFailure.item.attemptCount,
+                          failureCode: afterFailure.item.failureCode,
+                          state: afterFailure.item.state,
+                      }
+                    : afterFailure,
+            afterUpload:
+                afterUpload.status === 'found'
+                    ? {
+                          uploadedUrl:
+                              afterUpload.item.attachments[0]?.uploadedUrl,
+                      }
+                    : afterUpload,
+            confirmed,
+            failed,
+            firstClaim,
+            listed,
+            release,
+            retry,
+            secondClaim,
+            thirdClaim,
+            upload,
+            tombstone:
+                tombstone.status === 'found'
+                    ? {
+                          attachmentCount: tombstone.item.attachments.length,
+                          claim: tombstone.item.claim,
+                          contentDiscardedAt: tombstone.item.contentDiscardedAt,
+                          notes: tombstone.item.notes,
+                          operationLabel: tombstone.item.operationLabel,
+                          scheduleDateKey: tombstone.item.scheduleDateKey,
+                          serverState: tombstone.item.serverState,
+                          state: tombstone.item.state,
+                      }
+                    : tombstone,
+        };
+    }, baseScope);
+
+    expect(result.firstClaim).toMatchObject({
+        item: { attemptCount: 1, state: 'syncing' },
+        status: 'claimed',
+    });
+    expect(result.upload).toEqual({ status: 'ok' });
+    expect(result.afterUpload).toEqual({
+        uploadedUrl: 'https://uploads.example/private.jpg',
+    });
+    expect(result.release).toEqual({ status: 'ok' });
+    expect(result.secondClaim).toMatchObject({
+        item: { attemptCount: 2, state: 'syncing' },
+        status: 'claimed',
+    });
+    expect(result.failed).toEqual({ status: 'ok' });
+    expect(result.afterFailure).toEqual({
+        attemptCount: 2,
+        failureCode: 'upload_failed',
+        state: 'failed',
+    });
+    expect(result.retry).toEqual({ status: 'ok' });
+    expect(result.thirdClaim).toMatchObject({
+        item: { attemptCount: 1, state: 'syncing' },
+        status: 'claimed',
+    });
+    expect(result.confirmed).toEqual({ status: 'ok' });
+    expect(result.tombstone).toMatchObject({
+        attachmentCount: 0,
+        claim: null,
+        notes: '',
+        operationLabel: '',
+        scheduleDateKey: null,
+        serverState: 'pendingVerification',
+        state: 'server_confirmed',
+    });
+    expect(
+        'contentDiscardedAt' in result.tombstone
+            ? result.tombstone.contentDiscardedAt
+            : null,
+    ).toEqual(expect.any(Number));
+    expect(result.listed).toMatchObject({
+        items: [
+            {
+                attachmentCount: 0,
+                contentAvailable: false,
+                operationLabel: '',
+                scheduleDateKey: null,
+                serverState: 'pendingVerification',
+                state: 'server_confirmed',
+            },
+        ],
+        status: 'ok',
+    });
+    expect(JSON.stringify(result.tombstone)).not.toContain('private');
+    expect(JSON.stringify(result.listed)).not.toContain('private');
+});
+
+test('expires queued private content into a durable scrubbed tombstone', async ({
+    page,
+}) => {
+    const result = await page.evaluate(
+        async ({ databaseName, queueStoreName, scope }) => {
+            const api = window.__operationCompletionDraftStoreTestApi;
+            if (!api) throw new Error('Draft store test API is unavailable');
+
+            const leaseResult = await api.acquireLease(
+                scope.userId,
+                api.captureLogoutNonce(scope.userId),
+                'expiry-session',
+            );
+            if (leaseResult.status !== 'ready') {
+                throw new Error('Expected a writer lease');
+            }
+            const handoff = await api.queue.handoff(
+                {
+                    ...scope,
+                    notes: 'Istekla privatna napomena',
+                    operationLabel: 'Istekla operacija',
+                    photos: [
+                        {
+                            file: new File(['expired bytes'], 'expired.jpg', {
+                                type: 'image/jpeg',
+                            }),
+                            id: 'expired-photo',
+                        },
+                    ],
+                    scheduleDateKey: '2026-07-14',
+                },
+                { lease: leaseResult.lease },
+            );
+            if (handoff.status !== 'enqueued') {
+                throw new Error('Expected an enqueued item');
+            }
+
+            await new Promise<void>((resolve, reject) => {
+                const request = indexedDB.open(databaseName);
+                request.onerror = () => reject(request.error);
+                request.onsuccess = () => {
+                    const database = request.result;
+                    const transaction = database.transaction(
+                        queueStoreName,
+                        'readwrite',
+                    );
+                    const store = transaction.objectStore(queueStoreName);
+                    const getRequest = store.get(handoff.item.key);
+                    getRequest.onerror = () => reject(getRequest.error);
+                    getRequest.onsuccess = () => {
+                        const item = getRequest.result;
+                        if (!item) {
+                            reject(new Error('Expected a queue item'));
+                            return;
+                        }
+                        item.expiresAt = Date.now() - 1;
+                        store.put(item);
+                    };
+                    transaction.onabort = () => reject(transaction.error);
+                    transaction.onerror = () => reject(transaction.error);
+                    transaction.oncomplete = () => {
+                        database.close();
+                        resolve();
+                    };
+                };
+            });
+
+            const expired = await api.queue.load(scope, leaseResult.lease);
+            const tombstone = await api.queue.load(scope, leaseResult.lease);
+            const lateSave = await api.save(
+                { ...scope, notes: 'Ne smije zaobići tombstone', photos: [] },
+                { lease: leaseResult.lease },
+            );
+            const repeated = await api.queue.handoff(
+                {
+                    ...scope,
+                    notes: 'Ne smije napraviti novi submission',
+                    operationLabel: 'Novi pokušaj',
+                    photos: [],
+                },
+                { lease: leaseResult.lease },
+            );
+            const discarded = await api.queue.discard(
+                {
+                    key: handoff.item.key,
+                    submissionId: handoff.item.submissionId,
+                },
+                leaseResult.lease,
+            );
+            const afterDiscard = await api.queue.load(scope, leaseResult.lease);
+            const replacement = await api.queue.handoff(
+                {
+                    ...scope,
+                    notes: 'Novi unos nakon izričitog odbacivanja',
+                    operationLabel: 'Novi pokušaj',
+                    photos: [],
+                },
+                { lease: leaseResult.lease },
+            );
+
+            return {
+                afterDiscard,
+                discarded,
+                expired,
+                lateSave,
+                originalSubmissionId: handoff.item.submissionId,
+                repeated,
+                replacement,
+                tombstone:
+                    tombstone.status === 'found'
+                        ? {
+                              attachments: tombstone.item.attachments.length,
+                              contentDiscardedAt:
+                                  tombstone.item.contentDiscardedAt,
+                              failureCode: tombstone.item.failureCode,
+                              notes: tombstone.item.notes,
+                              operationLabel: tombstone.item.operationLabel,
+                              scheduleDateKey: tombstone.item.scheduleDateKey,
+                              state: tombstone.item.state,
+                              submissionId: tombstone.item.submissionId,
+                          }
+                        : tombstone,
+            };
+        },
+        {
+            databaseName: FARM_OFFLINE_DATABASE_NAME,
+            queueStoreName: OPERATION_COMPLETION_QUEUE_STORE_NAME,
+            scope: baseScope,
+        },
+    );
+
+    expect(result.expired).toMatchObject({
+        item: {
+            attachments: [],
+            contentDiscardedAt: expect.any(Number),
+            failureCode: 'expired',
+            notes: '',
+            operationLabel: '',
+            scheduleDateKey: null,
+            state: 'failed',
+            submissionId: result.originalSubmissionId,
+        },
+        status: 'expired',
+    });
+    expect(result.tombstone).toMatchObject({
+        attachments: 0,
+        failureCode: 'expired',
+        notes: '',
+        operationLabel: '',
+        scheduleDateKey: null,
+        state: 'failed',
+        submissionId: result.originalSubmissionId,
+    });
+    expect(
+        'contentDiscardedAt' in result.tombstone
+            ? result.tombstone.contentDiscardedAt
+            : null,
+    ).toEqual(expect.any(Number));
+    expect(result.lateSave).toEqual({
+        reason: 'incompatible',
+        status: 'error',
+    });
+    expect(result.repeated).toEqual({
+        reason: 'queue_conflict',
+        status: 'error',
+    });
+    expect(result.discarded).toEqual({ status: 'ok' });
+    expect(result.afterDiscard).toEqual({ status: 'missing' });
+    expect(result.replacement).toMatchObject({ status: 'enqueued' });
+    expect(
+        result.replacement.status === 'enqueued'
+            ? result.replacement.item.submissionId
+            : null,
+    ).not.toBe(result.originalSubmissionId);
+});
+
+test('isolates queue content and fences every old claim after logout', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const oldSession = 'old-logout-session';
+        const oldLeaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            oldSession,
+        );
+        if (oldLeaseResult.status !== 'ready') {
+            throw new Error('Expected the old writer lease');
+        }
+        const secondAccount = { ...scope, accountId: 'account-b' };
+        const otherUser = { ...scope, userId: 'farmer-b' };
+        const otherLeaseResult = await api.acquireLease(
+            otherUser.userId,
+            api.captureLogoutNonce(otherUser.userId),
+            'other-user-session',
+        );
+        if (otherLeaseResult.status !== 'ready') {
+            throw new Error('Expected the other user lease');
+        }
+
+        const first = await api.queue.handoff(
+            {
+                ...scope,
+                notes: 'Prvi račun',
+                operationLabel: 'Prva operacija',
+                photos: [],
+            },
+            { lease: oldLeaseResult.lease },
+        );
+        const second = await api.queue.handoff(
+            {
+                ...secondAccount,
+                notes: 'Drugi račun',
+                operationLabel: 'Druga operacija',
+                photos: [],
+            },
+            { lease: oldLeaseResult.lease },
+        );
+        const other = await api.queue.handoff(
+            {
+                ...otherUser,
+                notes: 'Drugi korisnik',
+                operationLabel: 'Tuđa operacija',
+                photos: [],
+            },
+            { lease: otherLeaseResult.lease },
+        );
+        if (
+            first.status !== 'enqueued' ||
+            second.status !== 'enqueued' ||
+            other.status !== 'enqueued'
+        ) {
+            throw new Error('Expected all isolated queue items');
+        }
+        const claim = await api.queue.claimNext(
+            { accountId: scope.accountId, userId: scope.userId },
+            { claimId: 'old-claim', lease: oldLeaseResult.lease },
+        );
+        if (claim.status !== 'claimed') {
+            throw new Error('Expected the old claim');
+        }
+
+        const beforePurge = {
+            otherAccount: await api.queue.list(
+                { accountId: secondAccount.accountId, userId: scope.userId },
+                oldLeaseResult.lease,
+            ),
+            otherUserWithWrongLease: await api.queue.load(
+                otherUser,
+                oldLeaseResult.lease,
+            ),
+            owner: await api.queue.list(
+                { accountId: scope.accountId, userId: scope.userId },
+                oldLeaseResult.lease,
+            ),
+        };
+        const purge = await api.purgeUser(scope.userId, oldSession);
+        const staleClaimMutation = await api.queue.releaseForRetry(
+            {
+                claimId: 'old-claim',
+                failureCode: 'network_unavailable',
+                key: first.item.key,
+                nextAttemptAt: Date.now(),
+                submissionId: first.item.submissionId,
+            },
+            oldLeaseResult.lease,
+        );
+        const newLeaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            'new-login-session',
+        );
+        if (newLeaseResult.status !== 'ready') {
+            throw new Error('Expected a new writer lease');
+        }
+
+        return {
+            beforePurge,
+            firstAfterPurge: await api.queue.load(scope, newLeaseResult.lease),
+            otherAfterPurge: await api.queue.load(
+                otherUser,
+                otherLeaseResult.lease,
+            ),
+            purge,
+            secondAfterPurge: await api.queue.load(
+                secondAccount,
+                newLeaseResult.lease,
+            ),
+            staleClaimMutation,
+        };
+    }, baseScope);
+
+    expect(result.beforePurge.owner).toMatchObject({
+        items: [{ accountId: 'account-a' }],
+        status: 'ok',
+    });
+    expect(result.beforePurge.otherAccount).toMatchObject({
+        items: [{ accountId: 'account-b' }],
+        status: 'ok',
+    });
+    expect(result.beforePurge.otherUserWithWrongLease).toEqual({
+        status: 'session_changed',
+    });
+    expect(result.purge).toEqual({ deletedCount: 2, status: 'ok' });
+    expect(result.staleClaimMutation).toEqual({ status: 'session_changed' });
+    expect(result.firstAfterPurge).toEqual({ status: 'missing' });
+    expect(result.secondAfterPurge).toEqual({ status: 'missing' });
+    expect(result.otherAfterPurge.status).toBe('found');
+});
+
+test('preserves a newer same-user queue when an old logout arrives late', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const oldSession = 'late-old-session';
+        const oldLeaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            oldSession,
+        );
+        if (oldLeaseResult.status !== 'ready') {
+            throw new Error('Expected the old lease');
+        }
+        await api.queue.handoff(
+            {
+                ...scope,
+                notes: 'Stara queue stavka',
+                operationLabel: 'Stara operacija',
+                photos: [],
+            },
+            { lease: oldLeaseResult.lease },
+        );
+
+        const newLeaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            'newer-session',
+        );
+        if (newLeaseResult.status !== 'ready') {
+            throw new Error('Expected the newer lease');
+        }
+        const newer = await api.queue.handoff(
+            {
+                ...scope,
+                notes: 'Nova queue stavka mora ostati',
+                operationLabel: 'Nova operacija',
+                photos: [],
+            },
+            { lease: newLeaseResult.lease },
+        );
+        if (newer.status !== 'enqueued') {
+            throw new Error('Expected the newer queue item');
+        }
+
+        const purge = await api.purgeUser(scope.userId, oldSession);
+        return {
+            newItem: await api.queue.load(scope, newLeaseResult.lease),
+            oldItem: await api.queue.load(scope, oldLeaseResult.lease),
+            purge,
+            retry: await api.queue.retry(
+                {
+                    key: newer.item.key,
+                    submissionId: newer.item.submissionId,
+                },
+                newLeaseResult.lease,
+            ),
+        };
+    }, baseScope);
+
+    expect(result.purge).toEqual({ deletedCount: 0, status: 'ok' });
+    expect(result.oldItem).toEqual({ status: 'session_changed' });
+    expect(result.newItem).toMatchObject({
+        item: {
+            notes: 'Nova queue stavka mora ostati',
+            operationLabel: 'Nova operacija',
+        },
+        status: 'found',
+    });
+    expect(result.retry).toEqual({ status: 'conflict' });
+});
+
+test('emits owner-scoped change notifications without private completion content', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const api = window.__operationCompletionDraftStoreTestApi;
+        if (!api) throw new Error('Draft store test API is unavailable');
+
+        const leaseResult = await api.acquireLease(
+            scope.userId,
+            api.captureLogoutNonce(scope.userId),
+            'change-event-session',
+        );
+        if (leaseResult.status !== 'ready') {
+            throw new Error('Expected a writer lease');
+        }
+        let ownerNotifications = 0;
+        let otherAccountNotifications = 0;
+        const details: unknown[] = [];
+        const unsubscribeOwner = api.queue.subscribe(
+            scope.userId,
+            scope.accountId,
+            () => {
+                ownerNotifications += 1;
+            },
+        );
+        const unsubscribeOther = api.queue.subscribe(
+            scope.userId,
+            'account-b',
+            () => {
+                otherAccountNotifications += 1;
+            },
+        );
+        const onChange = (event: Event) => {
+            if (event instanceof CustomEvent) details.push(event.detail);
+        };
+        window.addEventListener(
+            'gredice:operation-completion-queue-change:v1',
+            onChange,
+        );
+        try {
+            await api.queue.handoff(
+                {
+                    ...scope,
+                    notes: 'Tajna napomena ne smije biti u događaju',
+                    operationLabel: 'Tajni naziv operacije',
+                    photos: [
+                        {
+                            file: new File(['secret bytes'], 'secret.jpg', {
+                                type: 'image/jpeg',
+                            }),
+                            id: 'secret-photo',
+                        },
+                    ],
+                },
+                { lease: leaseResult.lease },
+            );
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        } finally {
+            unsubscribeOwner();
+            unsubscribeOther();
+            window.removeEventListener(
+                'gredice:operation-completion-queue-change:v1',
+                onChange,
+            );
+        }
+
+        return {
+            details,
+            otherAccountNotifications,
+            ownerNotifications,
+        };
+    }, baseScope);
+
+    expect(result.ownerNotifications).toBeGreaterThanOrEqual(1);
+    expect(result.otherAccountNotifications).toBe(0);
+    expect(result.details).toEqual([
+        {
+            accountId: baseScope.accountId,
+            kind: 'changed',
+            userId: baseScope.userId,
+        },
+    ]);
+    expect(JSON.stringify(result)).not.toContain('Tajna');
+    expect(JSON.stringify(result)).not.toContain('secret');
+});

--- a/apps/farm/lib/offline/operationCompletionQueueStore.ts
+++ b/apps/farm/lib/offline/operationCompletionQueueStore.ts
@@ -1,0 +1,1424 @@
+'use client';
+
+import {
+    isCompatibleOperationCompletionDraft,
+    isOperationCompletionDraftRecord,
+    OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+    OPERATION_COMPLETION_DRAFT_MAX_BYTES,
+    OPERATION_COMPLETION_DRAFT_MAX_COUNT,
+    type OperationCompletionDraftLease,
+    type OperationCompletionDraftPhotoInput,
+    type OperationCompletionDraftScope,
+    operationCompletionDraftByteSize,
+    operationCompletionDraftLeaseMatches,
+    operationCompletionDraftRecordKey,
+    operationCompletionQueueRecordKey,
+    requestOperationCompletionStoreResult,
+    withOperationCompletionOfflineStores,
+} from './operationCompletionDraftStore';
+
+export { OPERATION_COMPLETION_QUEUE_STORE_NAME } from './operationCompletionDraftStore';
+
+const OPERATION_COMPLETION_QUEUE_SCHEMA_VERSION = 1;
+const OPERATION_COMPLETION_QUEUE_CHANGE_EVENT =
+    'gredice:operation-completion-queue-change:v1';
+const OPERATION_COMPLETION_QUEUE_CLAIM_MAX_AGE_MS = 2 * 60 * 1000;
+const OPERATION_COMPLETION_QUEUE_MAX_LABEL_LENGTH = 200;
+const OPERATION_COMPLETION_QUEUE_MAX_URL_LENGTH = 2048;
+
+export type OperationCompletionQueueState =
+    | 'queued'
+    | 'syncing'
+    | 'failed'
+    | 'server_confirmed';
+
+export type OperationCompletionQueueFailureCode =
+    | 'assignment_changed'
+    | 'discarded'
+    | 'expired'
+    | 'idempotency_conflict'
+    | 'invalid_input'
+    | 'invalid_status'
+    | 'network_unavailable'
+    | 'not_authorized'
+    | 'not_found'
+    | 'server_unavailable'
+    | 'task_changed'
+    | 'upload_failed';
+
+export type OperationCompletionQueueServerState =
+    | 'completed'
+    | 'pendingVerification';
+
+export type OperationCompletionQueueAttachment = {
+    blob: Blob;
+    id: string;
+    lastModified: number;
+    name: string;
+    size: number;
+    type: string;
+    uploadedUrl: string | null;
+};
+
+export type OperationCompletionQueueClaim = {
+    claimId: string;
+    claimedAt: number;
+    expiresAt: number;
+};
+
+export type OperationCompletionQueueItem = OperationCompletionDraftScope & {
+    attachments: OperationCompletionQueueAttachment[];
+    attemptCount: number;
+    claim: OperationCompletionQueueClaim | null;
+    contentDiscardedAt: number | null;
+    createdAt: number;
+    expiresAt: number;
+    failureCode: OperationCompletionQueueFailureCode | null;
+    key: string;
+    nextAttemptAt: number | null;
+    notes: string;
+    operationLabel: string;
+    revisionId: string;
+    scheduleDateKey: string | null;
+    schemaVersion: 1;
+    serverConfirmedAt: number | null;
+    serverState: OperationCompletionQueueServerState | null;
+    state: OperationCompletionQueueState;
+    submissionId: string;
+    updatedAt: number;
+    writerGeneration: string;
+};
+
+export type OperationCompletionQueueSummary = OperationCompletionDraftScope & {
+    attachmentCount: number;
+    attemptCount: number;
+    contentAvailable: boolean;
+    createdAt: number;
+    expiresAt: number;
+    failureCode: OperationCompletionQueueFailureCode | null;
+    key: string;
+    nextAttemptAt: number | null;
+    operationLabel: string;
+    scheduleDateKey: string | null;
+    serverConfirmedAt: number | null;
+    serverState: OperationCompletionQueueServerState | null;
+    state: OperationCompletionQueueState;
+    submissionId: string;
+    updatedAt: number;
+};
+
+export type OperationCompletionQueueMutationTarget = {
+    key: string;
+    submissionId: string;
+};
+
+export type OperationCompletionQueueHandoffInput =
+    OperationCompletionDraftScope & {
+        notes: string;
+        operationLabel: string;
+        photos: OperationCompletionDraftPhotoInput[];
+        scheduleDateKey?: string;
+    };
+
+export type HandoffOperationCompletionDraftToQueueResult =
+    | {
+          item: OperationCompletionQueueSummary;
+          status: 'enqueued' | 'existing';
+      }
+    | {
+          reason:
+              | 'draft_changed'
+              | 'draft_count_limit'
+              | 'draft_size_limit'
+              | 'incompatible'
+              | 'invalid_input'
+              | 'queue_conflict'
+              | 'quota_exceeded'
+              | 'server_confirmed'
+              | 'session_changed'
+              | 'storage_unavailable';
+          status: 'error';
+      };
+
+export type LoadOperationCompletionQueueItemResult =
+    | { item: OperationCompletionQueueItem; status: 'found' }
+    | { item: OperationCompletionQueueItem; status: 'expired' }
+    | { status: 'missing' }
+    | { status: 'session_changed' }
+    | { status: 'unavailable' };
+
+export type ListOperationCompletionQueueItemsResult =
+    | { items: OperationCompletionQueueSummary[]; status: 'ok' }
+    | { status: 'session_changed' }
+    | { status: 'unavailable' };
+
+export type ClaimNextOperationCompletionQueueItemResult =
+    | { item: OperationCompletionQueueItem; status: 'claimed' }
+    | { status: 'empty' }
+    | { status: 'session_changed' }
+    | { status: 'unavailable' };
+
+export type OperationCompletionQueueMutationResult =
+    | { status: 'ok' }
+    | { status: 'conflict' }
+    | { status: 'session_changed' }
+    | { status: 'unavailable' };
+
+type QueueChangeMessage = {
+    accountId: string;
+    kind: 'changed';
+    userId: string;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNullableFiniteNumber(value: unknown): value is number | null {
+    return value === null || isFiniteNumber(value);
+}
+
+function isQueueState(value: unknown): value is OperationCompletionQueueState {
+    return (
+        value === 'queued' ||
+        value === 'syncing' ||
+        value === 'failed' ||
+        value === 'server_confirmed'
+    );
+}
+
+function isQueueFailureCode(
+    value: unknown,
+): value is OperationCompletionQueueFailureCode {
+    return (
+        value === 'assignment_changed' ||
+        value === 'discarded' ||
+        value === 'expired' ||
+        value === 'idempotency_conflict' ||
+        value === 'invalid_input' ||
+        value === 'invalid_status' ||
+        value === 'network_unavailable' ||
+        value === 'not_authorized' ||
+        value === 'not_found' ||
+        value === 'server_unavailable' ||
+        value === 'task_changed' ||
+        value === 'upload_failed'
+    );
+}
+
+function isServerState(
+    value: unknown,
+): value is OperationCompletionQueueServerState {
+    return value === 'completed' || value === 'pendingVerification';
+}
+
+function isQueueClaim(value: unknown): value is OperationCompletionQueueClaim {
+    return (
+        isObject(value) &&
+        typeof value.claimId === 'string' &&
+        value.claimId.length > 0 &&
+        isFiniteNumber(value.claimedAt) &&
+        isFiniteNumber(value.expiresAt)
+    );
+}
+
+function isQueueAttachment(
+    value: unknown,
+): value is OperationCompletionQueueAttachment {
+    return (
+        isObject(value) &&
+        value.blob instanceof Blob &&
+        typeof value.id === 'string' &&
+        value.id.length > 0 &&
+        isFiniteNumber(value.lastModified) &&
+        typeof value.name === 'string' &&
+        isFiniteNumber(value.size) &&
+        value.size === value.blob.size &&
+        typeof value.type === 'string' &&
+        (value.uploadedUrl === null || typeof value.uploadedUrl === 'string')
+    );
+}
+
+function hasValidQueueStateShape(value: Record<string, unknown>) {
+    if (!isQueueState(value.state)) {
+        return false;
+    }
+    if (value.state === 'syncing') {
+        return isQueueClaim(value.claim) && value.contentDiscardedAt === null;
+    }
+    if (value.claim !== null) {
+        return false;
+    }
+    if (value.contentDiscardedAt === null) {
+        return (
+            value.state !== 'server_confirmed' &&
+            value.failureCode !== 'discarded' &&
+            value.failureCode !== 'expired'
+        );
+    }
+    return (
+        Array.isArray(value.attachments) &&
+        value.attachments.length === 0 &&
+        value.notes === '' &&
+        value.operationLabel === '' &&
+        value.scheduleDateKey === null &&
+        (value.state === 'server_confirmed' ||
+            value.failureCode === 'discarded' ||
+            value.failureCode === 'expired')
+    );
+}
+
+export function isOperationCompletionQueueItem(
+    value: unknown,
+): value is OperationCompletionQueueItem {
+    if (!isObject(value)) {
+        return false;
+    }
+
+    return (
+        value.schemaVersion === OPERATION_COMPLETION_QUEUE_SCHEMA_VERSION &&
+        hasValidQueueStateShape(value) &&
+        typeof value.accountId === 'string' &&
+        Array.isArray(value.attachments) &&
+        value.attachments.every(isQueueAttachment) &&
+        isFiniteNumber(value.attemptCount) &&
+        Number.isSafeInteger(value.attemptCount) &&
+        value.attemptCount >= 0 &&
+        (value.claim === null || isQueueClaim(value.claim)) &&
+        isNullableFiniteNumber(value.contentDiscardedAt) &&
+        isFiniteNumber(value.createdAt) &&
+        isFiniteNumber(value.expectedEntityId) &&
+        isFiniteNumber(value.expectedTaskVersionEventId) &&
+        isFiniteNumber(value.expiresAt) &&
+        (value.failureCode === null || isQueueFailureCode(value.failureCode)) &&
+        typeof value.key === 'string' &&
+        isNullableFiniteNumber(value.nextAttemptAt) &&
+        typeof value.notes === 'string' &&
+        isFiniteNumber(value.operationId) &&
+        typeof value.operationLabel === 'string' &&
+        typeof value.requirementsFingerprint === 'string' &&
+        typeof value.revisionId === 'string' &&
+        (value.scheduleDateKey === null ||
+            typeof value.scheduleDateKey === 'string') &&
+        isNullableFiniteNumber(value.serverConfirmedAt) &&
+        (value.serverState === null || isServerState(value.serverState)) &&
+        isQueueState(value.state) &&
+        typeof value.submissionId === 'string' &&
+        isFiniteNumber(value.updatedAt) &&
+        typeof value.userId === 'string' &&
+        typeof value.writerGeneration === 'string'
+    );
+}
+
+function compatibleQueueItem(
+    item: OperationCompletionQueueItem,
+    scope: OperationCompletionDraftScope,
+) {
+    return (
+        item.userId === scope.userId &&
+        item.accountId === scope.accountId &&
+        item.operationId === scope.operationId &&
+        item.expectedEntityId === scope.expectedEntityId &&
+        item.expectedTaskVersionEventId === scope.expectedTaskVersionEventId &&
+        item.requirementsFingerprint === scope.requirementsFingerprint
+    );
+}
+
+function queueByteSize(item: OperationCompletionQueueItem) {
+    const notesBytes = new TextEncoder().encode(item.notes).byteLength;
+    return item.attachments.reduce(
+        (bytes, attachment) => bytes + attachment.blob.size,
+        notesBytes,
+    );
+}
+
+export function summarizeOperationCompletionQueueItem(
+    item: OperationCompletionQueueItem,
+) {
+    return {
+        accountId: item.accountId,
+        attachmentCount: item.attachments.length,
+        attemptCount: item.attemptCount,
+        contentAvailable: item.contentDiscardedAt === null,
+        createdAt: item.createdAt,
+        expectedEntityId: item.expectedEntityId,
+        expectedTaskVersionEventId: item.expectedTaskVersionEventId,
+        expiresAt: item.expiresAt,
+        failureCode: item.failureCode,
+        key: item.key,
+        nextAttemptAt: item.nextAttemptAt,
+        operationId: item.operationId,
+        operationLabel: item.operationLabel,
+        requirementsFingerprint: item.requirementsFingerprint,
+        scheduleDateKey: item.scheduleDateKey,
+        serverConfirmedAt: item.serverConfirmedAt,
+        serverState: item.serverState,
+        state: item.state,
+        submissionId: item.submissionId,
+        updatedAt: item.updatedAt,
+        userId: item.userId,
+    } satisfies OperationCompletionQueueSummary;
+}
+
+function newId() {
+    return globalThis.crypto.randomUUID();
+}
+
+function isQuotaExceeded(error: unknown) {
+    return error instanceof DOMException && error.name === 'QuotaExceededError';
+}
+
+function normalizedOperationLabel(value: string) {
+    const label = value.trim();
+    return label.length > 0 &&
+        label.length <= OPERATION_COMPLETION_QUEUE_MAX_LABEL_LENGTH
+        ? label
+        : null;
+}
+
+function normalizedScheduleDateKey(value: string | undefined) {
+    if (value === undefined) {
+        return null;
+    }
+    return /^\d{4}-\d{2}-\d{2}$/u.test(value) ? value : null;
+}
+
+function normalizedUploadedUrl(value: string) {
+    if (
+        value.length === 0 ||
+        value.length > OPERATION_COMPLETION_QUEUE_MAX_URL_LENGTH
+    ) {
+        return null;
+    }
+    try {
+        const url = new URL(value);
+        return url.protocol === 'https:' ? url.toString() : null;
+    } catch {
+        return null;
+    }
+}
+
+function hasValidAttachmentIds(photos: OperationCompletionDraftPhotoInput[]) {
+    const ids = new Set<string>();
+    for (const photo of photos) {
+        if (!photo.id || ids.has(photo.id)) {
+            return false;
+        }
+        ids.add(photo.id);
+    }
+    return true;
+}
+
+function queueItemMatchesHandoff(
+    item: OperationCompletionQueueItem,
+    {
+        notes,
+        operationLabel,
+        photos,
+        scheduleDateKey,
+    }: {
+        notes: string;
+        operationLabel: string;
+        photos: OperationCompletionDraftPhotoInput[];
+        scheduleDateKey: string | null;
+    },
+) {
+    return (
+        item.contentDiscardedAt === null &&
+        item.notes === notes &&
+        item.operationLabel === operationLabel &&
+        item.scheduleDateKey === scheduleDateKey &&
+        item.attachments.length === photos.length &&
+        item.attachments.every((attachment, index) => {
+            const photo = photos[index];
+            return (
+                photo !== undefined &&
+                attachment.id === photo.id &&
+                attachment.name === photo.file.name &&
+                attachment.type === photo.file.type &&
+                attachment.size === photo.file.size &&
+                attachment.lastModified === photo.file.lastModified
+            );
+        })
+    );
+}
+
+function scrubbedQueueItem(
+    item: OperationCompletionQueueItem,
+    now: number,
+    failureCode: 'discarded' | 'expired',
+): OperationCompletionQueueItem {
+    return {
+        ...item,
+        attachments: [],
+        claim: null,
+        contentDiscardedAt: now,
+        expiresAt: now + OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+        failureCode,
+        nextAttemptAt: null,
+        notes: '',
+        operationLabel: '',
+        revisionId: newId(),
+        scheduleDateKey: null,
+        serverConfirmedAt: null,
+        serverState: null,
+        state: 'failed',
+        updatedAt: now,
+    };
+}
+
+function isHiddenTombstone(item: OperationCompletionQueueItem) {
+    return item.contentDiscardedAt !== null && item.failureCode === 'discarded';
+}
+
+function isQueueChangeMessage(value: unknown): value is QueueChangeMessage {
+    return (
+        isObject(value) &&
+        value.kind === 'changed' &&
+        typeof value.accountId === 'string' &&
+        typeof value.userId === 'string'
+    );
+}
+
+export function notifyOperationCompletionQueueChanged(
+    userId: string,
+    accountId: string,
+) {
+    if (typeof window === 'undefined') {
+        return;
+    }
+    const message = {
+        accountId,
+        kind: 'changed',
+        userId,
+    } satisfies QueueChangeMessage;
+    window.dispatchEvent(
+        new CustomEvent(OPERATION_COMPLETION_QUEUE_CHANGE_EVENT, {
+            detail: message,
+        }),
+    );
+    if (!('BroadcastChannel' in window)) {
+        return;
+    }
+    try {
+        const channel = new BroadcastChannel(
+            OPERATION_COMPLETION_QUEUE_CHANGE_EVENT,
+        );
+        channel.postMessage(message);
+        channel.close();
+    } catch {
+        // IndexedDB remains authoritative when cross-tab messaging is absent.
+    }
+}
+
+export function subscribeToOperationCompletionQueueChanges(
+    userId: string,
+    accountId: string,
+    listener: () => void,
+) {
+    if (typeof window === 'undefined') {
+        return () => undefined;
+    }
+    const handleWindowEvent = (event: Event) => {
+        if (
+            event instanceof CustomEvent &&
+            isQueueChangeMessage(event.detail) &&
+            event.detail.userId === userId &&
+            event.detail.accountId === accountId
+        ) {
+            listener();
+        }
+    };
+    const handleChannelMessage = (event: MessageEvent<unknown>) => {
+        if (
+            isQueueChangeMessage(event.data) &&
+            event.data.userId === userId &&
+            event.data.accountId === accountId
+        ) {
+            listener();
+        }
+    };
+    window.addEventListener(
+        OPERATION_COMPLETION_QUEUE_CHANGE_EVENT,
+        handleWindowEvent,
+    );
+    let channel: BroadcastChannel | null = null;
+    if ('BroadcastChannel' in window) {
+        try {
+            channel = new BroadcastChannel(
+                OPERATION_COMPLETION_QUEUE_CHANGE_EVENT,
+            );
+            channel.addEventListener('message', handleChannelMessage);
+        } catch {
+            channel = null;
+        }
+    }
+    return () => {
+        window.removeEventListener(
+            OPERATION_COMPLETION_QUEUE_CHANGE_EVENT,
+            handleWindowEvent,
+        );
+        channel?.removeEventListener('message', handleChannelMessage);
+        channel?.close();
+    };
+}
+
+export async function handoffOperationCompletionDraftToQueue(
+    {
+        notes,
+        operationLabel: rawOperationLabel,
+        photos,
+        scheduleDateKey: rawScheduleDateKey,
+        ...scope
+    }: OperationCompletionQueueHandoffInput,
+    {
+        expectedDraftRevisionId,
+        lease,
+    }: {
+        expectedDraftRevisionId?: string | null;
+        lease: OperationCompletionDraftLease;
+    },
+): Promise<HandoffOperationCompletionDraftToQueueResult> {
+    const operationLabel = normalizedOperationLabel(rawOperationLabel);
+    const scheduleDateKey = normalizedScheduleDateKey(rawScheduleDateKey);
+    if (lease.userId !== scope.userId) {
+        return { reason: 'session_changed', status: 'error' };
+    }
+    if (
+        !operationLabel ||
+        !hasValidAttachmentIds(photos) ||
+        (rawScheduleDateKey !== undefined && !scheduleDateKey)
+    ) {
+        return { reason: 'invalid_input', status: 'error' };
+    }
+    try {
+        const result = await withOperationCompletionOfflineStores(
+            'readwrite',
+            async ({ drafts, queue }) => {
+                if (
+                    !(await operationCompletionDraftLeaseMatches(drafts, lease))
+                ) {
+                    return {
+                        reason: 'session_changed',
+                        status: 'error',
+                    } satisfies HandoffOperationCompletionDraftToQueueResult;
+                }
+                const now = Date.now();
+                const key = operationCompletionQueueRecordKey(scope);
+                const queuedValue: unknown =
+                    await requestOperationCompletionStoreResult(queue.get(key));
+                if (isOperationCompletionQueueItem(queuedValue)) {
+                    if (queuedValue.expiresAt <= now) {
+                        if (queuedValue.contentDiscardedAt !== null) {
+                            await requestOperationCompletionStoreResult(
+                                queue.delete(key),
+                            );
+                        } else {
+                            const expiredItem = scrubbedQueueItem(
+                                queuedValue,
+                                now,
+                                'expired',
+                            );
+                            await requestOperationCompletionStoreResult(
+                                queue.put(expiredItem),
+                            );
+                            return {
+                                item: summarizeOperationCompletionQueueItem(
+                                    expiredItem,
+                                ),
+                                status: 'existing',
+                            } satisfies HandoffOperationCompletionDraftToQueueResult;
+                        }
+                    } else if (!compatibleQueueItem(queuedValue, scope)) {
+                        return {
+                            reason: 'incompatible',
+                            status: 'error',
+                        } satisfies HandoffOperationCompletionDraftToQueueResult;
+                    } else if (queuedValue.state === 'server_confirmed') {
+                        return {
+                            reason: 'server_confirmed',
+                            status: 'error',
+                        } satisfies HandoffOperationCompletionDraftToQueueResult;
+                    } else if (
+                        !isHiddenTombstone(queuedValue) &&
+                        queueItemMatchesHandoff(queuedValue, {
+                            notes,
+                            operationLabel,
+                            photos,
+                            scheduleDateKey,
+                        })
+                    ) {
+                        return {
+                            item: summarizeOperationCompletionQueueItem(
+                                queuedValue,
+                            ),
+                            status: 'existing',
+                        } satisfies HandoffOperationCompletionDraftToQueueResult;
+                    } else {
+                        return {
+                            reason: 'queue_conflict',
+                            status: 'error',
+                        } satisfies HandoffOperationCompletionDraftToQueueResult;
+                    }
+                } else if (queuedValue !== undefined) {
+                    await requestOperationCompletionStoreResult(
+                        queue.delete(key),
+                    );
+                }
+
+                const draftKey = operationCompletionDraftRecordKey(scope);
+                const draftValue: unknown =
+                    await requestOperationCompletionStoreResult(
+                        drafts.get(draftKey),
+                    );
+                let draft = isOperationCompletionDraftRecord(draftValue)
+                    ? draftValue
+                    : null;
+                if (draftValue !== undefined && !draft) {
+                    if (expectedDraftRevisionId !== undefined) {
+                        return {
+                            reason: 'draft_changed',
+                            status: 'error',
+                        } satisfies HandoffOperationCompletionDraftToQueueResult;
+                    }
+                    await requestOperationCompletionStoreResult(
+                        drafts.delete(draftKey),
+                    );
+                }
+                if (draft && draft.expiresAt <= now) {
+                    await requestOperationCompletionStoreResult(
+                        drafts.delete(draftKey),
+                    );
+                    draft = null;
+                }
+                if (draft) {
+                    if (
+                        draft.writerGeneration !== lease.generation ||
+                        !isCompatibleOperationCompletionDraft(draft, scope)
+                    ) {
+                        return {
+                            reason: 'incompatible',
+                            status: 'error',
+                        } satisfies HandoffOperationCompletionDraftToQueueResult;
+                    }
+                    if (draft.serverConfirmedAt !== null) {
+                        return {
+                            reason: 'server_confirmed',
+                            status: 'error',
+                        } satisfies HandoffOperationCompletionDraftToQueueResult;
+                    }
+                }
+                if (
+                    expectedDraftRevisionId !== undefined &&
+                    (draft?.revisionId ?? null) !== expectedDraftRevisionId
+                ) {
+                    return {
+                        reason: 'draft_changed',
+                        status: 'error',
+                    } satisfies HandoffOperationCompletionDraftToQueueResult;
+                }
+
+                const draftValues: unknown[] =
+                    await requestOperationCompletionStoreResult(
+                        drafts.getAll(),
+                    );
+                const queueValues: unknown[] =
+                    await requestOperationCompletionStoreResult(queue.getAll());
+                let ownerCount = 0;
+                let ownerBytes = 0;
+                for (const value of draftValues) {
+                    if (
+                        !isOperationCompletionDraftRecord(value) ||
+                        value.userId !== scope.userId ||
+                        value.accountId !== scope.accountId ||
+                        value.key === draftKey ||
+                        value.serverConfirmedAt !== null
+                    ) {
+                        continue;
+                    }
+                    if (value.expiresAt <= now) {
+                        drafts.delete(value.key);
+                        continue;
+                    }
+                    ownerCount += 1;
+                    ownerBytes += operationCompletionDraftByteSize(value);
+                }
+                for (const value of queueValues) {
+                    if (
+                        !isOperationCompletionQueueItem(value) ||
+                        value.userId !== scope.userId ||
+                        value.accountId !== scope.accountId ||
+                        value.key === key ||
+                        value.contentDiscardedAt !== null
+                    ) {
+                        continue;
+                    }
+                    if (value.expiresAt <= now) {
+                        await requestOperationCompletionStoreResult(
+                            queue.put(scrubbedQueueItem(value, now, 'expired')),
+                        );
+                        continue;
+                    }
+                    ownerCount += 1;
+                    ownerBytes += queueByteSize(value);
+                }
+                if (ownerCount >= OPERATION_COMPLETION_DRAFT_MAX_COUNT) {
+                    return {
+                        reason: 'draft_count_limit',
+                        status: 'error',
+                    } satisfies HandoffOperationCompletionDraftToQueueResult;
+                }
+
+                const item: OperationCompletionQueueItem = {
+                    ...scope,
+                    attachments: photos.map(({ file, id }) => ({
+                        blob: file,
+                        id,
+                        lastModified: file.lastModified,
+                        name: file.name,
+                        size: file.size,
+                        type: file.type,
+                        uploadedUrl: null,
+                    })),
+                    attemptCount: 0,
+                    claim: null,
+                    contentDiscardedAt: null,
+                    createdAt: draft?.createdAt ?? now,
+                    expiresAt: now + OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+                    failureCode: null,
+                    key,
+                    nextAttemptAt: now,
+                    notes,
+                    operationLabel,
+                    revisionId: newId(),
+                    scheduleDateKey,
+                    schemaVersion: OPERATION_COMPLETION_QUEUE_SCHEMA_VERSION,
+                    serverConfirmedAt: null,
+                    serverState: null,
+                    state: 'queued',
+                    submissionId: newId(),
+                    updatedAt: now,
+                    writerGeneration: lease.generation,
+                };
+                if (
+                    ownerBytes + queueByteSize(item) >
+                    OPERATION_COMPLETION_DRAFT_MAX_BYTES
+                ) {
+                    return {
+                        reason: 'draft_size_limit',
+                        status: 'error',
+                    } satisfies HandoffOperationCompletionDraftToQueueResult;
+                }
+                await requestOperationCompletionStoreResult(queue.put(item));
+                if (draftValue !== undefined) {
+                    await requestOperationCompletionStoreResult(
+                        drafts.delete(draftKey),
+                    );
+                }
+                return {
+                    item: summarizeOperationCompletionQueueItem(item),
+                    status: 'enqueued',
+                } satisfies HandoffOperationCompletionDraftToQueueResult;
+            },
+        );
+        if (result.status === 'enqueued' || result.status === 'existing') {
+            notifyOperationCompletionQueueChanged(
+                scope.userId,
+                scope.accountId,
+            );
+        }
+        return result;
+    } catch (error) {
+        return {
+            reason: isQuotaExceeded(error)
+                ? 'quota_exceeded'
+                : 'storage_unavailable',
+            status: 'error',
+        };
+    }
+}
+
+export async function loadOperationCompletionQueueItem(
+    scope: OperationCompletionDraftScope,
+    lease: OperationCompletionDraftLease,
+): Promise<LoadOperationCompletionQueueItemResult> {
+    if (lease.userId !== scope.userId) {
+        return { status: 'session_changed' };
+    }
+    let changed = false;
+    try {
+        const result = await withOperationCompletionOfflineStores(
+            'readwrite',
+            async ({ drafts, queue }) => {
+                if (
+                    !(await operationCompletionDraftLeaseMatches(drafts, lease))
+                ) {
+                    return { status: 'session_changed' } as const;
+                }
+                const key = operationCompletionQueueRecordKey(scope);
+                const value: unknown =
+                    await requestOperationCompletionStoreResult(queue.get(key));
+                if (value === undefined) {
+                    return { status: 'missing' } as const;
+                }
+                if (!isOperationCompletionQueueItem(value)) {
+                    await requestOperationCompletionStoreResult(
+                        queue.delete(key),
+                    );
+                    changed = true;
+                    return { status: 'missing' } as const;
+                }
+                if (value.writerGeneration !== lease.generation) {
+                    await requestOperationCompletionStoreResult(
+                        queue.delete(key),
+                    );
+                    changed = true;
+                    return { status: 'missing' } as const;
+                }
+                const now = Date.now();
+                if (value.expiresAt <= now) {
+                    if (value.contentDiscardedAt !== null) {
+                        await requestOperationCompletionStoreResult(
+                            queue.delete(key),
+                        );
+                        changed = true;
+                        return { status: 'missing' } as const;
+                    }
+                    const expiredItem = scrubbedQueueItem(
+                        value,
+                        now,
+                        'expired',
+                    );
+                    await requestOperationCompletionStoreResult(
+                        queue.put(expiredItem),
+                    );
+                    changed = true;
+                    return { item: expiredItem, status: 'expired' } as const;
+                }
+                if (!compatibleQueueItem(value, scope)) {
+                    return { status: 'missing' } as const;
+                }
+                return { item: value, status: 'found' } as const;
+            },
+        );
+        if (changed) {
+            notifyOperationCompletionQueueChanged(
+                scope.userId,
+                scope.accountId,
+            );
+        }
+        return result;
+    } catch {
+        return { status: 'unavailable' };
+    }
+}
+
+export async function listOperationCompletionQueueItems(
+    owner: { accountId: string; userId: string },
+    lease: OperationCompletionDraftLease,
+): Promise<ListOperationCompletionQueueItemsResult> {
+    if (lease.userId !== owner.userId) {
+        return { status: 'session_changed' };
+    }
+    let changed = false;
+    try {
+        const result = await withOperationCompletionOfflineStores(
+            'readwrite',
+            async ({ drafts, queue }) => {
+                if (
+                    !(await operationCompletionDraftLeaseMatches(drafts, lease))
+                ) {
+                    return { status: 'session_changed' } as const;
+                }
+                const now = Date.now();
+                const values: unknown[] =
+                    await requestOperationCompletionStoreResult(queue.getAll());
+                const items: OperationCompletionQueueSummary[] = [];
+                for (const value of values) {
+                    if (!isOperationCompletionQueueItem(value)) {
+                        if (isObject(value) && typeof value.key === 'string') {
+                            queue.delete(value.key);
+                            changed = true;
+                        }
+                        continue;
+                    }
+                    if (
+                        value.userId !== owner.userId ||
+                        value.accountId !== owner.accountId
+                    ) {
+                        continue;
+                    }
+                    if (value.writerGeneration !== lease.generation) {
+                        queue.delete(value.key);
+                        changed = true;
+                        continue;
+                    }
+                    if (value.expiresAt <= now) {
+                        if (value.contentDiscardedAt !== null) {
+                            queue.delete(value.key);
+                        } else {
+                            queue.put(scrubbedQueueItem(value, now, 'expired'));
+                        }
+                        changed = true;
+                        continue;
+                    }
+                    if (!isHiddenTombstone(value)) {
+                        items.push(
+                            summarizeOperationCompletionQueueItem(value),
+                        );
+                    }
+                }
+                items.sort((left, right) => left.createdAt - right.createdAt);
+                return { items, status: 'ok' } as const;
+            },
+        );
+        if (changed) {
+            notifyOperationCompletionQueueChanged(
+                owner.userId,
+                owner.accountId,
+            );
+        }
+        return result;
+    } catch {
+        return { status: 'unavailable' };
+    }
+}
+
+export async function claimNextOperationCompletionQueueItem(
+    owner: { accountId: string; userId: string },
+    {
+        claimId,
+        lease,
+    }: {
+        claimId: string;
+        lease: OperationCompletionDraftLease;
+    },
+): Promise<ClaimNextOperationCompletionQueueItemResult> {
+    if (lease.userId !== owner.userId) {
+        return { status: 'session_changed' };
+    }
+    if (!claimId) {
+        return { status: 'unavailable' };
+    }
+    let changed = false;
+    try {
+        const result = await withOperationCompletionOfflineStores(
+            'readwrite',
+            async ({ drafts, queue }) => {
+                if (
+                    !(await operationCompletionDraftLeaseMatches(drafts, lease))
+                ) {
+                    return { status: 'session_changed' } as const;
+                }
+                const now = Date.now();
+                const values: unknown[] =
+                    await requestOperationCompletionStoreResult(queue.getAll());
+                const candidates: OperationCompletionQueueItem[] = [];
+                for (const value of values) {
+                    if (
+                        !isOperationCompletionQueueItem(value) ||
+                        value.userId !== owner.userId ||
+                        value.accountId !== owner.accountId
+                    ) {
+                        continue;
+                    }
+                    if (value.writerGeneration !== lease.generation) {
+                        queue.delete(value.key);
+                        changed = true;
+                        continue;
+                    }
+                    if (value.expiresAt <= now) {
+                        if (value.contentDiscardedAt !== null) {
+                            queue.delete(value.key);
+                        } else {
+                            queue.put(scrubbedQueueItem(value, now, 'expired'));
+                        }
+                        changed = true;
+                        continue;
+                    }
+                    let candidate = value;
+                    if (
+                        candidate.state === 'syncing' &&
+                        candidate.claim &&
+                        candidate.claim.expiresAt <= now
+                    ) {
+                        candidate = {
+                            ...candidate,
+                            claim: null,
+                            nextAttemptAt: now,
+                            revisionId: newId(),
+                            state: 'queued',
+                            updatedAt: now,
+                        };
+                        await requestOperationCompletionStoreResult(
+                            queue.put(candidate),
+                        );
+                        changed = true;
+                    }
+                    if (
+                        candidate.state === 'queued' &&
+                        candidate.contentDiscardedAt === null &&
+                        (candidate.nextAttemptAt === null ||
+                            candidate.nextAttemptAt <= now)
+                    ) {
+                        candidates.push(candidate);
+                    }
+                }
+                candidates.sort(
+                    (left, right) => left.createdAt - right.createdAt,
+                );
+                const candidate = candidates[0];
+                if (!candidate) {
+                    return { status: 'empty' } as const;
+                }
+                const claimed: OperationCompletionQueueItem = {
+                    ...candidate,
+                    attemptCount: candidate.attemptCount + 1,
+                    claim: {
+                        claimId,
+                        claimedAt: now,
+                        expiresAt:
+                            now + OPERATION_COMPLETION_QUEUE_CLAIM_MAX_AGE_MS,
+                    },
+                    failureCode: null,
+                    nextAttemptAt: null,
+                    revisionId: newId(),
+                    state: 'syncing',
+                    updatedAt: now,
+                };
+                await requestOperationCompletionStoreResult(queue.put(claimed));
+                changed = true;
+                return { item: claimed, status: 'claimed' } as const;
+            },
+        );
+        if (changed) {
+            notifyOperationCompletionQueueChanged(
+                owner.userId,
+                owner.accountId,
+            );
+        }
+        return result;
+    } catch {
+        return { status: 'unavailable' };
+    }
+}
+
+async function mutateQueueItem(
+    target: OperationCompletionQueueMutationTarget,
+    lease: OperationCompletionDraftLease,
+    mutation: (
+        item: OperationCompletionQueueItem,
+    ) => OperationCompletionQueueItem | null | 'conflict',
+): Promise<OperationCompletionQueueMutationResult> {
+    try {
+        const result = await withOperationCompletionOfflineStores(
+            'readwrite',
+            async ({ drafts, queue }) => {
+                if (
+                    !(await operationCompletionDraftLeaseMatches(drafts, lease))
+                ) {
+                    return { status: 'session_changed' } as const;
+                }
+                const value: unknown =
+                    await requestOperationCompletionStoreResult(
+                        queue.get(target.key),
+                    );
+                if (
+                    !isOperationCompletionQueueItem(value) ||
+                    value.submissionId !== target.submissionId ||
+                    value.userId !== lease.userId ||
+                    value.writerGeneration !== lease.generation
+                ) {
+                    return { status: 'conflict' } as const;
+                }
+                const next = mutation(value);
+                if (next === 'conflict') {
+                    return { status: 'conflict' } as const;
+                }
+                if (next === null) {
+                    await requestOperationCompletionStoreResult(
+                        queue.delete(target.key),
+                    );
+                } else {
+                    await requestOperationCompletionStoreResult(
+                        queue.put(next),
+                    );
+                }
+                return {
+                    accountId: value.accountId,
+                    status: 'ok',
+                    userId: value.userId,
+                } as const;
+            },
+        );
+        if (result.status === 'ok') {
+            notifyOperationCompletionQueueChanged(
+                result.userId,
+                result.accountId,
+            );
+            return { status: 'ok' };
+        }
+        return result;
+    } catch {
+        return { status: 'unavailable' };
+    }
+}
+
+export async function markOperationCompletionQueueAttachmentUploaded(
+    target: OperationCompletionQueueMutationTarget & {
+        attachmentId: string;
+        claimId: string;
+        uploadedUrl: string;
+    },
+    lease: OperationCompletionDraftLease,
+) {
+    const uploadedUrl = normalizedUploadedUrl(target.uploadedUrl);
+    if (!uploadedUrl) {
+        return {
+            status: 'conflict',
+        } satisfies OperationCompletionQueueMutationResult;
+    }
+    return mutateQueueItem(target, lease, (item) => {
+        if (
+            item.state !== 'syncing' ||
+            item.claim?.claimId !== target.claimId
+        ) {
+            return 'conflict';
+        }
+        const attachmentIndex = item.attachments.findIndex(
+            (attachment) => attachment.id === target.attachmentId,
+        );
+        if (attachmentIndex < 0) {
+            return 'conflict';
+        }
+        const attachments = item.attachments.map((attachment, index) =>
+            index === attachmentIndex
+                ? { ...attachment, uploadedUrl }
+                : attachment,
+        );
+        return {
+            ...item,
+            attachments,
+            revisionId: newId(),
+            updatedAt: Date.now(),
+        };
+    });
+}
+
+export async function clearOperationCompletionQueueAttachmentUploads(
+    target: OperationCompletionQueueMutationTarget & {
+        claimId: string;
+        uploadedUrls: string[];
+    },
+    lease: OperationCompletionDraftLease,
+) {
+    const uploadedUrls = new Set(
+        target.uploadedUrls
+            .map(normalizedUploadedUrl)
+            .filter((value): value is string => value !== null),
+    );
+    if (
+        uploadedUrls.size === 0 ||
+        uploadedUrls.size !== target.uploadedUrls.length
+    ) {
+        return {
+            status: 'conflict',
+        } satisfies OperationCompletionQueueMutationResult;
+    }
+    return mutateQueueItem(target, lease, (item) => {
+        if (
+            item.state !== 'syncing' ||
+            item.claim?.claimId !== target.claimId
+        ) {
+            return 'conflict';
+        }
+        const matchedUrls = new Set<string>();
+        const attachments = item.attachments.map((attachment) => {
+            if (
+                attachment.uploadedUrl &&
+                uploadedUrls.has(attachment.uploadedUrl)
+            ) {
+                matchedUrls.add(attachment.uploadedUrl);
+                return { ...attachment, uploadedUrl: null };
+            }
+            return attachment;
+        });
+        if (matchedUrls.size !== uploadedUrls.size) {
+            return 'conflict';
+        }
+        return {
+            ...item,
+            attachments,
+            revisionId: newId(),
+            updatedAt: Date.now(),
+        };
+    });
+}
+
+export async function renewOperationCompletionQueueClaim(
+    target: OperationCompletionQueueMutationTarget & {
+        claimId: string;
+    },
+    lease: OperationCompletionDraftLease,
+) {
+    return mutateQueueItem(target, lease, (item) => {
+        const now = Date.now();
+        if (
+            item.state !== 'syncing' ||
+            item.claim?.claimId !== target.claimId ||
+            item.claim.expiresAt <= now
+        ) {
+            return 'conflict';
+        }
+        return {
+            ...item,
+            claim: {
+                ...item.claim,
+                expiresAt: now + OPERATION_COMPLETION_QUEUE_CLAIM_MAX_AGE_MS,
+            },
+            revisionId: newId(),
+            updatedAt: now,
+        };
+    });
+}
+
+export async function releaseOperationCompletionQueueClaimForRetry(
+    target: OperationCompletionQueueMutationTarget & {
+        claimId: string;
+        failureCode: Exclude<
+            OperationCompletionQueueFailureCode,
+            'discarded' | 'expired'
+        >;
+        nextAttemptAt: number;
+    },
+    lease: OperationCompletionDraftLease,
+) {
+    return mutateQueueItem(target, lease, (item) => {
+        if (
+            item.state !== 'syncing' ||
+            item.claim?.claimId !== target.claimId ||
+            !isQueueFailureCode(target.failureCode) ||
+            !Number.isFinite(target.nextAttemptAt)
+        ) {
+            return 'conflict';
+        }
+        return {
+            ...item,
+            claim: null,
+            failureCode: target.failureCode,
+            nextAttemptAt: target.nextAttemptAt,
+            revisionId: newId(),
+            state: 'queued',
+            updatedAt: Date.now(),
+        };
+    });
+}
+
+export async function markOperationCompletionQueueFailed(
+    target: OperationCompletionQueueMutationTarget & {
+        claimId: string;
+        failureCode: Exclude<
+            OperationCompletionQueueFailureCode,
+            'discarded' | 'expired'
+        >;
+    },
+    lease: OperationCompletionDraftLease,
+) {
+    return mutateQueueItem(target, lease, (item) => {
+        if (
+            item.state !== 'syncing' ||
+            item.claim?.claimId !== target.claimId ||
+            !isQueueFailureCode(target.failureCode)
+        ) {
+            return 'conflict';
+        }
+        return {
+            ...item,
+            claim: null,
+            failureCode: target.failureCode,
+            nextAttemptAt: null,
+            revisionId: newId(),
+            state: 'failed',
+            updatedAt: Date.now(),
+        };
+    });
+}
+
+export async function retryOperationCompletionQueueItem(
+    target: OperationCompletionQueueMutationTarget,
+    lease: OperationCompletionDraftLease,
+) {
+    return mutateQueueItem(target, lease, (item) => {
+        if (
+            item.contentDiscardedAt !== null ||
+            (item.state !== 'failed' &&
+                !(item.state === 'queued' && item.failureCode !== null))
+        ) {
+            return 'conflict';
+        }
+        const now = Date.now();
+        return {
+            ...item,
+            attemptCount: 0,
+            failureCode: null,
+            nextAttemptAt: now,
+            revisionId: newId(),
+            state: 'queued',
+            updatedAt: now,
+        };
+    });
+}
+
+export async function markOperationCompletionQueueServerConfirmed(
+    target: OperationCompletionQueueMutationTarget & {
+        claimId: string;
+        serverState?: OperationCompletionQueueServerState;
+    },
+    lease: OperationCompletionDraftLease,
+) {
+    return mutateQueueItem(target, lease, (item) => {
+        if (
+            item.state !== 'syncing' ||
+            item.claim?.claimId !== target.claimId
+        ) {
+            return 'conflict';
+        }
+        if (target.serverState && !isServerState(target.serverState)) {
+            return 'conflict';
+        }
+        const now = Date.now();
+        return {
+            ...item,
+            attachments: [],
+            claim: null,
+            contentDiscardedAt: now,
+            expiresAt: now + OPERATION_COMPLETION_DRAFT_MAX_AGE_MS,
+            failureCode: null,
+            nextAttemptAt: null,
+            notes: '',
+            operationLabel: '',
+            revisionId: newId(),
+            scheduleDateKey: null,
+            serverConfirmedAt: now,
+            serverState: target.serverState ?? null,
+            state: 'server_confirmed',
+            updatedAt: now,
+        };
+    });
+}
+
+export async function discardOperationCompletionQueueItem(
+    target: OperationCompletionQueueMutationTarget,
+    lease: OperationCompletionDraftLease,
+) {
+    return mutateQueueItem(target, lease, (item) => {
+        if (item.state === 'syncing') {
+            return 'conflict';
+        }
+        return null;
+    });
+}

--- a/apps/farm/lib/offline/operationCompletionQueueSync.spec.tsx
+++ b/apps/farm/lib/offline/operationCompletionQueueSync.spec.tsx
@@ -1,0 +1,573 @@
+import { expect, test } from '@playwright/experimental-ct-react';
+import { OperationCompletionQueueSyncHarness } from '../../playwright/OperationCompletionQueueSyncHarness';
+
+const attachmentId = '11111111-1111-4111-8111-111111111111';
+const baseScope = {
+    accountId: 'account-sync',
+    expectedEntityId: 101,
+    expectedTaskVersionEventId: 201,
+    operationId: 301,
+    requirementsFingerprint: 'optional:optional',
+    userId: 'farmer-sync',
+};
+
+test.beforeEach(async ({ mount, page }) => {
+    await mount(<OperationCompletionQueueSyncHarness />);
+    await expect(page.getByTestId('operation-draft-store-ready')).toHaveText(
+        'ready',
+    );
+});
+
+test('recovers an existing photo without uploading and completes with the stable submission', async ({
+    page,
+}) => {
+    const recoveredUrl = 'https://blob.example/already-uploaded-photo.jpg';
+    const result = await page.evaluate(
+        async ({ photoId, recoveredImageUrl, scope }) => {
+            const store = window.__operationCompletionDraftStoreTestApi;
+            const sync = window.__operationCompletionQueueSyncTestApi;
+            if (!store || !sync) throw new Error('Test API is unavailable');
+            sync.configure({
+                recoveryPlans: [{ imageUrl: recoveredImageUrl, kind: 'found' }],
+            });
+
+            const leaseResult = await store.acquireLease(
+                scope.userId,
+                store.captureLogoutNonce(scope.userId),
+                'photo-recovery-session',
+            );
+            if (leaseResult.status !== 'ready') {
+                throw new Error('Expected a writer lease');
+            }
+            const handoff = await store.queue.handoff(
+                {
+                    ...scope,
+                    notes: 'Fotografija je već poslana',
+                    operationLabel: 'Berba',
+                    photos: [
+                        {
+                            file: new File(['existing photo'], 'berba.jpg', {
+                                lastModified: 1_725_000_000_000,
+                                type: 'image/jpeg',
+                            }),
+                            id: photoId,
+                        },
+                    ],
+                },
+                { lease: leaseResult.lease },
+            );
+            if (handoff.status !== 'enqueued') {
+                throw new Error('Expected an enqueued completion');
+            }
+            const claimed = await store.queue.claimNext(
+                { accountId: scope.accountId, userId: scope.userId },
+                {
+                    claimId: 'photo-recovery-claim',
+                    lease: leaseResult.lease,
+                },
+            );
+            if (claimed.status !== 'claimed') {
+                throw new Error('Expected a claimed completion');
+            }
+
+            const outcome = await sync.sync(claimed.item, leaseResult.lease);
+            const stored = await store.queue.load(scope, leaseResult.lease);
+            return {
+                calls: sync.getState(),
+                outcome,
+                stored,
+                submissionId: claimed.item.submissionId,
+            };
+        },
+        {
+            photoId: attachmentId,
+            recoveredImageUrl: recoveredUrl,
+            scope: baseScope,
+        },
+    );
+
+    expect(result.outcome).toEqual({
+        serverState: 'pendingVerification',
+        status: 'confirmed',
+    });
+    expect(result.calls.uploadCalls).toEqual([]);
+    expect(result.calls.recoveryCalls).toEqual([
+        {
+            attachmentId,
+            expectedEntityId: baseScope.expectedEntityId,
+            expectedRequirementsFingerprint: baseScope.requirementsFingerprint,
+            expectedTaskVersionEventId: baseScope.expectedTaskVersionEventId,
+            fileName: 'berba.jpg',
+            operationId: baseScope.operationId,
+            submissionId: result.submissionId,
+        },
+    ]);
+    expect(result.calls.completionCalls).toEqual([
+        {
+            expectedEntityId: baseScope.expectedEntityId,
+            expectedRequirementsFingerprint: baseScope.requirementsFingerprint,
+            expectedTaskVersionEventId: baseScope.expectedTaskVersionEventId,
+            imageUrls: [recoveredUrl],
+            notes: 'Fotografija je već poslana',
+            operationId: baseScope.operationId,
+            submissionId: result.submissionId,
+        },
+    ]);
+    expect(result.stored).toMatchObject({
+        item: {
+            attachments: [],
+            notes: '',
+            serverState: 'pendingVerification',
+            state: 'server_confirmed',
+            submissionId: result.submissionId,
+        },
+        status: 'found',
+    });
+});
+
+test('recovers an ambiguous upload at the deterministic path with stable identifiers and filename', async ({
+    page,
+}) => {
+    const recoveredUrl = 'https://blob.example/recovered-ambiguous-photo.jpg';
+    const result = await page.evaluate(
+        async ({ photoId, recoveredImageUrl, scope }) => {
+            const store = window.__operationCompletionDraftStoreTestApi;
+            const sync = window.__operationCompletionQueueSyncTestApi;
+            if (!store || !sync) throw new Error('Test API is unavailable');
+            sync.configure({
+                recoveryPlans: [
+                    { kind: 'missing' },
+                    { imageUrl: recoveredImageUrl, kind: 'found' },
+                ],
+                uploadPlans: [{ kind: 'throw' }],
+            });
+
+            const leaseResult = await store.acquireLease(
+                scope.userId,
+                store.captureLogoutNonce(scope.userId),
+                'ambiguous-upload-session',
+            );
+            if (leaseResult.status !== 'ready') {
+                throw new Error('Expected a writer lease');
+            }
+            const handoff = await store.queue.handoff(
+                {
+                    ...scope,
+                    notes: '  Fotografija nakon kiše  ',
+                    operationLabel: 'Pregled usjeva',
+                    photos: [
+                        {
+                            file: new File(
+                                ['ambiguous upload bytes'],
+                                'Pregled Nakon Kiše.JPG',
+                                {
+                                    lastModified: 1_725_000_123_456,
+                                    type: 'image/jpeg',
+                                },
+                            ),
+                            id: photoId,
+                        },
+                    ],
+                },
+                { lease: leaseResult.lease },
+            );
+            if (handoff.status !== 'enqueued') {
+                throw new Error('Expected an enqueued completion');
+            }
+            const claimed = await store.queue.claimNext(
+                { accountId: scope.accountId, userId: scope.userId },
+                {
+                    claimId: 'ambiguous-upload-claim',
+                    lease: leaseResult.lease,
+                },
+            );
+            if (claimed.status !== 'claimed') {
+                throw new Error('Expected a claimed completion');
+            }
+
+            const outcome = await sync.sync(claimed.item, leaseResult.lease);
+            return {
+                calls: sync.getState(),
+                outcome,
+                submissionId: claimed.item.submissionId,
+            };
+        },
+        {
+            photoId: attachmentId,
+            recoveredImageUrl: recoveredUrl,
+            scope: baseScope,
+        },
+    );
+
+    const expectedPath =
+        `operations/${baseScope.operationId}/entity-${baseScope.expectedEntityId}` +
+        `/version-${baseScope.expectedTaskVersionEventId}/submissions/` +
+        `${result.submissionId}/attachments/${attachmentId}.jpg`;
+    expect(result.outcome).toEqual({
+        serverState: 'pendingVerification',
+        status: 'confirmed',
+    });
+    expect(result.calls.recoveryCalls).toHaveLength(2);
+    expect(result.calls.recoveryCalls[0]).toEqual(
+        result.calls.recoveryCalls[1],
+    );
+    expect(result.calls.recoveryCalls[0]).toMatchObject({
+        attachmentId,
+        fileName: 'Pregled Nakon Kiše.JPG',
+        submissionId: result.submissionId,
+    });
+    expect(result.calls.uploadCalls).toEqual([
+        {
+            access: 'public',
+            clientPayload: expect.any(String),
+            file: {
+                lastModified: 1_725_000_123_456,
+                name: 'Pregled Nakon Kiše.JPG',
+                size: 22,
+                text: 'ambiguous upload bytes',
+                type: 'image/jpeg',
+            },
+            handleUploadUrl: '/api/operations/images/upload',
+            multipart: false,
+            pathname: expectedPath,
+        },
+    ]);
+    expect(
+        JSON.parse(result.calls.uploadCalls[0]?.clientPayload ?? '{}'),
+    ).toEqual({
+        attachmentId,
+        expectedEntityId: baseScope.expectedEntityId,
+        expectedRequirementsFingerprint: baseScope.requirementsFingerprint,
+        expectedTaskVersionEventId: baseScope.expectedTaskVersionEventId,
+        fileName: 'Pregled Nakon Kiše.JPG',
+        operationId: baseScope.operationId,
+        submissionId: result.submissionId,
+    });
+    expect(result.calls.completionCalls).toEqual([
+        {
+            expectedEntityId: baseScope.expectedEntityId,
+            expectedRequirementsFingerprint: baseScope.requirementsFingerprint,
+            expectedTaskVersionEventId: baseScope.expectedTaskVersionEventId,
+            imageUrls: [recoveredUrl],
+            notes: 'Fotografija nakon kiše',
+            operationId: baseScope.operationId,
+            submissionId: result.submissionId,
+        },
+    ]);
+});
+
+test('schedules a transient completion retry and reuses the same queue key and submission', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const store = window.__operationCompletionDraftStoreTestApi;
+        const sync = window.__operationCompletionQueueSyncTestApi;
+        if (!store || !sync) throw new Error('Test API is unavailable');
+        sync.configure({
+            completionPlans: [
+                { kind: 'throw' },
+                { kind: 'success', state: 'completed' },
+            ],
+        });
+
+        const leaseResult = await store.acquireLease(
+            scope.userId,
+            store.captureLogoutNonce(scope.userId),
+            'transient-retry-session',
+        );
+        if (leaseResult.status !== 'ready') {
+            throw new Error('Expected a writer lease');
+        }
+        const handoff = await store.queue.handoff(
+            {
+                ...scope,
+                notes: 'Ista napomena kroz pokušaje',
+                operationLabel: 'Zalijevanje',
+                photos: [],
+            },
+            { lease: leaseResult.lease },
+        );
+        if (handoff.status !== 'enqueued') {
+            throw new Error('Expected an enqueued completion');
+        }
+        const firstClaim = await store.queue.claimNext(
+            { accountId: scope.accountId, userId: scope.userId },
+            { claimId: 'first-retry-claim', lease: leaseResult.lease },
+        );
+        if (firstClaim.status !== 'claimed') {
+            throw new Error('Expected the first claim');
+        }
+        const firstOutcome = await sync.sync(
+            firstClaim.item,
+            leaseResult.lease,
+        );
+        const retryQueued = await store.queue.load(scope, leaseResult.lease);
+        if (retryQueued.status !== 'found') {
+            throw new Error('Expected a retryable queue item');
+        }
+        const retryResult = await store.queue.retry(
+            {
+                key: retryQueued.item.key,
+                submissionId: retryQueued.item.submissionId,
+            },
+            leaseResult.lease,
+        );
+        const secondClaim = await store.queue.claimNext(
+            { accountId: scope.accountId, userId: scope.userId },
+            { claimId: 'second-retry-claim', lease: leaseResult.lease },
+        );
+        if (secondClaim.status !== 'claimed') {
+            throw new Error('Expected the second claim');
+        }
+        const secondOutcome = await sync.sync(
+            secondClaim.item,
+            leaseResult.lease,
+        );
+        const confirmed = await store.queue.load(scope, leaseResult.lease);
+
+        return {
+            calls: sync.getState(),
+            confirmed,
+            first: {
+                key: firstClaim.item.key,
+                submissionId: firstClaim.item.submissionId,
+            },
+            firstOutcome,
+            retryQueued,
+            retryResult,
+            second: {
+                key: secondClaim.item.key,
+                submissionId: secondClaim.item.submissionId,
+            },
+            secondOutcome,
+        };
+    }, baseScope);
+
+    expect(result.firstOutcome).toEqual({
+        failureCode: 'server_unavailable',
+        status: 'retry_scheduled',
+    });
+    expect(result.retryQueued).toMatchObject({
+        item: {
+            claim: null,
+            failureCode: 'server_unavailable',
+            key: result.first.key,
+            nextAttemptAt: expect.any(Number),
+            state: 'queued',
+            submissionId: result.first.submissionId,
+        },
+        status: 'found',
+    });
+    expect(result.retryResult).toEqual({ status: 'ok' });
+    expect(result.second).toEqual(result.first);
+    expect(result.secondOutcome).toEqual({
+        serverState: 'completed',
+        status: 'confirmed',
+    });
+    expect(
+        result.calls.completionCalls.map(({ submissionId }) => submissionId),
+    ).toEqual([result.first.submissionId, result.first.submissionId]);
+    expect(result.confirmed).toMatchObject({
+        item: {
+            key: result.first.key,
+            serverState: 'completed',
+            state: 'server_confirmed',
+            submissionId: result.first.submissionId,
+        },
+        status: 'found',
+    });
+});
+
+test('clears a retryable missing Blob receipt and reuploads the same attachment path', async ({
+    page,
+}) => {
+    const retryUrl = 'https://blob.example/retry-missing-photo.jpg';
+    const result = await page.evaluate(
+        async ({ photoId, retryImageUrl, scope }) => {
+            const store = window.__operationCompletionDraftStoreTestApi;
+            const sync = window.__operationCompletionQueueSyncTestApi;
+            if (!store || !sync) throw new Error('Test API is unavailable');
+
+            const leaseResult = await store.acquireLease(
+                scope.userId,
+                store.captureLogoutNonce(scope.userId),
+                'missing-blob-retry-session',
+            );
+            if (leaseResult.status !== 'ready') {
+                throw new Error('Expected a writer lease');
+            }
+            const handoff = await store.queue.handoff(
+                {
+                    ...scope,
+                    notes: 'Ponovno pošalji fotografiju',
+                    operationLabel: 'Pregled navodnjavanja',
+                    photos: [
+                        {
+                            file: new File(
+                                ['retry photo bytes'],
+                                'navodnjavanje.jpg',
+                                { type: 'image/jpeg' },
+                            ),
+                            id: photoId,
+                        },
+                    ],
+                },
+                { lease: leaseResult.lease },
+            );
+            if (handoff.status !== 'enqueued') {
+                throw new Error('Expected an enqueued completion');
+            }
+            sync.configure({
+                completionPlans: [
+                    {
+                        canRetry: true,
+                        code: 'invalid_input',
+                        kind: 'failure',
+                        retryImageUrls: [retryImageUrl],
+                    },
+                    { kind: 'success', state: 'pendingVerification' },
+                ],
+                uploadPlans: [
+                    { kind: 'success', url: retryImageUrl },
+                    { kind: 'success', url: retryImageUrl },
+                ],
+            });
+            const firstClaim = await store.queue.claimNext(
+                { accountId: scope.accountId, userId: scope.userId },
+                { claimId: 'missing-blob-first', lease: leaseResult.lease },
+            );
+            if (firstClaim.status !== 'claimed') {
+                throw new Error('Expected the first claim');
+            }
+            const firstOutcome = await sync.sync(
+                firstClaim.item,
+                leaseResult.lease,
+            );
+            const retryQueued = await store.queue.load(
+                scope,
+                leaseResult.lease,
+            );
+            if (retryQueued.status !== 'found') {
+                throw new Error('Expected a retryable queue item');
+            }
+            const retryResult = await store.queue.retry(
+                {
+                    key: retryQueued.item.key,
+                    submissionId: retryQueued.item.submissionId,
+                },
+                leaseResult.lease,
+            );
+            const secondClaim = await store.queue.claimNext(
+                { accountId: scope.accountId, userId: scope.userId },
+                { claimId: 'missing-blob-second', lease: leaseResult.lease },
+            );
+            if (secondClaim.status !== 'claimed') {
+                throw new Error('Expected the second claim');
+            }
+            const secondOutcome = await sync.sync(
+                secondClaim.item,
+                leaseResult.lease,
+            );
+
+            return {
+                calls: sync.getState(),
+                firstOutcome,
+                retryResult,
+                retryUploadedUrl: retryQueued.item.attachments[0]?.uploadedUrl,
+                secondOutcome,
+                submissionId: firstClaim.item.submissionId,
+            };
+        },
+        { photoId: attachmentId, retryImageUrl: retryUrl, scope: baseScope },
+    );
+
+    expect(result.firstOutcome).toEqual({
+        failureCode: 'upload_failed',
+        status: 'retry_scheduled',
+    });
+    expect(result.retryUploadedUrl).toBeNull();
+    expect(result.retryResult).toEqual({ status: 'ok' });
+    expect(result.secondOutcome).toEqual({
+        serverState: 'pendingVerification',
+        status: 'confirmed',
+    });
+    expect(result.calls.uploadCalls).toHaveLength(2);
+    expect(result.calls.uploadCalls[0]?.pathname).toBe(
+        result.calls.uploadCalls[1]?.pathname,
+    );
+    expect(
+        result.calls.completionCalls.map(({ submissionId }) => submissionId),
+    ).toEqual([result.submissionId, result.submissionId]);
+});
+
+test('maps a terminal submission conflict to an idempotency conflict without changing the key', async ({
+    page,
+}) => {
+    const result = await page.evaluate(async (scope) => {
+        const store = window.__operationCompletionDraftStoreTestApi;
+        const sync = window.__operationCompletionQueueSyncTestApi;
+        if (!store || !sync) throw new Error('Test API is unavailable');
+        sync.configure({
+            completionPlans: [{ code: 'submission_conflict', kind: 'failure' }],
+        });
+
+        const leaseResult = await store.acquireLease(
+            scope.userId,
+            store.captureLogoutNonce(scope.userId),
+            'terminal-conflict-session',
+        );
+        if (leaseResult.status !== 'ready') {
+            throw new Error('Expected a writer lease');
+        }
+        const handoff = await store.queue.handoff(
+            {
+                ...scope,
+                notes: 'Sadržaj ostaje za pregled',
+                operationLabel: 'Berba',
+                photos: [],
+            },
+            { lease: leaseResult.lease },
+        );
+        if (handoff.status !== 'enqueued') {
+            throw new Error('Expected an enqueued completion');
+        }
+        const claimed = await store.queue.claimNext(
+            { accountId: scope.accountId, userId: scope.userId },
+            { claimId: 'terminal-conflict-claim', lease: leaseResult.lease },
+        );
+        if (claimed.status !== 'claimed') {
+            throw new Error('Expected a claimed completion');
+        }
+        const outcome = await sync.sync(claimed.item, leaseResult.lease);
+        const stored = await store.queue.load(scope, leaseResult.lease);
+
+        return {
+            calls: sync.getState(),
+            key: claimed.item.key,
+            outcome,
+            stored,
+            submissionId: claimed.item.submissionId,
+        };
+    }, baseScope);
+
+    expect(result.outcome).toEqual({
+        failureCode: 'idempotency_conflict',
+        status: 'failed',
+    });
+    expect(result.calls.completionCalls).toHaveLength(1);
+    expect(result.calls.completionCalls[0]?.submissionId).toBe(
+        result.submissionId,
+    );
+    expect(result.stored).toMatchObject({
+        item: {
+            claim: null,
+            contentDiscardedAt: null,
+            failureCode: 'idempotency_conflict',
+            key: result.key,
+            notes: 'Sadržaj ostaje za pregled',
+            state: 'failed',
+            submissionId: result.submissionId,
+        },
+        status: 'found',
+    });
+});

--- a/apps/farm/lib/offline/operationCompletionQueueSync.ts
+++ b/apps/farm/lib/offline/operationCompletionQueueSync.ts
@@ -1,0 +1,449 @@
+'use client';
+
+import { upload } from '@vercel/blob/client';
+import {
+    completeFarmOperationWithImageUrls,
+    recoverFarmOperationCompletionImage,
+} from '../../app/schedule/actions';
+import { getFarmOperationCompletionSubmissionImagePath } from '../../app/schedule/operationCompletionProof';
+import {
+    parseScheduleOperationCompletionRequirementsFingerprint,
+    type ScheduleOperationCompletionRequirementsFingerprint,
+} from '../../app/schedule/scheduleOperationRequirements';
+import type { ScheduleTaskSubmissionFailureCode } from '../../app/schedule/scheduleTaskSubmissionResult';
+import type { OperationCompletionDraftLease } from './operationCompletionDraftStore';
+import {
+    clearOperationCompletionQueueAttachmentUploads,
+    markOperationCompletionQueueAttachmentUploaded,
+    markOperationCompletionQueueFailed,
+    markOperationCompletionQueueServerConfirmed,
+    type OperationCompletionQueueFailureCode,
+    type OperationCompletionQueueItem,
+    type OperationCompletionQueueMutationResult,
+    releaseOperationCompletionQueueClaimForRetry,
+} from './operationCompletionQueueStore';
+
+const MULTIPART_UPLOAD_THRESHOLD_BYTES = 5 * 1024 * 1024;
+const RETRY_BACKOFF_MS = [5_000, 30_000, 2 * 60_000, 10 * 60_000, 30 * 60_000];
+
+type ActionableQueueFailureCode = Exclude<
+    OperationCompletionQueueFailureCode,
+    'discarded' | 'expired'
+>;
+
+export type OperationCompletionQueueSyncOutcome =
+    | { serverState: 'completed' | 'pendingVerification'; status: 'confirmed' }
+    | { failureCode: OperationCompletionQueueFailureCode; status: 'failed' }
+    | {
+          failureCode: OperationCompletionQueueFailureCode;
+          status: 'retry_scheduled';
+      }
+    | { status: 'abandoned' };
+
+type QueueSyncDependencies = {
+    complete: typeof completeFarmOperationWithImageUrls;
+    recoverImage: typeof recoverFarmOperationCompletionImage;
+    uploadImage: typeof upload;
+};
+
+const defaultDependencies: QueueSyncDependencies = {
+    complete: completeFarmOperationWithImageUrls,
+    recoverImage: recoverFarmOperationCompletionImage,
+    uploadImage: upload,
+};
+
+function nextAttemptAt(attemptCount: number) {
+    const index = Math.max(
+        0,
+        Math.min(attemptCount - 1, RETRY_BACKOFF_MS.length - 1),
+    );
+    return Date.now() + (RETRY_BACKOFF_MS[index] ?? RETRY_BACKOFF_MS[0]);
+}
+
+function terminalFailureCode(
+    code: ScheduleTaskSubmissionFailureCode,
+): ActionableQueueFailureCode {
+    switch (code) {
+        case 'submission_conflict':
+            return 'idempotency_conflict';
+        case 'assignment_changed':
+        case 'invalid_input':
+        case 'invalid_status':
+        case 'not_authorized':
+        case 'not_found':
+        case 'task_changed':
+            return code;
+    }
+}
+
+function mutationSucceeded(result: OperationCompletionQueueMutationResult) {
+    return result.status === 'ok';
+}
+
+function requestIsStillOwned(
+    item: OperationCompletionQueueItem,
+    isActive: () => boolean,
+) {
+    return Boolean(item.claim?.claimId) && isActive();
+}
+
+async function scheduleRetry(
+    item: OperationCompletionQueueItem,
+    lease: OperationCompletionDraftLease,
+    failureCode: ActionableQueueFailureCode,
+): Promise<OperationCompletionQueueSyncOutcome> {
+    const claimId = item.claim?.claimId;
+    if (!claimId) {
+        return { status: 'abandoned' };
+    }
+    const result = await releaseOperationCompletionQueueClaimForRetry(
+        {
+            claimId,
+            failureCode,
+            key: item.key,
+            nextAttemptAt: nextAttemptAt(item.attemptCount),
+            submissionId: item.submissionId,
+        },
+        lease,
+    );
+    return mutationSucceeded(result)
+        ? { failureCode, status: 'retry_scheduled' }
+        : { status: 'abandoned' };
+}
+
+async function failTerminally(
+    item: OperationCompletionQueueItem,
+    lease: OperationCompletionDraftLease,
+    failureCode: ActionableQueueFailureCode,
+): Promise<OperationCompletionQueueSyncOutcome> {
+    const claimId = item.claim?.claimId;
+    if (!claimId) {
+        return { status: 'abandoned' };
+    }
+    const result = await markOperationCompletionQueueFailed(
+        {
+            claimId,
+            failureCode,
+            key: item.key,
+            submissionId: item.submissionId,
+        },
+        lease,
+    );
+    return mutationSucceeded(result)
+        ? { failureCode, status: 'failed' }
+        : { status: 'abandoned' };
+}
+
+function uploadClientPayload(
+    item: OperationCompletionQueueItem,
+    attachment: OperationCompletionQueueItem['attachments'][number],
+    requirementsFingerprint: ScheduleOperationCompletionRequirementsFingerprint,
+) {
+    return JSON.stringify({
+        attachmentId: attachment.id,
+        expectedEntityId: item.expectedEntityId,
+        expectedRequirementsFingerprint: requirementsFingerprint,
+        expectedTaskVersionEventId: item.expectedTaskVersionEventId,
+        fileName: attachment.name,
+        operationId: item.operationId,
+        submissionId: item.submissionId,
+    });
+}
+
+async function recoverAttachment(
+    item: OperationCompletionQueueItem,
+    attachment: OperationCompletionQueueItem['attachments'][number],
+    requirementsFingerprint: ScheduleOperationCompletionRequirementsFingerprint,
+    dependencies: QueueSyncDependencies,
+) {
+    return await dependencies.recoverImage(
+        item.operationId,
+        item.expectedEntityId,
+        item.expectedTaskVersionEventId,
+        requirementsFingerprint,
+        item.submissionId,
+        attachment.id,
+        attachment.name,
+    );
+}
+
+async function persistUploadedAttachment(
+    item: OperationCompletionQueueItem,
+    attachmentId: string,
+    uploadedUrl: string,
+    lease: OperationCompletionDraftLease,
+) {
+    const claimId = item.claim?.claimId;
+    if (!claimId) {
+        return false;
+    }
+    return mutationSucceeded(
+        await markOperationCompletionQueueAttachmentUploaded(
+            {
+                attachmentId,
+                claimId,
+                key: item.key,
+                submissionId: item.submissionId,
+                uploadedUrl,
+            },
+            lease,
+        ),
+    );
+}
+
+type AttachmentResult =
+    | { status: 'abandoned' }
+    | { code: ActionableQueueFailureCode; status: 'retry' }
+    | { code: ActionableQueueFailureCode; status: 'terminal' }
+    | { status: 'uploaded'; url: string };
+
+async function ensureAttachmentUploaded(
+    item: OperationCompletionQueueItem,
+    attachment: OperationCompletionQueueItem['attachments'][number],
+    requirementsFingerprint: ScheduleOperationCompletionRequirementsFingerprint,
+    lease: OperationCompletionDraftLease,
+    isActive: () => boolean,
+    dependencies: QueueSyncDependencies,
+): Promise<AttachmentResult> {
+    if (attachment.uploadedUrl) {
+        return { status: 'uploaded', url: attachment.uploadedUrl };
+    }
+    if (!requestIsStillOwned(item, isActive)) {
+        return { status: 'abandoned' };
+    }
+
+    let recovered: Awaited<
+        ReturnType<typeof recoverFarmOperationCompletionImage>
+    >;
+    try {
+        recovered = await recoverAttachment(
+            item,
+            attachment,
+            requirementsFingerprint,
+            dependencies,
+        );
+    } catch {
+        return {
+            code: navigator.onLine
+                ? 'server_unavailable'
+                : 'network_unavailable',
+            status: 'retry',
+        };
+    }
+    if (!requestIsStillOwned(item, isActive)) {
+        return { status: 'abandoned' };
+    }
+    if (!recovered.success) {
+        return {
+            code: terminalFailureCode(recovered.code),
+            status: 'terminal',
+        };
+    }
+    if (recovered.imageUrl) {
+        return (await persistUploadedAttachment(
+            item,
+            attachment.id,
+            recovered.imageUrl,
+            lease,
+        ))
+            ? { status: 'uploaded', url: recovered.imageUrl }
+            : { status: 'abandoned' };
+    }
+
+    const pathname = getFarmOperationCompletionSubmissionImagePath(
+        item.operationId,
+        item.expectedEntityId,
+        item.expectedTaskVersionEventId,
+        item.submissionId,
+        attachment.id,
+        attachment.name,
+    );
+    try {
+        const uploaded = await dependencies.uploadImage(
+            pathname,
+            new File([attachment.blob], attachment.name, {
+                lastModified: attachment.lastModified,
+                type: attachment.type,
+            }),
+            {
+                access: 'public',
+                contentType: attachment.type || undefined,
+                handleUploadUrl: '/api/operations/images/upload',
+                clientPayload: uploadClientPayload(
+                    item,
+                    attachment,
+                    requirementsFingerprint,
+                ),
+                multipart: attachment.size > MULTIPART_UPLOAD_THRESHOLD_BYTES,
+            },
+        );
+        if (!requestIsStillOwned(item, isActive)) {
+            return { status: 'abandoned' };
+        }
+        return (await persistUploadedAttachment(
+            item,
+            attachment.id,
+            uploaded.url,
+            lease,
+        ))
+            ? { status: 'uploaded', url: uploaded.url }
+            : { status: 'abandoned' };
+    } catch {
+        if (!requestIsStillOwned(item, isActive)) {
+            return { status: 'abandoned' };
+        }
+        try {
+            recovered = await recoverAttachment(
+                item,
+                attachment,
+                requirementsFingerprint,
+                dependencies,
+            );
+        } catch {
+            return {
+                code: navigator.onLine
+                    ? 'upload_failed'
+                    : 'network_unavailable',
+                status: 'retry',
+            };
+        }
+        if (!requestIsStillOwned(item, isActive)) {
+            return { status: 'abandoned' };
+        }
+        if (!recovered.success) {
+            return {
+                code: terminalFailureCode(recovered.code),
+                status: 'terminal',
+            };
+        }
+        if (!recovered.imageUrl) {
+            return {
+                code: navigator.onLine
+                    ? 'upload_failed'
+                    : 'network_unavailable',
+                status: 'retry',
+            };
+        }
+        return (await persistUploadedAttachment(
+            item,
+            attachment.id,
+            recovered.imageUrl,
+            lease,
+        ))
+            ? { status: 'uploaded', url: recovered.imageUrl }
+            : { status: 'abandoned' };
+    }
+}
+
+export async function syncClaimedOperationCompletionQueueItem(
+    item: OperationCompletionQueueItem,
+    lease: OperationCompletionDraftLease,
+    isActive: () => boolean,
+    dependencies: QueueSyncDependencies = defaultDependencies,
+): Promise<OperationCompletionQueueSyncOutcome> {
+    if (!item.claim || item.state !== 'syncing' || !isActive()) {
+        return { status: 'abandoned' };
+    }
+
+    let requirementsFingerprint: ScheduleOperationCompletionRequirementsFingerprint;
+    try {
+        requirementsFingerprint =
+            parseScheduleOperationCompletionRequirementsFingerprint(
+                item.requirementsFingerprint,
+            );
+    } catch {
+        return await failTerminally(item, lease, 'invalid_input');
+    }
+
+    const imageUrls: string[] = [];
+    for (const attachment of item.attachments) {
+        const result = await ensureAttachmentUploaded(
+            item,
+            attachment,
+            requirementsFingerprint,
+            lease,
+            isActive,
+            dependencies,
+        );
+        if (result.status === 'abandoned') {
+            return result;
+        }
+        if (result.status === 'retry') {
+            return await scheduleRetry(item, lease, result.code);
+        }
+        if (result.status === 'terminal') {
+            return await failTerminally(item, lease, result.code);
+        }
+        imageUrls.push(result.url);
+    }
+
+    if (!requestIsStillOwned(item, isActive)) {
+        return { status: 'abandoned' };
+    }
+    let completion: Awaited<
+        ReturnType<typeof completeFarmOperationWithImageUrls>
+    >;
+    try {
+        completion = await dependencies.complete(
+            item.operationId,
+            item.expectedEntityId,
+            item.expectedTaskVersionEventId,
+            requirementsFingerprint,
+            imageUrls,
+            item.notes.trim() || undefined,
+            item.submissionId,
+        );
+    } catch {
+        if (!isActive()) {
+            return { status: 'abandoned' };
+        }
+        return await scheduleRetry(
+            item,
+            lease,
+            navigator.onLine ? 'server_unavailable' : 'network_unavailable',
+        );
+    }
+    if (!requestIsStillOwned(item, isActive)) {
+        return { status: 'abandoned' };
+    }
+    if (!completion.success) {
+        if (
+            completion.canRetry &&
+            completion.retryImageUrls &&
+            completion.retryImageUrls.length > 0
+        ) {
+            const cleared =
+                await clearOperationCompletionQueueAttachmentUploads(
+                    {
+                        claimId: item.claim.claimId,
+                        key: item.key,
+                        submissionId: item.submissionId,
+                        uploadedUrls: completion.retryImageUrls,
+                    },
+                    lease,
+                );
+            if (!mutationSucceeded(cleared)) {
+                return { status: 'abandoned' };
+            }
+            return await scheduleRetry(item, lease, 'upload_failed');
+        }
+        return await failTerminally(
+            item,
+            lease,
+            terminalFailureCode(completion.code),
+        );
+    }
+
+    const result = await markOperationCompletionQueueServerConfirmed(
+        {
+            claimId: item.claim.claimId,
+            key: item.key,
+            serverState: completion.state,
+            submissionId: item.submissionId,
+        },
+        lease,
+    );
+    return mutationSucceeded(result)
+        ? { serverState: completion.state, status: 'confirmed' }
+        : { status: 'abandoned' };
+}

--- a/apps/farm/lib/offline/operationCompletionSyncMode.ts
+++ b/apps/farm/lib/offline/operationCompletionSyncMode.ts
@@ -1,0 +1,14 @@
+export const farmOperationCompletionSyncModes = [
+    'off',
+    'drain_only',
+    'enabled',
+] as const;
+
+export type FarmOperationCompletionSyncMode =
+    (typeof farmOperationCompletionSyncModes)[number];
+
+export function isFarmOperationCompletionSyncMode(
+    value: unknown,
+): value is FarmOperationCompletionSyncMode {
+    return farmOperationCompletionSyncModes.some((mode) => mode === value);
+}

--- a/apps/farm/playwright.config.ts
+++ b/apps/farm/playwright.config.ts
@@ -40,8 +40,12 @@ export const config: PlaywrightTestConfig = {
                     enforce: 'pre',
                     resolveId(source, importer) {
                         if (
-                            source === './actions' &&
-                            importer?.includes('/app/schedule/')
+                            (source === './actions' &&
+                                importer?.includes('/app/schedule/')) ||
+                            (source === '../../app/schedule/actions' &&
+                                importer?.includes(
+                                    '/lib/offline/operationCompletionQueueSync',
+                                ))
                         ) {
                             return scheduleActionsMockPath;
                         }

--- a/apps/farm/playwright/FarmAnalyticsHarness.tsx
+++ b/apps/farm/playwright/FarmAnalyticsHarness.tsx
@@ -8,6 +8,7 @@ import type {
     FarmTodayDataStatus,
     FarmTodayViewedProperties,
 } from '../components/analytics/farmAnalytics';
+import { useFarmAnalytics } from '../components/analytics/farmAnalyticsContext';
 
 type FarmAnalyticsHarnessProps = {
     dataStatus?: FarmTodayDataStatus;
@@ -15,6 +16,30 @@ type FarmAnalyticsHarnessProps = {
     todayMountKey?: string;
     workState?: FarmTodayViewedProperties['work_state'];
 };
+
+function CompletionSyncAnalyticsControl() {
+    const analytics = useFarmAnalytics();
+
+    return (
+        <button
+            data-private-note="PRIVATE_SYNC_NOTE_SENTINEL"
+            data-testid="completion-sync-analytics"
+            onClick={() =>
+                analytics?.captureCompletionSyncState({
+                    age_bucket: 'under_1h',
+                    attempt_bucket: 'two',
+                    failure_code: 'network',
+                    queue_size_bucket: 'two_to_five',
+                    state: 'failed',
+                    trigger: 'online',
+                })
+            }
+            type="button"
+        >
+            PRIVATE_SYNC_NOTE_SENTINEL
+        </button>
+    );
+}
 
 export function FarmAnalyticsHarness({
     dataStatus = 'ready',
@@ -45,6 +70,8 @@ export function FarmAnalyticsHarness({
             <button data-testid="plain-action" type="button">
                 Radnja bez analitike
             </button>
+
+            <CompletionSyncAnalyticsControl />
 
             <a
                 data-farm-analytics="today_task"

--- a/apps/farm/playwright/FarmShellAuthTransitionHarness.tsx
+++ b/apps/farm/playwright/FarmShellAuthTransitionHarness.tsx
@@ -8,6 +8,12 @@ import { FarmTodayViewTracker } from '../components/analytics/FarmTodayViewTrack
 import type { FarmAnalyticsCapture } from '../components/analytics/farmAnalytics';
 import { FarmShellAuthGate } from '../components/navigation/FarmShellAuthGate';
 
+declare global {
+    interface Window {
+        __resolveFarmShellAuth?: () => void;
+    }
+}
+
 function TodayMountProbe() {
     const [mountMarker] = useState(() => crypto.randomUUID());
 
@@ -51,10 +57,17 @@ export function FarmShellAuthTransitionHarness({
         setCapturedEvents((current) => [...current, eventName]);
     }, []);
     const currentUserFactory = useCallback(async () => {
-        await new Promise((resolve) => window.setTimeout(resolve, 250));
+        await new Promise<void>((resolve) => {
+            window.__resolveFarmShellAuth = resolve;
+        });
+        window.__resolveFarmShellAuth = undefined;
         return {
+            accountId: 'account-test',
+            accounts: [{ accountId: 'account-test' }],
             id: 'farmer-test',
+            operationCompletionSyncMode: 'off' as const,
             role: userRole,
+            sessionIncarnation: 'session-test',
             userName: 'Farmer Test',
         };
     }, [userRole]);

--- a/apps/farm/playwright/LogoutDraftStories.tsx
+++ b/apps/farm/playwright/LogoutDraftStories.tsx
@@ -11,6 +11,7 @@ import { OperationCompletionDraftStoreHarness } from './OperationCompletionDraft
 
 const nextNavigationRouter = {
     back: () => undefined,
+    bfcacheId: 'farm-logout-draft-story',
     forward: () => undefined,
     prefetch: () => undefined,
     push: () => undefined,

--- a/apps/farm/playwright/LogoutDraftStories.tsx
+++ b/apps/farm/playwright/LogoutDraftStories.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import {
+    AppRouterContext,
+    type AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { useState } from 'react';
+import { CompleteOperationModal } from '../app/schedule/CompleteOperationModal';
+import { LogoutButton } from '../components/auth/LogoutButton';
+import { OperationCompletionDraftStoreHarness } from './OperationCompletionDraftStoreHarness';
+
+const nextNavigationRouter = {
+    back: () => undefined,
+    forward: () => undefined,
+    prefetch: () => undefined,
+    push: () => undefined,
+    refresh: () => undefined,
+    replace: () => undefined,
+} satisfies AppRouterInstance;
+
+export function LogoutWithLateModalMountStory({
+    accountId,
+    expectedEntityId,
+    expectedTaskVersionEventId,
+    operationId,
+    sessionIncarnation,
+    userId,
+}: {
+    accountId: string;
+    expectedEntityId: number;
+    expectedTaskVersionEventId: number;
+    operationId: number;
+    sessionIncarnation: string;
+    userId: string;
+}) {
+    const [showStaleModal, setShowStaleModal] = useState(false);
+
+    return (
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <OperationCompletionDraftStoreHarness />
+            <LogoutButton
+                sessionIncarnation={sessionIncarnation}
+                userId={userId}
+            />
+            <button type="button" onClick={() => setShowStaleModal(true)}>
+                Prikaži stari zadatak
+            </button>
+            {showStaleModal ? (
+                <CompleteOperationModal
+                    accountId={accountId}
+                    conditions={{ completionAttachNotes: true }}
+                    defaultOpen
+                    expectedEntityId={expectedEntityId}
+                    expectedTaskVersionEventId={expectedTaskVersionEventId}
+                    label="Zadatak iz odjavljene sesije"
+                    operationId={operationId}
+                    sessionIncarnation={sessionIncarnation}
+                    userId={userId}
+                />
+            ) : null}
+        </AppRouterContext.Provider>
+    );
+}
+
+export function StaleLogoutWithCurrentModalStory({
+    accountId,
+    currentSessionIncarnation,
+    currentUserId,
+    expectedEntityId,
+    expectedTaskVersionEventId,
+    operationId,
+    staleSessionIncarnation,
+    staleUserId,
+}: {
+    accountId: string;
+    currentSessionIncarnation: string;
+    currentUserId: string;
+    expectedEntityId: number;
+    expectedTaskVersionEventId: number;
+    operationId: number;
+    staleSessionIncarnation: string;
+    staleUserId: string;
+}) {
+    return (
+        <AppRouterContext.Provider value={nextNavigationRouter}>
+            <OperationCompletionDraftStoreHarness />
+            <CompleteOperationModal
+                accountId={accountId}
+                conditions={{ completionAttachNotes: true }}
+                defaultOpen
+                expectedEntityId={expectedEntityId}
+                expectedTaskVersionEventId={expectedTaskVersionEventId}
+                label="Zadatak trenutačne sesije"
+                operationId={operationId}
+                sessionIncarnation={currentSessionIncarnation}
+                userId={currentUserId}
+            />
+            <LogoutButton
+                sessionIncarnation={staleSessionIncarnation}
+                userId={staleUserId}
+            />
+        </AppRouterContext.Provider>
+    );
+}

--- a/apps/farm/playwright/OperationCompletionDraftHookHarness.tsx
+++ b/apps/farm/playwright/OperationCompletionDraftHookHarness.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState } from 'react';
+import { useOperationCompletionDraft } from '../app/schedule/useOperationCompletionDraft';
+import {
+    acquireOperationCompletionDraftLease,
+    captureOperationCompletionDraftLogoutNonce,
+    type OperationCompletionDraftScope,
+} from '../lib/offline/operationCompletionDraftStore';
+import {
+    claimNextOperationCompletionQueueItem,
+    markOperationCompletionQueueServerConfirmed,
+} from '../lib/offline/operationCompletionQueueStore';
+
+type OperationCompletionDraftHookHarnessProps =
+    OperationCompletionDraftScope & {
+        operationLabel: string;
+        scheduleDateKey?: string;
+        sessionIncarnation: string;
+    };
+
+export function OperationCompletionDraftHookHarness({
+    operationLabel,
+    scheduleDateKey,
+    sessionIncarnation,
+    ...scope
+}: OperationCompletionDraftHookHarnessProps) {
+    const [notes, setNotes] = useState('');
+    const [handoffResult, setHandoffResult] = useState<unknown>(null);
+    const [confirmationResult, setConfirmationResult] = useState<unknown>(null);
+    const localDraft = useOperationCompletionDraft({
+        ...scope,
+        enabled: true,
+        notes,
+        photos: [],
+        sessionIncarnation,
+    });
+
+    const confirmQueuedItem = async () => {
+        if (
+            localDraft.gate.kind !== 'queued' &&
+            localDraft.gate.kind !== 'server_confirmed'
+        ) {
+            setConfirmationResult({ status: 'missing' });
+            return;
+        }
+        if (localDraft.gate.kind === 'server_confirmed') {
+            setConfirmationResult({ status: 'ok' });
+            return;
+        }
+        const leaseResult = await acquireOperationCompletionDraftLease(
+            scope.userId,
+            captureOperationCompletionDraftLogoutNonce(scope.userId),
+            sessionIncarnation,
+        );
+        if (leaseResult.status !== 'ready') {
+            setConfirmationResult(leaseResult);
+            return;
+        }
+        const claimId = crypto.randomUUID();
+        const claimResult = await claimNextOperationCompletionQueueItem(
+            { accountId: scope.accountId, userId: scope.userId },
+            { claimId, lease: leaseResult.lease },
+        );
+        if (claimResult.status !== 'claimed') {
+            setConfirmationResult(claimResult);
+            return;
+        }
+        setConfirmationResult(
+            await markOperationCompletionQueueServerConfirmed(
+                {
+                    claimId,
+                    key: claimResult.item.key,
+                    serverState: 'completed',
+                    submissionId: claimResult.item.submissionId,
+                },
+                leaseResult.lease,
+            ),
+        );
+    };
+
+    return (
+        <>
+            <label htmlFor="operation-completion-hook-notes">Napomena</label>
+            <textarea
+                id="operation-completion-hook-notes"
+                onChange={(event) => setNotes(event.currentTarget.value)}
+                value={notes}
+            />
+            <button
+                onClick={async () => {
+                    setHandoffResult(
+                        await localDraft.handoffToQueue({
+                            operationLabel,
+                            ...(scheduleDateKey === undefined
+                                ? {}
+                                : { scheduleDateKey }),
+                        }),
+                    );
+                }}
+                type="button"
+            >
+                Predaj u red
+            </button>
+            <button onClick={confirmQueuedItem} type="button">
+                Označi potvrđeno
+            </button>
+            <output data-testid="operation-draft-gate">
+                {JSON.stringify(localDraft.gate)}
+            </output>
+            <output data-testid="operation-draft-save-state">
+                {JSON.stringify(localDraft.saveState)}
+            </output>
+            <output data-testid="operation-draft-handoff-result">
+                {JSON.stringify(handoffResult)}
+            </output>
+            <output data-testid="operation-draft-confirmation-result">
+                {JSON.stringify(confirmationResult)}
+            </output>
+        </>
+    );
+}

--- a/apps/farm/playwright/OperationCompletionDraftStoreHarness.tsx
+++ b/apps/farm/playwright/OperationCompletionDraftStoreHarness.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+import {
+    acquireOperationCompletionDraftLease,
+    captureOperationCompletionDraftLogoutNonce,
+    discardOperationCompletionDraft,
+    loadOperationCompletionDraft,
+    markOperationCompletionDraftServerConfirmed,
+    operationCompletionDraftPhotoToFile,
+    purgeOperationCompletionDraftsForUser,
+    saveOperationCompletionDraft,
+} from '../lib/offline/operationCompletionDraftStore';
+
+declare global {
+    interface Window {
+        __operationCompletionDraftStoreTestApi?: {
+            acquireLease: typeof acquireOperationCompletionDraftLease;
+            captureLogoutNonce: typeof captureOperationCompletionDraftLogoutNonce;
+            discard: typeof discardOperationCompletionDraft;
+            load: typeof loadOperationCompletionDraft;
+            markServerConfirmed: typeof markOperationCompletionDraftServerConfirmed;
+            photoToFile: typeof operationCompletionDraftPhotoToFile;
+            purgeUser: typeof purgeOperationCompletionDraftsForUser;
+            save: typeof saveOperationCompletionDraft;
+        };
+    }
+}
+
+export function OperationCompletionDraftStoreHarness() {
+    useEffect(() => {
+        window.__operationCompletionDraftStoreTestApi = {
+            acquireLease: acquireOperationCompletionDraftLease,
+            captureLogoutNonce: captureOperationCompletionDraftLogoutNonce,
+            discard: discardOperationCompletionDraft,
+            load: loadOperationCompletionDraft,
+            markServerConfirmed: markOperationCompletionDraftServerConfirmed,
+            photoToFile: operationCompletionDraftPhotoToFile,
+            purgeUser: purgeOperationCompletionDraftsForUser,
+            save: saveOperationCompletionDraft,
+        };
+
+        return () => {
+            delete window.__operationCompletionDraftStoreTestApi;
+        };
+    }, []);
+
+    return <output data-testid="operation-draft-store-ready">ready</output>;
+}

--- a/apps/farm/playwright/OperationCompletionDraftStoreHarness.tsx
+++ b/apps/farm/playwright/OperationCompletionDraftStoreHarness.tsx
@@ -11,6 +11,21 @@ import {
     purgeOperationCompletionDraftsForUser,
     saveOperationCompletionDraft,
 } from '../lib/offline/operationCompletionDraftStore';
+import {
+    claimNextOperationCompletionQueueItem,
+    clearOperationCompletionQueueAttachmentUploads,
+    discardOperationCompletionQueueItem,
+    handoffOperationCompletionDraftToQueue,
+    listOperationCompletionQueueItems,
+    loadOperationCompletionQueueItem,
+    markOperationCompletionQueueAttachmentUploaded,
+    markOperationCompletionQueueFailed,
+    markOperationCompletionQueueServerConfirmed,
+    releaseOperationCompletionQueueClaimForRetry,
+    renewOperationCompletionQueueClaim,
+    retryOperationCompletionQueueItem,
+    subscribeToOperationCompletionQueueChanges,
+} from '../lib/offline/operationCompletionQueueStore';
 
 declare global {
     interface Window {
@@ -23,6 +38,21 @@ declare global {
             photoToFile: typeof operationCompletionDraftPhotoToFile;
             purgeUser: typeof purgeOperationCompletionDraftsForUser;
             save: typeof saveOperationCompletionDraft;
+            queue: {
+                claimNext: typeof claimNextOperationCompletionQueueItem;
+                clearAttachmentUploads: typeof clearOperationCompletionQueueAttachmentUploads;
+                discard: typeof discardOperationCompletionQueueItem;
+                handoff: typeof handoffOperationCompletionDraftToQueue;
+                list: typeof listOperationCompletionQueueItems;
+                load: typeof loadOperationCompletionQueueItem;
+                markAttachmentUploaded: typeof markOperationCompletionQueueAttachmentUploaded;
+                markFailed: typeof markOperationCompletionQueueFailed;
+                markServerConfirmed: typeof markOperationCompletionQueueServerConfirmed;
+                releaseForRetry: typeof releaseOperationCompletionQueueClaimForRetry;
+                renewClaim: typeof renewOperationCompletionQueueClaim;
+                retry: typeof retryOperationCompletionQueueItem;
+                subscribe: typeof subscribeToOperationCompletionQueueChanges;
+            };
         };
     }
 }
@@ -38,6 +68,24 @@ export function OperationCompletionDraftStoreHarness() {
             photoToFile: operationCompletionDraftPhotoToFile,
             purgeUser: purgeOperationCompletionDraftsForUser,
             save: saveOperationCompletionDraft,
+            queue: {
+                claimNext: claimNextOperationCompletionQueueItem,
+                clearAttachmentUploads:
+                    clearOperationCompletionQueueAttachmentUploads,
+                discard: discardOperationCompletionQueueItem,
+                handoff: handoffOperationCompletionDraftToQueue,
+                list: listOperationCompletionQueueItems,
+                load: loadOperationCompletionQueueItem,
+                markAttachmentUploaded:
+                    markOperationCompletionQueueAttachmentUploaded,
+                markFailed: markOperationCompletionQueueFailed,
+                markServerConfirmed:
+                    markOperationCompletionQueueServerConfirmed,
+                releaseForRetry: releaseOperationCompletionQueueClaimForRetry,
+                renewClaim: renewOperationCompletionQueueClaim,
+                retry: retryOperationCompletionQueueItem,
+                subscribe: subscribeToOperationCompletionQueueChanges,
+            },
         };
 
         return () => {

--- a/apps/farm/playwright/OperationCompletionQueueSyncHarness.tsx
+++ b/apps/farm/playwright/OperationCompletionQueueSyncHarness.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useEffect } from 'react';
+import type { ScheduleTaskSubmissionFailureCode } from '../app/schedule/scheduleTaskSubmissionResult';
+import type { OperationCompletionDraftLease } from '../lib/offline/operationCompletionDraftStore';
+import type { OperationCompletionQueueItem } from '../lib/offline/operationCompletionQueueStore';
+import {
+    type OperationCompletionQueueSyncOutcome,
+    syncClaimedOperationCompletionQueueItem,
+} from '../lib/offline/operationCompletionQueueSync';
+import { OperationCompletionDraftStoreHarness } from './OperationCompletionDraftStoreHarness';
+
+type SyncDependencies = NonNullable<
+    Parameters<typeof syncClaimedOperationCompletionQueueItem>[3]
+>;
+
+type CompletionPlan =
+    | { kind: 'throw' }
+    | {
+          kind: 'success';
+          state: 'completed' | 'pendingVerification';
+      }
+    | {
+          canRetry?: boolean;
+          code: ScheduleTaskSubmissionFailureCode;
+          kind: 'failure';
+          retryImageUrls?: string[];
+      };
+
+type RecoveryPlan =
+    | { kind: 'missing' }
+    | { kind: 'throw' }
+    | { imageUrl: string; kind: 'found' }
+    | {
+          code: ScheduleTaskSubmissionFailureCode;
+          kind: 'failure';
+      };
+
+type UploadPlan = { kind: 'throw' } | { kind: 'success'; url: string };
+
+type CompletionCall = {
+    expectedEntityId: number;
+    expectedRequirementsFingerprint: string;
+    expectedTaskVersionEventId: number;
+    imageUrls: string[];
+    notes: string | undefined;
+    operationId: number;
+    submissionId: string | undefined;
+};
+
+type RecoveryCall = {
+    attachmentId: string;
+    expectedEntityId: number;
+    expectedRequirementsFingerprint: string;
+    expectedTaskVersionEventId: number;
+    fileName: string;
+    operationId: number;
+    submissionId: string;
+};
+
+type UploadCall = {
+    access: 'public' | 'private';
+    clientPayload: string | null;
+    file: {
+        lastModified: number;
+        name: string;
+        size: number;
+        text: string;
+        type: string;
+    } | null;
+    handleUploadUrl: string;
+    multipart: boolean;
+    pathname: string;
+};
+
+export type OperationCompletionQueueSyncTestConfiguration = {
+    completionPlans?: CompletionPlan[];
+    recoveryPlans?: RecoveryPlan[];
+    uploadPlans?: UploadPlan[];
+};
+
+export type OperationCompletionQueueSyncTestState = {
+    completionCalls: CompletionCall[];
+    completionPlans: CompletionPlan[];
+    recoveryCalls: RecoveryCall[];
+    recoveryPlans: RecoveryPlan[];
+    uploadCalls: UploadCall[];
+    uploadPlans: UploadPlan[];
+};
+
+type OperationCompletionQueueSyncTestApi = {
+    configure: (
+        configuration?: OperationCompletionQueueSyncTestConfiguration,
+    ) => void;
+    getState: () => OperationCompletionQueueSyncTestState;
+    sync: (
+        item: OperationCompletionQueueItem,
+        lease: OperationCompletionDraftLease,
+        active?: boolean,
+    ) => Promise<OperationCompletionQueueSyncOutcome>;
+};
+
+declare global {
+    interface Window {
+        __operationCompletionQueueSyncTestApi?: OperationCompletionQueueSyncTestApi;
+    }
+}
+
+function createState(
+    configuration: OperationCompletionQueueSyncTestConfiguration = {},
+): OperationCompletionQueueSyncTestState {
+    return {
+        completionCalls: [],
+        completionPlans: [...(configuration.completionPlans ?? [])],
+        recoveryCalls: [],
+        recoveryPlans: [...(configuration.recoveryPlans ?? [])],
+        uploadCalls: [],
+        uploadPlans: [...(configuration.uploadPlans ?? [])],
+    };
+}
+
+let state = createState();
+
+const complete: SyncDependencies['complete'] = async (
+    operationId,
+    expectedEntityId,
+    expectedTaskVersionEventId,
+    expectedRequirementsFingerprint,
+    imageUrls,
+    notes,
+    submissionId,
+) => {
+    state.completionCalls.push({
+        expectedEntityId,
+        expectedRequirementsFingerprint,
+        expectedTaskVersionEventId,
+        imageUrls,
+        notes,
+        operationId,
+        submissionId,
+    });
+    const plan = state.completionPlans.shift() ?? {
+        kind: 'success',
+        state: 'pendingVerification',
+    };
+    if (plan.kind === 'throw') {
+        throw new Error('Controlled completion transport failure');
+    }
+    if (plan.kind === 'failure') {
+        return {
+            canRetry: plan.canRetry ?? false,
+            code: plan.code,
+            message: 'Controlled terminal completion failure',
+            ...(plan.retryImageUrls
+                ? { retryImageUrls: plan.retryImageUrls }
+                : {}),
+            success: false,
+        };
+    }
+    return {
+        recordedAt: '2026-07-15T10:00:00.000Z',
+        state: plan.state,
+        success: true,
+    };
+};
+
+const recoverImage: SyncDependencies['recoverImage'] = async (
+    operationId,
+    expectedEntityId,
+    expectedTaskVersionEventId,
+    expectedRequirementsFingerprint,
+    submissionId,
+    attachmentId,
+    fileName,
+) => {
+    state.recoveryCalls.push({
+        attachmentId,
+        expectedEntityId,
+        expectedRequirementsFingerprint,
+        expectedTaskVersionEventId,
+        fileName,
+        operationId,
+        submissionId,
+    });
+    const plan = state.recoveryPlans.shift() ?? { kind: 'missing' };
+    if (plan.kind === 'throw') {
+        throw new Error('Controlled image recovery failure');
+    }
+    if (plan.kind === 'failure') {
+        return {
+            canRetry: false,
+            code: plan.code,
+            message: 'Controlled terminal image recovery failure',
+            success: false,
+        };
+    }
+    return {
+        imageUrl: plan.kind === 'found' ? plan.imageUrl : null,
+        success: true,
+    };
+};
+
+const uploadImage: SyncDependencies['uploadImage'] = async (
+    pathname,
+    body,
+    options,
+) => {
+    const file = body instanceof File ? body : null;
+    state.uploadCalls.push({
+        access: options.access,
+        clientPayload: options.clientPayload ?? null,
+        file: file
+            ? {
+                  lastModified: file.lastModified,
+                  name: file.name,
+                  size: file.size,
+                  text: await file.text(),
+                  type: file.type,
+              }
+            : null,
+        handleUploadUrl: options.handleUploadUrl,
+        multipart: options.multipart ?? false,
+        pathname,
+    });
+    const plan = state.uploadPlans.shift() ?? {
+        kind: 'success',
+        url: `https://blob.example/${pathname}`,
+    };
+    if (plan.kind === 'throw') {
+        throw new Error('Controlled ambiguous image upload failure');
+    }
+    return {
+        contentDisposition: 'inline',
+        contentType: file?.type ?? 'application/octet-stream',
+        downloadUrl: `${plan.url}?download=1`,
+        etag: 'test-etag',
+        pathname,
+        url: plan.url,
+    };
+};
+
+const dependencies = {
+    complete,
+    recoverImage,
+    uploadImage,
+} satisfies SyncDependencies;
+
+export function OperationCompletionQueueSyncHarness() {
+    useEffect(() => {
+        window.__operationCompletionQueueSyncTestApi = {
+            configure(configuration) {
+                state = createState(configuration);
+            },
+            getState() {
+                return state;
+            },
+            sync(item, lease, active = true) {
+                return syncClaimedOperationCompletionQueueItem(
+                    item,
+                    lease,
+                    () => active,
+                    dependencies,
+                );
+            },
+        };
+
+        return () => {
+            delete window.__operationCompletionQueueSyncTestApi;
+        };
+    }, []);
+
+    return <OperationCompletionDraftStoreHarness />;
+}

--- a/apps/farm/playwright/OperationCompletionSyncProviderHarness.tsx
+++ b/apps/farm/playwright/OperationCompletionSyncProviderHarness.tsx
@@ -31,9 +31,17 @@ const router = {
 } satisfies AppRouterInstance;
 
 export function OperationCompletionSyncProviderHarness({
+    accountId = 'account-test',
+    enabled = true,
     mode = 'enabled',
+    sessionIncarnation = 'session-test',
+    userId = 'user-test',
 }: {
+    accountId?: string;
+    enabled?: boolean;
     mode?: FarmOperationCompletionSyncMode;
+    sessionIncarnation?: string;
+    userId?: string;
 }) {
     const capture = useCallback<FarmAnalyticsCapture>(
         (eventName, properties) => {
@@ -50,10 +58,11 @@ export function OperationCompletionSyncProviderHarness({
         <AppRouterContext.Provider value={router}>
             <FarmAnalyticsProvider capture={capture}>
                 <OperationCompletionSyncProvider
-                    accountId="account-test"
+                    accountId={accountId}
+                    enabled={enabled}
                     mode={mode}
-                    sessionIncarnation="session-test"
-                    userId="user-test"
+                    sessionIncarnation={sessionIncarnation}
+                    userId={userId}
                 >
                     <OperationCompletionSyncBanner />
                     <main className="mx-auto w-full max-w-xl p-3">

--- a/apps/farm/playwright/OperationCompletionSyncProviderHarness.tsx
+++ b/apps/farm/playwright/OperationCompletionSyncProviderHarness.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import {
+    AppRouterContext,
+    type AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { useCallback } from 'react';
+import { OperationCompletionSyncSettings } from '../app/settings/_components/OperationCompletionSyncSettings';
+import { FarmAnalyticsProvider } from '../components/analytics/FarmAnalyticsProvider';
+import type { FarmAnalyticsCapture } from '../components/analytics/farmAnalytics';
+import { OperationCompletionSyncBanner } from '../components/offline/OperationCompletionSyncBanner';
+import { OperationCompletionSyncProvider } from '../components/offline/OperationCompletionSyncProvider';
+import type { FarmOperationCompletionSyncMode } from '../lib/offline/operationCompletionSyncMode';
+
+declare global {
+    interface Window {
+        __farmSyncRouterRefreshes?: number;
+    }
+}
+
+const router = {
+    back: () => undefined,
+    forward: () => undefined,
+    prefetch: () => undefined,
+    push: () => undefined,
+    refresh: () => {
+        window.__farmSyncRouterRefreshes =
+            (window.__farmSyncRouterRefreshes ?? 0) + 1;
+    },
+    replace: () => undefined,
+} satisfies AppRouterInstance;
+
+export function OperationCompletionSyncProviderHarness({
+    mode = 'enabled',
+}: {
+    mode?: FarmOperationCompletionSyncMode;
+}) {
+    const capture = useCallback<FarmAnalyticsCapture>(
+        (eventName, properties) => {
+            window.dispatchEvent(
+                new CustomEvent('gredice:farm-sync-analytics', {
+                    detail: { eventName, properties },
+                }),
+            );
+        },
+        [],
+    );
+
+    return (
+        <AppRouterContext.Provider value={router}>
+            <FarmAnalyticsProvider capture={capture}>
+                <OperationCompletionSyncProvider
+                    accountId="account-test"
+                    mode={mode}
+                    sessionIncarnation="session-test"
+                    userId="user-test"
+                >
+                    <OperationCompletionSyncBanner />
+                    <main className="mx-auto w-full max-w-xl p-3">
+                        <OperationCompletionSyncSettings />
+                    </main>
+                </OperationCompletionSyncProvider>
+            </FarmAnalyticsProvider>
+        </AppRouterContext.Provider>
+    );
+}

--- a/apps/farm/playwright/OperationCompletionSyncProviderHarness.tsx
+++ b/apps/farm/playwright/OperationCompletionSyncProviderHarness.tsx
@@ -20,6 +20,7 @@ declare global {
 
 const router = {
     back: () => undefined,
+    bfcacheId: 'farm-sync-provider-harness',
     forward: () => undefined,
     prefetch: () => undefined,
     push: () => undefined,

--- a/apps/farm/playwright/ScheduleTaskAttemptVersionStories.tsx
+++ b/apps/farm/playwright/ScheduleTaskAttemptVersionStories.tsx
@@ -4,6 +4,10 @@ import type { ComponentProps } from 'react';
 import { CompleteOperationModal as CompleteOperationModalComponent } from '../app/schedule/CompleteOperationModal';
 import { CompletePlantingModal as CompletePlantingModalComponent } from '../app/schedule/CompletePlantingModal';
 import { ScheduleTaskBlockerModal as ScheduleTaskBlockerModalComponent } from '../app/schedule/ScheduleTaskBlockerModal';
+import {
+    OperationCompletionSyncContext,
+    type OperationCompletionSyncContextValue,
+} from '../components/offline/OperationCompletionSyncContext';
 
 export const expectedTaskVersionEventId = 81;
 export const expectedPlantCycleVersionEventId = 802;
@@ -25,6 +29,29 @@ export function CompleteOperationModalAttemptStory(
             userId="user-test"
             {...props}
         />
+    );
+}
+
+export function OfflineQueueCompleteOperationModalStory({
+    syncContext,
+    ...props
+}: Parameters<typeof CompleteOperationModalAttemptStory>[0] & {
+    syncContext?: Partial<OperationCompletionSyncContextValue>;
+}) {
+    const contextValue: OperationCompletionSyncContextValue = {
+        discard: async () => true,
+        isStorageAvailable: true,
+        items: [],
+        mode: 'enabled',
+        retry: async () => undefined,
+        retryAll: async () => undefined,
+        ...syncContext,
+    };
+
+    return (
+        <OperationCompletionSyncContext.Provider value={contextValue}>
+            <CompleteOperationModalAttemptStory {...props} />
+        </OperationCompletionSyncContext.Provider>
     );
 }
 

--- a/apps/farm/playwright/ScheduleTaskAttemptVersionStories.tsx
+++ b/apps/farm/playwright/ScheduleTaskAttemptVersionStories.tsx
@@ -11,12 +11,18 @@ export const expectedPlantCycleVersionEventId = 802;
 export function CompleteOperationModalAttemptStory(
     props: Omit<
         ComponentProps<typeof CompleteOperationModalComponent>,
-        'expectedTaskVersionEventId'
+        | 'accountId'
+        | 'expectedTaskVersionEventId'
+        | 'sessionIncarnation'
+        | 'userId'
     >,
 ) {
     return (
         <CompleteOperationModalComponent
+            accountId="account-test"
             expectedTaskVersionEventId={expectedTaskVersionEventId}
+            sessionIncarnation="session-test"
+            userId="user-test"
             {...props}
         />
     );

--- a/apps/farm/playwright/scheduleActionsMock.ts
+++ b/apps/farm/playwright/scheduleActionsMock.ts
@@ -7,7 +7,10 @@ type ScheduleActionTestState = {
         expectedEntityId: number;
         expectedRequirementsFingerprint: string;
         expectedTaskVersionEventId: number;
+        imageUrls?: string[];
+        notes?: string;
         operationId: number;
+        submissionId?: string;
     };
     lastPlantingSubmission?: {
         expectedPlantCycleEventId: number;
@@ -30,6 +33,7 @@ type ScheduleActionTestState = {
             | 'invalid_status'
             | 'not_authorized'
             | 'not_found'
+            | 'submission_conflict'
             | 'task_changed';
         message: string;
         retryImageUrls?: string[];
@@ -43,6 +47,7 @@ type ScheduleActionTestState = {
             | 'invalid_status'
             | 'not_authorized'
             | 'not_found'
+            | 'submission_conflict'
             | 'task_changed';
         message: string;
         success: false;
@@ -127,6 +132,9 @@ export async function completeFarmOperation(
     expectedEntityId: number,
     expectedTaskVersionEventId: number,
     expectedRequirementsFingerprint: string,
+    imageUrls?: string[],
+    notes?: string,
+    submissionId?: string,
 ) {
     const state = getTestState();
     state.operationCalls += 1;
@@ -135,6 +143,7 @@ export async function completeFarmOperation(
         expectedRequirementsFingerprint,
         expectedTaskVersionEventId,
         operationId,
+        ...(submissionId ? { imageUrls, notes, submissionId } : {}),
     };
     await waitForRelease(state);
     failWhenRequested(state, 'operationFailuresRemaining');
@@ -146,6 +155,9 @@ export async function completeFarmOperationWithImageUrls(
     expectedEntityId: number,
     expectedTaskVersionEventId: number,
     expectedRequirementsFingerprint: string,
+    imageUrls: string[],
+    notes?: string,
+    submissionId?: string,
 ) {
     const state = getTestState();
     state.operationCalls += 1;
@@ -154,10 +166,15 @@ export async function completeFarmOperationWithImageUrls(
         expectedRequirementsFingerprint,
         expectedTaskVersionEventId,
         operationId,
+        ...(submissionId ? { imageUrls, notes, submissionId } : {}),
     };
     await waitForRelease(state);
     failWhenRequested(state, 'operationFailuresRemaining');
     return takeSubmissionFailure(state) ?? success('pendingVerification');
+}
+
+export async function recoverFarmOperationCompletionImage() {
+    return { imageUrl: null, success: true as const };
 }
 
 export async function completeFarmPlanting(

--- a/apps/farm/playwright/scheduleActionsMock.ts
+++ b/apps/farm/playwright/scheduleActionsMock.ts
@@ -21,6 +21,7 @@ type ScheduleActionTestState = {
     };
     operationCalls: number;
     operationFailuresRemaining?: number;
+    operationResolutions?: number;
     plantingCalls: number;
     plantingFailuresRemaining?: number;
     refreshCalls?: number;
@@ -146,6 +147,7 @@ export async function completeFarmOperation(
         ...(submissionId ? { imageUrls, notes, submissionId } : {}),
     };
     await waitForRelease(state);
+    state.operationResolutions = (state.operationResolutions ?? 0) + 1;
     failWhenRequested(state, 'operationFailuresRemaining');
     return takeSubmissionFailure(state) ?? success('pendingVerification');
 }
@@ -169,6 +171,7 @@ export async function completeFarmOperationWithImageUrls(
         ...(submissionId ? { imageUrls, notes, submissionId } : {}),
     };
     await waitForRelease(state);
+    state.operationResolutions = (state.operationResolutions ?? 0) + 1;
     failWhenRequested(state, 'operationFailuresRemaining');
     return takeSubmissionFailure(state) ?? success('pendingVerification');
 }

--- a/docs/farm-offline-operation-completion.md
+++ b/docs/farm-offline-operation-completion.md
@@ -1,0 +1,202 @@
+# Farm offline operation completion
+
+## Summary
+
+Farm operators can finish a scheduled operation with notes and photographs even
+when connectivity is unavailable or unreliable. The Farm app first stores one
+immutable completion command on the current device and then sends that same
+command when the authenticated app is open with connectivity.
+
+This workflow covers operation completion only. Planting completion, blocker
+reports, schedule caching, service-worker background synchronization, and farm
+selection are outside its scope.
+
+## Actors
+
+- **Farm operator:** prepares and confirms the completion on a phone.
+- **Farm app:** stores drafts and queued commands in IndexedDB, displays their
+  state, and drains the queue while the authenticated app is in the foreground.
+- **Farm Server Actions and upload route:** authenticate the current user,
+  selected account, operation target, task version, requirements, and evidence.
+- **Storage repository:** serializes completion under the operation lock and
+  resolves keyed replays.
+- **Vercel Blob:** stores completion photographs at deterministic paths.
+- **Internal verifier:** reviews work whose domain state is
+  `pendingVerification`; synchronization does not imply verification.
+
+## Configuration
+
+`farmOperationCompletionSyncMode` is a three-state Farm feature flag declared in
+`apps/farm/app/flags.ts`:
+
+| Mode | New local commands | Existing commands | Farmer UI |
+| --- | --- | --- | --- |
+| `off` | Uses the legacy online path | Does not drain | Existing records remain visible for recovery |
+| `drain_only` | Uses the legacy online path | Drains in the foreground | Queue and resolution UI remain visible |
+| `enabled` | Persists before any network work | Drains in the foreground | Full queue and resolution UI |
+
+Production defaults to `off`. Development and test default to `enabled`. A
+Vercel flag override can select another mode for a controlled environment or
+pilot.
+
+The workflow uses the existing authenticated Farm session and Vercel Blob
+configuration. It adds no database migration and no service-worker background
+sync registration.
+
+## Entry points
+
+- `apps/farm/app/schedule/CompleteOperationModal.tsx` collects the proof and
+  confirms the local handoff.
+- `apps/farm/app/schedule/useOperationCompletionDraft.ts` serializes draft
+  writes and performs the atomic draft-to-queue transition.
+- `apps/farm/lib/offline/operationCompletionQueueStore.ts` owns IndexedDB queue
+  records, claims, retries, tombstones, expiry, and session fences.
+- `apps/farm/components/offline/OperationCompletionSyncProvider.tsx` drains the
+  queue after authenticated mount, queue creation, `online`, `pageshow`, visible
+  `visibilitychange`, or an explicit retry.
+- `apps/farm/app/api/operations/images/upload/route.ts` authorizes exact
+  deterministic Blob paths.
+- `apps/farm/app/schedule/actions.ts` recovers uncertain uploads and submits or
+  replays a completion.
+- `packages/storage/src/repositories/scheduleTaskSubmissionsRepo.ts` is the
+  completion source of truth and idempotency boundary.
+
+## State model
+
+| State | Meaning | Retained private content | Next transition |
+| --- | --- | --- | --- |
+| `saved_local` | Editable draft on this device; the farmer has not confirmed it | Notes and photographs | `queued` or discarded |
+| `queued` | Immutable completion command waiting for a foreground send | Notes and photographs | `syncing`, `failed`, or expired |
+| `syncing` | One tab owns a time-bounded IndexedDB claim | Notes, photographs, and recovered Blob URLs | `server_confirmed`, `failed`, or stale-claim recovery |
+| `failed` | Retry is delayed or explicit farmer resolution is required | Notes and photographs until expiry or discard | `queued`, discarded, or expired |
+| `server_confirmed` | The server returned the receipt for this exact submission ID | None; the record is a content-free tombstone | Automatic tombstone expiry |
+
+The app must describe local persistence, transport, and domain verification as
+different facts. A `server_confirmed` submission can still have the domain state
+`pendingVerification`.
+
+## Happy path
+
+1. The modal saves notes and selected photographs as a device-local draft.
+2. **Dovrši radnju** stops and flushes pending draft writes, then atomically
+   converts that draft into a queue record. Its persisted submission UUID and
+   attachment UUIDs never change during retry.
+3. A foreground coordinator claims the record with IndexedDB compare-and-swap.
+   Web Locks reduce duplicate work between tabs but are not the correctness
+   boundary. While slow photographs are uploading, the active coordinator
+   renews the exact claim; an expired or replaced claim cannot be renewed.
+4. Each photograph uses one deterministic path derived from operation, entity,
+   task version, submission UUID, and attachment UUID. Before retrying an
+   uncertain upload, an authenticated recovery action checks that exact object.
+5. The completion Server Action sends the persisted submission UUID. The
+   storage repository runs under the operation lock:
+   - the same UUID and canonical command returns the original receipt;
+   - the same UUID with different content is a terminal conflict;
+   - a different UUID against already-terminal work is a terminal conflict.
+6. The client stores a content-free `server_confirmed` tombstone, refreshes the
+   schedule, and reports the server receipt separately from
+   `pendingVerification` or verified completion.
+
+## Authentication and device isolation
+
+Queue work is scoped to the exact `userId`, selected `accountId`, session
+incarnation, and local writer generation returned by the authenticated claims
+route. The coordinator fails closed until all values are available and checks
+the scope before every local transition.
+
+Successful logout revokes the session generation and purges only that session's
+drafts and queue records. A delayed request or an older tab cannot mutate a
+newer session. Work is never adopted automatically by another user, account, or
+session.
+
+## Failure handling
+
+- Offline, network, Blob transport, and server-unavailable failures return the
+  record to a retryable state with persisted bounded backoff.
+- A stale `syncing` claim becomes claimable again after its lease expires.
+- Assignment, authorization, task version, requirement, target status, or
+  submission-content conflicts are resolution-required. The UI preserves the
+  local evidence and offers review or explicit discard; it does not loop.
+- Expired commands scrub notes, photographs, and URLs before reporting that
+  farmer action is required.
+- Discarding during or after an in-flight request only removes the local copy.
+  The UI never claims that it canceled a command that may already have reached
+  the server.
+- If IndexedDB is unavailable or full, `enabled` mode does not start network
+  work. The modal keeps the current form open and explains that it is not safely
+  queued.
+
+Blob upload and event append cannot be one transaction. A terminal conflict or
+discard may therefore leave an unreferenced deterministic Blob. Cleanup must be
+authenticated and may delete an object only after proving no completion event
+references it. Until that cleanup exists, monitor orphan growth during the
+pilot and never bulk-delete by path prefix alone.
+
+## Foreground and mobile behavior
+
+Synchronization runs only while an authenticated Farm page is open. The push
+service worker remains notification-only. Phone copy therefore asks the farmer
+to reopen the app with connectivity and stay in it while photographs are sent.
+
+The app-wide banner and settings panel distinguish:
+
+- saved only on this device;
+- waiting for connectivity;
+- sending;
+- action required;
+- receipt confirmed by the server.
+
+The affected operation modal is gated by the same local record so another tab
+or a late draft save cannot create a second completion. Controls are designed
+for 320–430 px widths and use at least 44 px targets.
+
+## Observability
+
+`farm_completion_sync_state_changed` accepts only bounded properties:
+
+- state and foreground trigger;
+- queue-size, age, and attempt buckets;
+- a controlled failure code.
+
+Never include notes, labels, image names, Blob contents or URLs, task/operation,
+account or user identifiers, coordinates, storage keys, pathnames, raw SDK
+errors, or session fingerprints. Logs should report controlled codes and
+counts, not serialized queue records.
+
+Pilot review should compare queue age, retry counts, terminal conflict rate,
+and successful receipts without joining them to private farmer content.
+
+## Rollout and rollback
+
+1. Keep production `off` while automated storage, concurrency, mobile,
+   accessibility, and privacy tests are incomplete.
+2. Enable a small internal cohort and complete GitHub task #4194 on physical
+   iOS standalone and Android Chrome devices, including weak connectivity,
+   background/force-close/reopen, lost response, and logout cases.
+3. Review controlled telemetry and unreferenced Blob growth.
+4. Expand `enabled` only after the real-device go/no-go record is approved.
+
+To stop new queue creation while preserving farmer work, change `enabled` to
+`drain_only`. Keep the app deployed until existing records reach a server
+receipt or explicit resolution. Use `off` only after the queue is drained or
+when the incident requires all automatic sends to stop; records remain visible
+so support can guide recovery. Rehearse `enabled` to `drain_only` during the
+pilot.
+
+## Validation
+
+Run the narrow checks from the repository root:
+
+```bash
+corepack pnpm --filter @gredice/storage test -- scheduleTaskSubmissionsRepo.node.spec.ts
+corepack pnpm --filter farm exec tsc --noEmit
+corepack pnpm --filter farm test:prepare
+corepack pnpm --filter farm exec playwright test app/schedule/CompleteOperationModal.spec.tsx app/schedule/useOperationCompletionDraft.spec.tsx lib/offline/operationCompletionDraftStore.spec.tsx lib/offline/operationCompletionQueueStore.spec.tsx lib/offline/operationCompletionQueueSync.spec.tsx components/offline/OperationCompletionSyncProvider.spec.tsx
+corepack pnpm --filter farm exec playwright test
+corepack pnpm --filter farm build
+git diff --check
+```
+
+Record physical device, operating-system, browser/PWA mode, connectivity case,
+result, and observed copy in #4194. Automated browser success does not close the
+real-device launch gate.

--- a/packages/storage/src/repositories/events/types.ts
+++ b/packages/storage/src/repositories/events/types.ts
@@ -322,8 +322,12 @@ export type OperationAssignPayload =
 
 export type OperationCompletePayload = {
     completedBy: string;
+    expectedAccountId?: string;
+    expectedEntityId?: number;
+    expectedTaskVersionEventId?: number;
     images?: string[];
     notes?: string;
+    submissionId?: string;
 };
 
 export type OperationBlockPayload = ScheduleTaskBlockPayload;

--- a/packages/storage/src/repositories/scheduleTaskSubmissionsRepo.ts
+++ b/packages/storage/src/repositories/scheduleTaskSubmissionsRepo.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { and, asc, eq, inArray } from 'drizzle-orm';
+import { validate as isUuid, version as uuidVersion } from 'uuid';
 import {
     events,
     farms,
@@ -55,7 +56,8 @@ export type ScheduleTaskSubmissionErrorCode =
     | 'not_authorized'
     | 'assignment_changed'
     | 'task_changed'
-    | 'invalid_status';
+    | 'invalid_status'
+    | 'submission_conflict';
 
 export class ScheduleTaskSubmissionError extends Error {
     constructor(
@@ -74,6 +76,24 @@ export type OperationTaskSubmissionResult = {
     eventId: number;
     occurredAt: Date;
     created: boolean;
+};
+
+export type OperationTaskCompletionInput = {
+    actor: ScheduleTaskActor;
+    expectedAccountId?: string;
+    expectedEntityId?: number;
+    expectedTaskVersionEventId?: number;
+    imageUrls?: readonly string[];
+    notes?: string;
+    operationId: number;
+    submissionId?: string;
+};
+
+export type OperationTaskCompletionReplayInput = Omit<
+    OperationTaskCompletionInput,
+    'submissionId'
+> & {
+    submissionId: string;
 };
 
 export type PlantingTaskSubmissionResult = {
@@ -149,6 +169,51 @@ function assertTaskVersionEventId(value: number) {
     return value;
 }
 
+function normalizeExpectedAccountId(value: string | undefined) {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (typeof value !== 'string') {
+        throw new ScheduleTaskSubmissionError(
+            'invalid_input',
+            'ID računa nije ispravan.',
+        );
+    }
+    const normalized = value.trim();
+    if (!normalized) {
+        throw new ScheduleTaskSubmissionError(
+            'invalid_input',
+            'ID računa ne smije biti prazan.',
+        );
+    }
+    return normalized;
+}
+
+function isOperationCompletionSubmissionId(value: string) {
+    if (!isUuid(value)) {
+        return false;
+    }
+    const version = uuidVersion(value);
+    return version >= 1 && version <= 8;
+}
+
+function normalizeSubmissionId(value: unknown) {
+    if (typeof value !== 'string') {
+        throw new ScheduleTaskSubmissionError(
+            'invalid_input',
+            'ID predaje nije ispravan.',
+        );
+    }
+    const normalized = value.trim().toLowerCase();
+    if (!isOperationCompletionSubmissionId(normalized)) {
+        throw new ScheduleTaskSubmissionError(
+            'invalid_input',
+            'ID predaje nije ispravan.',
+        );
+    }
+    return normalized;
+}
+
 function normalizeUserIds(userIds: readonly string[]) {
     return normalizeAssignedUserIds(
         userIds.map((userId) => userId.trim()),
@@ -206,6 +271,55 @@ function sameStrings(left: readonly string[], right: readonly string[]) {
         left.length === right.length &&
         left.every((value, index) => value === right[index])
     );
+}
+
+function normalizeOperationTaskCompletionTarget(
+    input: OperationTaskCompletionInput,
+) {
+    const operationId = assertPositiveSafeInteger(
+        input.operationId,
+        'ID radnje',
+    );
+    const expectedEntityId =
+        input.expectedEntityId === undefined
+            ? undefined
+            : assertPositiveSafeInteger(
+                  input.expectedEntityId,
+                  'ID vrste radnje',
+              );
+    const expectedTaskVersionEventId =
+        input.expectedTaskVersionEventId === undefined
+            ? undefined
+            : assertTaskVersionEventId(input.expectedTaskVersionEventId);
+    if (
+        input.actor.role === 'farmer' &&
+        (expectedEntityId === undefined ||
+            expectedTaskVersionEventId === undefined)
+    ) {
+        throw new ScheduleTaskSubmissionError(
+            'invalid_input',
+            'Nedostaje identitet zadatka. Osvježi zadatke i pokušaj ponovno.',
+        );
+    }
+
+    return {
+        actor: input.actor,
+        expectedAccountId: normalizeExpectedAccountId(input.expectedAccountId),
+        expectedEntityId,
+        expectedTaskVersionEventId,
+        operationId,
+    };
+}
+
+function normalizeOperationTaskCompletionReplayInput(
+    input: OperationTaskCompletionReplayInput,
+) {
+    return {
+        ...normalizeOperationTaskCompletionTarget(input),
+        imageUrls: normalizeImageUrls(input.imageUrls, maxCompletionImageCount),
+        notes: normalizeOptionalNote(input.notes),
+        submissionId: normalizeSubmissionId(input.submissionId),
+    };
 }
 
 function buildBlockPayload({
@@ -410,6 +524,131 @@ function existingOperationTerminalResult(
             created: false,
         };
     }
+    return null;
+}
+
+function assertExpectedOperationAccount(
+    operation: Awaited<ReturnType<typeof getAuthorizedOperation>>,
+    expectedAccountId: string | undefined,
+) {
+    if (
+        expectedAccountId !== undefined &&
+        operation.accountId !== expectedAccountId
+    ) {
+        throw new ScheduleTaskSubmissionError(
+            'not_authorized',
+            'Odabrani račun nema pristup ovom zadatku.',
+        );
+    }
+}
+
+function persistedSubmissionId(value: unknown) {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const normalized = value.trim().toLowerCase();
+    return isOperationCompletionSubmissionId(normalized)
+        ? normalized
+        : undefined;
+}
+
+function operationCompletionEventMatches(
+    data: unknown,
+    input: ReturnType<typeof normalizeOperationTaskCompletionReplayInput>,
+    accountId: string | null,
+) {
+    if (!isRecord(data)) {
+        return false;
+    }
+    const images = data.images;
+    if (
+        !Array.isArray(images) ||
+        !images.every((imageUrl) => typeof imageUrl === 'string')
+    ) {
+        return false;
+    }
+
+    return (
+        persistedSubmissionId(data.submissionId) === input.submissionId &&
+        data.completedBy === input.actor.userId &&
+        data.expectedAccountId === (accountId ?? undefined) &&
+        data.expectedEntityId === input.expectedEntityId &&
+        data.expectedTaskVersionEventId === input.expectedTaskVersionEventId &&
+        sameStrings(images, input.imageUrls) &&
+        data.notes === input.notes
+    );
+}
+
+async function resolveOperationTaskCompletionSubmissionInTransaction(
+    input: ReturnType<typeof normalizeOperationTaskCompletionReplayInput>,
+    operation: Awaited<ReturnType<typeof getAuthorizedOperation>>,
+    transaction: ScheduleTaskTransaction,
+): Promise<OperationTaskSubmissionResult | null> {
+    const completionEvents = await transaction
+        .select({
+            createdAt: events.createdAt,
+            data: events.data,
+            id: events.id,
+        })
+        .from(events)
+        .where(
+            and(
+                eq(events.aggregateId, input.operationId.toString()),
+                eq(events.type, knownEventTypes.operations.complete),
+            ),
+        )
+        .orderBy(asc(events.id));
+    const submissionEvents = completionEvents.filter(
+        (event) =>
+            persistedSubmissionId(
+                isRecord(event.data) ? event.data.submissionId : undefined,
+            ) === input.submissionId,
+    );
+
+    if (submissionEvents.length > 0) {
+        const [event] = submissionEvents;
+        if (
+            submissionEvents.length !== 1 ||
+            !event ||
+            !operationCompletionEventMatches(
+                event.data,
+                input,
+                operation.accountId,
+            )
+        ) {
+            throw new ScheduleTaskSubmissionError(
+                'submission_conflict',
+                'Ova je predaja već iskorištena s drukčijim podacima.',
+            );
+        }
+
+        const terminalResult = existingOperationTerminalResult(operation);
+        if (
+            terminalResult?.outcome === 'completed' &&
+            terminalResult.eventId === event.id
+        ) {
+            return terminalResult;
+        }
+        return {
+            kind: 'operation',
+            outcome: 'completed',
+            status:
+                input.actor.role === 'admin'
+                    ? 'completed'
+                    : 'pendingVerification',
+            eventId: event.id,
+            occurredAt: event.createdAt,
+            created: false,
+        };
+    }
+
+    if (existingOperationTerminalResult(operation)) {
+        throw new ScheduleTaskSubmissionError(
+            'submission_conflict',
+            'Zadatak već ima drugu završnu predaju.',
+        );
+    }
+
     return null;
 }
 
@@ -645,103 +884,124 @@ function assertPlantingAssignment(
     }
 }
 
-export async function submitOperationTaskCompletion(
-    {
-        actor,
-        expectedEntityId,
-        expectedTaskVersionEventId,
-        imageUrls,
-        notes,
-        operationId,
-    }: {
-        actor: ScheduleTaskActor;
-        expectedEntityId?: number;
-        expectedTaskVersionEventId?: number;
-        imageUrls?: readonly string[];
-        notes?: string;
-        operationId: number;
-    },
+export async function resolveOperationTaskCompletionSubmission(
+    input: OperationTaskCompletionReplayInput,
     transaction?: ScheduleTaskTransaction,
-): Promise<OperationTaskSubmissionResult> {
-    const validOperationId = assertPositiveSafeInteger(
-        operationId,
-        'ID radnje',
-    );
-    const validExpectedEntityId =
-        expectedEntityId === undefined
-            ? undefined
-            : assertPositiveSafeInteger(expectedEntityId, 'ID vrste radnje');
-    const validExpectedTaskVersionEventId =
-        expectedTaskVersionEventId === undefined
-            ? undefined
-            : assertTaskVersionEventId(expectedTaskVersionEventId);
-    if (
-        actor.role === 'farmer' &&
-        (validExpectedEntityId === undefined ||
-            validExpectedTaskVersionEventId === undefined)
-    ) {
-        throw new ScheduleTaskSubmissionError(
-            'invalid_input',
-            'Nedostaje identitet zadatka. Osvježi zadatke i pokušaj ponovno.',
-        );
-    }
+): Promise<OperationTaskSubmissionResult | null> {
+    const normalizedInput = normalizeOperationTaskCompletionReplayInput(input);
     return withOperationScheduleTaskTransaction(
-        validOperationId,
+        normalizedInput.operationId,
         async (transaction) => {
             const operation = await getAuthorizedOperation(
                 transaction,
-                actor,
-                validOperationId,
+                normalizedInput.actor,
+                normalizedInput.operationId,
             );
+            assertExpectedOperationAccount(
+                operation,
+                normalizedInput.expectedAccountId,
+            );
+            return resolveOperationTaskCompletionSubmissionInTransaction(
+                normalizedInput,
+                operation,
+                transaction,
+            );
+        },
+        transaction,
+    );
+}
+
+export async function submitOperationTaskCompletion(
+    input: OperationTaskCompletionInput,
+    transaction?: ScheduleTaskTransaction,
+): Promise<OperationTaskSubmissionResult> {
+    const normalizedTarget = normalizeOperationTaskCompletionTarget(input);
+    const normalizedReplayInput =
+        input.submissionId === undefined
+            ? undefined
+            : normalizeOperationTaskCompletionReplayInput({
+                  ...input,
+                  submissionId: input.submissionId,
+              });
+    return withOperationScheduleTaskTransaction(
+        normalizedTarget.operationId,
+        async (transaction) => {
+            const operation = await getAuthorizedOperation(
+                transaction,
+                normalizedTarget.actor,
+                normalizedTarget.operationId,
+            );
+            assertExpectedOperationAccount(
+                operation,
+                normalizedTarget.expectedAccountId,
+            );
+            if (normalizedReplayInput) {
+                const replay =
+                    await resolveOperationTaskCompletionSubmissionInTransaction(
+                        normalizedReplayInput,
+                        operation,
+                        transaction,
+                    );
+                if (replay) {
+                    return replay;
+                }
+            }
             if (
-                validExpectedEntityId !== undefined &&
-                operation.entityId !== validExpectedEntityId
+                normalizedTarget.expectedEntityId !== undefined &&
+                operation.entityId !== normalizedTarget.expectedEntityId
             ) {
                 throw new ScheduleTaskSubmissionError(
                     'task_changed',
                     'Radnja se u međuvremenu promijenila. Osvježi zadatke i pokušaj ponovno.',
                 );
             }
-            const existing = existingOperationTerminalResult(operation);
-            if (existing) {
-                if (existing.outcome === 'completed') {
-                    if (
-                        actor.role === 'admin' &&
-                        operation.status === 'pendingVerification'
-                    ) {
+            if (!normalizedReplayInput) {
+                const existing = existingOperationTerminalResult(operation);
+                if (existing) {
+                    if (existing.outcome === 'completed') {
                         if (
-                            validExpectedTaskVersionEventId !== undefined &&
-                            operation.taskVersionEventId !==
-                                validExpectedTaskVersionEventId
+                            normalizedTarget.actor.role === 'admin' &&
+                            operation.status === 'pendingVerification'
                         ) {
-                            throw new ScheduleTaskSubmissionError(
-                                'task_changed',
-                                'Zadatak je u međuvremenu promijenjen. Osvježi zadatke i pokušaj ponovno.',
+                            if (
+                                normalizedTarget.expectedTaskVersionEventId !==
+                                    undefined &&
+                                operation.taskVersionEventId !==
+                                    normalizedTarget.expectedTaskVersionEventId
+                            ) {
+                                throw new ScheduleTaskSubmissionError(
+                                    'task_changed',
+                                    'Zadatak je u međuvremenu promijenjen. Osvježi zadatke i pokušaj ponovno.',
+                                );
+                            }
+                            await createEvent(
+                                knownEvents.operations.verifiedV1(
+                                    normalizedTarget.operationId.toString(),
+                                    {
+                                        verifiedBy:
+                                            normalizedTarget.actor.userId,
+                                    },
+                                ),
+                                transaction,
                             );
+                            return {
+                                ...existing,
+                                status: 'completed' as const,
+                                created: true,
+                            };
                         }
-                        await createEvent(
-                            knownEvents.operations.verifiedV1(
-                                validOperationId.toString(),
-                                { verifiedBy: actor.userId },
-                            ),
-                            transaction,
-                        );
-                        return {
-                            ...existing,
-                            status: 'completed' as const,
-                            created: true,
-                        };
+                        return existing;
                     }
-                    return existing;
+                    throw new ScheduleTaskSubmissionError(
+                        'invalid_status',
+                        'Radnja je već označena kao blokirana.',
+                    );
                 }
-                throw new ScheduleTaskSubmissionError(
-                    'invalid_status',
-                    'Radnja je već označena kao blokirana.',
-                );
             }
             if (
-                validExpectedTaskVersionEventId !== undefined &&
-                operation.taskVersionEventId !== validExpectedTaskVersionEventId
+                normalizedTarget.expectedTaskVersionEventId !== undefined &&
+                operation.taskVersionEventId !==
+                    normalizedTarget.expectedTaskVersionEventId
             ) {
                 throw new ScheduleTaskSubmissionError(
                     'task_changed',
@@ -757,27 +1017,48 @@ export async function submitOperationTaskCompletion(
                     `Radnja sa stanjem ${operation.status} ne može biti dovršena.`,
                 );
             }
-            assertOperationAssignment(operation, actor);
+            assertOperationAssignment(operation, normalizedTarget.actor);
 
             const event = await createEvent(
                 knownEvents.operations.completedV1(
-                    validOperationId.toString(),
+                    normalizedTarget.operationId.toString(),
                     {
-                        completedBy: actor.userId,
-                        images: normalizeImageUrls(
-                            imageUrls,
-                            maxCompletionImageCount,
-                        ),
-                        notes: normalizeOptionalNote(notes),
+                        completedBy: normalizedTarget.actor.userId,
+                        ...(normalizedReplayInput
+                            ? {
+                                  ...(operation.accountId !== null
+                                      ? {
+                                            expectedAccountId:
+                                                operation.accountId,
+                                        }
+                                      : {}),
+                                  expectedEntityId:
+                                      normalizedReplayInput.expectedEntityId,
+                                  expectedTaskVersionEventId:
+                                      normalizedReplayInput.expectedTaskVersionEventId,
+                                  submissionId:
+                                      normalizedReplayInput.submissionId,
+                              }
+                            : {}),
+                        images:
+                            normalizedReplayInput?.imageUrls ??
+                            normalizeImageUrls(
+                                input.imageUrls,
+                                maxCompletionImageCount,
+                            ),
+                        notes:
+                            normalizedReplayInput !== undefined
+                                ? normalizedReplayInput.notes
+                                : normalizeOptionalNote(input.notes),
                     },
                 ),
                 transaction,
             );
-            if (actor.role === 'admin') {
+            if (normalizedTarget.actor.role === 'admin') {
                 await createEvent(
                     knownEvents.operations.verifiedV1(
-                        validOperationId.toString(),
-                        { verifiedBy: actor.userId },
+                        normalizedTarget.operationId.toString(),
+                        { verifiedBy: normalizedTarget.actor.userId },
                     ),
                     transaction,
                 );
@@ -786,7 +1067,7 @@ export async function submitOperationTaskCompletion(
                 kind: 'operation',
                 outcome: 'completed',
                 status:
-                    actor.role === 'admin'
+                    normalizedTarget.actor.role === 'admin'
                         ? 'completed'
                         : 'pendingVerification',
                 eventId: event.id,

--- a/packages/storage/tests/scheduleTaskSubmissionsRepo.node.spec.ts
+++ b/packages/storage/tests/scheduleTaskSubmissionsRepo.node.spec.ts
@@ -29,6 +29,7 @@ import {
     raisedBeds,
     rescheduleGardenDiaryOperation,
     rescheduleGardenDiaryRaisedBedField,
+    resolveOperationTaskCompletionSubmission,
     ScheduleTaskSubmissionError,
     sql,
     storage,
@@ -292,6 +293,300 @@ test('concurrent operation completion creates one terminal event and one automat
                 automationDefinitionId: definition.id,
                 limit: 20,
             })
+        ).length,
+        1,
+    );
+});
+
+test('keyed operation completion stores one canonical command and replays it after verification', async () => {
+    const fixture = await createTaskFixture();
+    const submissionId = randomUUID();
+    const input = {
+        operationId: fixture.operationId,
+        expectedAccountId: ` ${fixture.accountId} `,
+        expectedEntityId: fixture.operationEntityId,
+        expectedTaskVersionEventId: fixture.operationTaskVersionEventId,
+        actor: { userId: fixture.farmerId, role: 'farmer' as const },
+        submissionId: ` ${submissionId.toUpperCase()} `,
+        imageUrls: [
+            ' https://example.com/second.jpg ',
+            'https://example.com/first.jpg',
+            'https://example.com/second.jpg',
+            '   ',
+        ],
+        notes: '  Završeno na terenu  ',
+    };
+
+    assert.strictEqual(
+        await resolveOperationTaskCompletionSubmission(input),
+        null,
+    );
+    const created = await submitOperationTaskCompletion(input);
+    assert.strictEqual(created.created, true);
+
+    const replay = await resolveOperationTaskCompletionSubmission(input);
+    assert.ok(replay);
+    assert.strictEqual(replay.created, false);
+    assert.strictEqual(replay.eventId, created.eventId);
+    assert.deepStrictEqual(replay.occurredAt, created.occurredAt);
+    const replayWithoutExpectedAccount =
+        await resolveOperationTaskCompletionSubmission({
+            ...input,
+            expectedAccountId: undefined,
+        });
+    assert.strictEqual(replayWithoutExpectedAccount?.eventId, created.eventId);
+    assert.strictEqual(replayWithoutExpectedAccount?.created, false);
+
+    const [completionEvent] = await getAllEvents(
+        knownEventTypes.operations.complete,
+        [fixture.operationId.toString()],
+    );
+    assert.ok(completionEvent);
+    assert.deepStrictEqual(completionEvent.data, {
+        completedBy: fixture.farmerId,
+        expectedAccountId: fixture.accountId,
+        expectedEntityId: fixture.operationEntityId,
+        expectedTaskVersionEventId: fixture.operationTaskVersionEventId,
+        images: [
+            'https://example.com/second.jpg',
+            'https://example.com/first.jpg',
+        ],
+        notes: 'Završeno na terenu',
+        submissionId,
+    });
+
+    const pendingOperation = await getOperationById(fixture.operationId);
+    await verifyOperationTaskCompletion({
+        operationId: fixture.operationId,
+        expectedTaskVersionEventId: pendingOperation.taskVersionEventId,
+        verifiedBy: fixture.adminId,
+    });
+    const verifiedReplay =
+        await resolveOperationTaskCompletionSubmission(input);
+    assert.ok(verifiedReplay);
+    assert.strictEqual(verifiedReplay.created, false);
+    assert.strictEqual(verifiedReplay.eventId, created.eventId);
+    assert.deepStrictEqual(verifiedReplay.occurredAt, created.occurredAt);
+    assert.strictEqual(verifiedReplay.status, 'completed');
+});
+
+test('keyed operation completion rejects malformed IDs and selected-account mismatches', async () => {
+    const fixture = await createTaskFixture();
+    const baseInput = {
+        operationId: fixture.operationId,
+        expectedEntityId: fixture.operationEntityId,
+        expectedTaskVersionEventId: fixture.operationTaskVersionEventId,
+        actor: { userId: fixture.farmerId, role: 'farmer' as const },
+        imageUrls: ['https://example.com/proof.jpg'],
+        notes: 'Završeno',
+    };
+
+    for (const submissionId of [
+        'not-a-uuid',
+        '00000000-0000-0000-0000-000000000000',
+        'ffffffff-ffff-ffff-ffff-ffffffffffff',
+    ]) {
+        await assertSubmissionError(
+            resolveOperationTaskCompletionSubmission({
+                ...baseInput,
+                submissionId,
+            }),
+            'invalid_input',
+        );
+    }
+    await assertSubmissionError(
+        submitOperationTaskCompletion({
+            ...baseInput,
+            expectedAccountId: randomUUID(),
+            submissionId: randomUUID(),
+        }),
+        'not_authorized',
+    );
+    assert.strictEqual(
+        (
+            await getAllEvents(knownEventTypes.operations.complete, [
+                fixture.operationId.toString(),
+            ])
+        ).length,
+        0,
+    );
+});
+
+test('same operation submission ID conflicts with any changed canonical command', async () => {
+    const fixture = await createTaskFixture();
+    const submissionId = randomUUID();
+    const baseInput = {
+        operationId: fixture.operationId,
+        expectedAccountId: fixture.accountId,
+        expectedEntityId: fixture.operationEntityId,
+        expectedTaskVersionEventId: fixture.operationTaskVersionEventId,
+        actor: { userId: fixture.farmerId, role: 'farmer' as const },
+        submissionId,
+        imageUrls: [
+            'https://example.com/first.jpg',
+            'https://example.com/second.jpg',
+        ],
+        notes: 'Završeno',
+    };
+    const created = await submitOperationTaskCompletion(baseInput);
+
+    const conflictingInputs = [
+        { ...baseInput, notes: 'Druga napomena' },
+        {
+            ...baseInput,
+            imageUrls: [
+                'https://example.com/second.jpg',
+                'https://example.com/first.jpg',
+            ],
+        },
+        {
+            ...baseInput,
+            imageUrls: [
+                'https://example.com/first.jpg',
+                'https://example.com/changed.jpg',
+            ],
+        },
+        {
+            ...baseInput,
+            actor: { userId: fixture.adminId, role: 'admin' as const },
+        },
+        {
+            ...baseInput,
+            expectedEntityId: fixture.operationEntityId + 1,
+        },
+        {
+            ...baseInput,
+            expectedTaskVersionEventId: fixture.operationTaskVersionEventId + 1,
+        },
+    ];
+    for (const conflictingInput of conflictingInputs) {
+        await assertSubmissionError(
+            submitOperationTaskCompletion(conflictingInput),
+            'submission_conflict',
+        );
+    }
+    await assertSubmissionError(
+        submitOperationTaskCompletion({
+            ...baseInput,
+            submissionId: randomUUID(),
+        }),
+        'submission_conflict',
+    );
+
+    const completionEvents = await getAllEvents(
+        knownEventTypes.operations.complete,
+        [fixture.operationId.toString()],
+    );
+    assert.strictEqual(completionEvents.length, 1);
+    assert.strictEqual(completionEvents[0]?.id, created.eventId);
+});
+
+test('keyed completion conflicts with an existing terminal block', async () => {
+    const fixture = await createTaskFixture();
+    await submitOperationTaskBlock({
+        operationId: fixture.operationId,
+        expectedEntityId: fixture.operationEntityId,
+        expectedTaskVersionEventId: fixture.operationTaskVersionEventId,
+        actor: { userId: fixture.farmerId, role: 'farmer' },
+        reasonCode: 'unsafe_conditions',
+    });
+
+    await assertSubmissionError(
+        resolveOperationTaskCompletionSubmission({
+            operationId: fixture.operationId,
+            expectedAccountId: fixture.accountId,
+            expectedEntityId: fixture.operationEntityId,
+            expectedTaskVersionEventId: fixture.operationTaskVersionEventId,
+            actor: { userId: fixture.farmerId, role: 'farmer' },
+            submissionId: randomUUID(),
+        }),
+        'submission_conflict',
+    );
+});
+
+test('concurrent retries of one keyed completion create one event and one automation run', async () => {
+    const fixture = await createTaskFixture();
+    const submissionId = randomUUID();
+    const definition = await createAutomationDefinition({
+        key: `test.keyed-operation-completion-${randomUUID()}`,
+        name: 'Keyed operation completion concurrency',
+        status: 'enabled',
+        graph: eventAutomationGraph(knownEventTypes.operations.complete),
+    });
+    const input = {
+        operationId: fixture.operationId,
+        expectedAccountId: fixture.accountId,
+        expectedEntityId: fixture.operationEntityId,
+        expectedTaskVersionEventId: fixture.operationTaskVersionEventId,
+        actor: { userId: fixture.farmerId, role: 'farmer' as const },
+        submissionId,
+        imageUrls: ['https://example.com/proof.jpg'],
+        notes: 'Završeno na terenu',
+    };
+
+    const results = await Promise.all(
+        Array.from({ length: 8 }, () => submitOperationTaskCompletion(input)),
+    );
+
+    assert.strictEqual(results.filter((result) => result.created).length, 1);
+    assert.strictEqual(
+        new Set(results.map((result) => result.eventId)).size,
+        1,
+    );
+    assert.strictEqual(
+        (
+            await getAllEvents(knownEventTypes.operations.complete, [
+                fixture.operationId.toString(),
+            ])
+        ).length,
+        1,
+    );
+    assert.strictEqual(
+        (
+            await listAutomationRuns({
+                automationDefinitionId: definition.id,
+                limit: 20,
+            })
+        ).length,
+        1,
+    );
+});
+
+test('concurrent different operation submission IDs create one event and one explicit conflict', async () => {
+    const fixture = await createTaskFixture();
+    const baseInput = {
+        operationId: fixture.operationId,
+        expectedAccountId: fixture.accountId,
+        expectedEntityId: fixture.operationEntityId,
+        expectedTaskVersionEventId: fixture.operationTaskVersionEventId,
+        actor: { userId: fixture.farmerId, role: 'farmer' as const },
+        imageUrls: ['https://example.com/proof.jpg'],
+        notes: 'Završeno na terenu',
+    };
+
+    const results = await Promise.allSettled([
+        submitOperationTaskCompletion({
+            ...baseInput,
+            submissionId: randomUUID(),
+        }),
+        submitOperationTaskCompletion({
+            ...baseInput,
+            submissionId: randomUUID(),
+        }),
+    ]);
+    const fulfilled = results.filter((result) => result.status === 'fulfilled');
+    const rejected = results.filter((result) => result.status === 'rejected');
+    assert.strictEqual(fulfilled.length, 1);
+    assert.strictEqual(rejected.length, 1);
+    const [conflict] = rejected;
+    assert.ok(conflict && conflict.status === 'rejected');
+    assert.ok(conflict.reason instanceof ScheduleTaskSubmissionError);
+    assert.strictEqual(conflict.reason.code, 'submission_conflict');
+    assert.strictEqual(
+        (
+            await getAllEvents(knownEventTypes.operations.complete, [
+                fixture.operationId.toString(),
+            ])
         ).length,
         1,
     );


### PR DESCRIPTION
## Summary

- atomically hand operation-completion drafts to a durable, account- and session-isolated queue before any network request
- expose mobile-first waiting, syncing, action-required, expired, and server-confirmed states in the task modal, app shell, and settings
- make evidence uploads and completion retries idempotent with deterministic Blob paths, stable submission IDs, receipt recovery, and explicit conflicts
- add privacy-bounded telemetry, foreground-only retry orchestration, and `off` / `drain_only` / `enabled` rollout modes
- document the operational rollout, recovery, rollback, and physical-device launch gate

## Scope boundaries

- queues operation completion only; planting and blocker mutations remain online
- keeps the ordinary farmer experience single-farm and adds no farm selector
- production defaults to `off`; broad enablement remains blocked on the physical-phone pilot in #4194
- server-confirmed state remains the source of truth

## Validation

- `corepack pnpm --filter farm build`
- `GREDICE_FARM_TEST_PORT=3217 GREDICE_FARM_START_PORT=3217 GREDICE_FARM_CT_PORT=3317 corepack pnpm --filter farm exec playwright test` — 356 passed
- `corepack pnpm --filter @gredice/storage test -- scheduleTaskSubmissionsRepo.node.spec.ts` — 38 passed
- Biome — 40 Farm files and 3 storage files checked
- `git diff --check`

Closes #4166
